### PR TITLE
Make provider-v2 attestations self-contained and independently verifiable

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,6 +56,7 @@ jobs:
           src/prob4d/calibration_compatibility.py
           src/prob4d/composition_jacobian.py
           src/prob4d/covariance_root.py
+          src/prob4d/provider_attestation.py
           src/prob4d/provider_manifest.py
           src/prob4d/provider_manifest_cli.py
           src/prob4d/provider_v1.py
@@ -128,6 +129,7 @@ jobs:
           import prob4d.cli
           import prob4d.composition_jacobian
           import prob4d.covariance_root
+          import prob4d.provider_attestation
           import prob4d.provider_manifest
           import prob4d.provider_v1
           import prob4d.provider_v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,10 @@ All notable changes to Prob4D are documented here.
 - Runtime source-revision attestation for provider-v2 export. Claim-bearing runs
   require independent VCS metadata or a clean source checkout; an environment-only
   `PROB4D_RUNTIME_REVISION` assertion is recorded only for exploratory deployments.
-- Content-addressed provider-v2 artifact metadata binding the provider manifest,
-  export mode, calibration IDs, covariance-root and composition-Jacobian modes, and
-  runtime revision evidence.
+- A versioned self-contained provider-attestation schema that embeds the complete
+  content-addressed provider manifest, export mode, calibration IDs, covariance-root
+  and composition-Jacobian modes, and runtime revision evidence. Consumers can
+  recompute and validate it without importing Prob4D.
 - Version-selectable provider manifest emission through
   `prob4d provider manifest --api-version {1,2}`.
 - Provider-v2 unit, type, import, wheel, and source-distribution coverage.
@@ -37,9 +38,9 @@ All notable changes to Prob4D are documented here.
 - Documentation now recommends the calibrated provider-v2 command for new
   claim-bearing experiments and labels provider-v1 commands as frozen compatibility
   surfaces.
-- CI verifies analytic-versus-finite-difference derivative parity, clean-checkout
-  runtime attestation, both provider manifests, and every provider-v2 command from
-  installed wheel and source artifacts.
+- CI verifies analytic-versus-finite-difference derivative parity, provider-manifest
+  and attestation hashing, clean-checkout runtime provenance, and every provider-v2
+  command from installed wheel and source artifacts.
 
 ## 0.2.0 — 2026-07-26
 

--- a/docs/provider-attestation.md
+++ b/docs/provider-attestation.md
@@ -1,0 +1,76 @@
+# Provider-v2 attestation contract
+
+Every artifact produced through `prob4d.provider_v2` embeds a versioned
+`prob4d.provider-attestation` record in
+`metadata.prob4d_provider_attestation`. The observation artifact content address
+covers this record, including the complete provider manifest.
+
+The purpose is not to make a self-signed producer statement magically trusted.
+It is to make the exact statement complete, immutable, and independently
+checkable by Bayesian-PhysTwin or Causal4D without importing Prob4D.
+
+## Schema version 1
+
+The attestation binds:
+
+- provider API version, repository revision, and Python import boundary;
+- the complete content-addressed provider-v2 capability manifest;
+- calibrated versus exploratory export mode;
+- whether prediction/calibration compatibility was checked;
+- gauge and point covariance-calibration artifact IDs;
+- covariance-root and composition-Jacobian modes; and
+- runtime-revision evidence, including source, observed commit, checkout
+  cleanliness, match status, and independent-verification status.
+
+Consumers recompute `provider_manifest_id` from the embedded manifest after
+removing its own ID field. They then validate the known provider name, API
+version, source repository, import boundary, observation schemas, limitations,
+and the required provider-v2 capabilities.
+
+## Claim-bearing requirements
+
+A claim-bearing version-1 attestation must declare all of the following:
+
+```text
+export_mode = calibrated
+claim_bearing = true
+calibration_compatibility_validated = true
+covariance_root_mode = canonical_eigenspaces
+composition_jacobian_mode = analytic
+```
+
+Both calibration artifact IDs must be lowercase SHA-256 digests. Runtime evidence
+must match the observation's exact Prob4D revision and must have been independently
+resolved from installed VCS metadata or a clean source checkout. An environment-only
+revision assertion remains recordable for exploratory deployment but cannot satisfy
+a claim-bearing attestation.
+
+## Compatibility boundary
+
+Provider-v1 artifacts remain valid for frozen reproduction and do not acquire a
+provider-v2 attestation retroactively. Consumers should:
+
+1. continue validating the neutral observation and causal-stream contracts;
+2. validate a provider attestation whenever one is present; and
+3. explicitly require a claim-bearing provider-v2 attestation for new prospective
+   Prob4D-to-Bayesian-PhysTwin evidence.
+
+Adding an undeclared field, changing the embedded manifest, weakening a required
+capability, changing a calibration ID, or contradicting runtime evidence changes
+the observation artifact ID and fails strict attestation validation.
+
+## Python validation
+
+```python
+from prob4d.provider_v2 import validate_provider_attestation
+
+validated = validate_provider_attestation(
+    observation.metadata["prob4d_provider_attestation"],
+    source_revision=observation.source_revision,
+    require_claim_bearing=True,
+)
+```
+
+Downstream repositories intentionally reimplement the small JSON/hash validator so
+they can reject an inconsistent provider artifact before importing or trusting the
+producer package.

