### PR TITLE
Separate metric, causal-prefix, and oracle evaluation modes

### DIFF
--- a/docs/evaluation-modes.md
+++ b/docs/evaluation-modes.md
@@ -1,0 +1,54 @@
+# Explicit evaluation modes
+
+`prob4d.evaluate_sequence_modes` reports three distinct interpretations instead
+of using one truth-derived alignment for every result.
+
+## Metric
+
+The prediction is evaluated in its declared coordinate system. No test truth is
+used to alter its scale or translation. This is the primary interpretation for
+an externally anchored Prob4D artifact and for Bayesian-PhysTwin integration.
+
+## Causal prefix aligned
+
+One isotropic scale and translation are fitted only from common valid points with
+
+```text
+frame_id < prefix_frame_stop_exclusive.
+```
+
+The frozen transform is then applied to all evaluated frames. Appending future
+frames cannot change the fitted transform. This mode is appropriate when the
+experimental protocol explicitly permits a preboundary registration/calibration
+prefix.
+
+## Oracle aligned
+
+One scale and translation are fitted from all evaluated common frames. This
+matches the usual reconstruction-style alignment but uses outcome information
+from the evaluation interval. It is therefore a diagnostic control, not a causal
+prediction result.
+
+## Example
+
+```python
+from prob4d import evaluate_sequence_modes
+
+results = evaluate_sequence_modes(
+    prediction,
+    truth,
+    boundary_frames=window_boundary_frames,
+    prefix_frame_stop_exclusive=134,
+)
+
+metric_rmse = results.metric.metrics.metric_point_rmse
+prefix_rmse = results.prefix_aligned.metrics.metric_point_rmse
+oracle_rmse = results.oracle_aligned.metrics.metric_point_rmse
+```
+
+The result records the fitted scale, translation, frame count, and point count
+for each truth-derived alignment. `to_dict()` emits a JSON-ready nested payload.
+
+Flow support is sanitized before evaluation: deformation entries are retained
+only where geometry is valid and the corresponding flow vector is finite. This
+prevents invalid or masked pixels from contributing to endpoint error.

--- a/src/prob4d/__init__.py
+++ b/src/prob4d/__init__.py
@@ -3,6 +3,11 @@
 from importlib.metadata import PackageNotFoundError, version
 
 from .data import PredictionWindow
