### PR TITLE
Add provider-v2 gauge parity ablation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -232,6 +232,7 @@ jobs:
           "$bin/prob4d" motioncrafter --help
           "$bin/prob4d-provider-manifest" --help
           "$bin/prob4d-ablate" --help
+          "$bin/prob4d-ablate-provider-v2-gauge" --help
           "$bin/prob4d-benchmark" --help
           "$bin/prob4d-export-observation-belief" --help
           "$bin/prob4d-export-calibrated-observation-belief" --help

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ All notable changes to Prob4D are documented here.
   recompute and validate it without importing Prob4D.
 - Version-selectable provider manifest emission through
   `prob4d provider manifest --api-version {1,2}`.
+- A provider-v2 gauge-backend ablation runner that preserves the seven-row
+  reconstruction contract while using the production causal spanning tree, analytic
+  composition Jacobians, and joint-covariance marginal adapter.
 - Provider-v2 unit, type, import, wheel, and source-distribution coverage.
 
 ### Changed

--- a/docs/provider-v2-gauge-ablation.md
+++ b/docs/provider-v2-gauge-ablation.md
@@ -30,7 +30,8 @@ upstream MotionCrafter baselines are unchanged. Prob4D rows use:
   provider-aligned marginals.
 
 The output metadata records the backend mode, provider API version, Jacobian mode,
-and whether cross-window covariance was preserved. Tests compare the adapter
+the availability of the joint cross-window covariance, and the explicit
+`per_window_marginals` adapter used by dense fusion. Tests compare the adapter
 against a direct call to the same tree estimator used by provider v2.
 
 ## Claim boundary

--- a/docs/provider-v2-gauge-ablation.md
+++ b/docs/provider-v2-gauge-ablation.md
@@ -1,0 +1,43 @@
+# Provider-v2 gauge-backend ablation
+
+`prob4d-ablate real` is retained as a frozen reproduction surface. Its sequential
+initialization combines every available earlier-window candidate with covariance
+intersection. Claim-bearing provider-v2 export instead selects one deterministic
+causal spanning tree and propagates its full joint cross-window `Sim(3)` covariance
+with analytic composition Jacobians.
+
+Use the provider-aligned runner when an experiment is intended to diagnose the
+same gauge backend that feeds a provider-v2 observation export:
+
+```bash
+prob4d-ablate-provider-v2-gauge \
+  --predictions outputs/test/predictions.json \
+  --truth data/test_truth.npz \
+  --calibration-predictions outputs/calibration/predictions.json \
+  --calibration-truth data/calibration_truth.npz \
+  --metric-anchor-every 2 \
+  --output-dir outputs/provider-v2-gauge-ablation
+```
+
+The command preserves the existing seven-row reconstruction contract. The two
+upstream MotionCrafter baselines are unchanged. Prob4D rows use:
+
+- posterior mode `sequential_joint_spanning_tree_v1`;
+- analytic `Sim(3)` composition Jacobians;
+- the full joint tree covariance before adapting its marginal blocks to the dense
+  fusion interface; and
+- the existing fixed-lag and simulated sparse-anchor rows initialized from those
+  provider-aligned marginals.
+
+The output metadata records the backend mode, provider API version, Jacobian mode,
+and whether cross-window covariance was preserved. Tests compare the adapter
+against a direct call to the same tree estimator used by provider v2.
+
+## Claim boundary
+
+This is a **gauge-backend parity benchmark**, not by itself a claim-bearing
+provider-v2 observation export. It reuses the historical point-uncertainty
+calibration and simulated metric-anchor protocol. A claim-bearing downstream run
+still requires independently fitted content-addressed gauge and point covariance
+calibrations, strict prediction/calibration compatibility, causal source sealing,
+runtime revision attestation, and the calibrated provider-v2 export entry point.

--- a/docs/provider-v2-gauge-ablation.md
+++ b/docs/provider-v2-gauge-ablation.md
@@ -7,7 +7,8 @@ causal spanning tree and propagates its full joint cross-window `Sim(3)` covaria
 with analytic composition Jacobians.
 
 Use the provider-aligned runner when an experiment is intended to diagnose the
