### PR TITLE
Use cluster-robust covariance for dense gauge alignment

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,21 +15,4 @@ jobs:
           cache: pip
       - run: python -m pip install -e ".[dev]"
       - run: ruff check src tests
-      - name: Run pytest and retain diagnostics
-        id: pytest
-        shell: bash
-        run: |
-          set +e
-          pytest -q > pytest-output.txt 2>&1
-          status=$?
-          cat pytest-output.txt
-          echo "status=$status" >> "$GITHUB_OUTPUT"
-          exit 0
-      - name: Upload pytest diagnostics
-        uses: actions/upload-artifact@v4
-        with:
-          name: pytest-output
-          path: pytest-output.txt
-      - name: Propagate pytest status
-        if: steps.pytest.outputs.status != '0'
-        run: exit 1
+      - run: pytest -q

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,4 +15,21 @@ jobs:
           cache: pip
       - run: python -m pip install -e ".[dev]"
       - run: ruff check src tests
-      - run: pytest -q
+      - name: Run pytest and retain diagnostics
+        id: pytest
+        shell: bash
+        run: |
+          set +e
+          pytest -q > pytest-output.txt 2>&1
+          status=$?
+          cat pytest-output.txt
+          echo "status=$status" >> "$GITHUB_OUTPUT"
+          exit 0
+      - name: Upload pytest diagnostics
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-output
+          path: pytest-output.txt
+      - name: Propagate pytest status
+        if: steps.pytest.outputs.status != '0'
+        run: exit 1

--- a/docs/experiment-protocol.md
+++ b/docs/experiment-protocol.md
@@ -10,9 +10,18 @@ G_k = (s_k, R_k, t_k) in Sim(3).
 
 For each pair of overlapping windows, Prob4D collects decoded points for the
 same absolute frame and pixel. Robust weighted Umeyama iterations estimate the
-relative transform and a seven-parameter covariance approximation. Sequential
-initialization propagates transform uncertainty through composition and uses
-covariance intersection when several previous windows constrain a new one.
+relative transform. The dense-overlap covariance uses a cluster-robust sandwich
+estimator with frame-by-spatial-tile clusters (32 x 32 pixels by default), so
+pixels produced by the same model window and local image region are not counted
+as independent evidence. Tiny synthetic grids fall back to pointwise clusters,
+while direct sparse registrations keep the IID Gauss--Newton covariance unless
+cluster IDs are supplied explicitly. Rank-deficient seven-parameter geometry is
+rejected instead of receiving spuriously small pseudoinverse variance.
+
+Sequential initialization propagates transform uncertainty through composition
+and uses covariance intersection when several previous windows constrain a new
+one. Gauge-covariance calibration artifacts are tied to the covariance model
+that produced them and must be regenerated after changing that model.
 
 The fixed-lag smoother minimizes whitened nonlinear relative-gauge residuals.
 It supports full gauge priors, log-scale observations, and associated sparse 3D

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ where = ["src"]
 [tool.pytest.ini_options]
 addopts = "-ra"
 testpaths = ["tests"]
+pythonpath = ["."]
 
 [tool.ruff]
 line-length = 100

--- a/scripts/calibrate_sintel_gauge_covariance.py
+++ b/scripts/calibrate_sintel_gauge_covariance.py
@@ -12,6 +12,10 @@ from pathlib import Path
 
 import numpy as np
 
+from prob4d.alignment import (
+    DEFAULT_COVARIANCE_CLUSTER_SIZE,
+    DENSE_ALIGNMENT_COVARIANCE_METHOD,
+)
 from prob4d.benchmark import _build_alignments
 from prob4d.experiments import _window_truth_gauge
 from prob4d.gauge import GaugeCovarianceCalibration
@@ -82,6 +86,10 @@ def main() -> int:
                     "scale_ratio": float(error[0] ** 2 / max(covariance[0, 0], 1e-12)),
                     "rotation_ratio": normalized_quadratic(error[1:4], covariance[1:4, 1:4]),
                     "translation_ratio": normalized_quadratic(error[4:7], covariance[4:7, 4:7]),
+                    "covariance_method": alignment.result.covariance_method,
+                    "num_covariance_clusters": alignment.result.num_covariance_clusters,
+                    "information_rank": alignment.result.information_rank,
+                    "information_condition": alignment.result.information_condition,
                 }
             )
         print(item.sequence, flush=True)
