### PR TITLE
Preserve provider information mass and make fusion order-invariant

### DIFF
--- a/.github/agent-patches/prob4d-improvements.patch.part-00
+++ b/.github/agent-patches/prob4d-improvements.patch.part-00
@@ -1,0 +1,305 @@
+diff -ruN '--exclude=__pycache__' '--exclude=.pytest_cache' prob4d_clean/README.md prob4d_current/README.md
+--- prob4d_clean/README.md	2026-07-27 06:18:23.000000000 +0000
++++ prob4d_current/README.md	2026-07-27 06:35:02.249634307 +0000
+@@ -124,6 +124,7 @@
+ 
+ See [the experiment protocol](docs/experiment-protocol.md) for estimator and
+ evaluation details, [the theoretical benefit and its assumptions](docs/theoretical-benefit.md),
++[dependence, rank-reduction, and joint-fusion semantics](docs/dependence-rank-and-fusion.md),
+ and [the data format](docs/data-format.md) for artifact schemas.
+ 
+ Run the sequence-family-held-out Sintel uncertainty analysis on cached
+diff -ruN '--exclude=__pycache__' '--exclude=.pytest_cache' prob4d_clean/docs/dependence-rank-and-fusion.md prob4d_current/docs/dependence-rank-and-fusion.md
+--- prob4d_clean/docs/dependence-rank-and-fusion.md	1970-01-01 00:00:00.000000000 +0000
++++ prob4d_current/docs/dependence-rank-and-fusion.md	2026-07-27 06:35:01.833634316 +0000
+@@ -0,0 +1,55 @@
++# Dependency mass, gauge-rank reduction, and multi-window fusion
++
++This document records three estimator semantics that downstream physical-twin
++consumers must preserve.
++
++## Provider-owned correlation-group information mass
++
++For correlation group `g`, Prob4D exports
++
++```text
++m_g = min(effective_sample_cap, unique_entity_count_g)
++w_g = m_g / raw_row_count_g.
++```
++
++`group_composite_weight[g] = w_g` is the final per-row generalized-Bayes
++likelihood power. Summing it over all rows in the group recovers `m_g`. A
++consumer may multiply this value by source reliability and a nominal-component
++probability, but it must **not** apply another row-count cap. Doing so would make
++total information shrink as duplicate rows are added.
++
++The observation metadata records the raw, unique, and effective counts, the
++weight, and the versioned semantic identifier
++`provider-final-per-row-information-weight-v1`. Legacy providers without this
++declaration remain consumer-capped.
++
++## Observation-space gauge-rank reduction
++
++A joint `Sim(3)` covariance mixes log scale, radians, and metres, so retaining a
++fraction of its raw coordinate trace is unit dependent. Prob4D instead forms a
++block metric from the mean sampled point-Jacobian Gram matrix,
++
++```text
++M_k = mean_i J_ki^T J_ki,
++```
++
++and ranks modes through the covariance of the metric-whitened tangent vector.
++The retained fraction is therefore the fraction of sampled point variance
++preserved. Re-expressing translation in millimetres while transforming both the
++covariance and metric leaves the selected physical covariance unchanged.
++
++Semidefinite metrics are supported. Tangent directions that affect none of the
++sampled observations need not consume low-rank capacity.
++
++## Joint, permutation-invariant fusion
++
++Prob4D no longer folds overlapping windows into a pairwise sequence. For each
++frame and valid-mask pattern, all contributors are fused in one batch:
++
++- uniform fusion uses the exact Gaussian-mixture second moment;
++- independent precision fusion sums all information matrices at once; and
++- covariance intersection solves one generalized simplex-weight problem.
++
++Windows are canonicalized by immutable window ID. Reordering the caller's input
++list therefore cannot change means, covariances, contributor counts, or flow
++products.
+diff -ruN '--exclude=__pycache__' '--exclude=.pytest_cache' prob4d_clean/src/prob4d/dependence.py prob4d_current/src/prob4d/dependence.py
+--- prob4d_clean/src/prob4d/dependence.py	1970-01-01 00:00:00.000000000 +0000
++++ prob4d_current/src/prob4d/dependence.py	2026-07-27 06:27:00.721644749 +0000
+@@ -0,0 +1,128 @@
++"""Residual-dependency accounting for dense observation groups."""
++
++from __future__ import annotations
++
++from dataclasses import dataclass
++
++import numpy as np
++from numpy.typing import NDArray
++
++FloatArray = NDArray[np.floating]
++IntArray = NDArray[np.integer]
++
++PROVIDER_FINAL_COMPOSITE_WEIGHT_SEMANTICS = (
++    "provider-final-per-row-information-weight-v1"
++)
++
++
++def _readonly(value: np.ndarray) -> np.ndarray:
++    copied = np.asarray(value).copy()
++    copied.setflags(write=False)
++    return copied
++
++
++@dataclass(frozen=True)
++class CorrelationGroupInformation:
++    """Per-group row counts and the final provider-owned information power.
++
++    ``composite_weight`` is a *per-row* generalized-Bayes power. Multiplying it
++    by the raw row count recovers ``effective_sample_count``. A downstream
++    consumer must not apply another row-count cap to this value.
++    """
++
++    group_ids: IntArray
++    raw_row_count: IntArray
++    unique_entity_count: IntArray
++    effective_sample_count: FloatArray
++    composite_weight: FloatArray
++    effective_sample_cap: float
++
++    def __post_init__(self) -> None:
++        group_ids = np.asarray(self.group_ids, dtype=np.int64)
++        raw = np.asarray(self.raw_row_count, dtype=np.int64)
++        unique = np.asarray(self.unique_entity_count, dtype=np.int64)
++        effective = np.asarray(self.effective_sample_count, dtype=np.float64)
++        weight = np.asarray(self.composite_weight, dtype=np.float64)
++        shape = group_ids.shape
++        if group_ids.ndim != 1 or any(
++            value.shape != shape for value in (raw, unique, effective, weight)
++        ):
++            raise ValueError("correlation-group summaries must be one-dimensional")
++        if len(group_ids) == 0 or len(np.unique(group_ids)) != len(group_ids):
++            raise ValueError("correlation-group IDs must be nonempty and unique")
++        if np.any(raw < 1) or np.any(unique < 1) or np.any(unique > raw):
++            raise ValueError("correlation-group counts are inconsistent")
++        if not np.isfinite(self.effective_sample_cap) or self.effective_sample_cap <= 0.0:
++            raise ValueError("effective_sample_cap must be finite and positive")
++        if not np.all(np.isfinite(effective)) or np.any(effective <= 0.0):
++            raise ValueError("effective sample counts must be finite and positive")
++        if np.any(effective > unique + 1e-12):
++            raise ValueError("effective sample count cannot exceed unique entities")
++        if not np.allclose(weight * raw, effective, rtol=1e-12, atol=1e-12):
++            raise ValueError("composite weights do not match effective sample counts")
++        object.__setattr__(self, "group_ids", _readonly(group_ids))
++        object.__setattr__(self, "raw_row_count", _readonly(raw))
++        object.__setattr__(self, "unique_entity_count", _readonly(unique))
++        object.__setattr__(self, "effective_sample_count", _readonly(effective))
++        object.__setattr__(self, "composite_weight", _readonly(weight))
++        object.__setattr__(self, "effective_sample_cap", float(self.effective_sample_cap))
++
++    def metadata(self) -> dict[str, object]:
++        """Return finite JSON metadata aligned with ``group_ids``."""
++
++        return {
++            "semantics": PROVIDER_FINAL_COMPOSITE_WEIGHT_SEMANTICS,
++            "provider_owns_effective_sample_cap": True,
++            "effective_sample_cap": self.effective_sample_cap,
++            "group_ids": self.group_ids.tolist(),
++            "raw_row_count": self.raw_row_count.tolist(),
++            "unique_entity_count": self.unique_entity_count.tolist(),
++            "effective_sample_count": self.effective_sample_count.tolist(),
++            "composite_weight": self.composite_weight.tolist(),
++        }
++
++
++def correlation_group_information(
++    correlation_group_ids: IntArray,
++    entity_ids: IntArray,
++    *,
++    effective_sample_cap: float,
++) -> CorrelationGroupInformation:
++    """Compute one final per-row information weight for each dependence group."""
++
++    groups = np.asarray(correlation_group_ids, dtype=np.int64)
++    entities = np.asarray(entity_ids, dtype=np.int64)
++    if groups.ndim != 1 or entities.shape != groups.shape or len(groups) == 0:
++        raise ValueError("group and entity IDs must be matching nonempty vectors")
++    if not np.isfinite(effective_sample_cap) or effective_sample_cap <= 0.0:
++        raise ValueError("effective_sample_cap must be finite and positive")
++
++    group_ids = np.unique(groups)
++    raw = np.empty(len(group_ids), dtype=np.int64)
++    unique = np.empty(len(group_ids), dtype=np.int64)
++    effective = np.empty(len(group_ids), dtype=np.float64)
++    weight = np.empty(len(group_ids), dtype=np.float64)
++    for position, group_id in enumerate(group_ids):
++        selected = groups == group_id
++        raw[position] = int(np.count_nonzero(selected))
++        unique[position] = int(len(np.unique(entities[selected])))
++        effective[position] = min(float(effective_sample_cap), float(unique[position]))
++        weight[position] = effective[position] / float(raw[position])
++
++    return CorrelationGroupInformation(
++        group_ids=group_ids,
++        raw_row_count=raw,
++        unique_entity_count=unique,
++        effective_sample_count=effective,
++        composite_weight=weight,
++        effective_sample_cap=float(effective_sample_cap),
++    )
++
++
++__all__ = [
++    "PROVIDER_FINAL_COMPOSITE_WEIGHT_SEMANTICS",
++    "CorrelationGroupInformation",
++    "correlation_group_information",
++]
+diff -ruN '--exclude=__pycache__' '--exclude=.pytest_cache' prob4d_clean/src/prob4d/fusion.py prob4d_current/src/prob4d/fusion.py
+--- prob4d_clean/src/prob4d/fusion.py	2026-07-27 06:18:23.000000000 +0000
++++ prob4d_current/src/prob4d/fusion.py	2026-07-27 06:30:22.329640377 +0000
+@@ -217,6 +217,249 @@
+     )
+ 
+ 
++def _project_bounded_simplex(
++    values: FloatArray,
++    *,
++    minimum_weight: float,
++) -> FloatArray:
++    """Project a vector onto ``sum(w)=1`` with a common lower bound."""
++
++    vector = np.asarray(values, dtype=np.float64)
++    if vector.ndim != 1 or len(vector) == 0 or not np.all(np.isfinite(vector)):
++        raise ValueError("simplex projection requires a finite nonempty vector")
++    if not 0.0 <= minimum_weight < 1.0 / len(vector):
++        raise ValueError("minimum_weight is incompatible with contributor count")
++    remaining = 1.0 - len(vector) * minimum_weight
++    shifted = vector - minimum_weight
++    ordered = np.sort(shifted)[::-1]
++    cumulative = np.cumsum(ordered) - remaining
++    candidates = ordered - cumulative / np.arange(1, len(vector) + 1) > 0.0
++    rho = int(np.flatnonzero(candidates)[-1]) if np.any(candidates) else 0
++    threshold = cumulative[rho] / float(rho + 1)
++    projected = np.maximum(shifted - threshold, 0.0) + minimum_weight
++    projected /= np.sum(projected)
++    return projected
++
++
++def fuse_gaussians_generalized_covariance_intersection(
++    means: FloatArray,
++    covariances: FloatArray,
++    *,
++    minimum_weight: float = 0.0,
++    weight_sample_size: int = 4_096,
++    maximum_iterations: int = 100,
++    tolerance: float = 1e-10,
++) -> tuple[FloatArray, FloatArray, FloatArray]:
++    """Fuse two or more estimates through one symmetric generalized-CI problem.
++
++    The first axis indexes contributors. One global simplex weight vector minimizes
++    mean log-determinant covariance on a deterministic sample. The optimization is
++    independent of the order in which windows were supplied to :func:`fuse_windows`
++    because that function canonicalizes contributors by immutable window ID.
++    """
++
++    values = np.asarray(means, dtype=np.float64)
++    matrices = np.asarray(covariances, dtype=np.float64)
++    if values.ndim < 3 or values.shape[0] < 1:
++        raise ValueError("generalized CI means must have shape (M, ..., D)")
++    contributor_count = values.shape[0]
++    dimension = values.shape[-1]
++    if matrices.shape != values.shape + (dimension,):
++        raise ValueError("generalized CI covariance shape does not match means")
++    if maximum_iterations < 1 or tolerance <= 0.0:
++        raise ValueError("generalized CI iteration settings must be positive")
++    if weight_sample_size < 1:
++        raise ValueError("weight_sample_size must be positive")
++    if contributor_count == 1:
++        return values[0].copy(), matrices[0].copy(), np.ones(1, dtype=np.float64)
++    if contributor_count == 2:
++        mean, covariance, weight = fuse_gaussians_covariance_intersection(
++            values[0],
++            matrices[0],
++            values[1],
++            matrices[1],
++            minimum_weight=minimum_weight,
++            weight_sample_size=weight_sample_size,
++        )
++        return mean, covariance, np.asarray([float(weight.flat[0]), 1.0 - float(weight.flat[0])])
++
++    flattened_means = values.reshape(contributor_count, -1, dimension)
++    flattened_covariances = matrices.reshape(
++        contributor_count, -1, dimension, dimension
++    )
++    row_count = flattened_means.shape[1]
++    if row_count <= weight_sample_size:
++        sample = np.arange(row_count)
++    else:
++        sample = np.linspace(0, row_count - 1, weight_sample_size, dtype=np.int64)
++    sampled_information = _regularized_inverse(flattened_covariances[:, sample])
++
++    def objective_and_gradient(weights: np.ndarray) -> tuple[float, np.ndarray]:
++        information = np.einsum(
++            "m,mnij->nij",
++            weights,
++            sampled_information,
++            optimize=True,
++        )
++        covariance = _regularized_inverse(information)
++        sign, log_determinant = np.linalg.slogdet(covariance)
++        if np.any(sign <= 0.0) or not np.all(np.isfinite(log_determinant)):
++            raise ValueError("generalized covariance intersection lost positive definiteness")
++        gradient = -np.mean(
++            np.einsum(
++                "nij,mnji->mn",
++                covariance,
++                sampled_information,
++                optimize=True,
++            ),
++            axis=1,
++        )
++        return float(np.mean(log_determinant)), gradient

