### PR TITLE
Document and advertise metric-anchor provenance

### DIFF
--- a/docs/observation-belief-export.md
+++ b/docs/observation-belief-export.md
@@ -1,16 +1,18 @@
 # Causally sealed observation-belief export
 
-Prob4D can expose independently decoded MotionCrafter windows through the
-provider-neutral `phys4d.observation_belief` version-1 artifact consumed by
-Bayesian-PhysTwin and validated independently by Causal4D.
+Prob4D exposes independently decoded MotionCrafter windows through the
+provider-neutral `phys4d.observation_belief` version-1 container consumed by
+Bayesian-PhysTwin and validated independently by Causal4D. Prob4D-specific
+statistical semantics are versioned separately; the strict causal stream contract
+is version 2.
 
-The export is deliberately distinct from the reconstruction products. A row is
+The export is deliberately distinct from reconstruction products. A row is
 admissible only when the entire independently decoded source window lies before
-an exclusive causal cutoff. The exporter reads the JSON manifest to decide
-which payloads are admissible, opens only those payloads, and then recomputes
-alignment, gauge estimation, overlap disagreement, uncertainty, and prior
-reliability on that admitted prefix. It never estimates on a full sequence and
-then slices the final rows.
+an exclusive causal cutoff. The exporter reads the JSON manifest to decide which
+payloads are admissible, opens only those payloads, and then recomputes alignment,
+gauge estimation, overlap disagreement, uncertainty, and prior reliability on
+that admitted prefix. It never estimates on a full sequence and then slices the
+final rows.
 
 ## Metric gauge anchor
 
@@ -20,7 +22,7 @@ independent metric prior for the first retained overlap window. The anchor is a
 content-addressed JSON document:
 
 ```python
-from prob4d.observation_export import MetricGaugeAnchor, save_metric_gauge_anchor
+from prob4d.provider_v1 import MetricGaugeAnchor, save_metric_gauge_anchor
 
 anchor = MetricGaugeAnchor(
     window_id="window_0000",
@@ -28,20 +30,35 @@ anchor = MetricGaugeAnchor(
     covariance=registration.covariance,
     coordinate_frame="phystwin-world",
     source_kind="prefix-only RGB-D registration",
-    source_artifact_sha256=registration_input_sha256,
-    metadata={"calibration_split": "source-only"},
+    source_artifact_sha256=reference_prediction_payload_sha256,
+    metadata={
+        "calibration_split": "source-only",
+        "calibration_artifact_sha256": calibration_artifact_sha256,
+    },
 )
 save_metric_gauge_anchor("outputs/metric_gauge_anchor.json", anchor)
 ```
+
+`source_artifact_sha256` must identify the exact first admitted prediction
+payload. `calibration_artifact_sha256` must identify the exact external
+registration or calibration artifact from which the transform and covariance
+were obtained. Strict stream-v2 export rejects anchors without either binding.
 
 The registration and its covariance must use only information authorized before
 the causal cutoff. Simulated benchmark truth may be used only for an explicitly
 labelled sensor-assisted ablation, not for a monocular claim.
 
