### PR TITLE
Preserve joint gauge covariance in unfused factors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to Prob4D are documented here.
 
 ### Added
 
+- `JointObservationFactorBundle` schema v4 for provider-v2 explicit-gauge
+  consumers. It serializes one ordered full cross-window `Sim(3)` covariance,
+  validates every marginal block against its `GaugeEstimate`, and preserves the
+  complete nuisance prior when factors are stacked.
+- Provider-v2 capability and schema declarations for joint observation-factor
+  gauge covariance while provider v1 continues to advertise frozen schema v3.
 - `prob4d.provider_v2` as a safe-by-default Python surface with distinct
   exploratory and claim-bearing export functions.
 - Strict prediction/calibration compatibility checks covering MotionCrafter
@@ -32,6 +38,10 @@ All notable changes to Prob4D are documented here.
 
 ### Changed
 
+- Observation-factor serialization now loads schema versions 2, 3, and 4 without
+  inventing cross-window covariance for legacy artifacts. Schema v3 retains its
+  historical block-diagonal stacked gauge prior; only schema v4 declares and
+  preserves a joint gauge covariance.
 - Fixed-lag gauge smoothing now Schur-marginalizes expired gauges into an
   uncertainty-bearing boundary prior. Portable historical covariance remains an
   explicit block-diagonal reconstruction approximation.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,15 +23,18 @@ Prob4D experiment helpers or underscore-prefixed modules.
 
 `prob4d.provider_v1` is frozen for existing experiments and exact reproduction. It
 exposes the causal source selector, fixed metric-anchor contract, portable
-observation belief, strict artifact loader, factor-bundle contract, and the
-version-1 provider manifest.
+observation belief, strict artifact loader, schema-v3 factor-bundle compatibility
+contract, and the version-1 provider manifest.
 
 New claim-bearing development should import `prob4d.provider_v2`. Version 2 keeps
-the same artifact and causal-stream schemas, but separates exploratory and
-calibrated exports. Its calibrated entry point validates the prediction manifest
-against both covariance calibrations before opening decoded payloads, requires an
-exact Prob4D source revision, fixes sequential gauge propagation, and forbids the
-pointwise covariance fallback. See [Provider API version 2](provider-v2.md).
+the same observation-belief and causal-stream schemas, but separates exploratory
+and calibrated exports. Its calibrated entry point validates the prediction
+manifest against both covariance calibrations before opening decoded payloads,
+requires an exact Prob4D source revision, fixes sequential gauge propagation, and
+forbids the pointwise covariance fallback. Provider v2 also advertises
+`JointObservationFactorBundle` schema v4 for explicit-gauge consumers that need
+the full ordered cross-window gauge covariance. See
+[Provider API version 2](provider-v2.md).
 
 A breaking change requires another versioned provider module rather than silently
 changing version 1 or 2. Frozen experiments must still record exact repository
@@ -66,14 +69,22 @@ preserves the resulting cross-window covariance. Rank reduction is trace-audited
 and fails closed below the declared retained-covariance threshold.
 
 `local_covariance_m2` is conditional point covariance and must not include the
-gauge contribution again. `ObservationFactorBundle` remains the richer interface
-when a downstream estimator keeps explicit gauge nuisance variables.
+gauge contribution again. A downstream estimator that keeps the shared low-rank
+factor as an explicit nuisance must not also add its marginal covariance.
 
-Fixed-lag smoothing carries a Schur-complement information prior when gauges
-leave the active window, so the moving boundary does not become exact. The
-portable all-window covariance still exports only historical marginal blocks and
-therefore remains an opt-in reconstruction control. The provider makes no
-prospective calibration or physical-twin-improvement claim.
+For unfused explicit-gauge inference, provider-v1
+`ObservationFactorBundle` schema v3 remains a frozen compatibility artifact. Its
+stacked gauge prior is block diagonal because the artifact contains only
+per-window marginals. Provider-v2 `JointObservationFactorBundle` schema v4 carries
+one ordered full gauge covariance; each diagonal block is validated against the
+corresponding `GaugeEstimate`, and stacking preserves all cross-window blocks.
+Consumers must use conditional point covariance with that explicit joint prior.
+
+Fixed-lag smoothing carries a Schur-complement information prior when gauges leave
+the active window, so the moving boundary does not become exact. The portable
+all-window covariance still exports only historical marginal blocks and therefore
+remains an opt-in reconstruction control. The provider makes no prospective
+calibration or physical-twin-improvement claim.
 
 ## Immutable validated inputs
 
@@ -82,10 +93,14 @@ validation. Caller-side mutations therefore cannot alter a window after it has
 entered a content-addressed workflow. Methods that intentionally provide mutable
 values, such as `rays()`, return copies.
 
+Observation-factor schema v4 similarly copies and freezes the complete joint gauge
+covariance after checking dimension, finiteness, symmetry, positive
+semidefiniteness, gauge ordering, and marginal-block consistency.
+
 ## Artifact ownership
 
-Prob4D owns MotionCrafter prediction manifests, decoded-window payloads, gauge
-and uncertainty calibration artifacts, portable observation beliefs,
+Prob4D owns MotionCrafter prediction manifests, decoded-window payloads, gauge and
+uncertainty calibration artifacts, portable observation beliefs,
 observation-factor bundles, provider manifests, benchmarks, and run manifests.
 Bayesian-PhysTwin owns physical priors, guarded updates, fallback behavior, and
 accepted twin beliefs. Causal4D owns realized-intervention inference downstream

--- a/docs/observation-factor-bundle.md
+++ b/docs/observation-factor-bundle.md
@@ -1,54 +1,76 @@
-# Unfused observation-factor bundle
+# Unfused observation-factor bundles
 
-Prob4D normally produces fused trajectories for reconstruction benchmarks. A
-Bayesian physical-twin update needs a second interface: individual window and
-view factors must remain separate so that uncertain `Sim(3)` gauges, shared
-backbone dependence, reliability, and causal timing are not erased before
-inference.
+Prob4D normally fuses overlapping windows into one reconstruction. A Bayesian
+physical-twin update also needs an unfused interface: individual window and view
+factors must remain separate so uncertain `Sim(3)` gauges, shared-backbone
+dependence, reliability, and causal timing are not erased before inference.
 
-`prob4d.observation_factors` implements this interface as schema version 3. The
-bundle contains:
+`prob4d.observation_factors` exposes two deliberately distinct contracts:
 
