### PR TITLE
Enforce causal MotionCrafter source lineage

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ The output manifest references:
 - MotionCrafter's exact latent-space overlap blend; and
 - independently decoded overlapping windows with absolute frame indices.
 
+It also records a versioned temporal-lineage contract for MotionCrafter's
+internal sliding windows. Causal consumers can therefore determine the exact
+source-frame bounds and contributing internal windows for any output frame.
+
 Prepare a separate calibration sequence and world-coordinate truth files, then
 run the real ablation:
 
@@ -161,12 +165,20 @@ prob4d-phystwin-uncertainty /path/to/double_stretch_sloth output.json \
   --corrected-trajectory /path/to/bayesian_anchor/trajectory.pkl
 ```
 
-To test the state-space direction directly, initialize once from the final
-preboundary MotionCrafter point map and roll PhysTwin forward without future
-visual updates:
+To test the state-space direction causally, create a separate prefix-aligned
+bundle. With a 25-frame window and `--fit-end-frame 134`, the first selected
+source frame must be 109 so that the endpoint at frame 133 depends only on
+frames 109--133:
 
 ```bash
-prob4d-phystwin-state outputs/camera0/predictions.json \
+prob4d-motioncrafter /path/to/double_stretch_sloth/color/0.mp4 \
+  --upstream-root /path/to/MotionCrafter \
+  --output-dir outputs/double_stretch_sloth_camera0_causal \
+  --cache-dir /path/to/huggingface-cache \
+  --frame-start 109 --frame-stop 159
+
+prob4d-phystwin-state \
+  outputs/double_stretch_sloth_camera0_causal/predictions.json \
   /path/to/double_stretch_sloth state_forecast.json \
   --product disjoint \
   --fit-end-frame 134 \
@@ -174,10 +186,12 @@ prob4d-phystwin-state outputs/camera0/predictions.json \
   --corrected-trajectory /path/to/bayesian_anchor/trajectory.pkl
 ```
 
-For a causal endpoint claim, the selected interval must begin exactly one
-window before `--fit-end-frame`; the disjoint product's first window then
-contains only preboundary RGB. Latent overlap is a reconstruction control and
-can blend post-boundary frames into the endpoint estimate.
+`prob4d-phystwin-state` audits the endpoint before reading metric or manual-track
+evaluation data. It rejects the run whenever the endpoint's maximum source
+frame is at or after `--fit-end-frame`. The latent overlap product is normally
+a reconstruction-only control because an endpoint blended across windows can
+depend on post-boundary RGB. Older manifests can be audited from their stored
+window configuration without rerunning MotionCrafter.
 
 ## Matched VGGT Comparison
 

--- a/docs/data-format.md
+++ b/docs/data-format.md
@@ -8,6 +8,24 @@
 {
   "format_version": 1,
   "motioncrafter_commit": "<git sha>",
+  "config": {
+    "window_size": 25,
+    "overlap": 8
+  },
+  "temporal_lineage": {
+    "schema_version": 1,
+    "model": "motioncrafter_sliding_window_v1",
+    "frame_index_source": "prediction archive frame_indices",
+    "source_bounds": "inclusive source-video frame identifiers",
+    "products": {
+      "disjoint_baseline": {"window_size": 25, "overlap": 0},
+      "latent_linear_baseline": {"window_size": 25, "overlap": 8},
+      "overlap_windows": {
+        "window_size_source": "prediction archive frame count",
+        "overlap": 0
+      }
+    }
+  },
   "overlap_windows": [
     {
       "window_id": "window_0000",
@@ -20,6 +38,15 @@
   "latent_linear_baseline": "baseline_latent_linear.npz"
 }
 ```
+
+The temporal-lineage section identifies the exact MotionCrafter sliding-window
+rule used by each product. Together with an archive's absolute `frame_indices`,
+it determines, for every output frame, the inclusive minimum and maximum source
+frame and the internal windows that contributed to the output. Causal consumers
+must require `source_frame_max < cutoff_frame`. Unknown lineage schemas or
+manifests without enough legacy configuration fail closed. Version-1 manifests
+created before this field was added can be audited without rerunning the GPU
+model when their `config.window_size` and `config.overlap` fields are present.
 
 Every prediction archive contains:
 
