### PR TITLE
Add versioned causal observation artifacts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,10 +15,4 @@ jobs:
           cache: pip
       - run: python -m pip install -e ".[dev]"
       - run: ruff check src tests
-      - run: pytest -q --junitxml=pytest-report.xml
-      - if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: pytest-report
-          path: pytest-report.xml
-          if-no-files-found: error
+      - run: pytest -q

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,4 +15,10 @@ jobs:
           cache: pip
       - run: python -m pip install -e ".[dev]"
       - run: ruff check src tests
-      - run: pytest -q
+      - run: pytest -q --junitxml=pytest-report.xml
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-report
+          path: pytest-report.xml
+          if-no-files-found: error

--- a/docs/data-format.md
+++ b/docs/data-format.md
@@ -41,6 +41,22 @@ video frame IDs directly into every baseline and overlap window. PhysTwin
 evaluation requires these absolute IDs because its calibration, depth frames,
 manual tracks, and physical trajectories all use the original sequence index.
 
+## Downstream Observation Artifact
+
+`prob4d-observation export` writes a version-2 JSON/NPZ pair for downstream
+Bayesian consumers. The artifact includes point and optional flow covariance,
+source-window identities, dependence groups, per-frame source limits, exact
+producer and upstream revisions, and an explicit metric or gauge-relative
+coordinate status.
+
+A causal export with `--causal-max-frame` removes every window that used a later
+source frame and re-runs gauge estimation and fusion. It does not slice an
+all-frame fusion result. Gauge-relative exports use `gauge_unit^2`, never `m^2`,
+and retain an unresolved global `Sim(3)` gauge for the downstream model.
+
+See [the observation artifact contract](observation-artifact.md) for the schema,
+causal semantics, validation rules, and command examples.
+
 ## Ground Truth
 
 Real evaluation expects a compressed NumPy archive with:

--- a/docs/observation-artifact.md
+++ b/docs/observation-artifact.md
@@ -1,0 +1,102 @@
+# Versioned Observation Artifact
+
+Prob4D can export a strict observation product for Bayesian-PhysTwin or another
+Bayesian consumer. The artifact records dense positions and optional scene flow,
+their marginal covariance, the unresolved global gauge, contributor structure,
+source revisions, and the latest source frame that could have influenced every
+output frame.
+
+## Export
+
+```bash
+prob4d-observation export \
+  outputs/sequence/predictions.json \
+  outputs/sequence/observation.json \
+  --method prob4d_uniform
+```
+
+A causal-prefix export must specify the final permitted source frame:
+
+```bash
+prob4d-observation export \
+  outputs/sequence/predictions.json \
+  outputs/sequence/prefix_133.json \
+  --method prob4d_uniform \
+  --causal-max-frame 133
+```
+
+The causal command does not slice an observation fused from the complete video.
+It first removes every MotionCrafter window whose maximum source-frame ID exceeds
+the boundary, then re-estimates the admissible gauges and re-runs fusion. Export
+fails when no complete source window is admissible. The resulting artifact is
+validated so that both its output frame IDs and all recorded source dependencies
+are at or before the requested boundary.
+
+## Files
+
+An export consists of two files in the same directory:
+
+- `observation.json`: version, gauge status, source-window and frame-level
+  provenance, SHA-256, and a compact summary;
+- `observation.npz`: dense arrays stored without pickle and with symmetric
+  covariance matrices packed into six upper-triangular entries.
+
+The JSON manifest hash-locks the NumPy payload. Moving or renaming the pair is
+allowed when the `array_file` entry remains a same-directory relative filename
+and its SHA-256 remains unchanged.
+
+## Coordinate and gauge semantics
+
+The standard MotionCrafter export is deliberately marked as:
+
+```text
+coordinate_status = gauge_relative
+gauge_status      = unresolved
+covariance_units  = gauge_unit^2
+```
+
+The first selected window names the internal gauge reference, but this is not a
+metric anchor. Downstream code must retain the unresolved `Sim(3)` gauge as a
+latent variable, supply independent metric information, or abstain from treating
+the observations as metric. In particular, gauge-relative covariance must never
+be labelled `m^2`.
+
+The in-memory contract also supports a metric artifact, but metric status is
+accepted only with an anchored seven-parameter gauge mean and positive
+semidefinite gauge covariance.
+
+## Dependence and support
+
+Each source window records its absolute source-frame IDs and a correlation-group
+identifier. Each output frame records the source-window IDs that can contribute
+to it, while the dense `contributors` array retains the number of valid
+predictions at every pixel. The exporter conservatively assigns the maximum
+source frame used anywhere in the selected gauge-estimation and fusion run to
+every output frame. This prevents a downstream consumer from claiming a tighter
+causal boundary merely by slicing a previously generated artifact.
+
+The artifact does not assert conditional independence between pixels or windows.
+The correlation group and contributor identities are intended for conservative
+prefusion, composite-likelihood grouping, or an explicit shared nuisance model.
+
+## Validation
+
+```bash
+prob4d-observation validate outputs/sequence/observation.json
+```
+
+Validation checks:
+
+- manifest and array format versions;
+- payload SHA-256 and same-directory path confinement;
+- array shapes, finite values, contributor consistency, and paired flow fields;
+- symmetric positive-semidefinite point, flow, and optional gauge covariance;
+- source-window identity and frame containment;
+- coordinate units and gauge-status consistency;
+- required producer, source-model, method, revision, and input-manifest
+  provenance;
+- the declared causal boundary, when present.
+
+Validation is intentionally fail-closed. An indefinite covariance, a missing
+revision, a future-dependent causal artifact, or a metric label without an
+anchored gauge raises an error rather than being silently regularized.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ where = ["src"]
 
 [tool.pytest.ini_options]
 addopts = "-ra"
