### PR TITLE
Align Prob4D release metadata with the canonical project notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to Prob4D are documented here.
   source distributions, installs both artifacts in isolation, and smoke-tests
   grouped and legacy commands.
 - Project metadata and documentation point to the canonical
-  `2026-07-Causal4D-BPT-Paper` project-notes repository.
+  `FlorianPfaff/BayesianPhysTwin-Paper` project-notes repository.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -260,8 +260,10 @@ selection protocol. They are not uncertainty-calibrated fusion weights.
 This repository owns code, tests, run definitions, and portable observation
 contracts. Videos, model weights, decoded predictions, and generated results are
 gitignored. Paper-facing result tables, figures, frozen run manifests, and exact
-Prob4D/MotionCrafter commit identifiers belong in
-`FlorianPfaff/2026-07-Causal4D-BPT-Paper`.
+Prob4D/MotionCrafter commit identifiers belong in the canonical
+[`FlorianPfaff/BayesianPhysTwin-Paper`](https://github.com/FlorianPfaff/BayesianPhysTwin-Paper)
+project-notes repository. The earlier date-stamped proposal repository remains
+an archival planning artifact.
 
 ## Development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = ["numpy>=1.24"]
 Repository = "https://github.com/FlorianPfaff/Prob4D"
 Documentation = "https://github.com/FlorianPfaff/Prob4D/tree/main/docs"
 Issues = "https://github.com/FlorianPfaff/Prob4D/issues"
-Project-Notes = "https://github.com/FlorianPfaff/2026-07-Causal4D-BPT-Paper"
+Project-Notes = "https://github.com/FlorianPfaff/BayesianPhysTwin-Paper"
 
 [project.optional-dependencies]
 dev = [

--- a/src/prob4d/__init__.py
+++ b/src/prob4d/__init__.py
@@ -1,5 +1,7 @@
 """Probabilistic long-horizon fusion for MotionCrafter predictions."""
 
+from importlib.metadata import PackageNotFoundError, version
+
 from .data import PredictionWindow
 from .observation_contract import (
     OBSERVATION_BELIEF_SCHEMA,
@@ -28,6 +30,11 @@ from .observation_factors import (
 from .observation_validation import load_observation_belief_export
 from .sim3 import Sim3
 
+try:
+    __version__ = version("prob4d")
+except PackageNotFoundError:  # Source tree without installed distribution metadata.
+    __version__ = "0.2.0"
+
 __all__ = [
     "OBSERVATION_BELIEF_SCHEMA",
     "OBSERVATION_BELIEF_VERSION",
@@ -51,4 +58,3 @@ __all__ = [
     "stack_observation_factors",
     "write_observation_factor_bundle",
 ]
-__version__ = "0.2.0"

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from importlib.metadata import version
+
+import prob4d
+
+
+def test_runtime_version_matches_installed_distribution() -> None:
+    assert prob4d.__version__ == version("prob4d")


### PR DESCRIPTION
## Summary

Finish the Prob4D 0.2.0 release hygiene after the provider and joint-covariance changes.

- derive `prob4d.__version__` from installed distribution metadata with a source-tree fallback;
- add a regression test requiring the runtime and installed versions to agree;
- point `pyproject.toml`, the README repository boundary, and the 0.2.0 changelog to the canonical `FlorianPfaff/BayesianPhysTwin-Paper` project-notes repository;
- explicitly identify the older date-stamped proposal repository as archival rather than a current result location.

## Why

The package version was still duplicated in `pyproject.toml` and `prob4d.__init__`, and several release-facing links still targeted the historical visit proposal after the canonical evidence/claim repository was established.

## Scope

Metadata, documentation, and one consistency test only. No estimator, schema, artifact digest, provider API, covariance, or scientific claim changes.