### PR TITLE
Add a stable provider facade and immutable prediction windows

### DIFF
--- a/docs/provider-contract.md
+++ b/docs/provider-contract.md
@@ -12,6 +12,27 @@ prob4d provider manifest \
   --output outputs/prob4d-provider.json
 ```
 
+## Stable Python import
+
+Downstream development code should import the versioned facade:
+
+```python
+from prob4d.provider_v1 import (
+    export_observation_belief,
+    load_observation_belief_export,
+    prob4d_provider_manifest,
+    select_causal_source,
+)
+```
+
+`prob4d.provider_v1` owns the dependency on the private causal-source and
+metric-anchor implementations. It exposes the portable observation contract,
+strict loader, joint-gauge utilities, and rich factor-bundle contract under one
+stable import path. Backward-compatible additions may be made on the 0.2.x
+package line. Removing or changing required semantics needs a new provider
+module/API version. Frozen experiments continue to record an exact Git revision;
+the versioned facade is for upgradeable development environments.
+
 The version-1 contract declares that Prob4D can:
 
 - select independently decoded windows whose complete source interval precedes
@@ -36,6 +57,16 @@ current boundary treatment fixes marginalized gauges at posterior means.
 The manifest does **not** claim that exported covariance has passed prospective
 target calibration, that redundant dense-edge fusion is validated, or that a
 valid observation artifact by itself improves a Bayesian physical twin.
+
+## Immutable prediction inputs
+
+`PredictionWindow` defensively copies every supplied NumPy array after
+validation and marks the stored copy read-only. Later mutation of the caller's
+arrays cannot change a source window already admitted to a content-addressed
+workflow. Frame IDs, point maps, validity, flow/deformation masks, and explicit
+rays therefore remain stable for hashing, alignment, uncertainty construction,
+and export. Methods that need temporary writable data return or construct their
+own copies.
 
 Use `prob4d-validate-observation` to reject schema drift, array drift, malformed
 archives, and content-address mismatches. The richer `ObservationFactorBundle`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = ["numpy>=1.24"]
 Repository = "https://github.com/FlorianPfaff/Prob4D"
 Documentation = "https://github.com/FlorianPfaff/Prob4D/tree/main/docs"
 Issues = "https://github.com/FlorianPfaff/Prob4D/issues"
-Project-Notes = "https://github.com/FlorianPfaff/2026-07-Causal4D-BPT-Paper"
+Project-Notes = "https://github.com/FlorianPfaff/BayesianPhysTwin-Paper"
 
 [project.optional-dependencies]
 dev = [

--- a/src/prob4d/__init__.py
+++ b/src/prob4d/__init__.py
@@ -1,5 +1,7 @@
 """Probabilistic long-horizon fusion for MotionCrafter predictions."""
 
+from importlib.metadata import PackageNotFoundError, version
+
 from .data import PredictionWindow
 from .observation_contract import (
     OBSERVATION_BELIEF_SCHEMA,
@@ -28,6 +30,11 @@ from .observation_factors import (
 from .observation_validation import load_observation_belief_export
 from .sim3 import Sim3
 
+try:
+    __version__ = version("prob4d")
+except PackageNotFoundError:  # Source tree without installed package metadata.
+    __version__ = "0.2.0"
+
 __all__ = [
     "OBSERVATION_BELIEF_SCHEMA",
     "OBSERVATION_BELIEF_VERSION",
@@ -51,4 +58,3 @@ __all__ = [
     "stack_observation_factors",
     "write_observation_factor_bundle",
 ]
-__version__ = "0.2.0"

--- a/src/prob4d/data.py
+++ b/src/prob4d/data.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 from numpy.typing import NDArray
@@ -13,12 +14,22 @@ BoolArray = NDArray[np.bool_]
 IntArray = NDArray[np.integer]
 
 
+def _readonly(value: np.ndarray, *, dtype: Any | None = None) -> np.ndarray:
+    """Return a defensive, read-only NumPy copy."""
+
+    result = np.array(value, dtype=dtype, copy=True)
+    result.setflags(write=False)
+    return result
+
+
 @dataclass(frozen=True)
 class PredictionWindow:
     """Decoded predictions for one local MotionCrafter temporal window.
 
     Point maps and scene flow use the window's local world gauge. Absolute
     ``frame_indices`` identify duplicate frames across overlapping windows.
+    Every NumPy field is defensively copied and made read-only so validated
+    content cannot change after entering a content-addressed workflow.
     """
 
     window_id: str
@@ -30,11 +41,12 @@ class PredictionWindow:
     ray_directions: FloatArray | None = None
 
     def __post_init__(self) -> None:
-        frame_indices = np.asarray(self.frame_indices, dtype=np.int64)
-        point_map = np.asarray(self.point_map, dtype=np.float64)
-        valid_mask = np.asarray(self.valid_mask, dtype=bool)
+        window_id = str(self.window_id)
+        frame_indices = np.array(self.frame_indices, dtype=np.int64, copy=True)
+        point_map = np.array(self.point_map, dtype=np.float64, copy=True)
+        valid_mask = np.array(self.valid_mask, dtype=bool, copy=True)
 
-        if not self.window_id:
+        if not window_id:
             raise ValueError("window_id must not be empty")
         if frame_indices.ndim != 1 or frame_indices.size == 0:
             raise ValueError("frame_indices must be a non-empty one-dimensional array")
@@ -58,6 +70,7 @@ class PredictionWindow:
         if (scene_flow is None) != (deform_mask is None):
             raise ValueError("scene_flow and deform_mask must either both be present or absent")
         if deform_mask is not None:
+            assert scene_flow is not None
             if np.any(deform_mask & ~valid_mask):
                 raise ValueError("deform_mask must be a subset of valid_mask")
             if not np.all(np.isfinite(scene_flow[deform_mask])):
@@ -68,23 +81,35 @@ class PredictionWindow:
             ray_norm = np.linalg.norm(rays, axis=-1)
             if np.any(valid_mask & (ray_norm <= np.finfo(np.float64).eps)):
                 raise ValueError("valid ray_directions entries must be nonzero")
-            rays = rays.copy()
             rays[valid_mask] /= ray_norm[valid_mask, None]
 
-        object.__setattr__(self, "frame_indices", frame_indices)
-        object.__setattr__(self, "point_map", point_map)
-        object.__setattr__(self, "valid_mask", valid_mask)
-        object.__setattr__(self, "scene_flow", scene_flow)
-        object.__setattr__(self, "deform_mask", deform_mask)
-        object.__setattr__(self, "ray_directions", rays)
+        object.__setattr__(self, "window_id", window_id)
+        object.__setattr__(self, "frame_indices", _readonly(frame_indices))
+        object.__setattr__(self, "point_map", _readonly(point_map))
+        object.__setattr__(self, "valid_mask", _readonly(valid_mask))
+        object.__setattr__(
+            self,
+            "scene_flow",
+            None if scene_flow is None else _readonly(scene_flow),
+        )
+        object.__setattr__(
+            self,
+            "deform_mask",
+            None if deform_mask is None else _readonly(deform_mask),
+        )
+        object.__setattr__(
+            self,
+            "ray_directions",
+            None if rays is None else _readonly(rays),
+        )
 
     @staticmethod
     def _optional_vector_field(
         name: str, value: FloatArray | None, reference: FloatArray
-    ) -> FloatArray | None:
+    ) -> np.ndarray | None:
         if value is None:
             return None
-        array = np.asarray(value, dtype=np.float64)
+        array = np.array(value, dtype=np.float64, copy=True)
         if array.shape != reference.shape:
             raise ValueError(f"{name} must have shape {reference.shape}")
         return array
@@ -92,10 +117,10 @@ class PredictionWindow:
     @staticmethod
     def _optional_mask(
         name: str, value: BoolArray | None, reference: BoolArray
-    ) -> BoolArray | None:
+    ) -> np.ndarray | None:
         if value is None:
             return None
-        array = np.asarray(value, dtype=bool)
+        array = np.array(value, dtype=bool, copy=True)
         if array.shape != reference.shape:
             raise ValueError(f"{name} must have shape {reference.shape}")
         return array
@@ -148,6 +173,7 @@ class PredictionWindow:
             "valid_mask": self.valid_mask,
         }
         if self.scene_flow is not None:
+            assert self.deform_mask is not None
             payload["scene_flow"] = self.scene_flow.astype(np.float32)
             payload["deform_mask"] = self.deform_mask
         if self.ray_directions is not None:

--- a/src/prob4d/provider_manifest.py
+++ b/src/prob4d/provider_manifest.py
@@ -20,6 +20,7 @@ PROB4D_PROVIDER_CAPABILITIES = (
     "joint_cross_window_sim3_gauge_covariance",
     "strict_observation_belief_validation",
     "trace_audited_gauge_rank_reduction",
+    "versioned_provider_api_v1",
 )
 PROB4D_ARTIFACT_SCHEMA_VERSIONS = {
     "ObservationBeliefV1": 1,
@@ -87,6 +88,7 @@ def prob4d_provider_manifest(
         "limitations": dict(PROB4D_PROVIDER_LIMITATIONS),
         "metadata": {
             "source_repository": "FlorianPfaff/Prob4D",
+            "provider_api": "prob4d.provider_v1",
             "observation_stream": "prob4d:causal-overlap-window-points",
             "observation_belief_covariance_semantics": (
                 "conditional local covariance plus one shared low-rank root of the "

--- a/src/prob4d/provider_v1.py
+++ b/src/prob4d/provider_v1.py
@@ -1,0 +1,139 @@
+"""Stable Prob4D provider API for Bayesian consumers.
+
+Downstream projects should import this module rather than underscore-prefixed
+source-selection or metric-anchor modules. Version 1 exposes the causal source
+selector, the joint-gauge portable observation path, strict artifact loading,
+and the richer unfused factor-bundle contract.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ._causal_observation_source import (
+    CausalOverlapSelection,
+    SelectedOverlapWindow,
+    select_causal_overlap_windows,
+)
+from ._metric_gauge_anchor import (
+    METRIC_GAUGE_ANCHOR_SCHEMA,
+    METRIC_GAUGE_ANCHOR_VERSION,
+    MetricGaugeAnchor,
+    load_metric_gauge_anchor,
+    save_metric_gauge_anchor,
+)
+from .observation_contract import (
+    OBSERVATION_BELIEF_SCHEMA,
+    OBSERVATION_BELIEF_VERSION,
+    ObservationBeliefExportV1,
+    save_observation_belief_export,
+)
+from .observation_export import (
+    JointGaugePosterior,
+    build_prob4d_observation_belief,
+    deterministic_covariance_root,
+    estimate_joint_gauge_tree,
+)
+from .observation_factors import (
+    OBSERVATION_FACTOR_SCHEMA,
+    OBSERVATION_FACTOR_SCHEMA_VERSION,
+    ObservationFactorBundle,
+    load_observation_factor_bundle,
+    write_observation_factor_bundle,
+)
+from .observation_validation import load_observation_belief_export
+from .provider_manifest import prob4d_provider_manifest
+from .uncertainty import DepthDisagreementModel
+
+PROVIDER_API_VERSION = 1
+
+
+def select_causal_source(
+    manifest_path: str | Path,
+    *,
+    causal_frame_stop: int,
+    metric_anchor: MetricGaugeAnchor,
+) -> CausalOverlapSelection:
+    """Select complete independently decoded windows before the causal cutoff."""
+
+    return select_causal_overlap_windows(
+        manifest_path,
+        causal_frame_stop=causal_frame_stop,
+        metric_anchor=metric_anchor,
+    )
+
+
+def export_observation_belief(
+    manifest_path: str | Path,
+    *,
+    case_id: str,
+    causal_frame_stop: int,
+    metric_anchor: MetricGaugeAnchor,
+    pixel_stride: int = 4,
+    effective_samples_per_group: float = 64.0,
+    minimum_prior_reliability: float = 0.05,
+    gauge_mode: str = "sequential",
+    fixed_lag: int = 4,
+    allow_approximate_fixed_lag_covariance: bool = False,
+    max_gauge_rank: int | None = 64,
+    minimum_retained_gauge_trace: float = 0.999,
+    view_name: str = "camera0",
+    source_revision: str | None = None,
+    uncertainty_model: DepthDisagreementModel | None = None,
+) -> ObservationBeliefExportV1:
+    """Export a causally sealed, uncertainty-bearing observation belief.
+
+    The production default propagates a fixed metric anchor and selected causal
+    relative-gauge constraints into one joint cross-window covariance. The
+    fixed-lag mode remains an explicitly acknowledged approximate reconstruction
+    control.
+    """
+
+    return build_prob4d_observation_belief(
+        manifest_path,
+        case_id=case_id,
+        causal_frame_stop=causal_frame_stop,
+        metric_anchor=metric_anchor,
+        pixel_stride=pixel_stride,
+        effective_samples_per_group=effective_samples_per_group,
+        minimum_prior_reliability=minimum_prior_reliability,
+        gauge_mode=gauge_mode,
+        fixed_lag=fixed_lag,
+        allow_approximate_fixed_lag_covariance=(
+            allow_approximate_fixed_lag_covariance
+        ),
+        max_gauge_rank=max_gauge_rank,
+        minimum_retained_gauge_trace=minimum_retained_gauge_trace,
+        view_name=view_name,
+        source_revision=source_revision,
+        uncertainty_model=uncertainty_model,
+    )
+
+
+__all__ = [
+    "METRIC_GAUGE_ANCHOR_SCHEMA",
+    "METRIC_GAUGE_ANCHOR_VERSION",
+    "OBSERVATION_BELIEF_SCHEMA",
+    "OBSERVATION_BELIEF_VERSION",
+    "OBSERVATION_FACTOR_SCHEMA",
+    "OBSERVATION_FACTOR_SCHEMA_VERSION",
+    "PROVIDER_API_VERSION",
+    "CausalOverlapSelection",
+    "DepthDisagreementModel",
+    "JointGaugePosterior",
+    "MetricGaugeAnchor",
+    "ObservationBeliefExportV1",
+    "ObservationFactorBundle",
+    "SelectedOverlapWindow",
+    "deterministic_covariance_root",
+    "estimate_joint_gauge_tree",
+    "export_observation_belief",
+    "load_metric_gauge_anchor",
+    "load_observation_belief_export",
+    "load_observation_factor_bundle",
+    "prob4d_provider_manifest",
+    "save_metric_gauge_anchor",
+    "save_observation_belief_export",
+    "select_causal_source",
+    "write_observation_factor_bundle",
+]

--- a/tests/test_data_immutability.py
+++ b/tests/test_data_immutability.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from prob4d.data import PredictionWindow
+
+
+def _inputs() -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    frames = np.asarray([3, 4], dtype=np.int64)
+    points = np.asarray(
+        [
+            [[[1.0, 0.0, 1.0], [0.0, 2.0, 1.0]]],
+            [[[1.5, 0.0, 1.0], [0.0, 2.5, 1.0]]],
+        ]
+    )
+    valid = np.ones(points.shape[:-1], dtype=bool)
+    return frames, points, valid
+
+
+def test_prediction_window_defensively_copies_and_freezes_arrays() -> None:
+    frames, points, valid = _inputs()
+    window = PredictionWindow(
+        window_id="window-a",
+        frame_indices=frames,
+        point_map=points,
+        valid_mask=valid,
+    )
+
+    frames[0] = 99
+    points[0, 0, 0] = 99.0
+    valid[0, 0, 0] = False
+
+    np.testing.assert_array_equal(window.frame_indices, [3, 4])
+    np.testing.assert_allclose(window.point_map[0, 0, 0], [1.0, 0.0, 1.0])
+    assert bool(window.valid_mask[0, 0, 0])
+    assert not window.frame_indices.flags.writeable
+    assert not window.point_map.flags.writeable
+    assert not window.valid_mask.flags.writeable
+
+    with pytest.raises(ValueError, match="read-only"):
+        window.point_map[0, 0, 0, 0] = 2.0
+
+
+def test_prediction_window_normalizes_and_freezes_optional_arrays() -> None:
+    frames, points, valid = _inputs()
+    flow = np.ones_like(points)
+    deform = valid.copy()
+    rays = 2.0 * points
+    window = PredictionWindow(
+        window_id="window-a",
+        frame_indices=frames,
+        point_map=points,
+        valid_mask=valid,
+        scene_flow=flow,
+        deform_mask=deform,
+        ray_directions=rays,
+    )
+
+    assert window.ray_directions is not None
+    assert window.scene_flow is not None
+    assert window.deform_mask is not None
+    np.testing.assert_allclose(
+        np.linalg.norm(window.ray_directions[window.valid_mask], axis=-1),
+        1.0,
+    )
+    assert not window.scene_flow.flags.writeable
+    assert not window.deform_mask.flags.writeable
+    assert not window.ray_directions.flags.writeable
+
+    flow[...] = 7.0
+    rays[...] = 0.0
+    np.testing.assert_allclose(window.scene_flow, 1.0)
+    assert np.all(
+        np.linalg.norm(window.ray_directions[window.valid_mask], axis=-1) > 0.0
+    )
+
+
+def test_prediction_window_npz_round_trip_stays_read_only(tmp_path) -> None:
+    frames, points, valid = _inputs()
+    source = PredictionWindow(
+        window_id="window-a",
+        frame_indices=frames,
+        point_map=points,
+        valid_mask=valid,
+    )
+    path = tmp_path / "window.npz"
+    source.to_npz(path)
+
+    loaded = PredictionWindow.from_npz(path)
+
+    assert not loaded.frame_indices.flags.writeable
+    assert not loaded.point_map.flags.writeable
+    assert not loaded.valid_mask.flags.writeable
+    np.testing.assert_allclose(loaded.point_map, source.point_map, rtol=1e-6, atol=1e-7)

--- a/tests/test_provider_v1.py
+++ b/tests/test_provider_v1.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import cast
+
+import prob4d.provider_v1 as provider
+from prob4d._metric_gauge_anchor import MetricGaugeAnchor
+from prob4d.observation_contract import ObservationBeliefExportV1
+
+
+def test_provider_v1_declares_current_joint_covariance_contract() -> None:
+    manifest = provider.prob4d_provider_manifest(provider_revision="a" * 40)
+
+    assert provider.PROVIDER_API_VERSION == 1
+    assert provider.OBSERVATION_BELIEF_VERSION == 1
+    assert provider.OBSERVATION_FACTOR_SCHEMA_VERSION == 3
+    assert "joint_cross_window_sim3_gauge_covariance" in manifest["capabilities"]
+    assert manifest["limitations"][
+        "joint_cross_window_gauge_covariance_in_observation_belief_v1"
+    ] is True
+
+
+def test_provider_v1_forwards_joint_gauge_options(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    sentinel = cast(ObservationBeliefExportV1, object())
+
+    def fake_build(manifest_path, **kwargs):
+        captured["manifest_path"] = manifest_path
+        captured.update(kwargs)
+        return sentinel
+
+    monkeypatch.setattr(provider, "build_prob4d_observation_belief", fake_build)
+    anchor = cast(MetricGaugeAnchor, object())
+
+    result = provider.export_observation_belief(
+        "predictions.json",
+        case_id="case-a",
+        causal_frame_stop=42,
+        metric_anchor=anchor,
+        max_gauge_rank=21,
+        minimum_retained_gauge_trace=0.995,
+    )
+
+    assert result is sentinel
+    assert captured["manifest_path"] == "predictions.json"
+    assert captured["gauge_mode"] == "sequential"
+    assert captured["max_gauge_rank"] == 21
+    assert captured["minimum_retained_gauge_trace"] == 0.995
+    assert captured["allow_approximate_fixed_lag_covariance"] is False


### PR DESCRIPTION
## Summary

Complete the remaining high-value parts of the older provider-hardening work on top of the current Prob4D 0.2.0 joint-covariance implementation.

### Stable provider API

- add `prob4d.provider_v1` as the supported Python import boundary for Bayesian consumers;
- expose causal source selection, metric-anchor I/O, the production joint-gauge observation export, strict artifact loading, trace-audited covariance utilities, and the rich factor-bundle contract;
- include every current 0.2.0 gauge option, including the sequential joint covariance default and explicit fixed-lag approximation acknowledgement;
- advertise the facade through the content-addressed provider manifest.

### Immutable validated inputs

- defensively copy every `PredictionWindow` NumPy field after validation;
- mark stored frame IDs, point maps, validity masks, flow, deformation masks, and explicit rays read-only;
- preserve existing finite-value, subset, nonzero-ray, and normalization checks;
- verify that caller-side mutation and NPZ round trips cannot alter admitted source content.

### Metadata and documentation

- derive `prob4d.__version__` from installed package metadata with a source-tree fallback;
- point package metadata to the canonical `BayesianPhysTwin-Paper` project notes;
- document the stable import path, 0.2.x compatibility policy, joint-covariance semantics, and immutability boundary.

## Why

The merged provider manifest describes compatibility, but downstream code still lacked one versioned Python import surface. In addition, a frozen dataclass alone does not prevent mutation of its NumPy arrays after validation, which is unsafe for content-addressed causal workflows.

## Compatibility

This PR does not change the observation schema, artifact digest algorithm, gauge estimator, likelihood, metric-anchor semantics, or scientific claims. The provider facade wraps the current production path rather than reintroducing the superseded per-window-marginal covariance implementation.

## Validation

Focused tests cover defensive copies, read-only arrays, optional-flow/ray handling, NPZ round trips, provider manifest capabilities, and forwarding of the current joint-gauge export options. The repository's full Python 3.10/3.12/3.14, Ruff, package-build, installed-artifact, and CLI workflows provide final validation.