### PR TITLE
Preserve joint gauge covariance in observation-factor bundles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to Prob4D are documented here.
 
 ### Added
 
+- `ObservationFactorBundle` schema v4 with an ordered joint `7K x 7K` gauge
+  covariance, explicit joint-versus-marginal covariance semantics, fail-closed
+  marginal-block validation, and conservative schema-v2/v3 migration.
 - `prob4d.provider_v2` as a safe-by-default Python surface with distinct
   exploratory and claim-bearing export functions.
 - Strict prediction/calibration compatibility checks covering MotionCrafter
@@ -32,6 +35,9 @@ All notable changes to Prob4D are documented here.
 
 ### Changed
 
+- Stacked unfused factors now retain cross-window gauge covariance rather than
+  reconstructing a block-diagonal prior from per-gauge marginals. The frozen
+  provider-v1 writer remains schema v3 and rejects joint covariance it cannot encode.
 - Fixed-lag gauge smoothing now Schur-marginalizes expired gauges into an
   uncertainty-bearing boundary prior. Portable historical covariance remains an
   explicit block-diagonal reconstruction approximation.

--- a/docs/observation-factor-bundle.md
+++ b/docs/observation-factor-bundle.md
@@ -6,12 +6,15 @@ view factors must remain separate so that uncertain `Sim(3)` gauges, shared
 backbone dependence, reliability, and causal timing are not erased before
 inference.
 
-`prob4d.observation_factors` implements this interface as schema version 3. The
+`prob4d.observation_factors` implements this interface as schema version 4. The
 bundle contains:
 
 - local 3-D points, full local covariance, material/association IDs, and optional
   viewing rays for every factor;
 - one `GaugeEstimate` for every local window gauge;
+- one ordered joint gauge covariance over all `7K` gauge coordinates;
+- explicit `joint-cross-window` or `marginal-blocks-only` gauge-covariance
+  semantics;
 - separate association probability and residual-independent prior reliability;
 - correlation-group nominal probabilities and composite-likelihood weights;
 - case, stream, sequence, repository, revision, view, window, frame, and
@@ -50,7 +53,7 @@ and composite weight. Stacking repeats those group values row-for-row without
 multiplying them into association probability. A zero-reliability row is not
 selected merely because its association probability is high.
 
-## Conditional and marginal covariance
+## Conditional, marginal, and joint gauge covariance
 
 For a local point `p` and gauge vector `g`, Prob4D exports the linearization
 
@@ -59,17 +62,29 @@ y = Sim3(g) p
 J_g = dy / dg.
 ```
 
-The stack deliberately exposes two covariance products:
+The stack deliberately exposes two point-covariance products:
 
 - `conditional_world_covariance_m2` transforms only the local point covariance;
 - `marginal_world_covariance_m2` additionally contains
-  `J_g Sigma_g J_g^T`.
+  `J_g Sigma_gg J_g^T`, using the corresponding diagonal gauge block.
+
+`gauge_prior_covariance` is the ordered `7K x 7K` covariance for
+`stacked.gauge_ids`. Under `joint-cross-window` semantics it retains off-diagonal
+blocks induced by a shared metric anchor or sequential gauge tree. The diagonal
+block for each gauge must exactly match the covariance stored in its
+`GaugeEstimate`; inconsistent or indefinite inputs fail closed.
 
 A downstream estimator that keeps gauge errors as explicit nuisance variables
-must use the **conditional** covariance together with `gauge_jacobian` and
-`gauge_prior_covariance`. Using the marginal covariance as well would count
-uncertain gauge variation twice. The marginal covariance remains useful for a
-consumer that does not estimate gauges explicitly.
+must use the **conditional** covariance together with `gauge_jacobian` and the
+full `gauge_prior_covariance`. Using the marginal covariance as well would count
+uncertain gauge variation twice. A consumer that does not estimate gauges may
+use the marginal point covariance, but row-wise marginals alone cannot reproduce
+cross-row covariance caused by a shared gauge prior.
+
+`marginal-blocks-only` is an explicit compatibility representation. It constructs
+a block-diagonal gauge prior from the per-gauge marginals and rejects nonzero
+off-diagonal blocks. It must not be described as preserving cross-window gauge
+uncertainty.
 
 ## Example
 
@@ -102,15 +117,17 @@ bundle = ObservationFactorBundle(
     sequence_id="double_stretch_sloth-camera0-prefix",
     case_id="double_stretch_sloth",
     stream_id="prob4d:motioncrafter-points:camera0",
-    factors=(factor,),
-    gauges=(gauge_window3_camera0,),
+    factors=(factor_window2, factor_window3),
+    gauges=(gauge_window2_camera0, gauge_window3_camera0),
+    joint_gauge_covariance=joint_gauge_covariance,
+    gauge_covariance_semantics="joint-cross-window",
     source_repository="FlorianPfaff/Prob4D",
     source_revision=prob4d_commit,
     causal_frame_stop=134,
     metadata={
         "upstream_repository": "TencentARC/MotionCrafter",
         "upstream_revision": motioncrafter_commit,
-        "metric_anchor_used": False,
+        "metric_anchor_used": True,
     },
 )
 
@@ -122,9 +139,11 @@ stacked = bundle.stack()
 ```
 
 `stacked.gauge_jacobian` has one seven-dimensional block per gauge. Rows from
-another gauge are exactly zero in that block. The stacked association,
-reliability, nominal-probability, and composite-weight arrays remain separate
-inputs for the consuming Bayesian estimator.
+another gauge are exactly zero in that block, while
+`stacked.gauge_prior_covariance` can contain nonzero covariance between those
+blocks. The stacked association, reliability, nominal-probability, and
+composite-weight arrays remain separate inputs for the consuming Bayesian
+estimator.
 
 ## Information boundary
 