--- a/src/prob4d/provider_attestation.py
+++ b/src/prob4d/provider_attestation.py
@@ -1,0 +1,478 @@
+"""Self-contained provider-v2 attestation schema and validation.
+
+The attestation embeds the complete content-addressed provider manifest so a
+consumer can validate its semantics without importing Prob4D. The observation
+artifact's own content address then binds the attestation and every manifest byte.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from typing import Any
+
+PROVIDER_ATTESTATION_SCHEMA = "prob4d.provider-attestation"
+PROVIDER_ATTESTATION_VERSION = 1
+PROVIDER_NAME = "prob4d"
+PROVIDER_API_VERSION = 2
+PROVIDER_SOURCE_REPOSITORY = "FlorianPfaff/Prob4D"
+PROVIDER_IMPORT_BOUNDARY = "prob4d.provider_v2"
+
+_REQUIRED_CAPABILITIES = frozenset(
+    {
+        "analytic_sim3_composition_jacobians",
+        "canonical_repeated_eigenspace_covariance_root",
+        "explicit_exploratory_and_claim_bearing_exports",
+        "provider_attested_observation_artifacts",
+        "runtime_revision_attestation",
+        "strict_prediction_calibration_compatibility",
+    }
+)
+_ATTESTATION_FIELDS = frozenset(
+    {
+        "schema_name",
+        "schema_version",
+        "provider_api_version",
+        "provider_manifest_id",
+        "provider_manifest",
+        "provider_revision",
+        "python_import_boundary",
+        "export_mode",
+        "claim_bearing",
+        "calibration_compatibility_validated",
+        "calibration_artifact_ids",
+        "covariance_root_mode",
+        "composition_jacobian_mode",
+        "runtime_revision",
+    }
+)
+_RUNTIME_FIELDS = frozenset(
+    {
+        "expected_revision",
+        "observed_revision",
+        "source",
+        "clean_checkout",
+        "matched",
+        "independently_verified",
+    }
+)
+_CALIBRATION_FIELDS = frozenset(
+    {
+        "gauge_artifact_id",
+        "point_artifact_id",
+    }
+)
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def _finite_json_mapping(value: Any, *, name: str) -> dict[str, Any]:
+    _require(isinstance(value, Mapping), f"{name} must be a mapping")
+    try:
+        normalized = json.loads(
+            json.dumps(
+                dict(value),
+                sort_keys=True,
+                separators=(",", ":"),
+                allow_nan=False,
+            )
+        )
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"{name} must contain finite JSON data") from error
+    _require(isinstance(normalized, dict), f"{name} must be a JSON object")
+    return normalized
+
+
+def _require_exact_fields(
+    value: Mapping[str, Any],
+    expected: frozenset[str],
+    *,
+    name: str,
+) -> None:
+    missing = expected - value.keys()
+    extra = value.keys() - expected
+    _require(
+        not missing and not extra,
+        f"{name} fields changed; missing={sorted(missing)}, extra={sorted(extra)}",
+    )
+
+
+def _require_sha256(value: Any, *, name: str) -> str:
+    result = str(value)
+    _require(
+        len(result) == 64
+        and all(character in "0123456789abcdef" for character in result),
+        f"{name} must be a lowercase SHA-256 digest",
+    )
+    return result
+
+
+def _require_revision(value: Any, *, name: str) -> str:
+    result = str(value)
+    _require(
+        len(result) in {40, 64}
+        and all(character in "0123456789abcdef" for character in result),
+        f"{name} must be an exact lowercase Git commit",
+    )
+    return result
+
+
+def _canonical_json(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        dict(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def compute_provider_manifest_id(manifest: Mapping[str, Any]) -> str:
+    """Return the manifest ID after removing its self-declared identifier."""
+
+    normalized = _finite_json_mapping(manifest, name="provider manifest")
+    normalized.pop("manifest_id", None)
+    return hashlib.sha256(_canonical_json(normalized)).hexdigest()
+
+
+def validate_provider_manifest(
+    manifest: Mapping[str, Any],
+    *,
+    expected_revision: str,
+) -> dict[str, Any]:
+    """Validate the embedded provider-v2 capability descriptor."""
+
+    normalized = _finite_json_mapping(manifest, name="provider manifest")
+    declared_id = _require_sha256(
+        normalized.get("manifest_id", ""),
+        name="provider manifest_id",
+    )
+    _require(
+        compute_provider_manifest_id(normalized) == declared_id,
+        "provider manifest ID does not match its descriptor",
+    )
+    revision = _require_revision(
+        normalized.get("provider_revision", ""),
+        name="provider manifest revision",
+    )
+    _require(
+        revision == _require_revision(expected_revision, name="expected provider revision"),
+        "provider manifest revision differs from the observation source revision",
+    )
+    _require(
+        normalized.get("provider_name") == PROVIDER_NAME,
+        "provider manifest has changed provider name",
+    )
+    _require(
+        normalized.get("provider_api_version") == PROVIDER_API_VERSION,
+        "provider manifest is not API version 2",
+    )
+
+    capabilities = normalized.get("capabilities")
+    _require(
+        isinstance(capabilities, list)
+        and all(isinstance(item, str) and item for item in capabilities)
+        and len(capabilities) == len(set(capabilities)),
+        "provider manifest capabilities must be unique nonempty strings",
+    )
+    _require(
+        _REQUIRED_CAPABILITIES.issubset(capabilities),
+        "provider manifest lacks required claim-bearing capabilities",
+    )
+
+    schemas = normalized.get("artifact_schema_versions")
+    _require(isinstance(schemas, Mapping), "provider artifact schemas must be a mapping")
+    _require(
+        schemas.get("ObservationBeliefV1") == 1
+        and schemas.get("Prob4DCausalObservationStream") == 2,
+        "provider manifest declares unsupported observation schemas",
+    )
+
+    limitations = normalized.get("limitations")
+    _require(isinstance(limitations, Mapping), "provider limitations must be a mapping")
+    _require(
+        limitations.get("uncalibrated_export_is_default") is False,
+        "provider-v2 manifest must not default to uncalibrated export",
+    )
+    _require(
+        limitations.get(
+            "deployment_environment_revision_is_independent_vcs_evidence"
+        )
+        is False,
+        "provider manifest misstates deployment revision evidence",
+    )
+
+    metadata = normalized.get("metadata")
+    _require(isinstance(metadata, Mapping), "provider metadata must be a mapping")
+    _require(
+        metadata.get("source_repository") == PROVIDER_SOURCE_REPOSITORY,
+        "provider manifest source repository changed",
+    )
+    _require(
+        metadata.get("python_import_boundary") == PROVIDER_IMPORT_BOUNDARY,
+        "provider manifest import boundary changed",
+    )
+    return normalized
+
+
+def _validate_runtime_revision(
+    value: Any,
+    *,
+    provider_revision: str,
+    claim_bearing: bool,
+) -> dict[str, Any]:
+    runtime = _finite_json_mapping(value, name="runtime revision attestation")
+    _require_exact_fields(runtime, _RUNTIME_FIELDS, name="runtime revision attestation")
+    expected = _require_revision(
+        runtime.get("expected_revision", ""),
+        name="runtime expected revision",
+    )
+    _require(
+        expected == provider_revision,
+        "runtime expected revision differs from provider revision",
+    )
+    observed_value = runtime.get("observed_revision")
+    observed = (
+        None
+        if observed_value is None
+        else _require_revision(observed_value, name="runtime observed revision")
+    )
+    source = runtime.get("source")
+    _require(
+        source
+        in {
+            "installed_vcs_metadata",
+            "source_checkout",
+            "deployment_environment",
+            "unavailable",
+        },
+        "runtime revision source is unsupported",
+    )
+    clean = runtime.get("clean_checkout")
+    _require(
+        clean is None or isinstance(clean, bool),
+        "runtime clean_checkout must be Boolean or null",
+    )
+    matched = runtime.get("matched")
+    independent = runtime.get("independently_verified")
+    _require(isinstance(matched, bool), "runtime matched must be Boolean")
+    _require(
+        isinstance(independent, bool),
+        "runtime independently_verified must be Boolean",
+    )
+    _require(
+        matched is (observed == expected),
+        "runtime matched flag disagrees with its revisions",
+    )
+    expected_independent = bool(
+        matched
+        and source in {"installed_vcs_metadata", "source_checkout"}
+        and clean is not False
+    )
+    _require(
+        independent is expected_independent,
+        "runtime independent-verification flag disagrees with its evidence",
+    )
+    if source == "source_checkout":
+        _require(
+            isinstance(clean, bool),
+            "source-checkout runtime evidence must declare checkout cleanliness",
+        )
+    else:
+        _require(
+            clean is None,
+            "non-checkout runtime evidence cannot declare checkout cleanliness",
+        )
+    if claim_bearing:
+        _require(
+            matched and independent,
+            "claim-bearing provider attestation requires independently matched runtime code",
+        )
+    return runtime
+
+
+def _validate_calibration_ids(
+    value: Any,
+    *,
+    claim_bearing: bool,
+) -> dict[str, Any]:
+    calibration = _finite_json_mapping(value, name="calibration artifact IDs")
+    _require_exact_fields(calibration, _CALIBRATION_FIELDS, name="calibration artifact IDs")
+    for field in sorted(_CALIBRATION_FIELDS):
+        artifact_id = calibration.get(field)
+        if artifact_id is not None:
+            calibration[field] = _require_sha256(
+                artifact_id,
+                name=f"calibration {field}",
+            )
+    if claim_bearing:
+        _require(
+            all(calibration[field] is not None for field in _CALIBRATION_FIELDS),
+            "claim-bearing provider attestation requires both calibration artifact IDs",
+        )
+    return calibration
+
+
+def validate_provider_attestation(
+    attestation: Mapping[str, Any],
+    *,
+    source_revision: str,
+    require_claim_bearing: bool = False,
+) -> dict[str, Any]:
+    """Validate and normalize a self-contained provider-v2 attestation."""
+
+    normalized = _finite_json_mapping(attestation, name="provider attestation")
+    _require_exact_fields(normalized, _ATTESTATION_FIELDS, name="provider attestation")
+    _require(
+        normalized.get("schema_name") == PROVIDER_ATTESTATION_SCHEMA,
+        "unsupported provider-attestation schema",
+    )
+    _require(
+        normalized.get("schema_version") == PROVIDER_ATTESTATION_VERSION,
+        "unsupported provider-attestation version",
+    )
+    _require(
+        normalized.get("provider_api_version") == PROVIDER_API_VERSION,
+        "provider attestation is not API version 2",
+    )
+
+    revision = _require_revision(
+        normalized.get("provider_revision", ""),
+        name="provider attestation revision",
+    )
+    _require(
+        revision == _require_revision(source_revision, name="observation source revision"),
+        "provider attestation revision differs from the observation source revision",
+    )
+    _require(
+        normalized.get("python_import_boundary") == PROVIDER_IMPORT_BOUNDARY,
+        "provider attestation import boundary changed",
+    )
+
+    manifest = validate_provider_manifest(
+        normalized.get("provider_manifest"),
+        expected_revision=revision,
+    )
+    declared_manifest_id = _require_sha256(
+        normalized.get("provider_manifest_id", ""),
+        name="provider attestation manifest ID",
+    )
+    _require(
+        declared_manifest_id == manifest["manifest_id"],
+        "provider attestation manifest ID differs from the embedded manifest",
+    )
+
+    export_mode = normalized.get("export_mode")
+    _require(
+        export_mode in {"calibrated", "exploratory"},
+        "provider attestation export mode is unsupported",
+    )
+    claim_bearing = normalized.get("claim_bearing")
+    _require(isinstance(claim_bearing, bool), "claim_bearing must be Boolean")
+    _require(
+        claim_bearing is (export_mode == "calibrated"),
+        "provider claim-bearing flag disagrees with export mode",
+    )
+    compatibility = normalized.get("calibration_compatibility_validated")
+    _require(
+        isinstance(compatibility, bool),
+        "calibration compatibility flag must be Boolean",
+    )
+    _require(
+        compatibility is claim_bearing,
+        "calibration compatibility flag disagrees with export mode",
+    )
+    if require_claim_bearing:
+        _require(claim_bearing, "a claim-bearing provider-v2 artifact is required")
+    calibration = _validate_calibration_ids(
+        normalized.get("calibration_artifact_ids"),
+        claim_bearing=claim_bearing,
+    )
+    covariance_mode = normalized.get("covariance_root_mode")
+    _require(
+        covariance_mode in {"canonical_eigenspaces", "legacy_eigenvectors"},
+        "provider covariance-root mode is unsupported",
+    )
+    composition_mode = normalized.get("composition_jacobian_mode")
+    _require(
+        composition_mode in {"analytic", "legacy_finite_difference"},
+        "provider composition-Jacobian mode is unsupported",
+    )
+    if claim_bearing:
+        _require(
+            covariance_mode == "canonical_eigenspaces",
+            "claim-bearing provider-v2 artifact requires canonical covariance roots",
+        )
+        _require(
+            composition_mode == "analytic",
+            "claim-bearing provider-v2 artifact requires analytic composition Jacobians",
+        )
+
+    runtime = _validate_runtime_revision(
+        normalized.get("runtime_revision"),
+        provider_revision=revision,
+        claim_bearing=claim_bearing,
+    )
+    normalized["provider_manifest"] = manifest
+    normalized["calibration_artifact_ids"] = calibration
+    normalized["runtime_revision"] = runtime
+    return normalized
+
+
+def build_provider_attestation(
+    *,
+    provider_manifest: Mapping[str, Any],
+    provider_revision: str,
+    export_mode: str,
+    calibration_compatibility_validated: bool,
+    calibration_artifact_ids: Mapping[str, Any],
+    covariance_root_mode: str,
+    composition_jacobian_mode: str,
+    runtime_revision: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Construct an attestation and validate the producer's own output."""
+
+    manifest = validate_provider_manifest(
+        provider_manifest,
+        expected_revision=provider_revision,
+    )
+    payload: dict[str, Any] = {
+        "schema_name": PROVIDER_ATTESTATION_SCHEMA,
+        "schema_version": PROVIDER_ATTESTATION_VERSION,
+        "provider_api_version": PROVIDER_API_VERSION,
+        "provider_manifest_id": manifest["manifest_id"],
+        "provider_manifest": manifest,
+        "provider_revision": provider_revision,
+        "python_import_boundary": PROVIDER_IMPORT_BOUNDARY,
+        "export_mode": export_mode,
+        "claim_bearing": export_mode == "calibrated",
+        "calibration_compatibility_validated": bool(
+            calibration_compatibility_validated
+        ),
+        "calibration_artifact_ids": dict(calibration_artifact_ids),
+        "covariance_root_mode": covariance_root_mode,
+        "composition_jacobian_mode": composition_jacobian_mode,
+        "runtime_revision": dict(runtime_revision),
+    }
+    return validate_provider_attestation(
+        payload,
+        source_revision=provider_revision,
+        require_claim_bearing=export_mode == "calibrated",
+    )
+
+
+__all__ = [
+    "PROVIDER_API_VERSION",
+    "PROVIDER_ATTESTATION_SCHEMA",
+    "PROVIDER_ATTESTATION_VERSION",
+    "PROVIDER_IMPORT_BOUNDARY",
+    "PROVIDER_NAME",
+    "PROVIDER_SOURCE_REPOSITORY",
+    "build_provider_attestation",
+    "compute_provider_manifest_id",
+    "validate_provider_attestation",
+    "validate_provider_manifest",
+]

