### PR TITLE
Make multi-parent gauge initialization order invariant

### DIFF
--- a/docs/gauge-covariance-intersection.md
+++ b/docs/gauge-covariance-intersection.md
@@ -1,0 +1,46 @@
+# Deterministic multi-estimate gauge initialization
+
+`SequentialGaugeEstimator` may obtain several candidate global gauges for a new
+MotionCrafter window. Those candidates share upstream windows and are therefore
+not safely fused as independent Gaussian estimates.
+
+## Previous behavior
+
+The estimator previously applied two-estimate covariance intersection repeatedly
+in the order in which overlap constraints were supplied. Pairwise covariance
+intersection is not associative, so permuting equivalent constraint records could
+change both the initialized gauge and its covariance. It also averaged global
+axis-angle coordinates directly, which is poorly behaved when equivalent
+rotations lie on opposite sides of the shortest-logarithm branch.
+
+## Current initializer
+
+The initializer now performs one deterministic n-way covariance-intersection
+operation:
+
+1. validate every candidate covariance and reject non-finite, asymmetric, or
+   materially indefinite matrices;
+2. canonically order the candidates independently of the input list;
+3. choose the candidate with the smallest regularized covariance determinant as
+   a deterministic local `Sim(3)` chart;
+4. transport each candidate mean and covariance into that chart with a centered
+   finite-difference Jacobian;
+5. minimize the fused log-determinant over the weight simplex by deterministic
+   pairwise coordinate minimization and one-dimensional derivative bisection;
+6. transport the fused result back to the global seven-vector coordinates.
+
+A small positive component-weight floor prevents a single overlap from being
+silently discarded. The floor is reduced automatically when many candidate
+parents are available so that the feasible simplex remains nonempty.
+
+## Scope and claim boundary
+
+This changes the recursive initializer used by reconstruction ablations and by
+the approximate fixed-lag path. It does **not** replace the strict portable
+causal export's selected spanning-tree covariance, whose cross-window covariance
+semantics remain unchanged.
+
+The change establishes deterministic numerical behavior and avoids a known
+rotation-coordinate failure mode. It is not evidence that Prob4D improves
+held-out reconstruction or Bayesian-PhysTwin prediction; those claims still
+require the registered prospective experiments.

--- a/src/prob4d/_gauge_ci.py
+++ b/src/prob4d/_gauge_ci.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 import numpy as np
 from numpy.typing import NDArray
 
+from .covariance import covariance_statistics, regularized_inverse_psd
 from .sim3 import Sim3
 
 FloatArray = NDArray[np.floating]
