### PR TITLE
Add order-invariant gauge graph inference

### DIFF
--- a/docs/gauge-estimator-v2.md
+++ b/docs/gauge-estimator-v2.md
@@ -1,0 +1,101 @@
+# Gauge Estimator V2: order-invariant graph inference
+
+Prob4D's portable causal observation stream deliberately retains the frozen
+`sequential_joint_spanning_tree_v1` behavior. This document describes an additive
+estimator and alignment path for controlled ablations before any production
+contract is changed.
+
+## Motivation
+
+The original sequential estimator processes an explicit temporal window order,
+but it fuses several already-initialized parent candidates through pairwise
+covariance intersection. Pairwise CI is not associative, so permuting otherwise
+identical constraints can change the result. The strict observation exporter also
+selects one parent for each new window greedily and does not use non-tree overlap
+edges except as recorded metadata.
+
+Dense overlap alignment has a related sampling problem. When more than the
+configured maximum number of correspondences are available, an unstratified
+random subset can retain many redundant pixels while omitting a small region that
+provides useful scale, rotation, or depth leverage.
+
+## Additive APIs
+
+`prob4d.gauge_graph` provides:
+
+- `OrderInvariantSequentialGaugeEstimator`, which maps all parent candidates to a
+  right-invariant local `Sim(3)` tangent and fuses them jointly with generalized
+  covariance intersection;
+- `select_uncertainty_volume_spanning_tree`, a deterministic global Kruskal
+  selection using covariance log-volume, correspondence count, residual RMS, and
+  content-addressed tie breakers;
+- `estimate_joint_gauge_tree`, which propagates the selected tree into one full
+  cross-window covariance;
+- `loop_closure_diagnostics`, which evaluates non-tree edges against the
+  tree-derived posterior without refitting it; and
+- `constraint_content_id`, an orientation-independent digest for overlap edges.
+
+`prob4d.stratified_alignment` provides:
+
+- `stratified_overlapping_correspondences`, which allocates an exact sample budget
+  over absolute-frame/spatial-tile clusters and samples each cluster across its
+  depth range; and
+- `align_windows_stratified`, which feeds that sample to the existing robust
+  `Sim(3)` estimator and retains the frame/tile sandwich covariance semantics.
+
+The stratified alignment path fails closed when fewer than eight independent
+clusters survive. A pointwise or IID covariance fallback requires explicit
+`fallback_policy="pointwise"` and is recorded in the returned alignment result.
+
+## Example
+
+```python
+from prob4d.gauge_graph import OrderInvariantSequentialGaugeEstimator
+from prob4d.stratified_alignment import align_windows_stratified
+
+alignment = align_windows_stratified(
+    reference_window,
+    moving_window,
+    max_correspondences=100_000,
+    spatial_tile_size=32,
+)
+
+estimates = OrderInvariantSequentialGaugeEstimator().estimate(
+    ordered_window_ids,
+    relative_constraints,
+    initial_transform=metric_anchor.global_from_local,
+    initial_covariance=metric_anchor.covariance,
+)
+```
+
+## Statistical boundary
+
+These APIs improve determinism and expose graph diagnostics. They do not establish
+that all dense overlap edges are independent. Generalized CI is used when several
+parent estimates can have unknown correlation. The globally selected tree assumes
+independent selected edge errors only for covariance propagation. Non-tree edge
+NIS values additionally use an independence approximation and must be interpreted
+as diagnostics until calibrated on independent sequence families.
+
+The local coordinates use the repository's
+`[log scale, shortest rotation vector, translation]` convention applied to a
+right-invariant relative transform. This avoids subtracting two global rotation
+vectors, but it is still a local first-order covariance approximation rather than
+a new exact `Sim(3)` probability distribution.
+
+## Promotion gate
+
+Do not replace the portable stream's frozen gauge mode solely because these unit
+tests pass. A production promotion requires a registered sequence-family-held-out
+comparison covering:
+
+1. permutation invariance and loop-fault localization;
+2. gauge scale, rotation, and translation error;
+3. low-dimensional gauge NIS and coverage;
+4. seam error and long-horizon drift;
+5. downstream Bayesian-PhysTwin acceptance, harmful-update frequency, and exact
+   fallback; and
+6. peak memory and runtime.
+
+The existing stream-contract version and artifact IDs remain unchanged in this
+implementation.