-- local 3-D points, full local covariance, material/association IDs, and optional
-  viewing rays for every factor;
+- `ObservationFactorBundle` is the frozen schema-v3 compatibility surface. It
+  stores one marginal covariance per gauge and stacks those marginals into a
+  block-diagonal prior.
+- `JointObservationFactorBundle` is schema v4 for new explicit-gauge work. It
+  additionally stores one ordered full covariance over all gauge parameters,
+  including cross-window blocks.
+
+Provider v1 continues to advertise schema v3 for exact reproduction. Provider v2
+advertises schema v4 and the
+`joint_observation_factor_gauge_covariance` capability. The loader accepts schema
+versions 2, 3, and 4 without reinterpreting an older artifact as having covariance
+that it never carried.
+
+## Contents
+
+Both bundle types contain:
+
+- local 3-D points, full local covariance, material or association IDs, and
+  optional viewing rays for every factor;
 - one `GaugeEstimate` for every local window gauge;
 - separate association probability and residual-independent prior reliability;
 - correlation-group nominal probabilities and composite-likelihood weights;
 - case, stream, sequence, repository, revision, view, window, frame, and
   correlation-group provenance;
-- one explicit **exclusive** causal frame stop;
-- a checksum-bound JSON manifest and non-pickled NPZ payload.
+- one explicit **exclusive** causal frame stop; and
+- a checksum-bound JSON manifest with a non-pickled NPZ payload.
 
-## Identity and provenance
+Schema v4 additionally contains `joint_gauge_covariance` in the exact order of
+`gauges`. Its manifest binds that order and the semantics identifier
+`ordered-full-cross-window-covariance-v1`.
 
-`case_id` names the physical case consumed downstream, while `stream_id`
-identifies the observation stream within that case. `sequence_id` remains the
-producer-side bundle identity and may be more specific, for example by naming a
-camera or extraction pass. `source_repository` and `source_revision` identify
-the exact producer implementation. They are serialized as first-class manifest
-fields so Bayesian-PhysTwin can carry the exact input into its posterior lineage
-and Causal4D can validate it without importing Prob4D.
+## Joint gauge covariance
 
-For compatibility, omitted `case_id` and `stream_id` default to `sequence_id`.
-New production exporters should supply all three explicitly.
+For ordered gauge perturbations
 
-## Reliability boundary
+```text
+delta_g = [delta_g_0, ..., delta_g_(K-1)],
+```
 
-The contract deliberately keeps four quantities separate:
+schema v4 carries
 
-- `association_probability` describes support for the named entity or material
-  point;
-- `prior_reliability` is source-side evidence that a row is nominal and must not
-  depend on a downstream physical innovation;
-- `prior_nominal_probability` is the fixed nominal-component prior for a
-  correlation group;
-- `composite_weight` limits that group's contribution when rows, windows, or
-  pixels are dependent.
+```text
+P_g = Cov(delta_g) in R^(7K x 7K).
+```
 
-Factors sharing one `correlation_group_id` must use the same nominal probability
-and composite weight. Stacking repeats those group values row-for-row without
-multiplying them into association probability. A zero-reliability row is not
-selected merely because its association probability is high.
+Every diagonal `7 x 7` block of `P_g` must equal the covariance in the
+corresponding `GaugeEstimate`. Construction and loading fail when the matrix is
+non-finite, asymmetric, non-positive-semidefinite, has the wrong dimension, uses
+a different gauge order, or disagrees with a marginal block.
+
+The redundancy is intentional. A factor can still be linearized against its local
+`GaugeEstimate`, while stacking returns the complete nuisance prior without
+silently replacing shared anchor and upstream-window uncertainty by independent
+marginals.
+
+For stacked conditional covariance `R` and gauge Jacobian `J`, a consumer that
+marginalizes gauges obtains
+
+```text
+Cov(y) = R + J P_g J^T.
+```
+
+The off-diagonal blocks of this observation covariance are generally nonzero.
+They are lost by the schema-v3 block-diagonal approximation.
 
 ## Conditional and marginal covariance
 
@@ -59,58 +81,58 @@ y = Sim3(g) p
 J_g = dy / dg.
 ```
 
-The stack deliberately exposes two covariance products:
+The stack exposes two row-level covariance products:
 
-- `conditional_world_covariance_m2` transforms only the local point covariance;
-- `marginal_world_covariance_m2` additionally contains
-  `J_g Sigma_g J_g^T`.
+- `conditional_world_covariance_m2` transforms only local point covariance;
+- `marginal_world_covariance_m2` additionally contains the row's marginal
+  `J_g Sigma_g J_g^T` contribution.
 
 A downstream estimator that keeps gauge errors as explicit nuisance variables
 must use the **conditional** covariance together with `gauge_jacobian` and
-`gauge_prior_covariance`. Using the marginal covariance as well would count
-uncertain gauge variation twice. The marginal covariance remains useful for a
-consumer that does not estimate gauges explicitly.
+`gauge_prior_covariance`. Adding the marginal covariance again would double-count
+gauge uncertainty. A consumer that eliminates the gauges should use the complete
+stacked expression above rather than treating row marginals as independent.
 
-## Example
+## Reliability boundary
+
+The contract keeps four quantities separate:
+
+- `association_probability` describes support for the named entity or material
+  point;
+- `prior_reliability` is source-side evidence that a row is nominal and must not
+  depend on a downstream physical innovation;
+- `prior_nominal_probability` is the fixed nominal-component prior for a
+  correlation group; and
+- `composite_weight` limits that group's contribution when rows, windows, or
+  pixels are dependent.
+
+Factors sharing one `correlation_group_id` must use the same nominal probability
+and composite weight. Stacking repeats those values row-for-row without
+multiplying them into association probability. A zero-reliability row is not
+selected merely because its association probability is high.
+
+## Schema-v4 example
 
 ```python