--- a/src/prob4d/provider_v2.py
+++ b/src/prob4d/provider_v2.py
@@ -27,6 +27,14 @@ from .composition_jacobian import (
     composition_jacobian_mode,
 )
 from .covariance_root import CovarianceRootMode, covariance_root_mode
+from .provider_attestation import (
+    PROVIDER_ATTESTATION_SCHEMA,
+    PROVIDER_ATTESTATION_VERSION,
+    build_provider_attestation,
+    compute_provider_manifest_id,
+    validate_provider_attestation,
+    validate_provider_manifest,
+)
 from .provider_v1 import (
     GAUGE_COVARIANCE_CALIBRATION_SCHEMA,
     GAUGE_COVARIANCE_CALIBRATION_VERSION,
@@ -129,10 +137,10 @@ def prob4d_provider_manifest(
                 "eigenspace covariance roots, and forbids pointwise covariance fallback"
             ),
             "provider_attestation_semantics": (
-                "every provider-v2 export embeds the version-2 manifest identity, "
-                "export mode, covariance-root and composition-Jacobian modes, and "
-                "runtime-revision evidence; claim-bearing export fails closed on "
-                "unavailable, mismatched, dirty, or non-independent runtime provenance"
+                "every provider-v2 export embeds the complete content-addressed "
+                "provider manifest, export mode, covariance-root and composition-"
+                "Jacobian modes, and runtime-revision evidence; downstream consumers "
+                "can validate the attestation without importing Prob4D"
             ),
         }
     )