+A zero `7 x 7` anchor covariance is declared as
+`fixed_external_calibration`. A nonzero covariance is declared as
+`propagated_external_prior` and is included in the shared joint gauge factor.
+The embedded anchor record states the case, world frame, exact source and
+calibration digests, and covariance treatment so consumers do not infer these
+semantics from factor names.
+
 ## Command
 
 ```bash
-prob4d-export-observation-belief \
+prob4d observation export \
   outputs/sequence/predictions.json \
   outputs/sequence/observation_belief.npz \
   --case-id sequence \
@@ -60,10 +77,15 @@ prob4d-validate-observation outputs/sequence/observation_belief.npz
 only when its declared stop is at most the cutoff and its payload contains the
 exact absolute frame IDs implied by the declared bounds and frame stride.
 Unknown lineage schemas, path traversal, inconsistent frame IDs, non-prefix
-window selections, and a metric anchor for the wrong first window fail closed.
-The exporter records an exact 40- or 64-character Prob4D commit. It also fails
-closed when that revision cannot be obtained from the checkout and is not
-provided explicitly.
+window selections, an anchor for the wrong first payload, and incomplete
+calibration provenance fail closed. The exporter records an exact 40- or
+64-character Prob4D commit. It also fails closed when that revision cannot be
+obtained from the checkout and is not provided explicitly.
+
+The strict command first writes a hidden temporary archive, reloads it through
+the strict validator, verifies the content address, flushes it, and atomically
+replaces the requested output. The summary JSON uses the same temporary-file and
+atomic-replace discipline.
 
 ## Joint gauge posterior
 
@@ -90,9 +112,9 @@ The legacy `--gauge-mode fixed_lag` path remains available only with
 `--allow-approximate-fixed-lag-covariance`. Its current covariance treats gauges
 outside the active lag as exact posterior means and exports only block-diagonal
 marginals. It is suitable for a labelled reconstruction ablation, not for the
-main Bayesian uncertainty claim. A future fixed-lag implementation must carry a
-marginalized boundary information prior before this acknowledgement can be
-removed.
+strict stream-v2 Bayesian uncertainty claim. A future fixed-lag implementation
+must carry a marginalized boundary information prior before this acknowledgement
+can be removed.
 
 ## Artifact semantics
 
@@ -133,10 +155,11 @@ address.
 
 ## Cross-repository checks
 
-Prob4D, Bayesian-PhysTwin, and Causal4D share a golden contract fixture. The
-same artifact must have the same content address in all three repositories.
+Prob4D, Bayesian-PhysTwin, and Causal4D share a golden contract fixture. The same
+artifact must have the same content address in all three repositories.
 Bayesian-PhysTwin consumes the shared low-rank gauge factor as explicit nuisance
 parameters, keeps association probability separate from reliability, and uses
-the group prior and composite weight as distinct inputs. Causal4D can bind the
-resulting selected twin belief to the exact observation artifact without
-importing Prob4D.
+the group prior and composite weight as distinct inputs. Causal4D independently
+checks the version, rank, parent lineage, exact anchor/calibration bindings, and
+covariance treatment before it binds the resulting twin belief to the
+observation artifact.

--- a/docs/provider-contract.md
+++ b/docs/provider-contract.md
@@ -37,13 +37,21 @@ can:
 - produce a content-addressed `ObservationBeliefV1` artifact and append-invariant
   causal-source digest;
 - keep local conditional point covariance separate from shared gauge factors;
-- propagate the fixed metric-anchor uncertainty and selected relative-gauge
-  constraints into one joint cross-window `Sim(3)` covariance;
+- propagate the metric-anchor prior and selected relative-gauge constraints into
+  one joint cross-window `Sim(3)` covariance;
 - export one shared low-rank latent factor whose window blocks preserve that
   covariance, with trace-audited rank reduction;
 - retain association probability separately from residual-independent prior
   reliability; and
-- bind metric coordinates to an independently checksummed fixed `Sim(3)` anchor.
+- bind metric coordinates to a content-addressed anchor that identifies the
+  exact first prediction payload, exact external calibration artifact, case, and
+  world frame.
+
+A zero anchor covariance is declared as `fixed_external_calibration`. A nonzero
+anchor covariance is declared as `propagated_external_prior` and is included in
+the same joint latent factor as the relative-gauge uncertainty. The producer and
+both consumers reject an explicit v2 artifact when this treatment, calibration
+digest, or inclusion flag is absent or inconsistent.
 
 The production default is a causal sequential spanning tree. It preserves the
 uncertainty of the selected causal constraints without pretending that redundant
@@ -56,17 +64,20 @@ Prob4D 0.2.0 artifacts that already contain canonical
 `joint_gauge_latent_####` factors but predate the explicit version field can be
 recognized by updated Bayesian-PhysTwin and Causal4D validators. Their validation
 report marks the version as inferred. Newly exported production artifacts carry
-the version, complete metric-anchor schema, and covariance treatment explicitly.
+the version, complete metric-anchor schema, calibration digest, and covariance
+treatment explicitly.
 
 The manifest does **not** claim that exported covariance has passed prospective
 target calibration, that redundant dense-edge fusion is validated, or that a
 valid observation artifact by itself improves a Bayesian physical twin.
 
 Use `prob4d-validate-observation` to reject schema drift, array drift, malformed