-same gauge backend that feeds a provider-v2 observation export:
+same gauge-tree and composition backend that feeds a provider-v2 observation
+export:
 
 ```bash
 prob4d-ablate-provider-v2-gauge \
@@ -31,14 +32,18 @@ upstream MotionCrafter baselines are unchanged. Prob4D rows use:
 
 The output metadata records the backend mode, provider API version, Jacobian mode,
 the availability of the joint cross-window covariance, and the explicit
-`per_window_marginals` adapter used by dense fusion. Tests compare the adapter
-against a direct call to the same tree estimator used by provider v2.
+`per_window_marginals` adapter used by dense fusion. It also records that alignment
+covariance retains the historical pointwise-fallback policy and has no claim-bearing
+gauge-calibration artifact. Tests compare the tree adapter against a direct call to
+the same estimator used by provider v2.
 
 ## Claim boundary
 
-This is a **gauge-backend parity benchmark**, not by itself a claim-bearing
-provider-v2 observation export. It reuses the historical point-uncertainty
-calibration and simulated metric-anchor protocol. A claim-bearing downstream run
-still requires independently fitted content-addressed gauge and point covariance
-calibrations, strict prediction/calibration compatibility, causal source sealing,
-runtime revision attestation, and the calibrated provider-v2 export entry point.
+This is a **gauge-tree and Jacobian parity benchmark**, not by itself a
+claim-bearing provider-v2 observation export. It reuses the historical
+point-uncertainty calibration, permits the historical pointwise alignment-covariance
+fallback, and uses simulated metric anchors. A claim-bearing downstream run still
+requires independently fitted content-addressed gauge and point covariance
+calibrations, strict prediction/calibration compatibility, fail-closed spatial
+cluster covariance, causal source sealing, runtime revision attestation, and the
+calibrated provider-v2 export entry point.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dev = [
 prob4d = "prob4d.cli:main"
 prob4d-provider-manifest = "prob4d.provider_manifest_cli:main"
 prob4d-ablate = "prob4d.experiments:main"
+prob4d-ablate-provider-v2-gauge = "prob4d.provider_v2_gauge_ablation:main"
 prob4d-benchmark = "prob4d.benchmark:main"
 prob4d-export-observation-belief = "prob4d.causal_stream_cli:main"
 prob4d-export-calibrated-observation-belief = "prob4d.provider_v2_cli:main_calibrated"

--- a/src/prob4d/provider_v2_gauge_ablation.py
+++ b/src/prob4d/provider_v2_gauge_ablation.py
@@ -1,0 +1,331 @@
+"""Ablation runner using the exact provider-v2 sequential gauge backend.
+
+The historical :mod:`prob4d.experiments` runner is retained for reproduction. This
+module reuses its seven-row evaluation contract while replacing the multi-parent
+initial gauge estimator with the causal spanning-tree posterior used by provider v2.
+"""
+
+from __future__ import annotations
+
+import argparse
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from .alignment import WindowAlignment
+from .composition_jacobian import composition_jacobian_mode
+from .data import PredictionWindow
+from .experiments import (
+    AblationRow,
+    _baseline_sequence,
+    _dataset_calibration,
+    _evaluate,
+    _simulated_scale_anchors,
+    _uncertainties,
+    _window_truth_gauge,
+    _write_results,
+)
+from .fusion import fuse_windows
+from .gauge import FixedLagGaugeSmoother, GaugeEstimate, RelativeGaugeConstraint
+from .io import load_prediction_bundle, load_truth
+from .observation_export import (
+    JointGaugePosterior,
+    _build_alignments as _build_provider_alignments,
+    estimate_joint_gauge_tree,
+)
+from .sim3 import Sim3
+from .uncertainty import CalibrationReport, DepthDisagreementModel
+
+PROVIDER_V2_GAUGE_POSTERIOR_MODE = "sequential_joint_spanning_tree_v1"
+PROVIDER_V2_COMPOSITION_JACOBIAN_MODE = "analytic"
+
+
+def _default_anchor_covariance() -> np.ndarray:
+    """Return the frozen near-deterministic anchor used by the legacy benchmark."""
+
+    return np.diag(np.full(7, 1e-10, dtype=np.float64))
+
+
+def marginal_gauge_estimates(
+    posterior: JointGaugePosterior,
+) -> dict[str, GaugeEstimate]:
+    """Convert a joint posterior to the marginal format expected by fusion code."""
+
+    estimates: dict[str, GaugeEstimate] = {}
+    for index, window_id in enumerate(posterior.window_ids):
+        block = slice(7 * index, 7 * (index + 1))
+        estimates[window_id] = GaugeEstimate(
+            window_id=window_id,
+            global_from_local=posterior.estimates[window_id],
+            covariance=posterior.joint_covariance[block, block],
+        )
+    return estimates
+
+
+def build_provider_v2_alignments(
+    windows: Sequence[PredictionWindow],
+) -> list[WindowAlignment]:
+    """Build overlap alignments with the provider export's deterministic seeds."""
+
+    return _build_provider_alignments(windows)
+
+
+def estimate_provider_v2_gauge_backend(
+    windows: Sequence[PredictionWindow],
+    alignments: Sequence[WindowAlignment],
+    *,
+    initial_transform: Sim3 | None = None,
+    initial_covariance: np.ndarray | None = None,
+) -> tuple[JointGaugePosterior, dict[str, GaugeEstimate]]:
+    """Run the provider-v2 causal tree with analytic composition Jacobians.
+
+    This function deliberately uses the same ``estimate_joint_gauge_tree`` routine
+    selected by claim-bearing provider-v2 exports. It returns both the full joint
+    posterior and its per-window marginal adapter for the legacy fusion interfaces.
+    """
+
+    transform = Sim3.identity() if initial_transform is None else initial_transform
+    covariance = (
+        _default_anchor_covariance()
+        if initial_covariance is None
+        else np.asarray(initial_covariance, dtype=np.float64)
+    )
+    with composition_jacobian_mode(PROVIDER_V2_COMPOSITION_JACOBIAN_MODE):
+        posterior = estimate_joint_gauge_tree(
+            windows,
+            alignments,
+            initial_transform=transform,
+            initial_covariance=covariance,
+        )
+    if posterior.mode != PROVIDER_V2_GAUGE_POSTERIOR_MODE:
+        raise RuntimeError("provider-v2 gauge posterior mode changed unexpectedly")
+    if not posterior.cross_window_covariance_preserved:
+        raise RuntimeError("provider-v2 gauge posterior lost cross-window covariance")
+    return posterior, marginal_gauge_estimates(posterior)
+
+
+def run_provider_v2_gauge_manifest_ablation(
+    *,
+    predictions: str | Path,
+    truth_path: str | Path,
+    calibration_predictions: str | Path,
+    calibration_truth_path: str | Path,
+    metric_anchor_every: int = 2,
+    metric_anchor_standard_deviation: float = 0.02,
+) -> tuple[list[AblationRow], CalibrationReport, dict[str, Any]]:
+    """Run the seven real-data variants with provider-v2 gauge-tree semantics."""
+
+    test_bundle = load_prediction_bundle(predictions)
+    truth = load_truth(truth_path)
+    calibration_bundle = load_prediction_bundle(calibration_predictions)
+    calibration_truth = load_truth(calibration_truth_path)
+    model, report, _ = _dataset_calibration(
+        calibration_bundle,
+        calibration_truth,
+        DepthDisagreementModel(),
+    )
+
+    alignments = build_provider_v2_alignments(test_bundle.overlap_windows)
+    constraints = [
+        RelativeGaugeConstraint.from_window_alignment(alignment)
+        for alignment in alignments
+    ]
+    ordered_ids = [window.window_id for window in test_bundle.overlap_windows]
+    sequential_posterior, sequential = estimate_provider_v2_gauge_backend(
+        test_bundle.overlap_windows,
+        alignments,
+    )
+    smoothed = FixedLagGaugeSmoother(lag=4).smooth(
+        ordered_ids,
+        sequential,
+        constraints,
+    )
+
+    anchors = _simulated_scale_anchors(
+        test_bundle.overlap_windows,
+        truth,
+        every=metric_anchor_every,
+        standard_deviation=metric_anchor_standard_deviation,
+    )
+    anchored_posterior, anchored_initial = estimate_provider_v2_gauge_backend(
+        test_bundle.overlap_windows,
+        alignments,
+        initial_transform=Sim3(scale=anchors[0].scale),
+    )
+    anchored = FixedLagGaugeSmoother(lag=4).smooth(
+        ordered_ids,
+        anchored_initial,
+        constraints,
+        scale_anchors=anchors,
+    )
+
+    true_gauges = {
+        window.window_id: _window_truth_gauge(window, truth)
+        for window in test_bundle.overlap_windows
+    }
+    uncertainties = _uncertainties(test_bundle.overlap_windows, alignments, model)
+    boundaries = [window.start_frame for window in test_bundle.overlap_windows[1:]]
+    transforms = {
+        "sequential": {
+            key: value.global_from_local for key, value in sequential.items()
+        },
+        "smoothed": {key: value.global_from_local for key, value in smoothed.items()},
+        "anchored": {key: value.global_from_local for key, value in anchored.items()},
+    }
+    gauge_covariances = {
+        "sequential": {key: value.covariance for key, value in sequential.items()},
+        "smoothed": {key: value.covariance for key, value in smoothed.items()},
+        "anchored": {key: value.covariance for key, value in anchored.items()},
+    }
+    sequences = {
+        "decoded_uniform": fuse_windows(
+            test_bundle.overlap_windows,
+            transforms["sequential"],
+            uncertainties,
+            method="uniform",
+            gauge_covariances=gauge_covariances["sequential"],
+        ),
+        "precision": fuse_windows(
+            test_bundle.overlap_windows,
+            transforms["sequential"],
+            uncertainties,
+            method="precision",
+            gauge_covariances=gauge_covariances["sequential"],
+        ),
+        "ci": fuse_windows(
+            test_bundle.overlap_windows,
+            transforms["sequential"],
+            uncertainties,
+            method="covariance_intersection",
+            gauge_covariances=gauge_covariances["sequential"],
+        ),
+        "ci_smoothed": fuse_windows(
+            test_bundle.overlap_windows,
+            transforms["smoothed"],
+            uncertainties,
+            method="covariance_intersection",
+            gauge_covariances=gauge_covariances["smoothed"],
+        ),
+        "ci_smoothed_anchored": fuse_windows(
+            test_bundle.overlap_windows,
+            transforms["anchored"],
+            uncertainties,
+            method="covariance_intersection",
+            gauge_covariances=gauge_covariances["anchored"],
+        ),
+    }
+    definitions = [
+        (
+            "disjoint",
+            "Disjoint 25-frame windows",
+            _baseline_sequence(test_bundle.disjoint_baseline, model),
+            None,
+            "upstream_motioncrafter",
+        ),
+        (
+            "latent_linear",
+            "Latent-space linear overlap blend",
+            _baseline_sequence(test_bundle.latent_linear_baseline, model),
+            None,
+            "upstream_motioncrafter",
+        ),
+        (
+            "decoded_uniform",
+            "Decoded Sim(3) alignment + uniform fusion",
+            sequences["decoded_uniform"],
+            sequential,
+            "prob4d_provider_v2_gauge",
+        ),
+        (
+            "precision",
+            "Naive precision-weighted fusion",
+            sequences["precision"],
+            sequential,
+            "prob4d_provider_v2_gauge",
+        ),
+        (
+            "ci",
+            "Covariance intersection",
+            sequences["ci"],
+            sequential,
+            "prob4d_provider_v2_gauge",
+        ),
+        (
+            "ci_smoothed",
+            "Covariance intersection + fixed-lag gauge smoothing",
+            sequences["ci_smoothed"],
+            smoothed,
+            "prob4d_provider_v2_gauge",
+        ),
+        (
+            "ci_smoothed_anchored",
+            "Smoothed covariance intersection + sparse metric anchors",
+            sequences["ci_smoothed_anchored"],
+            anchored,
+            "prob4d_provider_v2_gauge",
+        ),
+    ]
+    rows = [
+        _evaluate(
+            key,
+            label,
+            sequence,
+            truth,
+            gauges=gauges,
+            true_gauges=true_gauges,
+            boundary_frames=boundaries,
+            baseline_source=source,
+        )
+        for key, label, sequence, gauges, source in definitions
+    ]
+    metadata = {
+        "benchmark": "motioncrafter_manifest_provider_v2_gauge",
+        "predictions": str(Path(predictions).resolve()),
+        "truth": str(Path(truth_path).resolve()),
+        "calibration_predictions": str(Path(calibration_predictions).resolve()),
+        "calibration_truth": str(Path(calibration_truth_path).resolve()),
+        "motioncrafter_commit": test_bundle.metadata.get("motioncrafter_commit"),
+        "metric_anchor_source": "simulated_from_ground_truth",
+        "metric_anchor_every": metric_anchor_every,
+        "metric_anchor_standard_deviation": metric_anchor_standard_deviation,
+        "gauge_backend": {
+            "provider_api_version": 2,
+            "posterior_mode": sequential_posterior.mode,
+            "anchored_posterior_mode": anchored_posterior.mode,
+            "composition_jacobian_mode": PROVIDER_V2_COMPOSITION_JACOBIAN_MODE,
+            "cross_window_covariance_preserved": (
+                sequential_posterior.cross_window_covariance_preserved
+            ),
+            "legacy_ablation_runner_unchanged": True,
+        },
+    }
+    return rows, report, metadata
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--predictions", type=Path, required=True)
+    parser.add_argument("--truth", type=Path, required=True)
+    parser.add_argument("--calibration-predictions", type=Path, required=True)
+    parser.add_argument("--calibration-truth", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--metric-anchor-every", type=int, default=2)
+    parser.add_argument("--metric-anchor-std", type=float, default=0.02)
+    arguments = parser.parse_args(argv)
+
+    rows, calibration, metadata = run_provider_v2_gauge_manifest_ablation(
+        predictions=arguments.predictions,
+        truth_path=arguments.truth,
+        calibration_predictions=arguments.calibration_predictions,
+        calibration_truth_path=arguments.calibration_truth,
+        metric_anchor_every=arguments.metric_anchor_every,
+        metric_anchor_standard_deviation=arguments.metric_anchor_std,
+    )
+    _write_results(arguments.output_dir, rows, calibration, metadata)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/prob4d/provider_v2_gauge_ablation.py
+++ b/src/prob4d/provider_v2_gauge_ablation.py
@@ -40,6 +40,7 @@ from .uncertainty import CalibrationReport, DepthDisagreementModel
 
 PROVIDER_V2_GAUGE_POSTERIOR_MODE = "sequential_joint_spanning_tree_v1"
 PROVIDER_V2_COMPOSITION_JACOBIAN_MODE = "analytic"
+ALIGNMENT_COVARIANCE_POLICY = "historical_pointwise_fallback"
 
 
 def _default_anchor_covariance() -> np.ndarray:
@@ -299,6 +300,9 @@ def run_provider_v2_gauge_manifest_ablation(
                 sequential_posterior.cross_window_covariance_preserved
             ),
             "dense_fusion_covariance_adapter": "per_window_marginals",
+            "alignment_covariance_policy": ALIGNMENT_COVARIANCE_POLICY,
+            "gauge_covariance_calibration_id": None,
+            "claim_bearing_provider_export": False,
             "legacy_ablation_runner_unchanged": True,
         },
     }

--- a/src/prob4d/provider_v2_gauge_ablation.py
+++ b/src/prob4d/provider_v2_gauge_ablation.py
@@ -1,4 +1,4 @@
-"""Ablation runner using the exact provider-v2 sequential gauge backend.
+"""Ablation runner using provider-v2 sequential gauge-tree semantics.
 
 The historical :mod:`prob4d.experiments` runner is retained for reproduction. This
 module reuses its seven-row evaluation contract while replacing the multi-parent
@@ -295,9 +295,10 @@ def run_provider_v2_gauge_manifest_ablation(
             "posterior_mode": sequential_posterior.mode,
             "anchored_posterior_mode": anchored_posterior.mode,
             "composition_jacobian_mode": PROVIDER_V2_COMPOSITION_JACOBIAN_MODE,
-            "cross_window_covariance_preserved": (
+            "joint_cross_window_covariance_available": (
                 sequential_posterior.cross_window_covariance_preserved
             ),
+            "dense_fusion_covariance_adapter": "per_window_marginals",
             "legacy_ablation_runner_unchanged": True,
         },
     }

--- a/tests/test_provider_v2_gauge_ablation.py
+++ b/tests/test_provider_v2_gauge_ablation.py
@@ -1,0 +1,110 @@
+import numpy as np
+from test_io import write_problem_bundle
+
+from prob4d.composition_jacobian import composition_jacobian_mode
+from prob4d.observation_export import estimate_joint_gauge_tree
+from prob4d.provider_v2_gauge_ablation import (
+    PROVIDER_V2_COMPOSITION_JACOBIAN_MODE,
+    PROVIDER_V2_GAUGE_POSTERIOR_MODE,
+    build_provider_v2_alignments,
+    estimate_provider_v2_gauge_backend,
+    run_provider_v2_gauge_manifest_ablation,
+)
+from prob4d.sim3 import Sim3
+from prob4d.synthetic import make_synthetic_problem
+
+
+def test_provider_v2_gauge_backend_matches_export_tree() -> None:
+    problem = make_synthetic_problem(
+        seed=41,
+        num_frames=45,
+        height=4,
+        width=6,
+        overlap=15,
+    )
+    alignments = build_provider_v2_alignments(problem.overlap_windows)
+    initial_covariance = np.diag(np.full(7, 1e-10))
+
+    posterior, marginals = estimate_provider_v2_gauge_backend(
+        problem.overlap_windows,
+        alignments,
+        initial_transform=Sim3.identity(),
+        initial_covariance=initial_covariance,
+    )
+    with composition_jacobian_mode(PROVIDER_V2_COMPOSITION_JACOBIAN_MODE):
+        direct = estimate_joint_gauge_tree(
+            problem.overlap_windows,
+            alignments,
+            initial_transform=Sim3.identity(),
+            initial_covariance=initial_covariance,
+        )
+
+    assert posterior.mode == PROVIDER_V2_GAUGE_POSTERIOR_MODE
+    assert posterior.parent_window_ids == direct.parent_window_ids
+    assert posterior.selected_alignment_indices == direct.selected_alignment_indices
+    np.testing.assert_allclose(posterior.joint_covariance, direct.joint_covariance)
+    for index, window_id in enumerate(posterior.window_ids):
+        np.testing.assert_allclose(
+            posterior.estimates[window_id].as_vector(),
+            direct.estimates[window_id].as_vector(),
+        )
+        block = slice(7 * index, 7 * (index + 1))
+        np.testing.assert_allclose(
+            marginals[window_id].covariance,
+            direct.joint_covariance[block, block],
+        )
+
+
+def test_provider_v2_gauge_ablation_preserves_seven_row_contract(tmp_path) -> None:
+    test_problem = make_synthetic_problem(
+        seed=51,
+        num_frames=45,
+        height=4,
+        width=6,
+        overlap=15,
+    )
+    calibration_problem = make_synthetic_problem(
+        seed=52,
+        num_frames=45,
+        height=4,
+        width=6,
+        overlap=15,
+    )
+    predictions, truth = write_problem_bundle(tmp_path / "test", test_problem)
+    calibration_predictions, calibration_truth = write_problem_bundle(
+        tmp_path / "calibration",
+        calibration_problem,
+    )
+
+    rows, calibration, metadata = run_provider_v2_gauge_manifest_ablation(
+        predictions=predictions,
+        truth_path=truth,
+        calibration_predictions=calibration_predictions,
+        calibration_truth_path=calibration_truth,
+    )
+
+    assert [row.key for row in rows] == [
+        "disjoint",
+        "latent_linear",
+        "decoded_uniform",
+        "precision",
+        "ci",
+        "ci_smoothed",
+        "ci_smoothed_anchored",
+    ]
+    assert calibration.count > 0
+    assert rows[0].baseline_source == "upstream_motioncrafter"
+    assert rows[1].baseline_source == "upstream_motioncrafter"
+    assert all(
+        row.baseline_source == "prob4d_provider_v2_gauge" for row in rows[2:]
+    )
+    assert metadata["benchmark"] == "motioncrafter_manifest_provider_v2_gauge"
+    assert metadata["metric_anchor_source"] == "simulated_from_ground_truth"
+    assert metadata["gauge_backend"] == {
+        "provider_api_version": 2,
+        "posterior_mode": PROVIDER_V2_GAUGE_POSTERIOR_MODE,
+        "anchored_posterior_mode": PROVIDER_V2_GAUGE_POSTERIOR_MODE,
+        "composition_jacobian_mode": PROVIDER_V2_COMPOSITION_JACOBIAN_MODE,
+        "cross_window_covariance_preserved": True,
+        "legacy_ablation_runner_unchanged": True,
+    }

--- a/tests/test_provider_v2_gauge_ablation.py
+++ b/tests/test_provider_v2_gauge_ablation.py
@@ -4,6 +4,7 @@ from test_io import write_problem_bundle
 from prob4d.composition_jacobian import composition_jacobian_mode
 from prob4d.observation_export import estimate_joint_gauge_tree
 from prob4d.provider_v2_gauge_ablation import (
+    ALIGNMENT_COVARIANCE_POLICY,
     PROVIDER_V2_COMPOSITION_JACOBIAN_MODE,
     PROVIDER_V2_GAUGE_POSTERIOR_MODE,
     build_provider_v2_alignments,
@@ -107,5 +108,8 @@ def test_provider_v2_gauge_ablation_preserves_seven_row_contract(tmp_path) -> No
         "composition_jacobian_mode": PROVIDER_V2_COMPOSITION_JACOBIAN_MODE,
         "joint_cross_window_covariance_available": True,
         "dense_fusion_covariance_adapter": "per_window_marginals",
+        "alignment_covariance_policy": ALIGNMENT_COVARIANCE_POLICY,
+        "gauge_covariance_calibration_id": None,
+        "claim_bearing_provider_export": False,
         "legacy_ablation_runner_unchanged": True,
     }

--- a/tests/test_provider_v2_gauge_ablation.py
+++ b/tests/test_provider_v2_gauge_ablation.py
@@ -105,6 +105,7 @@ def test_provider_v2_gauge_ablation_preserves_seven_row_contract(tmp_path) -> No
         "posterior_mode": PROVIDER_V2_GAUGE_POSTERIOR_MODE,
         "anchored_posterior_mode": PROVIDER_V2_GAUGE_POSTERIOR_MODE,
         "composition_jacobian_mode": PROVIDER_V2_COMPOSITION_JACOBIAN_MODE,
-        "cross_window_covariance_preserved": True,
+        "joint_cross_window_covariance_available": True,
+        "dense_fusion_covariance_adapter": "per_window_marginals",
         "legacy_ablation_runner_unchanged": True,
     }


### PR DESCRIPTION
## Summary

- add a separate seven-row real-data ablation runner that uses the provider-v2 causal spanning-tree gauge posterior and analytic `Sim(3)` composition Jacobians;
- adapt the joint gauge posterior to the existing dense-fusion interfaces through audited marginal blocks while preserving the full posterior for metadata and parity checks;
- retain `prob4d-ablate real` unchanged as the frozen multi-parent-CI reproduction surface;
- add direct provider-tree parity tests and a manifest-level seven-row regression test;
- expose `prob4d-ablate-provider-v2-gauge`, document its claim boundary, and smoke-test the installed wheel/sdist command.

## Why

The historical ablation runner initialized gauges with multi-parent covariance intersection, whereas provider v2 exports a deterministic causal spanning tree. A reconstruction result could therefore exercise a different gauge mean and covariance propagation backend from the observation provider consumed by Bayesian-PhysTwin and Causal4D.

This PR adds an explicit tree/Jacobian-parity benchmark without silently reinterpreting existing frozen results.

## Claim boundary

The new command establishes provider-v2 gauge-tree and composition-Jacobian parity only. Dense fusion consumes audited per-window marginal blocks. Alignment covariance retains the historical pointwise-fallback policy, no claim-bearing gauge-calibration artifact is attached, and sparse metric anchors remain simulated from truth. These limitations are machine-readable in the output metadata.

The command is not a substitute for calibrated provider-v2 observation export, fail-closed cluster covariance, provenance attestation, or a prospective Prob4D-to-Bayesian-PhysTwin result.

## Validation

- direct regression comparison against `estimate_joint_gauge_tree` under analytic composition Jacobians;
- manifest-level test preserving the seven-row output contract and explicit limitation metadata;
- branch CI runs Ruff, the full Python 3.10/3.12/3.14 test matrix, builds wheel/sdist artifacts, and smoke-tests the new installed command.