@@ -173,21 +181,16 @@ def _provider_attested_artifact(
             "gauge_artifact_id": calibration.get("gauge_artifact_id"),
             "point_artifact_id": calibration.get("point_artifact_id"),
         }
-    metadata["prob4d_provider_attestation"] = {
-        "provider_api_version": PROVIDER_API_VERSION,
-        "provider_manifest_id": manifest["manifest_id"],
-        "provider_revision": artifact.source_revision,
-        "python_import_boundary": "prob4d.provider_v2",
-        "export_mode": export_mode,
-        "claim_bearing": export_mode == "calibrated",
-        "calibration_compatibility_validated": bool(
-            calibration_compatibility_validated
-        ),
-        "calibration_artifact_ids": calibration_ids,
-        "covariance_root_mode": covariance_root_mode_name,
-        "composition_jacobian_mode": composition_jacobian_mode_name,
-        "runtime_revision": runtime_attestation.as_metadata(),
-    }
+    metadata["prob4d_provider_attestation"] = build_provider_attestation(
+        provider_manifest=manifest,
+        provider_revision=artifact.source_revision,
+        export_mode=export_mode,
+        calibration_compatibility_validated=calibration_compatibility_validated,
+        calibration_artifact_ids=calibration_ids,
+        covariance_root_mode=covariance_root_mode_name,
+        composition_jacobian_mode=composition_jacobian_mode_name,
+        runtime_revision=runtime_attestation.as_metadata(),
+    )
     return replace(artifact, metadata=metadata)
 
 