+pythonpath = ["."]
 testpaths = ["tests"]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dev = [
 prob4d-ablate = "prob4d.experiments:main"
 prob4d-benchmark = "prob4d.benchmark:main"
 prob4d-motioncrafter = "prob4d.motioncrafter:main"
+prob4d-observation = "prob4d.observation_cli:main"
 prob4d-phystwin = "prob4d.phystwin_experiment:main"
 prob4d-phystwin-state = "prob4d.phystwin_state:main"
 prob4d-phystwin-uncertainty = "prob4d.phystwin_uncertainty:main"

--- a/src/prob4d/__init__.py
+++ b/src/prob4d/__init__.py
@@ -1,7 +1,16 @@
 """Probabilistic long-horizon fusion for MotionCrafter predictions."""
 
 from .data import PredictionWindow
+from .observation import ObservationArtifact, SourceWindowProvenance
+from .observation_io import load_observation_artifact, save_observation_artifact
 from .sim3 import Sim3
 
-__all__ = ["PredictionWindow", "Sim3"]
+__all__ = [
+    "ObservationArtifact",
+    "PredictionWindow",
+    "Sim3",
+    "SourceWindowProvenance",
+    "load_observation_artifact",
+    "save_observation_artifact",
+]
 __version__ = "0.1.0"

--- a/src/prob4d/_observation_validation.py
+++ b/src/prob4d/_observation_validation.py
@@ -1,0 +1,124 @@
+"""Internal validation helpers for observation artifacts."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+_REQUIRED_PROVENANCE = {
+    "producer",
+    "producer_revision",
+    "source_model",
+    "source_model_revision",
+    "source_manifest_sha256",
+    "method",
+}
+
+
+def _validate_sha256(value: object, name: str) -> str:
+    text = str(value)
+    if len(text) != 64 or any(character not in "0123456789abcdef" for character in text):
+        raise ValueError(f"{name} must be a lowercase hexadecimal SHA-256 digest")
+    return text
+
+
+def _json_value(value: Any, *, path: str = "provenance") -> Any:
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if not np.isfinite(value):
+            raise ValueError(f"{path} contains a non-finite float")
+        return value
+    if isinstance(value, (list, tuple)):
+        return [_json_value(item, path=f"{path}[]") for item in value]
+    if isinstance(value, dict):
+        output: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str) or not key:
+                raise ValueError(f"{path} keys must be non-empty strings")
+            output[key] = _json_value(item, path=f"{path}.{key}")
+        return output
+    raise ValueError(f"{path} contains unsupported value type {type(value).__name__}")
+
+
+def _integer_array(value: Any, *, name: str, ndim: int) -> np.ndarray:
+    raw = np.asarray(value)
+    if raw.ndim != ndim:
+        raise ValueError(f"{name} must have {ndim} dimensions")
+    if not np.issubdtype(raw.dtype, np.integer):
+        integer_valued = (
+            np.issubdtype(raw.dtype, np.floating)
+            and np.all(np.isfinite(raw))
+            and np.all(np.equal(raw, np.floor(raw)))
+        )
+        if not integer_valued:
+            raise ValueError(f"{name} must contain integers")
+    if not np.all(np.isfinite(raw)):
+        raise ValueError(f"{name} must be finite")
+    return np.asarray(raw, dtype=np.int64)
+
+
+def _integer_scalar(value: Any, *, name: str) -> int:
+    array = _integer_array([value], name=name, ndim=1)
+    return int(array[0])
+
+
+def _validate_covariances(
+    covariance: np.ndarray,
+    *,
+    name: str,
+    active: np.ndarray | None = None,
+    chunk_size: int = 65_536,
+) -> None:
+    matrices = np.asarray(covariance)
+    if not np.issubdtype(matrices.dtype, np.floating):
+        raise ValueError(f"{name} must use a floating-point dtype")
+    if matrices.shape[-2:] not in {(3, 3), (7, 7)}:
+        raise ValueError(f"{name} must end in shape (3, 3) or (7, 7)")
+    flattened = matrices.reshape(-1, matrices.shape[-1], matrices.shape[-1])
+    active_flat = None if active is None else np.asarray(active, dtype=bool).reshape(-1)
+    if active_flat is not None and active_flat.size != flattened.shape[0]:
+        raise ValueError(f"{name} active mask has incompatible shape")
+
+    for start in range(0, flattened.shape[0], chunk_size):
+        stop = min(start + chunk_size, flattened.shape[0])
+        chunk = np.asarray(flattened[start:stop], dtype=np.float64)
+        if not np.all(np.isfinite(chunk)):
+            raise ValueError(f"{name} contains non-finite values")
+        if active_flat is not None:
+            chunk = chunk[active_flat[start:stop]]
+        if chunk.size == 0:
+            continue
+        transpose = np.swapaxes(chunk, -1, -2)
+        if np.max(np.abs(chunk - transpose)) > 1e-9:
+            raise ValueError(f"{name} must be symmetric")
+        eigenvalues = np.linalg.eigvalsh(0.5 * (chunk + transpose))
+        scale = np.maximum(1.0, np.max(np.abs(eigenvalues), axis=1))
+        if np.any(np.min(eigenvalues, axis=1) < -1e-10 * scale):
+            raise ValueError(f"{name} must be positive semidefinite")
+
+
+def pack_symmetric_covariance(covariance: np.ndarray) -> np.ndarray:
+    """Pack the upper triangle of dense 3x3 covariance matrices into six values."""
+
+    covariance = np.asarray(covariance)
+    if covariance.shape[-2:] != (3, 3):
+        raise ValueError("covariance must end in shape (3, 3)")
+    return covariance[..., (0, 0, 0, 1, 1, 2), (0, 1, 2, 1, 2, 2)]
+
+
+def unpack_symmetric_covariance(packed: np.ndarray) -> np.ndarray:
+    """Restore dense 3x3 covariance matrices from six upper-triangle values."""
+
+    packed = np.asarray(packed)
+    if packed.shape[-1] != 6:
+        raise ValueError("packed covariance must end in six values")
+    covariance = np.empty(packed.shape[:-1] + (3, 3), dtype=packed.dtype)
+    covariance[..., 0, 0] = packed[..., 0]
+    covariance[..., 0, 1] = covariance[..., 1, 0] = packed[..., 1]
+    covariance[..., 0, 2] = covariance[..., 2, 0] = packed[..., 2]
+    covariance[..., 1, 1] = packed[..., 3]
+    covariance[..., 1, 2] = covariance[..., 2, 1] = packed[..., 4]
+    covariance[..., 2, 2] = packed[..., 5]
+    return covariance

--- a/src/prob4d/observation.py
+++ b/src/prob4d/observation.py
@@ -1,0 +1,362 @@
+"""Validated, versioned observations for downstream Bayesian fusion."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from itertools import pairwise
+from typing import Any, Literal
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ._observation_validation import (
+    _REQUIRED_PROVENANCE,
+    _integer_array,
+    _integer_scalar,
+    _json_value,
+    _validate_covariances,
+    _validate_sha256,
+)
+
+FloatArray = NDArray[np.floating]
+BoolArray = NDArray[np.bool_]
+IntArray = NDArray[np.integer]
+CoordinateStatus = Literal["gauge_relative", "metric"]
+GaugeStatus = Literal["unresolved", "anchored"]
+
+OBSERVATION_FORMAT_VERSION = 2
+FUSION_METHOD_NAMES = (
+    "prob4d_uniform",
+    "prob4d_uniform_smoothed",
+    "prob4d_precision",
+    "prob4d_ci",
+    "prob4d_ci_smoothed_uncalibrated",
+)
+
+
+@dataclass(frozen=True)
+class SourceWindowProvenance:
+    """Source frames and dependence group for one decoded prediction window."""
+
+    window_id: str
+    frame_indices: tuple[int, ...]
+    correlation_group: str
+
+    def __post_init__(self) -> None:
+        if not self.window_id:
+            raise ValueError("source window_id must not be empty")
+        if not self.correlation_group:
+            raise ValueError("source correlation_group must not be empty")
+        frame_array = _integer_array(self.frame_indices, name="source frame_indices", ndim=1)
+        frames = tuple(int(frame) for frame in frame_array)
+        if not frames or any(second <= first for first, second in pairwise(frames)):
+            raise ValueError("source frame_indices must be non-empty and strictly increasing")
+        if frames[0] < 0:
+            raise ValueError("source frame_indices must be non-negative")
+        object.__setattr__(self, "frame_indices", frames)
+
+    @property
+    def maximum_source_frame(self) -> int:
+        return self.frame_indices[-1]
+
+    def contains(self, frame: int) -> bool:
+        return int(frame) in self.frame_indices
+
+    @classmethod
+    def from_prediction_window(
+        cls,
+        window: Any,
+        *,
+        correlation_group: str,
+    ) -> SourceWindowProvenance:
+        return cls(
+            window_id=str(window.window_id),
+            frame_indices=tuple(int(frame) for frame in np.asarray(window.frame_indices)),
+            correlation_group=correlation_group,
+        )
+
+
+@dataclass(frozen=True)
+class ObservationArtifact:
+    """Dense observations plus uncertainty, gauge status, and causal provenance."""
+
+    frame_indices: IntArray
+    point_mean: FloatArray
+    valid_mask: BoolArray
+    point_covariance: FloatArray
+    contributors: IntArray
+    source_windows: tuple[SourceWindowProvenance, ...]
+    frame_contributor_window_ids: tuple[tuple[str, ...], ...]
+    max_source_frame_used: IntArray
+    coordinate_status: CoordinateStatus
+    gauge_status: GaugeStatus
+    covariance_units: str
+    gauge_reference: str | None
+    provenance: dict[str, Any]
+    causal_max_frame: int | None = None
+    gauge_mean: FloatArray | None = None
+    gauge_covariance: FloatArray | None = None
+    scene_flow: FloatArray | None = None
+    deform_mask: BoolArray | None = None
+    flow_covariance: FloatArray | None = None
+
+    def __post_init__(self) -> None:
+        frames = _integer_array(self.frame_indices, name="frame_indices", ndim=1)
+        if frames.size == 0 or np.any(np.diff(frames) <= 0):
+            raise ValueError("frame_indices must be non-empty and strictly increasing")
+        if frames[0] < 0:
+            raise ValueError("frame_indices must be non-negative")
+
+        points = np.asarray(self.point_mean)
+        mask = np.asarray(self.valid_mask, dtype=bool)
+        covariance = np.asarray(self.point_covariance)
+        if not np.issubdtype(points.dtype, np.floating):
+            raise ValueError("point_mean must use a floating-point dtype")
+        if not np.issubdtype(covariance.dtype, np.floating):
+            raise ValueError("point_covariance must use a floating-point dtype")
+        contributor_raw = np.asarray(self.contributors)
+        if points.ndim != 4 or points.shape[-1] != 3:
+            raise ValueError("point_mean must have shape (T, H, W, 3)")
+        if points.shape[1] == 0 or points.shape[2] == 0:
+            raise ValueError("point_mean spatial dimensions must be non-empty")
+        if mask.shape != points.shape[:-1]:
+            raise ValueError("valid_mask must have shape (T, H, W)")
+        if covariance.shape != points.shape + (3,):
+            raise ValueError("point_covariance must have shape (T, H, W, 3, 3)")
+        if contributor_raw.shape != mask.shape:
+            raise ValueError("contributors must have shape (T, H, W)")
+        if frames.shape != (points.shape[0],):
+            raise ValueError("frame_indices must match the point_mean time dimension")
+        if not np.issubdtype(contributor_raw.dtype, np.integer):
+            raise ValueError("contributors must contain integers")
+        if np.any(contributor_raw < 0):
+            raise ValueError("contributors must be non-negative")
+        if np.any(contributor_raw > np.iinfo(np.uint16).max):
+            raise ValueError("contributors exceed the uint16 artifact representation")
+        contributors = np.asarray(contributor_raw, dtype=np.uint16)
+        if not np.array_equal(contributors > 0, mask):
+            raise ValueError("contributors must be positive exactly where valid_mask is true")
+        if not np.all(np.isfinite(points)):
+            raise ValueError("point_mean must be finite")
+        _validate_covariances(covariance, name="point_covariance", active=mask)
+
+        source_windows = tuple(self.source_windows)
+        if not source_windows:
+            raise ValueError("source_windows must not be empty")
+        source_ids = [window.window_id for window in source_windows]
+        if len(set(source_ids)) != len(source_ids):
+            raise ValueError("source window IDs must be unique")
+        source_map = {window.window_id: window for window in source_windows}
+
+        frame_contributors = tuple(tuple(ids) for ids in self.frame_contributor_window_ids)
+        if len(frame_contributors) != frames.size:
+            raise ValueError("frame_contributor_window_ids must have one entry per frame")
+        maximum_source = _integer_array(
+            self.max_source_frame_used,
+            name="max_source_frame_used",
+            ndim=1,
+        )
+        if maximum_source.shape != frames.shape:
+            raise ValueError("max_source_frame_used must have one entry per frame")
+
+        for index, (frame, ids) in enumerate(zip(frames, frame_contributors, strict=True)):
+            if not ids or len(set(ids)) != len(ids):
+                raise ValueError("each frame must have unique, non-empty source window IDs")
+            unknown = set(ids).difference(source_map)
+            if unknown:
+                raise ValueError(f"frame provenance references unknown source windows: {unknown}")
+            if any(not source_map[window_id].contains(int(frame)) for window_id in ids):
+                raise ValueError("frame provenance must reference windows containing that frame")
+            direct_limit = max(source_map[window_id].maximum_source_frame for window_id in ids)
+            if maximum_source[index] < direct_limit:
+                raise ValueError("max_source_frame_used cannot precede a direct contributor")
+            if int(np.max(contributors[index])) > len(ids):
+                raise ValueError("pixel contributor count exceeds frame source-window count")
+
+        if self.coordinate_status not in {"gauge_relative", "metric"}:
+            raise ValueError("coordinate_status must be gauge_relative or metric")
+        if self.gauge_status not in {"unresolved", "anchored"}:
+            raise ValueError("gauge_status must be unresolved or anchored")
+        if not self.covariance_units:
+            raise ValueError("covariance_units must not be empty")
+        if self.coordinate_status == "metric":
+            if self.gauge_status != "anchored":
+                raise ValueError("metric coordinates require an anchored gauge")
+            if self.covariance_units != "m^2":
+                raise ValueError("metric observation covariance must use m^2")
+        elif self.covariance_units == "m^2":
+            raise ValueError("gauge-relative covariance must not be labelled m^2")
+
+        gauge_mean = (
+            None
+            if self.gauge_mean is None
+            else np.asarray(self.gauge_mean, dtype=np.float64)
+        )
+        gauge_covariance = (
+            None
+            if self.gauge_covariance is None
+            else np.asarray(self.gauge_covariance, dtype=np.float64)
+        )
+        if self.gauge_status == "anchored":
+            if gauge_mean is None or gauge_mean.shape != (7,):
+                raise ValueError("anchored gauge_mean must have shape (7,)")
+            if gauge_covariance is None or gauge_covariance.shape != (7, 7):
+                raise ValueError("anchored gauge_covariance must have shape (7, 7)")
+            if not np.all(np.isfinite(gauge_mean)):
+                raise ValueError("gauge_mean must be finite")
+            _validate_covariances(gauge_covariance, name="gauge_covariance")
+        elif gauge_mean is not None or gauge_covariance is not None:
+            raise ValueError("unresolved gauge must not claim Gaussian gauge moments")
+        if self.gauge_reference is not None and not self.gauge_reference:
+            raise ValueError("gauge_reference must be non-empty when supplied")
+
+        flow = None if self.scene_flow is None else np.asarray(self.scene_flow)
+        flow_mask = None if self.deform_mask is None else np.asarray(self.deform_mask, dtype=bool)
+        flow_covariance = (
+            None
+            if self.flow_covariance is None
+            else np.asarray(self.flow_covariance)
+        )
+        presence = (flow is not None, flow_mask is not None, flow_covariance is not None)
+        if len(set(presence)) != 1:
+            raise ValueError("scene_flow, deform_mask, and flow_covariance must appear together")
+        if flow is not None:
+            if not np.issubdtype(flow.dtype, np.floating):
+                raise ValueError("scene_flow must use a floating-point dtype")
+            if not np.issubdtype(flow_covariance.dtype, np.floating):
+                raise ValueError("flow_covariance must use a floating-point dtype")
+            if flow.shape != points.shape or flow_mask.shape != mask.shape:
+                raise ValueError("scene-flow arrays must match point observation shapes")
+            if flow_covariance.shape != covariance.shape:
+                raise ValueError("flow_covariance must match point_covariance shape")
+            if np.any(flow_mask & ~mask):
+                raise ValueError("deform_mask must be a subset of valid_mask")
+            if not np.all(np.isfinite(flow)):
+                raise ValueError("scene_flow must be finite")
+            _validate_covariances(flow_covariance, name="flow_covariance", active=flow_mask)
+
+        provenance = _json_value(dict(self.provenance))
+        missing_provenance = _REQUIRED_PROVENANCE.difference(provenance)
+        if missing_provenance:
+            raise ValueError(f"provenance is missing required fields: {sorted(missing_provenance)}")
+        for key in _REQUIRED_PROVENANCE - {"source_manifest_sha256"}:
+            if not isinstance(provenance[key], str) or not provenance[key]:
+                raise ValueError(f"provenance field {key!r} must be a non-empty string")
+        provenance["source_manifest_sha256"] = _validate_sha256(
+            provenance["source_manifest_sha256"],
+            "provenance.source_manifest_sha256",
+        )
+
+        causal_limit = (
+            None
+            if self.causal_max_frame is None
+            else _integer_scalar(self.causal_max_frame, name="causal_max_frame")
+        )
+        if causal_limit is not None:
+            if causal_limit < 0:
+                raise ValueError("causal_max_frame must be non-negative")
+            if np.any(frames > causal_limit) or np.any(maximum_source > causal_limit):
+                raise ValueError(
+                    "causal artifact contains an output or source dependency after causal_max_frame"
+                )
+
+        object.__setattr__(self, "frame_indices", frames)
+        object.__setattr__(self, "point_mean", points)
+        object.__setattr__(self, "valid_mask", mask)
+        object.__setattr__(self, "point_covariance", covariance)
+        object.__setattr__(self, "contributors", contributors)
+        object.__setattr__(self, "source_windows", source_windows)
+        object.__setattr__(self, "frame_contributor_window_ids", frame_contributors)
+        object.__setattr__(self, "max_source_frame_used", maximum_source)
+        object.__setattr__(self, "gauge_mean", gauge_mean)
+        object.__setattr__(self, "gauge_covariance", gauge_covariance)
+        object.__setattr__(self, "scene_flow", flow)
+        object.__setattr__(self, "deform_mask", flow_mask)
+        object.__setattr__(self, "flow_covariance", flow_covariance)
+        object.__setattr__(self, "provenance", provenance)
+        object.__setattr__(self, "causal_max_frame", causal_limit)
+
+    @classmethod
+    def from_fused_sequence(
+        cls,
+        sequence: Any,
+        source_windows: tuple[SourceWindowProvenance, ...],
+        *,
+        coordinate_status: CoordinateStatus,
+        gauge_status: GaugeStatus,
+        covariance_units: str,
+        gauge_reference: str | None,
+        provenance: dict[str, Any],
+        causal_max_frame: int | None = None,
+        global_estimator_source_frame_limit: int | None = None,
+        gauge_mean: FloatArray | None = None,
+        gauge_covariance: FloatArray | None = None,
+    ) -> ObservationArtifact:
+        """Build an artifact while conservatively tracking source-frame dependencies."""
+
+        if not source_windows:
+            raise ValueError("source_windows must not be empty")
+        frames = np.asarray(sequence.frame_indices, dtype=np.int64)
+        contributors_by_frame: list[tuple[str, ...]] = []
+        maximum_source: list[int] = []
+        global_limit = (
+            max(window.maximum_source_frame for window in source_windows)
+            if global_estimator_source_frame_limit is None
+            else _integer_scalar(
+                global_estimator_source_frame_limit,
+                name="global_estimator_source_frame_limit",
+            )
+        )
+        for frame in frames:
+            ids = tuple(
+                window.window_id
+                for window in source_windows
+                if window.contains(int(frame))
+            )
+            if not ids:
+                raise ValueError(f"output frame {int(frame)} has no declared source window")
+            contributors_by_frame.append(ids)
+            direct_limit = max(
+                window.maximum_source_frame
+                for window in source_windows
+                if window.window_id in ids
+            )
+            maximum_source.append(max(global_limit, direct_limit))
+        return cls(
+            frame_indices=frames,
+            point_mean=sequence.point_map,
+            valid_mask=sequence.valid_mask,
+            point_covariance=sequence.point_covariance,
+            contributors=sequence.contributors,
+            source_windows=source_windows,
+            frame_contributor_window_ids=tuple(contributors_by_frame),
+            max_source_frame_used=np.asarray(maximum_source, dtype=np.int64),
+            coordinate_status=coordinate_status,
+            gauge_status=gauge_status,
+            covariance_units=covariance_units,
+            gauge_reference=gauge_reference,
+            provenance=provenance,
+            causal_max_frame=causal_max_frame,
+            gauge_mean=gauge_mean,
+            gauge_covariance=gauge_covariance,
+            scene_flow=sequence.scene_flow,
+            deform_mask=sequence.deform_mask,
+            flow_covariance=sequence.flow_covariance,
+        )
+
+    def summary(self) -> dict[str, Any]:
+        return {
+            "format_version": OBSERVATION_FORMAT_VERSION,
+            "frames": int(self.frame_indices.size),
+            "first_frame": int(self.frame_indices[0]),
+            "last_frame": int(self.frame_indices[-1]),
+            "height": int(self.point_mean.shape[1]),
+            "width": int(self.point_mean.shape[2]),
+            "coordinate_status": self.coordinate_status,
+            "gauge_status": self.gauge_status,
+            "covariance_units": self.covariance_units,
+            "causal_max_frame": self.causal_max_frame,
+            "maximum_source_frame_used": int(np.max(self.max_source_frame_used)),
+            "source_window_count": len(self.source_windows),
+            "has_scene_flow": self.scene_flow is not None,
+        }

--- a/src/prob4d/observation_cli.py
+++ b/src/prob4d/observation_cli.py
@@ -1,0 +1,142 @@
+"""Command-line export and validation for Prob4D observation artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from dataclasses import replace
+from pathlib import Path
+
+import numpy as np
+
+from ._observation_validation import _integer_scalar
+from .observation import FUSION_METHOD_NAMES, ObservationArtifact, SourceWindowProvenance
+from .observation_io import _sha256, load_observation_artifact, save_observation_artifact
+
+
+def _git_revision(repository: Path) -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def export_observation_artifact(
+    prediction_manifest: str | Path,
+    output_manifest: str | Path,
+    *,
+    method: str = "prob4d_uniform",
+    causal_max_frame: int | None = None,
+    correlation_group: str = "motioncrafter_shared_backbone",
+    prob4d_revision: str | None = None,
+) -> ObservationArtifact:
+    """Re-fuse admissible windows and export a gauge-relative observation artifact."""
+
+    if method not in FUSION_METHOD_NAMES:
+        raise ValueError(f"unknown fusion method {method!r}")
+    from .benchmark import fuse_prediction_bundle_methods
+    from .io import load_prediction_bundle
+
+    manifest_path = Path(prediction_manifest).resolve()
+    bundle = load_prediction_bundle(manifest_path)
+    windows = bundle.overlap_windows
+    causal_limit = (
+        None
+        if causal_max_frame is None
+        else _integer_scalar(causal_max_frame, name="causal_max_frame")
+    )
+    if causal_limit is not None:
+        windows = [
+            window
+            for window in windows
+            if int(np.max(window.frame_indices)) <= causal_limit
+        ]
+        if not windows:
+            raise ValueError("no complete prediction window satisfies causal_max_frame")
+        bundle = replace(bundle, overlap_windows=windows)
+
+    sequence = fuse_prediction_bundle_methods(bundle, method_names={method})[method]
+    source_windows = tuple(
+        SourceWindowProvenance.from_prediction_window(
+            window,
+            correlation_group=correlation_group,
+        )
+        for window in windows
+    )
+    revision = prob4d_revision or _git_revision(Path(__file__).resolve().parents[2])
+    motioncrafter_revision = bundle.metadata.get("motioncrafter_commit")
+    if not isinstance(motioncrafter_revision, str) or not motioncrafter_revision:
+        raise ValueError("prediction manifest does not identify the MotionCrafter revision")
+    provenance = {
+        "producer": "Prob4D",
+        "producer_revision": revision,
+        "source_model": "MotionCrafter",
+        "source_model_revision": motioncrafter_revision,
+        "source_manifest_sha256": _sha256(manifest_path),
+        "method": method,
+        "prediction_manifest": str(manifest_path),
+    }
+    artifact = ObservationArtifact.from_fused_sequence(
+        sequence,
+        source_windows,
+        coordinate_status="gauge_relative",
+        gauge_status="unresolved",
+        covariance_units="gauge_unit^2",
+        gauge_reference=source_windows[0].window_id,
+        provenance=provenance,
+        causal_max_frame=causal_limit,
+        global_estimator_source_frame_limit=max(
+            window.maximum_source_frame for window in source_windows
+        ),
+    )
+    save_observation_artifact(output_manifest, artifact)
+    return artifact
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    validate = subparsers.add_parser("validate", help="validate a saved observation artifact")
+    validate.add_argument("manifest", type=Path)
+
+    export = subparsers.add_parser(
+        "export",
+        help="re-fuse a prediction bundle and export a causally bounded observation artifact",
+    )
+    export.add_argument("prediction_manifest", type=Path)
+    export.add_argument("output_manifest", type=Path)
+    export.add_argument("--method", choices=FUSION_METHOD_NAMES, default="prob4d_uniform")
+    export.add_argument("--causal-max-frame", type=int)
+    export.add_argument(
+        "--correlation-group",
+        default="motioncrafter_shared_backbone",
+    )
+    export.add_argument("--prob4d-revision")
+
+    arguments = parser.parse_args(argv)
+    if arguments.command == "validate":
+        artifact = load_observation_artifact(arguments.manifest)
+        print(json.dumps(artifact.summary(), indent=2, sort_keys=True))
+        return 0
+    if arguments.command == "export":
+        artifact = export_observation_artifact(
+            arguments.prediction_manifest,
+            arguments.output_manifest,
+            method=arguments.method,
+            causal_max_frame=arguments.causal_max_frame,
+            correlation_group=arguments.correlation_group,
+            prob4d_revision=arguments.prob4d_revision,
+        )
+        print(json.dumps(artifact.summary(), indent=2, sort_keys=True))
+        return 0
+    raise AssertionError("unreachable")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/prob4d/observation_io.py
+++ b/src/prob4d/observation_io.py
@@ -1,0 +1,177 @@
+"""Serialization for versioned Prob4D observation artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from dataclasses import asdict
+from pathlib import Path
+
+import numpy as np
+
+from ._observation_validation import (
+    _validate_sha256,
+    pack_symmetric_covariance,
+    unpack_symmetric_covariance,
+)
+from .observation import (
+    OBSERVATION_FORMAT_VERSION,
+    ObservationArtifact,
+    SourceWindowProvenance,
+)
+
+
+def _sha256(path: str | Path) -> str:
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def save_observation_artifact(
+    manifest_path: str | Path,
+    artifact: ObservationArtifact,
+) -> Path:
+    """Write a JSON manifest plus a hash-locked compressed NumPy payload."""
+
+    manifest = Path(manifest_path)
+    if manifest.suffix.lower() != ".json":
+        raise ValueError("observation manifest path must end in .json")
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    array_path = manifest.with_suffix(".npz")
+    temporary_array = array_path.with_name(f".{array_path.name}.tmp")
+    temporary_manifest = manifest.with_name(f".{manifest.name}.tmp")
+
+    arrays: dict[str, np.ndarray] = {
+        "frame_indices": artifact.frame_indices,
+        "point_mean": artifact.point_mean.astype(np.float32),
+        "valid_mask": artifact.valid_mask,
+        "point_covariance_packed": pack_symmetric_covariance(
+            artifact.point_covariance
+        ).astype(np.float32),
+        "contributors": artifact.contributors,
+        "max_source_frame_used": artifact.max_source_frame_used,
+    }
+    if artifact.gauge_mean is not None:
+        arrays["gauge_mean"] = artifact.gauge_mean.astype(np.float64)
+        arrays["gauge_covariance"] = artifact.gauge_covariance.astype(np.float64)
+    if artifact.scene_flow is not None:
+        arrays["scene_flow"] = artifact.scene_flow.astype(np.float32)
+        arrays["deform_mask"] = artifact.deform_mask
+        arrays["flow_covariance_packed"] = pack_symmetric_covariance(
+            artifact.flow_covariance
+        ).astype(np.float32)
+
+    try:
+        with temporary_array.open("wb") as handle:
+            np.savez_compressed(handle, **arrays)
+        os.replace(temporary_array, array_path)
+        payload = {
+            "format_version": OBSERVATION_FORMAT_VERSION,
+            "array_file": array_path.name,
+            "array_sha256": _sha256(array_path),
+            "coordinate_status": artifact.coordinate_status,
+            "gauge_status": artifact.gauge_status,
+            "covariance_units": artifact.covariance_units,
+            "gauge_reference": artifact.gauge_reference,
+            "causal_max_frame": artifact.causal_max_frame,
+            "source_windows": [asdict(window) for window in artifact.source_windows],
+            "frame_contributor_window_ids": [
+                list(ids) for ids in artifact.frame_contributor_window_ids
+            ],
+            "provenance": artifact.provenance,
+            "summary": artifact.summary(),
+        }
+        temporary_manifest.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        os.replace(temporary_manifest, manifest)
+    finally:
+        temporary_array.unlink(missing_ok=True)
+        temporary_manifest.unlink(missing_ok=True)
+    return manifest
+
+
+def load_observation_artifact(
+    manifest_path: str | Path,
+    *,
+    verify_hash: bool = True,
+) -> ObservationArtifact:
+    """Load and validate a versioned observation artifact."""
+
+    manifest = Path(manifest_path).resolve()
+    payload = json.loads(manifest.read_text(encoding="utf-8"))
+    if payload.get("format_version") != OBSERVATION_FORMAT_VERSION:
+        raise ValueError("unsupported observation artifact format_version")
+    array_file = payload.get("array_file")
+    if not isinstance(array_file, str) or not array_file:
+        raise ValueError("observation manifest has no array_file")
+    array_path = (manifest.parent / array_file).resolve()
+    if array_path.parent != manifest.parent:
+        raise ValueError("array_file must remain in the observation manifest directory")
+    if verify_hash:
+        expected = _validate_sha256(payload.get("array_sha256"), "array_sha256")
+        actual = _sha256(array_path)
+        if actual != expected:
+            raise ValueError("observation array SHA-256 does not match the manifest")
+
+    with np.load(array_path, allow_pickle=False) as data:
+        required = {
+            "frame_indices",
+            "point_mean",
+            "valid_mask",
+            "point_covariance_packed",
+            "contributors",
+            "max_source_frame_used",
+        }
+        missing = required.difference(data.files)
+        if missing:
+            raise ValueError(f"observation array is missing fields: {sorted(missing)}")
+        gauge_mean = data["gauge_mean"] if "gauge_mean" in data else None
+        gauge_covariance = data["gauge_covariance"] if "gauge_covariance" in data else None
+        has_flow = any(
+            field in data
+            for field in ("scene_flow", "deform_mask", "flow_covariance_packed")
+        )
+        if has_flow and not all(
+            field in data
+            for field in ("scene_flow", "deform_mask", "flow_covariance_packed")
+        ):
+            raise ValueError("observation array contains an incomplete scene-flow product")
+        return ObservationArtifact(
+            frame_indices=data["frame_indices"],
+            point_mean=data["point_mean"],
+            valid_mask=data["valid_mask"],
+            point_covariance=unpack_symmetric_covariance(data["point_covariance_packed"]),
+            contributors=data["contributors"],
+            source_windows=tuple(
+                SourceWindowProvenance(
+                    window_id=item["window_id"],
+                    frame_indices=tuple(item["frame_indices"]),
+                    correlation_group=item["correlation_group"],
+                )
+                for item in payload["source_windows"]
+            ),
+            frame_contributor_window_ids=tuple(
+                tuple(ids) for ids in payload["frame_contributor_window_ids"]
+            ),
+            max_source_frame_used=data["max_source_frame_used"],
+            coordinate_status=payload["coordinate_status"],
+            gauge_status=payload["gauge_status"],
+            covariance_units=payload["covariance_units"],
+            gauge_reference=payload.get("gauge_reference"),
+            provenance=payload["provenance"],
+            causal_max_frame=payload.get("causal_max_frame"),
+            gauge_mean=gauge_mean,
+            gauge_covariance=gauge_covariance,
+            scene_flow=data["scene_flow"] if has_flow else None,
+            deform_mask=data["deform_mask"] if has_flow else None,
+            flow_covariance=(
+                unpack_symmetric_covariance(data["flow_covariance_packed"])
+                if has_flow
+                else None
+            ),
+        )

--- a/tests/test_observation.py
+++ b/tests/test_observation.py
@@ -1,0 +1,126 @@
+import json
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from prob4d.observation import ObservationArtifact, SourceWindowProvenance
+from prob4d.observation_io import load_observation_artifact, save_observation_artifact
+
+
+def provenance() -> dict[str, str]:
+    return {
+        "producer": "Prob4D",
+        "producer_revision": "a" * 40,
+        "source_model": "MotionCrafter",
+        "source_model_revision": "b" * 40,
+        "source_manifest_sha256": "c" * 64,
+        "method": "prob4d_uniform",
+    }
+
+
+def sequence() -> SimpleNamespace:
+    points = np.zeros((2, 1, 2, 3))
+    mask = np.ones((2, 1, 2), dtype=bool)
+    covariance = np.broadcast_to(np.eye(3), points.shape + (3,)).copy()
+    return SimpleNamespace(
+        frame_indices=np.array([0, 1]),
+        point_map=points,
+        valid_mask=mask,
+        point_covariance=covariance,
+        contributors=np.ones(mask.shape, dtype=np.uint16),
+        scene_flow=np.zeros_like(points),
+        deform_mask=mask.copy(),
+        flow_covariance=covariance.copy(),
+    )
+
+
+def sources() -> tuple[SourceWindowProvenance, ...]:
+    return (SourceWindowProvenance("w0", (0, 1), "shared"),)
+
+
+def test_artifact_round_trip(tmp_path) -> None:
+    artifact = ObservationArtifact.from_fused_sequence(
+        sequence(),
+        sources(),
+        coordinate_status="gauge_relative",
+        gauge_status="unresolved",
+        covariance_units="gauge_unit^2",
+        gauge_reference="w0",
+        provenance=provenance(),
+        causal_max_frame=1,
+        global_estimator_source_frame_limit=1,
+    )
+
+    manifest = save_observation_artifact(tmp_path / "observation.json", artifact)
+    restored = load_observation_artifact(manifest)
+
+    np.testing.assert_array_equal(restored.frame_indices, artifact.frame_indices)
+    np.testing.assert_allclose(restored.point_mean, artifact.point_mean)
+    np.testing.assert_allclose(restored.point_covariance, artifact.point_covariance)
+    assert restored.frame_contributor_window_ids == (("w0",), ("w0",))
+    assert restored.summary()["maximum_source_frame_used"] == 1
+
+
+def test_causal_limit_rejects_future_source_dependency() -> None:
+    source = (SourceWindowProvenance("w0", (0, 1, 2), "shared"),)
+    with pytest.raises(ValueError, match="after causal_max_frame"):
+        ObservationArtifact.from_fused_sequence(
+            sequence(),
+            source,
+            coordinate_status="gauge_relative",
+            gauge_status="unresolved",
+            covariance_units="gauge_unit^2",
+            gauge_reference="w0",
+            provenance=provenance(),
+            causal_max_frame=1,
+            global_estimator_source_frame_limit=2,
+        )
+
+
+def test_metric_coordinates_require_anchored_gauge() -> None:
+    with pytest.raises(ValueError, match="anchored gauge"):
+        ObservationArtifact.from_fused_sequence(
+            sequence(),
+            sources(),
+            coordinate_status="metric",
+            gauge_status="unresolved",
+            covariance_units="m^2",
+            gauge_reference="world",
+            provenance=provenance(),
+        )
+
+
+def test_indefinite_covariance_is_rejected() -> None:
+    value = sequence()
+    value.point_covariance[0, 0, 0] = np.diag([1.0, 1.0, -0.1])
+    with pytest.raises(ValueError, match="positive semidefinite"):
+        ObservationArtifact.from_fused_sequence(
+            value,
+            sources(),
+            coordinate_status="gauge_relative",
+            gauge_status="unresolved",
+            covariance_units="gauge_unit^2",
+            gauge_reference="w0",
+            provenance=provenance(),
+        )
+
+
+def test_array_hash_detects_mutation(tmp_path) -> None:
+    artifact = ObservationArtifact.from_fused_sequence(
+        sequence(),
+        sources(),
+        coordinate_status="gauge_relative",
+        gauge_status="unresolved",
+        covariance_units="gauge_unit^2",
+        gauge_reference="w0",
+        provenance=provenance(),
+    )
+    manifest = save_observation_artifact(tmp_path / "observation.json", artifact)
+    payload = json.loads(manifest.read_text(encoding="utf-8"))
+    array_path = manifest.parent / payload["array_file"]
+    with array_path.open("ab") as handle:
+        handle.write(b"tampered")
+
+    with pytest.raises(ValueError, match="SHA-256"):
+        load_observation_artifact(manifest)


### PR DESCRIPTION
## What changed

- add a versioned `ObservationArtifact` contract for downstream Bayesian consumers
- record explicit metric versus gauge-relative status, gauge state, covariance units, source-window identities, correlation groups, and per-frame source limits
- add fail-closed validation for shapes, finiteness, contributor consistency, covariance symmetry and positive semidefiniteness, provenance, and causal boundaries
- add hash-locked JSON/NPZ serialization without pickle
- add `prob4d-observation export` and `prob4d-observation validate`
- make causal export discard future-dependent MotionCrafter windows and rerun gauge estimation and fusion rather than slicing an all-frame result
- document the artifact schema and causal semantics
- add focused regression tests for round trips, future-dependency rejection, gauge/metric consistency, indefinite covariance rejection, and payload tampering
- make the repository root explicit on pytest's import path so existing tests can import utilities from `scripts/`

## Why

Prob4D currently exports dense fused arrays, but Bayesian-PhysTwin and Causal4D need a narrow, auditable observation boundary. In particular, a downstream consumer must be able to distinguish metric observations from unresolved monocular gauge coordinates and verify that no source frame after a causal prefix influenced the product.

## Impact

Existing prediction manifests and fusion commands remain unchanged. The new command is additive. Standard MotionCrafter exports are deliberately labelled `gauge_relative` with covariance in `gauge_unit^2`; they cannot be silently treated as metric observations.

## Validation

- full GitHub Actions workflow passed
- Ruff passed on `src` and `tests`
- complete pytest suite passed
- focused observation-artifact test suite contains five regression tests
- Python byte-compilation passed in the isolated implementation check

The initial PR run exposed a pre-existing test-collection issue: two tests imported repository utilities from `scripts/`, but the repository root was not explicit on pytest's import path. The final diff fixes that in `pyproject.toml`; the temporary JUnit diagnostic workflow change was removed.