--- a/src/prob4d/gauge_ci.py
+++ b/src/prob4d/gauge_ci.py
@@ -1,0 +1,439 @@
+"""Order-invariant generalized covariance intersection on local ``Sim(3)`` tangents."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .covariance import (
+    covariance_eigendecomposition,
+    covariance_statistics,
+    regularized_inverse_psd,
+)
+from .sim3 import Sim3
+
+FloatArray = NDArray[np.floating]
+
+
+def _readonly_covariance(values: FloatArray, *, name: str) -> FloatArray:
+    _, eigenvalues, eigenvectors = covariance_eigendecomposition(
+        values,
+        name=name,
+        eigenvalue_floor=1e-15,
+    )
+    result = (eigenvectors * eigenvalues) @ eigenvectors.T
+    result = 0.5 * (result + result.T)
+    result.setflags(write=False)
+    return result
+
+
+def _numerical_jacobian(function, vector: FloatArray) -> FloatArray:
+    vector = np.asarray(vector, dtype=np.float64)
+    baseline = np.asarray(function(vector), dtype=np.float64)
+    jacobian = np.empty((baseline.size, vector.size), dtype=np.float64)
+    for index in range(vector.size):
+        step = 1e-6 * max(1.0, abs(float(vector[index])))
+        plus = vector.copy()
+        minus = vector.copy()
+        plus[index] += step
+        minus[index] -= step
+        jacobian[:, index] = (
+            np.asarray(function(plus), dtype=np.float64)
+            - np.asarray(function(minus), dtype=np.float64)
+        ) / (2.0 * step)
+    if not np.all(np.isfinite(jacobian)):
+        raise ValueError("numerical Sim(3) Jacobian contains non-finite values")
+    return jacobian
+
+
+def _inverse_with_covariance(
+    transform: Sim3,
+    covariance: FloatArray,
+) -> tuple[Sim3, FloatArray]:
+    vector = transform.as_vector()
+    inverse = transform.inverse()
+    jacobian = _numerical_jacobian(
+        lambda value: Sim3.from_vector(value).inverse().as_vector(),
+        vector,
+    )
+    propagated = jacobian @ covariance @ jacobian.T
+    return inverse, _readonly_covariance(propagated, name="inverted gauge covariance")
+
+
+def _compose_with_covariance(
+    parent: Sim3,
+    parent_covariance: FloatArray,
+    relative: Sim3,
+    relative_covariance: FloatArray,
+) -> tuple[Sim3, FloatArray]:
+    parent_vector = parent.as_vector()
+    relative_vector = relative.as_vector()
+    parent_jacobian = _numerical_jacobian(
+        lambda value: Sim3.from_vector(value).compose(relative).as_vector(),
+        parent_vector,
+    )
+    relative_jacobian = _numerical_jacobian(
+        lambda value: parent.compose(Sim3.from_vector(value)).as_vector(),
+        relative_vector,
+    )
+    covariance = (
+        parent_jacobian @ parent_covariance @ parent_jacobian.T
+        + relative_jacobian @ relative_covariance @ relative_jacobian.T
+    )
+    return parent.compose(relative), _readonly_covariance(
+        covariance,
+        name="composed gauge covariance",
+    )
+
+
+def right_invariant_residual(reference: Sim3, value: Sim3) -> FloatArray:
+    """Return local coordinates of ``value`` relative to ``reference``.
+
+    The coordinates are the repository's seven-vector convention applied to the
+    right-invariant relative transform.  Unlike subtraction of two global
+    rotation vectors, this remains finite when equivalent gauges lie on opposite
+    sides of the SO(3) logarithm branch.
+    """
+
+    residual = reference.inverse().compose(value).as_vector()
+    if not np.all(np.isfinite(residual)):
+        raise ValueError("Sim(3) residual contains non-finite values")
+    return residual
+
+
+def constraint_residual(
+    measured_reference_from_moving: Sim3,
+    predicted_reference_from_moving: Sim3,
+) -> FloatArray:
+    """Return the intrinsic residual of one relative-gauge measurement."""
+
+    return right_invariant_residual(
+        measured_reference_from_moving,
+        predicted_reference_from_moving,
+    )
+
+
+@dataclass(frozen=True)
+class GaugeCandidate:
+    """One uncertain estimate of a window's global gauge."""
+
+    label: str
+    global_from_local: Sim3
+    covariance: FloatArray
+
+    def __post_init__(self) -> None:
+        label = str(self.label)
+        if not label:
+            raise ValueError("gauge candidate label must be nonempty")
+        covariance = np.asarray(self.covariance, dtype=np.float64)
+        if covariance.shape != (7, 7):
+            raise ValueError("gauge candidate covariance must have shape (7, 7)")
+        object.__setattr__(self, "label", label)
+        object.__setattr__(
+            self,
+            "covariance",
+            _readonly_covariance(covariance, name=f"candidate {label!r} covariance"),
+        )
+
+
+@dataclass(frozen=True)
+class GeneralizedCIFusionResult:
+    """Order-invariant generalized-CI result in a local ``Sim(3)`` tangent."""
+
+    global_from_local: Sim3
+    covariance: FloatArray
+    candidate_labels: tuple[str, ...]
+    weights: FloatArray
+    iterations: int
+    converged: bool
+
+    def __post_init__(self) -> None:
+        labels = tuple(map(str, self.candidate_labels))
+        if not labels or any(not label for label in labels):
+            raise ValueError("CI candidate labels must be nonempty")
+        if len(set(labels)) != len(labels):
+            raise ValueError("CI candidate labels must be unique")
+        weights = np.asarray(self.weights, dtype=np.float64).copy()
+        if weights.shape != (len(labels),):
+            raise ValueError("CI weights changed shape")
+        if (
+            not np.all(np.isfinite(weights))
+            or np.any(weights < -1e-12)
+            or not np.isclose(np.sum(weights), 1.0, atol=1e-10)
+        ):
+            raise ValueError("CI weights must be a finite probability vector")
+        weights = np.maximum(weights, 0.0)
+        weights /= np.sum(weights)
+        weights.setflags(write=False)
+        covariance = np.asarray(self.covariance, dtype=np.float64)
+        if covariance.shape != (7, 7):
+            raise ValueError("CI covariance must have shape (7, 7)")
+        if self.iterations < 1:
+            raise ValueError("CI iteration count must be positive")
+        object.__setattr__(self, "candidate_labels", labels)
+        object.__setattr__(self, "weights", weights)
+        object.__setattr__(
+            self,
+            "covariance",
+            _readonly_covariance(covariance, name="generalized-CI covariance"),
+        )
+
+
+def _project_probability_simplex(values: FloatArray) -> FloatArray:
+    values = np.asarray(values, dtype=np.float64)
+    if values.ndim != 1 or values.size == 0 or not np.all(np.isfinite(values)):
+        raise ValueError("simplex projection requires a finite nonempty vector")
+    ordered = np.sort(values)[::-1]
+    cumulative = np.cumsum(ordered) - 1.0
+    candidates = ordered - cumulative / np.arange(1, len(values) + 1) > 0.0
+    if not np.any(candidates):
+        return np.full(len(values), 1.0 / len(values))
+    rho = int(np.flatnonzero(candidates)[-1])
+    threshold = cumulative[rho] / float(rho + 1)
+    projected = np.maximum(values - threshold, 0.0)
+    total = float(np.sum(projected))
+    if total <= 0.0:
+        return np.full(len(values), 1.0 / len(values))
+    return projected / total
+
+
+def _ci_objective(weights: FloatArray, information: FloatArray) -> float:
+    combined = np.einsum("i,ijk->jk", weights, information, optimize=True)
+    sign, log_determinant = np.linalg.slogdet(combined)
+    if sign <= 0 or not np.isfinite(log_determinant):
+        raise ValueError("generalized-CI information matrix is not positive definite")
+    return -float(log_determinant)
+
+
+def generalized_ci_weights(
+    covariances: Sequence[FloatArray],
+    *,
+    maximum_iterations: int = 200,
+    tolerance: float = 1e-11,
+) -> tuple[FloatArray, FloatArray, int, bool]:
+    """Optimize generalized covariance-intersection weights on the simplex.
+
+    The objective is the log determinant of the fused covariance.  Projected
+    gradient descent with deterministic backtracking is used to avoid an optional
+    SciPy dependency.  Inputs are validated fail-closed before regularization.
+    """
+
+    if not covariances:
+        raise ValueError("generalized CI requires at least one covariance")
+    if maximum_iterations < 1:
+        raise ValueError("maximum_iterations must be positive")
+    if not np.isfinite(tolerance) or tolerance <= 0.0:
+        raise ValueError("tolerance must be finite and positive")
+    information = np.stack(
+        [
+            regularized_inverse_psd(
+                covariance,
+                name=f"generalized-CI covariance {index}",
+            )
+            for index, covariance in enumerate(covariances)
+        ]
+    )
+    count = len(information)
+    if count == 1:
+        return (
+            np.ones(1, dtype=np.float64),
+            regularized_inverse_psd(information[0], name="generalized-CI information"),
+            1,
+            True,
+        )
+
+    weights = np.full(count, 1.0 / count, dtype=np.float64)
+    objective = _ci_objective(weights, information)
+    converged = False
+    iteration = 0
+    for iteration in range(1, maximum_iterations + 1):
+        combined = np.einsum("i,ijk->jk", weights, information, optimize=True)
+        covariance = regularized_inverse_psd(
+            combined,
+            name="generalized-CI information",
+        )
+        gradient = -np.asarray(
+            [np.trace(covariance @ item) for item in information],
+            dtype=np.float64,
+        )
+        centered = gradient - np.mean(gradient)
+        scale = max(float(np.linalg.norm(centered)), 1.0)
+        step = 1.0 / scale
+        accepted = False
+        for _ in range(40):
+            candidate = _project_probability_simplex(weights - step * gradient)
+            difference = candidate - weights
+            if np.linalg.norm(difference) <= tolerance:
+                weights = candidate
+                converged = True
+                accepted = True
+                break
+            candidate_objective = _ci_objective(candidate, information)
+            if candidate_objective <= objective + 1e-4 * float(gradient @ difference):
+                weights = candidate
+                objective = candidate_objective
+                accepted = True
+                break
+            step *= 0.5
+        if converged or not accepted:
+            break
+        if np.linalg.norm(difference) <= tolerance:
+            converged = True
+            break
+
+    combined = np.einsum("i,ijk->jk", weights, information, optimize=True)
+    covariance = regularized_inverse_psd(
+        combined,
+        name="generalized-CI information",
+    )
+    return weights, covariance, iteration, converged
+
+
+def _candidate_in_tangent(
+    reference: Sim3,
+    candidate: GaugeCandidate,
+) -> tuple[FloatArray, FloatArray]:
+    candidate_vector = candidate.global_from_local.as_vector()
+
+    def coordinates(value: FloatArray) -> FloatArray:
+        return reference.inverse().compose(Sim3.from_vector(value)).as_vector()
+
+    mean = coordinates(candidate_vector)
+    jacobian = _numerical_jacobian(coordinates, candidate_vector)
+    covariance = jacobian @ candidate.covariance @ jacobian.T
+    return mean, _readonly_covariance(
+        covariance,
+        name=f"candidate {candidate.label!r} tangent covariance",
+    )
+
+
+def _tangent_result(
+    reference: Sim3,
+    mean: FloatArray,
+    covariance: FloatArray,
+) -> tuple[Sim3, FloatArray]:
+    mean = np.asarray(mean, dtype=np.float64)
+    if mean.shape != (7,):
+        raise ValueError("fused tangent mean must have shape (7,)")
+
+    def global_coordinates(value: FloatArray) -> FloatArray:
+        return reference.compose(Sim3.from_vector(value)).as_vector()
+
+    transform = reference.compose(Sim3.from_vector(mean))
+    jacobian = _numerical_jacobian(global_coordinates, mean)
+    propagated = jacobian @ covariance @ jacobian.T
+    return transform, _readonly_covariance(
+        propagated,
+        name="fused global gauge covariance",
+    )
+
+
+def fuse_sim3_generalized_ci(
+    candidates: Sequence[GaugeCandidate],
+    *,
+    maximum_manifold_iterations: int = 12,
+    maximum_weight_iterations: int = 200,
+    tolerance: float = 1e-9,
+) -> GeneralizedCIFusionResult:
+    """Fuse correlated gauge candidates without depending on input order.
+
+    Candidate labels define the deterministic ordering.  Each iteration maps all
+    candidates to the right-invariant tangent at the current estimate, solves one
+    generalized-CI problem, and retracts the fused local mean back to ``Sim(3)``.
+    """
+
+    if not candidates:
+        raise ValueError("at least one gauge candidate is required")
+    if maximum_manifold_iterations < 1:
+        raise ValueError("maximum_manifold_iterations must be positive")
+    if not np.isfinite(tolerance) or tolerance <= 0.0:
+        raise ValueError("tolerance must be finite and positive")
+    ordered = tuple(sorted(candidates, key=lambda item: item.label))
+    labels = tuple(candidate.label for candidate in ordered)
+    if len(set(labels)) != len(labels):
+        raise ValueError("gauge candidate labels must be unique")
+    if len(ordered) == 1:
+        return GeneralizedCIFusionResult(
+            global_from_local=ordered[0].global_from_local,
+            covariance=ordered[0].covariance,
+            candidate_labels=labels,
+            weights=np.ones(1),
+            iterations=1,
+            converged=True,
+        )
+
+    ranked = []
+    for candidate in ordered:
+        _, _, log_determinant = covariance_statistics(
+            candidate.covariance,
+            name=f"candidate {candidate.label!r} covariance",
+        )
+        ranked.append((float(log_determinant), candidate.label, candidate))
+    current = min(ranked, key=lambda item: (item[0], item[1]))[2].global_from_local
+
+    last_weights = np.full(len(ordered), 1.0 / len(ordered))
+    last_covariance = np.eye(7)
+    last_transform = current
+    converged = False
+    iteration = 0
+    for iteration in range(1, maximum_manifold_iterations + 1):
+        local_means: list[FloatArray] = []
+        local_covariances: list[FloatArray] = []
+        for candidate in ordered:
+            mean, covariance = _candidate_in_tangent(current, candidate)
+            local_means.append(mean)
+            local_covariances.append(covariance)
+        weights, tangent_covariance, _, _ = generalized_ci_weights(
+            local_covariances,
+            maximum_iterations=maximum_weight_iterations,
+        )
+        information = np.stack(
+            [
+                regularized_inverse_psd(
+                    covariance,
+                    name=f"candidate {label!r} tangent covariance",
+                )
+                for label, covariance in zip(labels, local_covariances, strict=True)
+            ]
+        )
+        information_vector = np.zeros(7, dtype=np.float64)
+        for weight, precision, mean in zip(
+            weights,
+            information,
+            local_means,
+            strict=True,
+        ):
+            information_vector += weight * (precision @ mean)
+        tangent_mean = tangent_covariance @ information_vector
+        last_transform, last_covariance = _tangent_result(
+            current,
+            tangent_mean,
+            tangent_covariance,
+        )
+        last_weights = weights
+        if np.linalg.norm(tangent_mean) <= tolerance:
+            converged = True
+            break
+        current = last_transform
+
+    return GeneralizedCIFusionResult(
+        global_from_local=last_transform,
+        covariance=last_covariance,
+        candidate_labels=labels,
+        weights=last_weights,
+        iterations=iteration,
+        converged=converged,
+    )
+
+
+__all__ = [
+    "GaugeCandidate",
+    "GeneralizedCIFusionResult",
+    "constraint_residual",
+    "fuse_sim3_generalized_ci",
+    "generalized_ci_weights",
+    "right_invariant_residual",
+]

