### PR TITLE
Export causally recomputed Phys4D observation beliefs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,9 +4,17 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
@@ -15,4 +23,52 @@ jobs:
           cache: pip
       - run: python -m pip install -e ".[dev]"
       - run: ruff check src tests
+
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.12", "3.14"]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - run: python -m pip install -e ".[dev]"
       - run: python -m pytest -q
+
+  package:
+    needs: [lint, test]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: python -m pip install ".[dev]"
+      - run: python -m build
+      - run: python -m twine check dist/*
+      - run: python -m venv /tmp/prob4d-wheel
+      - run: /tmp/prob4d-wheel/bin/python -m pip install dist/*.whl
+      - run: /tmp/prob4d-wheel/bin/python -c "import prob4d; print(prob4d.__version__)"
+      - name: Smoke-test installed command help
+        run: |
+          for command in \
+            prob4d-ablate \
+            prob4d-benchmark \
+            prob4d-export-observation \
+            prob4d-motioncrafter \
+            prob4d-phystwin \
+            prob4d-phystwin-state \
+            prob4d-phystwin-uncertainty \
+            prob4d-sintel-uncertainty \
+            prob4d-validate-observation \
+            prob4d-vggt-baseline
+          do
+            "/tmp/prob4d-wheel/bin/${command}" --help >/dev/null
+          done

--- a/docs/data-format.md
+++ b/docs/data-format.md
@@ -68,6 +68,45 @@ video frame IDs directly into every baseline and overlap window. PhysTwin
 evaluation requires these absolute IDs because its calibration, depth frames,
 manual tracks, and physical trajectories all use the original sequence index.
 
+## Phys4D Observation Belief
+
+`prob4d-export-observation` writes a non-pickled NPZ implementing schema
+`phys4d.observation_belief`, version 1. The descriptor and every array name,
+dtype, shape, and byte payload contribute to one content address. The required
+arrays are:
+
+| Field | Shape | Meaning |
+| --- | --- | --- |
+| `declared_frame_ids` | `F` | Strictly increasing admissible source frames |
+| `mean_xyz_m` | `M x 3` | Observation means; metric only when explicitly anchored |
+| `frame_ids` | `M` | Absolute source frame per row |
+| `entity_ids` | `M` | Persistent pixel or material identity per row |
+| `view_indices` | `M` | Index into `view_names` |
+| `window_indices` | `M` | Index into `window_names` |
+| `correlation_group_ids` | `M` | Effective robust-likelihood group |
+| `factor_group_ids` | `M` | Shared low-rank latent identity |
+| `prior_reliability` | `M` | Residual-independent feeder reliability |
+| `association_probability` | `M` | Association support, kept separate from reliability |
+| `local_covariance_m2` | `M x 3 x 3` | Conditional point covariance excluding gauge uncertainty |
+| `low_rank_factor_m` | `M x 3 x R` | Coherent joint-gauge covariance factor |
+| `group_ids` | `G` | Sorted unique effective groups |
+| `group_prior_nominal_probability` | `G` | Frozen nominal-component prior |
+| `group_composite_weight` | `G` | Evidence-power cap in `(0, 1]` |
+
+The causal cutoff is exclusive: all declared and observed frames must satisfy
+`frame_id < causal_frame_stop`. Before loading payloads, the exporter selects
+only independently decoded overlap windows with
+`stop_frame <= causal_frame_stop`; all gauge estimation, disagreement
+accumulation, uncertainty construction, and row export are recomputed from that
+prefix. Excluded future payloads are neither opened nor hashed.
+
+The descriptor records `coordinate_mode`. `gauge_relative` artifacts use an
+arbitrary first-window reference and do not authorize metric state updates.
+`metric_anchored` artifacts require an independent `Sim(3)` anchor and include
+its digest, mean, and covariance in the content address. See
+[the observation-export contract](observation-belief-export.md) for the exact
+causal, gauge, and reliability semantics.
+
 ## Ground Truth
 
 Real evaluation expects a compressed NumPy archive with:

--- a/docs/observation-belief-export.md
+++ b/docs/observation-belief-export.md
@@ -1,0 +1,119 @@
+# Causal Phys4D observation export
+
+`prob4d-export-observation` converts independently decoded MotionCrafter overlap
+windows into the shared `phys4d.observation_belief` schema consumed by
+Bayesian-PhysTwin. The exporter is deliberately separate from reconstruction
+fusion: it preserves window provenance, association probability, prior
+reliability, correlation groups, and coherent gauge uncertainty.
+
+## Causal prefix construction
+
+The cutoff is exclusive. For `--causal-frame-stop-exclusive 134`, source frame
+133 is admissible and source frame 134 is not.
+
+The exporter reads `predictions.json` before opening prediction payloads. It
+selects only overlap-window records whose complete half-open interval satisfies
+
+```text
+window.stop_frame <= causal_frame_stop_exclusive.
+```
+
+Excluded suffix payloads are never opened or hashed. Alignment, gauge
+estimation, overlap-disagreement accumulation, uncertainty construction, and
+row export are then rerun from the retained windows only. This prevents an
+apparently pre-cutoff row from inheriting information from a window that also
+read post-cutoff RGB.
+
+The source artifact digest covers the causal manifest subset and every selected
+window payload. It intentionally excludes later windows, absolute output paths,
+and the full-sequence stop frame. Mutating an excluded suffix payload therefore
+does not change the causal artifact ID, while mutating a selected payload does.
+
+## Gauge posterior
+
+The exporter selects one well-supported earlier overlap constraint for each new
+window, forming a causal spanning tree. It propagates the complete joint gauge
+covariance through this tree, including cross-window covariance. A deterministic
+square root of that joint covariance is mapped through each point's `Sim(3)`
+Jacobian and exported as one shared low-rank factor. Thus rows from different
+windows retain coherent gauge covariance instead of receiving independent
+marginal gauge factors.
+
+`--max-gauge-rank` caps the exported factor rank for large sequences. The
+retained covariance-trace fraction is stored in artifact metadata. When the
+joint rank is below the cap, the representation is exact up to numerical
+linearization.
+
+## Coordinate modes
+
+Every exported artifact declares one of two modes:
+
+- `gauge_relative`: the first retained window defines an arbitrary reference
+  gauge. Values are in `gauge_unit`, even though the version-1 schema retains
+  its historical `*_m` array names. This mode does not authorize a metric
+  physical-state update by itself. A downstream estimator must retain the
+  unresolved global gauge as a nuisance variable or abstain.
+- `metric_anchored`: the first window receives an independent metric `Sim(3)`
+  prior from `--metric-anchor`. Metric claims are authorized only in this mode.
+
+A metric-anchor NPZ contains exactly:
+
+```text
+mean:       7       # [log scale, rotation vector (3), translation (3)]
+covariance: 7 x 7
+```
+
+The anchor file digest, mean, and covariance are included in the content
+addressed metadata.
+
+## Reliability and dependence
+
+Association probability and prior reliability are separate arrays. Retained
+valid pixels currently have association probability one. Prior reliability is
+computed only from overlap disagreement and the declared observation covariance;
+it never uses a Bayesian-PhysTwin physical innovation.
+
+Rows sharing an absolute source frame form one effective correlation group.
+The group composite weight caps the effective number of pixel identities, so
+duplicating windows or rows cannot increase group power without bound.
+
+The local `3 x 3` covariance excludes gauge uncertainty. Gauge uncertainty is
+represented only by the shared low-rank factor, avoiding double counting.
+
+## Commands
+
+Gauge-relative export:
+
+```bash
+prob4d-export-observation \
+  outputs/camera0/predictions.json \
+  outputs/camera0/observation_belief.npz \
+  --case-id double_stretch_sloth \
+  --causal-frame-stop-exclusive 134 \
+  --coordinate-mode gauge_relative \
+  --pixel-stride 4 \
+  --source-revision <prob4d-git-sha>
+```
+
+Metric-anchored export:
+
+```bash
+prob4d-export-observation \
+  outputs/camera0/predictions.json \
+  outputs/camera0/observation_belief_metric.npz \
+  --case-id double_stretch_sloth \
+  --causal-frame-stop-exclusive 134 \
+  --coordinate-mode metric_anchored \
+  --metric-anchor outputs/camera0/metric_anchor.npz \
+  --source-revision <prob4d-git-sha>
+```
+
+Validate the schema, exact array set, and content address:
+
+```bash
+prob4d-validate-observation outputs/camera0/observation_belief.npz
+```
+
+The contract has the same golden artifact digest as Bayesian-PhysTwin. Causal4D
+should bind only the selected Bayesian-PhysTwin belief and its actually consumed
+observation artifact; Prob4D does not provide a direct Causal4D inference path.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,19 +13,23 @@ dependencies = ["numpy>=1.24"]
 
 [project.optional-dependencies]
 dev = [
+  "build>=1.2",
   "pytest>=7.4",
   "pytest-cov>=4.1",
   "ruff>=0.6",
+  "twine>=5.0",
 ]
 
 [project.scripts]
 prob4d-ablate = "prob4d.experiments:main"
 prob4d-benchmark = "prob4d.benchmark:main"
+prob4d-export-observation = "prob4d.observation_export:main"
 prob4d-motioncrafter = "prob4d.motioncrafter:main"
 prob4d-phystwin = "prob4d.phystwin_experiment:main"
 prob4d-phystwin-state = "prob4d.phystwin_state:main"
 prob4d-phystwin-uncertainty = "prob4d.phystwin_uncertainty:main"
 prob4d-sintel-uncertainty = "prob4d.sintel_uncertainty:main"
+prob4d-validate-observation = "prob4d.observation_contract:validate_main"
 prob4d-vggt-baseline = "prob4d.vggt_baseline:main"
 
 [tool.setuptools.packages.find]

--- a/src/prob4d/__init__.py
+++ b/src/prob4d/__init__.py
@@ -1,6 +1,19 @@
 """Probabilistic long-horizon fusion for MotionCrafter predictions."""
 
 from .data import PredictionWindow
+from .observation_contract import (
+    ObservationBeliefExportV1,
+    load_observation_belief_export,
+    save_observation_belief_export,
+)
+from .observation_export import (
+    CausalPredictionPrefix,
+    JointGaugeTree,
+    MetricGaugeAnchor,
+    build_prob4d_observation_belief,
+    load_causal_prediction_prefix,
+    load_metric_gauge_anchor,
+)
 from .observation_factors import (
     LinearizedObservationFactor,
     ObservationFactor,
@@ -13,13 +26,22 @@ from .observation_factors import (
 from .sim3 import Sim3
 
 __all__ = [
+    "CausalPredictionPrefix",
+    "JointGaugeTree",
     "LinearizedObservationFactor",
+    "MetricGaugeAnchor",
+    "ObservationBeliefExportV1",
     "ObservationFactor",
     "ObservationFactorBundle",
     "PredictionWindow",
     "Sim3",
     "StackedObservationFactors",
+    "build_prob4d_observation_belief",
+    "load_causal_prediction_prefix",
+    "load_metric_gauge_anchor",
+    "load_observation_belief_export",
     "load_observation_factor_bundle",
+    "save_observation_belief_export",
     "stack_observation_factors",
     "write_observation_factor_bundle",
 ]

--- a/src/prob4d/observation_contract.py
+++ b/src/prob4d/observation_contract.py
@@ -1,0 +1,476 @@
+"""Portable, content-addressed Phys4D observation-belief contract."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+OBSERVATION_BELIEF_SCHEMA = "phys4d.observation_belief"
+OBSERVATION_BELIEF_VERSION = 1
+
+
+def array_sha256(values: np.ndarray) -> str:
+    """Hash an array including its dtype, shape, and byte payload."""
+
+    array = np.ascontiguousarray(np.asarray(values))
+    digest = hashlib.sha256()
+    digest.update(array.dtype.str.encode("ascii"))
+    digest.update(json.dumps(array.shape, separators=(",", ":")).encode("ascii"))
+    digest.update(array.view(np.uint8))
+    return digest.hexdigest()
+
+
+def file_sha256(path: str | Path) -> str:
+    """Hash a file without loading it completely into memory."""
+
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _canonical_json(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        dict(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _artifact_id(
+    descriptor: Mapping[str, Any], arrays: Mapping[str, np.ndarray]
+) -> str:
+    digest = hashlib.sha256()
+    digest.update(_canonical_json(descriptor))
+    for name, values in sorted(arrays.items()):
+        digest.update(name.encode("utf-8"))
+        digest.update(array_sha256(values).encode("ascii"))
+    return digest.hexdigest()
+
+
+def _validate_sha256(value: str, *, name: str) -> None:
+    if len(value) != 64 or any(
+        character not in "0123456789abcdef" for character in value
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+
+
+def _validated_metadata(values: Mapping[str, Any]) -> dict[str, Any]:
+    try:
+        return json.loads(json.dumps(dict(values), sort_keys=True, allow_nan=False))
+    except (TypeError, ValueError) as error:
+        raise ValueError("metadata must be finite JSON data") from error
+
+
+def _readonly(
+    values: np.ndarray,
+    *,
+    dtype: np.dtype[Any] | type | None = None,
+) -> np.ndarray:
+    array = np.asarray(values, dtype=dtype).copy()
+    array.setflags(write=False)
+    return array
+
+
+@dataclass(frozen=True)
+class ObservationBeliefExportV1:
+    """Validated producer-side representation of ``ObservationBeliefV1``."""
+
+    case_id: str
+    stream_id: str
+    causal_frame_stop: int
+    view_names: tuple[str, ...]
+    window_names: tuple[str, ...]
+    factor_names: tuple[str, ...]
+    source_repository: str
+    source_revision: str
+    source_artifact_sha256: str
+
+    declared_frame_ids: np.ndarray
+    mean_xyz_m: np.ndarray
+    frame_ids: np.ndarray
+    entity_ids: np.ndarray
+    view_indices: np.ndarray
+    window_indices: np.ndarray
+    correlation_group_ids: np.ndarray
+    factor_group_ids: np.ndarray
+    prior_reliability: np.ndarray
+    association_probability: np.ndarray
+    local_covariance_m2: np.ndarray
+    low_rank_factor_m: np.ndarray
+    group_ids: np.ndarray
+    group_prior_nominal_probability: np.ndarray
+    group_composite_weight: np.ndarray
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.case_id or not self.stream_id:
+            raise ValueError("case_id and stream_id must be nonempty")
+        if self.causal_frame_stop < 1:
+            raise ValueError("causal_frame_stop must be positive")
+        if not self.view_names or any(not name for name in self.view_names):
+            raise ValueError("view_names must contain nonempty names")
+        if not self.window_names or any(not name for name in self.window_names):
+            raise ValueError("window_names must contain nonempty names")
+        if any(not name for name in self.factor_names):
+            raise ValueError("factor_names must be nonempty when present")
+        if not self.source_repository or not self.source_revision:
+            raise ValueError("source repository and revision must be nonempty")
+        _validate_sha256(
+            self.source_artifact_sha256,
+            name="source_artifact_sha256",
+        )
+
+        declared_frames = _readonly(self.declared_frame_ids, dtype=np.int64)
+        mean = _readonly(self.mean_xyz_m, dtype=np.float64)
+        frame_ids = _readonly(self.frame_ids, dtype=np.int64)
+        entity_ids = _readonly(self.entity_ids, dtype=np.int64)
+        view_indices = _readonly(self.view_indices, dtype=np.int64)
+        window_indices = _readonly(self.window_indices, dtype=np.int64)
+        correlation_groups = _readonly(
+            self.correlation_group_ids, dtype=np.int64
+        )
+        factor_groups = _readonly(self.factor_group_ids, dtype=np.int64)
+        prior_reliability = _readonly(
+            self.prior_reliability, dtype=np.float64
+        )
+        association_probability = _readonly(
+            self.association_probability, dtype=np.float64
+        )
+        local_covariance = _readonly(
+            self.local_covariance_m2, dtype=np.float64
+        )
+        factors = _readonly(self.low_rank_factor_m, dtype=np.float64)
+        group_ids = _readonly(self.group_ids, dtype=np.int64)
+        group_prior = _readonly(
+            self.group_prior_nominal_probability, dtype=np.float64
+        )
+        group_weight = _readonly(
+            self.group_composite_weight, dtype=np.float64
+        )
+
+        if (
+            declared_frames.ndim != 1
+            or len(declared_frames) == 0
+            or np.any(declared_frames < 0)
+            or np.any(np.diff(declared_frames) <= 0)
+        ):
+            raise ValueError(
+                "declared_frame_ids must be nonempty, nonnegative, and "
+                "strictly increasing"
+            )
+        if np.any(declared_frames >= self.causal_frame_stop):
+            raise ValueError("declared frames must lie before causal_frame_stop")
+        if mean.ndim != 2 or mean.shape[1] != 3 or len(mean) == 0:
+            raise ValueError("mean_xyz_m must have nonempty shape (N, 3)")
+        observation_count = len(mean)
+        vectors = {
+            "frame_ids": frame_ids,
+            "entity_ids": entity_ids,
+            "view_indices": view_indices,
+            "window_indices": window_indices,
+            "correlation_group_ids": correlation_groups,
+            "factor_group_ids": factor_groups,
+            "prior_reliability": prior_reliability,
+            "association_probability": association_probability,
+        }
+        for name, values in vectors.items():
+            if values.shape != (observation_count,):
+                raise ValueError(f"{name} must have shape ({observation_count},)")
+        if local_covariance.shape != (observation_count, 3, 3):
+            raise ValueError("local_covariance_m2 must have shape (N, 3, 3)")
+        factor_rank = len(self.factor_names)
+        if factors.shape != (observation_count, 3, factor_rank):
+            raise ValueError(
+                "low_rank_factor_m must have shape "
+                f"(N, 3, {factor_rank})"
+            )
+        if not np.all(np.isfinite(mean)):
+            raise ValueError("mean_xyz_m must be finite")
+        if not np.all(np.isfinite(local_covariance)):
+            raise ValueError("local covariance must be finite")
+        if not np.all(np.isfinite(factors)):
+            raise ValueError("low-rank factors must be finite")
+        if np.any(entity_ids < 0):
+            raise ValueError("entity_ids must be nonnegative")
+        if np.any(frame_ids < 0) or np.any(frame_ids >= self.causal_frame_stop):
+            raise ValueError("observation frames cross the causal boundary")
+        if not np.all(np.isin(frame_ids, declared_frames)):
+            raise ValueError("frame_ids must be contained in declared_frame_ids")
+        if np.any(view_indices < 0) or np.any(
+            view_indices >= len(self.view_names)
+        ):
+            raise ValueError("view_indices reference unavailable views")
+        if np.any(window_indices < 0) or np.any(
+            window_indices >= len(self.window_names)
+        ):
+            raise ValueError("window_indices reference unavailable windows")
+        if np.any(correlation_groups < 0) or np.any(factor_groups < 0):
+            raise ValueError("group identifiers must be nonnegative")
+        for name, values in (
+            ("prior_reliability", prior_reliability),
+            ("association_probability", association_probability),
+        ):
+            if not np.all(np.isfinite(values)) or np.any(
+                (values < 0.0) | (values > 1.0)
+            ):
+                raise ValueError(f"{name} must lie in [0, 1]")
+
+        symmetric = 0.5 * (
+            local_covariance + np.swapaxes(local_covariance, 1, 2)
+        )
+        if not np.allclose(
+            local_covariance, symmetric, atol=1e-12, rtol=1e-10
+        ):
+            raise ValueError("local covariance must be symmetric")
+        minimum_eigenvalue = np.min(np.linalg.eigvalsh(symmetric), axis=1)
+        if np.any(minimum_eigenvalue <= 0.0):
+            raise ValueError("local covariance must be positive definite")
+
+        expected_groups = np.unique(correlation_groups)
+        if group_ids.ndim != 1 or not np.array_equal(group_ids, expected_groups):
+            raise ValueError(
+                "group_ids must equal sorted unique correlation_group_ids"
+            )
+        group_count = len(group_ids)
+        if group_prior.shape != (group_count,) or group_weight.shape != (
+            group_count,
+        ):
+            raise ValueError(
+                "group prior and composite weight must identify every group"
+            )
+        if not np.all(np.isfinite(group_prior)) or np.any(
+            (group_prior < 0.0) | (group_prior > 1.0)
+        ):
+            raise ValueError(
+                "group prior nominal probabilities must lie in [0, 1]"
+            )
+        if not np.all(np.isfinite(group_weight)) or np.any(
+            (group_weight <= 0.0) | (group_weight > 1.0)
+        ):
+            raise ValueError("group composite weights must lie in (0, 1]")
+
+        order = np.lexsort(
+            (window_indices, view_indices, entity_ids, frame_ids)
+        )
+        sorted_keys = np.column_stack(
+            (
+                frame_ids[order],
+                entity_ids[order],
+                view_indices[order],
+                window_indices[order],
+            )
+        )
+        if len(sorted_keys) > 1 and np.any(
+            np.all(sorted_keys[1:] == sorted_keys[:-1], axis=1)
+        ):
+            raise ValueError(
+                "observation identity (frame, entity, view, window) must be unique"
+            )
+
+        object.__setattr__(self, "declared_frame_ids", declared_frames)
+        object.__setattr__(self, "mean_xyz_m", mean)
+        object.__setattr__(self, "frame_ids", frame_ids)
+        object.__setattr__(self, "entity_ids", entity_ids)
+        object.__setattr__(self, "view_indices", view_indices)
+        object.__setattr__(self, "window_indices", window_indices)
+        object.__setattr__(self, "correlation_group_ids", correlation_groups)
+        object.__setattr__(self, "factor_group_ids", factor_groups)
+        object.__setattr__(self, "prior_reliability", prior_reliability)
+        object.__setattr__(
+            self, "association_probability", association_probability
+        )
+        object.__setattr__(self, "local_covariance_m2", local_covariance)
+        object.__setattr__(self, "low_rank_factor_m", factors)
+        object.__setattr__(self, "group_ids", group_ids)
+        object.__setattr__(
+            self, "group_prior_nominal_probability", group_prior
+        )
+        object.__setattr__(self, "group_composite_weight", group_weight)
+        object.__setattr__(self, "metadata", _validated_metadata(self.metadata))
+
+    def descriptor(self) -> dict[str, Any]:
+        return {
+            "schema_name": OBSERVATION_BELIEF_SCHEMA,
+            "schema_version": OBSERVATION_BELIEF_VERSION,
+            "case_id": self.case_id,
+            "stream_id": self.stream_id,
+            "causal_frame_stop": self.causal_frame_stop,
+            "view_names": list(self.view_names),
+            "window_names": list(self.window_names),
+            "factor_names": list(self.factor_names),
+            "source_repository": self.source_repository,
+            "source_revision": self.source_revision,
+            "source_artifact_sha256": self.source_artifact_sha256,
+            "metadata": self.metadata,
+        }
+
+    def arrays(self) -> dict[str, np.ndarray]:
+        return {
+            "declared_frame_ids": self.declared_frame_ids,
+            "mean_xyz_m": self.mean_xyz_m,
+            "frame_ids": self.frame_ids,
+            "entity_ids": self.entity_ids,
+            "view_indices": self.view_indices,
+            "window_indices": self.window_indices,
+            "correlation_group_ids": self.correlation_group_ids,
+            "factor_group_ids": self.factor_group_ids,
+            "prior_reliability": self.prior_reliability,
+            "association_probability": self.association_probability,
+            "local_covariance_m2": self.local_covariance_m2,
+            "low_rank_factor_m": self.low_rank_factor_m,
+            "group_ids": self.group_ids,
+            "group_prior_nominal_probability": (
+                self.group_prior_nominal_probability
+            ),
+            "group_composite_weight": self.group_composite_weight,
+        }
+
+    @property
+    def artifact_id(self) -> str:
+        """Content address of the descriptor and every numeric array."""
+
+        return _artifact_id(self.descriptor(), self.arrays())
+
+    def summary(self) -> dict[str, Any]:
+        group_sizes = np.asarray(
+            [
+                np.sum(self.correlation_group_ids == group_id)
+                for group_id in self.group_ids
+            ],
+            dtype=np.int64,
+        )
+        return {
+            "artifact_id": self.artifact_id,
+            "schema_name": OBSERVATION_BELIEF_SCHEMA,
+            "schema_version": OBSERVATION_BELIEF_VERSION,
+            "case_id": self.case_id,
+            "stream_id": self.stream_id,
+            "causal_frame_stop": self.causal_frame_stop,
+            "frame_count": int(len(self.declared_frame_ids)),
+            "observation_count": int(len(self.mean_xyz_m)),
+            "group_count": int(len(self.group_ids)),
+            "factor_rank": int(len(self.factor_names)),
+            "minimum_group_size": int(np.min(group_sizes)),
+            "maximum_group_size": int(np.max(group_sizes)),
+            "source_repository": self.source_repository,
+            "source_revision": self.source_revision,
+            "source_artifact_sha256": self.source_artifact_sha256,
+        }
+
+
+def save_observation_belief_export(
+    path: str | Path, artifact: ObservationBeliefExportV1
+) -> None:
+    """Write a non-pickled, content-addressed observation artifact."""
+
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    descriptor = artifact.descriptor()
+    descriptor["artifact_id"] = artifact.artifact_id
+    np.savez_compressed(
+        target,
+        descriptor_json=np.asarray(
+            json.dumps(
+                descriptor,
+                sort_keys=True,
+                separators=(",", ":"),
+                allow_nan=False,
+            )
+        ),
+        **artifact.arrays(),
+    )
+
+
+def load_observation_belief_export(
+    path: str | Path,
+) -> ObservationBeliefExportV1:
+    """Load and fully revalidate a producer-side observation artifact."""
+
+    with np.load(path, allow_pickle=False) as archive:
+        if "descriptor_json" not in archive:
+            raise ValueError("observation artifact has no descriptor_json")
+        descriptor = json.loads(str(archive["descriptor_json"]))
+        if descriptor.get("schema_name") != OBSERVATION_BELIEF_SCHEMA:
+            raise ValueError("unsupported observation-belief schema")
+        if int(descriptor.get("schema_version", -1)) != OBSERVATION_BELIEF_VERSION:
+            raise ValueError("unsupported observation-belief version")
+        arrays = {
+            name: np.asarray(archive[name])
+            for name in archive.files
+            if name != "descriptor_json"
+        }
+    required_arrays = {
+        "declared_frame_ids",
+        "mean_xyz_m",
+        "frame_ids",
+        "entity_ids",
+        "view_indices",
+        "window_indices",
+        "correlation_group_ids",
+        "factor_group_ids",
+        "prior_reliability",
+        "association_probability",
+        "local_covariance_m2",
+        "low_rank_factor_m",
+        "group_ids",
+        "group_prior_nominal_probability",
+        "group_composite_weight",
+    }
+    missing = required_arrays - arrays.keys()
+    extra = arrays.keys() - required_arrays
+    if missing or extra:
+        raise ValueError(
+            "observation artifact arrays changed; "
+            f"missing={sorted(missing)}, extra={sorted(extra)}"
+        )
+    artifact = ObservationBeliefExportV1(
+        case_id=str(descriptor["case_id"]),
+        stream_id=str(descriptor["stream_id"]),
+        causal_frame_stop=int(descriptor["causal_frame_stop"]),
+        view_names=tuple(map(str, descriptor["view_names"])),
+        window_names=tuple(map(str, descriptor["window_names"])),
+        factor_names=tuple(map(str, descriptor["factor_names"])),
+        source_repository=str(descriptor["source_repository"]),
+        source_revision=str(descriptor["source_revision"]),
+        source_artifact_sha256=str(descriptor["source_artifact_sha256"]),
+        metadata=descriptor["metadata"],
+        **arrays,
+    )
+    expected = str(descriptor.get("artifact_id", ""))
+    _validate_sha256(expected, name="artifact_id")
+    if artifact.artifact_id != expected:
+        raise ValueError("observation artifact digest does not match its payload")
+    return artifact
+
+
+def validate_main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate a content-addressed Phys4D observation artifact."
+    )
+    parser.add_argument("artifact", type=Path)
+    arguments = parser.parse_args(argv)
+    artifact = load_observation_belief_export(arguments.artifact)
+    print(json.dumps(artifact.summary(), indent=2, sort_keys=True))
+    return 0
+
+
+__all__ = [
+    "OBSERVATION_BELIEF_SCHEMA",
+    "OBSERVATION_BELIEF_VERSION",
+    "ObservationBeliefExportV1",
+    "array_sha256",
+    "file_sha256",
+    "load_observation_belief_export",
+    "save_observation_belief_export",
+    "validate_main",
+]

--- a/src/prob4d/observation_export.py
+++ b/src/prob4d/observation_export.py
@@ -1,0 +1,934 @@
+"""Export a causally sealed Prob4D prefix as a Phys4D observation belief."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import subprocess
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from .alignment import WindowAlignment, align_windows
+from .data import PredictionWindow
+from .observation_contract import (
+    ObservationBeliefExportV1,
+    file_sha256,
+    save_observation_belief_export,
+)
+from .observation_factors import sim3_point_jacobian
+from .sim3 import Sim3
+from .uncertainty import DepthDisagreementModel, accumulate_disagreement
+
+SOURCE_REPOSITORY = "FlorianPfaff/Prob4D"
+COORDINATE_MODES = ("gauge_relative", "metric_anchored")
+_LINEAGE_SCHEMA_VERSION = 1
+_LINEAGE_MODEL = "motioncrafter_sliding_window_v1"
+_STABLE_CONFIG_KEYS = (
+    "model_type",
+    "unet_path",
+    "vae_path",
+    "height",
+    "width",
+    "window_size",
+    "overlap",
+    "frame_start",
+    "frame_stride",
+    "seed",
+    "num_inference_steps",
+    "guidance_scale",
+)
+
+
+@dataclass(frozen=True)
+class CausalPredictionPrefix:
+    """Only complete overlap windows whose source frames precede the cutoff."""
+
+    manifest_path: Path
+    metadata: Mapping[str, Any]
+    windows: tuple[PredictionWindow, ...]
+    selected_records: tuple[Mapping[str, Any], ...]
+    excluded_records: tuple[Mapping[str, Any], ...]
+    payload_sha256: tuple[str, ...]
+    source_artifact_sha256: str
+    full_manifest_sha256: str
+    causal_frame_stop: int
+    frame_stride: int
+
+
+@dataclass(frozen=True)
+class MetricGaugeAnchor:
+    """Metric prior for the first retained overlap-window gauge."""
+
+    global_from_first_window: Sim3
+    covariance: np.ndarray
+    source_path: Path
+    source_sha256: str
+
+    def __post_init__(self) -> None:
+        covariance = np.asarray(self.covariance, dtype=np.float64)
+        if covariance.shape != (7, 7) or not np.all(np.isfinite(covariance)):
+            raise ValueError("metric-anchor covariance must have finite shape (7, 7)")
+        if not np.allclose(covariance, covariance.T, atol=1e-12, rtol=1e-10):
+            raise ValueError("metric-anchor covariance must be symmetric")
+        if np.any(np.linalg.eigvalsh(0.5 * (covariance + covariance.T)) < -1e-12):
+            raise ValueError("metric-anchor covariance must be positive semidefinite")
+        object.__setattr__(self, "covariance", 0.5 * (covariance + covariance.T))
+
+
+@dataclass(frozen=True)
+class JointGaugeTree:
+    """Causal spanning-tree gauge posterior with full cross-window covariance."""
+
+    window_ids: tuple[str, ...]
+    estimates: Mapping[str, Sim3]
+    joint_covariance: np.ndarray
+    parent_window_ids: tuple[str | None, ...]
+    selected_alignment_indices: tuple[int | None, ...]
+
+    def __post_init__(self) -> None:
+        dimension = 7 * len(self.window_ids)
+        covariance = np.asarray(self.joint_covariance, dtype=np.float64)
+        if covariance.shape != (dimension, dimension):
+            raise ValueError("joint gauge covariance has changed shape")
+        if not np.all(np.isfinite(covariance)):
+            raise ValueError("joint gauge covariance must be finite")
+        symmetric = 0.5 * (covariance + covariance.T)
+        if np.any(np.linalg.eigvalsh(symmetric) < -1e-9):
+            raise ValueError("joint gauge covariance must be positive semidefinite")
+        object.__setattr__(self, "joint_covariance", symmetric)
+
+
+def _canonical_json(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        dict(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _git_revision() -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=Path(__file__).resolve().parents[2],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return "installed-prob4d"
+    return result.stdout.strip() or "installed-prob4d"
+
+
+def _safe_payload_path(root: Path, relative_path: object) -> Path:
+    if not isinstance(relative_path, str) or not relative_path:
+        raise ValueError("overlap-window path must be a nonempty string")
+    candidate = (root / relative_path).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError as error:
+        raise ValueError("overlap-window path escapes the prediction directory") from error
+    return candidate
+
+
+def _validate_overlap_lineage(manifest: Mapping[str, Any]) -> None:
+    lineage = manifest.get("temporal_lineage")
+    if not isinstance(lineage, Mapping):
+        raise ValueError(
+            "prediction manifest lacks temporal_lineage; regenerate it with current Prob4D"
+        )
+    if int(lineage.get("schema_version", -1)) != _LINEAGE_SCHEMA_VERSION:
+        raise ValueError("unsupported temporal-lineage schema version")
+    if lineage.get("model") != _LINEAGE_MODEL:
+        raise ValueError("unsupported temporal-lineage model")
+    products = lineage.get("products")
+    if not isinstance(products, Mapping):
+        raise ValueError("temporal_lineage products must be a mapping")
+    overlap = products.get("overlap_windows")
+    if not isinstance(overlap, Mapping):
+        raise ValueError("temporal_lineage is missing overlap_windows")
+    if overlap.get("window_size_source") != "prediction archive frame count":
+        raise ValueError("unsupported overlap-window source-lineage rule")
+    if int(overlap.get("overlap", -1)) != 0:
+        raise ValueError("overlap-window archives must be independently decoded")
+
+
+def _causal_source_digest(
+    manifest: Mapping[str, Any],
+    records: tuple[Mapping[str, Any], ...],
+    payload_digests: tuple[str, ...],
+    *,
+    causal_frame_stop: int,
+) -> str:
+    config = manifest.get("config")
+    if not isinstance(config, Mapping):
+        raise ValueError("prediction manifest config must be a mapping")
+    selected_config = {
+        key: config[key]
+        for key in _STABLE_CONFIG_KEYS
+        if key in config
+    }
+    descriptor = {
+        "format_version": int(manifest["format_version"]),
+        "motioncrafter_commit": manifest["motioncrafter_commit"],
+        "temporal_lineage": manifest["temporal_lineage"],
+        "config": selected_config,
+        "causal_frame_stop_exclusive": causal_frame_stop,
+        "selected_windows": [
+            {
+                "window_id": str(record["window_id"]),
+                "start_frame": int(record["start_frame"]),
+                "stop_frame": int(record["stop_frame"]),
+                "payload_sha256": payload_digest,
+            }
+            for record, payload_digest in zip(records, payload_digests, strict=True)
+        ],
+    }
+    return hashlib.sha256(_canonical_json(descriptor)).hexdigest()
+
+
+def load_causal_prediction_prefix(
+    manifest_path: str | Path,
+    *,
+    causal_frame_stop: int,
+) -> CausalPredictionPrefix:
+    """Load only complete pre-cutoff overlap windows and never open excluded payloads."""
+
+    if causal_frame_stop < 1:
+        raise ValueError("causal_frame_stop must be positive")
+    path = Path(manifest_path).resolve()
+    manifest = json.loads(path.read_text(encoding="utf-8"))
+    if manifest.get("format_version") != 1:
+        raise ValueError("unsupported prediction-manifest format_version")
+    motioncrafter_commit = manifest.get("motioncrafter_commit")
+    if not isinstance(motioncrafter_commit, str) or not motioncrafter_commit:
+        raise ValueError("prediction manifest must identify the MotionCrafter revision")
+    _validate_overlap_lineage(manifest)
+    config = manifest.get("config")
+    if not isinstance(config, Mapping):
+        raise ValueError("prediction manifest config must be a mapping")
+    frame_stride = int(config.get("frame_stride", 1))
+    if frame_stride < 1:
+        raise ValueError("prediction frame_stride must be positive")
+    raw_records = manifest.get("overlap_windows")
+    if not isinstance(raw_records, list) or not raw_records:
+        raise ValueError("prediction manifest has no overlap windows")
+
+    selected: list[Mapping[str, Any]] = []
+    excluded: list[Mapping[str, Any]] = []
+    seen_ids: set[str] = set()
+    seen_paths: set[str] = set()
+    for raw in raw_records:
+        if not isinstance(raw, Mapping):
+            raise ValueError("overlap-window records must be mappings")
+        window_id = str(raw.get("window_id", ""))
+        relative_path = str(raw.get("path", ""))
+        if not window_id or not relative_path:
+            raise ValueError("overlap-window ID and path must be nonempty")
+        if window_id in seen_ids or relative_path in seen_paths:
+            raise ValueError("overlap-window IDs and paths must be unique")
+        seen_ids.add(window_id)
+        seen_paths.add(relative_path)
+        start_frame = int(raw.get("start_frame", -1))
+        stop_frame = int(raw.get("stop_frame", -1))
+        if start_frame < 0 or stop_frame <= start_frame:
+            raise ValueError("overlap-window source bounds are invalid")
+        record = {
+            "window_id": window_id,
+            "path": relative_path,
+            "start_frame": start_frame,
+            "stop_frame": stop_frame,
+        }
+        if stop_frame <= causal_frame_stop:
+            selected.append(record)
+        else:
+            excluded.append(record)
+    selected.sort(key=lambda item: (int(item["start_frame"]), str(item["window_id"])))
+    excluded.sort(key=lambda item: (int(item["start_frame"]), str(item["window_id"])))
+    if not selected:
+        raise ValueError(
+            "no complete overlap window lies strictly before causal_frame_stop"
+        )
+
+    root = path.parent.resolve()
+    windows: list[PredictionWindow] = []
+    payload_digests: list[str] = []
+    expected_shape: tuple[int, int] | None = None
+    for record in selected:
+        payload = _safe_payload_path(root, record["path"])
+        payload_digest = file_sha256(payload)
+        window = PredictionWindow.from_npz(
+            payload,
+            start_frame=int(record["start_frame"]),
+            window_id=str(record["window_id"]),
+        )
+        expected_frames = np.arange(
+            int(record["start_frame"]),
+            int(record["stop_frame"]),
+            frame_stride,
+            dtype=np.int64,
+        )
+        if not np.array_equal(window.frame_indices, expected_frames):
+            raise ValueError(
+                f"window {window.window_id!r} frame IDs disagree with its manifest bounds"
+            )
+        if int(window.frame_indices[-1]) >= causal_frame_stop:
+            raise ValueError("selected overlap window crosses causal_frame_stop")
+        spatial_shape = window.shape[1:]
+        if expected_shape is None:
+            expected_shape = spatial_shape
+        elif spatial_shape != expected_shape:
+            raise ValueError("causal overlap windows changed spatial resolution")
+        windows.append(window)
+        payload_digests.append(payload_digest)
+
+    selected_tuple = tuple(selected)
+    digest_tuple = tuple(payload_digests)
+    return CausalPredictionPrefix(
+        manifest_path=path,
+        metadata=manifest,
+        windows=tuple(windows),
+        selected_records=selected_tuple,
+        excluded_records=tuple(excluded),
+        payload_sha256=digest_tuple,
+        source_artifact_sha256=_causal_source_digest(
+            manifest,
+            selected_tuple,
+            digest_tuple,
+            causal_frame_stop=causal_frame_stop,
+        ),
+        full_manifest_sha256=file_sha256(path),
+        causal_frame_stop=causal_frame_stop,
+        frame_stride=frame_stride,
+    )
+
+
+def load_metric_gauge_anchor(path: str | Path) -> MetricGaugeAnchor:
+    """Load ``mean`` (Sim(3) vector) and ``covariance`` from a non-pickled NPZ."""
+
+    source = Path(path).resolve()
+    with np.load(source, allow_pickle=False) as archive:
+        required = {"mean", "covariance"}
+        missing = required - set(archive.files)
+        extra = set(archive.files) - required
+        if missing or extra:
+            raise ValueError(
+                "metric-anchor arrays changed; "
+                f"missing={sorted(missing)}, extra={sorted(extra)}"
+            )
+        mean = np.asarray(archive["mean"], dtype=np.float64)
+        covariance = np.asarray(archive["covariance"], dtype=np.float64)
+    if mean.shape != (7,) or not np.all(np.isfinite(mean)):
+        raise ValueError("metric-anchor mean must have finite shape (7,)")
+    return MetricGaugeAnchor(
+        global_from_first_window=Sim3.from_vector(mean),
+        covariance=covariance,
+        source_path=source,
+        source_sha256=file_sha256(source),
+    )
+
+
+def _build_alignments(windows: tuple[PredictionWindow, ...]) -> list[WindowAlignment]:
+    alignments: list[WindowAlignment] = []
+    for moving_index, moving in enumerate(windows):
+        for reference in windows[:moving_index]:
+            if reference.common_frames(moving).size:
+                alignments.append(
+                    align_windows(reference, moving, seed=moving_index)
+                )
+    return alignments
+
+
+def _numerical_jacobian(function, vector: np.ndarray) -> np.ndarray:
+    vector = np.asarray(vector, dtype=np.float64)
+    baseline = np.asarray(function(vector), dtype=np.float64)
+    jacobian = np.empty((baseline.size, vector.size), dtype=np.float64)
+    for index in range(vector.size):
+        step = 1e-6 * max(1.0, abs(float(vector[index])))
+        plus = vector.copy()
+        minus = vector.copy()
+        plus[index] += step
+        minus[index] -= step
+        jacobian[:, index] = (
+            np.asarray(function(plus), dtype=np.float64)
+            - np.asarray(function(minus), dtype=np.float64)
+        ) / (2.0 * step)
+    return jacobian
+
+
+def _compose_jacobians(
+    parent: Sim3,
+    relative: Sim3,
+) -> tuple[np.ndarray, np.ndarray]:
+    parent_vector = parent.as_vector()
+    relative_vector = relative.as_vector()
+    parent_jacobian = _numerical_jacobian(
+        lambda value: Sim3.from_vector(value).compose(relative).as_vector(),
+        parent_vector,
+    )
+    relative_jacobian = _numerical_jacobian(
+        lambda value: parent.compose(Sim3.from_vector(value)).as_vector(),
+        relative_vector,
+    )
+    return parent_jacobian, relative_jacobian
+
+
+def estimate_joint_gauge_tree(
+    windows: tuple[PredictionWindow, ...],
+    alignments: list[WindowAlignment],
+    *,
+    initial_transform: Sim3 | None = None,
+    initial_covariance: np.ndarray | None = None,
+) -> JointGaugeTree:
+    """Estimate a causal spanning tree and propagate its full joint covariance."""
+
+    if not windows:
+        raise ValueError("joint gauge estimation requires at least one window")
+    window_ids = tuple(window.window_id for window in windows)
+    if len(set(window_ids)) != len(window_ids):
+        raise ValueError("window IDs must be unique")
+    position = {window_id: index for index, window_id in enumerate(window_ids)}
+    first_transform = initial_transform or Sim3.identity()
+    first_covariance = (
+        np.zeros((7, 7), dtype=np.float64)
+        if initial_covariance is None
+        else np.asarray(initial_covariance, dtype=np.float64)
+    )
+    if first_covariance.shape != (7, 7):
+        raise ValueError("initial gauge covariance must have shape (7, 7)")
+    first_covariance = 0.5 * (first_covariance + first_covariance.T)
+    if np.any(np.linalg.eigvalsh(first_covariance) < -1e-12):
+        raise ValueError("initial gauge covariance must be positive semidefinite")
+
+    dimension = 7 * len(windows)
+    joint = np.zeros((dimension, dimension), dtype=np.float64)
+    joint[:7, :7] = first_covariance
+    estimates: dict[str, Sim3] = {window_ids[0]: first_transform}
+    parent_ids: list[str | None] = [None]
+    alignment_indices: list[int | None] = [None]
+
+    for child_index, child_id in enumerate(window_ids[1:], start=1):
+        candidates = [
+            (index, alignment)
+            for index, alignment in enumerate(alignments)
+            if alignment.moving_id == child_id
+            and alignment.reference_id in estimates
+        ]
+        if not candidates:
+            raise ValueError(
+                f"window {child_id!r} has no causal overlap with an earlier window"
+            )
+        selected_index, selected = min(
+            candidates,
+            key=lambda item: (
+                -item[1].result.num_correspondences,
+                item[1].result.residual_rms,
+                position[item[1].reference_id],
+            ),
+        )
+        parent_id = selected.reference_id
+        parent_index = position[parent_id]
+        parent = estimates[parent_id]
+        relative = selected.result.transform
+        child = parent.compose(relative)
+        parent_jacobian, relative_jacobian = _compose_jacobians(
+            parent,
+            relative,
+        )
+        parent_slice = slice(7 * parent_index, 7 * (parent_index + 1))
+        child_slice = slice(7 * child_index, 7 * (child_index + 1))
+        for previous_index in range(child_index):
+            previous_slice = slice(7 * previous_index, 7 * (previous_index + 1))
+            cross = parent_jacobian @ joint[parent_slice, previous_slice]
+            joint[child_slice, previous_slice] = cross
+            joint[previous_slice, child_slice] = cross.T
+        child_covariance = (
+            parent_jacobian
+            @ joint[parent_slice, parent_slice]
+            @ parent_jacobian.T
+            + relative_jacobian
+            @ np.asarray(selected.result.covariance, dtype=np.float64)
+            @ relative_jacobian.T
+        )
+        joint[child_slice, child_slice] = 0.5 * (
+            child_covariance + child_covariance.T
+        )
+        estimates[child_id] = child
+        parent_ids.append(parent_id)
+        alignment_indices.append(selected_index)
+
+    symmetric = 0.5 * (joint + joint.T)
+    eigenvalues, eigenvectors = np.linalg.eigh(symmetric)
+    if np.min(eigenvalues) < -1e-7:
+        raise ValueError("propagated joint gauge covariance is not positive semidefinite")
+    joint = (eigenvectors * np.maximum(eigenvalues, 0.0)) @ eigenvectors.T
+    return JointGaugeTree(
+        window_ids=window_ids,
+        estimates=estimates,
+        joint_covariance=joint,
+        parent_window_ids=tuple(parent_ids),
+        selected_alignment_indices=tuple(alignment_indices),
+    )
+
+
+def deterministic_covariance_root(
+    covariance: np.ndarray,
+    *,
+    max_rank: int | None = None,
+    relative_eigenvalue_floor: float = 1e-12,
+) -> tuple[np.ndarray, float]:
+    """Return a deterministic PSD square root and retained trace fraction."""
+
+    matrix = np.asarray(covariance, dtype=np.float64)
+    if matrix.ndim != 2 or matrix.shape[0] != matrix.shape[1]:
+        raise ValueError("covariance root requires a square matrix")
+    if not np.all(np.isfinite(matrix)):
+        raise ValueError("covariance root requires finite values")
+    if max_rank is not None and max_rank < 1:
+        raise ValueError("max_rank must be positive when supplied")
+    if not 0.0 <= relative_eigenvalue_floor < 1.0:
+        raise ValueError("relative_eigenvalue_floor must lie in [0, 1)")
+    symmetric = 0.5 * (matrix + matrix.T)
+    eigenvalues, eigenvectors = np.linalg.eigh(symmetric)
+    if np.min(eigenvalues) < -1e-9:
+        raise ValueError("covariance root requires positive semidefinite input")
+    order = np.argsort(eigenvalues)[::-1]
+    eigenvalues = np.maximum(eigenvalues[order], 0.0)
+    eigenvectors = eigenvectors[:, order]
+    maximum = float(eigenvalues[0]) if len(eigenvalues) else 0.0
+    keep = eigenvalues > maximum * relative_eigenvalue_floor
+    indices = np.flatnonzero(keep)
+    if max_rank is not None:
+        indices = indices[:max_rank]
+    total_trace = float(np.sum(eigenvalues))
+    retained_trace = float(np.sum(eigenvalues[indices]))
+    retained_fraction = 1.0 if total_trace == 0.0 else retained_trace / total_trace
+    selected_vectors = eigenvectors[:, indices].copy()
+    for column in range(selected_vectors.shape[1]):
+        pivot = int(np.argmax(np.abs(selected_vectors[:, column])))
+        if selected_vectors[pivot, column] < 0.0:
+            selected_vectors[:, column] *= -1.0
+    root = selected_vectors * np.sqrt(eigenvalues[indices])[None]
+    return root, retained_fraction
+
+
+def joint_gauge_factor(
+    points_local: np.ndarray,
+    transform: Sim3,
+    joint_root_block: np.ndarray,
+) -> np.ndarray:
+    """Map a joint gauge square-root block into observation coordinates."""
+
+    points = np.asarray(points_local, dtype=np.float64)
+    if points.shape[-1] != 3:
+        raise ValueError("joint gauge factors require three-dimensional points")
+    block = np.asarray(joint_root_block, dtype=np.float64)
+    if block.ndim != 2 or block.shape[0] != 7:
+        raise ValueError("joint_root_block must have shape (7, R)")
+    flattened = points.reshape(-1, 3)
+    jacobian = sim3_point_jacobian(transform, flattened)
+    factor = np.einsum("nij,jr->nir", jacobian, block, optimize=True)
+    return factor.reshape(points.shape + (block.shape[1],))
+
+
+def _prior_reliability(
+    parallel_disagreement: np.ndarray,
+    lateral_disagreement: np.ndarray,
+    parallel_variance: np.ndarray,
+    lateral_variance: np.ndarray,
+    overlap_count: np.ndarray,
+) -> np.ndarray:
+    normalized = (
+        parallel_disagreement / np.maximum(parallel_variance, 1e-12)
+        + lateral_disagreement / np.maximum(lateral_variance, 1e-12)
+    )
+    reliability = np.exp(-0.5 * np.minimum(normalized, 50.0))
+    reliability = np.where(overlap_count > 0.0, reliability, 1.0)
+    return np.clip(reliability, 0.05, 1.0)
+
+
+def _group_metadata(
+    correlation_group_ids: np.ndarray,
+    entity_ids: np.ndarray,
+    prior_reliability: np.ndarray,
+    *,
+    effective_samples_per_group: float,
+    group_prior_quantile: float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    groups = np.asarray(correlation_group_ids, dtype=np.int64)
+    entities = np.asarray(entity_ids, dtype=np.int64)
+    reliability = np.asarray(prior_reliability, dtype=np.float64)
+    if groups.shape != entities.shape or groups.shape != reliability.shape:
+        raise ValueError("group metadata arrays must have matching shapes")
+    if not np.isfinite(effective_samples_per_group) or (
+        effective_samples_per_group <= 0.0
+    ):
+        raise ValueError("effective_samples_per_group must be positive")
+    if not 0.0 <= group_prior_quantile <= 1.0:
+        raise ValueError("group_prior_quantile must lie in [0, 1]")
+    group_ids = np.unique(groups)
+    group_prior = np.empty(len(group_ids), dtype=np.float64)
+    group_weight = np.empty(len(group_ids), dtype=np.float64)
+    for position, group_id in enumerate(group_ids):
+        selected = groups == group_id
+        group_prior[position] = float(
+            np.quantile(reliability[selected], group_prior_quantile)
+        )
+        unique_entities = len(np.unique(entities[selected]))
+        effective = min(effective_samples_per_group, float(unique_entities))
+        group_weight[position] = min(
+            1.0,
+            effective / float(np.sum(selected)),
+        )
+    return group_ids, group_prior, group_weight
+
+
+def _load_uncertainty_model(path: str | Path | None) -> DepthDisagreementModel:
+    if path is None:
+        return DepthDisagreementModel()
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping):
+        raise ValueError("uncertainty-model JSON must contain an object")
+    allowed = set(DepthDisagreementModel.__dataclass_fields__)
+    extra = set(payload) - allowed
+    if extra:
+        raise ValueError(f"unknown uncertainty-model fields: {sorted(extra)}")
+    return DepthDisagreementModel(**{key: float(value) for key, value in payload.items()})
+
+
+def build_prob4d_observation_belief(
+    manifest_path: str | Path,
+    *,
+    case_id: str,
+    causal_frame_stop: int,
+    coordinate_mode: str = "gauge_relative",
+    metric_anchor: MetricGaugeAnchor | None = None,
+    pixel_stride: int = 4,
+    effective_samples_per_group: float = 64.0,
+    group_prior_quantile: float = 0.25,
+    max_gauge_rank: int | None = 64,
+    view_name: str = "camera0",
+    source_revision: str | None = None,
+    uncertainty_model: DepthDisagreementModel | None = None,
+) -> ObservationBeliefExportV1:
+    """Build a canonical artifact after prefix restriction and full re-estimation."""
+
+    if not case_id:
+        raise ValueError("case_id must be nonempty")
+    if coordinate_mode not in COORDINATE_MODES:
+        raise ValueError(f"coordinate_mode must be one of {COORDINATE_MODES}")
+    if coordinate_mode == "metric_anchored" and metric_anchor is None:
+        raise ValueError("metric_anchored export requires a metric gauge anchor")
+    if coordinate_mode == "gauge_relative" and metric_anchor is not None:
+        raise ValueError("metric gauge anchors require coordinate_mode='metric_anchored'")
+    if pixel_stride < 1:
+        raise ValueError("pixel_stride must be positive")
+    if not view_name:
+        raise ValueError("view_name must be nonempty")
+
+    prefix = load_causal_prediction_prefix(
+        manifest_path,
+        causal_frame_stop=causal_frame_stop,
+    )
+    alignments = _build_alignments(prefix.windows)
+    initial_transform = (
+        Sim3.identity()
+        if metric_anchor is None
+        else metric_anchor.global_from_first_window
+    )
+    initial_covariance = (
+        np.zeros((7, 7), dtype=np.float64)
+        if metric_anchor is None
+        else metric_anchor.covariance
+    )
+    gauges = estimate_joint_gauge_tree(
+        prefix.windows,
+        alignments,
+        initial_transform=initial_transform,
+        initial_covariance=initial_covariance,
+    )
+    joint_root, retained_trace_fraction = deterministic_covariance_root(
+        gauges.joint_covariance,
+        max_rank=max_gauge_rank,
+    )
+    rank = joint_root.shape[1]
+    windows_by_id = {window.window_id: window for window in prefix.windows}
+    evidence = accumulate_disagreement(windows_by_id, alignments)
+    model = uncertainty_model or DepthDisagreementModel()
+
+    eligible_frames = sorted(
+        {
+            int(frame)
+            for window in prefix.windows
+            for frame in window.frame_indices
+        }
+    )
+    frame_to_group = {
+        frame: group for group, frame in enumerate(eligible_frames)
+    }
+    means: list[np.ndarray] = []
+    frame_ids: list[np.ndarray] = []
+    entity_ids: list[np.ndarray] = []
+    view_indices: list[np.ndarray] = []
+    window_indices: list[np.ndarray] = []
+    correlation_groups: list[np.ndarray] = []
+    factor_groups: list[np.ndarray] = []
+    reliabilities: list[np.ndarray] = []
+    associations: list[np.ndarray] = []
+    local_covariances: list[np.ndarray] = []
+    factors: list[np.ndarray] = []
+
+    for window_index, window in enumerate(prefix.windows):
+        transform = gauges.estimates[window.window_id]
+        transformed = transform.transform_points(window.point_map)
+        uncertainty = model.predict(window, evidence[window.window_id])
+        conditional_covariance = uncertainty.transformed(transform).matrices()
+        root_block = joint_root[
+            7 * window_index : 7 * (window_index + 1), :
+        ]
+        gauge_factor = joint_gauge_factor(
+            window.point_map,
+            transform,
+            root_block,
+        )
+        reliability = _prior_reliability(
+            evidence[window.window_id].parallel_mean,
+            evidence[window.window_id].lateral_mean,
+            uncertainty.parallel_variance,
+            uncertainty.lateral_variance,
+            evidence[window.window_id].count,
+        )
+        height, width = window.shape[1:]
+        sample_mask = np.zeros((height, width), dtype=bool)
+        sample_mask[::pixel_stride, ::pixel_stride] = True
+        linear_entity = np.arange(height * width, dtype=np.int64).reshape(
+            height, width
+        )
+        for local_index, frame in enumerate(window.frame_indices):
+            absolute_frame = int(frame)
+            selected = window.valid_mask[local_index] & sample_mask
+            if not np.any(selected):
+                continue
+            count = int(np.sum(selected))
+            means.append(transformed[local_index][selected])
+            frame_ids.append(np.full(count, absolute_frame, dtype=np.int64))
+            entity_ids.append(linear_entity[selected])
+            view_indices.append(np.zeros(count, dtype=np.int64))
+            window_indices.append(np.full(count, window_index, dtype=np.int64))
+            correlation_groups.append(
+                np.full(
+                    count,
+                    frame_to_group[absolute_frame],
+                    dtype=np.int64,
+                )
+            )
+            factor_groups.append(np.zeros(count, dtype=np.int64))
+            reliabilities.append(reliability[local_index][selected])
+            associations.append(np.ones(count, dtype=np.float64))
+            local_covariances.append(
+                conditional_covariance[local_index][selected]
+            )
+            factors.append(gauge_factor[local_index][selected])
+
+    if not means:
+        raise ValueError("no valid sampled observation remains in the causal prefix")
+    mean_array = np.concatenate(means)
+    frame_array = np.concatenate(frame_ids)
+    entity_array = np.concatenate(entity_ids)
+    view_array = np.concatenate(view_indices)
+    window_array = np.concatenate(window_indices)
+    correlation_array = np.concatenate(correlation_groups)
+    factor_group_array = np.concatenate(factor_groups)
+    reliability_array = np.concatenate(reliabilities)
+    association_array = np.concatenate(associations)
+    local_covariance_array = np.concatenate(local_covariances)
+    factor_array = np.concatenate(factors)
+    group_ids, group_prior, group_weight = _group_metadata(
+        correlation_array,
+        entity_array,
+        reliability_array,
+        effective_samples_per_group=effective_samples_per_group,
+        group_prior_quantile=group_prior_quantile,
+    )
+
+    alignment_records = []
+    for index, alignment in enumerate(alignments):
+        alignment_records.append(
+            {
+                "index": index,
+                "reference_id": alignment.reference_id,
+                "moving_id": alignment.moving_id,
+                "common_frames": [int(value) for value in alignment.common_frames],
+                "residual_rms": float(alignment.result.residual_rms),
+                "num_correspondences": int(alignment.result.num_correspondences),
+                "covariance_method": alignment.result.covariance_method,
+                "selected_for_gauge_tree": index
+                in {
+                    value
+                    for value in gauges.selected_alignment_indices
+                    if value is not None
+                },
+            }
+        )
+    anchor_metadata: dict[str, Any] | None = None
+    if metric_anchor is not None:
+        anchor_metadata = {
+            "source_sha256": metric_anchor.source_sha256,
+            "mean": metric_anchor.global_from_first_window.as_vector().tolist(),
+            "covariance": metric_anchor.covariance.tolist(),
+        }
+    source_revision_value = source_revision or _git_revision()
+    selected_window_records = [
+        {
+            "window_id": str(record["window_id"]),
+            "start_frame": int(record["start_frame"]),
+            "stop_frame": int(record["stop_frame"]),
+            "payload_sha256": payload_sha,
+        }
+        for record, payload_sha in zip(
+            prefix.selected_records,
+            prefix.payload_sha256,
+            strict=True,
+        )
+    ]
+    stream_suffix = "metric" if coordinate_mode == "metric_anchored" else "gauge-relative"
+    return ObservationBeliefExportV1(
+        case_id=case_id,
+        stream_id=f"prob4d:{stream_suffix}:overlap-window-points",
+        causal_frame_stop=causal_frame_stop,
+        view_names=(view_name,),
+        window_names=gauges.window_ids,
+        factor_names=tuple(
+            f"joint_gauge_latent_{index:04d}" for index in range(rank)
+        ),
+        source_repository=SOURCE_REPOSITORY,
+        source_revision=source_revision_value,
+        source_artifact_sha256=prefix.source_artifact_sha256,
+        declared_frame_ids=np.asarray(eligible_frames, dtype=np.int64),
+        mean_xyz_m=mean_array,
+        frame_ids=frame_array,
+        entity_ids=entity_array,
+        view_indices=view_array,
+        window_indices=window_array,
+        correlation_group_ids=correlation_array,
+        factor_group_ids=factor_group_array,
+        prior_reliability=reliability_array,
+        association_probability=association_array,
+        local_covariance_m2=local_covariance_array,
+        low_rank_factor_m=factor_array,
+        group_ids=group_ids,
+        group_prior_nominal_probability=group_prior,
+        group_composite_weight=group_weight,
+        metadata={
+            "coordinate_mode": coordinate_mode,
+            "coordinate_units": (
+                "m" if coordinate_mode == "metric_anchored" else "gauge_unit"
+            ),
+            "metric_claim_authorized": coordinate_mode == "metric_anchored",
+            "metric_gauge_anchor": anchor_metadata,
+            "causal_information_boundary": {
+                "causal_frame_stop_exclusive": causal_frame_stop,
+                "maximum_source_frame_read": max(eligible_frames),
+                "selected_complete_window_count": len(prefix.windows),
+                "excluded_future_payloads_opened": 0,
+                "admissibility_rule": "window_stop_frame <= causal_frame_stop_exclusive",
+                "selected_windows": selected_window_records,
+            },
+            "source_inputs": {
+                "causal_source_artifact_sha256": prefix.source_artifact_sha256,
+                "motioncrafter_commit": prefix.metadata["motioncrafter_commit"],
+                "prediction_manifest_format_version": prefix.metadata["format_version"],
+            },
+            "gauge_posterior": {
+                "model": "causal_spanning_tree_joint_covariance_v1",
+                "window_count": len(gauges.window_ids),
+                "full_dimension": int(gauges.joint_covariance.shape[0]),
+                "exported_factor_rank": rank,
+                "retained_covariance_trace_fraction": retained_trace_fraction,
+                "max_gauge_rank": max_gauge_rank,
+                "cross_window_covariance_preserved": True,
+                "parent_window_ids": list(gauges.parent_window_ids),
+                "alignments": alignment_records,
+            },
+            "observation_model": {
+                "pixel_stride": pixel_stride,
+                "group_definition": "absolute source frame across overlap windows",
+                "factor_group_definition": "one shared joint-gauge latent vector",
+                "association_probability_definition": "one for retained valid pixels",
+                "prior_reliability_definition": (
+                    "overlap disagreement only; independent of physical innovation"
+                ),
+                "effective_samples_per_group": effective_samples_per_group,
+                "group_prior_quantile": group_prior_quantile,
+                "conditional_covariance_excludes_gauge_uncertainty": True,
+                "uncertainty_model": {
+                    key: float(getattr(model, key))
+                    for key in DepthDisagreementModel.__dataclass_fields__
+                },
+            },
+        },
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("predictions_manifest", type=Path)
+    parser.add_argument("output_npz", type=Path)
+    parser.add_argument("--case-id", required=True)
+    parser.add_argument(
+        "--causal-frame-stop-exclusive",
+        "--causal-frame-stop",
+        dest="causal_frame_stop",
+        type=int,
+        required=True,
+    )
+    parser.add_argument(
+        "--coordinate-mode",
+        choices=COORDINATE_MODES,
+        default="gauge_relative",
+    )
+    parser.add_argument("--metric-anchor", type=Path)
+    parser.add_argument("--pixel-stride", type=int, default=4)
+    parser.add_argument("--effective-samples-per-group", type=float, default=64.0)
+    parser.add_argument("--group-prior-quantile", type=float, default=0.25)
+    parser.add_argument("--max-gauge-rank", type=int, default=64)
+    parser.add_argument("--view-name", default="camera0")
+    parser.add_argument("--source-revision")
+    parser.add_argument("--uncertainty-json", type=Path)
+    arguments = parser.parse_args(argv)
+
+    anchor = (
+        None
+        if arguments.metric_anchor is None
+        else load_metric_gauge_anchor(arguments.metric_anchor)
+    )
+    artifact = build_prob4d_observation_belief(
+        arguments.predictions_manifest,
+        case_id=arguments.case_id,
+        causal_frame_stop=arguments.causal_frame_stop,
+        coordinate_mode=arguments.coordinate_mode,
+        metric_anchor=anchor,
+        pixel_stride=arguments.pixel_stride,
+        effective_samples_per_group=arguments.effective_samples_per_group,
+        group_prior_quantile=arguments.group_prior_quantile,
+        max_gauge_rank=arguments.max_gauge_rank,
+        view_name=arguments.view_name,
+        source_revision=arguments.source_revision,
+        uncertainty_model=_load_uncertainty_model(arguments.uncertainty_json),
+    )
+    save_observation_belief_export(arguments.output_npz, artifact)
+    summary = artifact.summary()
+    summary["coordinate_mode"] = artifact.metadata["coordinate_mode"]
+    summary["output"] = str(arguments.output_npz.resolve())
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_observation_contract.py
+++ b/tests/test_observation_contract.py
@@ -1,0 +1,112 @@
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from prob4d.observation_contract import (
+    ObservationBeliefExportV1,
+    load_observation_belief_export,
+    save_observation_belief_export,
+)
+
+GOLDEN_ARTIFACT_ID = (
+    "9c02e638f60424cca7738d347d1258acd208eb562f422efacd077db4edb2fe80"
+)
+
+
+def _artifact() -> ObservationBeliefExportV1:
+    local = np.repeat(np.eye(3)[None], 4, axis=0) * 1e-4
+    factors = np.zeros((4, 3, 2))
+    factors[:2, 0, 0] = 0.002
+    factors[2:, 1, 1] = 0.003
+    return ObservationBeliefExportV1(
+        case_id="case-1",
+        stream_id="prob4d:points",
+        causal_frame_stop=12,
+        view_names=("camera0",),
+        window_names=("window0", "window1"),
+        factor_names=("gauge_latent_0", "gauge_latent_1"),
+        source_repository="FlorianPfaff/Prob4D",
+        source_revision="a" * 40,
+        source_artifact_sha256="b" * 64,
+        declared_frame_ids=np.asarray([8, 9]),
+        mean_xyz_m=np.asarray(
+            [
+                [0.0, 0.0, 1.0],
+                [1.0, 0.0, 1.0],
+                [0.1, 0.0, 1.0],
+                [1.1, 0.0, 1.0],
+            ]
+        ),
+        frame_ids=np.asarray([8, 8, 9, 9]),
+        entity_ids=np.asarray([0, 1, 0, 1]),
+        view_indices=np.zeros(4, dtype=int),
+        window_indices=np.asarray([0, 0, 1, 1]),
+        correlation_group_ids=np.asarray([0, 0, 1, 1]),
+        factor_group_ids=np.asarray([0, 0, 1, 1]),
+        prior_reliability=np.asarray([0.9, 0.8, 0.7, 0.6]),
+        association_probability=np.ones(4),
+        local_covariance_m2=local,
+        low_rank_factor_m=factors,
+        group_ids=np.asarray([0, 1]),
+        group_prior_nominal_probability=np.asarray([0.85, 0.65]),
+        group_composite_weight=np.asarray([0.5, 0.5]),
+        metadata={"causal_source": "prefix only"},
+    )
+
+
+def test_contract_matches_cross_repository_golden_digest(tmp_path: Path) -> None:
+    artifact = _artifact()
+    assert artifact.artifact_id == GOLDEN_ARTIFACT_ID
+    path = tmp_path / "observation.npz"
+    save_observation_belief_export(path, artifact)
+    loaded = load_observation_belief_export(path)
+    assert loaded.artifact_id == GOLDEN_ARTIFACT_ID
+    np.testing.assert_array_equal(loaded.mean_xyz_m, artifact.mean_xyz_m)
+
+
+def test_contract_rejects_future_frame() -> None:
+    artifact = _artifact()
+    with pytest.raises(ValueError, match="causal_frame_stop"):
+        ObservationBeliefExportV1(
+            **{
+                **artifact.__dict__,
+                "declared_frame_ids": np.asarray([8, 12]),
+                "frame_ids": np.asarray([8, 8, 12, 12]),
+            }
+        )
+
+
+def test_contract_rejects_duplicate_observation_identity() -> None:
+    artifact = _artifact()
+    with pytest.raises(ValueError, match="must be unique"):
+        ObservationBeliefExportV1(
+            **{
+                **artifact.__dict__,
+                "entity_ids": np.asarray([0, 0, 0, 1]),
+            }
+        )
+
+
+def test_loader_rejects_descriptor_tampering(tmp_path: Path) -> None:
+    source = tmp_path / "observation.npz"
+    tampered = tmp_path / "tampered.npz"
+    save_observation_belief_export(source, _artifact())
+    with np.load(source, allow_pickle=False) as archive:
+        descriptor = json.loads(str(archive["descriptor_json"]))
+        arrays = {
+            name: np.asarray(archive[name])
+            for name in archive.files
+            if name != "descriptor_json"
+        }
+    descriptor["case_id"] = "changed"
+    np.savez_compressed(
+        tampered,
+        descriptor_json=np.asarray(
+            json.dumps(descriptor, sort_keys=True, separators=(",", ":"))
+        ),
+        **arrays,
+    )
+    with pytest.raises(ValueError, match="digest does not match"):
+        load_observation_belief_export(tampered)

--- a/tests/test_observation_export.py
+++ b/tests/test_observation_export.py
@@ -1,0 +1,200 @@
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from prob4d.data import PredictionWindow
+from prob4d.observation_export import (
+    _group_metadata,
+    build_prob4d_observation_belief,
+    deterministic_covariance_root,
+    joint_gauge_factor,
+    load_metric_gauge_anchor,
+)
+from prob4d.observation_factors import sim3_point_jacobian
+from prob4d.sim3 import Sim3
+
+
+def _lineage(window_size: int = 2, overlap: int = 1) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "model": "motioncrafter_sliding_window_v1",
+        "frame_index_source": "prediction archive frame_indices",
+        "source_bounds": "inclusive source-video frame identifiers",
+        "products": {
+            "disjoint_baseline": {"window_size": window_size, "overlap": 0},
+            "latent_linear_baseline": {
+                "window_size": window_size,
+                "overlap": overlap,
+            },
+            "overlap_windows": {
+                "window_size_source": "prediction archive frame count",
+                "overlap": 0,
+            },
+        },
+    }
+
+
+def _points(offset: float = 0.0) -> np.ndarray:
+    values = np.zeros((2, 2, 2, 3), dtype=np.float64)
+    values[..., 0] = np.asarray([[0.0, 1.0], [0.2, 1.2]])
+    values[..., 1] = np.asarray([[0.0, 0.1], [1.0, 1.1]])
+    values[..., 2] = 1.0
+    values[1, ..., 0] += 0.1
+    values += offset
+    return values
+
+
+def _write_prefix_fixture(root: Path, *, future_payload: bytes = b"not an npz") -> Path:
+    (root / "windows").mkdir(parents=True)
+    PredictionWindow(
+        window_id="window_0000",
+        frame_indices=np.asarray([0, 1]),
+        point_map=_points(),
+        valid_mask=np.ones((2, 2, 2), dtype=bool),
+    ).to_npz(root / "windows" / "window_0000.npz")
+    (root / "windows" / "window_0001.npz").write_bytes(future_payload)
+    manifest = {
+        "format_version": 1,
+        "motioncrafter_commit": "c" * 40,
+        "config": {
+            "model_type": "determ",
+            "window_size": 2,
+            "overlap": 1,
+            "frame_start": 0,
+            "frame_stop": 3,
+            "frame_stride": 1,
+            "seed": 7,
+        },
+        "temporal_lineage": _lineage(),
+        "overlap_windows": [
+            {
+                "window_id": "window_0000",
+                "path": "windows/window_0000.npz",
+                "start_frame": 0,
+                "stop_frame": 2,
+            },
+            {
+                "window_id": "window_0001",
+                "path": "windows/window_0001.npz",
+                "start_frame": 1,
+                "stop_frame": 3,
+            },
+        ],
+        "disjoint_baseline": "unread-disjoint.npz",
+        "latent_linear_baseline": "unread-latent.npz",
+    }
+    path = root / "predictions.json"
+    path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def _build(manifest: Path, **kwargs):
+    return build_prob4d_observation_belief(
+        manifest,
+        case_id="case-a",
+        causal_frame_stop=2,
+        pixel_stride=1,
+        source_revision="a" * 40,
+        **kwargs,
+    )
+
+
+def test_export_never_opens_excluded_future_payload(tmp_path: Path) -> None:
+    manifest = _write_prefix_fixture(tmp_path)
+    first = _build(manifest)
+    assert first.metadata["causal_information_boundary"][
+        "excluded_future_payloads_opened"
+    ] == 0
+    (tmp_path / "windows" / "window_0001.npz").write_bytes(b"changed future")
+    second = _build(manifest)
+    assert second.artifact_id == first.artifact_id
+
+
+def test_export_digest_changes_when_selected_payload_changes(tmp_path: Path) -> None:
+    manifest = _write_prefix_fixture(tmp_path)
+    first = _build(manifest)
+    PredictionWindow(
+        window_id="window_0000",
+        frame_indices=np.asarray([0, 1]),
+        point_map=_points(offset=0.5),
+        valid_mask=np.ones((2, 2, 2), dtype=bool),
+    ).to_npz(tmp_path / "windows" / "window_0000.npz")
+    second = _build(manifest)
+    assert second.artifact_id != first.artifact_id
+    assert second.source_artifact_sha256 != first.source_artifact_sha256
+
+
+def test_manifest_bounds_must_match_selected_archive(tmp_path: Path) -> None:
+    manifest = _write_prefix_fixture(tmp_path)
+    payload = json.loads(manifest.read_text(encoding="utf-8"))
+    payload["overlap_windows"][0]["start_frame"] = 1
+    manifest.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError, match="frame IDs disagree"):
+        _build(manifest)
+
+
+def test_metric_export_requires_and_records_anchor(tmp_path: Path) -> None:
+    manifest = _write_prefix_fixture(tmp_path)
+    with pytest.raises(ValueError, match="requires a metric gauge anchor"):
+        _build(manifest, coordinate_mode="metric_anchored")
+    anchor_path = tmp_path / "anchor.npz"
+    mean = np.asarray([0.0, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0])
+    covariance = np.eye(7) * 1e-4
+    np.savez_compressed(anchor_path, mean=mean, covariance=covariance)
+    anchor = load_metric_gauge_anchor(anchor_path)
+    artifact = _build(
+        manifest,
+        coordinate_mode="metric_anchored",
+        metric_anchor=anchor,
+    )
+    assert artifact.metadata["coordinate_mode"] == "metric_anchored"
+    assert artifact.metadata["metric_claim_authorized"] is True
+    assert artifact.metadata["metric_gauge_anchor"]["source_sha256"]
+    assert np.min(artifact.mean_xyz_m[:, 2]) > 3.0
+
+
+def test_joint_gauge_factor_preserves_cross_window_covariance() -> None:
+    generator = np.random.default_rng(7)
+    basis = generator.normal(size=(14, 5))
+    covariance = basis @ basis.T
+    root, retained = deterministic_covariance_root(covariance, max_rank=None)
+    first_point = np.asarray([[1.0, 0.2, 0.3]])
+    second_point = np.asarray([[0.1, 1.2, 0.4]])
+    first_factor = joint_gauge_factor(
+        first_point, Sim3.identity(), root[:7]
+    )[0]
+    second_factor = joint_gauge_factor(
+        second_point, Sim3.identity(), root[7:]
+    )[0]
+    first_jacobian = sim3_point_jacobian(Sim3.identity(), first_point)[0]
+    second_jacobian = sim3_point_jacobian(Sim3.identity(), second_point)[0]
+    expected = first_jacobian @ covariance[:7, 7:] @ second_jacobian.T
+    np.testing.assert_allclose(first_factor @ second_factor.T, expected, atol=1e-10)
+    assert retained == pytest.approx(1.0)
+
+
+def test_group_composite_weight_caps_duplicate_information() -> None:
+    groups = np.zeros(8, dtype=np.int64)
+    entities = np.tile(np.arange(4, dtype=np.int64), 2)
+    reliability = np.ones(8)
+    _, _, weight = _group_metadata(
+        groups,
+        entities,
+        reliability,
+        effective_samples_per_group=2.0,
+        group_prior_quantile=0.25,
+    )
+    duplicated_groups = np.tile(groups, 2)
+    duplicated_entities = np.tile(entities, 2)
+    duplicated_reliability = np.tile(reliability, 2)
+    _, _, duplicated_weight = _group_metadata(
+        duplicated_groups,
+        duplicated_entities,
+        duplicated_reliability,
+        effective_samples_per_group=2.0,
+        group_prior_quantile=0.25,
+    )
+    assert weight[0] * len(groups) == pytest.approx(2.0)
+    assert duplicated_weight[0] * len(duplicated_groups) == pytest.approx(2.0)


### PR DESCRIPTION
## What changed

- add the canonical, content-addressed `phys4d.observation_belief` version-1 producer contract and validator;
- add `prob4d-export-observation`, which reads lineage metadata first and opens only independently decoded overlap-window payloads whose complete source interval precedes the exclusive cutoff;
- rerun alignment, gauge estimation, overlap-disagreement accumulation, uncertainty construction, and row export solely from that retained causal prefix;
- make the causal source digest depend on the selected manifest subset and selected payload bytes, while excluding suffix payloads and machine-specific paths;
- propagate a full joint cross-window gauge covariance through a causal spanning tree and export it as one shared low-rank factor;
- keep association probability separate from residual-independent prior reliability and cap repeated frame/window evidence with composite-likelihood weights;
- distinguish `gauge_relative` from `metric_anchored` coordinates and require a checksummed independent `Sim(3)` prior before authorizing metric claims;
- retain conditional point covariance separately from gauge uncertainty to prevent double counting;
- add exact contract round-trip validation, cross-repository golden-digest coverage, suffix-perturbation invariance, selected-input tamper sensitivity, metric-gate, joint-covariance, and duplicate-information regression tests;
- expand CI to Ruff, Python 3.10/3.12/3.14, wheel/sdist validation, isolated wheel import, and installed CLI `--help` smoke tests.

## Why

The earlier observation-export prototype filtered rows after loading and processing the full prediction bundle. A nominally pre-cutoff row could therefore inherit gauge or disagreement information from a window that also consumed future RGB. In addition, independent per-window gauge factors discarded posterior correlations induced by shared relative constraints.

The new exporter fails closed before excluded payloads are opened, recomputes every derived quantity from the admitted prefix, and represents the resulting joint gauge dependence explicitly.

## User and research impact

Bayesian-PhysTwin can consume a portable Prob4D observation artifact with exact causal, covariance, reliability, coordinate, and provenance semantics. The producer contract uses the same golden content address as Bayesian-PhysTwin. Causal4D remains downstream of the selected Bayesian-PhysTwin belief; this change deliberately does not add a direct Prob4D-to-Causal4D inference path.

Gauge-relative artifacts are explicitly non-metric. Metric updates require a separately checksummed anchor and carry its mean and covariance in the artifact content address.

## Validation

- focused local suites: `10 passed`;
- Python byte compilation: passed;
- cross-repository golden artifact ID: `9c02e638f60424cca7738d347d1258acd208eb562f422efacd077db4edb2fe80`;
- GitHub Actions `Tests` run 173: passed;
- Ruff: passed;
- complete pytest suite: passed on Python 3.10, 3.12, and 3.14;
- wheel and source distribution build: passed;
- Twine metadata validation: passed;
- isolated built-wheel import and every installed CLI's `--help`: passed;
- branch is current with `main`, including merged causal-lineage PR #5, and is mergeable without conflicts.