### PR TITLE
Use analytic Sim(3) composition Jacobians in provider v2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,6 +54,7 @@ jobs:
           python -m mypy
           src/prob4d/cli.py
           src/prob4d/calibration_compatibility.py
+          src/prob4d/composition_jacobian.py
           src/prob4d/covariance_root.py
           src/prob4d/provider_manifest.py
           src/prob4d/provider_manifest_cli.py
@@ -125,6 +126,7 @@ jobs:
           import sys
 
           import prob4d.cli
+          import prob4d.composition_jacobian
           import prob4d.covariance_root
           import prob4d.provider_manifest
           import prob4d.provider_v1
@@ -208,10 +210,12 @@ jobs:
           import prob4d
           import prob4d.provider_v1 as provider_v1
           import prob4d.provider_v2 as provider_v2
+          from prob4d.composition_jacobian import current_composition_jacobian_mode
 
           print(prob4d.__version__)
           assert provider_v1.PROVIDER_API_VERSION == 1
           assert provider_v2.PROVIDER_API_VERSION == 2
+          assert current_composition_jacobian_mode() == "legacy_finite_difference"
           PY
       - name: Exercise grouped and legacy command help
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ All notable changes to Prob4D are documented here.
   cluster size, and gauge/point covariance methods before payload loading.
 - A context-local canonical covariance-root basis for repeated eigenspaces in
   provider v2, with fail-closed rank boundaries and unchanged provider-v1 defaults.
+- Context-local analytic `Sim(3)` composition Jacobians for provider-v2 sequential
+  covariance propagation, with fail-closed handling at the SO(3) logarithm branch
+  cut and exact provider-v1 finite-difference compatibility.
 - Explicit `prob4d observation export-calibrated` and
   `prob4d observation export-exploratory` commands, plus installed legacy-style
   entry points for scripted use.
@@ -20,7 +23,8 @@ All notable changes to Prob4D are documented here.
   require independent VCS metadata or a clean source checkout; an environment-only
   `PROB4D_RUNTIME_REVISION` assertion is recorded only for exploratory deployments.
 - Content-addressed provider-v2 artifact metadata binding the provider manifest,
-  export mode, calibration IDs, covariance-root mode, and runtime revision evidence.
+  export mode, calibration IDs, covariance-root and composition-Jacobian modes, and
+  runtime revision evidence.
 - Version-selectable provider manifest emission through
   `prob4d provider manifest --api-version {1,2}`.
 - Provider-v2 unit, type, import, wheel, and source-distribution coverage.
@@ -33,8 +37,9 @@ All notable changes to Prob4D are documented here.
 - Documentation now recommends the calibrated provider-v2 command for new
   claim-bearing experiments and labels provider-v1 commands as frozen compatibility
   surfaces.
-- CI verifies clean-checkout runtime attestation, publishes both provider manifests,
-  and smoke-tests every provider-v2 command from installed wheel and source artifacts.
+- CI verifies analytic-versus-finite-difference derivative parity, clean-checkout
+  runtime attestation, both provider manifests, and every provider-v2 command from
+  installed wheel and source artifacts.
 
 ## 0.2.0 — 2026-07-26
 

--- a/docs/provider-v2.md
+++ b/docs/provider-v2.md
@@ -87,19 +87,22 @@ For `G = G_parent compose G_relative`, the derivatives account for:
 - scale and rotation transport of the relative translation; and
 - the direct parent and relative translation blocks.
 
-The SO(3) logarithm is not differentiable at its pi branch cut. Provider v2 fails
-closed at that numerically ambiguous boundary instead of exporting a
-platform-dependent covariance. Random-transform, near-identity, and right-Jacobian
-inverse tests compare the analytic result with the frozen central-difference
-implementation.
+The SO(3) logarithm is not differentiable at its pi branch cut. Provider-v2
+sequential export fails closed at that numerically ambiguous boundary instead of
+exporting a platform-dependent covariance. Random-transform, near-identity, and
+right-Jacobian inverse tests compare the analytic result with the frozen
+central-difference implementation.
 
 A task-local dispatcher keeps the compatibility boundary explicit:
 
-- provider v2 uses `analytic`;
+- provider-v2 sequential joint-gauge export uses `analytic`;
 - provider v1 defaults to `legacy_finite_difference` even after provider v2 has
-  been imported; and
-- nested or concurrent export contexts cannot leak the provider-v2 choice into a
-  frozen provider-v1 run.
+  been imported;
+- the exploratory fixed-lag reconstruction path retains
+  `legacy_finite_difference`, because its rolling smoother has separate nonlinear
+  derivatives; and
+- nested or concurrent export contexts cannot leak the provider-v2 sequential
+  choice into a frozen provider-v1 run.
 
 The selected mode is recorded in the provider-v2 artifact attestation.
 

--- a/docs/provider-v2.md
+++ b/docs/provider-v2.md
@@ -49,7 +49,7 @@ record binds:
 - calibrated versus exploratory export mode;
 - whether prediction/calibration compatibility was validated;
 - gauge and point calibration artifact identifiers;
