### PR TITLE
Export causally sealed portable observation beliefs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,44 @@ It also records a versioned temporal-lineage contract for MotionCrafter's
 internal sliding windows. Causal consumers can therefore determine the exact
 source-frame bounds and contributing internal windows for any output frame.
 
+### Portable Bayesian observation export
+
+First bind a prefix-only metric calibration to the exact first retained window:
+
+```bash
+prob4d-create-metric-gauge-anchor \
+  outputs/sequence_name/predictions.json \
+  outputs/sequence_name/metric_gauge_anchor.json \
+  --case-id sequence_name \
+  --world-frame-id phystwin-world \
+  --reference-window-id window_0000 \
+  --calibration-artifact outputs/sequence_name/prefix_registration.json \
+  --sim3-vector LOG_SCALE RX RY RZ TX TY TZ
+```
+
+Then export the provider-neutral observation artifact consumed by
+Bayesian-PhysTwin and independently validated by Causal4D:
+
+```bash
+prob4d-export-observation-belief \
+  outputs/sequence_name/predictions.json \
+  outputs/sequence_name/observation_belief.npz \
+  --case-id sequence_name \
+  --causal-frame-stop 134 \
+  --metric-gauge-anchor outputs/sequence_name/metric_gauge_anchor.json \
+  --summary-json outputs/sequence_name/observation_belief_summary.json
+```
+
+The exporter opens only independently decoded windows wholly before the
+exclusive cutoff, then recomputes alignment, gauge estimation, overlap
+disagreement, uncertainty, and residual-independent reliability on that prefix.
+Appending post-cutoff windows cannot change the exported artifact ID.
+Association probability remains separate from prior reliability, and gauge
+uncertainty is represented as shared low-rank factors rather than counted again
+inside each local covariance. The portable version-1 contract requires a fixed
+global metric anchor; use `ObservationFactorBundle` when that anchor must remain
+uncertain. See [the causal observation export contract](docs/observation-belief-export.md).
+
 Prepare a separate calibration sequence and world-coordinate truth files, then
 run the real ablation:
 

--- a/docs/data-format.md
+++ b/docs/data-format.md
@@ -68,6 +68,54 @@ video frame IDs directly into every baseline and overlap window. PhysTwin
 evaluation requires these absolute IDs because its calibration, depth frames,
 manual tracks, and physical trajectories all use the original sequence index.
 
+## Portable Observation Belief
+
+`prob4d-export-observation-belief` writes the provider-neutral
+`phys4d.observation_belief` version-1 NPZ consumed by Bayesian-PhysTwin and
+validated independently by Causal4D. Its descriptor and every array name, dtype,
+shape, and byte payload are covered by one artifact ID.
+
+The exporter admits only independently decoded overlap windows whose complete
+source interval lies before the exclusive `causal_frame_stop`. It decides
+admissibility from manifest metadata before opening prediction payloads and then
+recomputes alignment, gauge estimation, overlap disagreement, uncertainty, and
+prior reliability on the admitted prefix.
+
+A content-addressed fixed metric anchor for the first retained window is
+mandatory before coordinates can be labelled in metres. Portable version 1
+cannot represent a nonzero global-anchor covariance together with one relative
+gauge factor per window without increasing the shared factor rank. Use
+`ObservationFactorBundle` when the global anchor must remain uncertain.
+
+The arrays are:
+
+| Field | Shape | Meaning |
+| --- | --- | --- |
+| `declared_frame_ids` | `F` | Sorted absolute frames authorized by the artifact |
+| `mean_xyz_m` | `N x 3` | Metric observation means |
+| `frame_ids` | `N` | Absolute frame identity per row |
+| `entity_ids` | `N` | Dense pixel/entity identity per row |
+| `view_indices` | `N` | Index into descriptor `view_names` |
+| `window_indices` | `N` | Index into descriptor `window_names` |
+| `correlation_group_ids` | `N` | Effective composite-likelihood group |
+| `factor_group_ids` | `N` | Shared gauge-latent group |
+| `prior_reliability` | `N` | Residual-independent nominal-source support |
+| `association_probability` | `N` | Association support, separate from reliability |
+| `local_covariance_m2` | `N x 3 x 3` | Conditional covariance in square metres |
+| `low_rank_factor_m` | `N x 3 x R` | Shared coherent gauge/window factor |
+| `group_ids` | `G` | Sorted effective group IDs |
+| `group_prior_nominal_probability` | `G` | Prior nominal probability per group |
+| `group_composite_weight` | `G` | Information-cap weight in `(0, 1]` |
+
+For a row assigned to window gauge `k`, the exported factor is
+`U_i = J_i L_k`, with `L_k L_k^T = Sigma_gauge,k`. A downstream estimator that
+keeps these factors as explicit nuisance variables must use
+`local_covariance_m2` without adding the gauge marginal again.
+
+See [the causal export contract](observation-belief-export.md) for the fixed
+metric-anchor schema, append-invariant source digest, command, and claim
+boundary.
+
 ## Ground Truth
 
 Real evaluation expects a compressed NumPy archive with:

--- a/docs/observation-belief-export.md
+++ b/docs/observation-belief-export.md
@@ -1,0 +1,110 @@
+# Causally sealed observation-belief export
+
+Prob4D can expose independently decoded MotionCrafter windows through the
+provider-neutral `phys4d.observation_belief` version-1 artifact consumed by
+Bayesian-PhysTwin and validated independently by Causal4D.
+
+The export is deliberately distinct from the reconstruction products. A window
+is admissible only when its complete independently decoded source interval lies
+before an exclusive causal cutoff. The exporter reads manifest metadata first,
+opens only admitted payloads, and then recomputes alignment, gauge estimation,
+overlap disagreement, uncertainty, and prior reliability on that admitted
+prefix. It never estimates on the full sequence and slices the final rows.
+
+## Fixed metric gauge anchor
+
+MotionCrafter points have an unresolved global `Sim(3)` gauge. An artifact whose
+coordinates and covariance are labelled in metres therefore requires an
+independent metric calibration for the first retained overlap window.
+
+The portable version-1 artifact uses one seven-dimensional coherent factor per
+window. A nonzero global-anchor covariance would require an additional latent
+factor shared by every window and would make the compact factor rank grow with
+the number of windows. Consequently, the portable exporter accepts only a
+**fixed** metric anchor. Use `ObservationFactorBundle` instead when the global
+metric anchor must remain uncertain.
+
+Create a content-addressed fixed anchor after fitting a prefix-only calibration:
+
+```bash
+prob4d-create-metric-gauge-anchor \
+  outputs/sequence/predictions.json \
+  outputs/sequence/metric_gauge_anchor.json \
+  --case-id sequence \
+  --world-frame-id phystwin-world \
+  --reference-window-id window_0000 \
+  --calibration-artifact outputs/sequence/prefix_registration.json \
+  --sim3-vector LOG_SCALE RX RY RZ TX TY TZ
+```
+
+The anchor binds the exact independently decoded reference-window payload and
+the calibration artifact by SHA-256. It does not hash or open later prediction
+windows. The calibration must use only information authorized before the causal
+cutoff. Simulated benchmark truth may be used only for an explicitly labelled
+sensor-assisted ablation, not for a monocular claim.
+
+## Export command
+
+```bash
+prob4d-export-observation-belief \
+  outputs/sequence/predictions.json \
+  outputs/sequence/observation_belief.npz \
+  --case-id sequence \
+  --causal-frame-stop 134 \
+  --metric-gauge-anchor outputs/sequence/metric_gauge_anchor.json \
+  --pixel-stride 4 \
+  --summary-json outputs/sequence/observation_belief_summary.json
+```
+
+`--causal-frame-stop` is exclusive. An overlap-window manifest entry is admitted
+only when its declared stop is no later than the cutoff and its payload contains
+the exact absolute frame IDs implied by the declared bounds and frame stride.
+Unknown lineage schemas, path traversal, inconsistent frame IDs, non-prefix
+window selections, anchor/payload mismatches, and uncertain global anchors fail
+closed.
+
+When Prob4D is run outside its Git checkout, pass `--source-revision` explicitly
+so the artifact retains an exact producer revision.
+
+## Artifact semantics
+
+The archive contains metric 3-D means, full conditional `3 x 3` covariance,
+absolute frame/entity/view/window identities, separate association probability
+and prior reliability, effective correlation groups, and composite-likelihood
+weights. For row `i` assigned to window gauge `k`, the shared low-rank factor is
+
+```text
+U_i = J_i L_k,       Sigma_gauge,k = L_k L_k^T.
+```
+
+A consumer that keeps these gauge terms as explicit nuisance variables must use
+`local_covariance_m2` and must not add `U_i U_i^T` again. Association probability
+records support for the decoded pixel identity. Prior reliability is derived
+from overlap disagreement without reading the downstream physical innovation.
+
+The current compact export retains one marginal relative-gauge factor per
+window. Remaining cross-window dependence is not asserted away; frame-level
+composite-likelihood weights cap repeated evidence. A future joint sparse gauge
+posterior can replace this approximation without changing the causal source
+selection rule.
+
+## Content addressing and append invariance
+
+The descriptor, every array name, dtype, shape, and byte payload are covered by
+the observation artifact ID. The causal source digest covers only admitted
+payload hashes, admitted source bounds, stable prediction-affecting settings,
+MotionCrafter revision, temporal-lineage declaration, and the metric-anchor ID.
+
+Appending post-cutoff windows therefore cannot change a previously valid prefix
+artifact. The operational summary may report how many future or crossing
+manifest entries were skipped, but that post-cutoff bookkeeping is intentionally
+excluded from the artifact content address. Future or crossing prediction
+payloads are not opened.
+
+## Cross-repository checks
+
+Prob4D, Bayesian-PhysTwin, and Causal4D share a golden contract fixture. The same
+artifact must have the same content address in all three repositories.
+Bayesian-PhysTwin consumes the low-rank gauge factors as nuisance parameters,
+while Causal4D can bind the resulting selected twin belief to the exact
+observation artifact without importing Prob4D.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ dev = [
 [project.scripts]
 prob4d-ablate = "prob4d.experiments:main"
 prob4d-benchmark = "prob4d.benchmark:main"
+prob4d-create-metric-gauge-anchor = "prob4d.metric_anchor:main"
+prob4d-export-observation-belief = "prob4d.observation_export:main"
 prob4d-motioncrafter = "prob4d.motioncrafter:main"
 prob4d-phystwin = "prob4d.phystwin_experiment:main"
 prob4d-phystwin-state = "prob4d.phystwin_state:main"

--- a/src/prob4d/__init__.py
+++ b/src/prob4d/__init__.py
@@ -1,6 +1,18 @@
 """Probabilistic long-horizon fusion for MotionCrafter predictions."""
 
 from .data import PredictionWindow
+from .metric_anchor import (
+    MetricGaugeAnchorV1,
+    load_metric_gauge_anchor,
+    save_metric_gauge_anchor,
+)
+from .observation_contract import (
+    OBSERVATION_BELIEF_SCHEMA,
+    OBSERVATION_BELIEF_VERSION,
+    ObservationBeliefExportV1,
+    save_observation_belief_export,
+)
+from .observation_export import build_prob4d_observation_belief
 from .observation_factors import (
     LinearizedObservationFactor,
     ObservationFactor,
@@ -13,13 +25,21 @@ from .observation_factors import (
 from .sim3 import Sim3
 
 __all__ = [
+    "OBSERVATION_BELIEF_SCHEMA",
+    "OBSERVATION_BELIEF_VERSION",
     "LinearizedObservationFactor",
+    "MetricGaugeAnchorV1",
+    "ObservationBeliefExportV1",
     "ObservationFactor",
     "ObservationFactorBundle",
     "PredictionWindow",
     "Sim3",
     "StackedObservationFactors",
+    "build_prob4d_observation_belief",
+    "load_metric_gauge_anchor",
     "load_observation_factor_bundle",
+    "save_metric_gauge_anchor",
+    "save_observation_belief_export",
     "stack_observation_factors",
     "write_observation_factor_bundle",
 ]

--- a/src/prob4d/_causal_observation_source.py
+++ b/src/prob4d/_causal_observation_source.py
@@ -1,0 +1,379 @@
+"""Fail-closed source selection for causal Prob4D observation artifacts."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from .data import PredictionWindow
+from .lineage import (
+    MOTIONCRAFTER_LINEAGE_SCHEMA_VERSION,
+    MOTIONCRAFTER_WINDOWING_MODEL,
+)
+from .metric_anchor import MetricGaugeAnchorV1
+from .observation_contract import (
+    array_sha256,
+    canonical_json_sha256,
+    file_sha256,
+)
+
+CAUSAL_SOURCE_LINEAGE_SCHEMA_VERSION = 1
+
+_PRODUCER_CONFIG_KEYS = (
+    "model_type",
+    "unet_path",
+    "vae_path",
+    "height",
+    "width",
+    "window_size",
+    "overlap",
+    "num_inference_steps",
+    "guidance_scale",
+    "decode_chunk_size",
+    "seed",
+    "low_memory_usage",
+    "frame_start",
+    "frame_stride",
+)
+
+
+def _require_sha256(value: str, *, name: str) -> None:
+    if len(value) != 64 or any(
+        character not in "0123456789abcdef" for character in value
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+
+
+@dataclass(frozen=True)
+class SelectedOverlapWindow:
+    """One independently decoded window admitted before future payloads open."""
+
+    manifest_index: int
+    window_id: str
+    source_frame_start: int
+    source_frame_stop: int
+    payload_sha256: str
+    prediction: PredictionWindow
+
+    def __post_init__(self) -> None:
+        if self.manifest_index < 0 or not self.window_id:
+            raise ValueError("selected overlap-window identity is invalid")
+        if (
+            self.source_frame_start < 0
+            or self.source_frame_stop <= self.source_frame_start
+        ):
+            raise ValueError("selected overlap-window source bounds are invalid")
+        _require_sha256(
+            self.payload_sha256,
+            name="overlap-window payload_sha256",
+        )
+        if self.prediction.window_id != self.window_id:
+            raise ValueError("selected overlap-window ID changed while loading")
+
+    def lineage_record(self) -> dict[str, Any]:
+        return {
+            "window_id": self.window_id,
+            "source_frame_start": self.source_frame_start,
+            "source_frame_stop_exclusive": self.source_frame_stop,
+            "source_frame_max": int(self.prediction.frame_indices[-1]),
+            "frame_indices_sha256": array_sha256(self.prediction.frame_indices),
+            "payload_sha256": self.payload_sha256,
+        }
+
+
+@dataclass(frozen=True)
+class CausalOverlapSelection:
+    """Causally complete windows and their append-invariant source digest."""
+
+    manifest_path: Path
+    manifest_sha256: str
+    manifest: Mapping[str, Any]
+    windows: tuple[SelectedOverlapWindow, ...]
+    skipped_window_count: int
+    source_artifact_sha256: str
+
+    def __post_init__(self) -> None:
+        if not self.windows:
+            raise ValueError(
+                "causal overlap selection must contain at least one window"
+            )
+        if self.skipped_window_count < 0:
+            raise ValueError("skipped_window_count must be nonnegative")
+        _require_sha256(
+            self.manifest_sha256,
+            name="prediction manifest sha256",
+        )
+        _require_sha256(
+            self.source_artifact_sha256,
+            name="causal source sha256",
+        )
+
+    @property
+    def predictions(self) -> list[PredictionWindow]:
+        return [item.prediction for item in self.windows]
+
+    def artifact_lineage_metadata(
+        self,
+        *,
+        causal_frame_stop: int,
+    ) -> dict[str, Any]:
+        """Return only prefix-stable information suitable for artifact hashing."""
+
+        return {
+            "schema_version": CAUSAL_SOURCE_LINEAGE_SCHEMA_VERSION,
+            "producer": "Prob4D",
+            "motioncrafter_lineage_schema_version": (
+                MOTIONCRAFTER_LINEAGE_SCHEMA_VERSION
+            ),
+            "motioncrafter_windowing_model": MOTIONCRAFTER_WINDOWING_MODEL,
+            "source_product": "independently_decoded_overlap_windows",
+            "causal_frame_stop_exclusive": causal_frame_stop,
+            "admissibility_rule": (
+                "source_frame_max < causal_frame_stop_exclusive"
+            ),
+            "future_prediction_payloads_opened": 0,
+            "selected_windows": [
+                item.lineage_record() for item in self.windows
+            ],
+            "source_artifact_sha256": self.source_artifact_sha256,
+            "source_digest_scope": (
+                "selected payload hashes, selected source bounds, MotionCrafter "
+                "revision, lineage declaration, prediction-affecting settings, "
+                "and metric anchor"
+            ),
+        }
+
+    def run_summary(self, *, causal_frame_stop: int) -> dict[str, Any]:
+        """Return an operational report that may mention unconsumed entries."""
+
+        return {
+            "prediction_manifest": str(self.manifest_path),
+            "prediction_manifest_sha256": self.manifest_sha256,
+            "causal_frame_stop_exclusive": causal_frame_stop,
+            "selected_window_ids": [
+                item.window_id for item in self.windows
+            ],
+            "selected_window_count": len(self.windows),
+            "skipped_future_or_crossing_window_count": (
+                self.skipped_window_count
+            ),
+            "future_prediction_payloads_opened": 0,
+            "causal_source_artifact_sha256": self.source_artifact_sha256,
+        }
+
+
+def _validate_overlap_lineage(manifest: Mapping[str, Any]) -> None:
+    if manifest.get("format_version") != 1:
+        raise ValueError("unsupported prediction-manifest format_version")
+    lineage = manifest.get("temporal_lineage")
+    if not isinstance(lineage, Mapping):
+        raise ValueError(
+            "causal observation export requires an explicit temporal_lineage "
+            "declaration"
+        )
+    if (
+        int(lineage.get("schema_version", -1))
+        != MOTIONCRAFTER_LINEAGE_SCHEMA_VERSION
+    ):
+        raise ValueError("unsupported MotionCrafter temporal-lineage schema")
+    if lineage.get("model") != MOTIONCRAFTER_WINDOWING_MODEL:
+        raise ValueError("unsupported MotionCrafter temporal-lineage model")
+    products = lineage.get("products")
+    if not isinstance(products, Mapping):
+        raise ValueError("temporal lineage has no product declarations")
+    overlap = products.get("overlap_windows")
+    if not isinstance(overlap, Mapping):
+        raise ValueError("temporal lineage has no overlap-window declaration")
+    if overlap.get("window_size_source") != "prediction archive frame count":
+        raise ValueError(
+            "overlap-window source extent is not explicitly declared"
+        )
+    if int(overlap.get("overlap", -1)) != 0:
+        raise ValueError(
+            "independently decoded overlap windows must have internal overlap zero"
+        )
+    if not str(manifest.get("motioncrafter_commit", "")):
+        raise ValueError("prediction manifest has no MotionCrafter revision")
+    if not isinstance(manifest.get("config"), Mapping):
+        raise ValueError("prediction manifest has no producer configuration")
+
+
+def _safe_payload_path(root: Path, relative_path: str) -> Path:
+    if not relative_path:
+        raise ValueError("overlap-window path must not be empty")
+    candidate = (root / relative_path).resolve()
+    try:
+        candidate.relative_to(root.resolve())
+    except ValueError as error:
+        raise ValueError(
+            "overlap-window path escapes the prediction directory"
+        ) from error
+    return candidate
+
+
+def _causal_source_digest(
+    manifest: Mapping[str, Any],
+    windows: Sequence[SelectedOverlapWindow],
+    *,
+    metric_anchor: MetricGaugeAnchorV1,
+) -> str:
+    config = manifest["config"]
+    stable_config = {
+        key: config[key]
+        for key in _PRODUCER_CONFIG_KEYS
+        if key in config
+    }
+    descriptor = {
+        "schema_name": "prob4d.causal-observation-source",
+        "schema_version": CAUSAL_SOURCE_LINEAGE_SCHEMA_VERSION,
+        "prediction_manifest_format_version": manifest["format_version"],
+        "motioncrafter_commit": manifest["motioncrafter_commit"],
+        "temporal_lineage": manifest["temporal_lineage"],
+        "producer_config": stable_config,
+        "selected_windows": [
+            window.lineage_record() for window in windows
+        ],
+        "metric_gauge_anchor_id": metric_anchor.artifact_id,
+    }
+    return canonical_json_sha256(descriptor)
+
+
+def select_causal_overlap_windows(
+    manifest_path: str | Path,
+    *,
+    causal_frame_stop: int,
+    metric_anchor: MetricGaugeAnchorV1,
+) -> CausalOverlapSelection:
+    """Open only independently decoded windows wholly before the cutoff."""
+
+    if causal_frame_stop < 1:
+        raise ValueError("causal_frame_stop must be positive")
+    manifest_file = Path(manifest_path).resolve()
+    manifest = json.loads(manifest_file.read_text(encoding="utf-8"))
+    _validate_overlap_lineage(manifest)
+    entries = manifest.get("overlap_windows")
+    if not isinstance(entries, list) or not entries:
+        raise ValueError("prediction manifest has no overlap windows")
+    frame_stride = int(manifest["config"].get("frame_stride", 1))
+    window_size = int(manifest["config"].get("window_size", 0))
+    if frame_stride < 1 or window_size < 1:
+        raise ValueError(
+            "prediction manifest has invalid frame_stride or window_size"
+        )
+
+    selected: list[SelectedOverlapWindow] = []
+    skipped = 0
+    skipping_started = False
+    seen_ids: set[str] = set()
+    previous_start = -1
+    for manifest_index, entry in enumerate(entries):
+        if not isinstance(entry, Mapping):
+            raise ValueError(
+                "overlap-window manifest entries must be mappings"
+            )
+        window_id = str(entry.get("window_id", ""))
+        if not window_id or window_id in seen_ids:
+            raise ValueError(
+                "overlap-window IDs must be nonempty and unique"
+            )
+        seen_ids.add(window_id)
+        start = int(entry.get("start_frame", -1))
+        stop = int(entry.get("stop_frame", -1))
+        if start < 0 or stop <= start:
+            raise ValueError(
+                f"overlap window {window_id!r} has invalid source bounds"
+            )
+        if start < previous_start:
+            raise ValueError(
+                "overlap-window manifest entries are not ordered by source frame"
+            )
+        previous_start = start
+        if stop > causal_frame_stop:
+            skipped += 1
+            skipping_started = True
+            continue
+        if skipping_started:
+            raise ValueError(
+                "causally complete overlap windows are not a manifest prefix"
+            )
+
+        path = _safe_payload_path(
+            manifest_file.parent,
+            str(entry.get("path", "")),
+        )
+        prediction = PredictionWindow.from_npz(
+            path,
+            start_frame=start,
+            window_id=window_id,
+        )
+        expected_frames = np.arange(
+            start,
+            stop,
+            frame_stride,
+            dtype=np.int64,
+        )
+        if not np.array_equal(prediction.frame_indices, expected_frames):
+            raise ValueError(
+                f"overlap window {window_id!r} frame IDs disagree with its "
+                "manifest bounds"
+            )
+        if len(prediction.frame_indices) > window_size:
+            raise ValueError(
+                f"overlap window {window_id!r} exceeds the declared independent "
+                "window size"
+            )
+        if int(prediction.frame_indices[-1]) >= causal_frame_stop:
+            raise ValueError(
+                f"overlap window {window_id!r} crosses the causal frame boundary"
+            )
+        selected.append(
+            SelectedOverlapWindow(
+                manifest_index=manifest_index,
+                window_id=window_id,
+                source_frame_start=start,
+                source_frame_stop=stop,
+                payload_sha256=file_sha256(path),
+                prediction=prediction,
+            )
+        )
+
+    if not selected:
+        raise ValueError(
+            "no independently decoded overlap window is wholly before "
+            "causal_frame_stop"
+        )
+    metric_anchor.require_fixed()
+    if selected[0].window_id != metric_anchor.reference_window_id:
+        raise ValueError(
+            "metric gauge anchor must identify the first retained overlap window"
+        )
+    if selected[0].payload_sha256 != metric_anchor.source_artifact_sha256:
+        raise ValueError(
+            "metric gauge anchor is bound to a different reference-window payload"
+        )
+    source_digest = _causal_source_digest(
+        manifest,
+        selected,
+        metric_anchor=metric_anchor,
+    )
+    return CausalOverlapSelection(
+        manifest_path=manifest_file,
+        manifest_sha256=file_sha256(manifest_file),
+        manifest=manifest,
+        windows=tuple(selected),
+        skipped_window_count=skipped,
+        source_artifact_sha256=source_digest,
+    )
+
+
+__all__ = [
+    "CAUSAL_SOURCE_LINEAGE_SCHEMA_VERSION",
+    "CausalOverlapSelection",
+    "SelectedOverlapWindow",
+    "select_causal_overlap_windows",
+]

--- a/src/prob4d/metric_anchor.py
+++ b/src/prob4d/metric_anchor.py
@@ -1,0 +1,263 @@
+"""Content-addressed fixed metric anchors for portable observation exports."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from .observation_contract import file_sha256
+from .sim3 import Sim3
+
+METRIC_GAUGE_ANCHOR_SCHEMA = "prob4d.metric-gauge-anchor"
+METRIC_GAUGE_ANCHOR_VERSION = 1
+
+
+def _canonical_json(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        dict(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _validate_sha256(value: str, *, name: str) -> None:
+    if len(value) != 64 or any(
+        character not in "0123456789abcdef" for character in value
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+
+
+def _validated_metadata(values: Mapping[str, Any]) -> dict[str, Any]:
+    try:
+        return json.loads(json.dumps(dict(values), sort_keys=True, allow_nan=False))
+    except (TypeError, ValueError) as error:
+        raise ValueError("metric-anchor metadata must be finite JSON data") from error
+
+
+def _safe_manifest_path(root: Path, relative_path: str) -> Path:
+    if not relative_path:
+        raise ValueError("prediction manifest entry has no path")
+    target = (root / relative_path).resolve()
+    try:
+        target.relative_to(root.resolve())
+    except ValueError as error:
+        raise ValueError("prediction manifest references a path outside its root") from error
+    return target
+
+
+def prediction_window_sha256(
+    manifest_path: str | Path,
+    reference_window_id: str,
+) -> str:
+    """Hash exactly one independently decoded reference-window payload."""
+
+    if not reference_window_id:
+        raise ValueError("reference_window_id must be nonempty")
+    manifest = Path(manifest_path).resolve()
+    payload = json.loads(manifest.read_text(encoding="utf-8"))
+    if payload.get("format_version") != 1:
+        raise ValueError("unsupported prediction-manifest format_version")
+    windows = payload.get("overlap_windows")
+    if not isinstance(windows, list) or not windows:
+        raise ValueError("prediction manifest has no overlap windows")
+    matches = [
+        item
+        for item in windows
+        if isinstance(item, Mapping)
+        and str(item.get("window_id", "")) == reference_window_id
+    ]
+    if len(matches) != 1:
+        raise ValueError("reference window must identify exactly one manifest entry")
+    target = _safe_manifest_path(manifest.parent, str(matches[0].get("path", "")))
+    if not target.is_file():
+        raise ValueError("reference-window prediction payload does not exist")
+    return file_sha256(target)
+
+
+@dataclass(frozen=True)
+class MetricGaugeAnchorV1:
+    """A fixed metric ``Sim(3)`` for the first retained Prob4D window.
+
+    ObservationBeliefV1 can compactly encode one coherent gauge factor group per
+    row. A nonzero global-anchor covariance would be shared across every window
+    in addition to each relative-window gauge, which this compact contract cannot
+    represent without a factor rank that grows with the number of windows.
+    Uncertain global anchors must therefore use ObservationFactorBundle instead.
+    """
+
+    case_id: str
+    world_frame_id: str
+    reference_window_id: str
+    source_artifact_sha256: str
+    calibration_artifact_sha256: str
+    global_from_reference: Sim3
+    covariance: np.ndarray = field(default_factory=lambda: np.zeros((7, 7)))
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.case_id or not self.world_frame_id or not self.reference_window_id:
+            raise ValueError("metric-anchor identities must be nonempty")
+        if not isinstance(self.global_from_reference, Sim3):
+            raise TypeError("global_from_reference must be a Sim3")
+        _validate_sha256(
+            self.source_artifact_sha256,
+            name="source_artifact_sha256",
+        )
+        _validate_sha256(
+            self.calibration_artifact_sha256,
+            name="calibration_artifact_sha256",
+        )
+        covariance = np.asarray(self.covariance, dtype=np.float64).copy()
+        if covariance.shape != (7, 7) or not np.all(np.isfinite(covariance)):
+            raise ValueError("metric-anchor covariance must have finite shape (7, 7)")
+        if not np.allclose(covariance, covariance.T, atol=1e-12, rtol=1e-10):
+            raise ValueError("metric-anchor covariance must be symmetric")
+        symmetric = 0.5 * (covariance + covariance.T)
+        if np.min(np.linalg.eigvalsh(symmetric)) < -1e-12:
+            raise ValueError("metric-anchor covariance must be positive semidefinite")
+        covariance.setflags(write=False)
+        object.__setattr__(self, "covariance", covariance)
+        object.__setattr__(self, "metadata", _validated_metadata(self.metadata))
+
+    def descriptor(self) -> dict[str, Any]:
+        return {
+            "schema_name": METRIC_GAUGE_ANCHOR_SCHEMA,
+            "schema_version": METRIC_GAUGE_ANCHOR_VERSION,
+            "case_id": self.case_id,
+            "world_frame_id": self.world_frame_id,
+            "reference_window_id": self.reference_window_id,
+            "source_artifact_sha256": self.source_artifact_sha256,
+            "calibration_artifact_sha256": self.calibration_artifact_sha256,
+            "global_from_reference_vector": (
+                self.global_from_reference.as_vector().tolist()
+            ),
+            "covariance": self.covariance.tolist(),
+            "metric_units": "m",
+            "metadata": self.metadata,
+        }
+
+    @property
+    def artifact_id(self) -> str:
+        return hashlib.sha256(_canonical_json(self.descriptor())).hexdigest()
+
+    @property
+    def is_fixed(self) -> bool:
+        return bool(np.max(np.abs(self.covariance), initial=0.0) <= 1e-18)
+
+    def require_fixed(self) -> None:
+        if not self.is_fixed:
+            raise ValueError(
+                "ObservationBeliefV1 cannot encode both uncertain global and "
+                "per-window gauges; provide a fixed metric calibration or use "
+                "ObservationFactorBundle"
+            )
+
+
+def save_metric_gauge_anchor(path: str | Path, anchor: MetricGaugeAnchorV1) -> None:
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    payload = anchor.descriptor()
+    payload["artifact_id"] = anchor.artifact_id
+    target.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def load_metric_gauge_anchor(path: str | Path) -> MetricGaugeAnchorV1:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if payload.get("schema_name") != METRIC_GAUGE_ANCHOR_SCHEMA:
+        raise ValueError("unsupported metric-gauge-anchor schema")
+    if int(payload.get("schema_version", -1)) != METRIC_GAUGE_ANCHOR_VERSION:
+        raise ValueError("unsupported metric-gauge-anchor version")
+    if payload.get("metric_units") != "m":
+        raise ValueError("metric gauge anchor must declare metric_units='m'")
+    anchor = MetricGaugeAnchorV1(
+        case_id=str(payload["case_id"]),
+        world_frame_id=str(payload["world_frame_id"]),
+        reference_window_id=str(payload["reference_window_id"]),
+        source_artifact_sha256=str(payload["source_artifact_sha256"]),
+        calibration_artifact_sha256=str(payload["calibration_artifact_sha256"]),
+        global_from_reference=Sim3.from_vector(
+            np.asarray(payload["global_from_reference_vector"], dtype=np.float64)
+        ),
+        covariance=np.asarray(payload["covariance"], dtype=np.float64),
+        metadata=payload.get("metadata", {}),
+    )
+    expected = str(payload.get("artifact_id", ""))
+    _validate_sha256(expected, name="artifact_id")
+    if anchor.artifact_id != expected:
+        raise ValueError("metric-gauge-anchor digest does not match its payload")
+    return anchor
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("predictions_manifest", type=Path)
+    parser.add_argument("output_json", type=Path)
+    parser.add_argument("--case-id", required=True)
+    parser.add_argument("--world-frame-id", required=True)
+    parser.add_argument("--reference-window-id", required=True)
+    parser.add_argument("--calibration-artifact", type=Path, required=True)
+    parser.add_argument(
+        "--sim3-vector",
+        type=float,
+        nargs=7,
+        metavar=("LOG_SCALE", "RX", "RY", "RZ", "TX", "TY", "TZ"),
+        required=True,
+    )
+    args = parser.parse_args(argv)
+
+    anchor = MetricGaugeAnchorV1(
+        case_id=args.case_id,
+        world_frame_id=args.world_frame_id,
+        reference_window_id=args.reference_window_id,
+        source_artifact_sha256=prediction_window_sha256(
+            args.predictions_manifest,
+            args.reference_window_id,
+        ),
+        calibration_artifact_sha256=file_sha256(args.calibration_artifact),
+        global_from_reference=Sim3.from_vector(np.asarray(args.sim3_vector)),
+        covariance=np.zeros((7, 7)),
+        metadata={
+            "calibration_artifact_name": args.calibration_artifact.name,
+            "covariance_treatment": "fixed_external_calibration",
+        },
+    )
+    save_metric_gauge_anchor(args.output_json, anchor)
+    print(
+        json.dumps(
+            {
+                "artifact_id": anchor.artifact_id,
+                "source_artifact_sha256": anchor.source_artifact_sha256,
+                "world_frame_id": anchor.world_frame_id,
+                "reference_window_id": anchor.reference_window_id,
+                "output": str(args.output_json.resolve()),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "METRIC_GAUGE_ANCHOR_SCHEMA",
+    "METRIC_GAUGE_ANCHOR_VERSION",
+    "MetricGaugeAnchorV1",
+    "load_metric_gauge_anchor",
+    "prediction_window_sha256",
+    "save_metric_gauge_anchor",
+]

--- a/src/prob4d/observation_contract.py
+++ b/src/prob4d/observation_contract.py
@@ -1,0 +1,359 @@
+"""Writer for the portable Phys4D observation-belief contract."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+OBSERVATION_BELIEF_SCHEMA = "phys4d.observation_belief"
+OBSERVATION_BELIEF_VERSION = 1
+
+
+def array_sha256(values: np.ndarray) -> str:
+    """Hash an array including its dtype and shape."""
+
+    array = np.ascontiguousarray(np.asarray(values))
+    digest = hashlib.sha256()
+    digest.update(array.dtype.str.encode("ascii"))
+    digest.update(json.dumps(array.shape, separators=(",", ":")).encode("ascii"))
+    digest.update(array.view(np.uint8))
+    return digest.hexdigest()
+
+
+def file_sha256(path: str | Path) -> str:
+    """Hash a file without loading it fully into memory."""
+
+    digest = hashlib.sha256()
+    with Path(path).open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def canonical_json_sha256(value: Mapping[str, Any]) -> str:
+    """Hash finite JSON data using the observation-contract canonicalization."""
+
+    return hashlib.sha256(_canonical_json(value)).hexdigest()
+
+
+def _canonical_json(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        dict(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _artifact_id(
+    descriptor: Mapping[str, Any], arrays: Mapping[str, np.ndarray]
+) -> str:
+    digest = hashlib.sha256()
+    digest.update(_canonical_json(descriptor))
+    for name, values in sorted(arrays.items()):
+        digest.update(name.encode("utf-8"))
+        digest.update(array_sha256(values).encode("ascii"))
+    return digest.hexdigest()
+
+
+def _validate_sha256(value: str, *, name: str) -> None:
+    if len(value) != 64 or any(
+        character not in "0123456789abcdef" for character in value
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+
+
+@dataclass(frozen=True)
+class ObservationBeliefExportV1:
+    """Validated data used to emit an ``ObservationBeliefV1`` archive."""
+
+    case_id: str
+    stream_id: str
+    causal_frame_stop: int
+    view_names: tuple[str, ...]
+    window_names: tuple[str, ...]
+    factor_names: tuple[str, ...]
+    source_repository: str
+    source_revision: str
+    source_artifact_sha256: str
+
+    declared_frame_ids: np.ndarray
+    mean_xyz_m: np.ndarray
+    frame_ids: np.ndarray
+    entity_ids: np.ndarray
+    view_indices: np.ndarray
+    window_indices: np.ndarray
+    correlation_group_ids: np.ndarray
+    factor_group_ids: np.ndarray
+    prior_reliability: np.ndarray
+    association_probability: np.ndarray
+    local_covariance_m2: np.ndarray
+    low_rank_factor_m: np.ndarray
+    group_ids: np.ndarray
+    group_prior_nominal_probability: np.ndarray
+    group_composite_weight: np.ndarray
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.case_id or not self.stream_id:
+            raise ValueError("case_id and stream_id must be nonempty")
+        if self.causal_frame_stop < 1:
+            raise ValueError("causal_frame_stop must be positive")
+        if (
+            not self.view_names
+            or any(not name for name in self.view_names)
+            or not self.window_names
+            or any(not name for name in self.window_names)
+        ):
+            raise ValueError("view and window names must be nonempty")
+        if any(not name for name in self.factor_names):
+            raise ValueError("factor names must be nonempty when present")
+        if not self.source_repository or not self.source_revision:
+            raise ValueError("source provenance must be nonempty")
+        _validate_sha256(
+            self.source_artifact_sha256,
+            name="source_artifact_sha256",
+        )
+
+        normalized = {
+            "declared_frame_ids": np.asarray(
+                self.declared_frame_ids, dtype=np.int64
+            ),
+            "mean_xyz_m": np.asarray(self.mean_xyz_m, dtype=np.float64),
+            "frame_ids": np.asarray(self.frame_ids, dtype=np.int64),
+            "entity_ids": np.asarray(self.entity_ids, dtype=np.int64),
+            "view_indices": np.asarray(self.view_indices, dtype=np.int64),
+            "window_indices": np.asarray(
+                self.window_indices, dtype=np.int64
+            ),
+            "correlation_group_ids": np.asarray(
+                self.correlation_group_ids, dtype=np.int64
+            ),
+            "factor_group_ids": np.asarray(
+                self.factor_group_ids, dtype=np.int64
+            ),
+            "prior_reliability": np.asarray(
+                self.prior_reliability, dtype=np.float64
+            ),
+            "association_probability": np.asarray(
+                self.association_probability, dtype=np.float64
+            ),
+            "local_covariance_m2": np.asarray(
+                self.local_covariance_m2, dtype=np.float64
+            ),
+            "low_rank_factor_m": np.asarray(
+                self.low_rank_factor_m, dtype=np.float64
+            ),
+            "group_ids": np.asarray(self.group_ids, dtype=np.int64),
+            "group_prior_nominal_probability": np.asarray(
+                self.group_prior_nominal_probability, dtype=np.float64
+            ),
+            "group_composite_weight": np.asarray(
+                self.group_composite_weight, dtype=np.float64
+            ),
+        }
+        count = len(normalized["mean_xyz_m"])
+        if normalized["mean_xyz_m"].shape != (count, 3) or count == 0:
+            raise ValueError("mean_xyz_m must have nonempty shape (N, 3)")
+        for name in (
+            "frame_ids",
+            "entity_ids",
+            "view_indices",
+            "window_indices",
+            "correlation_group_ids",
+            "factor_group_ids",
+            "prior_reliability",
+            "association_probability",
+        ):
+            if normalized[name].shape != (count,):
+                raise ValueError(f"{name} must have shape ({count},)")
+        if normalized["local_covariance_m2"].shape != (count, 3, 3):
+            raise ValueError("local_covariance_m2 must have shape (N, 3, 3)")
+        if normalized["low_rank_factor_m"].shape != (
+            count,
+            3,
+            len(self.factor_names),
+        ):
+            raise ValueError("low_rank_factor_m rank does not match factor_names")
+        frames = normalized["declared_frame_ids"]
+        if (
+            frames.ndim != 1
+            or len(frames) == 0
+            or np.any(np.diff(frames) <= 0)
+            or np.any(frames < 0)
+            or np.any(frames >= self.causal_frame_stop)
+        ):
+            raise ValueError("declared frames violate the causal boundary")
+        if not np.all(np.isin(normalized["frame_ids"], frames)):
+            raise ValueError("observation frames are not declared")
+        if np.any(normalized["entity_ids"] < 0):
+            raise ValueError("entity_ids must be nonnegative")
+        if np.any(normalized["view_indices"] < 0) or np.any(
+            normalized["view_indices"] >= len(self.view_names)
+        ):
+            raise ValueError("view_indices reference unavailable views")
+        if np.any(normalized["window_indices"] < 0) or np.any(
+            normalized["window_indices"] >= len(self.window_names)
+        ):
+            raise ValueError("window_indices reference unavailable windows")
+        if np.any(normalized["correlation_group_ids"] < 0) or np.any(
+            normalized["factor_group_ids"] < 0
+        ):
+            raise ValueError("group identifiers must be nonnegative")
+        for name in ("prior_reliability", "association_probability"):
+            values = normalized[name]
+            if not np.all(np.isfinite(values)) or np.any(
+                (values < 0.0) | (values > 1.0)
+            ):
+                raise ValueError(f"{name} must lie in [0, 1]")
+        if not np.array_equal(
+            normalized["group_ids"],
+            np.unique(normalized["correlation_group_ids"]),
+        ):
+            raise ValueError("group_ids do not match correlation groups")
+        group_count = len(normalized["group_ids"])
+        if normalized["group_prior_nominal_probability"].shape != (
+            group_count,
+        ) or normalized["group_composite_weight"].shape != (group_count,):
+            raise ValueError("group metadata shape changed")
+        group_prior = normalized["group_prior_nominal_probability"]
+        group_weight = normalized["group_composite_weight"]
+        if not np.all(np.isfinite(group_prior)) or np.any(
+            (group_prior < 0.0) | (group_prior > 1.0)
+        ):
+            raise ValueError("group prior probabilities must lie in [0, 1]")
+        if not np.all(np.isfinite(group_weight)) or np.any(
+            (group_weight <= 0.0) | (group_weight > 1.0)
+        ):
+            raise ValueError("group composite weights must lie in (0, 1]")
+        if not np.all(np.isfinite(normalized["mean_xyz_m"])):
+            raise ValueError("observation means must be finite")
+        if not np.all(np.isfinite(normalized["local_covariance_m2"])):
+            raise ValueError("local covariance must be finite")
+        if not np.all(np.isfinite(normalized["low_rank_factor_m"])):
+            raise ValueError("low-rank factors must be finite")
+        symmetric = 0.5 * (
+            normalized["local_covariance_m2"]
+            + np.swapaxes(normalized["local_covariance_m2"], 1, 2)
+        )
+        if not np.allclose(
+            symmetric,
+            normalized["local_covariance_m2"],
+            atol=1e-12,
+            rtol=1e-10,
+        ) or np.any(np.min(np.linalg.eigvalsh(symmetric), axis=1) <= 0.0):
+            raise ValueError("local covariance must be symmetric positive definite")
+        order = np.lexsort(
+            (
+                normalized["window_indices"],
+                normalized["view_indices"],
+                normalized["entity_ids"],
+                normalized["frame_ids"],
+            )
+        )
+        sorted_keys = np.column_stack(
+            (
+                normalized["frame_ids"][order],
+                normalized["entity_ids"][order],
+                normalized["view_indices"][order],
+                normalized["window_indices"][order],
+            )
+        )
+        if len(sorted_keys) > 1 and np.any(
+            np.all(sorted_keys[1:] == sorted_keys[:-1], axis=1)
+        ):
+            raise ValueError(
+                "observation identity (frame, entity, view, window) must be unique"
+            )
+        try:
+            metadata = json.loads(
+                json.dumps(dict(self.metadata), sort_keys=True, allow_nan=False)
+            )
+        except (TypeError, ValueError) as error:
+            raise ValueError("metadata must be finite JSON data") from error
+        for name, values in normalized.items():
+            values = values.copy()
+            values.setflags(write=False)
+            object.__setattr__(self, name, values)
+        object.__setattr__(self, "metadata", metadata)
+
+    def descriptor(self) -> dict[str, Any]:
+        return {
+            "schema_name": OBSERVATION_BELIEF_SCHEMA,
+            "schema_version": OBSERVATION_BELIEF_VERSION,
+            "case_id": self.case_id,
+            "stream_id": self.stream_id,
+            "causal_frame_stop": self.causal_frame_stop,
+            "view_names": list(self.view_names),
+            "window_names": list(self.window_names),
+            "factor_names": list(self.factor_names),
+            "source_repository": self.source_repository,
+            "source_revision": self.source_revision,
+            "source_artifact_sha256": self.source_artifact_sha256,
+            "metadata": self.metadata,
+        }
+
+    def arrays(self) -> dict[str, np.ndarray]:
+        return {
+            "declared_frame_ids": self.declared_frame_ids,
+            "mean_xyz_m": self.mean_xyz_m,
+            "frame_ids": self.frame_ids,
+            "entity_ids": self.entity_ids,
+            "view_indices": self.view_indices,
+            "window_indices": self.window_indices,
+            "correlation_group_ids": self.correlation_group_ids,
+            "factor_group_ids": self.factor_group_ids,
+            "prior_reliability": self.prior_reliability,
+            "association_probability": self.association_probability,
+            "local_covariance_m2": self.local_covariance_m2,
+            "low_rank_factor_m": self.low_rank_factor_m,
+            "group_ids": self.group_ids,
+            "group_prior_nominal_probability": (
+                self.group_prior_nominal_probability
+            ),
+            "group_composite_weight": self.group_composite_weight,
+        }
+
+    @property
+    def artifact_id(self) -> str:
+        return _artifact_id(self.descriptor(), self.arrays())
+
+
+def save_observation_belief_export(
+    path: str | Path, artifact: ObservationBeliefExportV1
+) -> None:
+    """Write the exact archive consumed by Bayesian-PhysTwin and Causal4D."""
+
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    descriptor = artifact.descriptor()
+    descriptor["artifact_id"] = artifact.artifact_id
+    np.savez_compressed(
+        target,
+        descriptor_json=np.asarray(
+            json.dumps(
+                descriptor,
+                sort_keys=True,
+                separators=(",", ":"),
+                allow_nan=False,
+            )
+        ),
+        **artifact.arrays(),
+    )
+
+
+__all__ = [
+    "OBSERVATION_BELIEF_SCHEMA",
+    "OBSERVATION_BELIEF_VERSION",
+    "ObservationBeliefExportV1",
+    "array_sha256",
+    "canonical_json_sha256",
+    "file_sha256",
+    "save_observation_belief_export",
+]

--- a/src/prob4d/observation_export.py
+++ b/src/prob4d/observation_export.py
@@ -1,0 +1,697 @@
+"""Export causally sealed, metric Prob4D observations for Bayesian consumers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from ._causal_observation_source import (
+    CAUSAL_SOURCE_LINEAGE_SCHEMA_VERSION,
+    CausalOverlapSelection,
+    SelectedOverlapWindow,
+    select_causal_overlap_windows,
+)
+from .alignment import WindowAlignment, align_windows
+from .data import PredictionWindow
+from .gauge import (
+    FixedLagGaugeSmoother,
+    GaugeEstimate,
+    RelativeGaugeConstraint,
+    SequentialGaugeEstimator,
+)
+from .metric_anchor import (
+    METRIC_GAUGE_ANCHOR_SCHEMA,
+    METRIC_GAUGE_ANCHOR_VERSION,
+    MetricGaugeAnchorV1,
+    load_metric_gauge_anchor,
+    save_metric_gauge_anchor,
+)
+from .observation_contract import (
+    ObservationBeliefExportV1,
+    save_observation_belief_export,
+)
+from .sim3 import Sim3, so3_log, so3_right_jacobian
+from .uncertainty import DepthDisagreementModel, accumulate_disagreement
+
+GAUGE_FACTOR_NAMES = tuple(
+    f"gauge_latent_{index}" for index in range(7)
+)
+
+
+def _git_revision() -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=Path(__file__).resolve().parents[2],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError) as error:
+        raise ValueError(
+            "Prob4D source revision is unavailable; pass source_revision "
+            "explicitly"
+        ) from error
+    revision = result.stdout.strip()
+    if not revision:
+        raise ValueError(
+            "Prob4D source revision is empty; pass source_revision explicitly"
+        )
+    return revision
+
+
+def _deterministic_covariance_root(covariance: np.ndarray) -> np.ndarray:
+    values = np.asarray(covariance, dtype=np.float64)
+    symmetric = 0.5 * (values + values.T)
+    if symmetric.shape != (7, 7) or not np.all(np.isfinite(symmetric)):
+        raise ValueError("gauge covariance must have finite shape (7, 7)")
+    eigenvalues, eigenvectors = np.linalg.eigh(symmetric)
+    order = np.argsort(eigenvalues)[::-1]
+    eigenvalues = np.maximum(eigenvalues[order], 0.0)
+    eigenvectors = eigenvectors[:, order]
+    for column in range(eigenvectors.shape[1]):
+        pivot = int(np.argmax(np.abs(eigenvectors[:, column])))
+        if eigenvectors[pivot, column] < 0.0:
+            eigenvectors[:, column] *= -1.0
+    return eigenvectors * np.sqrt(eigenvalues)[None]
+
+
+def gauge_covariance_factor(
+    values: np.ndarray,
+    transform: Sim3,
+    gauge_covariance: np.ndarray,
+    *,
+    include_translation: bool,
+    chunk_size: int = 16_384,
+) -> np.ndarray:
+    """Return ``J L`` so rows from one window share gauge uncertainty."""
+
+    points = np.asarray(values, dtype=np.float64)
+    if points.shape[-1] != 3:
+        raise ValueError(
+            "gauge factors require three-dimensional values"
+        )
+    if chunk_size < 1:
+        raise ValueError("chunk_size must be positive")
+    root = _deterministic_covariance_root(gauge_covariance)
+    flattened = points.reshape(-1, 3)
+    factors = np.empty((len(flattened), 3, 7), dtype=np.float64)
+    right_jacobian = so3_right_jacobian(so3_log(transform.rotation))
+    identity = np.eye(3, dtype=np.float64)
+    for start in range(0, len(flattened), chunk_size):
+        stop = min(start + chunk_size, len(flattened))
+        chunk = flattened[start:stop]
+        scaled_rotated = transform.scale * np.einsum(
+            "ij,nj->ni",
+            transform.rotation,
+            chunk,
+        )
+        skew = np.zeros((len(chunk), 3, 3), dtype=np.float64)
+        skew[:, 0, 1] = -chunk[:, 2]
+        skew[:, 0, 2] = chunk[:, 1]
+        skew[:, 1, 0] = chunk[:, 2]
+        skew[:, 1, 2] = -chunk[:, 0]
+        skew[:, 2, 0] = -chunk[:, 1]
+        skew[:, 2, 1] = chunk[:, 0]
+        jacobian = np.zeros((len(chunk), 3, 7), dtype=np.float64)
+        jacobian[:, :, 0] = scaled_rotated
+        jacobian[:, :, 1:4] = -transform.scale * np.einsum(
+            "ij,njk,kl->nil",
+            transform.rotation,
+            skew,
+            right_jacobian,
+        )
+        if include_translation:
+            jacobian[:, :, 4:7] = identity
+        factors[start:stop] = np.einsum(
+            "nij,jk->nik",
+            jacobian,
+            root,
+        )
+    return factors.reshape(points.shape + (7,))
+
+
+def _build_alignments(
+    windows: Sequence[PredictionWindow],
+) -> list[WindowAlignment]:
+    alignments: list[WindowAlignment] = []
+    for moving_index, moving in enumerate(windows):
+        for reference_index, reference in enumerate(
+            windows[:moving_index]
+        ):
+            if reference.common_frames(moving).size:
+                seed = 10_000 * moving_index + reference_index
+                alignments.append(
+                    align_windows(reference, moving, seed=seed)
+                )
+    return alignments
+
+
+def _gauge_estimates(
+    windows: Sequence[PredictionWindow],
+    *,
+    gauge_mode: str,
+    fixed_lag: int,
+    metric_anchor: MetricGaugeAnchorV1,
+) -> tuple[list[WindowAlignment], dict[str, GaugeEstimate]]:
+    if gauge_mode not in {"sequential", "fixed_lag"}:
+        raise ValueError(
+            "gauge_mode must be 'sequential' or 'fixed_lag'"
+        )
+    alignments = _build_alignments(windows)
+    constraints = [
+        RelativeGaugeConstraint.from_window_alignment(alignment)
+        for alignment in alignments
+    ]
+    ordered_ids = [window.window_id for window in windows]
+    sequential = SequentialGaugeEstimator().estimate(
+        ordered_ids,
+        constraints,
+        initial_transform=metric_anchor.global_from_reference,
+        initial_covariance=metric_anchor.covariance,
+    )
+    if gauge_mode == "sequential" or len(ordered_ids) == 1:
+        estimates = sequential
+    elif gauge_mode == "fixed_lag":
+        if fixed_lag < 2:
+            raise ValueError("fixed_lag must be at least two")
+        estimates = FixedLagGaugeSmoother(lag=fixed_lag).smooth(
+            ordered_ids,
+            sequential,
+            constraints,
+        )
+    else:
+        raise ValueError(
+            "gauge_mode must be 'sequential' or 'fixed_lag'"
+        )
+    return alignments, estimates
+
+
+def _prior_reliability(
+    parallel_disagreement: np.ndarray,
+    lateral_disagreement: np.ndarray,
+    parallel_variance: np.ndarray,
+    lateral_variance: np.ndarray,
+    overlap_count: np.ndarray,
+    *,
+    minimum: float,
+) -> np.ndarray:
+    if not 0.0 < minimum <= 1.0:
+        raise ValueError(
+            "minimum prior reliability must lie in (0, 1]"
+        )
+    normalized = (
+        parallel_disagreement
+        / np.maximum(parallel_variance, 1e-12)
+        + lateral_disagreement
+        / np.maximum(lateral_variance, 1e-12)
+    )
+    reliability = np.exp(-0.5 * np.minimum(normalized, 50.0))
+    reliability = np.where(
+        overlap_count > 0.0,
+        reliability,
+        1.0,
+    )
+    return np.clip(reliability, minimum, 1.0)
+
+
+def _row_covariance(
+    rays_local: np.ndarray,
+    parallel_variance: np.ndarray,
+    lateral_variance: np.ndarray,
+    transform: Sim3,
+) -> np.ndarray:
+    rays_world = transform.rotate_directions(rays_local)
+    parallel = transform.scale**2 * np.asarray(
+        parallel_variance,
+        dtype=np.float64,
+    )
+    lateral = transform.scale**2 * np.asarray(
+        lateral_variance,
+        dtype=np.float64,
+    )
+    outer = np.einsum("ni,nj->nij", rays_world, rays_world)
+    identity = np.eye(3, dtype=np.float64)
+    return lateral[:, None, None] * identity + (
+        parallel - lateral
+    )[:, None, None] * outer
+
+
+def _build_prob4d_observation_belief(
+    selection: CausalOverlapSelection,
+    *,
+    case_id: str,
+    causal_frame_stop: int,
+    metric_anchor: MetricGaugeAnchorV1,
+    pixel_stride: int = 4,
+    effective_samples_per_group: float = 64.0,
+    minimum_prior_reliability: float = 0.05,
+    gauge_mode: str = "fixed_lag",
+    fixed_lag: int = 4,
+    view_name: str = "camera0",
+    source_revision: str | None = None,
+    uncertainty_model: DepthDisagreementModel | None = None,
+) -> ObservationBeliefExportV1:
+    """Build without opening or using post-cutoff prediction payloads."""
+
+    if not case_id or not view_name:
+        raise ValueError("case_id and view_name must be nonempty")
+    if case_id != metric_anchor.case_id:
+        raise ValueError(
+            "case_id does not match the metric gauge anchor"
+        )
+    metric_anchor.require_fixed()
+    if pixel_stride < 1:
+        raise ValueError("pixel_stride must be positive")
+    if not np.isfinite(effective_samples_per_group) or (
+        effective_samples_per_group <= 0.0
+    ):
+        raise ValueError(
+            "effective_samples_per_group must be positive"
+        )
+
+    windows = selection.predictions
+    alignments, estimates = _gauge_estimates(
+        windows,
+        gauge_mode=gauge_mode,
+        fixed_lag=fixed_lag,
+        metric_anchor=metric_anchor,
+    )
+    window_map = {
+        window.window_id: window for window in windows
+    }
+    evidence = accumulate_disagreement(window_map, alignments)
+    model = uncertainty_model or DepthDisagreementModel()
+
+    eligible_frames = sorted(
+        {
+            int(frame)
+            for window in windows
+            for frame in window.frame_indices
+        }
+    )
+    if not eligible_frames or eligible_frames[-1] >= causal_frame_stop:
+        raise RuntimeError(
+            "causal overlap selection produced an invalid frame set"
+        )
+    frame_to_group = {
+        frame: group
+        for group, frame in enumerate(eligible_frames)
+    }
+
+    means: list[np.ndarray] = []
+    frame_ids: list[np.ndarray] = []
+    entity_ids: list[np.ndarray] = []
+    view_indices: list[np.ndarray] = []
+    window_indices: list[np.ndarray] = []
+    correlation_groups: list[np.ndarray] = []
+    factor_groups: list[np.ndarray] = []
+    reliabilities: list[np.ndarray] = []
+    associations: list[np.ndarray] = []
+    local_covariances: list[np.ndarray] = []
+    factors: list[np.ndarray] = []
+
+    for window_index, window in enumerate(windows):
+        estimate = estimates[window.window_id]
+        disagreement = evidence[window.window_id]
+        uncertainty = model.predict(window, disagreement)
+        reliability = _prior_reliability(
+            disagreement.parallel_mean,
+            disagreement.lateral_mean,
+            uncertainty.parallel_variance,
+            uncertainty.lateral_variance,
+            disagreement.count,
+            minimum=minimum_prior_reliability,
+        )
+        rays = window.rays()
+        height, width = window.shape[1:]
+        sample_mask = np.zeros((height, width), dtype=bool)
+        sample_mask[::pixel_stride, ::pixel_stride] = True
+        linear_entity = np.arange(
+            height * width,
+            dtype=np.int64,
+        ).reshape(height, width)
+        for local_index, frame in enumerate(window.frame_indices):
+            absolute_frame = int(frame)
+            selected = window.valid_mask[local_index] & sample_mask
+            if not np.any(selected):
+                continue
+            count = int(np.count_nonzero(selected))
+            local_points = window.point_map[local_index][selected]
+            means.append(
+                estimate.global_from_local.transform_points(
+                    local_points
+                )
+            )
+            frame_ids.append(
+                np.full(
+                    count,
+                    absolute_frame,
+                    dtype=np.int64,
+                )
+            )
+            entity_ids.append(linear_entity[selected])
+            view_indices.append(
+                np.zeros(count, dtype=np.int64)
+            )
+            window_indices.append(
+                np.full(
+                    count,
+                    window_index,
+                    dtype=np.int64,
+                )
+            )
+            correlation_groups.append(
+                np.full(
+                    count,
+                    frame_to_group[absolute_frame],
+                    dtype=np.int64,
+                )
+            )
+            factor_groups.append(
+                np.full(
+                    count,
+                    window_index,
+                    dtype=np.int64,
+                )
+            )
+            reliabilities.append(
+                reliability[local_index][selected]
+            )
+            associations.append(
+                np.ones(count, dtype=np.float64)
+            )
+            local_covariances.append(
+                _row_covariance(
+                    rays[local_index][selected],
+                    uncertainty.parallel_variance[
+                        local_index
+                    ][selected],
+                    uncertainty.lateral_variance[
+                        local_index
+                    ][selected],
+                    estimate.global_from_local,
+                )
+            )
+            factors.append(
+                gauge_covariance_factor(
+                    local_points,
+                    estimate.global_from_local,
+                    estimate.covariance,
+                    include_translation=True,
+                )
+            )
+
+    if not means:
+        raise ValueError(
+            "no valid sampled observation remains in the causal prefix"
+        )
+    mean_array = np.concatenate(means)
+    frame_array = np.concatenate(frame_ids)
+    entity_array = np.concatenate(entity_ids)
+    view_array = np.concatenate(view_indices)
+    window_array = np.concatenate(window_indices)
+    correlation_array = np.concatenate(correlation_groups)
+    factor_group_array = np.concatenate(factor_groups)
+    reliability_array = np.concatenate(reliabilities)
+    association_array = np.concatenate(associations)
+    local_covariance_array = np.concatenate(local_covariances)
+    factor_array = np.concatenate(factors)
+
+    group_ids = np.unique(correlation_array)
+    group_prior = np.empty(len(group_ids), dtype=np.float64)
+    group_weight = np.empty(len(group_ids), dtype=np.float64)
+    for position, group_id in enumerate(group_ids):
+        selected = correlation_array == group_id
+        group_prior[position] = float(
+            np.quantile(reliability_array[selected], 0.25)
+        )
+        unique_entities = len(
+            np.unique(entity_array[selected])
+        )
+        effective = min(
+            effective_samples_per_group,
+            float(unique_entities),
+        )
+        group_weight[position] = min(
+            1.0,
+            effective / float(np.count_nonzero(selected)),
+        )
+
+    revision = source_revision or _git_revision()
+    metadata = {
+        "metric_coordinates": True,
+        "metric_units": "m",
+        "coordinate_frame": metric_anchor.world_frame_id,
+        "metric_gauge_anchor": {
+            "artifact_id": metric_anchor.artifact_id,
+            "window_id": metric_anchor.reference_window_id,
+            "world_frame_id": metric_anchor.world_frame_id,
+            "source_artifact_sha256": (
+                metric_anchor.source_artifact_sha256
+            ),
+            "calibration_artifact_sha256": (
+                metric_anchor.calibration_artifact_sha256
+            ),
+            "covariance_treatment": (
+                "fixed_external_calibration"
+            ),
+        },
+        "causal_source_lineage": (
+            selection.artifact_lineage_metadata(
+                causal_frame_stop=causal_frame_stop
+            )
+        ),
+        "gauge_mode": gauge_mode,
+        "fixed_lag": (
+            fixed_lag if gauge_mode == "fixed_lag" else None
+        ),
+        "pixel_stride": pixel_stride,
+        "effective_samples_per_group": (
+            effective_samples_per_group
+        ),
+        "minimum_prior_reliability": (
+            minimum_prior_reliability
+        ),
+        "uncertainty_model": asdict(model),
+        "group_definition": (
+            "absolute source frame across overlap windows"
+        ),
+        "factor_definition": (
+            "shared seven-dimensional gauge latent per window"
+        ),
+        "factor_group_semantics": (
+            "window gauge marginals are explicit nuisance factors; "
+            "remaining cross-window dependence is capped by "
+            "composite weights"
+        ),
+        "association_probability_definition": (
+            "same decoded pixel identity within one independently "
+            "decoded window"
+        ),
+        "prior_reliability_definition": (
+            "overlap disagreement only; independent of downstream "
+            "physical innovation"
+        ),
+        "motioncrafter_commit": (
+            selection.manifest["motioncrafter_commit"]
+        ),
+        "prediction_manifest_format_version": (
+            selection.manifest["format_version"]
+        ),
+    }
+    return ObservationBeliefExportV1(
+        case_id=case_id,
+        stream_id="prob4d:causal-overlap-window-points",
+        causal_frame_stop=causal_frame_stop,
+        view_names=(view_name,),
+        window_names=tuple(
+            window.window_id for window in windows
+        ),
+        factor_names=GAUGE_FACTOR_NAMES,
+        source_repository="FlorianPfaff/Prob4D",
+        source_revision=revision,
+        source_artifact_sha256=(
+            selection.source_artifact_sha256
+        ),
+        declared_frame_ids=np.asarray(
+            eligible_frames,
+            dtype=np.int64,
+        ),
+        mean_xyz_m=mean_array,
+        frame_ids=frame_array,
+        entity_ids=entity_array,
+        view_indices=view_array,
+        window_indices=window_array,
+        correlation_group_ids=correlation_array,
+        factor_group_ids=factor_group_array,
+        prior_reliability=reliability_array,
+        association_probability=association_array,
+        local_covariance_m2=local_covariance_array,
+        low_rank_factor_m=factor_array,
+        group_ids=group_ids,
+        group_prior_nominal_probability=group_prior,
+        group_composite_weight=group_weight,
+        metadata=metadata,
+    )
+
+
+def build_prob4d_observation_belief(
+    manifest_path: str | Path,
+    *,
+    case_id: str,
+    causal_frame_stop: int,
+    metric_anchor: MetricGaugeAnchorV1,
+    pixel_stride: int = 4,
+    effective_samples_per_group: float = 64.0,
+    minimum_prior_reliability: float = 0.05,
+    gauge_mode: str = "fixed_lag",
+    fixed_lag: int = 4,
+    view_name: str = "camera0",
+    source_revision: str | None = None,
+    uncertainty_model: DepthDisagreementModel | None = None,
+) -> ObservationBeliefExportV1:
+    """Select a causal prefix and build a portable observation belief."""
+
+    selection = select_causal_overlap_windows(
+        manifest_path,
+        causal_frame_stop=causal_frame_stop,
+        metric_anchor=metric_anchor,
+    )
+    return _build_prob4d_observation_belief(
+        selection,
+        case_id=case_id,
+        causal_frame_stop=causal_frame_stop,
+        metric_anchor=metric_anchor,
+        pixel_stride=pixel_stride,
+        effective_samples_per_group=(
+            effective_samples_per_group
+        ),
+        minimum_prior_reliability=(
+            minimum_prior_reliability
+        ),
+        gauge_mode=gauge_mode,
+        fixed_lag=fixed_lag,
+        view_name=view_name,
+        source_revision=source_revision,
+        uncertainty_model=uncertainty_model,
+    )
+
+
+def _write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("predictions_manifest", type=Path)
+    parser.add_argument("output_npz", type=Path)
+    parser.add_argument("--case-id", required=True)
+    parser.add_argument(
+        "--causal-frame-stop",
+        type=int,
+        required=True,
+    )
+    parser.add_argument(
+        "--metric-gauge-anchor",
+        type=Path,
+        required=True,
+    )
+    parser.add_argument("--pixel-stride", type=int, default=4)
+    parser.add_argument(
+        "--effective-samples-per-group",
+        type=float,
+        default=64.0,
+    )
+    parser.add_argument(
+        "--minimum-prior-reliability",
+        type=float,
+        default=0.05,
+    )
+    parser.add_argument(
+        "--gauge-mode",
+        choices=("sequential", "fixed_lag"),
+        default="fixed_lag",
+    )
+    parser.add_argument("--fixed-lag", type=int, default=4)
+    parser.add_argument("--view-name", default="camera0")
+    parser.add_argument("--source-revision")
+    parser.add_argument("--summary-json", type=Path)
+    args = parser.parse_args(argv)
+
+    anchor = load_metric_gauge_anchor(
+        args.metric_gauge_anchor
+    )
+    selection = select_causal_overlap_windows(
+        args.predictions_manifest,
+        causal_frame_stop=args.causal_frame_stop,
+        metric_anchor=anchor,
+    )
+    artifact = _build_prob4d_observation_belief(
+        selection,
+        case_id=args.case_id,
+        causal_frame_stop=args.causal_frame_stop,
+        metric_anchor=anchor,
+        pixel_stride=args.pixel_stride,
+        effective_samples_per_group=(
+            args.effective_samples_per_group
+        ),
+        minimum_prior_reliability=(
+            args.minimum_prior_reliability
+        ),
+        gauge_mode=args.gauge_mode,
+        fixed_lag=args.fixed_lag,
+        view_name=args.view_name,
+        source_revision=args.source_revision,
+    )
+    save_observation_belief_export(
+        args.output_npz,
+        artifact,
+    )
+    summary = {
+        **selection.run_summary(
+            causal_frame_stop=args.causal_frame_stop
+        ),
+        "artifact_id": artifact.artifact_id,
+        "case_id": artifact.case_id,
+        "observation_count": len(artifact.mean_xyz_m),
+        "group_count": len(artifact.group_ids),
+        "factor_rank": len(artifact.factor_names),
+        "metric_gauge_anchor_id": anchor.artifact_id,
+        "output": str(args.output_npz.resolve()),
+    }
+    if args.summary_json is not None:
+        _write_json(args.summary_json, summary)
+    print(json.dumps(summary, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "CAUSAL_SOURCE_LINEAGE_SCHEMA_VERSION",
+    "GAUGE_FACTOR_NAMES",
+    "METRIC_GAUGE_ANCHOR_SCHEMA",
+    "METRIC_GAUGE_ANCHOR_VERSION",
+    "CausalOverlapSelection",
+    "MetricGaugeAnchorV1",
+    "SelectedOverlapWindow",
+    "build_prob4d_observation_belief",
+    "gauge_covariance_factor",
+    "load_metric_gauge_anchor",
+    "save_metric_gauge_anchor",
+    "select_causal_overlap_windows",
+]

--- a/tests/test_observation_contract.py
+++ b/tests/test_observation_contract.py
@@ -1,0 +1,89 @@
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from prob4d.observation_contract import (
+    ObservationBeliefExportV1,
+    save_observation_belief_export,
+)
+
+GOLDEN_ARTIFACT_ID = (
+    "9c02e638f60424cca7738d347d1258acd208eb562f422efacd077db4edb2fe80"
+)
+
+
+def _artifact() -> ObservationBeliefExportV1:
+    local = np.repeat(np.eye(3)[None], 4, axis=0) * 1e-4
+    factors = np.zeros((4, 3, 2))
+    factors[:2, 0, 0] = 0.002
+    factors[2:, 1, 1] = 0.003
+    return ObservationBeliefExportV1(
+        case_id="case-1",
+        stream_id="prob4d:points",
+        causal_frame_stop=12,
+        view_names=("camera0",),
+        window_names=("window0", "window1"),
+        factor_names=("gauge_latent_0", "gauge_latent_1"),
+        source_repository="FlorianPfaff/Prob4D",
+        source_revision="a" * 40,
+        source_artifact_sha256="b" * 64,
+        declared_frame_ids=np.asarray([8, 9]),
+        mean_xyz_m=np.asarray(
+            [
+                [0.0, 0.0, 1.0],
+                [1.0, 0.0, 1.0],
+                [0.1, 0.0, 1.0],
+                [1.1, 0.0, 1.0],
+            ]
+        ),
+        frame_ids=np.asarray([8, 8, 9, 9]),
+        entity_ids=np.asarray([0, 1, 0, 1]),
+        view_indices=np.zeros(4, dtype=int),
+        window_indices=np.asarray([0, 0, 1, 1]),
+        correlation_group_ids=np.asarray([0, 0, 1, 1]),
+        factor_group_ids=np.asarray([0, 0, 1, 1]),
+        prior_reliability=np.asarray([0.9, 0.8, 0.7, 0.6]),
+        association_probability=np.ones(4),
+        local_covariance_m2=local,
+        low_rank_factor_m=factors,
+        group_ids=np.asarray([0, 1]),
+        group_prior_nominal_probability=np.asarray([0.85, 0.65]),
+        group_composite_weight=np.asarray([0.5, 0.5]),
+        metadata={"causal_source": "prefix only"},
+    )
+
+
+def test_contract_matches_cross_repository_golden_digest(
+    tmp_path: Path,
+) -> None:
+    artifact = _artifact()
+    assert artifact.artifact_id == GOLDEN_ARTIFACT_ID
+    path = tmp_path / "observation.npz"
+    save_observation_belief_export(path, artifact)
+    with np.load(path, allow_pickle=False) as archive:
+        assert "descriptor_json" in archive.files
+        assert archive["low_rank_factor_m"].shape == (4, 3, 2)
+
+
+def test_contract_rejects_future_frame() -> None:
+    artifact = _artifact()
+    with pytest.raises(ValueError, match="causal boundary"):
+        ObservationBeliefExportV1(
+            **{
+                **artifact.__dict__,
+                "declared_frame_ids": np.asarray([8, 12]),
+                "frame_ids": np.asarray([8, 8, 12, 12]),
+            }
+        )
+
+
+def test_contract_rejects_duplicate_observation_identity() -> None:
+    artifact = _artifact()
+    with pytest.raises(ValueError, match="must be unique"):
+        ObservationBeliefExportV1(
+            **{
+                **artifact.__dict__,
+                "entity_ids": np.asarray([0, 0, 0, 1]),
+            }
+        )

--- a/tests/test_observation_export.py
+++ b/tests/test_observation_export.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from prob4d.gauge import GaugeEstimate
+from prob4d.observation_contract import file_sha256
+from prob4d.observation_export import (
+    MetricGaugeAnchorV1,
+    build_prob4d_observation_belief,
+    gauge_covariance_factor,
+    load_metric_gauge_anchor,
+    save_metric_gauge_anchor,
+    select_causal_overlap_windows,
+)
+from prob4d.sim3 import Sim3
+
+
+def _anchor(source_sha256: str = "a" * 64) -> MetricGaugeAnchorV1:
+    return MetricGaugeAnchorV1(
+        case_id="case-a",
+        world_frame_id="phystwin-world",
+        reference_window_id="window_0000",
+        source_artifact_sha256=source_sha256,
+        calibration_artifact_sha256="b" * 64,
+        global_from_reference=Sim3.identity(),
+        covariance=np.zeros((7, 7)),
+    )
+
+
+def _window(
+    path: Path,
+    frames: list[int],
+    offset: float = 0.0,
+) -> None:
+    grid = np.asarray(
+        [
+            [[0.0, 0.0, 1.0], [1.0, 0.0, 1.0]],
+            [[0.0, 1.0, 1.0], [1.0, 1.0, 1.0]],
+        ]
+    )
+    points = np.stack(
+        [
+            grid + np.asarray([offset, 0.0, 0.0])
+            for _ in frames
+        ]
+    )
+    np.savez_compressed(
+        path,
+        frame_indices=np.asarray(frames),
+        point_map=points,
+        valid_mask=np.ones(points.shape[:-1], dtype=bool),
+    )
+
+
+def _manifest(
+    directory: Path,
+    *,
+    name: str,
+    include_future: bool,
+) -> Path:
+    entries = [
+        {
+            "window_id": "window_0000",
+            "path": "window_0000.npz",
+            "start_frame": 0,
+            "stop_frame": 4,
+        },
+        {
+            "window_id": "window_0001",
+            "path": "window_0001.npz",
+            "start_frame": 2,
+            "stop_frame": 6,
+        },
+    ]
+    if include_future:
+        entries.append(
+            {
+                "window_id": "window_0002",
+                "path": "future-does-not-exist.npz",
+                "start_frame": 4,
+                "stop_frame": 8,
+            }
+        )
+    payload = {
+        "format_version": 1,
+        "motioncrafter_commit": "b" * 40,
+        "config": {
+            "model_type": "determ",
+            "window_size": 4,
+            "overlap": 2,
+            "height": 2,
+            "width": 2,
+            "seed": 42,
+            "frame_start": 0,
+            "frame_stop": 8 if include_future else 6,
+            "frame_stride": 1,
+        },
+        "temporal_lineage": {
+            "schema_version": 1,
+            "model": "motioncrafter_sliding_window_v1",
+            "products": {
+                "overlap_windows": {
+                    "window_size_source": (
+                        "prediction archive frame count"
+                    ),
+                    "overlap": 0,
+                }
+            },
+        },
+        "overlap_windows": entries,
+        "disjoint_baseline": "unused.npz",
+        "latent_linear_baseline": "unused2.npz",
+    }
+    path = directory / name
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_metric_anchor_round_trip(tmp_path: Path) -> None:
+    path = tmp_path / "anchor.json"
+    save_metric_gauge_anchor(path, _anchor())
+    restored = load_metric_gauge_anchor(path)
+    assert restored.artifact_id == _anchor().artifact_id
+    assert restored.world_frame_id == "phystwin-world"
+
+
+def test_causal_selection_does_not_open_future_payload(
+    tmp_path: Path,
+) -> None:
+    _window(tmp_path / "window_0000.npz", [0, 1, 2, 3])
+    _window(
+        tmp_path / "window_0001.npz",
+        [2, 3, 4, 5],
+        offset=0.1,
+    )
+    manifest = _manifest(
+        tmp_path,
+        name="predictions.json",
+        include_future=True,
+    )
+    selection = select_causal_overlap_windows(
+        manifest,
+        causal_frame_stop=6,
+        metric_anchor=_anchor(
+            file_sha256(tmp_path / "window_0000.npz")
+        ),
+    )
+    assert [item.window_id for item in selection.windows] == [
+        "window_0000",
+        "window_0001",
+    ]
+    assert selection.skipped_window_count == 1
+    assert selection.artifact_lineage_metadata(
+        causal_frame_stop=6
+    )["future_prediction_payloads_opened"] == 0
+
+
+def test_future_append_does_not_change_exported_artifact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _window(tmp_path / "window_0000.npz", [0, 1, 2, 3])
+    _window(
+        tmp_path / "window_0001.npz",
+        [2, 3, 4, 5],
+        offset=0.1,
+    )
+    prefix = _manifest(
+        tmp_path,
+        name="prefix.json",
+        include_future=False,
+    )
+    appended = _manifest(
+        tmp_path,
+        name="appended.json",
+        include_future=True,
+    )
+
+    def fake_gauge_estimates(
+        windows,
+        *,
+        gauge_mode,
+        fixed_lag,
+        metric_anchor,
+    ):
+        del gauge_mode, fixed_lag
+        return [], {
+            window.window_id: GaugeEstimate(
+                window.window_id,
+                metric_anchor.global_from_reference,
+                metric_anchor.covariance,
+            )
+            for window in windows
+        }
+
+    monkeypatch.setattr(
+        "prob4d.observation_export._gauge_estimates",
+        fake_gauge_estimates,
+    )
+
+    common = {
+        "case_id": "case-a",
+        "causal_frame_stop": 6,
+        "metric_anchor": _anchor(
+            file_sha256(tmp_path / "window_0000.npz")
+        ),
+        "pixel_stride": 1,
+        "gauge_mode": "sequential",
+        "source_revision": "c" * 40,
+    }
+    first = build_prob4d_observation_belief(prefix, **common)
+    second = build_prob4d_observation_belief(appended, **common)
+
+    assert first.source_artifact_sha256 == (
+        second.source_artifact_sha256
+    )
+    assert first.artifact_id == second.artifact_id
+    np.testing.assert_array_equal(
+        first.mean_xyz_m,
+        second.mean_xyz_m,
+    )
+
+
+def test_selection_rejects_payload_frame_ids_that_cross_cutoff(
+    tmp_path: Path,
+) -> None:
+    _window(tmp_path / "window_0000.npz", [0, 1, 2, 5])
+    manifest = _manifest(
+        tmp_path,
+        name="bad.json",
+        include_future=False,
+    )
+    payload = json.loads(manifest.read_text())
+    payload["overlap_windows"] = payload["overlap_windows"][:1]
+    manifest.write_text(json.dumps(payload))
+
+    with pytest.raises(ValueError, match="frame IDs disagree"):
+        select_causal_overlap_windows(
+            manifest,
+            causal_frame_stop=6,
+            metric_anchor=_anchor(
+                file_sha256(tmp_path / "window_0000.npz")
+            ),
+        )
+
+
+def test_gauge_factor_recovers_linearized_marginal() -> None:
+    covariance = np.diag(
+        [0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07]
+    )
+    points = np.asarray(
+        [[1.0, 2.0, 3.0], [0.5, -1.0, 2.0]]
+    )
+    factor = gauge_covariance_factor(
+        points,
+        Sim3.identity(),
+        covariance,
+        include_translation=True,
+    )
+    marginal = np.einsum("nir,njr->nij", factor, factor)
+
+    expected = []
+    for point in points:
+        skew = np.asarray(
+            [
+                [0.0, -point[2], point[1]],
+                [point[2], 0.0, -point[0]],
+                [-point[1], point[0], 0.0],
+            ]
+        )
+        jacobian = np.zeros((3, 7))
+        jacobian[:, 0] = point
+        jacobian[:, 1:4] = -skew
+        jacobian[:, 4:7] = np.eye(3)
+        expected.append(jacobian @ covariance @ jacobian.T)
+    np.testing.assert_allclose(
+        marginal,
+        np.asarray(expected),
+        atol=1e-12,
+    )
+
+
+def test_portable_export_rejects_uncertain_global_anchor(
+    tmp_path: Path,
+) -> None:
+    _window(tmp_path / "window_0000.npz", [0, 1, 2, 3])
+    manifest = _manifest(
+        tmp_path,
+        name="predictions.json",
+        include_future=False,
+    )
+    payload = json.loads(manifest.read_text())
+    payload["overlap_windows"] = payload["overlap_windows"][:1]
+    manifest.write_text(json.dumps(payload))
+    anchor = MetricGaugeAnchorV1(
+        **{
+            **_anchor(
+                file_sha256(tmp_path / "window_0000.npz")
+            ).__dict__,
+            "covariance": np.eye(7) * 1e-6,
+        }
+    )
+    with pytest.raises(
+        ValueError,
+        match="cannot encode both uncertain global",
+    ):
+        select_causal_overlap_windows(
+            manifest,
+            causal_frame_stop=4,
+            metric_anchor=anchor,
+        )


### PR DESCRIPTION
## Summary

Add the missing production bridge from MotionCrafter prediction bundles to the provider-neutral `phys4d.observation_belief` artifact consumed by Bayesian-PhysTwin and independently validated by Causal4D.

## What changed

- add a byte-addressed `ObservationBeliefExportV1` writer matching the existing cross-repository schema and golden digest;
- add a content-addressed fixed metric-gauge anchor bound to the exact first retained prediction window and calibration artifact;
- select causally complete independently decoded windows from manifest metadata before opening prediction payloads;
- recompute relative alignment, gauge estimation/smoothing, overlap disagreement, uncertainty, and prior reliability only on the admitted prefix;
- export conditional metric covariance plus shared low-rank `Sim(3)` gauge factors, avoiding gauge double counting;
- retain association probability and prior reliability as separate fields;
- cap repeated dense evidence with frame-level correlation groups and composite-likelihood weights;
- add `prob4d-create-metric-gauge-anchor` and `prob4d-export-observation-belief` CLIs;
- document the causal, covariance, metric-anchor, and provenance contracts.

## Root cause addressed

Filtering output rows after estimating gauges and uncertainty on a full prediction bundle is not causally safe: post-cutoff overlap frames can alter pre-cutoff transforms, covariance, disagreement, and reliability. The new path admits complete source windows first and performs every statistical operation after that selection.

The source content address deliberately excludes unconsumed future-entry bookkeeping. Appending post-cutoff windows therefore leaves the selected source digest and final observation artifact ID unchanged, and crossing payload files are never opened.

## Metric-anchor boundary

Portable `ObservationBeliefV1` has one coherent seven-dimensional gauge factor per window. A nonzero global metric-anchor covariance would require another coherent factor shared across every window and cannot be represented correctly at the fixed rank used by V1. This exporter therefore requires a fixed external metric calibration. Users who need an uncertain global anchor must use the existing `ObservationFactorBundle` interface instead.

## Validation

Focused regression coverage includes:

- the shared cross-repository golden artifact ID;
- descriptor/array content addressing;
- future-frame and duplicate-row rejection;
- metric-anchor round trip and reference-payload binding;
- fail-closed source-frame validation;
- future payloads that do not exist because they must not be opened;
- exact artifact invariance after appending post-cutoff windows;
- recovery of `J Sigma_g J^T` from the exported low-rank factor;
- rejection of uncertain global anchors on the compact V1 path.

The repository workflow will run Ruff and the complete pytest suite on this draft PR.

## Claim boundary

This PR creates an auditable uncertainty/provenance boundary. It does not claim that Prob4D observations improve a physical twin or that the exported covariance is prospectively calibrated. Relative window gauges are represented by marginal low-rank factors; residual cross-window dependence remains conservatively capped by composite weights pending a future joint sparse gauge posterior.