### PR TITLE
Add immutable prediction inputs and a versioned provider API

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,9 +4,17 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-python@v6
@@ -15,4 +23,61 @@ jobs:
           cache: pip
       - run: python -m pip install -e ".[dev]"
       - run: ruff check src tests
+      - run: python -m compileall -q src
+
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.12", "3.14"]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - run: python -m pip install -e ".[dev]"
       - run: python -m pytest -q
+
+  package:
+    needs: [lint, test]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
+      - run: python -m pip install ".[dev]"
+      - run: python -m build
+      - run: python -m twine check dist/*
+      - run: python -m venv /tmp/prob4d-wheel
+      - run: /tmp/prob4d-wheel/bin/python -m pip install dist/*.whl
+      - run: /tmp/prob4d-wheel/bin/python -m pip check
+      - name: Smoke-test installed imports
+        run: |
+          /tmp/prob4d-wheel/bin/python - <<'PY'
+          import prob4d
+          import prob4d.provider_v1 as provider
+
+          print(prob4d.__version__)
+          assert provider.PROVIDER_API_VERSION == 1
+          PY
+      - name: Smoke-test installed command help
+        run: |
+          for command in \
+            prob4d-ablate \
+            prob4d-benchmark \
+            prob4d-export-observation-belief \
+            prob4d-motioncrafter \
+            prob4d-phystwin \
+            prob4d-phystwin-state \
+            prob4d-phystwin-uncertainty \
+            prob4d-sintel-uncertainty \
+            prob4d-vggt-baseline
+          do
+            "/tmp/prob4d-wheel/bin/${command}" --help >/dev/null
+          done

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,89 @@
+# Prob4D architecture and repository boundary
+
+Prob4D is an optional 4-D perception provider. It estimates uncertain `Sim(3)`
+gauges for independently decoded MotionCrafter windows, calibrates conditional
+point uncertainty, and exports observations without performing a physical-state
+update.
+
+The intended dependency direction is:
+
+```text
+MotionCrafter / alternative 4-D provider
+    -> Prob4D provider API
+    -> phys4d.observation_belief or ObservationFactorBundle
+    -> Bayesian-PhysTwin guarded physical belief
+    -> conditional Causal4D intervention analysis
+```
+
+Prob4D must not depend on Bayesian-PhysTwin or Causal4D at runtime. Those
+repositories may validate the neutral artifacts independently, but should not
+import Prob4D experiment helpers or underscore-prefixed modules.
+
+## Stable provider API
+
+Downstream development code should import `prob4d.provider_v1`. Version 1
+exposes:
+
+- causal source selection before any excluded payload is opened;
+- the content-addressed metric-gauge anchor;
+- the portable `phys4d.observation_belief` version-1 writer;
+- the richer `ObservationFactorBundle` contract and serializer.
+
+Root-package imports remain available for compatibility, but
+`prob4d.provider_v1` is the versioned cross-repository boundary. A breaking
+change requires a new provider module rather than silently changing version 1.
+Frozen experiments should continue to record exact repository commits and input
+artifact hashes even when they use a compatible provider API.
+
+## Causal information boundary
+
+Predictive exports use an exclusive `causal_frame_stop`. A selected window must
+be independently decoded and every source frame used by that window must satisfy
+
+```text
+source_frame < causal_frame_stop.
+```
+
+Selection is performed from manifest metadata before payload loading. Alignment,
+gauge estimation, overlap disagreement, uncertainty, and prior reliability are
+then recomputed using only the admitted prefix. Appending future manifest entries
+must not change the selected-source digest or the exported artifact.
+
+## Covariance boundary
+
+`ObservationBeliefV1` is a compact contract conditional on a fixed external
+metric anchor. It stores conditional `3 x 3` point covariance and one coherent
+rank-seven gauge factor per retained window. It does not represent the complete
+joint cross-window gauge posterior; residual dependence is capped with
+composite-likelihood weights.
+
+`ObservationFactorBundle` is the lossless interface when a downstream estimator
+needs explicit gauge nuisance blocks, an uncertain global anchor, or richer
+factor-level provenance. Conditional covariance and gauge uncertainty must not be
+added twice.
+
+Association probability, source-side prior reliability, group nominal
+probability, and composite weight are separate quantities. In particular,
+overlap reliability is not reused as a nominal/outlier prior unless that prior
+has been calibrated independently.
+
+## Artifact ownership
+
+Prob4D owns:
+
+- MotionCrafter prediction manifests and decoded-window payloads;
+- gauge and uncertainty calibration artifacts;
+- portable observation beliefs and observation-factor bundles;
+- provider-side benchmarks and run manifests.
+
+Bayesian-PhysTwin owns physical priors, guarded updates, fallback behavior, and
+accepted twin beliefs. Causal4D owns realized-intervention inference downstream
+of an accepted, content-bound twin belief. Paper-facing tables and sealed result
+manifests belong in the corresponding paper or reproduction repository rather
+than the Python package.
+
+## Experimental modules
+
+The `prob4d-phystwin*` commands are integration experiments, not the stable
+provider interface. They may evolve with a particular study. External consumers
+should depend only on `prob4d.provider_v1` and the versioned artifact contracts.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "prob4d"
-version = "0.1.0"
+version = "0.2.0"
 description = "Probabilistic recursive fusion for long-horizon 4D reconstruction"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -13,9 +13,11 @@ dependencies = ["numpy>=1.24"]
 
 [project.optional-dependencies]
 dev = [
+  "build>=1.2",
   "pytest>=7.4",
   "pytest-cov>=4.1",
   "ruff>=0.6",
+  "twine>=5.0",
 ]
 
 [project.scripts]

--- a/src/prob4d/__init__.py
+++ b/src/prob4d/__init__.py
@@ -1,5 +1,7 @@
 """Probabilistic long-horizon fusion for MotionCrafter predictions."""
 
+from importlib.metadata import PackageNotFoundError, version
+
 from .data import PredictionWindow
 from .observation_contract import (
     OBSERVATION_BELIEF_SCHEMA,
@@ -43,4 +45,8 @@ __all__ = [
     "stack_observation_factors",
     "write_observation_factor_bundle",
 ]
-__version__ = "0.1.0"
+
+try:
+    __version__ = version("prob4d")
+except PackageNotFoundError:  # pragma: no cover - source tree without installation
+    __version__ = "0+unknown"

--- a/src/prob4d/data.py
+++ b/src/prob4d/data.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 from numpy.typing import NDArray
@@ -13,12 +14,22 @@ BoolArray = NDArray[np.bool_]
 IntArray = NDArray[np.integer]
 
 
+def _readonly(value: np.ndarray, *, dtype: Any | None = None) -> np.ndarray:
+    """Return a defensive, read-only NumPy copy."""
+
+    result = np.asarray(value, dtype=dtype).copy()
+    result.setflags(write=False)
+    return result
+
+
 @dataclass(frozen=True)
 class PredictionWindow:
     """Decoded predictions for one local MotionCrafter temporal window.
 
     Point maps and scene flow use the window's local world gauge. Absolute
     ``frame_indices`` identify duplicate frames across overlapping windows.
+    Every NumPy field is defensively copied and made read-only so a validated
+    window cannot be mutated after it has entered a content-addressed artifact.
     """
 
     window_id: str
@@ -30,14 +41,17 @@ class PredictionWindow:
     ray_directions: FloatArray | None = None
 
     def __post_init__(self) -> None:
-        frame_indices = np.asarray(self.frame_indices, dtype=np.int64)
-        point_map = np.asarray(self.point_map, dtype=np.float64)
-        valid_mask = np.asarray(self.valid_mask, dtype=bool)
+        window_id = str(self.window_id)
+        frame_indices = np.asarray(self.frame_indices, dtype=np.int64).copy()
+        point_map = np.asarray(self.point_map, dtype=np.float64).copy()
+        valid_mask = np.asarray(self.valid_mask, dtype=bool).copy()
 
-        if not self.window_id:
+        if not window_id:
             raise ValueError("window_id must not be empty")
         if frame_indices.ndim != 1 or frame_indices.size == 0:
             raise ValueError("frame_indices must be a non-empty one-dimensional array")
+        if np.any(frame_indices < 0):
+            raise ValueError("frame_indices must be non-negative")
         if np.any(np.diff(frame_indices) <= 0):
             raise ValueError("frame_indices must be strictly increasing")
         if point_map.ndim != 4 or point_map.shape[-1] != 3:
@@ -55,27 +69,40 @@ class PredictionWindow:
 
         if (scene_flow is None) != (deform_mask is None):
             raise ValueError("scene_flow and deform_mask must either both be present or absent")
+        if scene_flow is not None and not np.all(np.isfinite(scene_flow[deform_mask])):
+            raise ValueError("active scene_flow entries must be finite")
         if rays is not None:
+            if not np.all(np.isfinite(rays[valid_mask])):
+                raise ValueError("valid ray directions must be finite")
             ray_norm = np.linalg.norm(rays, axis=-1)
-            active = valid_mask & (ray_norm > 0)
-            if np.any(active):
-                rays = rays.copy()
-                rays[active] /= ray_norm[active, None]
+            if np.any(valid_mask & (ray_norm <= np.finfo(np.float64).eps)):
+                raise ValueError("valid ray directions must be nonzero")
+            normalize = ray_norm > np.finfo(np.float64).eps
+            rays[normalize] /= ray_norm[normalize, None]
 
-        object.__setattr__(self, "frame_indices", frame_indices)
-        object.__setattr__(self, "point_map", point_map)
-        object.__setattr__(self, "valid_mask", valid_mask)
-        object.__setattr__(self, "scene_flow", scene_flow)
-        object.__setattr__(self, "deform_mask", deform_mask)
-        object.__setattr__(self, "ray_directions", rays)
+        object.__setattr__(self, "window_id", window_id)
+        object.__setattr__(self, "frame_indices", _readonly(frame_indices))
+        object.__setattr__(self, "point_map", _readonly(point_map))
+        object.__setattr__(self, "valid_mask", _readonly(valid_mask))
+        object.__setattr__(
+            self,
+            "scene_flow",
+            None if scene_flow is None else _readonly(scene_flow),
+        )
+        object.__setattr__(
+            self,
+            "deform_mask",
+            None if deform_mask is None else _readonly(deform_mask),
+        )
+        object.__setattr__(self, "ray_directions", None if rays is None else _readonly(rays))
 
     @staticmethod
     def _optional_vector_field(
         name: str, value: FloatArray | None, reference: FloatArray
-    ) -> FloatArray | None:
+    ) -> np.ndarray | None:
         if value is None:
             return None
-        array = np.asarray(value, dtype=np.float64)
+        array = np.asarray(value, dtype=np.float64).copy()
         if array.shape != reference.shape:
             raise ValueError(f"{name} must have shape {reference.shape}")
         return array
@@ -83,10 +110,10 @@ class PredictionWindow:
     @staticmethod
     def _optional_mask(
         name: str, value: BoolArray | None, reference: BoolArray
-    ) -> BoolArray | None:
+    ) -> np.ndarray | None:
         if value is None:
             return None
-        array = np.asarray(value, dtype=bool)
+        array = np.asarray(value, dtype=bool).copy()
         if array.shape != reference.shape:
             raise ValueError(f"{name} must have shape {reference.shape}")
         return array

--- a/src/prob4d/provider_v1.py
+++ b/src/prob4d/provider_v1.py
@@ -1,0 +1,117 @@
+"""Stable Prob4D provider API for Bayesian-PhysTwin and Causal4D.
+
+Downstream repositories should import this module rather than experiment helpers
+or underscore-prefixed implementation modules. Version 1 exposes the causal
+source selector, the fixed metric-anchor contract, the portable observation
+belief writer, and the richer unfused factor-bundle contract.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ._causal_observation_source import (
+    CausalOverlapSelection,
+    SelectedOverlapWindow,
+    select_causal_overlap_windows,
+)
+from ._metric_gauge_anchor import (
+    METRIC_GAUGE_ANCHOR_SCHEMA,
+    METRIC_GAUGE_ANCHOR_VERSION,
+    MetricGaugeAnchor,
+    load_metric_gauge_anchor,
+    save_metric_gauge_anchor,
+)
+from .observation_contract import (
+    OBSERVATION_BELIEF_SCHEMA,
+    OBSERVATION_BELIEF_VERSION,
+    ObservationBeliefExportV1,
+    save_observation_belief_export,
+)
+from .observation_export import build_prob4d_observation_belief
+from .observation_factors import (
+    OBSERVATION_FACTOR_SCHEMA,
+    OBSERVATION_FACTOR_SCHEMA_VERSION,
+    ObservationFactorBundle,
+    load_observation_factor_bundle,
+    write_observation_factor_bundle,
+)
+from .uncertainty import DepthDisagreementModel
+
+PROVIDER_API_VERSION = 1
+
+
+def select_causal_source(
+    manifest_path: str | Path,
+    *,
+    causal_frame_stop: int,
+    metric_anchor: MetricGaugeAnchor,
+) -> CausalOverlapSelection:
+    """Select the complete independently decoded source prefix for prediction."""
+
+    return select_causal_overlap_windows(
+        manifest_path,
+        causal_frame_stop=causal_frame_stop,
+        metric_anchor=metric_anchor,
+    )
+
+
+def export_observation_belief(
+    manifest_path: str | Path,
+    *,
+    case_id: str,
+    causal_frame_stop: int,
+    metric_anchor: MetricGaugeAnchor,
+    pixel_stride: int = 4,
+    effective_samples_per_group: float = 64.0,
+    minimum_prior_reliability: float = 0.05,
+    gauge_mode: str = "fixed_lag",
+    fixed_lag: int = 4,
+    view_name: str = "camera0",
+    source_revision: str | None = None,
+    uncertainty_model: DepthDisagreementModel | None = None,
+) -> ObservationBeliefExportV1:
+    """Export a causally sealed portable observation belief.
+
+    Version 1 is conditional on a fixed metric anchor and carries per-window
+    gauge marginals as explicit low-rank nuisance factors. It intentionally does
+    not claim to encode the full joint cross-window gauge posterior.
+    """
+
+    return build_prob4d_observation_belief(
+        manifest_path,
+        case_id=case_id,
+        causal_frame_stop=causal_frame_stop,
+        metric_anchor=metric_anchor,
+        pixel_stride=pixel_stride,
+        effective_samples_per_group=effective_samples_per_group,
+        minimum_prior_reliability=minimum_prior_reliability,
+        gauge_mode=gauge_mode,
+        fixed_lag=fixed_lag,
+        view_name=view_name,
+        source_revision=source_revision,
+        uncertainty_model=uncertainty_model,
+    )
+
+
+__all__ = [
+    "METRIC_GAUGE_ANCHOR_SCHEMA",
+    "METRIC_GAUGE_ANCHOR_VERSION",
+    "OBSERVATION_BELIEF_SCHEMA",
+    "OBSERVATION_BELIEF_VERSION",
+    "OBSERVATION_FACTOR_SCHEMA",
+    "OBSERVATION_FACTOR_SCHEMA_VERSION",
+    "PROVIDER_API_VERSION",
+    "CausalOverlapSelection",
+    "MetricGaugeAnchor",
+    "ObservationBeliefExportV1",
+    "ObservationFactorBundle",
+    "SelectedOverlapWindow",
+    "export_observation_belief",
+    "load_metric_gauge_anchor",
+    "load_observation_factor_bundle",
+    "save_metric_gauge_anchor",
+    "save_observation_belief_export",
+    "select_causal_source",
+    "write_observation_factor_bundle",
+]

--- a/tests/test_data_immutability.py
+++ b/tests/test_data_immutability.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from prob4d.data import PredictionWindow
+
+
+def _inputs() -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    frames = np.asarray([3, 4], dtype=np.int64)
+    points = np.asarray(
+        [
+            [[[1.0, 0.0, 1.0], [0.0, 2.0, 1.0]]],
+            [[[1.5, 0.0, 1.0], [0.0, 2.5, 1.0]]],
+        ]
+    )
+    valid = np.ones(points.shape[:-1], dtype=bool)
+    return frames, points, valid
+
+
+def test_prediction_window_defensively_copies_and_freezes_arrays() -> None:
+    frames, points, valid = _inputs()
+    window = PredictionWindow(
+        window_id="window-a",
+        frame_indices=frames,
+        point_map=points,
+        valid_mask=valid,
+    )
+
+    frames[0] = 99
+    points[0, 0, 0] = 99.0
+    valid[0, 0, 0] = False
+
+    np.testing.assert_array_equal(window.frame_indices, [3, 4])
+    np.testing.assert_allclose(window.point_map[0, 0, 0], [1.0, 0.0, 1.0])
+    assert bool(window.valid_mask[0, 0, 0])
+    assert not window.frame_indices.flags.writeable
+    assert not window.point_map.flags.writeable
+    assert not window.valid_mask.flags.writeable
+
+    with pytest.raises(ValueError, match="read-only"):
+        window.point_map[0, 0, 0, 0] = 2.0
+
+
+def test_prediction_window_normalizes_and_freezes_optional_arrays() -> None:
+    frames, points, valid = _inputs()
+    flow = np.ones_like(points)
+    deform = valid.copy()
+    rays = 2.0 * points
+    window = PredictionWindow(
+        window_id="window-a",
+        frame_indices=frames,
+        point_map=points,
+        valid_mask=valid,
+        scene_flow=flow,
+        deform_mask=deform,
+        ray_directions=rays,
+    )
+
+    np.testing.assert_allclose(
+        np.linalg.norm(window.ray_directions[window.valid_mask], axis=-1),
+        1.0,
+    )
+    assert not window.scene_flow.flags.writeable
+    assert not window.deform_mask.flags.writeable
+    assert not window.ray_directions.flags.writeable
+
+    flow[...] = 7.0
+    rays[...] = 0.0
+    np.testing.assert_allclose(window.scene_flow, 1.0)
+    assert np.all(np.linalg.norm(window.ray_directions[window.valid_mask], axis=-1) > 0.0)
+
+
+def test_prediction_window_rejects_nonfinite_active_optional_values() -> None:
+    frames, points, valid = _inputs()
+    flow = np.ones_like(points)
+    flow[0, 0, 0, 0] = np.nan
+    with pytest.raises(ValueError, match="active scene_flow"):
+        PredictionWindow(
+            window_id="window-a",
+            frame_indices=frames,
+            point_map=points,
+            valid_mask=valid,
+            scene_flow=flow,
+            deform_mask=valid,
+        )
+
+    rays = points.copy()
+    rays[0, 0, 0] = 0.0
+    with pytest.raises(ValueError, match="ray directions must be nonzero"):
+        PredictionWindow(
+            window_id="window-a",
+            frame_indices=frames,
+            point_map=points,
+            valid_mask=valid,
+            ray_directions=rays,
+        )

--- a/tests/test_provider_v1.py
+++ b/tests/test_provider_v1.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import prob4d.provider_v1 as provider
+
+
+def test_provider_v1_exposes_versioned_contracts() -> None:
+    assert provider.PROVIDER_API_VERSION == 1
+    assert provider.OBSERVATION_BELIEF_SCHEMA == "phys4d.observation_belief"
+    assert provider.OBSERVATION_BELIEF_VERSION == 1
+    assert provider.OBSERVATION_FACTOR_SCHEMA_VERSION == 3
+
+
+def test_select_causal_source_forwards_exact_boundary(monkeypatch) -> None:
+    sentinel = object()
+    anchor = object()
+    captured = {}
+
+    def fake_select(manifest_path, *, causal_frame_stop, metric_anchor):
+        captured.update(
+            manifest_path=manifest_path,
+            causal_frame_stop=causal_frame_stop,
+            metric_anchor=metric_anchor,
+        )
+        return sentinel
+
+    monkeypatch.setattr(provider, "select_causal_overlap_windows", fake_select)
+    result = provider.select_causal_source(
+        Path("predictions.json"),
+        causal_frame_stop=134,
+        metric_anchor=anchor,
+    )
+
+    assert result is sentinel
+    assert captured == {
+        "manifest_path": Path("predictions.json"),
+        "causal_frame_stop": 134,
+        "metric_anchor": anchor,
+    }
+
+
+def test_export_observation_belief_forwards_stable_parameters(monkeypatch) -> None:
+    sentinel = object()
+    anchor = object()
+    model = object()
+    captured = {}
+
+    def fake_export(manifest_path, **kwargs):
+        captured.update(manifest_path=manifest_path, **kwargs)
+        return sentinel
+
+    monkeypatch.setattr(provider, "build_prob4d_observation_belief", fake_export)
+    result = provider.export_observation_belief(
+        "predictions.json",
+        case_id="case-a",
+        causal_frame_stop=134,
+        metric_anchor=anchor,
+        pixel_stride=8,
+        effective_samples_per_group=32.0,
+        minimum_prior_reliability=0.1,
+        gauge_mode="sequential",
+        fixed_lag=5,
+        view_name="left-camera",
+        source_revision="a" * 40,
+        uncertainty_model=model,
+    )
+
+    assert result is sentinel
+    assert captured == {
+        "manifest_path": "predictions.json",
+        "case_id": "case-a",
+        "causal_frame_stop": 134,
+        "metric_anchor": anchor,
+        "pixel_stride": 8,
+        "effective_samples_per_group": 32.0,
+        "minimum_prior_reliability": 0.1,
+        "gauge_mode": "sequential",
+        "fixed_lag": 5,
+        "view_name": "left-camera",
+        "source_revision": "a" * 40,
+        "uncertainty_model": model,
+    }


### PR DESCRIPTION
## Summary

Retain the nonredundant provider-boundary work after merging #11 and #12.

## What changed

- add `prob4d.provider_v1` as the stable Python import surface for Bayesian-PhysTwin and Causal4D;
- expose causal source selection, metric-anchor contracts, the current sequential joint-covariance observation export, strict artifact loading, factor bundles, and the provider manifest without requiring downstream imports from underscore-prefixed modules;
- defensively copy and freeze every NumPy field in `PredictionWindow` after validation so caller-side mutation cannot change content-bound inputs;
- declare the versioned Python API and immutable-input guarantees in the provider manifest;
- add focused provider-forwarding and immutability regression tests;
- extend architecture and provider-contract documentation and smoke-test `prob4d.provider_v1` from installed wheel and source distributions.

## Conflict resolution

Merged current `main` at `9fac9e5d9b4f125940e2e8c7771d43783ce36918` into this branch and retained only the unique work above. Redundant release, packaging, grouped-CLI, and generic CI edits already delivered by #11 and #12 were dropped. Obsolete claims about fixed-lag defaults and missing cross-window covariance were replaced with the merged Prob4D 0.2.0 semantics.

## Validation

Integrated GitHub Actions validation is running on resolved head `6a663a833036e007136946926a3889f6c89cfd8f`. The workflow covers Ruff, mypy, Python 3.10/3.12/3.14, provider import isolation, complete tests, distribution build and Twine validation, and isolated wheel/sdist import and CLI smoke tests.

## Scope boundary

This PR does not change the gauge estimator, observation likelihood, serialized artifact schema, or scientific claim boundary. It makes validated inputs immutable and provides a stable versioned import surface over the contracts already merged in Prob4D 0.2.0.