@@ -73,3 +100,9 @@ proxies and records when metric anchors are simulated from benchmark truth.
 gauge for each MotionCrafter baseline, same-view geometry summaries, manual
 track flow methods and frozen fusion weights, held-out-view surface coverage,
 input and output hashes, and explicit claim boundaries.
+
+`prob4d-phystwin-state` writes a `causal_source_lineage` audit containing the
+endpoint output frame, inclusive source-frame bounds, contributing internal
+window IDs, the causal cutoff, and the fail-closed admission decision. The
+state experiment does not open metric or manual-track evaluation data when the
+endpoint depends on a source frame at or after the cutoff.

--- a/src/prob4d/lineage.py
+++ b/src/prob4d/lineage.py
@@ -1,0 +1,214 @@
+"""Temporal source-lineage contracts for MotionCrafter prediction products."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+IntArray = NDArray[np.integer]
+
+MOTIONCRAFTER_LINEAGE_SCHEMA_VERSION = 1
+MOTIONCRAFTER_WINDOWING_MODEL = "motioncrafter_sliding_window_v1"
+_PRODUCT_MANIFEST_KEYS = {
+    "disjoint": "disjoint_baseline",
+    "latent_linear": "latent_linear_baseline",
+}
+
+
+@dataclass(frozen=True)
+class MotionCrafterWindowing:
+    """Sliding-window parameters used by MotionCrafter's ``_process_windows``."""
+
+    window_size: int
+    overlap: int
+
+    def __post_init__(self) -> None:
+        if self.window_size < 1:
+            raise ValueError("window_size must be positive")
+        if not 0 <= self.overlap < self.window_size:
+            raise ValueError("overlap must lie in [0, window_size)")
+
+    def window_slices(self, frame_count: int) -> tuple[tuple[int, int], ...]:
+        """Return the exact half-open input slices used by MotionCrafter."""
+
+        if frame_count < 1:
+            raise ValueError("frame_count must be positive")
+        window_size = min(self.window_size, frame_count)
+        overlap = 0 if frame_count <= self.window_size else self.overlap
+        stride = window_size - overlap
+        windows: list[tuple[int, int]] = []
+        start = 0
+        while start < frame_count - overlap:
+            windows.append((start, min(start + window_size, frame_count)))
+            start += stride
+        if not windows or windows[-1][1] != frame_count:
+            raise RuntimeError("MotionCrafter window schedule does not cover every frame")
+        return tuple(windows)
+
+    def dependency_for_output(
+        self,
+        frame_indices: IntArray,
+        output_frame: int,
+    ) -> tuple[int, int, tuple[int, ...], int]:
+        """Return inclusive source bounds and contributing internal windows."""
+
+        frames = np.asarray(frame_indices, dtype=np.int64)
+        if frames.ndim != 1 or frames.size == 0:
+            raise ValueError("frame_indices must be a nonempty vector")
+        if np.any(np.diff(frames) <= 0):
+            raise ValueError("frame_indices must be strictly increasing")
+        output_index = int(np.searchsorted(frames, output_frame))
+        if output_index == len(frames) or frames[output_index] != output_frame:
+            raise ValueError(f"output frame {output_frame} is absent from the prediction")
+
+        windows = self.window_slices(len(frames))
+        contributors = tuple(
+            index for index, (start, stop) in enumerate(windows) if start <= output_index < stop
+        )
+        if not contributors:
+            raise RuntimeError("output frame has no MotionCrafter source window")
+        source_start = min(windows[index][0] for index in contributors)
+        source_stop = max(windows[index][1] for index in contributors)
+        return (
+            int(frames[source_start]),
+            int(frames[source_stop - 1]),
+            contributors,
+            output_index,
+        )
+
+
+@dataclass(frozen=True)
+class CausalFrameAudit:
+    """Fail-closed source-lineage decision for one prediction frame."""
+
+    product: str
+    output_frame: int
+    output_index: int
+    cutoff_frame: int
+    source_frame_min: int
+    source_frame_max: int
+    source_window_indices: tuple[int, ...]
+    window_size: int
+    overlap: int
+    lineage_source: str
+    admissible: bool
+
+    def to_dict(self) -> dict[str, object]:
+        payload = asdict(self)
+        payload["source_window_indices"] = list(self.source_window_indices)
+        payload["source_window_ids"] = [
+            f"internal_window_{index:04d}" for index in self.source_window_indices
+        ]
+        payload["source_window_count"] = len(self.source_window_indices)
+        payload["source_bounds_inclusive"] = True
+        payload["admissibility_rule"] = "source_frame_max < cutoff_frame"
+        return payload
+
+
+def motioncrafter_temporal_lineage_manifest(
+    *,
+    window_size: int,
+    overlap: int,
+) -> dict[str, object]:
+    """Build the versioned temporal-lineage section of ``predictions.json``."""
+
+    disjoint = MotionCrafterWindowing(window_size=window_size, overlap=0)
+    latent = MotionCrafterWindowing(window_size=window_size, overlap=overlap)
+    return {
+        "schema_version": MOTIONCRAFTER_LINEAGE_SCHEMA_VERSION,
+        "model": MOTIONCRAFTER_WINDOWING_MODEL,
+        "frame_index_source": "prediction archive frame_indices",
+        "source_bounds": "inclusive source-video frame identifiers",
+        "products": {
+            "disjoint_baseline": asdict(disjoint),
+            "latent_linear_baseline": asdict(latent),
+            "overlap_windows": {
+                "window_size_source": "prediction archive frame count",
+                "overlap": 0,
+            },
+        },
+    }
+
+
+def _windowing_from_manifest(
+    manifest: Mapping[str, Any],
+    product: str,
+) -> tuple[MotionCrafterWindowing, str]:
+    if product not in _PRODUCT_MANIFEST_KEYS:
+        raise ValueError("prediction product must be disjoint or latent_linear")
+    product_key = _PRODUCT_MANIFEST_KEYS[product]
+    lineage = manifest.get("temporal_lineage")
+    if lineage is not None:
+        if not isinstance(lineage, Mapping):
+            raise ValueError("temporal_lineage must be a mapping")
+        version = int(lineage.get("schema_version", -1))
+        if version != MOTIONCRAFTER_LINEAGE_SCHEMA_VERSION:
+            raise ValueError(f"unsupported temporal-lineage schema_version {version}")
+        if lineage.get("model") != MOTIONCRAFTER_WINDOWING_MODEL:
+            raise ValueError("unsupported temporal-lineage model")
+        products = lineage.get("products")
+        if not isinstance(products, Mapping) or product_key not in products:
+            raise ValueError(f"temporal lineage is missing {product_key}")
+        settings = products[product_key]
+        if not isinstance(settings, Mapping):
+            raise ValueError(f"temporal lineage for {product_key} must be a mapping")
+        return (
+            MotionCrafterWindowing(
+                window_size=int(settings["window_size"]),
+                overlap=int(settings["overlap"]),
+            ),
+            "manifest_temporal_lineage_v1",
+        )
+
+    config = manifest.get("config")
+    if not isinstance(config, Mapping) or "window_size" not in config:
+        raise ValueError(
+            "prediction manifest lacks temporal lineage and legacy window configuration; "
+            "regenerate the prediction bundle"
+        )
+    overlap = 0 if product == "disjoint" else int(config.get("overlap", -1))
+    return (
+        MotionCrafterWindowing(
+            window_size=int(config["window_size"]),
+            overlap=overlap,
+        ),
+        "reconstructed_from_legacy_manifest_config",
+    )
+
+
+def audit_motioncrafter_product_frame(
+    manifest: Mapping[str, Any],
+    frame_indices: IntArray,
+    *,
+    product: str,
+    output_frame: int,
+    cutoff_frame: int,
+) -> CausalFrameAudit:
+    """Audit whether one output was computed exclusively from pre-cutoff RGB."""
+
+    if cutoff_frame < 1:
+        raise ValueError("cutoff_frame must be positive")
+    if output_frame >= cutoff_frame:
+        raise ValueError("output_frame must precede cutoff_frame")
+    windowing, lineage_source = _windowing_from_manifest(manifest, product)
+    source_min, source_max, contributors, output_index = windowing.dependency_for_output(
+        frame_indices,
+        output_frame,
+    )
+    return CausalFrameAudit(
+        product=product,
+        output_frame=output_frame,
+        output_index=output_index,
+        cutoff_frame=cutoff_frame,
+        source_frame_min=source_min,
+        source_frame_max=source_max,
+        source_window_indices=contributors,
+        window_size=windowing.window_size,
+        overlap=windowing.overlap,
+        lineage_source=lineage_source,
+        admissible=source_max < cutoff_frame,
+    )