@@ -335,6 +338,8 @@ __all__ = [
     "PROB4D_CAUSAL_STREAM_CONTRACT_VERSION",
     "PROB4D_PROVIDER_API_VERSION",
     "PROVIDER_API_VERSION",
+    "PROVIDER_ATTESTATION_SCHEMA",
+    "PROVIDER_ATTESTATION_VERSION",
     "CalibrationCompatibilityError",
     "CausalOverlapSelection",
     "CompositionJacobianMode",
@@ -351,6 +356,8 @@ __all__ = [
     "assert_calibration_pair_compatible",
     "assert_runtime_revision",
     "bind_causal_stream_contract_v2",
+    "build_provider_attestation",
+    "compute_provider_manifest_id",
     "export_calibrated_observation_belief",
     "export_exploratory_observation_belief",
     "inspect_runtime_revision",
@@ -367,5 +374,7 @@ __all__ = [
     "save_observation_belief_export",
     "save_point_uncertainty_calibration",
     "select_causal_source",
+    "validate_provider_attestation",
+    "validate_provider_manifest",
     "write_observation_factor_bundle",
 ]

--- a/tests/test_provider_attestation.py
+++ b/tests/test_provider_attestation.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import copy
+
+import pytest
+
+import prob4d.provider_v2 as provider
+from prob4d.provider_attestation import (
+    PROVIDER_ATTESTATION_SCHEMA,
+    PROVIDER_ATTESTATION_VERSION,
+    build_provider_attestation,
+    compute_provider_manifest_id,
+    validate_provider_attestation,
+)
+
+
+def _runtime(*, source: str = "source_checkout") -> dict[str, object]:
+    if source == "source_checkout":
+        return {
+            "expected_revision": "a" * 40,
+            "observed_revision": "a" * 40,
+            "source": source,
+            "clean_checkout": True,
+            "matched": True,
+            "independently_verified": True,
+        }
+    if source == "deployment_environment":
+        return {
+            "expected_revision": "a" * 40,
+            "observed_revision": "a" * 40,
+            "source": source,
+            "clean_checkout": None,
+            "matched": True,
+            "independently_verified": False,
+        }
+    return {
+        "expected_revision": "a" * 40,
+        "observed_revision": None,
+        "source": "unavailable",
+        "clean_checkout": None,
+        "matched": False,
+        "independently_verified": False,
+    }
+
+
+def _calibrated_attestation() -> dict[str, object]:
+    return build_provider_attestation(
+        provider_manifest=provider.prob4d_provider_manifest(
+            provider_revision="a" * 40
+        ),
+        provider_revision="a" * 40,
+        export_mode="calibrated",
+        calibration_compatibility_validated=True,
+        calibration_artifact_ids={
+            "gauge_artifact_id": "1" * 64,
+            "point_artifact_id": "2" * 64,
+        },
+        covariance_root_mode="canonical_eigenspaces",
+        composition_jacobian_mode="analytic",
+        runtime_revision=_runtime(),
+    )
+
+
+def test_provider_attestation_embeds_a_verifiable_complete_manifest() -> None:
+    attestation = _calibrated_attestation()
+    validated = validate_provider_attestation(
+        attestation,
+        source_revision="a" * 40,
+        require_claim_bearing=True,
+    )
+
+    assert validated["schema_name"] == PROVIDER_ATTESTATION_SCHEMA
+    assert validated["schema_version"] == PROVIDER_ATTESTATION_VERSION
+    assert validated["provider_manifest_id"] == validated["provider_manifest"][
+        "manifest_id"
+    ]
+    assert compute_provider_manifest_id(validated["provider_manifest"]) == validated[
+        "provider_manifest_id"
+    ]
+    assert validated["runtime_revision"]["independently_verified"] is True
+
+
+def test_manifest_payload_tampering_is_rejected() -> None:
+    attestation = _calibrated_attestation()
+    tampered = copy.deepcopy(attestation)
+    tampered["provider_manifest"]["provider_version"] = "999.0"
+
+    with pytest.raises(ValueError, match="manifest ID does not match"):
+        validate_provider_attestation(tampered, source_revision="a" * 40)
+
+
+def test_rehashed_manifest_without_required_capability_is_rejected() -> None:
+    attestation = _calibrated_attestation()
+    tampered = copy.deepcopy(attestation)
+    manifest = tampered["provider_manifest"]
+    manifest["capabilities"].remove("runtime_revision_attestation")
+    manifest["manifest_id"] = compute_provider_manifest_id(manifest)
+    tampered["provider_manifest_id"] = manifest["manifest_id"]
+
+    with pytest.raises(ValueError, match="required claim-bearing capabilities"):
+        validate_provider_attestation(tampered, source_revision="a" * 40)
+
+
+def test_attestation_is_bound_to_observation_source_revision() -> None:
+    with pytest.raises(ValueError, match="observation source revision"):
+        validate_provider_attestation(
+            _calibrated_attestation(),
+            source_revision="b" * 40,
+        )
+
+
+def test_claim_bearing_attestation_rejects_environment_only_revision() -> None:
+    with pytest.raises(ValueError, match="independently matched runtime code"):
+        build_provider_attestation(
+            provider_manifest=provider.prob4d_provider_manifest(
+                provider_revision="a" * 40
+            ),
+            provider_revision="a" * 40,
+            export_mode="calibrated",
+            calibration_compatibility_validated=True,
+            calibration_artifact_ids={
+                "gauge_artifact_id": "1" * 64,
+                "point_artifact_id": "2" * 64,
+            },
+            covariance_root_mode="canonical_eigenspaces",
+            composition_jacobian_mode="analytic",
+            runtime_revision=_runtime(source="deployment_environment"),
+        )
+
+
+def test_exploratory_attestation_can_record_unavailable_runtime_and_no_calibration() -> None:
+    attestation = build_provider_attestation(
+        provider_manifest=provider.prob4d_provider_manifest(
+            provider_revision="a" * 40
+        ),
+        provider_revision="a" * 40,
+        export_mode="exploratory",
+        calibration_compatibility_validated=False,
+        calibration_artifact_ids={
+            "gauge_artifact_id": None,
+            "point_artifact_id": None,
+        },
+        covariance_root_mode="legacy_eigenvectors",
+        composition_jacobian_mode="legacy_finite_difference",
+        runtime_revision=_runtime(source="unavailable"),
+    )
+
+    validated = validate_provider_attestation(
+        attestation,
+        source_revision="a" * 40,
+    )
+    assert validated["claim_bearing"] is False
+    assert validated["runtime_revision"]["matched"] is False
+
+
+def test_attestation_schema_rejects_undeclared_fields() -> None:
+    attestation = _calibrated_attestation()
+    attestation["unexpected"] = True
+
+    with pytest.raises(ValueError, match="fields changed"):
+        validate_provider_attestation(attestation, source_revision="a" * 40)

--- a/tests/test_provider_v2.py
+++ b/tests/test_provider_v2.py
@@ -11,6 +11,9 @@ from prob4d.covariance_root import current_covariance_root_mode
 from prob4d.observation_contract import ObservationBeliefExportV1
 from prob4d.runtime_revision import RuntimeRevisionAttestation
 
+GAUGE_CALIBRATION_ID = "1" * 64
+POINT_CALIBRATION_ID = "2" * 64
+
 
 def _observation() -> ObservationBeliefExportV1:
     return ObservationBeliefExportV1(
@@ -41,8 +44,8 @@ def _observation() -> ObservationBeliefExportV1:
         metadata={
             "existing": True,
             "covariance_calibration": {
-                "gauge_artifact_id": "gauge-id",
-                "point_artifact_id": "point-id",
+                "gauge_artifact_id": GAUGE_CALIBRATION_ID,
+                "point_artifact_id": POINT_CALIBRATION_ID,
             },
         },
     )
@@ -126,11 +129,20 @@ def test_exploratory_export_is_explicit_context_local_and_attested(
     assert captured["allow_pointwise_covariance_fallback"] is True
     assert captured["sampling_mode"] == "information_stratified"
     attestation = result.metadata["prob4d_provider_attestation"]
+    assert attestation["schema_name"] == provider.PROVIDER_ATTESTATION_SCHEMA
+    assert attestation["schema_version"] == provider.PROVIDER_ATTESTATION_VERSION
     assert attestation["export_mode"] == "exploratory"
     assert attestation["claim_bearing"] is False
     assert attestation["calibration_compatibility_validated"] is False
     assert attestation["composition_jacobian_mode"] == "analytic"
+    assert attestation["provider_manifest_id"] == attestation["provider_manifest"][
+        "manifest_id"
+    ]
     assert attestation["runtime_revision"]["independently_verified"] is False
+    provider.validate_provider_attestation(
+        attestation,
+        source_revision=result.source_revision,
+    )
 
 
 def test_exploratory_export_can_reproduce_legacy_root_basis(monkeypatch) -> None:
@@ -239,10 +251,18 @@ def test_calibrated_export_validates_runtime_and_calibration_before_delegating(
     assert attestation["calibration_compatibility_validated"] is True
     assert attestation["composition_jacobian_mode"] == "analytic"
     assert attestation["calibration_artifact_ids"] == {
-        "gauge_artifact_id": "gauge-id",
-        "point_artifact_id": "point-id",
+        "gauge_artifact_id": GAUGE_CALIBRATION_ID,
+        "point_artifact_id": POINT_CALIBRATION_ID,
     }
+    assert attestation["provider_manifest_id"] == attestation["provider_manifest"][
+        "manifest_id"
+    ]
     assert attestation["runtime_revision"]["matched"] is True
+    provider.validate_provider_attestation(
+        attestation,
+        source_revision=result.source_revision,
+        require_claim_bearing=True,
+    )
 
 
 def test_calibrated_export_stops_before_manifest_on_runtime_failure(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- define versioned `prob4d.provider-attestation` schema v1;
- embed the complete content-addressed provider-v2 manifest in every provider-v2 observation artifact rather than storing only its ID;
- validate manifest hashing, provider identity, source revision, API version, neutral observation schemas, limitations, and required claim-bearing capabilities;
- validate export-mode consistency, calibration artifact IDs, covariance-root mode, composition-Jacobian mode, and runtime-revision evidence;
- require canonical roots, analytic sequential derivatives, both calibration IDs, and independently matched runtime code for a claim-bearing attestation;
- keep exploratory artifacts able to record missing or environment-only runtime evidence without mislabelling it as claim-bearing;
- expose producer-side build/validate helpers and document the neutral downstream validation contract.

## Why

The existing provider-v2 artifact binds a `provider_manifest_id`, but a downstream repository that intentionally does not import Prob4D cannot recompute that ID or inspect the exact capability descriptor. Embedding the complete manifest makes the producer statement immutable and self-contained under the observation artifact content address.

This is not a claim that a self-signed producer statement creates external trust. It ensures that Bayesian-PhysTwin and Causal4D can independently check the exact statement, reject internal contradictions, and require the known claim-bearing semantics without importing the producer package.

## Validation

Tests cover:

- complete manifest round-trip and ID recomputation;
- payload tampering without rehashing;
- rehashed removal of a required capability;
- source-revision mismatch;
- environment-only runtime evidence in a claim-bearing artifact;
- exploratory missing runtime/calibration evidence; and
- undeclared attestation fields.

The branch also updates provider-v2 export tests, mypy coverage, stable-import checks, documentation, and the changelog.

## Stack

This PR is based on `agent/analytic-sim3-composition-jacobians` / PR #32 because claim-bearing schema v1 requires and records the analytic composition-Jacobian capability. Retarget it to `main` after #32 merges.