--- a/src/prob4d/gauge_graph.py
+++ b/src/prob4d/gauge_graph.py
@@ -1,0 +1,658 @@
+"""Order-invariant graph estimation and diagnostics for uncertain ``Sim(3)`` gauges.
+
+The portable Prob4D observation stream keeps its frozen causal-tree default. This
+module provides additive generalized-CI sequential inference, deterministic
+global tree selection, full joint covariance propagation, and held-out loop-edge
+diagnostics for controlled ablations.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections import deque
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Protocol
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .covariance import (
+    covariance_eigendecomposition,
+    covariance_statistics,
+    regularized_inverse_psd,
+)
+from .gauge_ci import (
+    GaugeCandidate,
+    GeneralizedCIFusionResult,
+    _compose_with_covariance,
+    _inverse_with_covariance,
+    _numerical_jacobian,
+    _readonly_covariance,
+    constraint_residual,
+    fuse_sim3_generalized_ci,
+    generalized_ci_weights,
+    right_invariant_residual,
+)
+from .sim3 import Sim3
+
+FloatArray = NDArray[np.floating]
+
+
+class RelativeGaugeConstraintLike(Protocol):
+    """Structural contract shared with :class:`prob4d.gauge.RelativeGaugeConstraint`."""
+
+    reference_id: str
+    moving_id: str
+    reference_from_moving: Sim3
+    covariance: FloatArray
+    residual_rms: float
+    num_correspondences: int
+
+
+@dataclass(frozen=True)
+class GaugeGraphEstimate:
+    """One estimated gauge plus the candidate weights used to obtain it."""
+
+    window_id: str
+    global_from_local: Sim3
+    covariance: FloatArray
+    source_labels: tuple[str, ...] = ()
+    source_weights: FloatArray = field(default_factory=lambda: np.zeros(0))
+
+    def __post_init__(self) -> None:
+        window_id = str(self.window_id)
+        if not window_id:
+            raise ValueError("window_id must be nonempty")
+        labels = tuple(map(str, self.source_labels))
+        weights = np.asarray(self.source_weights, dtype=np.float64).copy()
+        if weights.shape != (len(labels),):
+            raise ValueError("source weights changed shape")
+        if labels:
+            if len(set(labels)) != len(labels):
+                raise ValueError("source labels must be unique")
+            if np.any(weights < 0.0) or not np.isclose(np.sum(weights), 1.0, atol=1e-10):
+                raise ValueError("source weights must form a probability vector")
+        elif weights.size:
+            raise ValueError("root estimate cannot carry source weights")
+        weights.setflags(write=False)
+        object.__setattr__(self, "window_id", window_id)
+        object.__setattr__(self, "source_labels", labels)
+        object.__setattr__(self, "source_weights", weights)
+        object.__setattr__(
+            self,
+            "covariance",
+            _readonly_covariance(self.covariance, name=f"gauge {window_id!r} covariance"),
+        )
+
+
+def _canonical_constraint_parts(
+    constraint: RelativeGaugeConstraintLike,
+) -> tuple[str, str, Sim3, FloatArray]:
+    reference_id = str(constraint.reference_id)
+    moving_id = str(constraint.moving_id)
+    if not reference_id or not moving_id or reference_id == moving_id:
+        raise ValueError("constraint window IDs must be nonempty and distinct")
+    covariance = np.asarray(constraint.covariance, dtype=np.float64)
+    if covariance.shape != (7, 7):
+        raise ValueError("relative gauge covariance must have shape (7, 7)")
+    covariance = _readonly_covariance(covariance, name="relative gauge covariance")
+    left, right = sorted((reference_id, moving_id))
+    if reference_id == left:
+        return left, right, constraint.reference_from_moving, covariance
+    inverse, inverse_covariance = _inverse_with_covariance(
+        constraint.reference_from_moving,
+        covariance,
+    )
+    return left, right, inverse, inverse_covariance
+
+
+def constraint_content_id(constraint: RelativeGaugeConstraintLike) -> str:
+    """Return an orientation-independent content ID for a relative constraint."""
+
+    left, right, left_from_right, covariance = _canonical_constraint_parts(constraint)
+    digest = hashlib.sha256()
+    digest.update(left.encode("utf-8"))
+    digest.update(b"\0")
+    digest.update(right.encode("utf-8"))
+    digest.update(b"\0")
+    transform_values = np.round(
+        np.asarray(left_from_right.as_vector(), dtype=np.float64),
+        decimals=12,
+    )
+    covariance_values = np.round(
+        np.asarray(covariance, dtype=np.float64),
+        decimals=12,
+    )
+    transform_values[transform_values == 0.0] = 0.0
+    covariance_values[covariance_values == 0.0] = 0.0
+    digest.update(np.asarray(transform_values, dtype="<f8").tobytes())
+    digest.update(np.asarray(covariance_values, dtype="<f8").tobytes())
+    residual_rms = float(getattr(constraint, "residual_rms", 0.0))
+    correspondences = int(getattr(constraint, "num_correspondences", 0))
+    if not np.isfinite(residual_rms) or residual_rms < 0.0:
+        raise ValueError("constraint residual_rms must be finite and non-negative")
+    if correspondences < 0:
+        raise ValueError("constraint num_correspondences must be non-negative")
+    digest.update(np.asarray([residual_rms], dtype="<f8").tobytes())
+    digest.update(np.asarray([correspondences], dtype="<i8").tobytes())
+    return digest.hexdigest()
+
+
+class OrderInvariantSequentialGaugeEstimator:
+    """Sequential gauge estimator with manifold-local generalized CI.
+
+    Temporal window order remains explicit, but the result is invariant to the
+    order in which constraints are supplied. Multiple already-initialized parent
+    candidates are fused jointly rather than through order-dependent pairwise CI.
+    """
+
+    def __init__(
+        self,
+        *,
+        maximum_manifold_iterations: int = 12,
+        maximum_weight_iterations: int = 200,
+        tolerance: float = 1e-9,
+    ) -> None:
+        self.maximum_manifold_iterations = maximum_manifold_iterations
+        self.maximum_weight_iterations = maximum_weight_iterations
+        self.tolerance = tolerance
+
+    def estimate(
+        self,
+        ordered_window_ids: Sequence[str],
+        constraints: Sequence[RelativeGaugeConstraintLike],
+        *,
+        initial_transform: Sim3 | None = None,
+        initial_covariance: FloatArray | None = None,
+    ) -> dict[str, GaugeGraphEstimate]:
+        window_ids = tuple(map(str, ordered_window_ids))
+        if not window_ids or any(not value for value in window_ids):
+            raise ValueError("ordered_window_ids must be nonempty")
+        if len(set(window_ids)) != len(window_ids):
+            raise ValueError("window IDs must be unique")
+        first_covariance = (
+            np.diag([1e-10] * 7)
+            if initial_covariance is None
+            else np.asarray(initial_covariance, dtype=np.float64)
+        )
+        estimates: dict[str, GaugeGraphEstimate] = {
+            window_ids[0]: GaugeGraphEstimate(
+                window_id=window_ids[0],
+                global_from_local=initial_transform or Sim3.identity(),
+                covariance=first_covariance,
+            )
+        }
+        known_ids = set(window_ids)
+        for constraint in constraints:
+            if (
+                constraint.reference_id not in known_ids
+                or constraint.moving_id not in known_ids
+            ):
+                raise ValueError(
+                    "constraint references a window outside ordered_window_ids"
+                )
+
+        for window_id in window_ids[1:]:
+            candidates_by_label: dict[str, GaugeCandidate] = {}
+            for constraint in constraints:
+                parent_id: str | None = None
+                relative: Sim3 | None = None
+                relative_covariance: FloatArray | None = None
+                if (
+                    constraint.moving_id == window_id
+                    and constraint.reference_id in estimates
+                ):
+                    parent_id = constraint.reference_id
+                    relative = constraint.reference_from_moving
+                    relative_covariance = np.asarray(
+                        constraint.covariance,
+                        dtype=np.float64,
+                    )
+                elif (
+                    constraint.reference_id == window_id
+                    and constraint.moving_id in estimates
+                ):
+                    parent_id = constraint.moving_id
+                    relative, relative_covariance = _inverse_with_covariance(
+                        constraint.reference_from_moving,
+                        np.asarray(constraint.covariance, dtype=np.float64),
+                    )
+                if parent_id is None or relative is None or relative_covariance is None:
+                    continue
+                parent = estimates[parent_id]
+                transform, covariance = _compose_with_covariance(
+                    parent.global_from_local,
+                    parent.covariance,
+                    relative,
+                    relative_covariance,
+                )
+                label = f"{parent_id}:{constraint_content_id(constraint)}"
+                candidates_by_label.setdefault(
+                    label,
+                    GaugeCandidate(
+                        label=label,
+                        global_from_local=transform,
+                        covariance=covariance,
+                    ),
+                )
+            if not candidates_by_label:
+                raise ValueError(
+                    f"window {window_id!r} has no constraint to an initialized gauge"
+                )
+            fusion = fuse_sim3_generalized_ci(
+                tuple(candidates_by_label.values()),
+                maximum_manifold_iterations=self.maximum_manifold_iterations,
+                maximum_weight_iterations=self.maximum_weight_iterations,
+                tolerance=self.tolerance,
+            )
+            estimates[window_id] = GaugeGraphEstimate(
+                window_id=window_id,
+                global_from_local=fusion.global_from_local,
+                covariance=fusion.covariance,
+                source_labels=fusion.candidate_labels,
+                source_weights=fusion.weights,
+            )
+        return estimates
+
+
+@dataclass(frozen=True)
+class GaugeGraphEdge:
+    """Canonical undirected edge storing the transform from right to left."""
+
+    edge_id: str
+    left_id: str
+    right_id: str
+    left_from_right: Sim3
+    covariance: FloatArray
+    residual_rms: float
+    num_correspondences: int
+
+    def __post_init__(self) -> None:
+        if (
+            not self.edge_id
+            or not self.left_id
+            or not self.right_id
+            or self.left_id >= self.right_id
+        ):
+            raise ValueError("canonical gauge edge identity is invalid")
+        if len(self.edge_id) != 64 or any(
+            character not in "0123456789abcdef" for character in self.edge_id
+        ):
+            raise ValueError("edge_id must be a lowercase SHA-256 digest")
+        if not np.isfinite(self.residual_rms) or self.residual_rms < 0.0:
+            raise ValueError("edge residual_rms must be finite and non-negative")
+        if self.num_correspondences < 0:
+            raise ValueError("edge num_correspondences must be non-negative")
+        object.__setattr__(
+            self,
+            "covariance",
+            _readonly_covariance(self.covariance, name=f"edge {self.edge_id} covariance"),
+        )
+
+    @classmethod
+    def from_constraint(cls, constraint: RelativeGaugeConstraintLike) -> GaugeGraphEdge:
+        left, right, transform, covariance = _canonical_constraint_parts(constraint)
+        return cls(
+            edge_id=constraint_content_id(constraint),
+            left_id=left,
+            right_id=right,
+            left_from_right=transform,
+            covariance=covariance,
+            residual_rms=float(getattr(constraint, "residual_rms", 0.0)),
+            num_correspondences=int(getattr(constraint, "num_correspondences", 0)),
+        )
+
+    def oriented(self, parent_id: str, child_id: str) -> tuple[Sim3, FloatArray]:
+        """Return ``parent_from_child`` and its covariance."""
+
+        if parent_id == self.left_id and child_id == self.right_id:
+            return self.left_from_right, self.covariance
+        if parent_id == self.right_id and child_id == self.left_id:
+            return _inverse_with_covariance(self.left_from_right, self.covariance)
+        raise ValueError("requested orientation does not match the edge endpoints")
+
+    @property
+    def quality_key(self) -> tuple[float, int, float, str, str, str]:
+        _, _, log_determinant = covariance_statistics(
+            self.covariance,
+            name=f"edge {self.edge_id} covariance",
+        )
+        return (
+            float(log_determinant),
+            -self.num_correspondences,
+            self.residual_rms,
+            self.left_id,
+            self.right_id,
+            self.edge_id,
+        )
+
+
+class _DisjointSet:
+    def __init__(self, values: Sequence[str]) -> None:
+        self.parent = {value: value for value in values}
+        self.rank = {value: 0 for value in values}
+
+    def find(self, value: str) -> str:
+        parent = self.parent[value]
+        if parent != value:
+            self.parent[value] = self.find(parent)
+        return self.parent[value]
+
+    def union(self, first: str, second: str) -> bool:
+        first_root = self.find(first)
+        second_root = self.find(second)
+        if first_root == second_root:
+            return False
+        if self.rank[first_root] < self.rank[second_root]:
+            first_root, second_root = second_root, first_root
+        self.parent[second_root] = first_root
+        if self.rank[first_root] == self.rank[second_root]:
+            self.rank[first_root] += 1
+        return True
+
+
+def select_uncertainty_volume_spanning_tree(
+    window_ids: Sequence[str],
+    constraints: Sequence[RelativeGaugeConstraintLike],
+) -> tuple[GaugeGraphEdge, ...]:
+    """Select a deterministic minimum-uncertainty-volume spanning tree."""
+
+    identifiers = tuple(map(str, window_ids))
+    if not identifiers or len(set(identifiers)) != len(identifiers):
+        raise ValueError("window_ids must be nonempty and unique")
+    known = set(identifiers)
+    edges_by_id: dict[str, GaugeGraphEdge] = {}
+    for constraint in constraints:
+        edge = GaugeGraphEdge.from_constraint(constraint)
+        if edge.left_id not in known or edge.right_id not in known:
+            raise ValueError("constraint references a window outside window_ids")
+        edges_by_id.setdefault(edge.edge_id, edge)
+    disjoint = _DisjointSet(identifiers)
+    selected: list[GaugeGraphEdge] = []
+    for edge in sorted(edges_by_id.values(), key=lambda value: value.quality_key):
+        if disjoint.union(edge.left_id, edge.right_id):
+            selected.append(edge)
+            if len(selected) == len(identifiers) - 1:
+                break
+    if len(selected) != len(identifiers) - 1:
+        components = sorted({disjoint.find(value) for value in identifiers})
+        raise ValueError(
+            "relative-gauge graph is disconnected; components are "
+            + ", ".join(components)
+        )
+    return tuple(selected)
+
+
+@dataclass(frozen=True)
+class GaugeGraphPosterior:
+    """Gauge means and full cross-window covariance from a selected graph tree."""
+
+    window_ids: tuple[str, ...]
+    estimates: Mapping[str, Sim3]
+    joint_covariance: FloatArray
+    root_window_id: str
+    parent_window_ids: tuple[str | None, ...]
+    parent_edge_ids: tuple[str | None, ...]
+    selected_edge_ids: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        window_ids = tuple(map(str, self.window_ids))
+        if not window_ids or len(set(window_ids)) != len(window_ids):
+            raise ValueError("posterior window_ids must be nonempty and unique")
+        if self.root_window_id not in window_ids:
+            raise ValueError("root_window_id is not in window_ids")
+        if set(self.estimates) != set(window_ids):
+            raise ValueError("posterior estimates do not match window_ids")
+        if (
+            len(self.parent_window_ids) != len(window_ids)
+            or len(self.parent_edge_ids) != len(window_ids)
+        ):
+            raise ValueError("posterior parent lineage changed length")
+        dimension = 7 * len(window_ids)
+        covariance = np.asarray(self.joint_covariance, dtype=np.float64)
+        if covariance.shape != (dimension, dimension):
+            raise ValueError("joint gauge covariance changed shape")
+        covariance = _readonly_covariance(covariance, name="joint gauge covariance")
+        if len(self.selected_edge_ids) != len(window_ids) - 1:
+            raise ValueError("selected edge count does not form a spanning tree")
+        if len(set(self.selected_edge_ids)) != len(self.selected_edge_ids):
+            raise ValueError("selected edge IDs must be unique")
+        root_position = window_ids.index(self.root_window_id)
+        if (
+            self.parent_window_ids[root_position] is not None
+            or self.parent_edge_ids[root_position] is not None
+        ):
+            raise ValueError("root gauge must not have a parent")
+        object.__setattr__(self, "window_ids", window_ids)
+        object.__setattr__(self, "joint_covariance", covariance)
+        object.__setattr__(self, "estimates", dict(self.estimates))
+
+
+def estimate_joint_gauge_tree(
+    window_ids: Sequence[str],
+    constraints: Sequence[RelativeGaugeConstraintLike],
+    *,
+    root_window_id: str,
+    initial_transform: Sim3,
+    initial_covariance: FloatArray,
+) -> GaugeGraphPosterior:
+    """Propagate a globally selected tree into one full joint covariance."""
+
+    identifiers = tuple(map(str, window_ids))
+    if root_window_id not in identifiers:
+        raise ValueError("root_window_id must be included in window_ids")
+    selected = select_uncertainty_volume_spanning_tree(identifiers, constraints)
+    adjacency: dict[str, list[GaugeGraphEdge]] = {value: [] for value in identifiers}
+    for edge in selected:
+        adjacency[edge.left_id].append(edge)
+        adjacency[edge.right_id].append(edge)
+    for value in adjacency.values():
+        value.sort(key=lambda edge: (edge.left_id, edge.right_id, edge.edge_id))
+
+    positions = {window_id: index for index, window_id in enumerate(identifiers)}
+    dimension = 7 * len(identifiers)
+    joint = np.zeros((dimension, dimension), dtype=np.float64)
+    root_covariance = _readonly_covariance(
+        initial_covariance,
+        name="initial gauge covariance",
+    )
+    root_position = positions[root_window_id]
+    root_slice = slice(7 * root_position, 7 * (root_position + 1))
+    joint[root_slice, root_slice] = root_covariance
+    estimates: dict[str, Sim3] = {root_window_id: initial_transform}
+    parent_ids: dict[str, str | None] = {root_window_id: None}
+    parent_edges: dict[str, str | None] = {root_window_id: None}
+    processed: list[str] = [root_window_id]
+    queue: deque[str] = deque([root_window_id])
+
+    while queue:
+        parent_id = queue.popleft()
+        for edge in adjacency[parent_id]:
+            child_id = edge.right_id if parent_id == edge.left_id else edge.left_id
+            if child_id in estimates:
+                continue
+            relative, relative_covariance = edge.oriented(parent_id, child_id)
+            parent = estimates[parent_id]
+            child = parent.compose(relative)
+            parent_jacobian = _numerical_jacobian(
+                lambda value: Sim3.from_vector(value).compose(relative).as_vector(),
+                parent.as_vector(),
+            )
+            relative_jacobian = _numerical_jacobian(
+                lambda value: parent.compose(Sim3.from_vector(value)).as_vector(),
+                relative.as_vector(),
+            )
+            parent_position = positions[parent_id]
+            child_position = positions[child_id]
+            parent_slice = slice(7 * parent_position, 7 * (parent_position + 1))
+            child_slice = slice(7 * child_position, 7 * (child_position + 1))
+            for previous_id in processed:
+                previous_position = positions[previous_id]
+                previous_slice = slice(
+                    7 * previous_position,
+                    7 * (previous_position + 1),
+                )
+                cross = parent_jacobian @ joint[parent_slice, previous_slice]
+                joint[child_slice, previous_slice] = cross
+                joint[previous_slice, child_slice] = cross.T
+            child_covariance = (
+                parent_jacobian
+                @ joint[parent_slice, parent_slice]
+                @ parent_jacobian.T
+                + relative_jacobian
+                @ relative_covariance
+                @ relative_jacobian.T
+            )
+            joint[child_slice, child_slice] = 0.5 * (
+                child_covariance + child_covariance.T
+            )
+            estimates[child_id] = child
+            parent_ids[child_id] = parent_id
+            parent_edges[child_id] = edge.edge_id
+            processed.append(child_id)
+            queue.append(child_id)
+
+    if len(estimates) != len(identifiers):
+        raise RuntimeError("selected spanning tree traversal did not reach every window")
+    _, eigenvalues, eigenvectors = covariance_eigendecomposition(
+        0.5 * (joint + joint.T),
+        name="propagated joint gauge covariance",
+        eigenvalue_floor=1e-15,
+    )
+    joint = (eigenvectors * eigenvalues) @ eigenvectors.T
+    return GaugeGraphPosterior(
+        window_ids=identifiers,
+        estimates=estimates,
+        joint_covariance=joint,
+        root_window_id=root_window_id,
+        parent_window_ids=tuple(parent_ids[window_id] for window_id in identifiers),
+        parent_edge_ids=tuple(parent_edges[window_id] for window_id in identifiers),
+        selected_edge_ids=tuple(edge.edge_id for edge in selected),
+    )
+
+
+@dataclass(frozen=True)
+class LoopClosureDiagnostic:
+    """Independent non-tree edge check against a tree-derived posterior."""
+
+    edge_id: str
+    left_id: str
+    right_id: str
+    residual: FloatArray
+    residual_norm: float
+    normalized_innovation_squared: float
+    threshold: float
+    suspicious: bool
+
+    def __post_init__(self) -> None:
+        residual = np.asarray(self.residual, dtype=np.float64).copy()
+        if residual.shape != (7,) or not np.all(np.isfinite(residual)):
+            raise ValueError("loop residual must be a finite seven-vector")
+        if not np.isfinite(self.residual_norm) or self.residual_norm < 0.0:
+            raise ValueError("loop residual norm must be finite and non-negative")
+        if (
+            not np.isfinite(self.normalized_innovation_squared)
+            or self.normalized_innovation_squared < 0.0
+        ):
+            raise ValueError("loop NIS must be finite and non-negative")
+        if not np.isfinite(self.threshold) or self.threshold <= 0.0:
+            raise ValueError("loop NIS threshold must be finite and positive")
+        residual.setflags(write=False)
+        object.__setattr__(self, "residual", residual)
+
+
+def loop_closure_diagnostics(
+    posterior: GaugeGraphPosterior,
+    constraints: Sequence[RelativeGaugeConstraintLike],
+    *,
+    nis_threshold: float = 24.321886347856854,
+) -> tuple[LoopClosureDiagnostic, ...]:
+    """Evaluate non-tree overlap edges without refitting the selected tree.
+
+    The threshold defaults to the 0.999 quantile of a seven-dimensional
+    chi-squared reference distribution. The calculation treats each held-out
+    edge as independent of the selected tree; correlated MotionCrafter residuals
+    should therefore be interpreted as diagnostics rather than calibrated tests.
+    """
+
+    if not np.isfinite(nis_threshold) or nis_threshold <= 0.0:
+        raise ValueError("nis_threshold must be finite and positive")
+    selected = set(posterior.selected_edge_ids)
+    positions = {window_id: index for index, window_id in enumerate(posterior.window_ids)}
+    edges_by_id: dict[str, GaugeGraphEdge] = {}
+    for constraint in constraints:
+        edge = GaugeGraphEdge.from_constraint(constraint)
+        edges_by_id.setdefault(edge.edge_id, edge)
+    diagnostics: list[LoopClosureDiagnostic] = []
+    for edge in sorted(edges_by_id.values(), key=lambda value: value.edge_id):
+        if edge.edge_id in selected:
+            continue
+        left = posterior.estimates[edge.left_id]
+        right = posterior.estimates[edge.right_id]
+        predicted = left.inverse().compose(right)
+        residual = constraint_residual(edge.left_from_right, predicted)
+
+        left_vector = left.as_vector()
+        right_vector = right.as_vector()
+        left_jacobian = _numerical_jacobian(
+            lambda value: Sim3.from_vector(value).inverse().compose(right).as_vector(),
+            left_vector,
+        )
+        right_jacobian = _numerical_jacobian(
+            lambda value: left.inverse().compose(Sim3.from_vector(value)).as_vector(),
+            right_vector,
+        )
+        left_position = positions[edge.left_id]
+        right_position = positions[edge.right_id]
+        left_slice = slice(7 * left_position, 7 * (left_position + 1))
+        right_slice = slice(7 * right_position, 7 * (right_position + 1))
+        joint = posterior.joint_covariance
+        predicted_covariance = (
+            left_jacobian @ joint[left_slice, left_slice] @ left_jacobian.T
+            + right_jacobian @ joint[right_slice, right_slice] @ right_jacobian.T
+            + left_jacobian @ joint[left_slice, right_slice] @ right_jacobian.T
+            + right_jacobian @ joint[right_slice, left_slice] @ left_jacobian.T
+        )
+        innovation_covariance = _readonly_covariance(
+            predicted_covariance + edge.covariance,
+            name=f"loop edge {edge.edge_id} innovation covariance",
+        )
+        precision = regularized_inverse_psd(
+            innovation_covariance,
+            name=f"loop edge {edge.edge_id} innovation covariance",
+        )
+        nis = float(residual @ precision @ residual)
+        diagnostics.append(
+            LoopClosureDiagnostic(
+                edge_id=edge.edge_id,
+                left_id=edge.left_id,
+                right_id=edge.right_id,
+                residual=residual,
+                residual_norm=float(np.linalg.norm(residual)),
+                normalized_innovation_squared=nis,
+                threshold=nis_threshold,
+                suspicious=nis > nis_threshold,
+            )
+        )
+    return tuple(diagnostics)
+
+
+__all__ = [
+    "GaugeCandidate",
+    "GaugeGraphEdge",
+    "GaugeGraphEstimate",
+    "GaugeGraphPosterior",
+    "GeneralizedCIFusionResult",
+    "LoopClosureDiagnostic",
+    "OrderInvariantSequentialGaugeEstimator",
+    "RelativeGaugeConstraintLike",
+    "constraint_content_id",
+    "constraint_residual",
+    "estimate_joint_gauge_tree",
+    "fuse_sim3_generalized_ci",
+    "generalized_ci_weights",
+    "loop_closure_diagnostics",
+    "right_invariant_residual",
+    "select_uncertainty_volume_spanning_tree",
+]

--- a/src/prob4d/stratified_alignment.py
+++ b/src/prob4d/stratified_alignment.py
@@ -1,0 +1,363 @@
+"""Deterministic geometry-aware sampling for dense overlap alignment.
+
+The legacy overlap path uses an unstratified random subset when more than the
+requested number of correspondences are available.  This module instead keeps
+broad frame and spatial-tile coverage and samples each tile across its depth
+range.  The resulting cluster IDs remain suitable for the existing
+frame-by-spatial-tile sandwich covariance.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .alignment import (
+    DENSE_ALIGNMENT_COVARIANCE_METHOD,
+    IID_COVARIANCE_FALLBACK,
+    POINTWISE_COVARIANCE_FALLBACK,
+    AlignmentCovarianceCalibration,
+    CovarianceFallbackPolicy,
+    WindowAlignment,
+    estimate_sim3_robust,
+)
+from .data import PredictionWindow
+
+FloatArray = NDArray[np.floating]
+IntArray = NDArray[np.integer]
+
+
+def _readonly(values: np.ndarray, *, dtype: type) -> np.ndarray:
+    result = np.asarray(values, dtype=dtype).copy()
+    result.setflags(write=False)
+    return result
+
+
+@dataclass(frozen=True)
+class StratifiedCorrespondenceSample:
+    """One deterministic overlap sample and its covariance-cluster metadata."""
+
+    source_points: FloatArray
+    target_points: FloatArray
+    common_frames: IntArray
+    frame_ids: IntArray
+    rows: IntArray
+    columns: IntArray
+    cluster_ids: IntArray
+    available_count: int
+
+    def __post_init__(self) -> None:
+        source = np.asarray(self.source_points, dtype=np.float64)
+        target = np.asarray(self.target_points, dtype=np.float64)
+        frames = np.asarray(self.common_frames, dtype=np.int64)
+        frame_ids = np.asarray(self.frame_ids, dtype=np.int64)
+        rows = np.asarray(self.rows, dtype=np.int64)
+        columns = np.asarray(self.columns, dtype=np.int64)
+        clusters = np.asarray(self.cluster_ids, dtype=np.int64)
+        if source.ndim != 2 or source.shape[1] != 3 or source.shape != target.shape:
+            raise ValueError("sampled source and target points must have shape (N, 3)")
+        count = len(source)
+        if count < 4:
+            raise ValueError("stratified overlap sample requires at least four points")
+        for name, values in (
+            ("frame_ids", frame_ids),
+            ("rows", rows),
+            ("columns", columns),
+            ("cluster_ids", clusters),
+        ):
+            if values.shape != (count,):
+                raise ValueError(f"{name} must have shape ({count},)")
+        if (
+            frames.ndim != 1
+            or frames.size == 0
+            or np.any(frames < 0)
+            or np.any(np.diff(frames) <= 0)
+        ):
+            raise ValueError(
+                "common_frames must be nonempty, nonnegative, and strictly increasing"
+            )
+        if not np.all(np.isfinite(source)) or not np.all(np.isfinite(target)):
+            raise ValueError("sampled overlap points must be finite")
+        if np.any(frame_ids < 0) or not np.all(np.isin(frame_ids, frames)):
+            raise ValueError("sampled frame IDs must be contained in common_frames")
+        if np.any(rows < 0) or np.any(columns < 0) or np.any(clusters < 0):
+            raise ValueError("sample indices and cluster IDs must be nonnegative")
+        available_count = int(self.available_count)
+        if available_count < count:
+            raise ValueError("available_count cannot be smaller than the sample")
+        object.__setattr__(self, "source_points", _readonly(source, dtype=np.float64))
+        object.__setattr__(self, "target_points", _readonly(target, dtype=np.float64))
+        object.__setattr__(self, "common_frames", _readonly(frames, dtype=np.int64))
+        object.__setattr__(self, "frame_ids", _readonly(frame_ids, dtype=np.int64))
+        object.__setattr__(self, "rows", _readonly(rows, dtype=np.int64))
+        object.__setattr__(self, "columns", _readonly(columns, dtype=np.int64))
+        object.__setattr__(self, "cluster_ids", _readonly(clusters, dtype=np.int64))
+        object.__setattr__(self, "available_count", available_count)
+
+    @property
+    def sample_count(self) -> int:
+        return len(self.source_points)
+
+    @property
+    def cluster_count(self) -> int:
+        return int(np.unique(self.cluster_ids).size)
+
+
+def _evenly_spaced_positions(count: int, requested: int) -> np.ndarray:
+    if count < 1 or requested < 1 or requested > count:
+        raise ValueError("evenly spaced selection has invalid size")
+    if requested == count:
+        return np.arange(count, dtype=np.int64)
+    if requested == 1:
+        return np.asarray([(count - 1) // 2], dtype=np.int64)
+    positions = np.rint(np.linspace(0, count - 1, requested)).astype(np.int64)
+    # Rounding can duplicate positions for very small groups. Fill any gaps with
+    # the earliest unused indices so the requested count remains exact.
+    positions = np.unique(positions)
+    if len(positions) < requested:
+        unused = np.setdiff1d(
+            np.arange(count, dtype=np.int64),
+            positions,
+            assume_unique=True,
+        )
+        positions = np.sort(
+            np.concatenate((positions, unused[: requested - len(positions)]))
+        )
+    return positions
+
+
+def _cluster_quotas(counts: np.ndarray, budget: int) -> np.ndarray:
+    """Allocate a deterministic exact budget across nonempty clusters."""
+
+    counts = np.asarray(counts, dtype=np.int64)
+    if counts.ndim != 1 or counts.size == 0 or np.any(counts <= 0):
+        raise ValueError("cluster counts must be a nonempty positive vector")
+    if budget < 1 or budget > int(np.sum(counts)):
+        raise ValueError("sampling budget lies outside available correspondences")
+    cluster_count = len(counts)
+    quotas = np.zeros(cluster_count, dtype=np.int64)
+    if budget < cluster_count:
+        selected = _evenly_spaced_positions(cluster_count, budget)
+        quotas[selected] = 1
+        return quotas
+
+    quotas[:] = 1
+    remaining = budget - cluster_count
+    capacity = counts - 1
+    while remaining > 0 and np.any(capacity > 0):
+        active = capacity > 0
+        weights = np.sqrt(counts.astype(np.float64)) * active
+        desired = remaining * weights / np.sum(weights)
+        additions = np.minimum(np.floor(desired).astype(np.int64), capacity)
+        if not np.any(additions):
+            fractional = desired - np.floor(desired)
+            order = np.lexsort((np.arange(cluster_count), -fractional))
+            for index in order:
+                if remaining == 0:
+                    break
+                if capacity[index] > 0:
+                    additions[index] += 1
+                    remaining -= 1
+            quotas += additions
+            capacity -= additions
+            continue
+        quotas += additions
+        capacity -= additions
+        remaining -= int(np.sum(additions))
+    return quotas
+
+
+def stratified_overlapping_correspondences(
+    reference: PredictionWindow,
+    moving: PredictionWindow,
+    *,
+    max_correspondences: int = 100_000,
+    spatial_tile_size: int = 32,
+) -> StratifiedCorrespondenceSample:
+    """Collect a deterministic frame/tile/depth-stratified overlap sample."""
+
+    if reference.shape[1:] != moving.shape[1:]:
+        raise ValueError("overlapping windows must use the same spatial resolution")
+    if max_correspondences < 4:
+        raise ValueError("max_correspondences must be at least four")
+    if spatial_tile_size < 1:
+        raise ValueError("spatial_tile_size must be positive")
+    common_frames = reference.common_frames(moving)
+    if common_frames.size == 0:
+        raise ValueError("windows do not overlap")
+
+    source_parts: list[np.ndarray] = []
+    target_parts: list[np.ndarray] = []
+    frame_parts: list[np.ndarray] = []
+    row_parts: list[np.ndarray] = []
+    column_parts: list[np.ndarray] = []
+    raw_cluster_parts: list[np.ndarray] = []
+    tile_columns = int(np.ceil(reference.shape[2] / spatial_tile_size))
+    tiles_per_frame = int(np.ceil(reference.shape[1] / spatial_tile_size)) * tile_columns
+
+    for frame_position, frame in enumerate(common_frames):
+        reference_index = reference.local_index(int(frame))
+        moving_index = moving.local_index(int(frame))
+        mask = reference.valid_mask[reference_index] & moving.valid_mask[moving_index]
+        rows, columns = np.nonzero(mask)
+        if rows.size == 0:
+            continue
+        source_parts.append(moving.point_map[moving_index][mask])
+        target_parts.append(reference.point_map[reference_index][mask])
+        frame_parts.append(np.full(rows.size, int(frame), dtype=np.int64))
+        row_parts.append(rows.astype(np.int64))
+        column_parts.append(columns.astype(np.int64))
+        tile_ids = rows // spatial_tile_size * tile_columns + columns // spatial_tile_size
+        raw_cluster_parts.append(
+            frame_position * tiles_per_frame + tile_ids.astype(np.int64)
+        )
+
+    if not source_parts:
+        raise ValueError("overlap has no valid point correspondences")
+    source = np.concatenate(source_parts)
+    target = np.concatenate(target_parts)
+    frame_ids = np.concatenate(frame_parts)
+    rows = np.concatenate(row_parts)
+    columns = np.concatenate(column_parts)
+    raw_clusters = np.concatenate(raw_cluster_parts)
+    available_count = len(source)
+    if available_count < 4:
+        raise ValueError("overlap has fewer than four valid point correspondences")
+
+    unique_clusters, inverse = np.unique(raw_clusters, return_inverse=True)
+    if available_count <= max_correspondences:
+        selected = np.arange(available_count, dtype=np.int64)
+    else:
+        counts = np.bincount(inverse, minlength=len(unique_clusters))
+        quotas = _cluster_quotas(counts, max_correspondences)
+        selected_parts: list[np.ndarray] = []
+        depth = 0.5 * (
+            np.linalg.norm(source, axis=1) + np.linalg.norm(target, axis=1)
+        )
+        for cluster_index, quota in enumerate(quotas):
+            if quota == 0:
+                continue
+            members = np.flatnonzero(inverse == cluster_index)
+            order = np.lexsort(
+                (
+                    members,
+                    columns[members],
+                    rows[members],
+                    depth[members],
+                )
+            )
+            ordered_members = members[order]
+            positions = _evenly_spaced_positions(len(ordered_members), int(quota))
+            selected_parts.append(ordered_members[positions])
+        selected = np.concatenate(selected_parts)
+        selected = selected[
+            np.lexsort(
+                (
+                    columns[selected],
+                    rows[selected],
+                    frame_ids[selected],
+                )
+            )
+        ]
+        if len(selected) != max_correspondences:
+            raise RuntimeError("stratified sampler did not fill the requested budget")
+
+    _, compact_clusters = np.unique(raw_clusters[selected], return_inverse=True)
+    return StratifiedCorrespondenceSample(
+        source_points=source[selected],
+        target_points=target[selected],
+        common_frames=common_frames,
+        frame_ids=frame_ids[selected],
+        rows=rows[selected],
+        columns=columns[selected],
+        cluster_ids=compact_clusters.astype(np.int64),
+        available_count=available_count,
+    )
+
+
+def align_windows_stratified(
+    reference: PredictionWindow,
+    moving: PredictionWindow,
+    *,
+    max_correspondences: int = 100_000,
+    spatial_tile_size: int = 32,
+    covariance_calibration: AlignmentCovarianceCalibration | None = None,
+    fallback_policy: CovarianceFallbackPolicy = "error",
+) -> WindowAlignment:
+    """Estimate a gauge using deterministic stratified correspondences.
+
+    Fewer than eight frame/tile clusters fail closed by default.  The explicit
+    ``pointwise`` fallback is intended only for small reconstruction controls and
+    is recorded in the returned :class:`~prob4d.alignment.AlignmentResult`.
+    """
+
+    if fallback_policy not in {"error", "pointwise"}:
+        raise ValueError("fallback_policy must be 'error' or 'pointwise'")
+    sample = stratified_overlapping_correspondences(
+        reference,
+        moving,
+        max_correspondences=max_correspondences,
+        spatial_tile_size=spatial_tile_size,
+    )
+    clusters: np.ndarray | None = np.asarray(sample.cluster_ids, dtype=np.int64)
+    covariance_fallback: str | None = None
+    if sample.cluster_count <= 7:
+        if fallback_policy == "error":
+            raise ValueError(
+                "stratified alignment produced fewer than eight independent spatial "
+                "clusters; explicitly allow the pointwise approximation for a "
+                "reconstruction control"
+            )
+        if sample.sample_count > 7:
+            clusters = np.arange(sample.sample_count, dtype=np.int64)
+            covariance_fallback = POINTWISE_COVARIANCE_FALLBACK
+        else:
+            clusters = None
+            covariance_fallback = IID_COVARIANCE_FALLBACK
+
+    result = estimate_sim3_robust(
+        sample.source_points,
+        sample.target_points,
+        covariance_cluster_ids=clusters,
+    )
+    result = replace(result, covariance_fallback=covariance_fallback)
+    if covariance_calibration is not None:
+        calibration_method = getattr(covariance_calibration, "covariance_method", None)
+        if calibration_method not in {None, DENSE_ALIGNMENT_COVARIANCE_METHOD}:
+            raise ValueError(
+                "gauge covariance calibration was fitted for a different "
+                "covariance method"
+            )
+        calibration_cluster_size = getattr(
+            covariance_calibration,
+            "covariance_cluster_size",
+            None,
+        )
+        if (
+            calibration_cluster_size is not None
+            and int(calibration_cluster_size) != spatial_tile_size
+        ):
+            raise ValueError(
+                "gauge covariance calibration spatial cluster size does not match "
+                "the stratified alignment"
+            )
+        result = replace(
+            result,
+            covariance=covariance_calibration.apply(result.covariance),
+            covariance_calibration_id=covariance_calibration.artifact_id,
+        )
+    return WindowAlignment(
+        reference_id=reference.window_id,
+        moving_id=moving.window_id,
+        common_frames=sample.common_frames,
+        result=result,
+    )
+
+
+__all__ = [
+    "StratifiedCorrespondenceSample",
+    "align_windows_stratified",
+    "stratified_overlapping_correspondences",
+]

--- a/tests/test_gauge_graph.py
+++ b/tests/test_gauge_graph.py
@@ -1,0 +1,236 @@
+from dataclasses import dataclass
+from itertools import permutations
+
+import numpy as np
+
+from prob4d.gauge_graph import (
+    GaugeCandidate,
+    GaugeGraphEdge,
+    OrderInvariantSequentialGaugeEstimator,
+    estimate_joint_gauge_tree,
+    fuse_sim3_generalized_ci,
+    loop_closure_diagnostics,
+    right_invariant_residual,
+    select_uncertainty_volume_spanning_tree,
+)
+from prob4d.sim3 import Sim3
+
+
+@dataclass(frozen=True)
+class Constraint:
+    reference_id: str
+    moving_id: str
+    reference_from_moving: Sim3
+    covariance: np.ndarray
+    residual_rms: float = 0.0
+    num_correspondences: int = 100
+
+
+def relative(
+    reference_id: str,
+    moving_id: str,
+    gauges: dict[str, Sim3],
+    *,
+    covariance_scale: float = 1e-4,
+    noise: np.ndarray | None = None,
+    correspondences: int = 100,
+) -> Constraint:
+    transform = gauges[reference_id].inverse().compose(gauges[moving_id])
+    if noise is not None:
+        transform = transform.compose(Sim3.from_vector(noise))
+    return Constraint(
+        reference_id=reference_id,
+        moving_id=moving_id,
+        reference_from_moving=transform,
+        covariance=np.eye(7) * covariance_scale,
+        residual_rms=0.0 if noise is None else float(np.linalg.norm(noise)),
+        num_correspondences=correspondences,
+    )
+
+
+def test_constraint_content_id_is_orientation_independent() -> None:
+    gauges = {
+        "left": Sim3.identity(),
+        "right": Sim3.from_vector(
+            np.array([0.03, 0.04, -0.02, 0.01, 0.3, 0.1, -0.2])
+        ),
+    }
+    forward = relative(
+        "left",
+        "right",
+        gauges,
+        covariance_scale=3e-4,
+        correspondences=123,
+    )
+    edge = GaugeGraphEdge.from_constraint(forward)
+    right_from_left, covariance = edge.oriented("right", "left")
+    reversed_constraint = Constraint(
+        reference_id="right",
+        moving_id="left",
+        reference_from_moving=right_from_left,
+        covariance=covariance,
+        residual_rms=forward.residual_rms,
+        num_correspondences=forward.num_correspondences,
+    )
+
+    assert GaugeGraphEdge.from_constraint(reversed_constraint).edge_id == edge.edge_id
+
+
+def test_generalized_ci_is_invariant_to_candidate_order() -> None:
+    candidates = [
+        GaugeCandidate(
+            "a",
+            Sim3.from_vector(
+                np.array([0.01, 0.02, -0.01, 0.0, 0.1, 0.0, 0.0])
+            ),
+            np.diag([1e-3, 2e-3, 2e-3, 2e-3, 4e-3, 4e-3, 4e-3]),
+        ),
+        GaugeCandidate(
+            "b",
+            Sim3.from_vector(
+                np.array([0.02, 0.01, -0.02, 0.01, 0.12, -0.01, 0.0])
+            ),
+            np.diag([2e-3, 1e-3, 1e-3, 1e-3, 3e-3, 3e-3, 3e-3]),
+        ),
+        GaugeCandidate(
+            "c",
+            Sim3.from_vector(
+                np.array([0.0, 0.03, -0.01, -0.01, 0.09, 0.01, 0.0])
+            ),
+            np.diag([3e-3, 3e-3, 3e-3, 3e-3, 2e-3, 2e-3, 2e-3]),
+        ),
+    ]
+
+    baseline = fuse_sim3_generalized_ci(candidates)
+    for ordering in permutations(candidates):
+        result = fuse_sim3_generalized_ci(ordering)
+        assert result.candidate_labels == baseline.candidate_labels
+        np.testing.assert_allclose(result.weights, baseline.weights, atol=1e-12)
+        np.testing.assert_allclose(
+            result.global_from_local.as_vector(),
+            baseline.global_from_local.as_vector(),
+            atol=1e-11,
+        )
+        np.testing.assert_allclose(result.covariance, baseline.covariance, atol=1e-11)
+
+
+def test_sequential_estimator_is_invariant_to_constraint_order() -> None:
+    truth = {
+        "w0": Sim3.identity(),
+        "w1": Sim3.from_vector(
+            np.array([0.01, 0.02, 0.0, 0.0, 0.5, 0.0, 0.0])
+        ),
+        "w2": Sim3.from_vector(
+            np.array([0.02, 0.03, 0.01, 0.0, 1.0, 0.1, 0.0])
+        ),
+    }
+    constraints = [
+        relative("w0", "w1", truth, covariance_scale=1e-3),
+        relative(
+            "w0",
+            "w2",
+            truth,
+            covariance_scale=2e-3,
+            noise=np.array([0.002, 0.0, 0.0, 0.0, 0.01, 0.0, 0.0]),
+        ),
+        relative(
+            "w1",
+            "w2",
+            truth,
+            covariance_scale=1e-3,
+            noise=np.array([-0.001, 0.0, 0.0, 0.0, -0.005, 0.0, 0.0]),
+        ),
+    ]
+    estimator = OrderInvariantSequentialGaugeEstimator()
+    baseline = estimator.estimate(["w0", "w1", "w2"], constraints)
+    for ordering in permutations(constraints):
+        result = estimator.estimate(["w0", "w1", "w2"], ordering)
+        for window_id in truth:
+            np.testing.assert_allclose(
+                result[window_id].global_from_local.as_vector(),
+                baseline[window_id].global_from_local.as_vector(),
+                atol=1e-11,
+            )
+            np.testing.assert_allclose(
+                result[window_id].covariance,
+                baseline[window_id].covariance,
+                atol=1e-11,
+            )
+
+
+def test_spanning_tree_is_global_and_order_invariant() -> None:
+    truth = {
+        "w0": Sim3.identity(),
+        "w1": Sim3.from_vector(
+            np.array([0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0])
+        ),
+        "w2": Sim3.from_vector(
+            np.array([0.0, 0.0, 0.0, 0.0, 2.0, 0.0, 0.0])
+        ),
+        "w3": Sim3.from_vector(
+            np.array([0.0, 0.0, 0.0, 0.0, 3.0, 0.0, 0.0])
+        ),
+    }
+    constraints = [
+        relative("w0", "w1", truth, covariance_scale=1e-2, correspondences=20),
+        relative("w0", "w2", truth, covariance_scale=1e-4, correspondences=200),
+        relative("w1", "w2", truth, covariance_scale=1e-4, correspondences=200),
+        relative("w1", "w3", truth, covariance_scale=1e-4, correspondences=200),
+        relative("w2", "w3", truth, covariance_scale=1e-2, correspondences=20),
+    ]
+    baseline = select_uncertainty_volume_spanning_tree(tuple(truth), constraints)
+    baseline_ids = {edge.edge_id for edge in baseline}
+    assert len(baseline_ids) == 3
+    for ordering in permutations(constraints):
+        result = select_uncertainty_volume_spanning_tree(tuple(truth), ordering)
+        assert {edge.edge_id for edge in result} == baseline_ids
+
+
+def test_joint_tree_preserves_cross_window_covariance_and_detects_bad_loop() -> None:
+    truth = {
+        "w0": Sim3.identity(),
+        "w1": Sim3.from_vector(
+            np.array([0.01, 0.01, 0.0, 0.0, 0.4, 0.0, 0.0])
+        ),
+        "w2": Sim3.from_vector(
+            np.array([0.02, 0.02, 0.0, 0.0, 0.8, 0.1, 0.0])
+        ),
+    }
+    good_edges = [
+        relative("w0", "w1", truth, covariance_scale=1e-5, correspondences=500),
+        relative("w1", "w2", truth, covariance_scale=1e-5, correspondences=500),
+    ]
+    bad_loop = relative(
+        "w0",
+        "w2",
+        truth,
+        covariance_scale=1e-5,
+        noise=np.array([0.0, 0.0, 0.0, 0.0, 0.15, 0.0, 0.0]),
+        correspondences=10,
+    )
+    posterior = estimate_joint_gauge_tree(
+        tuple(truth),
+        [*good_edges, bad_loop],
+        root_window_id="w0",
+        initial_transform=Sim3.identity(),
+        initial_covariance=np.eye(7) * 1e-6,
+    )
+    cross = posterior.joint_covariance[7:14, 14:21]
+    assert np.linalg.norm(cross) > 0.0
+    assert np.min(np.linalg.eigvalsh(posterior.joint_covariance)) >= -1e-11
+    diagnostics = loop_closure_diagnostics(posterior, [*good_edges, bad_loop])
+    assert len(diagnostics) == 1
+    assert diagnostics[0].suspicious
+    assert diagnostics[0].normalized_innovation_squared > diagnostics[0].threshold
+
+
+def test_intrinsic_residual_is_finite_across_rotation_branch() -> None:
+    first = Sim3.from_vector(
+        np.array([0.0, np.pi - 1e-6, 0.0, 0.0, 0.0, 0.0, 0.0])
+    )
+    second = Sim3.from_vector(
+        np.array([0.0, -np.pi + 1e-6, 0.0, 0.0, 0.0, 0.0, 0.0])
+    )
+    residual = right_invariant_residual(first, second)
+    assert np.all(np.isfinite(residual))
+    assert np.linalg.norm(residual[1:4]) < 1e-4

--- a/tests/test_stratified_alignment.py
+++ b/tests/test_stratified_alignment.py
@@ -1,0 +1,124 @@
+import numpy as np
+import pytest
+
+from prob4d.data import PredictionWindow
+from prob4d.sim3 import Sim3
+from prob4d.stratified_alignment import (
+    align_windows_stratified,
+    stratified_overlapping_correspondences,
+)
+
+
+def windows(
+    *,
+    frames: int = 2,
+    height: int = 16,
+    width: int = 16,
+    transform: Sim3 | None = None,
+) -> tuple[PredictionWindow, PredictionWindow]:
+    frame_indices = np.arange(10, 10 + frames)
+    rows, columns = np.meshgrid(
+        np.arange(height),
+        np.arange(width),
+        indexing="ij",
+    )
+    base = np.stack(
+        (
+            0.03 * columns,
+            0.03 * rows,
+            0.5 + 0.01 * rows + 0.02 * columns + 0.001 * rows * columns,
+        ),
+        axis=-1,
+    )
+    source = np.stack(
+        [base + np.array([0.0, 0.0, 0.05 * index]) for index in range(frames)]
+    )
+    transform = transform or Sim3.identity()
+    target = transform.transform_points(source)
+    mask = np.ones((frames, height, width), dtype=bool)
+    return (
+        PredictionWindow("reference", frame_indices, target, mask),
+        PredictionWindow("moving", frame_indices, source, mask),
+    )
+
+
+def test_stratified_sample_is_deterministic_and_covers_all_tiles() -> None:
+    reference, moving = windows()
+    first = stratified_overlapping_correspondences(
+        reference,
+        moving,
+        max_correspondences=40,
+        spatial_tile_size=4,
+    )
+    second = stratified_overlapping_correspondences(
+        reference,
+        moving,
+        max_correspondences=40,
+        spatial_tile_size=4,
+    )
+
+    assert first.available_count == 512
+    assert first.sample_count == 40
+    assert first.cluster_count == 32
+    np.testing.assert_array_equal(first.source_points, second.source_points)
+    np.testing.assert_array_equal(first.target_points, second.target_points)
+    np.testing.assert_array_equal(first.frame_ids, second.frame_ids)
+    np.testing.assert_array_equal(first.rows, second.rows)
+    np.testing.assert_array_equal(first.columns, second.columns)
+    np.testing.assert_array_equal(first.cluster_ids, second.cluster_ids)
+
+
+def test_stratified_sample_spans_the_depth_range_within_one_tile() -> None:
+    reference, moving = windows(frames=1, height=1, width=20)
+    sample = stratified_overlapping_correspondences(
+        reference,
+        moving,
+        max_correspondences=5,
+        spatial_tile_size=32,
+    )
+    depths = np.linalg.norm(sample.source_points, axis=1)
+    all_depths = np.linalg.norm(moving.point_map.reshape(-1, 3), axis=1)
+    assert depths.min() == pytest.approx(all_depths.min())
+    assert depths.max() == pytest.approx(all_depths.max())
+
+
+def test_stratified_alignment_recovers_exact_similarity_transform() -> None:
+    truth = Sim3.from_vector(
+        np.array([0.04, 0.05, -0.03, 0.02, 0.3, -0.1, 0.2])
+    )
+    reference, moving = windows(transform=truth)
+    alignment = align_windows_stratified(
+        reference,
+        moving,
+        max_correspondences=80,
+        spatial_tile_size=4,
+    )
+
+    np.testing.assert_allclose(
+        alignment.result.transform.as_vector(),
+        truth.as_vector(),
+        atol=1e-10,
+    )
+    assert alignment.result.num_correspondences == 80
+    assert alignment.result.num_covariance_clusters == 32
+    assert alignment.result.covariance_fallback is None
+
+
+def test_stratified_alignment_fails_closed_on_too_few_clusters() -> None:
+    reference, moving = windows(frames=1, height=2, width=4)
+    with pytest.raises(ValueError, match="fewer than eight"):
+        align_windows_stratified(
+            reference,
+            moving,
+            max_correspondences=8,
+            spatial_tile_size=32,
+        )
+
+    alignment = align_windows_stratified(
+        reference,
+        moving,
+        max_correspondences=8,
+        spatial_tile_size=32,
+        fallback_policy="pointwise",
+    )
+    assert alignment.result.covariance_fallback.endswith("pointwise_v1")


### PR DESCRIPTION
## Summary

- add deterministic frame/tile/depth-stratified sampling for dense overlap alignment;
- preserve frame-by-spatial-tile sandwich covariance and fail closed when fewer than eight independent clusters survive;
- add manifold-local generalized covariance intersection for several uncertain `Sim(3)` candidates without pairwise order dependence;
- add orientation-independent overlap-edge content IDs and a deterministic global minimum-uncertainty-volume spanning tree;
- propagate the selected tree into one full cross-window gauge covariance;
- add held-out loop-closure residual and NIS diagnostics without silently treating redundant edges as independent updates;
- cover constraint permutations, near-π rotations, graph connectivity, covariance propagation, loop faults, exact sampling budgets, depth coverage, and fallback semantics;
- document the estimator as an additive V2 ablation path rather than changing the frozen portable observation stream.

## Why

The current sequential gauge initializer applies pairwise covariance intersection in candidate iteration order, while the strict observation export selects one parent greedily for each new window. Dense overlap alignment also uses an unstratified random subset when correspondence count exceeds the configured cap. These choices can make diagnostics sensitive to ordering or sampling while discarding useful graph structure.

This PR provides deterministic alternatives while preserving all existing defaults, artifact schemas, stream-contract versions, and frozen experiment semantics.

## Validation

Focused local validation against the current NumPy core:

```text
10 passed
```

The focused suite exercises generalized-CI permutation invariance, sequential constraint-order invariance, deterministic global tree selection, full joint covariance, loop-fault detection, SO(3) branch handling, stratified sampling determinism, spatial/depth coverage, exact `Sim(3)` recovery, and fail-closed covariance fallback.

GitHub Actions remains authoritative for Ruff, the complete Python 3.10/3.12/3.14 suite, distribution builds, and installed wheel/sdist smoke tests.

## Claim boundary

This is an estimator and diagnostic implementation, not a held-out performance result. Generalized CI handles unknown correlation among parent candidates; selected tree-edge errors remain a first-order covariance model, and non-tree NIS values are explicitly diagnostic. Promotion into the production observation stream still requires the registered sequence-family-held-out Prob4D and downstream Bayesian-PhysTwin gates.