-- covariance-root mode; and
+- covariance-root and composition-Jacobian modes; and
 - the observed runtime revision, its evidence source, checkout cleanliness, and
   whether the observation was independently verified from VCS metadata.
 
@@ -69,6 +69,39 @@ CI emits both provider manifests with:
 prob4d provider manifest --api-version 1 --provider-revision "<commit>"
 prob4d provider manifest --api-version 2 --provider-revision "<commit>"
 ```
+
+## Analytic Sim(3) composition Jacobians
+
+Sequential gauge covariance propagation composes a parent gauge with an uncertain
+relative gauge. Provider v2 now differentiates that composition analytically in
+the repository's seven-coordinate convention:
+
+```text
+[log scale, axis-angle rotation (3), translation (3)].
+```
+
+For `G = G_parent compose G_relative`, the derivatives account for:
+
+- additive log scale;
+- the SO(3) right Jacobians of the parent, relative, and composed rotations;
+- scale and rotation transport of the relative translation; and
+- the direct parent and relative translation blocks.
+
+The SO(3) logarithm is not differentiable at its pi branch cut. Provider v2 fails
+closed at that numerically ambiguous boundary instead of exporting a
+platform-dependent covariance. Random-transform, near-identity, and right-Jacobian
+inverse tests compare the analytic result with the frozen central-difference
+implementation.
+
+A task-local dispatcher keeps the compatibility boundary explicit:
+
+- provider v2 uses `analytic`;
+- provider v1 defaults to `legacy_finite_difference` even after provider v2 has
+  been imported; and
+- nested or concurrent export contexts cannot leak the provider-v2 choice into a
+  frozen provider-v1 run.
+
+The selected mode is recorded in the provider-v2 artifact attestation.
 
 ## Canonical covariance-root basis
 

--- a/src/prob4d/composition_jacobian.py
+++ b/src/prob4d/composition_jacobian.py
@@ -1,0 +1,162 @@
+"""Context-local analytic Jacobians for seven-coordinate ``Sim(3)`` composition.
+
+Provider v1 retains the historical central-finite-difference implementation.
+Provider v2 selects the analytic implementation through a task-local context,
+so importing the new provider cannot silently reinterpret frozen v1 artifacts.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from typing import Literal
+
+import numpy as np
+
+from . import observation_export as _observation_export
+from .sim3 import Sim3, skew, so3_log, so3_right_jacobian
+
+CompositionJacobianMode = Literal["legacy_finite_difference", "analytic"]
+COMPOSITION_JACOBIAN_MODES: tuple[CompositionJacobianMode, ...] = (
+    "legacy_finite_difference",
+    "analytic",
+)
+_MODE: ContextVar[CompositionJacobianMode] = ContextVar(
+    "prob4d_composition_jacobian_mode",
+    default="legacy_finite_difference",
+)
+_LEGACY_COMPOSE_JACOBIANS = _observation_export._compose_jacobians
+
+
+def so3_right_jacobian_inverse(rotation_vector: np.ndarray) -> np.ndarray:
+    """Return the inverse SO(3) right Jacobian in axis-angle coordinates."""
+
+    vector = np.asarray(rotation_vector, dtype=np.float64)
+    if vector.shape != (3,) or not np.all(np.isfinite(vector)):
+        raise ValueError("rotation_vector must contain three finite values")
+    angle = float(np.linalg.norm(vector))
+    generator = skew(vector)
+    if angle < 1e-4:
+        coefficient = (
+            1.0 / 12.0
+            + angle**2 / 720.0
+            + angle**4 / 30_240.0
+        )
+    else:
+        coefficient = 1.0 / angle**2 - 1.0 / (
+            2.0 * angle * np.tan(0.5 * angle)
+        )
+    return np.eye(3) + 0.5 * generator + coefficient * generator @ generator
+
+
+def analytic_sim3_compose_jacobians(
+    parent: Sim3,
+    relative: Sim3,
+    *,
+    branch_cut_tolerance: float = 1e-7,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return exact first derivatives of ``parent.compose(relative)``.
+
+    Coordinates follow :meth:`prob4d.sim3.Sim3.as_vector`:
+    ``[log_scale, rotation_vector(3), translation(3)]``. The SO(3) logarithm is
+    non-differentiable at its pi branch cut, so that numerically ambiguous boundary
+    fails closed instead of producing a platform-dependent covariance.
+    """
+
+    tolerance = float(branch_cut_tolerance)
+    if not np.isfinite(tolerance) or tolerance < 0.0:
+        raise ValueError("branch_cut_tolerance must be finite and non-negative")
+
+    output_rotation = so3_log(parent.rotation @ relative.rotation)
+    output_angle = float(np.linalg.norm(output_rotation))
+    if np.pi - output_angle <= tolerance:
+        raise ValueError(
+            "Sim(3) composition Jacobian is undefined at the SO(3) log branch cut"
+        )
+
+    output_right_inverse = so3_right_jacobian_inverse(output_rotation)
+    parent_right = so3_right_jacobian(parent.as_vector()[1:4])
+    relative_right = so3_right_jacobian(relative.as_vector()[1:4])
+
+    parent_jacobian = np.zeros((7, 7), dtype=np.float64)
+    relative_jacobian = np.zeros((7, 7), dtype=np.float64)
+    parent_jacobian[0, 0] = 1.0
+    relative_jacobian[0, 0] = 1.0
+    parent_jacobian[1:4, 1:4] = (
+        output_right_inverse @ relative.rotation.T @ parent_right
+    )
+    relative_jacobian[1:4, 1:4] = output_right_inverse @ relative_right
+
+    transported_translation = parent.scale * (
+        parent.rotation @ relative.translation
+    )
+    parent_jacobian[4:7, 0] = transported_translation
+    parent_jacobian[4:7, 1:4] = (
+        -parent.scale
+        * parent.rotation
+        @ skew(relative.translation)
+        @ parent_right
+    )
+    parent_jacobian[4:7, 4:7] = np.eye(3)
+    relative_jacobian[4:7, 4:7] = parent.scale * parent.rotation
+
+    if not np.all(np.isfinite(parent_jacobian)) or not np.all(
+        np.isfinite(relative_jacobian)
+    ):
+        raise ValueError("analytic Sim(3) composition Jacobian is non-finite")
+    return parent_jacobian, relative_jacobian
+
+
+def current_composition_jacobian_mode() -> CompositionJacobianMode:
+    """Return the task-local composition-Jacobian mode."""
+
+    return _MODE.get()
+
+
+@contextmanager
+def composition_jacobian_mode(
+    mode: CompositionJacobianMode,
+) -> Iterator[None]:
+    """Select composition derivatives without process-global mode leakage."""
+
+    if mode not in COMPOSITION_JACOBIAN_MODES:
+        raise ValueError(
+            f"composition Jacobian mode must be one of {COMPOSITION_JACOBIAN_MODES}"
+        )
+    token = _MODE.set(mode)
+    try:
+        yield
+    finally:
+        _MODE.reset(token)
+
+
+def _dispatch_compose_jacobians(
+    parent: Sim3,
+    relative: Sim3,
+) -> tuple[np.ndarray, np.ndarray]:
+    if current_composition_jacobian_mode() == "analytic":
+        return analytic_sim3_compose_jacobians(parent, relative)
+    return _LEGACY_COMPOSE_JACOBIANS(parent, relative)
+
+
+def _install_dispatcher() -> None:
+    current = _observation_export._compose_jacobians
+    if current is _dispatch_compose_jacobians:
+        return
+    if current is not _LEGACY_COMPOSE_JACOBIANS:
+        raise RuntimeError("Prob4D composition-Jacobian implementation changed unexpectedly")
+    _observation_export._compose_jacobians = _dispatch_compose_jacobians
+
+
+_install_dispatcher()
+
+
+__all__ = [
+    "COMPOSITION_JACOBIAN_MODES",
+    "CompositionJacobianMode",
+    "analytic_sim3_compose_jacobians",
+    "composition_jacobian_mode",
+    "current_composition_jacobian_mode",
+    "so3_right_jacobian_inverse",
+]

--- a/src/prob4d/composition_jacobian.py
+++ b/src/prob4d/composition_jacobian.py
@@ -59,25 +59,33 @@ def analytic_sim3_compose_jacobians(
     """Return exact first derivatives of ``parent.compose(relative)``.
 
     Coordinates follow :meth:`prob4d.sim3.Sim3.as_vector`:
-    ``[log_scale, rotation_vector(3), translation(3)]``. The SO(3) logarithm is
-    non-differentiable at its pi branch cut, so that numerically ambiguous boundary
-    fails closed instead of producing a platform-dependent covariance.
+    ``[log_scale, rotation_vector(3), translation(3)]``. Axis-angle coordinates
+    are non-differentiable at the SO(3) logarithm's pi branch cut, so ambiguous
+    parent, relative, or composed coordinates fail closed rather than producing
+    platform-dependent covariance.
     """
 
     tolerance = float(branch_cut_tolerance)
     if not np.isfinite(tolerance) or tolerance < 0.0:
         raise ValueError("branch_cut_tolerance must be finite and non-negative")
 
+    parent_rotation = so3_log(parent.rotation)
+    relative_rotation = so3_log(relative.rotation)
     output_rotation = so3_log(parent.rotation @ relative.rotation)
-    output_angle = float(np.linalg.norm(output_rotation))
-    if np.pi - output_angle <= tolerance:
-        raise ValueError(
-            "Sim(3) composition Jacobian is undefined at the SO(3) log branch cut"
-        )
+    for label, vector in (
+        ("parent", parent_rotation),
+        ("relative", relative_rotation),
+        ("composed", output_rotation),
+    ):
+        if np.pi - float(np.linalg.norm(vector)) <= tolerance:
+            raise ValueError(
+                f"Sim(3) composition Jacobian is undefined at the {label} "
+                "SO(3) log branch cut"
+            )
 
     output_right_inverse = so3_right_jacobian_inverse(output_rotation)
-    parent_right = so3_right_jacobian(parent.as_vector()[1:4])
-    relative_right = so3_right_jacobian(relative.as_vector()[1:4])
+    parent_right = so3_right_jacobian(parent_rotation)
+    relative_right = so3_right_jacobian(relative_rotation)
 
     parent_jacobian = np.zeros((7, 7), dtype=np.float64)
     relative_jacobian = np.zeros((7, 7), dtype=np.float64)

--- a/src/prob4d/provider_v2.py
+++ b/src/prob4d/provider_v2.py
@@ -112,10 +112,11 @@ def prob4d_provider_manifest(
                 "before opening prediction payloads"
             ),
             "composition_jacobian_semantics": (
-                "provider v2 propagates sequential Sim(3) gauge covariance with "
-                "closed-form derivatives in log-scale, axis-angle, and translation "
-                "coordinates; the SO(3) log branch cut fails closed and provider v1 "
-                "retains its frozen finite-difference behavior"
+                "provider-v2 sequential joint-gauge propagation uses closed-form "
+                "derivatives in log-scale, axis-angle, and translation coordinates; "
+                "the SO(3) log branch cut fails closed, while provider v1 and the "
+                "exploratory fixed-lag reconstruction path retain frozen finite-"
+                "difference behavior"
             ),
             "covariance_root_semantics": (
                 "version 2 uses a context-local canonical basis for numerically "
@@ -220,9 +221,12 @@ def export_exploratory_observation_belief(
     Runtime provenance is recorded but is not required to be independently verified.
     """
 
+    selected_composition_mode: CompositionJacobianMode = (
+        "analytic" if gauge_mode == "sequential" else "legacy_finite_difference"
+    )
     with (
         covariance_root_mode(gauge_root_mode),
-        composition_jacobian_mode("analytic"),
+        composition_jacobian_mode(selected_composition_mode),
     ):
         artifact = _v1.export_observation_belief(
             manifest_path,
@@ -253,7 +257,7 @@ def export_exploratory_observation_belief(
         artifact,
         export_mode="exploratory",
         covariance_root_mode_name=gauge_root_mode,
-        composition_jacobian_mode_name="analytic",
+        composition_jacobian_mode_name=selected_composition_mode,
         calibration_compatibility_validated=False,
         runtime_attestation=runtime_attestation,
     )

--- a/src/prob4d/provider_v2.py
+++ b/src/prob4d/provider_v2.py
@@ -22,6 +22,10 @@ from .calibration_compatibility import (
     load_prediction_calibration_target,
     motioncrafter_model_identifier,
 )
+from .composition_jacobian import (
+    CompositionJacobianMode,
+    composition_jacobian_mode,
+)
 from .covariance_root import CovarianceRootMode, covariance_root_mode
 from .provider_v1 import (
     GAUGE_COVARIANCE_CALIBRATION_SCHEMA,
@@ -88,6 +92,7 @@ def prob4d_provider_manifest(
     inherited.pop("manifest_id", None)
     capabilities = list(cast(list[str], inherited["capabilities"]))
     for capability in (
+        "analytic_sim3_composition_jacobians",
         "canonical_repeated_eigenspace_covariance_root",
         "explicit_exploratory_and_claim_bearing_exports",
         "provider_attested_observation_artifacts",
@@ -106,6 +111,12 @@ def prob4d_provider_manifest(
                 "geometry, covariance cluster size, and gauge/point covariance methods "
                 "before opening prediction payloads"
             ),
+            "composition_jacobian_semantics": (
+                "provider v2 propagates sequential Sim(3) gauge covariance with "
+                "closed-form derivatives in log-scale, axis-angle, and translation "
+                "coordinates; the SO(3) log branch cut fails closed and provider v1 "
+                "retains its frozen finite-difference behavior"
+            ),
             "covariance_root_semantics": (
                 "version 2 uses a context-local canonical basis for numerically "
                 "repeated covariance eigenspaces and fails closed if a rank boundary "
@@ -118,9 +129,9 @@ def prob4d_provider_manifest(
             ),
             "provider_attestation_semantics": (
                 "every provider-v2 export embeds the version-2 manifest identity, "
-                "export mode, covariance-root mode, and runtime-revision evidence; "
-                "claim-bearing export fails closed on unavailable, mismatched, or dirty "
-                "runtime source provenance"
+                "export mode, covariance-root and composition-Jacobian modes, and "
+                "runtime-revision evidence; claim-bearing export fails closed on "
+                "unavailable, mismatched, dirty, or non-independent runtime provenance"
             ),
         }
     )
@@ -143,6 +154,7 @@ def _provider_attested_artifact(
     *,
     export_mode: str,
     covariance_root_mode_name: CovarianceRootMode,
+    composition_jacobian_mode_name: CompositionJacobianMode,
     calibration_compatibility_validated: bool,
     runtime_attestation: RuntimeRevisionAttestation,
 ) -> ObservationBeliefExportV1:
@@ -172,6 +184,7 @@ def _provider_attested_artifact(
         ),
         "calibration_artifact_ids": calibration_ids,
         "covariance_root_mode": covariance_root_mode_name,
+        "composition_jacobian_mode": composition_jacobian_mode_name,
         "runtime_revision": runtime_attestation.as_metadata(),
     }
     return replace(artifact, metadata=metadata)
@@ -207,7 +220,10 @@ def export_exploratory_observation_belief(
     Runtime provenance is recorded but is not required to be independently verified.
     """
 
-    with covariance_root_mode(gauge_root_mode):
+    with (
+        covariance_root_mode(gauge_root_mode),
+        composition_jacobian_mode("analytic"),
+    ):
         artifact = _v1.export_observation_belief(
             manifest_path,
             case_id=case_id,
@@ -237,6 +253,7 @@ def export_exploratory_observation_belief(
         artifact,
         export_mode="exploratory",
         covariance_root_mode_name=gauge_root_mode,
+        composition_jacobian_mode_name="analytic",
         calibration_compatibility_validated=False,
         runtime_attestation=runtime_attestation,
     )
@@ -268,7 +285,10 @@ def export_calibrated_observation_belief(
         point_uncertainty_calibration,
         target,
     )
-    with covariance_root_mode("canonical_eigenspaces"):
+    with (
+        covariance_root_mode("canonical_eigenspaces"),
+        composition_jacobian_mode("analytic"),
+    ):
         artifact = _v1.export_calibrated_observation_belief(
             manifest_path,
             case_id=case_id,
@@ -291,6 +311,7 @@ def export_calibrated_observation_belief(
         artifact,
         export_mode="calibrated",
         covariance_root_mode_name="canonical_eigenspaces",
+        composition_jacobian_mode_name="analytic",
         calibration_compatibility_validated=True,
         runtime_attestation=runtime_attestation,
     )
@@ -312,6 +333,7 @@ __all__ = [
     "PROVIDER_API_VERSION",
     "CalibrationCompatibilityError",
     "CausalOverlapSelection",
+    "CompositionJacobianMode",
     "CovarianceRootMode",
     "GaugeCovarianceCalibrationV1",
     "MetricGaugeAnchor",

--- a/tests/test_composition_jacobian.py
+++ b/tests/test_composition_jacobian.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from contextvars import copy_context
+
+import numpy as np
+import pytest
+
+import prob4d.observation_export as observation_export
+from prob4d.composition_jacobian import (
+    _LEGACY_COMPOSE_JACOBIANS,
+    analytic_sim3_compose_jacobians,
+    composition_jacobian_mode,
+    current_composition_jacobian_mode,
+    so3_right_jacobian_inverse,
+)
+from prob4d.sim3 import Sim3, so3_exp, so3_right_jacobian
+
+
+def _random_sim3(rng: np.random.Generator) -> Sim3:
+    return Sim3(
+        scale=float(np.exp(rng.normal(scale=0.35))),
+        rotation=so3_exp(rng.normal(size=3) * 0.55),
+        translation=rng.normal(size=3),
+    )
+
+
+def test_right_jacobian_inverse_is_an_inverse() -> None:
+    for vector in (
+        np.zeros(3),
+        np.asarray([1e-8, -2e-8, 3e-8]),
+        np.asarray([0.2, -0.3, 0.4]),
+        np.asarray([2.5, 0.1, -0.2]),
+    ):
+        inverse = so3_right_jacobian_inverse(vector)
+        np.testing.assert_allclose(
+            inverse @ so3_right_jacobian(vector),
+            np.eye(3),
+            atol=2e-12,
+            rtol=2e-12,
+        )
+
+
+def test_analytic_composition_jacobians_match_finite_differences() -> None:
+    rng = np.random.default_rng(2718)
+    checked = 0
+    while checked < 64:
+        parent = _random_sim3(rng)
+        relative = _random_sim3(rng)
+        output_angle = np.linalg.norm(parent.compose(relative).as_vector()[1:4])
+        if np.pi - output_angle < 1e-3:
+            continue
+        analytic_parent, analytic_relative = analytic_sim3_compose_jacobians(
+            parent,
+            relative,
+        )
+        numeric_parent, numeric_relative = _LEGACY_COMPOSE_JACOBIANS(
+            parent,
+            relative,
+        )
+        np.testing.assert_allclose(
+            analytic_parent,
+            numeric_parent,
+            atol=4e-8,
+            rtol=4e-8,
+        )
+        np.testing.assert_allclose(
+            analytic_relative,
+            numeric_relative,
+            atol=4e-8,
+            rtol=4e-8,
+        )
+        checked += 1
+
+
+def test_analytic_composition_jacobians_handle_near_identity_rotation() -> None:
+    parent = Sim3(
+        scale=1.2,
+        rotation=so3_exp(np.asarray([1e-10, -2e-10, 3e-10])),
+        translation=np.asarray([0.1, -0.2, 0.3]),
+    )
+    relative = Sim3(
+        scale=0.9,
+        rotation=so3_exp(np.asarray([-4e-10, 1e-10, 2e-10])),
+        translation=np.asarray([-0.4, 0.5, 0.6]),
+    )
+    analytic_parent, analytic_relative = analytic_sim3_compose_jacobians(
+        parent,
+        relative,
+    )
+    numeric_parent, numeric_relative = _LEGACY_COMPOSE_JACOBIANS(parent, relative)
+    np.testing.assert_allclose(analytic_parent, numeric_parent, atol=2e-9, rtol=2e-9)
+    np.testing.assert_allclose(
+        analytic_relative,
+        numeric_relative,
+        atol=2e-9,
+        rtol=2e-9,
+    )
+
+
+def test_analytic_jacobian_fails_closed_at_so3_log_branch() -> None:
+    parent = Sim3(rotation=so3_exp(np.asarray([np.pi, 0.0, 0.0])))
+    with pytest.raises(ValueError, match="log branch cut"):
+        analytic_sim3_compose_jacobians(parent, Sim3.identity())
+
+
+def test_dispatcher_preserves_provider_v1_default_and_context_locality() -> None:
+    parent = Sim3(
+        scale=1.1,
+        rotation=so3_exp(np.asarray([0.2, -0.1, 0.3])),
+        translation=np.asarray([0.5, -0.2, 0.1]),
+    )
+    relative = Sim3(
+        scale=0.8,
+        rotation=so3_exp(np.asarray([-0.3, 0.1, 0.2])),
+        translation=np.asarray([-0.4, 0.7, 0.2]),
+    )
+    legacy = _LEGACY_COMPOSE_JACOBIANS(parent, relative)
+    assert current_composition_jacobian_mode() == "legacy_finite_difference"
+    dispatched = observation_export._compose_jacobians(parent, relative)
+    np.testing.assert_array_equal(dispatched[0], legacy[0])
+    np.testing.assert_array_equal(dispatched[1], legacy[1])
+
+    with composition_jacobian_mode("analytic"):
+        assert current_composition_jacobian_mode() == "analytic"
+        dispatched = observation_export._compose_jacobians(parent, relative)
+        analytic = analytic_sim3_compose_jacobians(parent, relative)
+        np.testing.assert_array_equal(dispatched[0], analytic[0])
+        np.testing.assert_array_equal(dispatched[1], analytic[1])
+
+        isolated = copy_context()
+        assert isolated.run(current_composition_jacobian_mode) == "analytic"
+
+    assert current_composition_jacobian_mode() == "legacy_finite_difference"
+
+
+def test_invalid_mode_and_branch_tolerance_fail_closed() -> None:
+    with pytest.raises(ValueError, match="mode must be one of"):
+        with composition_jacobian_mode("unsupported"):  # type: ignore[arg-type]
+            pass
+    with pytest.raises(ValueError, match="branch_cut_tolerance"):
+        analytic_sim3_compose_jacobians(
+            Sim3.identity(),
+            Sim3.identity(),
+            branch_cut_tolerance=-1.0,
+        )

--- a/tests/test_composition_jacobian.py
+++ b/tests/test_composition_jacobian.py
@@ -97,10 +97,17 @@ def test_analytic_composition_jacobians_handle_near_identity_rotation() -> None:
     )
 
 
-def test_analytic_jacobian_fails_closed_at_so3_log_branch() -> None:
-    parent = Sim3(rotation=so3_exp(np.asarray([np.pi, 0.0, 0.0])))
-    with pytest.raises(ValueError, match="log branch cut"):
-        analytic_sim3_compose_jacobians(parent, Sim3.identity())
+def test_analytic_jacobian_fails_closed_at_composed_so3_log_branch() -> None:
+    parent = Sim3(rotation=so3_exp(np.asarray([0.5 * np.pi, 0.0, 0.0])))
+    relative = Sim3(rotation=so3_exp(np.asarray([0.5 * np.pi, 0.0, 0.0])))
+    with pytest.raises(ValueError, match="composed SO\(3\) log branch cut"):
+        analytic_sim3_compose_jacobians(parent, relative)
+
+
+def test_analytic_jacobian_fails_closed_at_input_so3_log_branch() -> None:
+    half_turn = Sim3(rotation=so3_exp(np.asarray([np.pi, 0.0, 0.0])))
+    with pytest.raises(ValueError, match="parent SO\(3\) log branch cut"):
+        analytic_sim3_compose_jacobians(half_turn, half_turn)
 
 
 def test_dispatcher_preserves_provider_v1_default_and_context_locality() -> None:

--- a/tests/test_provider_v2.py
+++ b/tests/test_provider_v2.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 import prob4d.provider_v2 as provider
+from prob4d.composition_jacobian import current_composition_jacobian_mode
 from prob4d.covariance_root import current_covariance_root_mode
 from prob4d.observation_contract import ObservationBeliefExportV1
 from prob4d.runtime_revision import RuntimeRevisionAttestation
@@ -74,10 +75,14 @@ def test_provider_v2_exposes_safe_capabilities() -> None:
     assert (
         "canonical_repeated_eigenspace_covariance_root" in manifest["capabilities"]
     )
+    assert "analytic_sim3_composition_jacobians" in manifest["capabilities"]
     assert "runtime_revision_attestation" in manifest["capabilities"]
     assert "provider_attested_observation_artifacts" in manifest["capabilities"]
     assert manifest["metadata"]["python_import_boundary"] == "prob4d.provider_v2"
     assert "canonical basis" in manifest["metadata"]["covariance_root_semantics"]
+    assert "closed-form derivatives" in manifest["metadata"][
+        "composition_jacobian_semantics"
+    ]
     assert manifest["limitations"]["uncalibrated_export_is_default"] is False
 
 
@@ -91,6 +96,7 @@ def test_exploratory_export_is_explicit_context_local_and_attested(
         captured.update(
             manifest_path=manifest_path,
             root_mode=current_covariance_root_mode(),
+            composition_mode=current_composition_jacobian_mode(),
             **kwargs,
         )
         return original
@@ -113,7 +119,9 @@ def test_exploratory_export_is_explicit_context_local_and_attested(
 
     assert result.artifact_id != original.artifact_id
     assert captured["root_mode"] == "canonical_eigenspaces"
+    assert captured["composition_mode"] == "analytic"
     assert current_covariance_root_mode() == "legacy_eigenvectors"
+    assert current_composition_jacobian_mode() == "legacy_finite_difference"
     assert captured["allow_uncalibrated_exploratory_covariance"] is True
     assert captured["allow_pointwise_covariance_fallback"] is True
     assert captured["sampling_mode"] == "information_stratified"
@@ -121,6 +129,7 @@ def test_exploratory_export_is_explicit_context_local_and_attested(
     assert attestation["export_mode"] == "exploratory"
     assert attestation["claim_bearing"] is False
     assert attestation["calibration_compatibility_validated"] is False
+    assert attestation["composition_jacobian_mode"] == "analytic"
     assert attestation["runtime_revision"]["independently_verified"] is False
 
 
@@ -129,6 +138,7 @@ def test_exploratory_export_can_reproduce_legacy_root_basis(monkeypatch) -> None
 
     def fake_export(manifest_path, **kwargs):
         captured["root_mode"] = current_covariance_root_mode()
+        captured["composition_mode"] = current_composition_jacobian_mode()
         return _observation()
 
     monkeypatch.setattr(provider._v1, "export_observation_belief", fake_export)
@@ -146,9 +156,13 @@ def test_exploratory_export_can_reproduce_legacy_root_basis(monkeypatch) -> None
         source_revision="a" * 40,
     )
     assert captured["root_mode"] == "legacy_eigenvectors"
+    assert captured["composition_mode"] == "analytic"
     assert result.metadata["prob4d_provider_attestation"][
         "covariance_root_mode"
     ] == "legacy_eigenvectors"
+    assert result.metadata["prob4d_provider_attestation"][
+        "composition_jacobian_mode"
+    ] == "analytic"
 
 
 def test_calibrated_export_validates_runtime_and_calibration_before_delegating(
@@ -185,6 +199,7 @@ def test_calibrated_export_validates_runtime_and_calibration_before_delegating(
                 manifest_path,
                 kwargs,
                 current_covariance_root_mode(),
+                current_composition_jacobian_mode(),
             )
         )
         return original
@@ -211,7 +226,9 @@ def test_calibrated_export_validates_runtime_and_calibration_before_delegating(
     assert [call[0] for call in calls] == ["runtime", "target", "assert", "export"]
     export_kwargs = calls[-1][2]
     assert calls[-1][3] == "canonical_eigenspaces"
+    assert calls[-1][4] == "analytic"
     assert current_covariance_root_mode() == "legacy_eigenvectors"
+    assert current_composition_jacobian_mode() == "legacy_finite_difference"
     assert export_kwargs["gauge_mode"] == "sequential"
     assert export_kwargs["allow_pointwise_covariance_fallback"] is False
     assert export_kwargs["source_revision"] == "a" * 40
@@ -220,6 +237,7 @@ def test_calibrated_export_validates_runtime_and_calibration_before_delegating(
     assert attestation["export_mode"] == "calibrated"
     assert attestation["claim_bearing"] is True
     assert attestation["calibration_compatibility_validated"] is True
+    assert attestation["composition_jacobian_mode"] == "analytic"
     assert attestation["calibration_artifact_ids"] == {
         "gauge_artifact_id": "gauge-id",
         "point_artifact_id": "point-id",

--- a/tests/test_provider_v2_fixed_lag_jacobian_mode.py
+++ b/tests/test_provider_v2_fixed_lag_jacobian_mode.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import numpy as np
+
+import prob4d.provider_v2 as provider
+from prob4d.composition_jacobian import current_composition_jacobian_mode
+from prob4d.observation_contract import ObservationBeliefExportV1
+from prob4d.runtime_revision import RuntimeRevisionAttestation
+
+
+def _observation() -> ObservationBeliefExportV1:
+    return ObservationBeliefExportV1(
+        case_id="case-a",
+        stream_id="prob4d:test",
+        causal_frame_stop=2,
+        view_names=("camera0",),
+        window_names=("window0",),
+        factor_names=(),
+        source_repository="FlorianPfaff/Prob4D",
+        source_revision="a" * 40,
+        source_artifact_sha256="d" * 64,
+        declared_frame_ids=np.asarray([0]),
+        mean_xyz_m=np.asarray([[0.0, 0.0, 1.0]]),
+        frame_ids=np.asarray([0]),
+        entity_ids=np.asarray([0]),
+        view_indices=np.asarray([0]),
+        window_indices=np.asarray([0]),
+        correlation_group_ids=np.asarray([0]),
+        factor_group_ids=np.asarray([0]),
+        prior_reliability=np.asarray([1.0]),
+        association_probability=np.asarray([1.0]),
+        local_covariance_m2=np.asarray([np.eye(3)]),
+        low_rank_factor_m=np.empty((1, 3, 0)),
+        group_ids=np.asarray([0]),
+        group_prior_nominal_probability=np.asarray([1.0]),
+        group_composite_weight=np.asarray([1.0]),
+        metadata={},
+    )
+
+
+def test_exploratory_fixed_lag_records_legacy_composition_derivatives(
+    monkeypatch,
+) -> None:
+    captured = {}
+
+    def fake_export(manifest_path, **kwargs):
+        captured["mode"] = current_composition_jacobian_mode()
+        return _observation()
+
+    monkeypatch.setattr(provider._v1, "export_observation_belief", fake_export)
+    monkeypatch.setattr(
+        provider,
+        "inspect_runtime_revision",
+        lambda revision: RuntimeRevisionAttestation(
+            expected_revision="a" * 40,
+            observed_revision="a" * 40,
+            source="source_checkout",
+            clean_checkout=True,
+            matched=True,
+            independently_verified=True,
+        ),
+    )
+
+    result = provider.export_exploratory_observation_belief(
+        "predictions.json",
+        case_id="case-a",
+        causal_frame_stop=10,
+        metric_anchor=object(),
+        gauge_mode="fixed_lag",
+        allow_approximate_fixed_lag_covariance=True,
+        source_revision="a" * 40,
+    )
+
+    assert captured["mode"] == "legacy_finite_difference"
+    assert result.metadata["prob4d_provider_attestation"][
+        "composition_jacobian_mode"
+    ] == "legacy_finite_difference"
+    assert current_composition_jacobian_mode() == "legacy_finite_difference"


### PR DESCRIPTION
## Summary

- add closed-form first derivatives for `Sim3.compose` in Prob4D's `[log scale, axis-angle, translation]` coordinates;
- use SO(3) right Jacobians and their stable inverse instead of repeated central finite differences for provider-v2 sequential joint-gauge covariance propagation;
- fail closed at the non-differentiable SO(3) logarithm branch cut near pi;
- install a context-local compatibility dispatcher so provider v1 remains byte-for-byte on its frozen finite-difference path after provider v2 is imported;
- retain and attest legacy finite-difference semantics for the exploratory fixed-lag reconstruction path, which has separate nonlinear derivatives;
- record the selected composition-Jacobian mode in every provider-v2 observation artifact and advertise it in the provider manifest;
- add random-transform, near-identity, right-Jacobian inverse, branch-cut, context-isolation, provider-v1 parity, and fixed-lag metadata tests.

## Why

The production sequential observation exporter propagated each new `Sim(3)` gauge through two seven-coordinate central finite-difference Jacobians. That adds repeated transform evaluations, step-size dependence, and avoidable platform sensitivity to the joint covariance used by Bayesian consumers.

The analytic derivatives cover additive log scale, composed rotation coordinates, scale/rotation transport of the relative translation, and both direct translation blocks. The only intrinsic singular boundary is the pi branch of the SO(3) logarithm, which now fails explicitly rather than emitting an unstable covariance.

## Compatibility

- `prob4d.provider_v1` remains frozen and defaults to `legacy_finite_difference`.
- Provider-v2 sequential export selects `analytic` through a `ContextVar`; the mode resets on success or failure and cannot leak into another task.
- Exploratory fixed-lag export records `legacy_finite_difference`, because its rolling smoother still uses its historical nonlinear finite-difference path.
- Observation and causal-stream schemas are unchanged; the content-addressed provider-v2 attestation gains `composition_jacobian_mode`.

## Validation

GitHub Actions will run Ruff, mypy, the complete suite on Python 3.10/3.12/3.14, distribution builds, and isolated wheel/sdist imports. The numerical tests compare 64 random transform pairs and a near-identity case against the frozen finite-difference implementation.