--- a/src/prob4d/motioncrafter.py
+++ b/src/prob4d/motioncrafter.py
@@ -18,6 +18,7 @@ from typing import Any
 import numpy as np
 
 from .data import PredictionWindow
+from .lineage import motioncrafter_temporal_lineage_manifest
 
 
 @dataclass(frozen=True)
@@ -287,6 +288,10 @@ class MotionCrafterAdapter:
                 key: str(value) if isinstance(value, Path) else value
                 for key, value in asdict(config).items()
             },
+            "temporal_lineage": motioncrafter_temporal_lineage_manifest(
+                window_size=config.window_size,
+                overlap=config.overlap,
+            ),
             "overlap_windows": manifest_windows,
             "disjoint_baseline": disjoint_path.name,
             "latent_linear_baseline": latent_path.name,

--- a/src/prob4d/phystwin_state.py
+++ b/src/prob4d/phystwin_state.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 import argparse
 import json
 import pickle
+from collections.abc import Mapping
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 from numpy.typing import NDArray
 
+from .data import PredictionWindow
+from .lineage import audit_motioncrafter_product_frame
 from .phystwin import CoverResizeCrop, PhysTwinCase, nearest_neighbor_indices
 from .phystwin_experiment import (
     ErrorSummary,
@@ -329,6 +333,32 @@ def state_forecast_metrics(
     }
 
 
+def validate_causal_source_lineage(
+    prediction: PredictionWindow,
+    manifest: Mapping[str, Any],
+    *,
+    product: str,
+    fit_end_frame: int,
+) -> dict[str, object]:
+    """Require the endpoint estimate to depend only on pre-boundary RGB."""
+
+    endpoint_frame = fit_end_frame - 1
+    audit = audit_motioncrafter_product_frame(
+        manifest,
+        prediction.frame_indices,
+        product=product,
+        output_frame=endpoint_frame,
+        cutoff_frame=fit_end_frame,
+    )
+    if not audit.admissible:
+        raise ValueError(
+            f"{product} endpoint frame {endpoint_frame} depends on source frame "
+            f"{audit.source_frame_max}, which is not before the causal cutoff "
+            f"{fit_end_frame}; regenerate a prefix-aligned prediction bundle"
+        )
+    return audit.to_dict()
+
+
 def run_state_experiment(
     manifest_path: str | Path,
     case_directory: str | Path,
@@ -345,8 +375,14 @@ def run_state_experiment(
     bootstrap_repetitions: int = 10_000,
     seed: int = 42,
 ) -> dict[str, object]:
-    case = PhysTwinCase.from_directory(case_directory)
     prediction, manifest = load_prediction_product(manifest_path, product)
+    causal_source_lineage = validate_causal_source_lineage(
+        prediction,
+        manifest,
+        product=product,
+        fit_end_frame=fit_end_frame,
+    )
+    case = PhysTwinCase.from_directory(case_directory)
     crop = CoverResizeCrop.from_shapes(
         case.source_height,
         case.source_width,
@@ -397,14 +433,17 @@ def run_state_experiment(
     }[product]
     prediction_path = Path(manifest_path).resolve().parent / manifest[prediction_field]
     result = {
-        "schema_version": 1,
+        "schema_version": 2,
         "status": "MotionCrafter endpoint state update followed by PhysTwin rollout",
         "case": Path(case_directory).name,
         "product": product,
         "input_camera": input_camera,
         "source_frames": prediction.frame_indices.tolist(),
         "fit_end_frame": fit_end_frame,
-        "future_visual_observations_used_by_forecasts": False,
+        "causal_source_lineage": causal_source_lineage,
+        "future_visual_observations_used_by_forecasts": not bool(
+            causal_source_lineage["admissible"]
+        ),
         "gauge": {
             "scale": gauge.transform.scale,
             "rotation_vector": so3_log(gauge.transform.rotation).tolist(),
@@ -438,8 +477,9 @@ def run_state_experiment(
                 "train_label_bias_corrected and oracle_truth methods are controls only"
             ),
             "forecast_information": (
-                "future PhysTwin action-conditioned trajectory is known; no future RGB or depth "
-                "updates enter forecast methods"
+                "future PhysTwin action-conditioned trajectory is known; the endpoint "
+                "MotionCrafter product passed an exact source-lineage audit proving that "
+                "no RGB frame at or after fit_end_frame entered the endpoint estimate"
             ),
             "missing_evidence": (
                 "all_finite_future_tracks includes tracks absent from camera-visible evaluation"

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -1,0 +1,98 @@
+import numpy as np
+import pytest
+
+from prob4d.lineage import (
+    audit_motioncrafter_product_frame,
+    motioncrafter_temporal_lineage_manifest,
+)
+
+
+def manifest(window_size: int = 25, overlap: int = 8) -> dict[str, object]:
+    return {
+        "format_version": 1,
+        "config": {"window_size": window_size, "overlap": overlap},
+        "temporal_lineage": motioncrafter_temporal_lineage_manifest(
+            window_size=window_size,
+            overlap=overlap,
+        ),
+    }
+
+
+def test_disjoint_endpoint_fails_when_first_window_reads_cutoff_frame() -> None:
+    frames = np.arange(110, 160)
+
+    audit = audit_motioncrafter_product_frame(
+        manifest(),
+        frames,
+        product="disjoint",
+        output_frame=133,
+        cutoff_frame=134,
+    )
+
+    assert audit.source_frame_min == 110
+    assert audit.source_frame_max == 134
+    assert audit.source_window_indices == (0,)
+    assert audit.admissible is False
+
+
+def test_prefix_aligned_disjoint_endpoint_is_admissible() -> None:
+    frames = np.arange(109, 159)
+
+    audit = audit_motioncrafter_product_frame(
+        manifest(),
+        frames,
+        product="disjoint",
+        output_frame=133,
+        cutoff_frame=134,
+    )
+
+    assert audit.source_frame_min == 109
+    assert audit.source_frame_max == 133
+    assert audit.admissible is True
+
+
+def test_latent_overlap_reports_both_contributing_windows() -> None:
+    frames = np.arange(109, 159)
+
+    audit = audit_motioncrafter_product_frame(
+        manifest(),
+        frames,
+        product="latent_linear",
+        output_frame=133,
+        cutoff_frame=134,
+    )
+
+    assert audit.source_frame_min == 109
+    assert audit.source_frame_max == 150
+    assert audit.source_window_indices == (0, 1)
+    assert audit.admissible is False
+
+
+def test_legacy_manifest_lineage_is_reconstructed_without_gpu_rerun() -> None:
+    frames = np.arange(109, 159)
+    legacy = {"format_version": 1, "config": {"window_size": 25, "overlap": 8}}
+
+    audit = audit_motioncrafter_product_frame(
+        legacy,
+        frames,
+        product="disjoint",
+        output_frame=133,
+        cutoff_frame=134,
+    )
+
+    assert audit.lineage_source == "reconstructed_from_legacy_manifest_config"
+    assert audit.admissible is True
+
+
+def test_unknown_lineage_schema_fails_closed() -> None:
+    broken = manifest()
+    broken["temporal_lineage"]["schema_version"] = 2
+
+    with pytest.raises(ValueError, match="unsupported temporal-lineage"):
+        audit_motioncrafter_product_frame(
+            broken,
+            np.arange(109, 159),
+            product="disjoint",
+            output_frame=133,
+            cutoff_frame=134,
+        )

--- a/tests/test_phystwin_state.py
+++ b/tests/test_phystwin_state.py
@@ -1,8 +1,12 @@
 import numpy as np
+import pytest
 
+from prob4d.data import PredictionWindow
+from prob4d.lineage import motioncrafter_temporal_lineage_manifest
 from prob4d.phystwin_state import (
     anchored_physics_rollout,
     paired_frame_block_bootstrap,
+    validate_causal_source_lineage,
 )
 
 
@@ -50,3 +54,55 @@ def test_paired_block_bootstrap_detects_uniform_improvement() -> None:
     assert result["probability_method_better"] == 1.0
     assert len(result["paired_frame_rows"]) == 6
     assert result["paired_frame_rows"][0]["count"] == 2
+
+
+def _prediction(frames: np.ndarray) -> PredictionWindow:
+    return PredictionWindow(
+        "state",
+        frames,
+        np.zeros((len(frames), 1, 1, 3)),
+        np.ones((len(frames), 1, 1), dtype=bool),
+    )
+
+
+def _manifest() -> dict[str, object]:
+    return {
+        "format_version": 1,
+        "config": {"window_size": 25, "overlap": 8},
+        "temporal_lineage": motioncrafter_temporal_lineage_manifest(
+            window_size=25,
+            overlap=8,
+        ),
+    }
+
+
+def test_causal_source_lineage_accepts_prefix_aligned_disjoint_endpoint() -> None:
+    audit = validate_causal_source_lineage(
+        _prediction(np.arange(109, 159)),
+        _manifest(),
+        product="disjoint",
+        fit_end_frame=134,
+    )
+
+    assert audit["admissible"] is True
+    assert audit["source_frame_max"] == 133
+
+
+def test_causal_source_lineage_rejects_future_dependent_endpoint() -> None:
+    with pytest.raises(ValueError, match="depends on source frame 134"):
+        validate_causal_source_lineage(
+            _prediction(np.arange(110, 160)),
+            _manifest(),
+            product="disjoint",
+            fit_end_frame=134,
+        )
+
+
+def test_causal_source_lineage_rejects_latent_overlap() -> None:
+    with pytest.raises(ValueError, match="depends on source frame 150"):
+        validate_causal_source_lineage(
+            _prediction(np.arange(109, 159)),
+            _manifest(),
+            product="latent_linear",
+            fit_end_frame=134,
+        )


### PR DESCRIPTION
## What changed

- add a versioned temporal-lineage contract for MotionCrafter prediction products
- reproduce MotionCrafter's exact sliding-window dependency rule and report each endpoint's contributing source-window IDs and inclusive source-frame bounds
- make `prob4d-phystwin-state` audit the endpoint before opening metric depth or manual-track evaluation data
- fail closed when any source RGB frame is at or beyond `--fit-end-frame`
- preserve compatibility with existing version-1 manifests by reconstructing lineage from their stored `window_size` and `overlap`; unknown or incomplete lineage fails closed
- record the complete audit in schema-version-2 state-result artifacts
- correct the documented 25-frame causal clip alignment: cutoff 134 requires a clip beginning at frame 109, so endpoint frame 133 depends on frames 109--133

## Root cause

The previous state experiment equated an output frame's index with its input dependency and unconditionally reported that no future visual observations were used. MotionCrafter predicts in temporal windows, so an endpoint may depend on later RGB frames within its disjoint window or within both windows of a latent overlap blend. This could invalidate a causal endpoint claim despite the endpoint itself preceding the cutoff.

## User and research impact

Causal state experiments now reject contaminated products before loading outcome data. Accepted artifacts contain a machine-readable source-lineage certificate instead of relying on command-line convention. Reconstruction workflows remain unchanged.

## Validation

- focused lineage tests: 5 passed locally
- Python compilation checks passed for the new lineage module and modified state/inference modules
- added endpoint-level acceptance and rejection tests for disjoint and latent-linear products
- GitHub Actions `Tests` workflow run 108: passed
- branch is one commit ahead of current `main`, zero commits behind, and mergeable without conflicts