-from prob4d.observation_factors import (
-    ObservationFactor,
-    ObservationFactorBundle,
+from prob4d.provider_v2 import (
+    JointObservationFactorBundle,
     write_observation_factor_bundle,
 )
 
-factor = ObservationFactor(
-    factor_id="camera0-window3-frame132",
-    frame_index=132,
-    view_id="camera0",
-    window_id="window3",
-    gauge_id="window3",
-    point_ids=point_ids,
-    points_local_m=points_local_m,
-    valid_mask=valid_mask,
-    local_covariance_m2=local_covariance_m2,
-    association_probability=association_probability,
-    prior_reliability=overlap_reliability,
-    prior_nominal_probability=0.9,
-    composite_weight=0.25,
-    correlation_group_id="shared-backbone-frame132",
-    causal_frame_stop=134,
-)
-
-bundle = ObservationFactorBundle(
+bundle = JointObservationFactorBundle(
     sequence_id="double_stretch_sloth-camera0-prefix",
     case_id="double_stretch_sloth",
     stream_id="prob4d:motioncrafter-points:camera0",
-    factors=(factor,),
-    gauges=(gauge_window3_camera0,),
+    factors=tuple(factors),
+    gauges=tuple(ordered_gauges),
+    joint_gauge_covariance=joint_gauge_covariance,
     source_repository="FlorianPfaff/Prob4D",
     source_revision=prob4d_commit,
     causal_frame_stop=134,
     metadata={
         "upstream_repository": "TencentARC/MotionCrafter",
         "upstream_revision": motioncrafter_commit,
-        "metric_anchor_used": False,
+        "metric_anchor_used": True,
     },
 )
 
@@ -121,12 +143,17 @@ manifest, payload = write_observation_factor_bundle(
 stacked = bundle.stack()
 ```
 
-`stacked.gauge_jacobian` has one seven-dimensional block per gauge. Rows from
-another gauge are exactly zero in that block. The stacked association,
-reliability, nominal-probability, and composite-weight arrays remain separate
-inputs for the consuming Bayesian estimator.
+`stacked.gauge_jacobian` has one seven-dimensional block per gauge.
+`stacked.gauge_prior_covariance` is the exact joint matrix supplied above. The
+association, reliability, nominal-probability, and composite-weight arrays remain
+separate inputs for the Bayesian estimator.
 
-## Information boundary
+## Identity and causal boundary
+
+`case_id` names the physical case consumed downstream, while `stream_id`
+identifies the observation stream within that case. `sequence_id` remains the
+producer-side bundle identity. `source_repository` and `source_revision` identify
+the exact producer implementation.
 
 Every factor must satisfy
 
@@ -134,19 +161,20 @@ Every factor must satisfy
 frame_index < causal_frame_stop
 ```
 
-and every factor in a bundle must use the same exclusive stop. This convention
-matches `ObservationBeliefV1` and avoids adapter-specific `+1` conversions.
-The contract does not authorize a predictor to read later RGB, point maps,
-target tracks, or outcome metrics. Reconstruction controls that use all frames
-must be written to a separately labelled bundle.
+and every factor in a bundle must use the same exclusive stop. The contract does
+not authorize a predictor to read later RGB, point maps, target tracks, or outcome
+metrics. Reconstruction controls that use all frames must be written to a
+separately labelled bundle.
 
-## Schema-v2 migration
+## Legacy migration
 
-The loader accepts legacy schema-v2 manifests, whose `causal_frame_limit` was
-inclusive. It converts them deterministically to
-`causal_frame_stop = causal_frame_limit + 1`. Because v2 had no distinct prior
-reliability or group weighting fields, those values are conservatively restored
-as one and the migration is recorded in bundle metadata. Missing case or stream
-identities are restored from the legacy `sequence_id`. New writes always use
-schema v3; the legacy inclusive aliases remain read-only compatibility
-properties.
+The loader accepts schema v2, whose `causal_frame_limit` was inclusive, and
+converts it deterministically to
+`causal_frame_stop = causal_frame_limit + 1`. Missing reliability and group
+weights are conservatively restored as one and the migration is recorded.
+
+Schema v3 remains a frozen compatibility representation. Loading it does **not**
+claim that cross-window gauge covariance was preserved; stacking reproduces its
+historical block-diagonal prior. New multi-window explicit-gauge experiments
+should construct schema v4 from the producer's joint gauge posterior rather than
+upgrading v3 marginals after the fact.

--- a/docs/provider-contract.md
+++ b/docs/provider-contract.md
@@ -3,8 +3,8 @@
 `prob4d provider manifest` exposes the narrow producer capabilities that a
 Bayesian estimator may rely on without importing Prob4D implementation modules.
 The manifest records the installed package version, an optional exact Git
-revision, supported artifact schema versions, positive capabilities, and
-explicit nonclaims.
+revision, supported artifact schema versions, positive capabilities, and explicit
+nonclaims.
 
 ```bash
 prob4d provider manifest \
@@ -14,26 +14,33 @@ prob4d provider manifest \
 
 ## Python import boundary
 
-Downstream development code should import `prob4d.provider_v1` instead of
-underscore-prefixed modules or experiment helpers. The Python call surface and
-the produced stream contract are versioned independently:
+Existing experiments import `prob4d.provider_v1`. That surface remains frozen for
+exact reproduction, including `ObservationFactorBundle` schema v3. New
+claim-bearing development imports `prob4d.provider_v2`, which adds explicit
+calibrated and exploratory observation exports, runtime/provider attestation, and
+`JointObservationFactorBundle` schema v4.
 
-- `provider_v1` identifies the stable Python signatures;
+The Python call surface and produced artifact contracts are versioned
+independently:
+
+- provider v1 identifies frozen signatures and schema-v3 factor compatibility;
+- provider v2 identifies safe-by-default claim-bearing development surfaces;
 - `prob4d_causal_stream_contract_version` identifies the provider-specific
-  interpretation of a strict observation artifact.
+  interpretation of a strict observation-belief artifact; and
+- each observation-factor manifest declares its own schema version.
 
 A breaking Python signature change requires a new provider module. A breaking
-gauge, factor-group, or lineage interpretation requires a new stream-contract
-version. Exact Git revisions and artifact hashes remain mandatory for frozen
+gauge, factor-group, or lineage interpretation requires a new artifact or stream
+schema. Exact Git revisions and artifact hashes remain mandatory for frozen
 experiments.
 
-## Artifact semantics
+## Observation-belief semantics
 
 The current strict causal stream contract is version 2. It declares that Prob4D
 can:
 
-- select independently decoded windows whose complete source interval precedes
-  an exclusive causal cutoff;
+- select independently decoded windows whose complete source interval precedes an
+  exclusive causal cutoff;
 - produce a content-addressed `ObservationBeliefV1` artifact and append-invariant
   causal-source digest;
 - keep local conditional point covariance separate from shared gauge factors;
@@ -43,42 +50,68 @@ can:
   covariance, with trace-audited rank reduction;
 - retain association probability separately from residual-independent prior
   reliability; and
-- bind metric coordinates to a content-addressed anchor that identifies the
-  exact first prediction payload, exact external calibration artifact, case, and
-  world frame.
+- bind metric coordinates to a content-addressed anchor that identifies the exact
+  first prediction payload, external calibration artifact, case, and world frame.
 
 A zero anchor covariance is declared as `fixed_external_calibration`. A nonzero
 anchor covariance is declared as `propagated_external_prior` and is included in
-the same joint latent factor as the relative-gauge uncertainty. The producer and
-both consumers reject an explicit v2 artifact when this treatment, calibration
-digest, or inclusion flag is absent or inconsistent.
+the same joint latent factor as relative-gauge uncertainty. Producer and consumers
+reject a version-2 artifact when this treatment, calibration digest, or inclusion
+flag is absent or inconsistent.
 
 The production default is a causal sequential spanning tree. It preserves the
-uncertainty of the selected causal constraints without pretending that redundant
-dense alignment edges are independent. Fixed-lag smoothing now carries a
-Schur-complement information prior across the moving boundary, but its portable
-all-window covariance contains only block-diagonal historical marginals. It
-therefore remains an explicit reconstruction control and is not labelled as
-strict stream contract v2.
+uncertainty of selected causal constraints without pretending that redundant dense
+alignment edges are independent. Fixed-lag smoothing carries a Schur-complement
+information prior across the moving boundary, but its portable all-window
+covariance contains only block-diagonal historical marginals. It therefore remains
+an explicit reconstruction control and is not labelled as strict stream contract
+version 2.
 
-Prob4D 0.2.0 artifacts that already contain canonical
-`joint_gauge_latent_####` factors but predate the explicit version field can be
-recognized by updated Bayesian-PhysTwin and Causal4D validators. Their validation
-report marks the version as inferred. Newly exported production artifacts carry
-the version, complete metric-anchor schema, calibration digest, and covariance
+## Unfused factor semantics
+
+`ObservationFactorBundle` schema v3 is the frozen provider-v1 representation. It
+contains per-window gauge marginals only, so stacking reproduces the historical
+block-diagonal gauge prior. It must not be relabelled as preserving cross-window
+covariance.
+
+Provider v2 additionally advertises `JointObservationFactorBundle` schema v4 and
+the `joint_observation_factor_gauge_covariance` capability. Schema v4 carries one
+ordered full `7K x 7K` gauge covariance under semantics
+`ordered-full-cross-window-covariance-v1`. The manifest binds gauge order and the
+payload checksum. Construction and loading validate:
+
+- exact matrix dimension and finite values;
+- symmetry and positive semidefiniteness;
+- exact gauge ordering; and
+- equality between each joint diagonal block and its `GaugeEstimate` marginal.
+
+A consumer that keeps gauges explicitly uses conditional point covariance,
+`gauge_jacobian`, and the full `gauge_prior_covariance`. A consumer that eliminates
+gauges uses `R + J P_g J^T`. It must not add row-marginal gauge covariance and an
+explicit gauge prior simultaneously.
+
+## Compatibility and validation
+
+Prob4D 0.2.0 observation-belief artifacts that contain canonical
+`joint_gauge_latent_####` factors but predate the explicit stream-version field can
+be recognized by updated Bayesian-PhysTwin and Causal4D validators. Their report
+marks the version as inferred. Newly exported production artifacts carry the
+version, complete metric-anchor schema, calibration digest, and covariance
 treatment explicitly.
 
-The manifest does **not** claim that exported covariance has passed prospective
-target calibration, that redundant dense-edge fusion is validated, or that a
-valid observation artifact by itself improves a Bayesian physical twin.
+The observation-factor loader accepts schema versions 2, 3, and 4. Schema v2 is
+upgraded from its inclusive frame limit and missing reliability fields. Schema v3
+remains schema v3 after loading. Only schema v4 claims to carry a joint gauge prior.
 
-Use `prob4d-validate-observation` to reject schema drift, array drift, malformed
-archives, and content-address mismatches. Strict causal export writes through a
-temporary archive, reloads and validates its content address, then atomically
-replaces the requested output. `PredictionWindow` inputs are copied and frozen
-after validation so caller-side mutation cannot alter a sealed source object.
-The richer `ObservationFactorBundle` schema v3 remains available when the
-consumer estimates gauge nuisance variables explicitly.
+The provider manifest does **not** claim that exported covariance has passed
+prospective target calibration, that redundant dense-edge fusion is validated, or
+that a valid observation artifact by itself improves a Bayesian physical twin.
+
+Use `prob4d-validate-observation` to reject observation-belief schema drift, array
+drift, malformed archives, and content-address mismatches. Observation-factor
+manifests independently bind their NPZ payload with SHA-256 and disallow pickle.
+`PredictionWindow` inputs are copied and frozen after validation so caller-side
+mutation cannot alter a sealed source object.
 
 The grouped `prob4d` command is the preferred discoverable interface. Existing
 `prob4d-*` commands remain available so historical run manifests and frozen

--- a/src/prob4d/__init__.py
+++ b/src/prob4d/__init__.py
@@ -36,6 +36,7 @@ from .observation_export import (
     save_metric_gauge_anchor,
 )
 from .observation_factors import (
+    JointObservationFactorBundle,
     LinearizedObservationFactor,
     ObservationFactor,
     ObservationFactorBundle,
@@ -63,6 +64,7 @@ __all__ = [
     "EvaluationModes",
     "GaugeCovarianceCalibrationV1",
     "JointGaugePosterior",
+    "JointObservationFactorBundle",
     "LinearizedObservationFactor",
     "MetricGaugeAnchor",
     "ObservationBeliefExportV1",

--- a/src/prob4d/_observation_factor_bundle.py
+++ b/src/prob4d/_observation_factor_bundle.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, ClassVar
 
 import numpy as np
 
@@ -21,9 +21,13 @@ from .sim3 import Sim3, skew, so3_right_jacobian
 
 OBSERVATION_FACTOR_SCHEMA = "prob4d.observation-factor-bundle"
 OBSERVATION_FACTOR_SCHEMA_VERSION = 3
+JOINT_OBSERVATION_FACTOR_SCHEMA_VERSION = 4
 LEGACY_OBSERVATION_FACTOR_SCHEMA_VERSION = 2
 OBSERVATION_FACTOR_SOURCE_REPOSITORY = "FlorianPfaff/Prob4D"
 GAUGE_PARAMETERIZATION = "log-scale-rotvec-translation-v1"
+JOINT_GAUGE_COVARIANCE_SEMANTICS = (
+    "ordered-full-cross-window-covariance-v1"
+)
 
 
 def _json_metadata(value: Mapping[str, Any]) -> dict[str, Any]:
@@ -37,7 +41,15 @@ def _json_metadata(value: Mapping[str, Any]) -> dict[str, Any]:
 
 @dataclass(frozen=True)
 class ObservationFactorBundle:
-    """Versioned collection of unfused factors and uncertain Sim(3) gauges."""
+    """Frozen schema-v3 bundle with marginal per-gauge covariance blocks.
+
+    Schema v3 predates an explicit joint gauge prior. Its stacked representation
+    therefore retains the historical block-diagonal covariance assembled from
+    the individual ``GaugeEstimate`` marginals. New explicit-gauge inference
+    should use :class:`JointObservationFactorBundle`.
+    """
+
+    EXPECTED_SCHEMA_VERSION: ClassVar[int] = OBSERVATION_FACTOR_SCHEMA_VERSION
 
     sequence_id: str
     factors: tuple[ObservationFactor, ...]
@@ -64,7 +76,7 @@ class ObservationFactorBundle:
         source_repository = str(self.source_repository)
         if not case_id or not stream_id or not source_repository:
             raise ValueError("case, stream, and source repository must not be empty")
-        if self.schema_version != OBSERVATION_FACTOR_SCHEMA_VERSION:
+        if self.schema_version != self.EXPECTED_SCHEMA_VERSION:
             raise ValueError("unsupported observation-factor schema version")
         causal_frame_stop = int(self.causal_frame_stop)
         if causal_frame_stop < 1:
@@ -186,8 +198,81 @@ class ObservationFactorBundle:
             ray_directions_world=rays,
         )
 
+    @property
+    def cross_window_gauge_covariance_preserved(self) -> bool:
+        """Whether the serialized gauge prior contains cross-window blocks."""
+
+        return False
+
     def stack(self, *, include_invalid: bool = False) -> StackedObservationFactors:
         return stack_observation_factors(self, include_invalid=include_invalid)
+
+
+@dataclass(frozen=True)
+class JointObservationFactorBundle(ObservationFactorBundle):
+    """Schema-v4 unfused factors with one ordered joint ``Sim(3)`` prior.
+
+    ``joint_gauge_covariance`` follows the exact order of ``gauges`` and contains
+    every marginal and cross-window block. The marginal block for each gauge must
+    match the covariance stored in its corresponding ``GaugeEstimate``. This
+    redundancy keeps row-level linearization convenient while making the full
+    nuisance prior auditable and impossible to silently replace by independent
+    gauge marginals.
+    """
+
+    schema_version: int = JOINT_OBSERVATION_FACTOR_SCHEMA_VERSION
+    joint_gauge_covariance: FloatArray | None = None
+
+    EXPECTED_SCHEMA_VERSION: ClassVar[int] = (
+        JOINT_OBSERVATION_FACTOR_SCHEMA_VERSION
+    )
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if self.joint_gauge_covariance is None:
+            raise ValueError(
+                "schema-v4 observation factors require joint_gauge_covariance"
+            )
+        dimension = 7 * len(self.gauges)
+        covariance = np.asarray(
+            self.joint_gauge_covariance, dtype=np.float64
+        ).copy()
+        if covariance.shape != (dimension, dimension):
+            raise ValueError(
+                "joint_gauge_covariance must have shape "
+                f"({dimension}, {dimension})"
+            )
+        if not np.all(np.isfinite(covariance)):
+            raise ValueError("joint_gauge_covariance must be finite")
+        symmetric = 0.5 * (covariance + covariance.T)
+        if not np.allclose(covariance, symmetric, atol=1e-12, rtol=1e-10):
+            raise ValueError("joint_gauge_covariance must be symmetric")
+        _require_psd(
+            symmetric,
+            "joint_gauge_covariance",
+            tolerance=1e-10,
+        )
+        for index, gauge in enumerate(self.gauges):
+            block = symmetric[
+                7 * index : 7 * (index + 1),
+                7 * index : 7 * (index + 1),
+            ]
+            if not np.allclose(
+                block,
+                np.asarray(gauge.covariance, dtype=np.float64),
+                atol=1e-12,
+                rtol=1e-10,
+            ):
+                raise ValueError(
+                    "joint gauge covariance marginal does not match "
+                    f"GaugeEstimate {gauge.window_id!r}"
+                )
+        symmetric.setflags(write=False)
+        object.__setattr__(self, "joint_gauge_covariance", symmetric)
+
+    @property
+    def cross_window_gauge_covariance_preserved(self) -> bool:
+        return True
 
 
 def sim3_point_jacobian(transform: Sim3, points_local_m: FloatArray) -> FloatArray:
@@ -278,8 +363,15 @@ def stack_observation_factors(
             correlation_groups.append(factor.correlation_group_id)
     if not means:
         raise ValueError("observation-factor stack has no selected rows")
-    gauge_prior = _block_diagonal(
-        [np.asarray(gauge.covariance, dtype=np.float64) for gauge in bundle.gauges]
+    gauge_prior = (
+        np.asarray(bundle.joint_gauge_covariance, dtype=np.float64)
+        if isinstance(bundle, JointObservationFactorBundle)
+        else _block_diagonal(
+            [
+                np.asarray(gauge.covariance, dtype=np.float64)
+                for gauge in bundle.gauges
+            ]
+        )
     )
     return StackedObservationFactors(
         world_mean_m=np.stack(means),

--- a/src/prob4d/_observation_factor_io.py
+++ b/src/prob4d/_observation_factor_io.py
@@ -12,9 +12,12 @@ import numpy as np
 
 from ._observation_factor_bundle import (
     GAUGE_PARAMETERIZATION,
+    JOINT_GAUGE_COVARIANCE_SEMANTICS,
+    JOINT_OBSERVATION_FACTOR_SCHEMA_VERSION,
     LEGACY_OBSERVATION_FACTOR_SCHEMA_VERSION,
     OBSERVATION_FACTOR_SCHEMA,
     OBSERVATION_FACTOR_SCHEMA_VERSION,
+    JointObservationFactorBundle,
     ObservationFactorBundle,
 )
 from ._observation_factor_types import ObservationFactor
@@ -36,7 +39,7 @@ def write_observation_factor_bundle(
     *,
     payload_path: str | Path | None = None,
 ) -> tuple[Path, Path]:
-    """Write a schema-v3 manifest with an exclusive causal frame stop."""
+    """Write a schema-v3 or joint-covariance schema-v4 factor bundle."""
 
     manifest = Path(manifest_path)
     payload = (
@@ -59,6 +62,17 @@ def write_observation_factor_bundle(
                 "covariance_key": f"{prefix}__covariance",
             }
         )
+    joint_gauge_covariance: dict[str, Any] | None = None
+    if isinstance(bundle, JointObservationFactorBundle):
+        joint_key = "joint_gauge_covariance"
+        arrays[joint_key] = np.asarray(bundle.joint_gauge_covariance)
+        joint_gauge_covariance = {
+            "array_key": joint_key,
+            "gauge_ids": [gauge.window_id for gauge in bundle.gauges],
+            "semantics": JOINT_GAUGE_COVARIANCE_SEMANTICS,
+            "cross_window_covariance_preserved": True,
+        }
+
     factors: list[dict[str, Any]] = []
     for index, factor in enumerate(bundle.factors):
         prefix = f"factor_{index:04d}"
@@ -116,6 +130,8 @@ def write_observation_factor_bundle(
         "gauges": gauges,
         "factors": factors,
     }
+    if joint_gauge_covariance is not None:
+        record["joint_gauge_covariance"] = joint_gauge_covariance
     manifest.write_text(
         json.dumps(record, indent=2, sort_keys=True, allow_nan=False) + "\n",
         encoding="utf-8",
@@ -124,10 +140,13 @@ def write_observation_factor_bundle(
 
 
 def _causal_frame_stop(record: dict[str, Any], *, schema_version: int) -> int:
-    if schema_version == OBSERVATION_FACTOR_SCHEMA_VERSION:
+    if schema_version in {
+        OBSERVATION_FACTOR_SCHEMA_VERSION,
+        JOINT_OBSERVATION_FACTOR_SCHEMA_VERSION,
+    }:
         convention = record.get("causal_frame_stop_convention")
         if convention is not None and convention != "exclusive":
-            raise ValueError("schema-v3 causal frame stop must be exclusive")
+            raise ValueError("schema-v3/v4 causal frame stop must be exclusive")
         return int(record["causal_frame_stop"])
     if schema_version == LEGACY_OBSERVATION_FACTOR_SCHEMA_VERSION:
         return int(record["causal_frame_limit"]) + 1
@@ -136,8 +155,8 @@ def _causal_frame_stop(record: dict[str, Any], *, schema_version: int) -> int:
 
 def load_observation_factor_bundle(
     manifest_path: str | Path,
-) -> ObservationFactorBundle:
-    """Load schema v3 or upgrade a schema-v2 bundle without ambiguity."""
+) -> ObservationFactorBundle | JointObservationFactorBundle:
+    """Load schema v3/v4 or upgrade a schema-v2 bundle without ambiguity."""
 
     manifest = Path(manifest_path)
     record = json.loads(manifest.read_text(encoding="utf-8"))
@@ -147,6 +166,7 @@ def load_observation_factor_bundle(
     if schema_version not in {
         LEGACY_OBSERVATION_FACTOR_SCHEMA_VERSION,
         OBSERVATION_FACTOR_SCHEMA_VERSION,
+        JOINT_OBSERVATION_FACTOR_SCHEMA_VERSION,
     }:
         raise ValueError("unsupported observation-factor schema version")
     if record.get("gauge_parameterization") != GAUGE_PARAMETERIZATION:
@@ -171,6 +191,28 @@ def load_observation_factor_bundle(
                     covariance=arrays[gauge_record["covariance_key"]],
                 )
             )
+        if schema_version == JOINT_OBSERVATION_FACTOR_SCHEMA_VERSION:
+            joint_record = record.get("joint_gauge_covariance")
+            if not isinstance(joint_record, dict):
+                raise ValueError("schema-v4 bundle is missing joint gauge covariance")
+            if (
+                joint_record.get("semantics")
+                != JOINT_GAUGE_COVARIANCE_SEMANTICS
+            ):
+                raise ValueError("unsupported joint gauge covariance semantics")
+            if joint_record.get("cross_window_covariance_preserved") is not True:
+                raise ValueError(
+                    "schema-v4 bundle must preserve cross-window gauge covariance"
+                )
+            gauge_ids = [gauge.window_id for gauge in gauges]
+            if joint_record.get("gauge_ids") != gauge_ids:
+                raise ValueError("joint gauge covariance gauge order changed")
+            joint_key = joint_record.get("array_key")
+            if not isinstance(joint_key, str) or joint_key not in arrays:
+                raise ValueError("joint gauge covariance payload key is missing")
+            joint_covariance = arrays[joint_key]
+        else:
+            joint_covariance = None
         for factor_record in record["factors"]:
             keys = factor_record["arrays"]
             ray_key = factor_record.get("ray_directions_local_key")
@@ -220,17 +262,22 @@ def load_observation_factor_bundle(
             "legacy_causal_frame_limit_upgraded_to_exclusive_stop": True,
             "legacy_missing_reliability_defaults": "ones",
         }
-    return ObservationFactorBundle(
-        sequence_id=str(record["sequence_id"]),
-        factors=tuple(factors),
-        gauges=tuple(gauges),
-        source_revision=str(record["source_revision"]),
-        causal_frame_stop=bundle_causal_frame_stop,
-        case_id=str(record.get("case_id", record["sequence_id"])),
-        stream_id=str(record.get("stream_id", record["sequence_id"])),
-        source_repository=str(
+    common = {
+        "sequence_id": str(record["sequence_id"]),
+        "factors": tuple(factors),
+        "gauges": tuple(gauges),
+        "source_revision": str(record["source_revision"]),
+        "causal_frame_stop": bundle_causal_frame_stop,
+        "case_id": str(record.get("case_id", record["sequence_id"])),
+        "stream_id": str(record.get("stream_id", record["sequence_id"])),
+        "source_repository": str(
             record.get("source_repository", "FlorianPfaff/Prob4D")
         ),
-        metadata=metadata,
-        schema_version=OBSERVATION_FACTOR_SCHEMA_VERSION,
-    )
+        "metadata": metadata,
+    }
+    if schema_version == JOINT_OBSERVATION_FACTOR_SCHEMA_VERSION:
+        return JointObservationFactorBundle(
+            **common,
+            joint_gauge_covariance=joint_covariance,
+        )
+    return ObservationFactorBundle(**common)

--- a/src/prob4d/observation_factors.py
+++ b/src/prob4d/observation_factors.py
@@ -8,10 +8,13 @@ timing.
 
 from ._observation_factor_bundle import (
     GAUGE_PARAMETERIZATION,
+    JOINT_GAUGE_COVARIANCE_SEMANTICS,
+    JOINT_OBSERVATION_FACTOR_SCHEMA_VERSION,
     LEGACY_OBSERVATION_FACTOR_SCHEMA_VERSION,
     OBSERVATION_FACTOR_SCHEMA,
     OBSERVATION_FACTOR_SCHEMA_VERSION,
     OBSERVATION_FACTOR_SOURCE_REPOSITORY,
+    JointObservationFactorBundle,
     ObservationFactorBundle,
     sim3_point_jacobian,
     stack_observation_factors,
@@ -28,10 +31,13 @@ from ._observation_factor_types import (
 
 __all__ = [
     "GAUGE_PARAMETERIZATION",
+    "JOINT_GAUGE_COVARIANCE_SEMANTICS",
+    "JOINT_OBSERVATION_FACTOR_SCHEMA_VERSION",
     "LEGACY_OBSERVATION_FACTOR_SCHEMA_VERSION",
     "OBSERVATION_FACTOR_SCHEMA",
     "OBSERVATION_FACTOR_SCHEMA_VERSION",
     "OBSERVATION_FACTOR_SOURCE_REPOSITORY",
+    "JointObservationFactorBundle",
     "LinearizedObservationFactor",
     "ObservationFactor",
     "ObservationFactorBundle",

--- a/src/prob4d/provider_v2.py
+++ b/src/prob4d/provider_v2.py
@@ -27,6 +27,11 @@ from .composition_jacobian import (
     composition_jacobian_mode,
 )
 from .covariance_root import CovarianceRootMode, covariance_root_mode
+from .observation_factors import (
+    JOINT_GAUGE_COVARIANCE_SEMANTICS,
+    JOINT_OBSERVATION_FACTOR_SCHEMA_VERSION,
+    JointObservationFactorBundle,
+)
 from .provider_attestation import (
     PROVIDER_ATTESTATION_SCHEMA,
     PROVIDER_ATTESTATION_VERSION,
@@ -103,12 +108,19 @@ def prob4d_provider_manifest(
         "analytic_sim3_composition_jacobians",
         "canonical_repeated_eigenspace_covariance_root",
         "explicit_exploratory_and_claim_bearing_exports",
+        "joint_observation_factor_gauge_covariance",
         "provider_attested_observation_artifacts",
         "runtime_revision_attestation",
         "strict_prediction_calibration_compatibility",
     ):
         if capability not in capabilities:
             capabilities.append(capability)
+    artifact_schema_versions = dict(
+        cast(dict[str, int], inherited["artifact_schema_versions"])
+    )
+    artifact_schema_versions["JointObservationFactorBundle"] = (
+        JOINT_OBSERVATION_FACTOR_SCHEMA_VERSION
+    )
     metadata = dict(cast(dict[str, object], inherited["metadata"]))
     metadata.update(
         {
@@ -136,6 +148,11 @@ def prob4d_provider_manifest(
                 "export fixes sequential gauge propagation, uses canonical repeated-"
                 "eigenspace covariance roots, and forbids pointwise covariance fallback"
             ),
+            "joint_observation_factor_gauge_covariance_semantics": (
+                f"{JOINT_GAUGE_COVARIANCE_SEMANTICS}; schema v4 carries one ordered "
+                "full Sim(3) covariance whose diagonal blocks must match the per-gauge "
+                "marginals; provider-v1 schema v3 remains frozen and block diagonal"
+            ),
             "provider_attestation_semantics": (
                 "every provider-v2 export embeds the complete content-addressed "
                 "provider manifest, export mode, covariance-root and composition-"
@@ -150,6 +167,7 @@ def prob4d_provider_manifest(
     descriptor: dict[str, object] = {
         **inherited,
         "provider_api_version": PROVIDER_API_VERSION,
+        "artifact_schema_versions": artifact_schema_versions,
         "capabilities": capabilities,
         "limitations": limitations,
         "metadata": metadata,
@@ -333,6 +351,8 @@ __all__ = [
     "OBSERVATION_BELIEF_VERSION",
     "OBSERVATION_FACTOR_SCHEMA",
     "OBSERVATION_FACTOR_SCHEMA_VERSION",
+    "JOINT_GAUGE_COVARIANCE_SEMANTICS",
+    "JOINT_OBSERVATION_FACTOR_SCHEMA_VERSION",
     "POINT_UNCERTAINTY_CALIBRATION_SCHEMA",
     "POINT_UNCERTAINTY_CALIBRATION_VERSION",
     "PROB4D_CAUSAL_STREAM_CONTRACT_VERSION",
@@ -345,6 +365,7 @@ __all__ = [
     "CompositionJacobianMode",
     "CovarianceRootMode",
     "GaugeCovarianceCalibrationV1",
+    "JointObservationFactorBundle",
     "MetricGaugeAnchor",
     "ObservationBeliefExportV1",
     "ObservationFactorBundle",

--- a/tests/test_observation_factors.py
+++ b/tests/test_observation_factors.py
@@ -6,7 +6,10 @@ import pytest
 
 from prob4d.gauge import GaugeEstimate
 from prob4d.observation_factors import (
+    JOINT_GAUGE_COVARIANCE_SEMANTICS,
+    JOINT_OBSERVATION_FACTOR_SCHEMA_VERSION,
     OBSERVATION_FACTOR_SCHEMA_VERSION,
+    JointObservationFactorBundle,
     ObservationFactor,
     ObservationFactorBundle,
     load_observation_factor_bundle,
@@ -84,6 +87,30 @@ def _bundle() -> ObservationFactorBundle:
     )
 
 
+def _joint_bundle() -> JointObservationFactorBundle:
+    legacy = _bundle()
+    joint_covariance = np.zeros((14, 14), dtype=np.float64)
+    for index, gauge in enumerate(legacy.gauges):
+        joint_covariance[
+            7 * index : 7 * (index + 1),
+            7 * index : 7 * (index + 1),
+        ] = gauge.covariance
+    joint_covariance[0, 7] = 0.001
+    joint_covariance[7, 0] = 0.001
+    return JointObservationFactorBundle(
+        sequence_id=legacy.sequence_id,
+        factors=legacy.factors,
+        gauges=legacy.gauges,
+        source_revision=legacy.source_revision,
+        causal_frame_stop=legacy.causal_frame_stop,
+        case_id=legacy.case_id,
+        stream_id=legacy.stream_id,
+        source_repository=legacy.source_repository,
+        metadata={**legacy.metadata, "joint_gauge_prior": True},
+        joint_gauge_covariance=joint_covariance,
+    )
+
+
 def test_bundle_roundtrip_preserves_unfused_provenance(tmp_path: Path) -> None:
     bundle = _bundle()
     manifest, payload = write_observation_factor_bundle(
@@ -118,6 +145,91 @@ def test_bundle_roundtrip_preserves_unfused_provenance(tmp_path: Path) -> None:
             "composite_weight": 0.25,
         },
     }
+
+
+def test_joint_bundle_roundtrip_preserves_cross_window_gauge_covariance(
+    tmp_path: Path,
+) -> None:
+    bundle = _joint_bundle()
+    manifest, _ = write_observation_factor_bundle(
+        bundle, tmp_path / "joint-factors.json"
+    )
+
+    loaded = load_observation_factor_bundle(manifest)
+    record = json.loads(manifest.read_text(encoding="utf-8"))
+
+    assert record["schema_version"] == JOINT_OBSERVATION_FACTOR_SCHEMA_VERSION
+    assert record["joint_gauge_covariance"]["semantics"] == (
+        JOINT_GAUGE_COVARIANCE_SEMANTICS
+    )
+    assert record["joint_gauge_covariance"][
+        "cross_window_covariance_preserved"
+    ] is True
+    assert isinstance(loaded, JointObservationFactorBundle)
+    assert loaded.cross_window_gauge_covariance_preserved is True
+    np.testing.assert_array_equal(
+        loaded.joint_gauge_covariance,
+        bundle.joint_gauge_covariance,
+    )
+    np.testing.assert_array_equal(
+        loaded.stack().gauge_prior_covariance,
+        bundle.joint_gauge_covariance,
+    )
+
+
+def test_joint_bundle_induces_cross_factor_observation_covariance() -> None:
+    stacked = _joint_bundle().stack()
+    row_jacobian = stacked.gauge_jacobian.reshape(-1, 14)
+    joint_observation_covariance = (
+        row_jacobian @ stacked.gauge_prior_covariance @ row_jacobian.T
+    )
+
+    # First point of factor 0 and first point of factor 1 both have unit
+    # sensitivity to their window log-scale coordinate. The explicit cross-gauge
+    # block must therefore survive into their observation covariance.
+    assert joint_observation_covariance[0, 6] == pytest.approx(0.001)
+    assert joint_observation_covariance[6, 0] == pytest.approx(0.001)
+
+
+def test_joint_bundle_requires_explicit_joint_covariance() -> None:
+    legacy = _bundle()
+    with pytest.raises(ValueError, match="require joint_gauge_covariance"):
+        JointObservationFactorBundle(
+            sequence_id=legacy.sequence_id,
+            factors=legacy.factors,
+            gauges=legacy.gauges,
+            source_revision=legacy.source_revision,
+            causal_frame_stop=legacy.causal_frame_stop,
+        )
+
+
+def test_joint_bundle_rejects_marginal_mismatch() -> None:
+    bundle = _joint_bundle()
+    changed = np.asarray(bundle.joint_gauge_covariance).copy()
+    changed[7, 7] += 1e-3
+    with pytest.raises(ValueError, match="marginal does not match"):
+        JointObservationFactorBundle(
+            sequence_id=bundle.sequence_id,
+            factors=bundle.factors,
+            gauges=bundle.gauges,
+            source_revision=bundle.source_revision,
+            causal_frame_stop=bundle.causal_frame_stop,
+            joint_gauge_covariance=changed,
+        )
+
+
+def test_joint_bundle_loader_rejects_changed_covariance_semantics(
+    tmp_path: Path,
+) -> None:
+    manifest, _ = write_observation_factor_bundle(
+        _joint_bundle(), tmp_path / "joint-factors.json"
+    )
+    record = json.loads(manifest.read_text(encoding="utf-8"))
+    record["joint_gauge_covariance"]["semantics"] = "independent-gauges"
+    manifest.write_text(json.dumps(record), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="unsupported joint gauge covariance"):
+        load_observation_factor_bundle(manifest)
 
 
 def test_linearized_covariance_includes_sim3_gauge_uncertainty() -> None:
@@ -157,6 +269,7 @@ def test_stacked_factors_keep_association_reliability_and_group_weights_separate
 
     assert stacked.world_mean_m.shape == (4, 3)
     assert stacked.gauge_jacobian.shape == (4, 3, 14)
+    np.testing.assert_array_equal(stacked.gauge_prior_covariance[:7, 7:], 0.0)
     np.testing.assert_allclose(stacked.association_probability, [0.9, 0.6, 0.9, 0.6])
     np.testing.assert_allclose(stacked.prior_reliability, [0.7, 0.4, 0.7, 0.4])
     np.testing.assert_allclose(stacked.prior_nominal_probability, [0.8, 0.8, 0.6, 0.6])

--- a/tests/test_provider_manifest.py
+++ b/tests/test_provider_manifest.py
@@ -76,4 +76,7 @@ def test_provider_manifest_cli_can_emit_version_two(capsys) -> None:
     )
     payload = json.loads(capsys.readouterr().out)
     assert payload["provider_api_version"] == 2
+    assert payload["artifact_schema_versions"]["ObservationFactorBundle"] == 3
+    assert payload["artifact_schema_versions"]["JointObservationFactorBundle"] == 4
+    assert "joint_observation_factor_gauge_covariance" in payload["capabilities"]
     assert "runtime_revision_attestation" in payload["capabilities"]

--- a/tests/test_provider_v2.py
+++ b/tests/test_provider_v2.py
@@ -72,6 +72,7 @@ def _runtime_attestation(
 def test_provider_v2_exposes_safe_capabilities() -> None:
     assert provider.PROVIDER_API_VERSION == 2
     assert provider.PROB4D_PROVIDER_API_VERSION == 2
+    assert provider.JOINT_OBSERVATION_FACTOR_SCHEMA_VERSION == 4
     manifest = provider.prob4d_provider_manifest(provider_revision="a" * 40)
     assert manifest["provider_api_version"] == 2
     assert "strict_prediction_calibration_compatibility" in manifest["capabilities"]
@@ -81,6 +82,8 @@ def test_provider_v2_exposes_safe_capabilities() -> None:
     assert "analytic_sim3_composition_jacobians" in manifest["capabilities"]
     assert "runtime_revision_attestation" in manifest["capabilities"]
     assert "provider_attested_observation_artifacts" in manifest["capabilities"]
+    assert "joint_observation_factor_gauge_covariance" in manifest["capabilities"]
+    assert manifest["artifact_schema_versions"]["JointObservationFactorBundle"] == 4
     assert manifest["metadata"]["python_import_boundary"] == "prob4d.provider_v2"
     assert "canonical basis" in manifest["metadata"]["covariance_root_semantics"]
     assert "closed-form derivatives" in manifest["metadata"][


### PR DESCRIPTION
## Summary

- add `JointObservationFactorBundle` schema v4 with one ordered full cross-window `Sim(3)` gauge covariance;
- validate covariance shape, finiteness, symmetry, positive semidefiniteness, gauge order, and equality of every diagonal block with its `GaugeEstimate` marginal;
- preserve the full joint prior when factors are stacked, so explicit-gauge consumers retain shared anchor and upstream-window uncertainty;
- serialize the joint covariance in the checksum-bound NPZ payload and bind its semantics and gauge order in the manifest;
- retain provider-v1 `ObservationFactorBundle` schema v3 and its historical block-diagonal stacking behavior unchanged;
- advertise schema v4 and `joint_observation_factor_gauge_covariance` only through provider v2;
- document the conditional-versus-marginal covariance boundary and legacy migration semantics.

## Why

Schema v3 stores only marginal gauge covariances. Its stack therefore constructs a block-diagonal nuisance prior, which discards cross-window covariance induced by a shared metric anchor and sequential relative-gauge constraints. Using that representation for new multi-window explicit-gauge inference can overstate independent information.

A silent reinterpretation of schema v3 would break frozen reproduction. Schema v4 makes the stronger covariance claim explicit and fail-closed while preserving exact v1 compatibility.

## Validation

Local validation:

- `31 passed`: observation-factor, provider-v1/v2 manifest, and provider-attestation focused tests;
- `231 passed`: all tests available in the downloaded source distribution;
- `git diff --check` passed;
- source and tests compile successfully.

GitHub Actions run 347 completed successfully:

- Ruff;
- mypy stable-provider checks;
- runtime revision attestation and provider-manifest emission;
- complete test suites on Python 3.10, 3.12, and 3.14;
- wheel and source-distribution build plus `twine check`;
- isolated wheel and sdist installation;
- grouped and legacy CLI smoke tests.