@@ -31,34 +32,15 @@ def _validated_covariance(
     matrix = np.asarray(values, dtype=np.float64)
     if matrix.shape != (_GAUGE_DIMENSION, _GAUGE_DIMENSION):
         raise ValueError(f"{name} must have shape (7, 7)")
-    if not np.all(np.isfinite(matrix)):
-        raise ValueError(f"{name} must be finite")
-    symmetric = 0.5 * (matrix + matrix.T)
-    scale = max(1.0, float(np.max(np.abs(symmetric))))
-    symmetry_tolerance = 64.0 * np.finfo(np.float64).eps * scale
-    if not np.allclose(
+    symmetric, precision, log_determinant = covariance_statistics(
         matrix,
-        symmetric,
-        atol=symmetry_tolerance,
-        rtol=1e-12,
-    ):
-        raise ValueError(f"{name} must be symmetric")
-    eigenvalues, eigenvectors = np.linalg.eigh(symmetric)
-    spectral_scale = max(
-        1.0,
-        float(np.max(np.abs(eigenvalues), initial=0.0)),
+        name=name,
     )
-    negative_tolerance = 128.0 * np.finfo(np.float64).eps * spectral_scale
-    if float(np.min(eigenvalues)) < -negative_tolerance:
-        raise ValueError(f"{name} must be positive semidefinite")
-    eigenvalue_floor = max(
-        float(np.max(eigenvalues, initial=0.0)) * 1e-12,
-        1e-12,
+    return (
+        np.asarray(symmetric, dtype=np.float64),
+        np.asarray(precision, dtype=np.float64),
+        float(log_determinant),
     )
-    regularized = np.maximum(eigenvalues, eigenvalue_floor)
-    precision = (eigenvectors * (1.0 / regularized)) @ eigenvectors.T
-    log_determinant = float(np.sum(np.log(regularized)))
-    return symmetric, 0.5 * (precision + precision.T), log_determinant
 
 
 def _canonical_candidate_key(transform: Sim3, covariance: np.ndarray) -> bytes:
@@ -85,12 +67,10 @@ def _central_numerical_jacobian(function, vector: np.ndarray) -> np.ndarray:
 
 def _information_inverse(information: np.ndarray) -> np.ndarray:
     symmetric = 0.5 * (information + information.T)
-    eigenvalues, eigenvectors = np.linalg.eigh(symmetric)
-    if float(np.min(eigenvalues)) <= 0.0:
-        raise ValueError(
-            "covariance-intersection information must be positive definite"
-        )
-    covariance = (eigenvectors * (1.0 / eigenvalues)) @ eigenvectors.T
+    covariance = regularized_inverse_psd(
+        symmetric,
+        name="covariance-intersection information",
+    )
     return 0.5 * (covariance + covariance.T)
 
 

--- a/src/prob4d/_gauge_ci.py
+++ b/src/prob4d/_gauge_ci.py
@@ -1,0 +1,274 @@
+"""Deterministic covariance intersection for uncertain ``Sim(3)`` estimates."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .sim3 import Sim3
+
+FloatArray = NDArray[np.floating]
+_GAUGE_DIMENSION = 7
+
+
+@dataclass(frozen=True)
+class _Candidate:
+    original_index: int
+    transform: Sim3
+    covariance: np.ndarray
+    log_determinant: float
+    key: bytes
+
+
+def _validated_covariance(
+    values: FloatArray,
+    *,
+    name: str,
+) -> tuple[np.ndarray, np.ndarray, float]:
+    matrix = np.asarray(values, dtype=np.float64)
+    if matrix.shape != (_GAUGE_DIMENSION, _GAUGE_DIMENSION):
+        raise ValueError(f"{name} must have shape (7, 7)")
+    if not np.all(np.isfinite(matrix)):
+        raise ValueError(f"{name} must be finite")
+    symmetric = 0.5 * (matrix + matrix.T)
+    scale = max(1.0, float(np.max(np.abs(symmetric))))
+    symmetry_tolerance = 64.0 * np.finfo(np.float64).eps * scale
+    if not np.allclose(
+        matrix,
+        symmetric,
+        atol=symmetry_tolerance,
+        rtol=1e-12,
+    ):
+        raise ValueError(f"{name} must be symmetric")
+    eigenvalues, eigenvectors = np.linalg.eigh(symmetric)
+    spectral_scale = max(
+        1.0,
+        float(np.max(np.abs(eigenvalues), initial=0.0)),
+    )
+    negative_tolerance = 128.0 * np.finfo(np.float64).eps * spectral_scale
+    if float(np.min(eigenvalues)) < -negative_tolerance:
+        raise ValueError(f"{name} must be positive semidefinite")
+    eigenvalue_floor = max(
+        float(np.max(eigenvalues, initial=0.0)) * 1e-12,
+        1e-12,
+    )
+    regularized = np.maximum(eigenvalues, eigenvalue_floor)
+    precision = (eigenvectors * (1.0 / regularized)) @ eigenvectors.T
+    log_determinant = float(np.sum(np.log(regularized)))
+    return symmetric, 0.5 * (precision + precision.T), log_determinant
+
+
+def _canonical_candidate_key(transform: Sim3, covariance: np.ndarray) -> bytes:
+    values = np.concatenate((transform.as_vector(), covariance.reshape(-1)))
+    return np.asarray(values, dtype="<f8").tobytes()
+
+
+def _central_numerical_jacobian(function, vector: np.ndarray) -> np.ndarray:
+    values = np.asarray(vector, dtype=np.float64)
+    baseline = np.asarray(function(values), dtype=np.float64)
+    jacobian = np.empty((baseline.size, values.size), dtype=np.float64)
+    for index in range(values.size):
+        step = 1e-6 * max(1.0, abs(float(values[index])))
+        plus = values.copy()
+        minus = values.copy()
+        plus[index] += step
+        minus[index] -= step
+        jacobian[:, index] = (
+            np.asarray(function(plus), dtype=np.float64)
+            - np.asarray(function(minus), dtype=np.float64)
+        ) / (2.0 * step)
+    return jacobian
+
+
+def _information_inverse(information: np.ndarray) -> np.ndarray:
+    symmetric = 0.5 * (information + information.T)
+    eigenvalues, eigenvectors = np.linalg.eigh(symmetric)
+    if float(np.min(eigenvalues)) <= 0.0:
+        raise ValueError(
+            "covariance-intersection information must be positive definite"
+        )
+    covariance = (eigenvectors * (1.0 / eigenvalues)) @ eigenvectors.T
+    return 0.5 * (covariance + covariance.T)
+
+
+def _pair_optimum(
+    base_information: np.ndarray,
+    first_precision: np.ndarray,
+    second_precision: np.ndarray,
+    total_weight: float,
+    lower: float,
+    upper: float,
+    *,
+    line_search_iterations: int,
+) -> float:
+    direction = first_precision - second_precision
+    origin = base_information + total_weight * second_precision
+
+    def derivative(weight: float) -> float:
+        covariance = _information_inverse(origin + weight * direction)
+        return -float(np.einsum("ij,ji->", covariance, direction))
+
+    if derivative(lower) >= 0.0:
+        return lower
+    if derivative(upper) <= 0.0:
+        return upper
+    left, right = lower, upper
+    for _ in range(line_search_iterations):
+        midpoint = 0.5 * (left + right)
+        if derivative(midpoint) <= 0.0:
+            left = midpoint
+        else:
+            right = midpoint
+    return 0.5 * (left + right)
+
+
+def _optimize_weights(
+    precisions: np.ndarray,
+    *,
+    minimum_weight: float,
+    max_sweeps: int,
+    line_search_iterations: int,
+    tolerance: float,
+) -> np.ndarray:
+    count = len(precisions)
+    if count == 1:
+        return np.ones(1, dtype=np.float64)
+    if not np.isfinite(minimum_weight) or minimum_weight < 0.0:
+        raise ValueError("minimum_weight must be finite and non-negative")
+    if minimum_weight * count >= 1.0:
+        raise ValueError("minimum_weight must leave positive simplex mass")
+    if max_sweeps < 1 or line_search_iterations < 1:
+        raise ValueError("CI iteration counts must be positive")
+    if not np.isfinite(tolerance) or tolerance <= 0.0:
+        raise ValueError("CI tolerance must be finite and positive")
+
+    weights = np.full(count, 1.0 / count, dtype=np.float64)
+    for _ in range(max_sweeps):
+        maximum_change = 0.0
+        for first in range(count - 1):
+            for second in range(first + 1, count):
+                total = float(weights[first] + weights[second])
+                lower = minimum_weight
+                upper = total - minimum_weight
+                if upper <= lower:
+                    continue
+                base = np.einsum("i,ijk->jk", weights, precisions)
+                base -= weights[first] * precisions[first]
+                base -= weights[second] * precisions[second]
+                optimized = _pair_optimum(
+                    base,
+                    precisions[first],
+                    precisions[second],
+                    total,
+                    lower,
+                    upper,
+                    line_search_iterations=line_search_iterations,
+                )
+                change = abs(optimized - float(weights[first]))
+                weights[first] = optimized
+                weights[second] = total - optimized
+                maximum_change = max(maximum_change, change)
+        if maximum_change <= tolerance:
+            break
+    weights /= float(np.sum(weights))
+    return weights
+
+
+def fuse_sim3_covariance_intersection(
+    candidates: Sequence[tuple[Sim3, FloatArray]],
+    *,
+    minimum_weight: float = 0.0,
+    max_sweeps: int = 64,
+    line_search_iterations: int = 48,
+    tolerance: float = 1e-10,
+) -> tuple[Sim3, np.ndarray, np.ndarray]:
+    """Fuse correlated ``Sim(3)`` estimates in one deterministic local chart.
+
+    Candidate ordering is canonicalized before optimization. Means and
+    covariances are transported into the tangent chart of the most precise
+    candidate, fused by n-way covariance intersection, and transported back to
+    the global seven-vector coordinates. Returned weights correspond to the
+    caller's original candidate order.
+    """
+
+    if not candidates:
+        raise ValueError("at least one Sim3 candidate is required")
+
+    entries: list[_Candidate] = []
+    for original_index, (transform, covariance) in enumerate(candidates):
+        if not isinstance(transform, Sim3):
+            raise TypeError("candidate transforms must be Sim3 instances")
+        matrix, _, log_determinant = _validated_covariance(
+            covariance,
+            name=f"candidate covariance {original_index}",
+        )
+        entries.append(
+            _Candidate(
+                original_index=original_index,
+                transform=transform,
+                covariance=matrix,
+                log_determinant=log_determinant,
+                key=_canonical_candidate_key(transform, matrix),
+            )
+        )
+    entries.sort(key=lambda item: item.key)
+    reference = min(
+        entries,
+        key=lambda item: (item.log_determinant, item.key),
+    ).transform
+    reference_inverse = reference.inverse()
+
+    local_means: list[np.ndarray] = []
+    local_precisions: list[np.ndarray] = []
+    for position, entry in enumerate(entries):
+        vector = entry.transform.as_vector()
+
+        def to_local(value: np.ndarray) -> np.ndarray:
+            return reference_inverse.compose(Sim3.from_vector(value)).as_vector()
+
+        local_mean = to_local(vector)
+        jacobian = _central_numerical_jacobian(to_local, vector)
+        local_covariance = jacobian @ entry.covariance @ jacobian.T
+        _, precision, _ = _validated_covariance(
+            local_covariance,
+            name=f"transported candidate covariance {position}",
+        )
+        local_means.append(local_mean)
+        local_precisions.append(precision)
+
+    mean_array = np.asarray(local_means, dtype=np.float64)
+    precision_array = np.asarray(local_precisions, dtype=np.float64)
+    weights = _optimize_weights(
+        precision_array,
+        minimum_weight=minimum_weight,
+        max_sweeps=max_sweeps,
+        line_search_iterations=line_search_iterations,
+        tolerance=tolerance,
+    )
+    information = np.einsum("i,ijk->jk", weights, precision_array)
+    local_covariance = _information_inverse(information)
+    information_vector = np.einsum(
+        "i,ijk,ik->j",
+        weights,
+        precision_array,
+        mean_array,
+    )
+    local_mean = local_covariance @ information_vector
+    fused_transform = reference.compose(Sim3.from_vector(local_mean))
+
+    def from_local(value: np.ndarray) -> np.ndarray:
+        return reference.compose(Sim3.from_vector(value)).as_vector()
+
+    output_jacobian = _central_numerical_jacobian(from_local, local_mean)
+    output_covariance = output_jacobian @ local_covariance @ output_jacobian.T
+    output_covariance = 0.5 * (output_covariance + output_covariance.T)
+    original_weights = np.empty(len(entries), dtype=np.float64)
+    for sorted_index, entry in enumerate(entries):
+        original_weights[entry.original_index] = weights[sorted_index]
+    return fused_transform, output_covariance, original_weights
+
+
+__all__ = ["fuse_sim3_covariance_intersection"]

--- a/src/prob4d/gauge.py
+++ b/src/prob4d/gauge.py
@@ -7,8 +7,8 @@ from dataclasses import dataclass
 import numpy as np
 from numpy.typing import NDArray
 
+from ._gauge_ci import fuse_sim3_covariance_intersection
 from .alignment import WindowAlignment
-from .fusion import fuse_gaussians_covariance_intersection
 from .sim3 import Sim3
 
 FloatArray = NDArray[np.floating]
@@ -263,9 +263,11 @@ def _whitener(covariance: FloatArray, floor: float = 1e-10) -> FloatArray:
 
 
 class SequentialGaugeEstimator:
-    """Initialize global gauges from all available backward overlap constraints."""
+    """Initialize gauges with deterministic multi-estimate covariance intersection."""
 
     def __init__(self, *, covariance_intersection_grid_size: int = 21) -> None:
+        if covariance_intersection_grid_size < 3:
+            raise ValueError("covariance_intersection_grid_size must be at least three")
         self.covariance_intersection_grid_size = covariance_intersection_grid_size
 
     def estimate(
@@ -318,18 +320,17 @@ class SequentialGaugeEstimator:
             if not candidates:
                 raise ValueError(f"window {window_id!r} has no constraint to an initialized gauge")
 
-            transform, covariance = candidates[0]
-            mean = transform.as_vector()
-            for candidate_transform, candidate_covariance in candidates[1:]:
-                mean, covariance, _ = fuse_gaussians_covariance_intersection(
-                    mean,
-                    covariance,
-                    candidate_transform.as_vector(),
-                    candidate_covariance,
-                    grid_size=self.covariance_intersection_grid_size,
-                    minimum_weight=0.05,
-                )
-            estimates[window_id] = GaugeEstimate(window_id, Sim3.from_vector(mean), covariance)
+            minimum_weight = min(0.05, 0.5 / len(candidates))
+            transform, covariance, _ = fuse_sim3_covariance_intersection(
+                candidates,
+                minimum_weight=minimum_weight,
+                max_sweeps=max(16, self.covariance_intersection_grid_size),
+                line_search_iterations=max(
+                    32,
+                    2 * self.covariance_intersection_grid_size,
+                ),
+            )
+            estimates[window_id] = GaugeEstimate(window_id, transform, covariance)
         return estimates
 
 

--- a/tests/test_gauge_ci.py
+++ b/tests/test_gauge_ci.py
@@ -1,0 +1,149 @@
+import itertools
+
+import numpy as np
+import pytest
+
+from prob4d.gauge import (
+    RelativeGaugeConstraint,
+    SequentialGaugeEstimator,
+    fuse_sim3_covariance_intersection,
+)
+from prob4d.sim3 import Sim3, so3_log
+
+
+def _translation_candidate(
+    translation_x: float,
+    covariance_scale: float,
+) -> tuple[Sim3, np.ndarray]:
+    transform = Sim3.from_vector(
+        np.array([0.0, 0.0, 0.0, 0.0, translation_x, 0.0, 0.0])
+    )
+    return transform, np.eye(7) * covariance_scale
+
+
+def _constraint(
+    reference_id: str,
+    moving_id: str,
+    reference: Sim3,
+    moving: Sim3,
+    *,
+    translation_noise: float = 0.0,
+    covariance_scale: float = 1e-3,
+) -> RelativeGaugeConstraint:
+    noise = Sim3.from_vector(
+        np.array([0.0, 0.0, 0.0, 0.0, translation_noise, 0.0, 0.0])
+    )
+    relative = reference.inverse().compose(moving).compose(noise)
+    return RelativeGaugeConstraint(
+        reference_id=reference_id,
+        moving_id=moving_id,
+        reference_from_moving=relative,
+        covariance=np.eye(7) * covariance_scale,
+    )
+
+
+def test_multi_estimate_ci_is_invariant_to_candidate_order() -> None:
+    candidates = [
+        _translation_candidate(0.00, 1e-3),
+        _translation_candidate(0.05, 2e-3),
+        _translation_candidate(-0.02, 5e-4),
+    ]
+    baseline_transform, baseline_covariance, _ = (
+        fuse_sim3_covariance_intersection(
+            candidates,
+            minimum_weight=0.05,
+        )
+    )
+
+    for permutation in itertools.permutations(candidates):
+        transform, covariance, weights = fuse_sim3_covariance_intersection(
+            permutation,
+            minimum_weight=0.05,
+        )
+        np.testing.assert_allclose(
+            transform.as_vector(),
+            baseline_transform.as_vector(),
+            atol=1e-12,
+        )
+        np.testing.assert_allclose(covariance, baseline_covariance, atol=1e-15)
+        np.testing.assert_allclose(np.sum(weights), 1.0, atol=1e-15)
+        assert np.all(weights >= 0.05 - 1e-15)
+
+
+def test_sequential_estimator_is_invariant_to_constraint_order() -> None:
+    truth = {
+        "w0": Sim3.identity(),
+        "w1": _translation_candidate(1.0, 1e-6)[0],
+        "w2": _translation_candidate(2.0, 1e-6)[0],
+        "w3": _translation_candidate(3.0, 1e-6)[0],
+    }
+    fixed = [
+        _constraint("w0", "w1", truth["w0"], truth["w1"], covariance_scale=1e-6),
+        _constraint("w1", "w2", truth["w1"], truth["w2"], covariance_scale=1e-6),
+    ]
+    alternatives = [
+        _constraint("w0", "w3", truth["w0"], truth["w3"], covariance_scale=1e-3),
+        _constraint(
+            "w1",
+            "w3",
+            truth["w1"],
+            truth["w3"],
+            translation_noise=0.05,
+            covariance_scale=2e-3,
+        ),
+        _constraint(
+            "w2",
+            "w3",
+            truth["w2"],
+            truth["w3"],
+            translation_noise=-0.02,
+            covariance_scale=5e-4,
+        ),
+    ]
+
+    baseline = None
+    for permutation in itertools.permutations(alternatives):
+        result = SequentialGaugeEstimator().estimate(
+            list(truth),
+            fixed + list(permutation),
+        )["w3"]
+        if baseline is None:
+            baseline = result
+            continue
+        np.testing.assert_allclose(
+            result.global_from_local.as_vector(),
+            baseline.global_from_local.as_vector(),
+            atol=1e-11,
+        )
+        np.testing.assert_allclose(
+            result.covariance,
+            baseline.covariance,
+            atol=1e-14,
+        )
+
+
+def test_ci_uses_a_local_chart_across_the_rotation_log_branch() -> None:
+    angle = np.deg2rad(179.0)
+    first = Sim3.from_vector(np.array([0.0, 0.0, 0.0, angle, 0.0, 0.0, 0.0]))
+    second = Sim3.from_vector(
+        np.array([0.0, 0.0, 0.0, -angle, 0.0, 0.0, 0.0])
+    )
+
+    fused, covariance, _ = fuse_sim3_covariance_intersection(
+        [
+            (first, np.eye(7) * 1e-4),
+            (second, np.eye(7) * 1e-4),
+        ],
+        minimum_weight=0.05,
+    )
+
+    assert np.linalg.norm(so3_log(fused.rotation)) > np.deg2rad(170.0)
+    assert np.min(np.linalg.eigvalsh(covariance)) > 0.0
+
+
+def test_ci_rejects_materially_indefinite_covariance() -> None:
+    covariance = np.eye(7)
+    covariance[0, 0] = -1.0
+
+    with pytest.raises(ValueError, match="positive semidefinite"):
+        fuse_sim3_covariance_intersection([(Sim3.identity(), covariance)])


### PR DESCRIPTION
## Summary

Replace order-sensitive repeated pairwise covariance intersection in `SequentialGaugeEstimator` with one deterministic n-way `Sim(3)` covariance-intersection operation.

## What changed

- canonicalize candidate ordering before optimization;
- choose a deterministic local `Sim(3)` chart from the most precise candidate;
- transport candidate means and covariances into that chart with centered numerical Jacobians;
- optimize all CI component weights jointly by deterministic pairwise coordinate minimization with derivative bisection;
- retain a feasible positive component-weight floor so no overlap is silently discarded;
- transport the fused mean and covariance back to the global seven-vector coordinates;
- reuse Prob4D's shared fail-closed covariance validation and regularized linear algebra;
- add permutation, rotation-log-branch, covariance-validation, and estimator-integration regressions;
- document the exact scope and claim boundary.

## Root cause

The previous initializer repeatedly applied two-estimate covariance intersection in the order in which overlap constraints were supplied. Pairwise CI is not associative, so an equivalent permutation of three or more constraints could change the initialized gauge and covariance. It also fused global shortest-axis rotation vectors directly, which can collapse two nearby rotations on opposite sides of the `SO(3)` logarithm branch toward the identity.

## Impact

Recursive reconstruction and the approximate fixed-lag initializer become deterministic under constraint permutations and avoid the known ±π rotation-coordinate failure mode. The strict portable causal export remains unchanged: it still uses its selected spanning-tree joint covariance and preserves the existing cross-window contract.

## Validation

GitHub Actions run `30242980075` passed on exact head `28efe746abd847e30bd91afb8768077eb3ec38ce`:

- Ruff: passed;
- stable provider type checking and provider-manifest emission: passed;
- complete NumPy suite: passed on Python 3.10, 3.12, and 3.14;
- wheel and source-distribution build and validation: passed;
- isolated wheel installation and grouped/legacy CLI smoke: passed;
- isolated source-distribution installation and grouped/legacy CLI smoke: passed.

Focused regressions cover candidate-order invariance, constraint-order invariance, the ±π rotation-logarithm branch, materially indefinite covariance rejection, exact chains, fixed-lag smoothing, sparse scale anchors, and covariance calibration.

## Claim boundary

This is a numerical-estimator improvement. It does not establish held-out Prob4D reconstruction benefit or downstream Bayesian-PhysTwin improvement; those remain prospective empirical gates.