-archives, and content-address mismatches. `PredictionWindow` inputs are copied
-and frozen after validation so caller-side mutation cannot alter a sealed source
-object. The richer `ObservationFactorBundle` schema v3 remains available when
-the consumer estimates gauge nuisance variables explicitly.
+archives, and content-address mismatches. Strict causal export writes through a
+temporary archive, reloads and validates its content address, then atomically
+replaces the requested output. `PredictionWindow` inputs are copied and frozen
+after validation so caller-side mutation cannot alter a sealed source object.
+The richer `ObservationFactorBundle` schema v3 remains available when the
+consumer estimates gauge nuisance variables explicitly.
 
 The grouped `prob4d` command is the preferred discoverable interface. Existing
 `prob4d-*` commands remain available so historical run manifests and frozen

--- a/src/prob4d/provider_manifest.py
+++ b/src/prob4d/provider_manifest.py
@@ -16,16 +16,18 @@ PROB4D_PROVIDER_CAPABILITIES = (
     "association_reliability_separation",
     "causal_prefix_selection",
     "conditional_point_covariance",
+    "content_addressed_metric_gauge_anchor",
     "content_addressed_observation_belief",
-    "fixed_metric_gauge_anchor",
     "immutable_prediction_window_inputs",
     "joint_cross_window_sim3_gauge_covariance",
+    "metric_anchor_covariance_propagation",
     "strict_observation_belief_validation",
     "trace_audited_gauge_rank_reduction",
     "versioned_causal_stream_contract",
     "versioned_python_provider_api",
 )
 PROB4D_ARTIFACT_SCHEMA_VERSIONS = {
+    "MetricGaugeAnchor": 1,
     "ObservationBeliefV1": 1,
     "ObservationFactorBundle": 3,
     "Prob4DCausalObservationStream": PROB4D_CAUSAL_STREAM_CONTRACT_VERSION,
@@ -99,7 +101,7 @@ def prob4d_provider_manifest(
             ),
             "observation_belief_covariance_semantics": (
                 "conditional local covariance plus one shared low-rank root of the "
-                "joint Sim(3) covariance induced by the fixed metric anchor and "
+                "joint Sim(3) covariance induced by the metric-anchor prior and "
                 "selected causal gauge tree"
             ),
             "gauge_posterior_semantics": (
@@ -111,8 +113,10 @@ def prob4d_provider_manifest(
                 "correlation-group fields"
             ),
             "metric_boundary": (
-                "ObservationBeliefV1 requires an independently checksummed fixed "
-                "metric Sim(3) anchor"
+                "the content-addressed anchor binds the exact first prediction "
+                "payload and external calibration digest, identifies the world "
+                "frame, and declares whether its covariance is zero-fixed or "
+                "propagated through the shared joint factor"
             ),
         },
     }

--- a/tests/test_provider_manifest.py
+++ b/tests/test_provider_manifest.py
@@ -13,12 +13,15 @@ def test_provider_manifest_declares_covariance_boundary() -> None:
 
     assert manifest["provider_revision"] == "a" * 40
     assert manifest["artifact_schema_versions"] == {
+        "MetricGaugeAnchor": 1,
         "ObservationBeliefV1": 1,
         "ObservationFactorBundle": 3,
         "Prob4DCausalObservationStream": 2,
     }
     assert "joint_cross_window_sim3_gauge_covariance" in manifest["capabilities"]
     assert "versioned_causal_stream_contract" in manifest["capabilities"]
+    assert "content_addressed_metric_gauge_anchor" in manifest["capabilities"]
+    assert "metric_anchor_covariance_propagation" in manifest["capabilities"]
     assert manifest["metadata"]["observation_stream_contract_version"] == 2
     assert manifest["limitations"][
         "joint_cross_window_gauge_covariance_in_observation_belief_v1"


### PR DESCRIPTION
## Summary

Follow up the merged stream-v2 implementation with the manifest and documentation needed to describe its actual metric-anchor semantics.

- advertise `MetricGaugeAnchor` schema v1, content-addressed calibration provenance, and anchor-covariance propagation in the provider manifest;
- distinguish zero-covariance `fixed_external_calibration` from nonzero `propagated_external_prior`;
- document the exact first-payload and calibration-artifact digest requirements;
- document strict staged validation and atomic publication;
- update the manifest regression test.

## Context

The executable producer repair is already merged in #17. This PR contains only the later manifest, test, and documentation changes that were committed after #17 auto-merged.