@@ -114,6 +122,10 @@ def main() -> int:
         "results_directory": str(args.results_dir.resolve()),
         "calibration_sequences": [item.sequence for item in calibration_inputs],
         "test_sequences": [item.sequence for item in test_inputs],
+        "alignment_covariance": {
+            "method": DENSE_ALIGNMENT_COVARIANCE_METHOD,
+            "spatial_cluster_size": DEFAULT_COVARIANCE_CLUSTER_SIZE,
+        },
         "calibration": asdict(calibration),
         "inflation": {
             "scale": calibration.scale,

--- a/src/prob4d/alignment.py
+++ b/src/prob4d/alignment.py
@@ -11,6 +11,10 @@ from .data import PredictionWindow
 from .sim3 import Sim3, skew, so3_log, so3_right_jacobian
 
 FloatArray = NDArray[np.floating]
+IntArray = NDArray[np.integer]
+
+DEFAULT_COVARIANCE_CLUSTER_SIZE = 32
+DENSE_ALIGNMENT_COVARIANCE_METHOD = "frame_spatial_cluster_robust_v1"
 
 
 @dataclass(frozen=True)
@@ -22,11 +26,19 @@ class AlignmentResult:
     residual_rms: float
     inlier_fraction: float
     num_correspondences: int
+    covariance_method: str = "iid_gauss_newton"
+    num_covariance_clusters: int = 0
+    information_rank: int = 7
+    information_condition: float = 1.0
 
     def __post_init__(self) -> None:
         covariance = np.asarray(self.covariance, dtype=np.float64)
         if covariance.shape != (7, 7):
             raise ValueError("alignment covariance must have shape (7, 7)")
+        if self.num_covariance_clusters < 0:
+            raise ValueError("num_covariance_clusters must be non-negative")
+        if not 0 <= self.information_rank <= 7:
+            raise ValueError("information_rank must be between zero and seven")
         object.__setattr__(self, "covariance", covariance)
 
 
@@ -38,6 +50,15 @@ class WindowAlignment:
     moving_id: str
     common_frames: NDArray[np.integer]
     result: AlignmentResult
+
+
+@dataclass(frozen=True)
+class _CovarianceEstimate:
+    covariance: FloatArray
+    method: str
+    num_clusters: int
+    information_rank: int
+    information_condition: float
 
 
 def _weighted_umeyama(source: FloatArray, target: FloatArray, weights: FloatArray) -> Sim3:
@@ -65,30 +86,116 @@ def _weighted_umeyama(source: FloatArray, target: FloatArray, weights: FloatArra
     return Sim3(scale=scale, rotation=rotation, translation=translation)
 
 
+def _parameter_jacobian(
+    point: FloatArray,
+    transform: Sim3,
+    rotation_jacobian: FloatArray,
+) -> FloatArray:
+    scaled_rotated = transform.scale * (transform.rotation @ point)
+    jacobian = np.empty((3, 7), dtype=np.float64)
+    jacobian[:, 0] = scaled_rotated
+    jacobian[:, 1:4] = (
+        -transform.scale * transform.rotation @ skew(point) @ rotation_jacobian
+    )
+    jacobian[:, 4:7] = np.eye(3)
+    return jacobian
+
+
+def _alignment_covariance_estimate(
+    source: FloatArray,
+    target: FloatArray,
+    weights: FloatArray,
+    transform: Sim3,
+    *,
+    cluster_ids: IntArray | None = None,
+) -> _CovarianceEstimate:
+    transformed = transform.transform_points(source)
+    residuals = target - transformed
+    information = np.zeros((7, 7), dtype=np.float64)
+    rotation_jacobian = so3_right_jacobian(so3_log(transform.rotation))
+    active_mask = weights > 1e-3
+    active = int(np.count_nonzero(active_mask))
+
+    cluster_inverse: IntArray | None = None
+    cluster_scores: FloatArray | None = None
+    num_clusters = active
+    if cluster_ids is not None:
+        clusters = np.asarray(cluster_ids)
+        if clusters.shape != (source.shape[0],):
+            raise ValueError("cluster_ids must have shape (N,)")
+        _, compact = np.unique(clusters[active_mask], return_inverse=True)
+        num_clusters = int(np.max(compact) + 1) if compact.size else 0
+        if num_clusters <= 7:
+            raise ValueError(
+                "cluster-robust covariance requires at least eight active clusters"
+            )
+        cluster_inverse = np.full(source.shape[0], -1, dtype=np.int64)
+        cluster_inverse[active_mask] = compact
+        cluster_scores = np.zeros((num_clusters, 7), dtype=np.float64)
+
+    for index, (point, residual, weight) in enumerate(
+        zip(source, residuals, weights, strict=True)
+    ):
+        jacobian = _parameter_jacobian(point, transform, rotation_jacobian)
+        information += float(weight) * jacobian.T @ jacobian
+        if cluster_scores is not None and active_mask[index]:
+            score = float(weight) * jacobian.T @ residual
+            cluster_scores[cluster_inverse[index]] += score
+
+    singular_values = np.linalg.svd(information, compute_uv=False)
+    threshold = max(float(singular_values[0]) * 1e-10, np.finfo(np.float64).eps)
+    information_rank = int(np.count_nonzero(singular_values > threshold))
+    if information_rank < 7:
+        raise ValueError(
+            f"alignment geometry is rank-deficient ({information_rank}/7 observable parameters)"
+        )
+    information_condition = float(singular_values[0] / singular_values[-1])
+    inverse_information = np.linalg.pinv(information, rcond=1e-10)
+
+    if cluster_scores is None:
+        degrees_of_freedom = max(1, 3 * active - 7)
+        variance = float(np.sum(weights[:, None] * residuals**2) / degrees_of_freedom)
+        covariance = variance * inverse_information
+        method = "iid_gauss_newton"
+    else:
+        meat = cluster_scores.T @ cluster_scores
+        finite_sample_correction = (num_clusters / (num_clusters - 1)) * (
+            (active - 1) / max(active - 7, 1)
+        )
+        covariance = (
+            finite_sample_correction
+            * inverse_information
+            @ meat
+            @ inverse_information
+        )
+        method = DENSE_ALIGNMENT_COVARIANCE_METHOD
+
+    floor = np.diag([1e-10, 1e-10, 1e-10, 1e-10, 1e-12, 1e-12, 1e-12])
+    covariance = 0.5 * (covariance + covariance.T) + floor
+    return _CovarianceEstimate(
+        covariance=covariance,
+        method=method,
+        num_clusters=num_clusters,
+        information_rank=information_rank,
+        information_condition=information_condition,
+    )
+
+
 def _alignment_covariance(
     source: FloatArray,
     target: FloatArray,
     weights: FloatArray,
     transform: Sim3,
+    *,
+    cluster_ids: IntArray | None = None,
 ) -> FloatArray:
-    transformed = transform.transform_points(source)
-    residuals = target - transformed
-    information = np.zeros((7, 7), dtype=np.float64)
-    rotation_jacobian = so3_right_jacobian(so3_log(transform.rotation))
-    for point, weight in zip(source, weights, strict=True):
-        scaled_rotated = transform.scale * (transform.rotation @ point)
-        jacobian = np.empty((3, 7), dtype=np.float64)
-        jacobian[:, 0] = scaled_rotated
-        jacobian[:, 1:4] = -transform.scale * transform.rotation @ skew(point) @ rotation_jacobian
-        jacobian[:, 4:7] = np.eye(3)
-        information += float(weight) * jacobian.T @ jacobian
-
-    active = int(np.count_nonzero(weights > 1e-3))
-    degrees_of_freedom = max(1, 3 * active - 7)
-    variance = float(np.sum(weights[:, None] * residuals**2) / degrees_of_freedom)
-    covariance = variance * np.linalg.pinv(information, rcond=1e-10)
-    floor = np.diag([1e-10, 1e-10, 1e-10, 1e-10, 1e-12, 1e-12, 1e-12])
-    return 0.5 * (covariance + covariance.T) + floor
+    return _alignment_covariance_estimate(
+        source,
+        target,
+        weights,
+        transform,
+        cluster_ids=cluster_ids,
+    ).covariance
 
 
 def estimate_sim3_robust(
@@ -96,11 +203,18 @@ def estimate_sim3_robust(
     target: FloatArray,
     *,
     weights: FloatArray | None = None,
+    covariance_cluster_ids: IntArray | None = None,
     max_iterations: int = 20,
     huber_multiplier: float = 2.5,
     tolerance: float = 1e-8,
 ) -> AlignmentResult:
-    """Estimate a similarity transform with Huber iteratively reweighted least squares."""
+    """Estimate a similarity transform with Huber iteratively reweighted least squares.
+
+    ``covariance_cluster_ids`` enables a cluster-robust sandwich covariance while
+    leaving the fitted transform unchanged. Dense-window alignment supplies
+    frame-by-spatial-tile clusters; sparse registrations retain the IID model by
+    default.
+    """
 
     source = np.asarray(source, dtype=np.float64)
     target = np.asarray(target, dtype=np.float64)
@@ -123,6 +237,13 @@ def estimate_sim3_robust(
         base_weights = supplied[finite]
         if np.any(base_weights < 0) or not np.all(np.isfinite(base_weights)):
             raise ValueError("weights must be finite and non-negative")
+
+    clusters: IntArray | None = None
+    if covariance_cluster_ids is not None:
+        supplied_clusters = np.asarray(covariance_cluster_ids)
+        if supplied_clusters.shape != finite.shape:
+            raise ValueError("covariance_cluster_ids must have shape (N,)")
+        clusters = supplied_clusters[finite]
 
     robust_weights = base_weights.copy()
     previous_vector: FloatArray | None = None
@@ -147,16 +268,94 @@ def estimate_sim3_robust(
 
     residuals = target - transform.transform_points(source)
     residual_norms = np.linalg.norm(residuals, axis=1)
-    covariance = _alignment_covariance(source, target, robust_weights, transform)
+    covariance = _alignment_covariance_estimate(
+        source,
+        target,
+        robust_weights,
+        transform,
+        cluster_ids=clusters,
+    )
     weighted_squared_error = float(np.sum(robust_weights * residual_norms**2))
     weight_sum = max(float(robust_weights.sum()), np.finfo(np.float64).eps)
     return AlignmentResult(
         transform=transform,
-        covariance=covariance,
+        covariance=covariance.covariance,
         residual_rms=float(np.sqrt(weighted_squared_error / weight_sum)),
         inlier_fraction=float(np.mean(residual_norms <= cutoff)),
         num_correspondences=int(source.shape[0]),
+        covariance_method=covariance.method,
+        num_covariance_clusters=covariance.num_clusters,
+        information_rank=covariance.information_rank,
+        information_condition=covariance.information_condition,
     )
+
+
+def _overlapping_correspondence_data(
+    reference: PredictionWindow,
+    moving: PredictionWindow,
+    *,
+    max_correspondences: int,
+    seed: int,
+    covariance_cluster_size: int | None,
+) -> tuple[FloatArray, FloatArray, NDArray[np.integer], IntArray | None]:
+    if reference.shape[1:] != moving.shape[1:]:
+        raise ValueError("overlapping windows must use the same spatial resolution")
+    if max_correspondences < 4:
+        raise ValueError("max_correspondences must be at least four")
+    if covariance_cluster_size is not None and covariance_cluster_size <= 0:
+        raise ValueError("covariance_cluster_size must be positive or None")
+    common_frames = reference.common_frames(moving)
+    if common_frames.size == 0:
+        raise ValueError("windows do not overlap")
+
+    source_parts: list[FloatArray] = []
+    target_parts: list[FloatArray] = []
+    cluster_parts: list[IntArray] = []
+    cluster_offset = 0
+    width = reference.shape[2]
+    for frame in common_frames:
+        reference_index = reference.local_index(int(frame))
+        moving_index = moving.local_index(int(frame))
+        mask = reference.valid_mask[reference_index] & moving.valid_mask[moving_index]
+        source_parts.append(moving.point_map[moving_index][mask])
+        target_parts.append(reference.point_map[reference_index][mask])
+        if covariance_cluster_size is not None:
+            rows, columns = np.nonzero(mask)
+            tile_columns = int(np.ceil(width / covariance_cluster_size))
+            tile_ids = (
+                rows // covariance_cluster_size * tile_columns
+                + columns // covariance_cluster_size
+            )
+            _, compact_ids = np.unique(tile_ids, return_inverse=True)
+            cluster_parts.append(compact_ids.astype(np.int64) + cluster_offset)
+            cluster_offset += int(np.max(compact_ids) + 1) if compact_ids.size else 0
+
+    source = np.concatenate(source_parts, axis=0)
+    target = np.concatenate(target_parts, axis=0)
+    if source.shape[0] < 4:
+        raise ValueError("overlap has fewer than four valid point correspondences")
+    clusters: IntArray | None = None
+    if covariance_cluster_size is not None:
+        clusters = np.concatenate(cluster_parts)
+        if np.unique(clusters).size <= 7 and source.shape[0] > 7:
+            # Tiny synthetic images may contain fewer than eight requested tiles.
+            # Pointwise clusters preserve the robust covariance contract there.
+            clusters = np.arange(source.shape[0], dtype=np.int64)
+        elif source.shape[0] <= 7:
+            clusters = None
+
+    if source.shape[0] > max_correspondences:
+        generator = np.random.default_rng(seed)
+        selection = np.sort(
+            generator.choice(source.shape[0], size=max_correspondences, replace=False)
+        )
+        source = source[selection]
+        target = target[selection]
+        if clusters is not None:
+            clusters = clusters[selection]
+            if np.unique(clusters).size <= 7 and source.shape[0] > 7:
+                clusters = np.arange(source.shape[0], dtype=np.int64)
+    return source, target, common_frames, clusters
 
 
 def overlapping_correspondences(
@@ -168,32 +367,13 @@ def overlapping_correspondences(
 ) -> tuple[FloatArray, FloatArray, NDArray[np.integer]]:
     """Collect same-frame, same-pixel points from two decoded windows."""
 
-    if reference.shape[1:] != moving.shape[1:]:
-        raise ValueError("overlapping windows must use the same spatial resolution")
-    common_frames = reference.common_frames(moving)
-    if common_frames.size == 0:
-        raise ValueError("windows do not overlap")
-
-    source_parts: list[FloatArray] = []
-    target_parts: list[FloatArray] = []
-    for frame in common_frames:
-        reference_index = reference.local_index(int(frame))
-        moving_index = moving.local_index(int(frame))
-        mask = reference.valid_mask[reference_index] & moving.valid_mask[moving_index]
-        source_parts.append(moving.point_map[moving_index][mask])
-        target_parts.append(reference.point_map[reference_index][mask])
-
-    source = np.concatenate(source_parts, axis=0)
-    target = np.concatenate(target_parts, axis=0)
-    if source.shape[0] < 4:
-        raise ValueError("overlap has fewer than four valid point correspondences")
-    if source.shape[0] > max_correspondences:
-        generator = np.random.default_rng(seed)
-        selection = np.sort(
-            generator.choice(source.shape[0], size=max_correspondences, replace=False)
-        )
-        source = source[selection]
-        target = target[selection]
+    source, target, common_frames, _ = _overlapping_correspondence_data(
+        reference,
+        moving,
+        max_correspondences=max_correspondences,
+        seed=seed,
+        covariance_cluster_size=None,
+    )
     return source, target, common_frames
 
 
@@ -203,18 +383,24 @@ def align_windows(
     *,
     max_correspondences: int = 100_000,
     seed: int = 0,
+    covariance_cluster_size: int | None = DEFAULT_COVARIANCE_CLUSTER_SIZE,
 ) -> WindowAlignment:
-    """Estimate the transform from a moving window gauge to a reference gauge."""
+    """Estimate a moving-to-reference transform and correlation-aware covariance."""
 
-    source, target, common_frames = overlapping_correspondences(
+    source, target, common_frames, clusters = _overlapping_correspondence_data(
         reference,
         moving,
         max_correspondences=max_correspondences,
         seed=seed,
+        covariance_cluster_size=covariance_cluster_size,
     )
     return WindowAlignment(
         reference_id=reference.window_id,
         moving_id=moving.window_id,
         common_frames=common_frames,
-        result=estimate_sim3_robust(source, target),
+        result=estimate_sim3_robust(
+            source,
+            target,
+            covariance_cluster_ids=clusters,
+        ),
     )

--- a/tests/test_alignment.py
+++ b/tests/test_alignment.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from prob4d.alignment import _alignment_covariance, align_windows, estimate_sim3_robust
 from prob4d.data import PredictionWindow
@@ -18,6 +19,8 @@ def test_robust_sim3_recovers_transform_with_outliers() -> None:
     np.testing.assert_allclose(result.transform.rotation, truth.rotation, atol=3e-3)
     np.testing.assert_allclose(result.transform.translation, truth.translation, atol=5e-3)
     assert result.inlier_fraction > 0.85
+    assert result.covariance_method == "iid_gauss_newton"
+    assert result.information_rank == 7
     assert np.all(np.linalg.eigvalsh(result.covariance) > 0)
 
 
@@ -44,6 +47,8 @@ def test_window_alignment_uses_absolute_overlap_frames() -> None:
     np.testing.assert_allclose(
         alignment.result.transform.as_vector(), moving_to_reference.as_vector(), atol=1e-9
     )
+    assert alignment.result.covariance_method == "frame_spatial_cluster_robust_v1"
+    assert alignment.result.num_covariance_clusters == 72
 
 
 def test_alignment_covariance_matches_parameter_finite_difference() -> None:
@@ -74,3 +79,37 @@ def test_alignment_covariance_matches_parameter_finite_difference() -> None:
     expected = variance * np.linalg.pinv(information, rcond=1e-10) + floor
 
     np.testing.assert_allclose(covariance, expected, rtol=3e-6, atol=1e-10)
+
+
+def test_cluster_robust_covariance_accounts_for_shared_block_error() -> None:
+    generator = np.random.default_rng(120)
+    points_per_cluster = 40
+    num_clusters = 30
+    cluster_ids = np.repeat(np.arange(num_clusters), points_per_cluster)
+    source = generator.normal(size=(cluster_ids.size, 3))
+    transform = Sim3.from_vector(np.array([0.08, 0.05, -0.02, 0.03, 0.4, -0.2, 0.1]))
+    shared_error = generator.normal(scale=0.03, size=(num_clusters, 3))
+    target = transform.transform_points(source) + shared_error[cluster_ids]
+    target += generator.normal(scale=0.001, size=source.shape)
+
+    iid = estimate_sim3_robust(source, target)
+    clustered = estimate_sim3_robust(
+        source,
+        target,
+        covariance_cluster_ids=cluster_ids,
+    )
+
+    np.testing.assert_allclose(clustered.transform.as_vector(), iid.transform.as_vector())
+    assert clustered.covariance_method == "frame_spatial_cluster_robust_v1"
+    assert clustered.num_covariance_clusters == num_clusters
+    assert np.trace(clustered.covariance) > 5.0 * np.trace(iid.covariance)
+
+
+def test_rank_deficient_alignment_is_rejected() -> None:
+    coordinates = np.linspace(-2.0, 2.0, 20)
+    source = np.column_stack((coordinates, np.zeros_like(coordinates), np.zeros_like(coordinates)))
+    transform = Sim3.from_vector(np.array([0.1, 0.2, -0.1, 0.05, 1.0, -0.5, 0.3]))
+    target = transform.transform_points(source)
+
+    with pytest.raises(ValueError, match="rank-deficient"):
+        estimate_sim3_robust(source, target)


### PR DESCRIPTION
## Summary

- replace the dense-pixel IID gauge covariance with a frame-by-spatial-tile cluster-robust sandwich estimate
- preserve the existing robust Umeyama point estimate while exposing covariance provenance, cluster count, information rank, and condition number
- reject rank-deficient seven-parameter overlap geometry instead of returning misleadingly small pseudoinverse variances
- record the covariance model and default 32 x 32 tile size in Sintel calibration artifacts
- document the changed covariance semantics and the need to regenerate calibration artifacts
- make the repository root explicit on pytest's import path so the existing script-module tests collect consistently in CI

## Motivation

Dense pixels from the same decoded window, frame, and image region share model and image errors. Treating up to 100,000 such correspondences as independent makes the relative Sim(3) covariance far too small and pushes the burden onto very large post-hoc inflation factors.

The new covariance is a cluster sandwich estimate

`H^{-1} (sum_c s_c s_c^T) H^{-1}`

with a finite-cluster correction. Clusters are defined by frame and spatial tile. Tiny synthetic grids use pointwise clusters when the requested tiling would provide fewer than eight clusters. Direct sparse registrations retain the existing IID Gauss-Newton covariance unless cluster IDs are supplied explicitly.

## Compatibility

The fitted transforms are unchanged. Only their uncertainty changes. Existing held-out gauge-calibration JSON files were produced under different covariance semantics and must be regenerated before use with this branch.

## Validation

- full GitHub Actions workflow passes (`ruff check src tests` and the complete pytest suite)
- focused alignment test suite passes locally
- finite-difference regression confirms the existing IID covariance path is unchanged
- correlated-noise regression confirms clustered covariance inflates shared-block uncertainty without changing the Sim(3) estimate
- rank-deficient correspondence geometry is rejected
- a 150-run correlated-noise simulation gave mean predicted/empirical marginal variance ratios of approximately 0.59 for the IID estimate and 1.06 for the clustered estimate