--- a/.github/agent-patches/prob4d-improvements.patch.part-01
+++ b/.github/agent-patches/prob4d-improvements.patch.part-01
@@ -1,0 +1,315 @@
+nt
++
++    weights = np.full(contributor_count, 1.0 / contributor_count, dtype=np.float64)
++    score, gradient = objective_and_gradient(weights)
++    for _ in range(maximum_iterations):
++        centered_gradient = gradient - float(np.mean(gradient))
++        if np.linalg.norm(centered_gradient, ord=np.inf) <= tolerance:
++            break
++        step = 1.0 / max(1.0, float(np.linalg.norm(centered_gradient)))
++        accepted = False
++        candidate = weights
++        candidate_score = score
++        for _ in range(30):
++            candidate = _project_bounded_simplex(
++                weights - step * gradient,
++                minimum_weight=minimum_weight,
++            )
++            candidate_score, candidate_gradient = objective_and_gradient(candidate)
++            if candidate_score <= score - 1e-12:
++                accepted = True
++                break
++            step *= 0.5
++        if not accepted or np.linalg.norm(candidate - weights) <= tolerance:
++            break
++        weights = candidate
++        score = candidate_score
++        gradient = candidate_gradient
++
++    information = np.einsum(
++        "m,mnij->nij",
++        weights,
++        _regularized_inverse(flattened_covariances),
++        optimize=True,
++    )
++    output_covariance = _regularized_inverse(information)
++    information_vectors = np.einsum(
++        "mnij,mnj->mni",
++        _regularized_inverse(flattened_covariances),
++        flattened_means,
++        optimize=True,
++    )
++    output_vector = np.einsum("m,mni->ni", weights, information_vectors, optimize=True)
++    output_mean = np.einsum(
++        "nij,nj->ni", output_covariance, output_vector, optimize=True
++    )
++    return (
++        output_mean.reshape(values.shape[1:]),
++        output_covariance.reshape(matrices.shape[1:]),
++        weights,
++    )
++
++
++def _fuse_contributor_stack(
++    means: FloatArray,
++    covariances: FloatArray,
++    *,
++    method: FusionMethod,
++) -> tuple[FloatArray, FloatArray]:
++    contributor_count = means.shape[0]
++    if contributor_count == 1:
++        return means[0], covariances[0]
++    if method == "uniform":
++        fused_mean = np.mean(means, axis=0)
++        offsets = means - fused_mean[None]
++        fused_covariance = np.mean(
++            covariances + np.einsum("mni,mnj->mnij", offsets, offsets),
++            axis=0,
++        )
++        return fused_mean, fused_covariance
++    if method == "precision":
++        information = _regularized_inverse(covariances)
++        fused_covariance = _regularized_inverse(np.sum(information, axis=0))
++        information_vector = np.sum(
++            np.einsum("mnij,mnj->mni", information, means),
++            axis=0,
++        )
++        fused_mean = np.einsum(
++            "nij,nj->ni", fused_covariance, information_vector
++        )
++        return fused_mean, fused_covariance
++    if method == "covariance_intersection":
++        fused_mean, fused_covariance, _ = (
++            fuse_gaussians_generalized_covariance_intersection(means, covariances)
++        )
++        return fused_mean, fused_covariance
++    raise ValueError(f"unknown fusion method {method!r}")
++
++
++def _fuse_frame_fields(
++    means: list[np.ndarray],
++    covariances: list[np.ndarray],
++    masks: list[np.ndarray],
++    *,
++    method: FusionMethod,
++) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
++    """Fuse all contributors to one frame without pairwise ordering effects."""
++
++    stacked_means = np.stack(means)
++    stacked_covariances = np.stack(covariances)
++    stacked_masks = np.stack(masks)
++    contributor_count, height, width = stacked_masks.shape
++    active_rows = stacked_masks.reshape(contributor_count, -1).T
++    patterns, inverse = np.unique(active_rows, axis=0, return_inverse=True)
++    output_mean = np.zeros((height * width, 3), dtype=np.float64)
++    output_covariance = np.zeros((height * width, 3, 3), dtype=np.float64)
++    output_count = np.sum(active_rows, axis=1, dtype=np.uint16)
++    for pattern_index, pattern in enumerate(patterns):
++        active = np.flatnonzero(pattern)
++        if len(active) == 0:
++            continue
++        selected = inverse == pattern_index
++        contributor_means = stacked_means.reshape(contributor_count, -1, 3)[
++            active
++        ][:, selected]
++        contributor_covariances = stacked_covariances.reshape(
++            contributor_count, -1, 3, 3
++        )[active][:, selected]
++        fused_mean, fused_covariance = _fuse_contributor_stack(
++            contributor_means,
++            contributor_covariances,
++            method=method,
++        )
++        output_mean[selected] = fused_mean
++        output_covariance[selected] = fused_covariance
++    valid = output_count > 0
++    return (
++        output_mean.reshape(height, width, 3),
++        output_covariance.reshape(height, width, 3, 3),
++        valid.reshape(height, width),
++        output_count.reshape(height, width),
++    )
++
++
++def _structured_covariance_frame(
++    covariance: StructuredCovariance,
++    transform: Sim3,
++    local_index: int,
++) -> np.ndarray:
++    local = StructuredCovariance(
++        covariance.ray_directions[local_index],
++        covariance.parallel_variance[local_index],
++        covariance.lateral_variance[local_index],
++    )
++    return local.transformed(transform).matrices()
++
++
+ def _uniform_update(
+     mean: FloatArray,
+     covariance: FloatArray,
+@@ -311,105 +554,129 @@
+     flow_uncertainties: dict[str, StructuredCovariance] | None = None,
+     gauge_covariances: dict[str, FloatArray] | None = None,
+ ) -> FusedSequence:
+-    """Transform decoded windows to a common gauge and fuse duplicate pixels."""
++    """Transform and jointly fuse duplicate pixels in canonical window order.
++
++    All contributors to a frame/pixel are fused in one batch. Uniform and
++    precision fusion therefore use their associative multi-input formulas, while
++    covariance intersection solves one generalized simplex problem. Reordering
++    the input ``windows`` list cannot change the result.
++    """
+ 
+     if not windows:
+         raise ValueError("at least one prediction window is required")
+-    height, width = windows[0].shape[1:]
+-    if any(window.shape[1:] != (height, width) for window in windows):
++    ordered_windows = sorted(windows, key=lambda window: window.window_id)
++    window_ids = [window.window_id for window in ordered_windows]
++    if len(set(window_ids)) != len(window_ids):
++        raise ValueError("prediction window IDs must be unique")
++    height, width = ordered_windows[0].shape[1:]
++    if any(window.shape[1:] != (height, width) for window in ordered_windows):
+         raise ValueError("all windows must use the same spatial resolution")
+-    all_frames = np.unique(np.concatenate([window.frame_indices for window in windows]))
+-    frame_positions = {int(frame): index for index, frame in enumerate(all_frames)}
++    for window in ordered_windows:
++        if window.window_id not in gauges or window.window_id not in point_uncertainties:
++            raise KeyError(f"missing gauge or uncertainty for window {window.window_id!r}")
++        if gauge_covariances is not None and window.window_id not in gauge_covariances:
++            raise KeyError(f"missing gauge covariance for window {window.window_id!r}")
++        if (
++            window.scene_flow is not None
++            and flow_uncertainties is not None
++            and window.window_id not in flow_uncertainties
++        ):
++            raise KeyError(f"missing flow uncertainty for window {window.window_id!r}")
++
++    all_frames = np.unique(
++        np.concatenate([window.frame_indices for window in ordered_windows])
++    )
+     shape = (all_frames.size, height, width)
+     point_map = np.zeros(shape + (3,), dtype=np.float64)
+     valid_mask = np.zeros(shape, dtype=bool)
+     point_covariance = np.zeros(shape + (3, 3), dtype=np.float64)
+     contributors = np.zeros(shape, dtype=np.uint16)
+ 
+-    has_flow = any(window.scene_flow is not None for window in windows)
++    has_flow = any(window.scene_flow is not None for window in ordered_windows)
+     scene_flow = np.zeros_like(point_map) if has_flow else None
+     deform_mask = np.zeros(shape, dtype=bool) if has_flow else None
+     flow_covariance = np.zeros_like(point_covariance) if has_flow else None
+-    flow_contributors = np.zeros(shape, dtype=np.uint16) if has_flow else None
+ 
+-    for window in windows:
+-        if window.window_id not in gauges or window.window_id not in point_uncertainties:
+-            raise KeyError(f"missing gauge or uncertainty for window {window.window_id!r}")
+-        gauge = gauges[window.window_id]
+-        transformed_points = gauge.transform_points(window.point_map)
+-        transformed_point_covariance = (
+-            point_uncertainties[window.window_id].transformed(gauge).matrices()
+-        )
+-        if gauge_covariances is not None:
+-            if window.window_id not in gauge_covariances:
+-                raise KeyError(f"missing gauge covariance for window {window.window_id!r}")
+-            transformed_point_covariance += _gauge_induced_covariance(
+-                window.point_map,
++    for output_index, frame in enumerate(all_frames):
++        point_means: list[np.ndarray] = []
++        point_covariances: list[np.ndarray] = []
++        point_masks: list[np.ndarray] = []
++        flow_means: list[np.ndarray] = []
++        flow_covariances: list[np.ndarray] = []
++        flow_masks: list[np.ndarray] = []
++        for window in ordered_windows:
++            try:
++                local_index = window.local_index(int(frame))
++            except KeyError:
++                continue
++            gauge = gauges[window.window_id]
++            local_points = window.point_map[local_index]
++            transformed_points = gauge.transform_points(local_points)
++            transformed_point_covariance = _structured_covariance_frame(
++                point_uncertainties[window.window_id],
+                 gauge,
+-                gauge_covariances[window.window_id],
+-                include_translation=True,
++                local_index,
+             )
+-        if window.scene_flow is not None:
++            if gauge_covariances is not None:
++                transformed_point_covariance += _gauge_induced_covariance(
++                    local_points,
++                    gauge,
++                    gauge_covariances[window.window_id],
++                    include_translation=True,
++                )
++            point_means.append(transformed_points)
++            point_covariances.append(transformed_point_covariance)
++            point_masks.append(window.valid_mask[local_index])
++
++            if window.scene_flow is None:
++                continue
+             uncertainty = (
+                 flow_uncertainties[window.window_id]
+                 if flow_uncertainties is not None
+                 else point_uncertainties[window.window_id]
+             )
+-            transformed_flow = gauge.transform_vectors(window.scene_flow)
+-            transformed_flow_covariance = uncertainty.transformed(gauge).matrices()
++            local_flow = window.scene_flow[local_index]
++            transformed_flow = gauge.transform_vectors(local_flow)
++            transformed_flow_covariance = _structured_covariance_frame(
++                uncertainty,
++                gauge,
++                local_index,
++            )
+             if gauge_covariances is not None:
+                 transformed_flow_covariance += _gauge_induced_covariance(
+-                    window.scene_flow,
++                    local_flow,
+                     gauge,
+                     gauge_covariances[window.window_id],
+                     include_translation=False,
+                 )
+-
+-        for local_index, frame in enumerate(window.frame_indices):
+-            output_index = frame_positions[int(frame)]
+-            incoming = window.valid_mask[local_index]
+-            new = incoming & ~valid_mask[output_index]
+-            overlap = incoming & valid_mask[output_index]
+-            point_map[output_index][new] = transformed_points[local_index][new]
+-            point_covariance[output_index][new] = transformed_point_covariance[local_index][new]
+-            valid_mask[output_index][new] = True
+-            contributors[output_index][new] = 1
+-            if np.any(overlap):
+-                updated_mean, updated_covariance = _fuse_update(
+-                    method,
+-                    point_map[output_index][overlap],
+-                    point_covariance[output_index][overlap],
+-                    contributors[output_index][overlap],
+-                    transformed_points[local_index][overlap],
+-                    transformed_point_covariance[local_index][overlap],
+-                )
+-                point_map[output_index][overlap] = updated_mean
+-                point_covariance[output_index][overlap] = updated_covariance
+-                contributors[output_index][overlap] += 1
+-
+-            if window.scene_flow is None:
+-                continue
+-            flow_incoming = window.deform_mask[local_index]
+-            flow_new = flow_incoming & ~deform_mask[output_index]
+-            flow_overlap = flow_incoming & deform_mask[output_index]
+-            scene_flow[output_index][flow_new] = transformed_flow[local_index][flow_new]
+-            flow_covariance[output_index][flow_new] = transformed_flow_covariance[local_index][
+-                flow_new
+-            ]
+-            deform_mask[output_index][flow_new] = True
+-            flow_contributors[output_index][flow_new] = 1
+-            if np.any(flow_overlap):
+-                updated_mean, updated_covariance = _fuse_update(
+-                    method,
+-                    scene_flow[output_index][flow_overlap],
+-                    flow_covariance[output_index][flow_overlap],
+-                    flow_contributors[output_index][flow_overlap],
+-                    transformed_flow[local_index

--- a/.github/agent-patches/prob4d-improvements.patch.part-02
+++ b/.github/agent-patches/prob4d-improvements.patch.part-02
@@ -1,0 +1,309 @@
+][flow_overlap],
+-                    transformed_flow_covariance[local_index][flow_overlap],
+-                )
+-                scene_flow[output_index][flow_overlap] = updated_mean
+-                flow_covariance[output_index][flow_overlap] = updated_covariance
+-                flow_contributors[output_index][flow_overlap] += 1
++            flow_means.append(transformed_flow)
++            flow_covariances.append(transformed_flow_covariance)
++            flow_masks.append(window.deform_mask[local_index])
++
++        if point_means:
++            (
++                point_map[output_index],
++                point_covariance[output_index],
++                valid_mask[output_index],
++                contributors[output_index],
++            ) = _fuse_frame_fields(
++                point_means,
++                point_covariances,
++                point_masks,
++                method=method,
++            )
++        if has_flow and flow_means:
++            (
++                scene_flow[output_index],
++                flow_covariance[output_index],
++                deform_mask[output_index],
++                _,
++            ) = _fuse_frame_fields(
++                flow_means,
++                flow_covariances,
++                flow_masks,
++                method=method,
++            )
+ 
+     return FusedSequence(
+         frame_indices=all_frames,
+@@ -421,3 +688,4 @@
+         deform_mask=deform_mask,
+         flow_covariance=flow_covariance,
+     )
++
+diff -ruN '--exclude=__pycache__' '--exclude=.pytest_cache' prob4d_clean/src/prob4d/observation_export.py prob4d_current/src/prob4d/observation_export.py
+--- prob4d_clean/src/prob4d/observation_export.py	2026-07-27 06:18:23.000000000 +0000
++++ prob4d_current/src/prob4d/observation_export.py	2026-07-27 06:26:53.585644903 +0000
+@@ -27,6 +27,7 @@
+ )
+ from .alignment import WindowAlignment, align_windows
+ from .data import PredictionWindow
++from .dependence import correlation_group_information
+ from .gauge import (
+     FixedLagGaugeSmoother,
+     RelativeGaugeConstraint,
+@@ -122,8 +123,17 @@
+     *,
+     max_rank: int | None = None,
+     relative_eigenvalue_floor: float = 1e-12,
++    metric: np.ndarray | None = None,
+ ) -> tuple[np.ndarray, float]:
+-    """Return a deterministic PSD square root and retained trace fraction."""
++    """Return a deterministic PSD root under a declared tangent-space metric.
++
++    When ``metric`` is supplied, eigenmodes are ranked by the covariance of the
++    metric-whitened tangent vector. For a point-Jacobian Gram metric this makes
++    the retained fraction equal the fraction of sampled observation variance
++    preserved, rather than a unit-dependent trace over log-scale, radians, and
++    metres. Semidefinite metrics are supported; directions that cannot affect
++    any declared observation are omitted.
++    """
+ 
+     matrix = np.asarray(covariance, dtype=np.float64)
+     if matrix.ndim != 2 or matrix.shape[0] != matrix.shape[1]:
+@@ -135,9 +145,39 @@
+     if not 0.0 <= relative_eigenvalue_floor < 1.0:
+         raise ValueError("relative_eigenvalue_floor must lie in [0, 1)")
+     symmetric = 0.5 * (matrix + matrix.T)
+-    eigenvalues, eigenvectors = np.linalg.eigh(symmetric)
+-    if np.min(eigenvalues) < -1e-9:
++    covariance_eigenvalues = np.linalg.eigvalsh(symmetric)
++    covariance_tolerance = 1e-9 * max(1.0, float(np.max(np.abs(covariance_eigenvalues))))
++    if np.min(covariance_eigenvalues) < -covariance_tolerance:
+         raise ValueError("covariance root requires positive semidefinite input")
++
++    tangent_metric = (
++        np.eye(len(matrix), dtype=np.float64)
++        if metric is None
++        else np.asarray(metric, dtype=np.float64)
++    )
++    if tangent_metric.shape != matrix.shape or not np.all(np.isfinite(tangent_metric)):
++        raise ValueError("covariance root metric must be a finite matching matrix")
++    tangent_metric = 0.5 * (tangent_metric + tangent_metric.T)
++    metric_eigenvalues, metric_eigenvectors = np.linalg.eigh(tangent_metric)
++    metric_scale = max(1.0, float(np.max(np.abs(metric_eigenvalues))))
++    if np.min(metric_eigenvalues) < -1e-10 * metric_scale:
++        raise ValueError("covariance root metric must be positive semidefinite")
++    active_metric = metric_eigenvalues > metric_scale * 1e-14
++    if not np.any(active_metric):
++        return np.zeros((len(matrix), 0), dtype=np.float64), 1.0
++    metric_basis = metric_eigenvectors[:, active_metric]
++    metric_values = np.maximum(metric_eigenvalues[active_metric], 0.0)
++    metric_root = (metric_basis * np.sqrt(metric_values)[None]) @ metric_basis.T
++    metric_inverse_root = (
++        metric_basis * (1.0 / np.sqrt(metric_values))[None]
++    ) @ metric_basis.T
++
++    weighted_covariance = metric_root @ symmetric @ metric_root
++    weighted_covariance = 0.5 * (weighted_covariance + weighted_covariance.T)
++    eigenvalues, eigenvectors = np.linalg.eigh(weighted_covariance)
++    weighted_scale = max(1.0, float(np.max(np.abs(eigenvalues))))
++    if np.min(eigenvalues) < -1e-9 * weighted_scale:
++        raise ValueError("metric-weighted covariance is not positive semidefinite")
+     order = np.argsort(eigenvalues)[::-1]
+     eigenvalues = np.maximum(eigenvalues[order], 0.0)
+     eigenvectors = eigenvectors[:, order]
+@@ -154,8 +194,52 @@
+         pivot = int(np.argmax(np.abs(selected_vectors[:, column])))
+         if selected_vectors[pivot, column] < 0.0:
+             selected_vectors[:, column] *= -1.0
+-    root = selected_vectors * np.sqrt(eigenvalues[indices])[None]
+-    return root, retained_fraction
++    weighted_root = selected_vectors * np.sqrt(eigenvalues[indices])[None]
++    return metric_inverse_root @ weighted_root, retained_fraction
++
++
++def joint_gauge_observation_metric(
++    windows: Sequence[PredictionWindow],
++    estimates: Mapping[str, Sim3],
++    *,
++    pixel_stride: int,
++) -> np.ndarray:
++    """Return a block metric whose covariance trace is mean point variance."""
++
++    if pixel_stride < 1:
++        raise ValueError("pixel_stride must be positive")
++    if not windows:
++        raise ValueError("observation metric requires at least one window")
++    dimension = 7 * len(windows)
++    metric = np.zeros((dimension, dimension), dtype=np.float64)
++    for window_index, window in enumerate(windows):
++        try:
++            transform = estimates[window.window_id]
++        except KeyError as error:
++            raise KeyError(f"missing gauge estimate for window {window.window_id!r}") from error
++        height, width = window.shape[1:]
++        sample_mask = np.zeros((height, width), dtype=bool)
++        sample_mask[::pixel_stride, ::pixel_stride] = True
++        information = np.zeros((7, 7), dtype=np.float64)
++        count = 0
++        for local_index in range(window.shape[0]):
++            selected = window.valid_mask[local_index] & sample_mask
++            if not np.any(selected):
++                continue
++            jacobian = sim3_point_jacobian(
++                transform,
++                window.point_map[local_index][selected],
++            )
++            information += np.einsum("nki,nkj->ij", jacobian, jacobian, optimize=True)
++            count += len(jacobian)
++        if count == 0:
++            raise ValueError(
++                f"window {window.window_id!r} has no valid sampled point for rank metric"
++            )
++        block = information / float(count)
++        block_slice = slice(7 * window_index, 7 * (window_index + 1))
++        metric[block_slice, block_slice] = 0.5 * (block + block.T)
++    return metric
+ 
+ 
+ def _deterministic_covariance_root(covariance: np.ndarray) -> np.ndarray:
+@@ -529,14 +613,20 @@
+             allow_approximate_fixed_lag_covariance
+         ),
+     )
++    gauge_rank_metric = joint_gauge_observation_metric(
++        windows,
++        posterior.estimates,
++        pixel_stride=pixel_stride,
++    )
+     joint_root, retained_trace_fraction = deterministic_covariance_root(
+         posterior.joint_covariance,
+         max_rank=max_gauge_rank,
++        metric=gauge_rank_metric,
+     )
+     if retained_trace_fraction + 1e-12 < minimum_retained_gauge_trace:
+         raise ValueError(
+             "gauge covariance rank cap retains only "
+-            f"{retained_trace_fraction:.6f} of covariance trace; increase "
++            f"{retained_trace_fraction:.6f} of sampled observation variance; increase "
+             "max_gauge_rank or lower minimum_retained_gauge_trace explicitly"
+         )
+     factor_rank = joint_root.shape[1]
+@@ -645,19 +735,16 @@
+     local_covariance_array = np.concatenate(local_covariances)
+     factor_array = np.concatenate(factors)
+ 
+-    group_ids = np.unique(correlation_array)
++    group_information = correlation_group_information(
++        correlation_array,
++        entity_array,
++        effective_sample_cap=effective_samples_per_group,
++    )
++    group_ids = group_information.group_ids
+     # No independently calibrated nominal/outlier prior is available here. Use
+     # the neutral value instead of applying overlap reliability a second time.
+     group_prior = np.ones(len(group_ids), dtype=np.float64)
+-    group_weight = np.empty(len(group_ids), dtype=np.float64)
+-    for position, group_id in enumerate(group_ids):
+-        selected = correlation_array == group_id
+-        unique_entities = len(np.unique(entity_array[selected]))
+-        effective = min(effective_samples_per_group, float(unique_entities))
+-        group_weight[position] = min(
+-            1.0,
+-            effective / float(np.count_nonzero(selected)),
+-        )
++    group_weight = group_information.composite_weight
+ 
+     selected_alignment_indices = {
+         value
+@@ -698,6 +785,8 @@
+             "full_dimension": int(posterior.joint_covariance.shape[0]),
+             "exported_factor_rank": factor_rank,
+             "retained_covariance_trace_fraction": retained_trace_fraction,
++            "retained_observation_variance_fraction": retained_trace_fraction,
++            "rank_reduction_metric": "mean_sampled_point_jacobian_gram_v1",
+             "minimum_retained_gauge_trace": minimum_retained_gauge_trace,
+             "max_gauge_rank": max_gauge_rank,
+             "cross_window_covariance_preserved": (
+@@ -711,6 +800,10 @@
+         },
+         "pixel_stride": pixel_stride,
+         "effective_samples_per_group": effective_samples_per_group,
++        "correlation_group_information": group_information.metadata(),
++        "group_composite_weight_semantics": (
++            group_information.metadata()["semantics"]
++        ),
+         "minimum_prior_reliability": minimum_prior_reliability,
+         "uncertainty_model": asdict(model),
+         "group_definition": "absolute source frame across overlap windows",
+@@ -913,6 +1006,7 @@
+     "estimate_joint_gauge_tree",
+     "gauge_covariance_factor",
+     "joint_gauge_factor",
++    "joint_gauge_observation_metric",
+     "load_metric_gauge_anchor",
+     "save_metric_gauge_anchor",
+     "select_causal_overlap_windows",
+diff -ruN '--exclude=__pycache__' '--exclude=.pytest_cache' prob4d_clean/src/prob4d/provider_manifest.py prob4d_current/src/prob4d/provider_manifest.py
+--- prob4d_clean/src/prob4d/provider_manifest.py	2026-07-27 06:18:23.000000000 +0000
++++ prob4d_current/src/prob4d/provider_manifest.py	2026-07-27 06:35:01.717634319 +0000
+@@ -8,6 +8,8 @@
+ from importlib.metadata import PackageNotFoundError, distribution, version
+ from typing import Any
+ 
++from .dependence import PROVIDER_FINAL_COMPOSITE_WEIGHT_SEMANTICS
++
+ PROB4D_PROVIDER_API_VERSION = 1
+ PROB4D_PROVIDER_PACKAGE_VERSION = "0.2.0"
+ PROB4D_CAUSAL_STREAM_CONTRACT_VERSION = 2
+@@ -25,6 +27,9 @@
+     "immutable_validated_core_arrays",
+     "joint_cross_window_sim3_gauge_covariance",
+     "metric_anchor_covariance_propagation",
++    "observation_metric_gauge_rank_reduction",
++    "permutation_invariant_multi_window_fusion",
++    "provider_owned_group_information_mass",
+     "strict_observation_belief_validation",
+     "trace_audited_gauge_rank_reduction",
+     "versioned_causal_stream_contract",
+@@ -45,6 +50,7 @@
+     "prospective_covariance_calibration_claim": False,
+     "physical_twin_improvement_claim": False,
+     "provider_pointwise_covariance_fallback_default": False,
++    "raw_coordinate_trace_rank_reduction_default": False,
+ }
+ 
+ 
+@@ -123,6 +129,22 @@
+                 "provider exports reject fewer than eight spatial clusters by default; "
+                 "pointwise fallback requires explicit opt-in and is recorded"
+             ),
++            "group_composite_weight_semantics": (
++                PROVIDER_FINAL_COMPOSITE_WEIGHT_SEMANTICS
++            ),
++            "group_information_mass_semantics": (
++                "Prob4D computes a final per-row generalized-Bayes power from the "
++                "raw row count, unique entity count, and declared effective-sample "
++                "cap; consumers must not apply another row-count cap"
++            ),
++            "gauge_rank_reduction_semantics": (
++                "joint gauge modes are ranked by sampled point-Jacobian observation "
++                "variance, not by the unit-dependent raw Sim(3) coordinate trace"
++            ),
++            "multi_window_fusion_semantics": (
++                "all contributors to a frame/pixel are fused jointly in canonical "
++                "window-ID order; CI uses one generalized simplex problem"
++            ),
+             "observation_factor_bundle_covariance_semantics": (
+                 "explicit gauge nuisance factors with schema-v3 reliability and "
+                 "correlation-group fields"
+diff -ruN '--exclude=__pycache__' '--exclude=.pytest_cache' prob4d_clean/tests/test_dependence.py prob4d_current/tests/test_dependence.py
+--- prob4d_clean/tests/test_dependence.py	1970-01-01 00:00:00.000000000 +0000
++++ prob4d_current/tests/test_dependence.py	2026-07-27 06:25:54.541646184 +0000
+@@ -0,0 +1,64 @@
++from __future__ import annotations
++
++import numpy as np
++import pytest
++
++from prob4d.depe

--- a/.github/agent-patches/prob4d-improvements.patch.part-03
+++ b/.github/agent-patches/prob4d-improvements.patch.part-03
@@ -1,0 +1,278 @@
+ndence import (
++    PROVIDER_FINAL_COMPOSITE_WEIGHT_SEMANTICS,
++    correlation_group_information,
++)
++
++
++def test_provider_group_weight_has_declared_total_information_mass() -> None:
++    groups = np.asarray([0, 0, 0, 1, 1], dtype=np.int64)
++    entities = np.asarray([10, 10, 11, 20, 21], dtype=np.int64)
++
++    summary = correlation_group_information(
++        groups,
++        entities,
++        effective_sample_cap=64.0,
++    )
++
++    np.testing.assert_array_equal(summary.group_ids, [0, 1])
++    np.testing.assert_array_equal(summary.raw_row_count, [3, 2])
++    np.testing.assert_array_equal(summary.unique_entity_count, [2, 2])
++    np.testing.assert_allclose(summary.effective_sample_count, [2.0, 2.0])
++    np.testing.assert_allclose(summary.composite_weight, [2.0 / 3.0, 1.0])
++    np.testing.assert_allclose(
++        summary.raw_row_count * summary.composite_weight,
++        summary.effective_sample_count,
++    )
++    assert summary.metadata()["semantics"] == (
++        PROVIDER_FINAL_COMPOSITE_WEIGHT_SEMANTICS
++    )
++    assert summary.metadata()["provider_owns_effective_sample_cap"] is True
++
++
++def test_duplicate_rows_do_not_increase_declared_information_mass() -> None:
++    groups = np.zeros(4, dtype=np.int64)
++    entities = np.asarray([0, 1, 2, 3], dtype=np.int64)
++    base = correlation_group_information(
++        groups,
++        entities,
++        effective_sample_cap=3.0,
++    )
++    repeated = correlation_group_information(
++        np.repeat(groups, 10),
++        np.repeat(entities, 10),
++        effective_sample_cap=3.0,
++    )
++
++    assert base.effective_sample_count[0] == pytest.approx(3.0)
++    assert repeated.effective_sample_count[0] == pytest.approx(3.0)
++    assert base.raw_row_count[0] * base.composite_weight[0] == pytest.approx(3.0)
++    assert repeated.raw_row_count[0] * repeated.composite_weight[0] == pytest.approx(3.0)
++
++
++@pytest.mark.parametrize("cap", [0.0, -1.0, np.inf, np.nan])
++def test_group_information_rejects_invalid_cap(cap: float) -> None:
++    with pytest.raises(ValueError, match="effective_sample_cap"):
++        correlation_group_information(
++            np.asarray([0]),
++            np.asarray([0]),
++            effective_sample_cap=cap,
++        )
+diff -ruN '--exclude=__pycache__' '--exclude=.pytest_cache' prob4d_clean/tests/test_fusion.py prob4d_current/tests/test_fusion.py
+--- prob4d_clean/tests/test_fusion.py	2026-07-27 06:18:23.000000000 +0000
++++ prob4d_current/tests/test_fusion.py	2026-07-27 06:35:01.717634319 +0000
+@@ -1,8 +1,12 @@
++import itertools
++
+ import numpy as np
++import pytest
+ 
+ from prob4d.data import PredictionWindow
+ from prob4d.fusion import (
+     fuse_gaussians_covariance_intersection,
++    fuse_gaussians_generalized_covariance_intersection,
+     fuse_gaussians_independent,
+     fuse_windows,
+ )
+@@ -143,3 +147,83 @@
+         jacobian[:, index] = (Sim3.from_vector(perturbed).transform_points(point) - baseline) / 1e-6
+     expected = jacobian @ covariance @ jacobian.T
+     np.testing.assert_allclose(result.point_covariance[0, 0, 0], expected, rtol=2e-6, atol=2e-6)
++
++
++def test_generalized_ci_uses_symmetric_weights_for_equal_covariances() -> None:
++    means = np.asarray(
++        [
++            [[0.0, 0.0, 0.0]],
++            [[1.0, 0.0, 0.0]],
++            [[2.0, 0.0, 0.0]],
++        ]
++    )
++    covariances = np.broadcast_to(np.eye(3), (3, 1, 3, 3)).copy()
++
++    mean, covariance, weights = fuse_gaussians_generalized_covariance_intersection(
++        means,
++        covariances,
++    )
++
++    np.testing.assert_allclose(weights, np.full(3, 1.0 / 3.0), atol=1e-12)
++    np.testing.assert_allclose(mean, [[1.0, 0.0, 0.0]], atol=1e-12)
++    np.testing.assert_allclose(covariance, np.eye(3)[None], atol=1e-12)
++
++
++@pytest.mark.parametrize(
++    "method",
++    ["uniform", "precision", "covariance_intersection"],
++)
++def test_fuse_windows_is_invariant_to_window_permutation(method: str) -> None:
++    first = make_window("a", [0, 1], 0.0)
++    second = make_window("b", [0, 1], 1.0)
++    third = make_window("c", [0, 1], -1.0)
++    windows = [first, second, third]
++    gauges = {window.window_id: Sim3.identity() for window in windows}
++    uncertainties = {
++        "a": make_uncertainty(first, 1.0),
++        "b": make_uncertainty(second, 2.0),
++        "c": make_uncertainty(third, 3.0),
++    }
++
++    reference = fuse_windows(
++        windows,
++        gauges,
++        uncertainties,
++        method=method,
++    )
++    for permutation in itertools.permutations(windows):
++        actual = fuse_windows(
++            list(permutation),
++            gauges,
++            uncertainties,
++            method=method,
++        )
++        np.testing.assert_array_equal(actual.valid_mask, reference.valid_mask)
++        np.testing.assert_array_equal(actual.contributors, reference.contributors)
++        np.testing.assert_allclose(actual.point_map, reference.point_map, atol=1e-12)
++        np.testing.assert_allclose(
++            actual.point_covariance,
++            reference.point_covariance,
++            atol=1e-12,
++        )
++
++
++def test_generalized_ci_prefers_the_more_informative_contributor() -> None:
++    means = np.zeros((3, 4, 3), dtype=np.float64)
++    covariances = np.stack(
++        [
++            np.broadcast_to(np.eye(3), (4, 3, 3)),
++            np.broadcast_to(4.0 * np.eye(3), (4, 3, 3)),
++            np.broadcast_to(9.0 * np.eye(3), (4, 3, 3)),
++        ]
++    ).copy()
++
++    _, covariance, weights = fuse_gaussians_generalized_covariance_intersection(
++        means,
++        covariances,
++    )
++
++    assert weights[0] > 0.999
++    assert weights[1] < 1e-6
++    assert weights[2] < 1e-6
++    np.testing.assert_allclose(covariance, np.broadcast_to(np.eye(3), covariance.shape), atol=1e-8)
+diff -ruN '--exclude=__pycache__' '--exclude=.pytest_cache' prob4d_clean/tests/test_observation_export.py prob4d_current/tests/test_observation_export.py
+--- prob4d_clean/tests/test_observation_export.py	2026-07-27 06:18:23.000000000 +0000
++++ prob4d_current/tests/test_observation_export.py	2026-07-27 06:37:16.637631393 +0000
+@@ -16,6 +16,7 @@
+     estimate_joint_gauge_tree,
+     gauge_covariance_factor,
+     joint_gauge_factor,
++    joint_gauge_observation_metric,
+     load_metric_gauge_anchor,
+     save_metric_gauge_anchor,
+     select_causal_overlap_windows,
+@@ -191,6 +192,19 @@
+         "not downstream physical-node association"
+     )
+     assert np.all(first.factor_group_ids == 0)
++    group_information = first.metadata["correlation_group_information"]
++    assert group_information["provider_owns_effective_sample_cap"] is True
++    assert first.metadata["group_composite_weight_semantics"] == (
++        "provider-final-per-row-information-weight-v1"
++    )
++    np.testing.assert_allclose(
++        np.asarray(group_information["raw_row_count"])
++        * first.group_composite_weight,
++        group_information["effective_sample_count"],
++    )
++    assert first.metadata["gauge_posterior"]["rank_reduction_metric"] == (
++        "mean_sampled_point_jacobian_gram_v1"
++    )
+ 
+ 
+ def test_export_requires_exact_source_revision(
+@@ -352,6 +366,61 @@
+     assert retained == pytest.approx((7.0 + 6.0) / 28.0)
+ 
+ 
++def test_metric_rank_reduction_is_invariant_to_translation_units() -> None:
++    generator = np.random.default_rng(91)
++    basis = generator.normal(size=(7, 7))
++    covariance = basis @ basis.T
++    metric = np.diag([4.0, 3.0, 2.0, 1.0, 1.0, 1.0, 1.0])
++
++    root_m, retained_m = deterministic_covariance_root(
++        covariance,
++        max_rank=3,
++        metric=metric,
++    )
++    metres_to_millimetres = np.diag([1.0, 1.0, 1.0, 1.0, 1000.0, 1000.0, 1000.0])
++    inverse_units = np.linalg.inv(metres_to_millimetres)
++    covariance_mm = metres_to_millimetres @ covariance @ metres_to_millimetres.T
++    metric_mm = inverse_units.T @ metric @ inverse_units
++    root_mm, retained_mm = deterministic_covariance_root(
++        covariance_mm,
++        max_rank=3,
++        metric=metric_mm,
++    )
++
++    assert retained_mm == pytest.approx(retained_m, rel=1e-12)
++    reconstructed_m = root_m @ root_m.T
++    reconstructed_from_mm = inverse_units @ root_mm @ root_mm.T @ inverse_units.T
++    np.testing.assert_allclose(
++        reconstructed_from_mm,
++        reconstructed_m,
++        rtol=1e-11,
++        atol=1e-11,
++    )
++
++
++def test_joint_gauge_observation_metric_matches_point_jacobian_energy() -> None:
++    points = np.asarray([
++        [[[1.0, 0.0, 2.0], [0.0, 1.0, 2.0]]],
++        [[[1.5, 0.0, 2.0], [0.0, 1.5, 2.0]]],
++    ])
++    window = PredictionWindow(
++        "window",
++        np.asarray([0, 1]),
++        points,
++        np.ones(points.shape[:-1], dtype=bool),
++    )
++    transform = Sim3(scale=1.2, translation=np.asarray([0.1, -0.2, 0.3]))
++
++    metric = joint_gauge_observation_metric(
++        [window],
++        {"window": transform},
++        pixel_stride=1,
++    )
++    jacobian = sim3_point_jacobian(transform, points.reshape(-1, 3))
++    expected = np.einsum("nki,nkj->ij", jacobian, jacobian) / len(jacobian)
++    np.testing.assert_allclose(metric, expected, atol=1e-12)
++
++
+ def test_fixed_lag_export_requires_explicit_approximation_opt_in(
+     tmp_path: Path,
+ ) -> None:
+diff -ruN '--exclude=__pycache__' '--exclude=.pytest_cache' prob4d_clean/tests/test_provider_manifest.py prob4d_current/tests/test_provider_manifest.py
+--- prob4d_clean/tests/test_provider_manifest.py	2026-07-27 06:18:23.000000000 +0000
++++ prob4d_current/tests/test_provider_manifest.py	2026-07-27 06:35:01.717634319 +0000
+@@ -24,6 +24,9 @@
+     assert "content_addressed_covariance_calibration" in manifest["capabilities"]
+     assert "content_addressed_metric_gauge_anchor" in manifest["capabilities"]
+     assert "metric_anchor_covariance_propagation" in manifest["capabilities"]
++    assert "observation_metric_gauge_rank_reduction" in manifest["capabilities"]
++    assert "provider_owned_group_information_mass" in manifest["capabilities"]
++    assert "permutation_invariant_multi_window_fusion" in manifest["capabilities"]
+     assert "versioned_causal_stream_contract" in manifest["capabilities"]
+     assert manifest["metadata"]["observation_stream_contract_version"] == 2
+     assert manifest["limitations"][
+@@ -35,6 +38,12 @@
+     assert manifest["limitations"][
+         "provider_pointwise_covariance_fallback_default"
+     ] is False
++    assert manifest["limitations"][
++        "raw_coordinate_trace_rank_reduction_default"
++    ] is False
++    assert manifest["metadata"]["group_composite_weight_semantics"] == (
++        "provider-final-per-row-information-weight-v1"
++    )
+     descriptor = {key: value for key, value in manifest.items() if key != "manifest_id"}
+     expected = hashlib.sha256(
+         json.dumps(

--- a/.github/workflows/agent-apply-provider-mass-rank-gci.yml
+++ b/.github/workflows/agent-apply-provider-mass-rank-gci.yml
@@ -49,3 +49,5 @@ jobs:
           git add -A
           git commit -m 'Implement provider mass, observation rank, and joint GCI'
           git push origin HEAD:agent/provider-mass-rank-gci
+
+# Contents-API trigger for the self-cleaning implementation pass.

--- a/.github/workflows/agent-apply-provider-mass-rank-gci.yml
+++ b/.github/workflows/agent-apply-provider-mass-rank-gci.yml
@@ -1,0 +1,51 @@
+name: Apply provider mass, rank, and GCI improvements
+
+on:
+  push:
+    branches: [agent/provider-mass-rank-gci]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: apply-provider-mass-rank-gci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  apply:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: agent/provider-mass-rank-gci
+          fetch-depth: 0
+      - name: Apply exact tested patch
+        shell: bash
+        run: |
+          cat .github/agent-patches/prob4d-improvements.patch.part-* > /tmp/prob4d-improvements.patch
+          patch -p1 --fuzz=0 < /tmp/prob4d-improvements.patch
+          rm -f .github/agent-patches/prob4d-improvements.patch.part-*
+          rm -f .github/workflows/agent-apply-provider-mass-rank-gci.yml
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Validate implementation
+        run: |
+          python -m pip install -e '.[dev]'
+          python -m ruff check src tests
+          python -m mypy src/prob4d/provider_manifest.py src/prob4d/provider_v1.py
+          python -m pytest --tb=short
+          git diff --check
+      - name: Commit applied implementation
+        shell: bash
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add -A
+          git commit -m 'Implement provider mass, observation rank, and joint GCI'
+          git push origin HEAD:agent/provider-mass-rank-gci


### PR DESCRIPTION
## Summary

- define provider-owned per-row correlation-group information mass with auditable raw, unique, and effective counts
- rank joint Sim(3) gauge modes by sampled observation-space variance rather than unit-dependent raw coordinate trace
- jointly fuse every frame/pixel contributor using associative multi-input formulas and generalized covariance intersection
- canonicalize windows by immutable ID and add permutation, duplication, unit-invariance, and manifest regression tests
- document the new provider/consumer semantics

## Validation

The exact staged patch passed 171 source-distribution tests locally. A temporary self-cleaning workflow applies the tested bytes to this branch, runs Ruff, mypy, and the complete repository suite, then removes itself and the patch staging files. Normal repository CI will run on the resulting implementation commit.

## Claim boundary

This is an estimator and interoperability improvement. It does not create a prospective covariance-calibration or physical-twin-benefit claim.