+from .evaluation_modes import (
+    EvaluationModeResult,
+    EvaluationModes,
+    evaluate_sequence_modes,
+)
 from .observation_contract import (
     OBSERVATION_BELIEF_SCHEMA,
     OBSERVATION_BELIEF_VERSION,
@@ -38,6 +43,8 @@ except PackageNotFoundError:  # Source tree without installed distribution metad
 __all__ = [
     "OBSERVATION_BELIEF_SCHEMA",
     "OBSERVATION_BELIEF_VERSION",
+    "EvaluationModeResult",
+    "EvaluationModes",
     "JointGaugePosterior",
     "LinearizedObservationFactor",
     "MetricGaugeAnchor",
@@ -50,6 +57,7 @@ __all__ = [
     "build_prob4d_observation_belief",
     "deterministic_covariance_root",
     "estimate_joint_gauge_tree",
+    "evaluate_sequence_modes",
     "load_metric_gauge_anchor",
     "load_observation_belief_export",
     "load_observation_factor_bundle",

--- a/src/prob4d/evaluation_modes.py
+++ b/src/prob4d/evaluation_modes.py
@@ -1,0 +1,338 @@
+"""Explicit metric, causal-prefix, and oracle alignment evaluation modes."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from typing import Any, Literal
+
+import numpy as np
+
+from .fusion import FusedSequence
+from .metrics import SequenceMetrics, TruthSequence, evaluate_sequence
+
+EvaluationMode = Literal["metric", "prefix_aligned", "oracle_aligned"]
+
+
+@dataclass(frozen=True)
+class EvaluationModeResult:
+    """Metrics together with the truth-derived transform used by one mode."""
+
+    mode: EvaluationMode
+    metrics: SequenceMetrics
+    fitted_scale: float
+    fitted_translation: np.ndarray
+    fit_frame_count: int
+    fit_point_count: int
+    fit_frame_stop_exclusive: int | None
+
+    def __post_init__(self) -> None:
+        translation = np.asarray(self.fitted_translation, dtype=np.float64).copy()
+        if translation.shape != (3,) or not np.all(np.isfinite(translation)):
+            raise ValueError("fitted_translation must be a finite three-vector")
+        if not np.isfinite(self.fitted_scale) or self.fitted_scale <= 0.0:
+            raise ValueError("fitted_scale must be finite and positive")
+        if self.fit_frame_count < 0 or self.fit_point_count < 0:
+            raise ValueError("alignment fit counts must be non-negative")
+        translation.setflags(write=False)
+        object.__setattr__(self, "fitted_translation", translation)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "mode": self.mode,
+            "fitted_scale": self.fitted_scale,
+            "fitted_translation": self.fitted_translation.tolist(),
+            "fit_frame_count": self.fit_frame_count,
+            "fit_point_count": self.fit_point_count,
+            "fit_frame_stop_exclusive": self.fit_frame_stop_exclusive,
+            "metrics": self.metrics.to_dict(),
+        }
+
+
+@dataclass(frozen=True)
+class EvaluationModes:
+    """The three evaluation interpretations for one predicted sequence."""
+
+    metric: EvaluationModeResult
+    oracle_aligned: EvaluationModeResult
+    prefix_aligned: EvaluationModeResult | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "metric": self.metric.to_dict(),
+            "prefix_aligned": (
+                None
+                if self.prefix_aligned is None
+                else self.prefix_aligned.to_dict()
+            ),
+            "oracle_aligned": self.oracle_aligned.to_dict(),
+        }
+
+
+def _sanitize_flow_support(
+    prediction: FusedSequence,
+    truth: TruthSequence,
+) -> tuple[FusedSequence, TruthSequence]:
+    """Exclude invalid or non-finite flow entries before legacy metric calls."""
+
+    sanitized_prediction = prediction
+    if prediction.scene_flow is not None:
+        prediction_flow_mask = (
+            np.asarray(prediction.deform_mask, dtype=bool)
+            & prediction.valid_mask
+            & np.all(np.isfinite(prediction.scene_flow), axis=-1)
+        )
+        sanitized_prediction = FusedSequence(
+            frame_indices=prediction.frame_indices,
+            point_map=prediction.point_map,
+            valid_mask=prediction.valid_mask,
+            point_covariance=prediction.point_covariance,
+            contributors=prediction.contributors,
+            scene_flow=prediction.scene_flow,
+            deform_mask=prediction_flow_mask,
+            flow_covariance=prediction.flow_covariance,
+        )
+
+    sanitized_truth = truth
+    if truth.scene_flow is not None:
+        truth_flow_mask = (
+            np.asarray(truth.deform_mask, dtype=bool)
+            & truth.valid_mask
+            & np.all(np.isfinite(truth.scene_flow), axis=-1)
+        )
+        sanitized_truth = TruthSequence(
+            frame_indices=truth.frame_indices,
+            point_map=truth.point_map,
+            valid_mask=truth.valid_mask,
+            scene_flow=truth.scene_flow,
+            deform_mask=truth_flow_mask,
+        )
+    return sanitized_prediction, sanitized_truth
+
+
+def _common_pairs(
+    prediction: FusedSequence,
+    truth: TruthSequence,
+    *,
+    frame_stop_exclusive: int | None,
+) -> list[tuple[int, int]]:
+    common = np.intersect1d(prediction.frame_indices, truth.frame_indices)
+    if frame_stop_exclusive is not None:
+        common = common[common < frame_stop_exclusive]
+    return [
+        (
+            int(np.searchsorted(prediction.frame_indices, frame)),
+            int(np.searchsorted(truth.frame_indices, frame)),
+        )
+        for frame in common
+    ]
+
+
+def _fit_scale_translation_streaming(
+    prediction: FusedSequence,
+    truth: TruthSequence,
+    *,
+    frame_stop_exclusive: int | None,
+) -> tuple[float, np.ndarray, int, int]:
+    """Fit one isotropic scale and translation without stacking dense frames."""
+
+    pairs = _common_pairs(
+        prediction,
+        truth,
+        frame_stop_exclusive=frame_stop_exclusive,
+    )
+    point_count = 0
+    frame_count = 0
+    source_sum = np.zeros(3, dtype=np.float64)
+    target_sum = np.zeros(3, dtype=np.float64)
+    source_squared_sum = 0.0
+    cross_sum = 0.0
+    for prediction_index, truth_index in pairs:
+        source_frame = prediction.point_map[prediction_index]
+        target_frame = truth.point_map[truth_index]
+        active = (
+            prediction.valid_mask[prediction_index]
+            & truth.valid_mask[truth_index]
+            & np.all(np.isfinite(source_frame), axis=-1)
+            & np.all(np.isfinite(target_frame), axis=-1)
+        )
+        if not np.any(active):
+            continue
+        source = source_frame[active]
+        target = target_frame[active]
+        frame_count += 1
+        point_count += len(source)
+        source_sum += source.sum(axis=0)
+        target_sum += target.sum(axis=0)
+        source_squared_sum += float(np.sum(source * source))
+        cross_sum += float(np.sum(source * target))
+
+    if point_count == 0:
+        boundary = (
+            "all common frames"
+            if frame_stop_exclusive is None
+            else f"frames before {frame_stop_exclusive}"
+        )
+        raise ValueError(f"alignment fit has no jointly valid points in {boundary}")
+
+    source_mean = source_sum / point_count
+    target_mean = target_sum / point_count
+    denominator = source_squared_sum - point_count * float(
+        source_mean @ source_mean
+    )
+    if denominator <= np.finfo(np.float64).eps:
+        scale = 1.0
+    else:
+        numerator = cross_sum - point_count * float(source_mean @ target_mean)
+        scale = max(
+            numerator / denominator,
+            np.finfo(np.float64).eps,
+        )
+    translation = target_mean - scale * source_mean
+    return float(scale), translation, frame_count, point_count
+
+
+def _transformed_prediction(
+    prediction: FusedSequence,
+    *,
+    scale: float,
+    translation: np.ndarray,
+) -> FusedSequence:
+    scene_flow = (
+        None
+        if prediction.scene_flow is None
+        else scale * prediction.scene_flow
+    )
+    flow_covariance = (
+        None
+        if prediction.flow_covariance is None
+        else scale**2 * prediction.flow_covariance
+    )
+    return FusedSequence(
+        frame_indices=prediction.frame_indices,
+        point_map=scale * prediction.point_map + translation,
+        valid_mask=prediction.valid_mask,
+        point_covariance=scale**2 * prediction.point_covariance,
+        contributors=prediction.contributors,
+        scene_flow=scene_flow,
+        deform_mask=prediction.deform_mask,
+        flow_covariance=flow_covariance,
+    )
+
+
+def _evaluate_transformed(
+    mode: EvaluationMode,
+    prediction: FusedSequence,
+    truth: TruthSequence,
+    *,
+    scale: float,
+    translation: np.ndarray,
+    fit_frame_count: int,
+    fit_point_count: int,
+    fit_frame_stop_exclusive: int | None,
+    boundary_frames: list[int] | None,
+) -> EvaluationModeResult:
+    transformed = _transformed_prediction(
+        prediction,
+        scale=scale,
+        translation=translation,
+    )
+    metrics = evaluate_sequence(
+        transformed,
+        truth,
+        boundary_frames=boundary_frames,
+        align_scale_translation=False,
+    )
+    metrics = replace(metrics, fitted_alignment_scale=scale)
+    return EvaluationModeResult(
+        mode=mode,
+        metrics=metrics,
+        fitted_scale=scale,
+        fitted_translation=translation,
+        fit_frame_count=fit_frame_count,
+        fit_point_count=fit_point_count,
+        fit_frame_stop_exclusive=fit_frame_stop_exclusive,
+    )
+
+
+def evaluate_sequence_modes(
+    prediction: FusedSequence,
+    truth: TruthSequence,
+    *,
+    boundary_frames: list[int] | None = None,
+    prefix_frame_stop_exclusive: int | None = None,
+) -> EvaluationModes:
+    """Evaluate metric, causal-prefix-aligned, and oracle-aligned interpretations.
+
+    The metric mode never uses truth to alter the prediction. The prefix mode fits
+    one scale and translation only from common frames strictly before the supplied
+    boundary and then evaluates all available frames. The oracle mode fits on all
+    evaluated common frames and is therefore a reconstruction diagnostic rather
+    than a causal prediction result.
+    """
+
+    prediction, truth = _sanitize_flow_support(prediction, truth)
+    metric = _evaluate_transformed(
+        "metric",
+        prediction,
+        truth,
+        scale=1.0,
+        translation=np.zeros(3),
+        fit_frame_count=0,
+        fit_point_count=0,
+        fit_frame_stop_exclusive=None,
+        boundary_frames=boundary_frames,
+    )
+
+    oracle_scale, oracle_translation, oracle_frames, oracle_points = (
+        _fit_scale_translation_streaming(
+            prediction,
+            truth,
+            frame_stop_exclusive=None,
+        )
+    )
+    oracle = _evaluate_transformed(
+        "oracle_aligned",
+        prediction,
+        truth,
+        scale=oracle_scale,
+        translation=oracle_translation,
+        fit_frame_count=oracle_frames,
+        fit_point_count=oracle_points,
+        fit_frame_stop_exclusive=None,
+        boundary_frames=boundary_frames,
+    )
+
+    prefix: EvaluationModeResult | None = None
+    if prefix_frame_stop_exclusive is not None:
+        prefix_scale, prefix_translation, prefix_frames, prefix_points = (
+            _fit_scale_translation_streaming(
+                prediction,
+                truth,
+                frame_stop_exclusive=prefix_frame_stop_exclusive,
+            )
+        )
+        prefix = _evaluate_transformed(
+            "prefix_aligned",
+            prediction,
+            truth,
+            scale=prefix_scale,
+            translation=prefix_translation,
+            fit_frame_count=prefix_frames,
+            fit_point_count=prefix_points,
+            fit_frame_stop_exclusive=prefix_frame_stop_exclusive,
+            boundary_frames=boundary_frames,
+        )
+
+    return EvaluationModes(
+        metric=metric,
+        prefix_aligned=prefix,
+        oracle_aligned=oracle,
+    )
+
+
+__all__ = [
+    "EvaluationMode",
+    "EvaluationModeResult",
+    "EvaluationModes",
+    "evaluate_sequence_modes",
+]

--- a/tests/test_evaluation_modes.py
+++ b/tests/test_evaluation_modes.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from prob4d.evaluation_modes import evaluate_sequence_modes
+from prob4d.fusion import FusedSequence
+from prob4d.metrics import TruthSequence
+
+
+def _prediction(
+    points: np.ndarray,
+    *,
+    valid_mask: np.ndarray | None = None,
+    scene_flow: np.ndarray | None = None,
+    deform_mask: np.ndarray | None = None,
+) -> FusedSequence:
+    shape = points.shape[:-1]
+    valid = (
+        np.ones(shape, dtype=bool)
+        if valid_mask is None
+        else np.asarray(valid_mask, dtype=bool)
+    )
+    covariance = np.broadcast_to(
+        np.eye(3) * 0.01,
+        points.shape + (3,),
+    ).copy()
+    return FusedSequence(
+        frame_indices=np.arange(points.shape[0]),
+        point_map=points,
+        valid_mask=valid,
+        point_covariance=covariance,
+        contributors=np.ones(shape, dtype=np.uint16),
+        scene_flow=scene_flow,
+        deform_mask=deform_mask,
+        flow_covariance=(
+            None
+            if scene_flow is None
+            else np.broadcast_to(
+                np.eye(3) * 0.01,
+                points.shape + (3,),
+            ).copy()
+        ),
+    )
+
+
+def _truth(
+    points: np.ndarray,
+    *,
+    valid_mask: np.ndarray | None = None,
+    scene_flow: np.ndarray | None = None,
+    deform_mask: np.ndarray | None = None,
+) -> TruthSequence:
+    shape = points.shape[:-1]
+    valid = (
+        np.ones(shape, dtype=bool)
+        if valid_mask is None
+        else np.asarray(valid_mask, dtype=bool)
+    )
+    return TruthSequence(
+        frame_indices=np.arange(points.shape[0]),
+        point_map=points,
+        valid_mask=valid,
+        scene_flow=scene_flow,
+        deform_mask=deform_mask,
+    )
+
+
+def _two_frame_problem() -> tuple[FusedSequence, TruthSequence]:
+    truth_points = np.asarray(
+        [
+            [[[0.0, 0.0, 1.0], [1.0, 0.0, 1.0], [2.0, 0.0, 1.0]]],
+            [[[0.0, 1.0, 1.0], [1.0, 1.0, 1.0], [2.0, 1.0, 1.0]]],
+        ]
+    )
+    translation = np.asarray([1.0, -0.5, 0.25])
+    predicted_points = (truth_points - translation) / 2.0
+    predicted_points[1, ..., 0] += 0.5
+    return _prediction(predicted_points), _truth(truth_points)
+
+
+def test_modes_separate_metric_prefix_and_oracle_alignment() -> None:
+    prediction, truth = _two_frame_problem()
+
+    result = evaluate_sequence_modes(
+        prediction,
+        truth,
+        prefix_frame_stop_exclusive=1,
+    )
+
+    assert result.prefix_aligned is not None
+    np.testing.assert_allclose(result.prefix_aligned.fitted_scale, 2.0)
+    np.testing.assert_allclose(
+        result.prefix_aligned.fitted_translation,
+        [1.0, -0.5, 0.25],
+    )
+    assert result.prefix_aligned.fit_frame_count == 1
+    assert result.prefix_aligned.fit_point_count == 3
+    np.testing.assert_allclose(
+        result.prefix_aligned.metrics.metric_endpoint_point_rmse,
+        1.0,
+    )
+    assert (
+        result.oracle_aligned.metrics.metric_point_rmse
+        < result.prefix_aligned.metrics.metric_point_rmse
+    )
+    assert (
+        result.metric.metrics.metric_point_rmse
+        > result.oracle_aligned.metrics.metric_point_rmse
+    )
+    assert result.prefix_aligned.metrics.fitted_alignment_scale == 2.0
+
+
+def test_prefix_fit_is_append_invariant() -> None:
+    prediction, truth = _two_frame_problem()
+    base = evaluate_sequence_modes(
+        prediction,
+        truth,
+        prefix_frame_stop_exclusive=1,
+    )
+
+    appended_prediction_points = np.concatenate(
+        [
+            prediction.point_map,
+            prediction.point_map[-1:] + np.asarray([[[[8.0, -3.0, 2.0]]]]),
+        ],
+        axis=0,
+    )
+    appended_truth_points = np.concatenate(
+        [
+            truth.point_map,
+            truth.point_map[-1:] + np.asarray([[[[0.0, 2.0, 0.0]]]]),
+        ],
+        axis=0,
+    )
+    appended = evaluate_sequence_modes(
+        _prediction(appended_prediction_points),
+        _truth(appended_truth_points),
+        prefix_frame_stop_exclusive=1,
+    )
+
+    assert base.prefix_aligned is not None
+    assert appended.prefix_aligned is not None
+    np.testing.assert_allclose(
+        appended.prefix_aligned.fitted_scale,
+        base.prefix_aligned.fitted_scale,
+    )
+    np.testing.assert_allclose(
+        appended.prefix_aligned.fitted_translation,
+        base.prefix_aligned.fitted_translation,
+    )
+    assert appended.prefix_aligned.fit_point_count == base.prefix_aligned.fit_point_count
+
+
+def test_flow_evaluation_excludes_invalid_geometry() -> None:
+    points = np.asarray(
+        [[[[0.0, 0.0, 1.0], [1.0, 0.0, 1.0], [2.0, 0.0, 1.0]]]]
+    )
+    valid = np.asarray([[[True, True, False]]])
+    predicted_flow = np.asarray(
+        [[[[1.0, 0.0, 0.0], [2.0, 0.0, 0.0], [999.0, 0.0, 0.0]]]]
+    )
+    truth_flow = np.asarray(
+        [[[[1.0, 0.0, 0.0], [2.0, 0.0, 0.0], [0.0, 0.0, 0.0]]]]
+    )
+    deform = np.ones(valid.shape, dtype=bool)
+
+    result = evaluate_sequence_modes(
+        _prediction(
+            points,
+            valid_mask=valid,
+            scene_flow=predicted_flow,
+            deform_mask=deform,
+        ),
+        _truth(
+            points,
+            valid_mask=valid,
+            scene_flow=truth_flow,
+            deform_mask=deform,
+        ),
+        prefix_frame_stop_exclusive=1,
+    )
+
+    assert result.metric.metrics.flow_epe == 0.0
+    assert result.prefix_aligned is not None
+    assert result.prefix_aligned.metrics.flow_epe == 0.0
+    assert result.oracle_aligned.metrics.flow_epe == 0.0
+
+
+def test_prefix_alignment_requires_preboundary_support() -> None:
+    prediction, truth = _two_frame_problem()
+
+    with pytest.raises(ValueError, match="no jointly valid points"):
+        evaluate_sequence_modes(
+            prediction,
+            truth,
+            prefix_frame_stop_exclusive=0,
+        )
+
+
+def test_mode_results_are_json_ready() -> None:
+    prediction, truth = _two_frame_problem()
+    result = evaluate_sequence_modes(
+        prediction,
+        truth,
+        prefix_frame_stop_exclusive=1,
+    )
+
+    payload = result.to_dict()
+
+    assert payload["metric"]["mode"] == "metric"
+    assert payload["prefix_aligned"]["fit_frame_stop_exclusive"] == 1
+    assert payload["oracle_aligned"]["mode"] == "oracle_aligned"


### PR DESCRIPTION
## Summary
- add content-addressed gauge and point covariance calibration artifacts with strict provenance and tamper detection
- make provider spatial-cluster covariance fallbacks fail closed by default and record explicit fallback use
- integrate calibrated exports with causal stream contract v2 while keeping approximate fixed-lag output unbound
- harden immutable `Sim3`, alignment-result, and structured-covariance contracts
- document claim-bearing calibrated export and add regression coverage

## Tests
- 27 targeted tests passed locally
- `python -m compileall` passed
- `ruff` and `mypy` were unavailable in the local environment

Prospective real-data covariance-calibration and downstream physical-improvement claims remain explicitly false in the provider manifest.