@@ -135,18 +154,26 @@ frame_index < causal_frame_stop
 ```
 
 and every factor in a bundle must use the same exclusive stop. This convention
-matches `ObservationBeliefV1` and avoids adapter-specific `+1` conversions.
-The contract does not authorize a predictor to read later RGB, point maps,
-target tracks, or outcome metrics. Reconstruction controls that use all frames
-must be written to a separately labelled bundle.
+matches `ObservationBeliefV1` and avoids adapter-specific `+1` conversions. The
+contract does not authorize a predictor to read later RGB, point maps, target
+tracks, or outcome metrics. Reconstruction controls that use all frames must be
+written to a separately labelled bundle.
 
-## Schema-v2 migration
+## Schema migration and provider versions
 
-The loader accepts legacy schema-v2 manifests, whose `causal_frame_limit` was
-inclusive. It converts them deterministically to
-`causal_frame_stop = causal_frame_limit + 1`. Because v2 had no distinct prior
-reliability or group weighting fields, those values are conservatively restored
-as one and the migration is recorded in bundle metadata. Missing case or stream
-identities are restored from the legacy `sequence_id`. New writes always use
-schema v3; the legacy inclusive aliases remain read-only compatibility
-properties.
+The current loader accepts schema v2, v3, and v4:
+
+- v2 used an inclusive `causal_frame_limit` and had no distinct reliability or
+  group weighting fields;
+- v3 added the exclusive causal stop and reliability fields but serialized only
+  per-gauge marginal covariance blocks;
+- v4 adds the ordered joint gauge covariance and explicit covariance semantics.
+
+Schema-v2/v3 inputs are upgraded conservatively as `marginal-blocks-only`; the
+loader records that their source schema did not preserve cross-window gauge
+covariance. It never infers missing off-diagonal blocks.
+
+New writes through `prob4d.observation_factors` and `prob4d.provider_v2` use
+schema v4. The frozen `prob4d.provider_v1` writer remains schema v3 and rejects a
+bundle that declares `joint-cross-window` semantics rather than silently dropping
+its off-diagonal covariance.

--- a/docs/provider-contract.md
+++ b/docs/provider-contract.md
@@ -77,8 +77,13 @@ archives, and content-address mismatches. Strict causal export writes through a
 temporary archive, reloads and validates its content address, then atomically
 replaces the requested output. `PredictionWindow` inputs are copied and frozen
 after validation so caller-side mutation cannot alter a sealed source object.
-The richer `ObservationFactorBundle` schema v3 remains available when the
-consumer estimates gauge nuisance variables explicitly.
+
+Provider v2 exposes `ObservationFactorBundle` schema v4 for consumers that keep
+explicit gauge nuisance variables. It stores one ordered joint `7K x 7K` gauge
+covariance and distinguishes `joint-cross-window` from
+`marginal-blocks-only` semantics. Schema-v2/v3 bundles upgrade conservatively as
+marginal-only because their missing off-diagonal blocks cannot be reconstructed.
+The frozen provider-v1 surface continues to advertise and write schema v3.
 
 The grouped `prob4d` command is the preferred discoverable interface. Existing
 `prob4d-*` commands remain available so historical run manifests and frozen

--- a/src/prob4d/_observation_factor_bundle.py
+++ b/src/prob4d/_observation_factor_bundle.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Literal
 
 import numpy as np
 
@@ -20,10 +20,19 @@ from .gauge import GaugeEstimate
 from .sim3 import Sim3, skew, so3_right_jacobian
 
 OBSERVATION_FACTOR_SCHEMA = "prob4d.observation-factor-bundle"
-OBSERVATION_FACTOR_SCHEMA_VERSION = 3
+OBSERVATION_FACTOR_SCHEMA_VERSION = 4
+PREVIOUS_OBSERVATION_FACTOR_SCHEMA_VERSION = 3
 LEGACY_OBSERVATION_FACTOR_SCHEMA_VERSION = 2
 OBSERVATION_FACTOR_SOURCE_REPOSITORY = "FlorianPfaff/Prob4D"
 GAUGE_PARAMETERIZATION = "log-scale-rotvec-translation-v1"
+GaugeCovarianceSemantics = Literal[
+    "marginal-blocks-only",
+    "joint-cross-window",
+]
+GAUGE_COVARIANCE_SEMANTICS: tuple[GaugeCovarianceSemantics, ...] = (
+    "marginal-blocks-only",
+    "joint-cross-window",
+)
 
 
 def _json_metadata(value: Mapping[str, Any]) -> dict[str, Any]:
@@ -49,6 +58,8 @@ class ObservationFactorBundle:
     source_repository: str = OBSERVATION_FACTOR_SOURCE_REPOSITORY
     metadata: Mapping[str, Any] = field(default_factory=dict)
     schema_version: int = OBSERVATION_FACTOR_SCHEMA_VERSION
+    joint_gauge_covariance: FloatArray | None = None
+    gauge_covariance_semantics: GaugeCovarianceSemantics = "marginal-blocks-only"
 
     @property
     def causal_frame_limit(self) -> int:
@@ -64,7 +75,11 @@ class ObservationFactorBundle:
         source_repository = str(self.source_repository)
         if not case_id or not stream_id or not source_repository:
             raise ValueError("case, stream, and source repository must not be empty")
-        if self.schema_version != OBSERVATION_FACTOR_SCHEMA_VERSION:
+        schema_version = int(self.schema_version)
+        if schema_version not in {
+            PREVIOUS_OBSERVATION_FACTOR_SCHEMA_VERSION,
+            OBSERVATION_FACTOR_SCHEMA_VERSION,
+        }:
             raise ValueError("unsupported observation-factor schema version")
         causal_frame_stop = int(self.causal_frame_stop)
         if causal_frame_stop < 1:
@@ -81,6 +96,7 @@ class ObservationFactorBundle:
             raise ValueError("gauge IDs must be non-empty and unique")
         gauge_id_set = set(gauge_ids)
         group_settings: dict[str, tuple[float, float]] = {}
+        gauge_covariances: list[np.ndarray] = []
         for gauge in gauges:
             covariance = np.asarray(gauge.covariance, dtype=np.float64)
             if covariance.shape != (7, 7) or not np.all(np.isfinite(covariance)):
@@ -88,6 +104,74 @@ class ObservationFactorBundle:
             if not np.allclose(covariance, covariance.T, atol=1e-12):
                 raise ValueError("gauge covariance must be symmetric")
             _require_psd(covariance, "gauge covariance")
+            gauge_covariances.append(covariance)
+
+        semantics = str(self.gauge_covariance_semantics)
+        if semantics not in GAUGE_COVARIANCE_SEMANTICS:
+            raise ValueError(
+                "gauge_covariance_semantics must be 'marginal-blocks-only' or "
+                "'joint-cross-window'"
+            )
+        if (
+            schema_version == PREVIOUS_OBSERVATION_FACTOR_SCHEMA_VERSION
+            and semantics != "marginal-blocks-only"
+        ):
+            raise ValueError(
+                "schema-v3 bundles cannot represent joint cross-window gauge covariance"
+            )
+        block_diagonal = _block_diagonal(gauge_covariances)
+        if self.joint_gauge_covariance is None:
+            if semantics == "joint-cross-window" and len(gauges) > 1:
+                raise ValueError(
+                    "joint-cross-window semantics require joint_gauge_covariance "
+                    "for multiple gauges"
+                )
+            joint_covariance = block_diagonal
+        else:
+            joint_covariance = np.asarray(
+                self.joint_gauge_covariance,
+                dtype=np.float64,
+            ).copy()
+            dimension = 7 * len(gauges)
+            if joint_covariance.shape != (dimension, dimension):
+                raise ValueError(
+                    "joint_gauge_covariance must have shape "
+                    f"({dimension}, {dimension})"
+                )
+            if not np.all(np.isfinite(joint_covariance)):
+                raise ValueError("joint_gauge_covariance must be finite")
+            symmetric = 0.5 * (joint_covariance + joint_covariance.T)
+            if not np.allclose(joint_covariance, symmetric, atol=1e-12, rtol=1e-10):
+                raise ValueError("joint_gauge_covariance must be symmetric")
+            _require_psd(symmetric, "joint_gauge_covariance")
+            joint_covariance = symmetric
+            for index, gauge_covariance in enumerate(gauge_covariances):
+                block = joint_covariance[
+                    7 * index : 7 * (index + 1),
+                    7 * index : 7 * (index + 1),
+                ]
+                if not np.allclose(
+                    block,
+                    gauge_covariance,
+                    atol=1e-12,
+                    rtol=1e-10,
+                ):
+                    raise ValueError(
+                        "joint_gauge_covariance diagonal blocks must match "
+                        "the per-gauge covariances"
+                    )
+            if semantics == "marginal-blocks-only" and not np.allclose(
+                joint_covariance,
+                block_diagonal,
+                atol=1e-12,
+                rtol=1e-10,
+            ):
+                raise ValueError(
+                    "marginal-blocks-only semantics require zero cross-window "
+                    "gauge covariance"
+                )
+        joint_covariance.setflags(write=False)
+
         for factor in factors:
             if factor.gauge_id not in gauge_id_set:
                 raise ValueError(
@@ -107,15 +191,24 @@ class ObservationFactorBundle:
                 )
         object.__setattr__(self, "factors", factors)
         object.__setattr__(self, "gauges", gauges)
+        object.__setattr__(self, "schema_version", schema_version)
         object.__setattr__(self, "causal_frame_stop", causal_frame_stop)
         object.__setattr__(self, "case_id", case_id)
         object.__setattr__(self, "stream_id", stream_id)
         object.__setattr__(self, "source_repository", source_repository)
         object.__setattr__(self, "metadata", _json_metadata(self.metadata))
+        object.__setattr__(self, "joint_gauge_covariance", joint_covariance)
+        object.__setattr__(self, "gauge_covariance_semantics", semantics)
 
     @property
     def gauge_map(self) -> dict[str, GaugeEstimate]:
         return {gauge.window_id: gauge for gauge in self.gauges}
+
+    @property
+    def cross_window_gauge_covariance_preserved(self) -> bool:
+        """Whether the serialized gauge prior represents cross-window blocks."""
+
+        return self.gauge_covariance_semantics == "joint-cross-window"
 
     @property
     def correlation_group_counts(self) -> dict[str, int]:
@@ -278,15 +371,12 @@ def stack_observation_factors(
             correlation_groups.append(factor.correlation_group_id)
     if not means:
         raise ValueError("observation-factor stack has no selected rows")
-    gauge_prior = _block_diagonal(
-        [np.asarray(gauge.covariance, dtype=np.float64) for gauge in bundle.gauges]
-    )
     return StackedObservationFactors(
         world_mean_m=np.stack(means),
         conditional_world_covariance_m2=np.stack(conditional_covariances),
         marginal_world_covariance_m2=np.stack(marginal_covariances),
         gauge_jacobian=np.stack(jacobians),
-        gauge_prior_covariance=gauge_prior,
+        gauge_prior_covariance=bundle.joint_gauge_covariance,
         association_probability=np.asarray(association_probabilities),
         prior_reliability=np.asarray(prior_reliabilities),
         prior_nominal_probability=np.asarray(prior_nominal_probabilities),

--- a/src/prob4d/_observation_factor_io.py
+++ b/src/prob4d/_observation_factor_io.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 
@@ -15,6 +16,7 @@ from ._observation_factor_bundle import (
     LEGACY_OBSERVATION_FACTOR_SCHEMA_VERSION,
     OBSERVATION_FACTOR_SCHEMA,
     OBSERVATION_FACTOR_SCHEMA_VERSION,
+    PREVIOUS_OBSERVATION_FACTOR_SCHEMA_VERSION,
     ObservationFactorBundle,
 )
 from ._observation_factor_types import ObservationFactor
@@ -30,13 +32,26 @@ def _sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
-def write_observation_factor_bundle(
+def _write_observation_factor_bundle(
     bundle: ObservationFactorBundle,
     manifest_path: str | Path,
     *,
     payload_path: str | Path | None = None,
+    schema_version: int,
 ) -> tuple[Path, Path]:
-    """Write a schema-v3 manifest with an exclusive causal frame stop."""
+    if schema_version not in {
+        PREVIOUS_OBSERVATION_FACTOR_SCHEMA_VERSION,
+        OBSERVATION_FACTOR_SCHEMA_VERSION,
+    }:
+        raise ValueError("writer supports only observation-factor schema v3 or v4")
+    if (
+        schema_version == PREVIOUS_OBSERVATION_FACTOR_SCHEMA_VERSION
+        and bundle.gauge_covariance_semantics != "marginal-blocks-only"
+    ):
+        raise ValueError(
+            "schema-v3 compatibility output cannot represent joint cross-window "
+            "gauge covariance"
+        )
 
     manifest = Path(manifest_path)
     payload = (
@@ -59,6 +74,9 @@ def write_observation_factor_bundle(
                 "covariance_key": f"{prefix}__covariance",
             }
         )
+    joint_covariance_key = "joint_gauge_covariance"
+    if schema_version == OBSERVATION_FACTOR_SCHEMA_VERSION:
+        arrays[joint_covariance_key] = bundle.joint_gauge_covariance
     factors: list[dict[str, Any]] = []
     for index, factor in enumerate(bundle.factors):
         prefix = f"factor_{index:04d}"
@@ -98,7 +116,7 @@ def write_observation_factor_bundle(
     np.savez_compressed(payload, **arrays)
     record = {
         "schema": OBSERVATION_FACTOR_SCHEMA,
-        "schema_version": bundle.schema_version,
+        "schema_version": schema_version,
         "gauge_parameterization": GAUGE_PARAMETERIZATION,
         "sequence_id": bundle.sequence_id,
         "case_id": bundle.case_id,
@@ -116,6 +134,16 @@ def write_observation_factor_bundle(
         "gauges": gauges,
         "factors": factors,
     }
+    if schema_version == OBSERVATION_FACTOR_SCHEMA_VERSION:
+        record["gauge_covariance"] = {
+            "semantics": bundle.gauge_covariance_semantics,
+            "joint_covariance_key": joint_covariance_key,
+            "ordered_gauge_ids": [gauge.window_id for gauge in bundle.gauges],
+            "cross_window_covariance_preserved": (
+                bundle.cross_window_gauge_covariance_preserved
+            ),
+            "diagonal_blocks_match_gauge_marginals": True,
+        }
     manifest.write_text(
         json.dumps(record, indent=2, sort_keys=True, allow_nan=False) + "\n",
         encoding="utf-8",
@@ -123,11 +151,46 @@ def write_observation_factor_bundle(
     return manifest, payload
 
 
+def write_observation_factor_bundle(
+    bundle: ObservationFactorBundle,
+    manifest_path: str | Path,
+    *,
+    payload_path: str | Path | None = None,
+) -> tuple[Path, Path]:
+    """Write a schema-v4 manifest with an ordered joint gauge covariance."""
+
+    return _write_observation_factor_bundle(
+        bundle,
+        manifest_path,
+        payload_path=payload_path,
+        schema_version=OBSERVATION_FACTOR_SCHEMA_VERSION,
+    )
+
+
+def write_observation_factor_bundle_v3(
+    bundle: ObservationFactorBundle,
+    manifest_path: str | Path,
+    *,
+    payload_path: str | Path | None = None,
+) -> tuple[Path, Path]:
+    """Write the frozen schema-v3 marginal-block compatibility representation."""
+
+    return _write_observation_factor_bundle(
+        bundle,
+        manifest_path,
+        payload_path=payload_path,
+        schema_version=PREVIOUS_OBSERVATION_FACTOR_SCHEMA_VERSION,
+    )
+
+
 def _causal_frame_stop(record: dict[str, Any], *, schema_version: int) -> int:
-    if schema_version == OBSERVATION_FACTOR_SCHEMA_VERSION:
+    if schema_version in {
+        PREVIOUS_OBSERVATION_FACTOR_SCHEMA_VERSION,
+        OBSERVATION_FACTOR_SCHEMA_VERSION,
+    }:
         convention = record.get("causal_frame_stop_convention")
         if convention is not None and convention != "exclusive":
-            raise ValueError("schema-v3 causal frame stop must be exclusive")
+            raise ValueError("nonlegacy causal frame stop must be exclusive")
         return int(record["causal_frame_stop"])
     if schema_version == LEGACY_OBSERVATION_FACTOR_SCHEMA_VERSION:
         return int(record["causal_frame_limit"]) + 1
@@ -137,7 +200,7 @@ def _causal_frame_stop(record: dict[str, Any], *, schema_version: int) -> int:
 def load_observation_factor_bundle(
     manifest_path: str | Path,
 ) -> ObservationFactorBundle:
-    """Load schema v3 or upgrade a schema-v2 bundle without ambiguity."""
+    """Load schema v4 or upgrade schema-v2/v3 bundles without ambiguity."""
 
     manifest = Path(manifest_path)
     record = json.loads(manifest.read_text(encoding="utf-8"))
@@ -146,6 +209,7 @@ def load_observation_factor_bundle(
     schema_version = int(record.get("schema_version", -1))
     if schema_version not in {
         LEGACY_OBSERVATION_FACTOR_SCHEMA_VERSION,
+        PREVIOUS_OBSERVATION_FACTOR_SCHEMA_VERSION,
         OBSERVATION_FACTOR_SCHEMA_VERSION,
     }:
         raise ValueError("unsupported observation-factor schema version")
@@ -160,6 +224,8 @@ def load_observation_factor_bundle(
         raise ValueError("observation-factor payload checksum mismatch")
     gauges: list[GaugeEstimate] = []
     factors: list[ObservationFactor] = []
+    joint_gauge_covariance: np.ndarray | None = None
+    gauge_covariance_semantics = "marginal-blocks-only"
     with np.load(payload, allow_pickle=False) as arrays:
         for gauge_record in record["gauges"]:
             gauges.append(
@@ -171,6 +237,35 @@ def load_observation_factor_bundle(
                     covariance=arrays[gauge_record["covariance_key"]],
                 )
             )
+        if schema_version == OBSERVATION_FACTOR_SCHEMA_VERSION:
+            covariance_record = record.get("gauge_covariance")
+            if not isinstance(covariance_record, dict):
+                raise ValueError("schema-v4 manifest is missing gauge_covariance")
+            gauge_covariance_semantics = str(covariance_record.get("semantics", ""))
+            preserved = covariance_record.get("cross_window_covariance_preserved")
+            if not isinstance(preserved, bool):
+                raise ValueError(
+                    "schema-v4 cross_window_covariance_preserved must be Boolean"
+                )
+            if preserved != (gauge_covariance_semantics == "joint-cross-window"):
+                raise ValueError(
+                    "schema-v4 gauge covariance semantics contradict the preservation flag"
+                )
+            if covariance_record.get("diagonal_blocks_match_gauge_marginals") is not True:
+                raise ValueError(
+                    "schema-v4 gauge covariance must declare matching marginal blocks"
+                )
+            joint_key = covariance_record.get("joint_covariance_key")
+            if not isinstance(joint_key, str) or not joint_key:
+                raise ValueError(
+                    "schema-v4 gauge covariance is missing joint_covariance_key"
+                )
+            ordered_gauge_ids = covariance_record.get("ordered_gauge_ids")
+            if ordered_gauge_ids != [gauge.window_id for gauge in gauges]:
+                raise ValueError(
+                    "schema-v4 joint gauge covariance order differs from gauge records"
+                )
+            joint_gauge_covariance = np.asarray(arrays[joint_key])
         for factor_record in record["factors"]:
             keys = factor_record["arrays"]
             ray_key = factor_record.get("ray_directions_local_key")
@@ -213,13 +308,20 @@ def load_observation_factor_bundle(
                 )
             )
     metadata = dict(record.get("metadata", {}))
-    if schema_version == LEGACY_OBSERVATION_FACTOR_SCHEMA_VERSION:
+    if schema_version != OBSERVATION_FACTOR_SCHEMA_VERSION:
         metadata = {
             **metadata,
             "loaded_from_schema_version": schema_version,
-            "legacy_causal_frame_limit_upgraded_to_exclusive_stop": True,
-            "legacy_missing_reliability_defaults": "ones",
+            "source_gauge_covariance_semantics": "marginal-blocks-only",
+            "source_cross_window_gauge_covariance_preserved": False,
         }
+        if schema_version == LEGACY_OBSERVATION_FACTOR_SCHEMA_VERSION:
+            metadata.update(
+                {
+                    "legacy_causal_frame_limit_upgraded_to_exclusive_stop": True,
+                    "legacy_missing_reliability_defaults": "ones",
+                }
+            )
     return ObservationFactorBundle(
         sequence_id=str(record["sequence_id"]),
         factors=tuple(factors),
@@ -233,4 +335,25 @@ def load_observation_factor_bundle(
         ),
         metadata=metadata,
         schema_version=OBSERVATION_FACTOR_SCHEMA_VERSION,
+        joint_gauge_covariance=joint_gauge_covariance,
+        gauge_covariance_semantics=gauge_covariance_semantics,
+    )
+
+
+def load_observation_factor_bundle_v3(
+    manifest_path: str | Path,
+) -> ObservationFactorBundle:
+    """Load through the frozen provider-v1 marginal-block schema boundary."""
+
+    bundle = load_observation_factor_bundle(manifest_path)
+    if bundle.gauge_covariance_semantics != "marginal-blocks-only":
+        raise ValueError(
+            "provider-v1 cannot load joint cross-window gauge covariance; "
+            "use prob4d.provider_v2"
+        )
+    return replace(
+        bundle,
+        schema_version=PREVIOUS_OBSERVATION_FACTOR_SCHEMA_VERSION,
+        joint_gauge_covariance=None,
+        gauge_covariance_semantics="marginal-blocks-only",
     )

--- a/src/prob4d/_observation_factor_types.py
+++ b/src/prob4d/_observation_factor_types.py
@@ -315,6 +315,16 @@ class StackedObservationFactors:
             raise ValueError("stacked gauge Jacobian has changed shape")
         if gauge_prior.shape != (gauge_dimension, gauge_dimension):
             raise ValueError("gauge prior covariance has changed shape")
+        if not np.all(np.isfinite(gauge_prior)):
+            raise ValueError("gauge prior covariance must be finite")
+        if not np.allclose(
+            gauge_prior,
+            gauge_prior.T,
+            atol=1e-12,
+            rtol=1e-10,
+        ):
+            raise ValueError("gauge prior covariance must be symmetric")
+        _require_psd(gauge_prior, "gauge prior covariance")
         for name, value in (
             ("association_probability", association),
             ("prior_reliability", reliability),

--- a/src/prob4d/observation_factors.py
+++ b/src/prob4d/observation_factors.py
@@ -7,11 +7,14 @@ timing.
 """
 
 from ._observation_factor_bundle import (
+    GAUGE_COVARIANCE_SEMANTICS,
     GAUGE_PARAMETERIZATION,
     LEGACY_OBSERVATION_FACTOR_SCHEMA_VERSION,
     OBSERVATION_FACTOR_SCHEMA,
     OBSERVATION_FACTOR_SCHEMA_VERSION,
     OBSERVATION_FACTOR_SOURCE_REPOSITORY,
+    PREVIOUS_OBSERVATION_FACTOR_SCHEMA_VERSION,
+    GaugeCovarianceSemantics,
     ObservationFactorBundle,
     sim3_point_jacobian,
     stack_observation_factors,
@@ -27,11 +30,14 @@ from ._observation_factor_types import (
 )
 
 __all__ = [
+    "GAUGE_COVARIANCE_SEMANTICS",
     "GAUGE_PARAMETERIZATION",
     "LEGACY_OBSERVATION_FACTOR_SCHEMA_VERSION",
     "OBSERVATION_FACTOR_SCHEMA",
     "OBSERVATION_FACTOR_SCHEMA_VERSION",
     "OBSERVATION_FACTOR_SOURCE_REPOSITORY",
+    "PREVIOUS_OBSERVATION_FACTOR_SCHEMA_VERSION",
+    "GaugeCovarianceSemantics",
     "LinearizedObservationFactor",
     "ObservationFactor",
     "ObservationFactorBundle",

--- a/src/prob4d/provider_v1.py
+++ b/src/prob4d/provider_v1.py
@@ -23,6 +23,10 @@ from ._metric_gauge_anchor import (
     load_metric_gauge_anchor,
     save_metric_gauge_anchor,
 )
+from ._observation_factor_io import (
+    load_observation_factor_bundle_v3,
+    write_observation_factor_bundle_v3,
+)
 from .alignment import CovarianceFallbackPolicy, alignment_covariance_context
 from .calibration import (
     GAUGE_COVARIANCE_CALIBRATION_SCHEMA,
@@ -49,10 +53,8 @@ from .observation_contract import (
 from .observation_export import SamplingMode, build_prob4d_observation_belief
 from .observation_factors import (
     OBSERVATION_FACTOR_SCHEMA,
-    OBSERVATION_FACTOR_SCHEMA_VERSION,
+    PREVIOUS_OBSERVATION_FACTOR_SCHEMA_VERSION,
     ObservationFactorBundle,
-    load_observation_factor_bundle,
-    write_observation_factor_bundle,
 )
 from .observation_validation import load_observation_belief_export
 from .provider_manifest import (
@@ -62,6 +64,9 @@ from .provider_manifest import (
 from .uncertainty import DepthDisagreementModel
 
 PROVIDER_API_VERSION = PROB4D_PROVIDER_API_VERSION
+OBSERVATION_FACTOR_SCHEMA_VERSION = PREVIOUS_OBSERVATION_FACTOR_SCHEMA_VERSION
+load_observation_factor_bundle = load_observation_factor_bundle_v3
+write_observation_factor_bundle = write_observation_factor_bundle_v3
 
 
 def select_causal_source(

--- a/src/prob4d/provider_v2.py
+++ b/src/prob4d/provider_v2.py
@@ -27,6 +27,13 @@ from .composition_jacobian import (
     composition_jacobian_mode,
 )
 from .covariance_root import CovarianceRootMode, covariance_root_mode
+from .observation_factors import (
+    OBSERVATION_FACTOR_SCHEMA,
+    OBSERVATION_FACTOR_SCHEMA_VERSION,
+    ObservationFactorBundle,
+    load_observation_factor_bundle,
+    write_observation_factor_bundle,
+)
 from .provider_attestation import (
     PROVIDER_ATTESTATION_SCHEMA,
     PROVIDER_ATTESTATION_VERSION,
@@ -42,8 +49,6 @@ from .provider_v1 import (
     METRIC_GAUGE_ANCHOR_VERSION,
     OBSERVATION_BELIEF_SCHEMA,
     OBSERVATION_BELIEF_VERSION,
-    OBSERVATION_FACTOR_SCHEMA,
-    OBSERVATION_FACTOR_SCHEMA_VERSION,
     POINT_UNCERTAINTY_CALIBRATION_SCHEMA,
     POINT_UNCERTAINTY_CALIBRATION_VERSION,
     PROB4D_CAUSAL_STREAM_CONTRACT_VERSION,
@@ -51,7 +56,6 @@ from .provider_v1 import (
     GaugeCovarianceCalibrationV1,
     MetricGaugeAnchor,
     ObservationBeliefExportV1,
-    ObservationFactorBundle,
     PointUncertaintyCalibrationV1,
     SamplingMode,
     SelectedOverlapWindow,
@@ -59,14 +63,12 @@ from .provider_v1 import (
     load_gauge_covariance_calibration,
     load_metric_gauge_anchor,
     load_observation_belief_export,
-    load_observation_factor_bundle,
     load_point_uncertainty_calibration,
     save_gauge_covariance_calibration,
     save_metric_gauge_anchor,
     save_observation_belief_export,
     save_point_uncertainty_calibration,
     select_causal_source,
-    write_observation_factor_bundle,
 )
 from .runtime_revision import (
     RuntimeRevisionAttestation,
@@ -103,6 +105,7 @@ def prob4d_provider_manifest(
         "analytic_sim3_composition_jacobians",
         "canonical_repeated_eigenspace_covariance_root",
         "explicit_exploratory_and_claim_bearing_exports",
+        "joint_cross_window_sim3_gauge_covariance_in_factor_bundle",
         "provider_attested_observation_artifacts",
         "runtime_revision_attestation",
         "strict_prediction_calibration_compatibility",
@@ -136,6 +139,12 @@ def prob4d_provider_manifest(
                 "export fixes sequential gauge propagation, uses canonical repeated-"
                 "eigenspace covariance roots, and forbids pointwise covariance fallback"
             ),
+            "observation_factor_bundle_covariance_semantics": (
+                "schema v4 stores an ordered joint 7K by 7K gauge covariance whose "
+                "diagonal blocks match the per-gauge marginals; explicit "
+                "joint-cross-window and marginal-blocks-only semantics are distinct, "
+                "while schema-v2/v3 inputs upgrade conservatively as marginal-only"
+            ),
             "provider_attestation_semantics": (
                 "every provider-v2 export embeds the complete content-addressed "
                 "provider manifest, export mode, covariance-root and composition-"
@@ -147,10 +156,18 @@ def prob4d_provider_manifest(
     limitations = dict(cast(dict[str, object], inherited["limitations"]))
     limitations["uncalibrated_export_is_default"] = False
     limitations["deployment_environment_revision_is_independent_vcs_evidence"] = False
+    limitations[
+        "schema_v2_v3_factor_bundles_preserve_cross_window_gauge_covariance"
+    ] = False
+    artifact_schema_versions = dict(
+        cast(dict[str, int], inherited["artifact_schema_versions"])
+    )
+    artifact_schema_versions["ObservationFactorBundle"] = OBSERVATION_FACTOR_SCHEMA_VERSION
     descriptor: dict[str, object] = {
         **inherited,
         "provider_api_version": PROVIDER_API_VERSION,
         "capabilities": capabilities,
+        "artifact_schema_versions": artifact_schema_versions,
         "limitations": limitations,
         "metadata": metadata,
     }

--- a/tests/test_observation_factors.py
+++ b/tests/test_observation_factors.py
@@ -1,9 +1,11 @@
 import json
+from dataclasses import replace
 from pathlib import Path
 
 import numpy as np
 import pytest
 
+import prob4d.provider_v1 as provider_v1
 from prob4d.gauge import GaugeEstimate
 from prob4d.observation_factors import (
     OBSERVATION_FACTOR_SCHEMA_VERSION,
@@ -62,6 +64,11 @@ def _bundle() -> ObservationFactorBundle:
             np.eye(7) * 1e-4,
         ),
     )
+    joint_gauge_covariance = np.zeros((14, 14), dtype=np.float64)
+    joint_gauge_covariance[:7, :7] = gauges[0].covariance
+    joint_gauge_covariance[7:, 7:] = gauges[1].covariance
+    joint_gauge_covariance[0, 7] = 1e-3
+    joint_gauge_covariance[7, 0] = 1e-3
     return ObservationFactorBundle(
         sequence_id="sequence-a",
         factors=(
@@ -81,6 +88,8 @@ def _bundle() -> ObservationFactorBundle:
         case_id="double-stretch-sloth",
         stream_id="prob4d:camera-points",
         metadata={"producer": "unit-test", "metric": True},
+        joint_gauge_covariance=joint_gauge_covariance,
+        gauge_covariance_semantics="joint-cross-window",
     )
 
 
@@ -94,7 +103,14 @@ def test_bundle_roundtrip_preserves_unfused_provenance(tmp_path: Path) -> None:
     record = json.loads(manifest.read_text(encoding="utf-8"))
 
     assert payload.is_file()
-    assert record["schema_version"] == 3
+    assert record["schema_version"] == 4
+    assert record["gauge_covariance"] == {
+        "cross_window_covariance_preserved": True,
+        "diagonal_blocks_match_gauge_marginals": True,
+        "joint_covariance_key": "joint_gauge_covariance",
+        "ordered_gauge_ids": ["window-0", "window-1"],
+        "semantics": "joint-cross-window",
+    }
     assert record["causal_frame_stop"] == 9
     assert record["causal_frame_stop_convention"] == "exclusive"
     assert loaded.sequence_id == bundle.sequence_id
@@ -104,6 +120,12 @@ def test_bundle_roundtrip_preserves_unfused_provenance(tmp_path: Path) -> None:
     assert loaded.source_repository == "FlorianPfaff/Prob4D"
     assert loaded.causal_frame_stop == 9
     assert loaded.causal_frame_limit == 8
+    assert loaded.gauge_covariance_semantics == "joint-cross-window"
+    assert loaded.cross_window_gauge_covariance_preserved
+    np.testing.assert_allclose(
+        loaded.joint_gauge_covariance,
+        bundle.joint_gauge_covariance,
+    )
     assert [factor.factor_id for factor in loaded.factors] == ["factor-0", "factor-1"]
     np.testing.assert_allclose(loaded.factors[0].prior_reliability, [0.7, 0.4])
     assert loaded.factors[0].prior_nominal_probability == pytest.approx(0.8)
@@ -163,12 +185,26 @@ def test_stacked_factors_keep_association_reliability_and_group_weights_separate
     np.testing.assert_allclose(stacked.composite_weight, [0.5, 0.5, 0.25, 0.25])
     assert stacked.causal_frame_stop == 9
     assert stacked.causal_frame_limit == 8
+    assert stacked.gauge_prior_covariance[0, 7] == pytest.approx(1e-3)
     assert stacked.correlation_group_ids == (
         "backbone-window-0",
         "backbone-window-0",
         "backbone-window-1",
         "backbone-window-1",
     )
+
+
+def test_stacked_joint_gauge_prior_preserves_cross_factor_covariance() -> None:
+    stacked = _bundle().stack()
+
+    cross_covariance = (
+        stacked.gauge_jacobian[0]
+        @ stacked.gauge_prior_covariance
+        @ stacked.gauge_jacobian[2].T
+    )
+
+    assert cross_covariance[0, 0] == pytest.approx(1e-3)
+    assert np.linalg.norm(cross_covariance) == pytest.approx(1e-3)
 
 
 def test_zero_reliability_row_is_not_stacked_even_with_high_association() -> None:
@@ -243,6 +279,102 @@ def test_bundle_rejects_inconsistent_group_parameters() -> None:
         )
 
 
+def test_bundle_rejects_joint_covariance_with_mismatched_marginal_block() -> None:
+    bundle = _bundle()
+    invalid = bundle.joint_gauge_covariance.copy()
+    invalid[0, 0] += 0.01
+
+    with pytest.raises(ValueError, match="diagonal blocks must match"):
+        ObservationFactorBundle(
+            sequence_id=bundle.sequence_id,
+            factors=bundle.factors,
+            gauges=bundle.gauges,
+            source_revision=bundle.source_revision,
+            causal_frame_stop=bundle.causal_frame_stop,
+            joint_gauge_covariance=invalid,
+            gauge_covariance_semantics="joint-cross-window",
+        )
+
+
+def test_bundle_rejects_cross_window_covariance_under_marginal_semantics() -> None:
+    bundle = _bundle()
+
+    with pytest.raises(ValueError, match="zero cross-window"):
+        ObservationFactorBundle(
+            sequence_id=bundle.sequence_id,
+            factors=bundle.factors,
+            gauges=bundle.gauges,
+            source_revision=bundle.source_revision,
+            causal_frame_stop=bundle.causal_frame_stop,
+            joint_gauge_covariance=bundle.joint_gauge_covariance,
+            gauge_covariance_semantics="marginal-blocks-only",
+        )
+
+
+def test_schema_v3_loader_upgrades_to_explicit_marginal_only_semantics(
+    tmp_path: Path,
+) -> None:
+    manifest, _ = write_observation_factor_bundle(
+        _bundle(), tmp_path / "factors.json"
+    )
+    record = json.loads(manifest.read_text(encoding="utf-8"))
+    record["schema_version"] = 3
+    record.pop("gauge_covariance")
+    manifest.write_text(json.dumps(record), encoding="utf-8")
+
+    loaded = load_observation_factor_bundle(manifest)
+
+    assert loaded.schema_version == OBSERVATION_FACTOR_SCHEMA_VERSION
+    assert loaded.metadata["loaded_from_schema_version"] == 3
+    assert loaded.gauge_covariance_semantics == "marginal-blocks-only"
+    assert not loaded.cross_window_gauge_covariance_preserved
+    assert loaded.joint_gauge_covariance[0, 7] == 0.0
+
+
+def test_schema_v4_loader_rejects_changed_joint_gauge_order(tmp_path: Path) -> None:
+    manifest, _ = write_observation_factor_bundle(
+        _bundle(), tmp_path / "factors.json"
+    )
+    record = json.loads(manifest.read_text(encoding="utf-8"))
+    record["gauge_covariance"]["ordered_gauge_ids"] = ["window-1", "window-0"]
+    manifest.write_text(json.dumps(record), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="order differs"):
+        load_observation_factor_bundle(manifest)
+
+
+def test_provider_v1_writer_remains_frozen_at_schema_v3(tmp_path: Path) -> None:
+    legacy_bundle = replace(
+        _bundle(),
+        joint_gauge_covariance=None,
+        gauge_covariance_semantics="marginal-blocks-only",
+    )
+
+    manifest, _ = provider_v1.write_observation_factor_bundle(
+        legacy_bundle,
+        tmp_path / "legacy-factors.json",
+    )
+    record = json.loads(manifest.read_text(encoding="utf-8"))
+
+    assert provider_v1.OBSERVATION_FACTOR_SCHEMA_VERSION == 3
+    assert record["schema_version"] == 3
+    assert "gauge_covariance" not in record
+    loaded = provider_v1.load_observation_factor_bundle(manifest)
+    assert loaded.schema_version == 3
+    assert loaded.gauge_covariance_semantics == "marginal-blocks-only"
+
+
+def test_provider_v1_loader_rejects_schema_v4_joint_covariance(
+    tmp_path: Path,
+) -> None:
+    manifest, _ = write_observation_factor_bundle(
+        _bundle(), tmp_path / "factors.json"
+    )
+
+    with pytest.raises(ValueError, match="use prob4d.provider_v2"):
+        provider_v1.load_observation_factor_bundle(manifest)
+
+
 def test_schema_v2_loader_upgrades_inclusive_limit_and_missing_reliability(
     tmp_path: Path,
 ) -> None:
@@ -251,6 +383,7 @@ def test_schema_v2_loader_upgrades_inclusive_limit_and_missing_reliability(
     )
     record = json.loads(manifest.read_text(encoding="utf-8"))
     record["schema_version"] = 2
+    record.pop("gauge_covariance")
     record["causal_frame_limit"] = record.pop("causal_frame_stop") - 1
     record.pop("causal_frame_stop_convention")
     for factor in record["factors"]:

--- a/tests/test_provider_manifest.py
+++ b/tests/test_provider_manifest.py
@@ -76,4 +76,12 @@ def test_provider_manifest_cli_can_emit_version_two(capsys) -> None:
     )
     payload = json.loads(capsys.readouterr().out)
     assert payload["provider_api_version"] == 2
+    assert payload["artifact_schema_versions"]["ObservationFactorBundle"] == 4
     assert "runtime_revision_attestation" in payload["capabilities"]
+    assert (
+        "joint_cross_window_sim3_gauge_covariance_in_factor_bundle"
+        in payload["capabilities"]
+    )
+    assert payload["limitations"][
+        "schema_v2_v3_factor_bundles_preserve_cross_window_gauge_covariance"
+    ] is False


### PR DESCRIPTION
## Summary

- introduce `ObservationFactorBundle` schema v4 with an ordered joint `7K x 7K` gauge covariance;
- distinguish `joint-cross-window` from `marginal-blocks-only` covariance semantics;
- validate finiteness, symmetry, positive semidefiniteness, gauge ordering, and equality between each joint diagonal block and its `GaugeEstimate` marginal;
- pass the full joint prior through `StackedObservationFactors` instead of reconstructing a block-diagonal approximation;
- serialize the joint covariance and its semantics in checksum-bound NPZ/JSON artifacts;
- upgrade schema-v2/v3 bundles conservatively as marginal-only without inferring missing cross-window blocks;
- keep `prob4d.provider_v1` frozen at schema v3 while `prob4d.provider_v2` advertises and exposes schema v4;
- document the covariance boundary and add regression coverage for cross-factor covariance, invalid semantics, schema migration, and provider compatibility.

## Why

The previous factor-bundle stack rebuilt the gauge prior from independent `7 x 7` marginal blocks. Sequential window gauges generally share metric-anchor and upstream gauge uncertainty, so this silently discarded nonzero cross-window covariance. A downstream explicit-gauge Bayesian update could therefore overstate information and disagree with the equivalent marginalized observation model.

Schema v4 makes the joint prior explicit and auditable. Legacy artifacts remain supported, but are labelled as marginal-only because their missing off-diagonal blocks cannot be reconstructed.

## Compatibility

- `prob4d.provider_v1` continues to advertise, write, and load factor schema v3.
- The provider-v1 writer rejects joint covariance rather than silently dropping it.
- The provider-v1 loader rejects schema-v4 joint bundles and directs callers to provider v2.
- `prob4d.provider_v2` advertises factor schema v4 and the new joint-covariance capability.

## Validation

Local validation against the latest successful source distribution:

- 233 available tests passed; three repository-only tests were unavailable because the source distribution omits their scripts/fixture inputs;
- focused factor-bundle and provider-manifest tests passed;
- source compilation and line-length checks passed;
- wheel build succeeded;
- an isolated installed-wheel smoke test verified the v1/v2 schema split, manifest declarations, and new capability.

GitHub Actions run 348 passed completely:

- Ruff and mypy;
- provider/runtime attestation checks and manifest emission;
- complete test suites on Python 3.10, 3.12, and 3.14;
- wheel and source-distribution builds;
- isolated wheel and source-distribution installation plus CLI smoke tests.