### PR TITLE
Add cross-fitted overlap disagreement diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ All notable changes to Prob4D are documented here.
 - `ObservationFactorBundle` schema v4 with an ordered joint `7K x 7K` gauge
   covariance, explicit joint-versus-marginal covariance semantics, fail-closed
   marginal-block validation, and conservative schema-v2/v3 migration.
+- A public cluster-cross-fitted overlap-disagreement diagnostic that holds out
+  frame-by-spatial-tile clusters, refits the relative gauge without them, fails
+  closed on unfittable folds, and reports the strictly out-of-fold evaluated fraction.
 - `prob4d.provider_v2` as a safe-by-default Python surface with distinct
   exploratory and claim-bearing export functions.
 - Strict prediction/calibration compatibility checks covering MotionCrafter

--- a/docs/cross-fitted-disagreement.md
+++ b/docs/cross-fitted-disagreement.md
@@ -28,7 +28,8 @@ print(report.to_dict())
 ## Information boundary
 
 The fit for a held-out fold cannot read any point in that fold. Fold assignment
-is deterministic for a fixed seed and uses the same frame-by-spatial-tile
+is deterministic for a fixed seed, derives its random stream from the alignment
+identity rather than list position, and uses the same frame-by-spatial-tile
 clustering concept as the dense gauge-covariance estimator.
 
 When a fold has fewer than four usable training correspondences, rank-deficient

--- a/docs/cross-fitted-disagreement.md
+++ b/docs/cross-fitted-disagreement.md
@@ -1,0 +1,68 @@
+# Cluster-cross-fitted overlap disagreement
+
+Prob4D normally estimates a relative `Sim(3)` gauge from overlapping
+MotionCrafter windows and then evaluates their residual disagreement. That
+in-sample residual is useful as an online consistency cue, but it can be
+optimistic because the same correspondences helped fit the gauge.
+
+`accumulate_cross_fitted_disagreement` provides an additive source-side
+diagnostic. It partitions overlap rows into whole frame-by-spatial-tile
+clusters, refits the relative gauge without one fold, and evaluates residual
+energy only on the held-out clusters.
+
+```python
+from prob4d import accumulate_cross_fitted_disagreement
+
+evidence, report = accumulate_cross_fitted_disagreement(
+    windows,
+    alignments,
+    folds=4,
+    cluster_size=32,
+    maximum_training_correspondences=100_000,
+    seed=0,
+)
+
+print(report.to_dict())
+```
+
+## Information boundary
+
+The fit for a held-out fold cannot read any point in that fold. Fold assignment
+is deterministic for a fixed seed and uses the same frame-by-spatial-tile
+clustering concept as the dense gauge-covariance estimator.
+
+When a fold has fewer than four usable training correspondences, rank-deficient
+geometry, or a failed numerical fit, Prob4D does **not** substitute the original
+in-sample alignment. The affected rows retain zero evidence count. The returned
+report records fitted and skipped folds, skipped alignments, overlap rows, and
+the strictly out-of-fold evaluated fraction.
+
+## Relationship to the existing uncertainty model
+
+The returned values use the same `DisagreementEvidence` representation consumed
+by `DepthDisagreementModel`. They can therefore be compared directly with the
+ordinary in-sample result:
+
+```python
+from prob4d.uncertainty import accumulate_disagreement
+
+in_sample = accumulate_disagreement(windows, alignments)
+cross_fitted, report = accumulate_cross_fitted_disagreement(
+    windows,
+    alignments,
+)
+```
+
+Cross-fitted evidence changes the statistical meaning and scale of the
+disagreement feature. Existing gauge and point-uncertainty calibration artifacts
+were fitted for the current production semantics and must not be reused
+silently. Before cross-fitted evidence enters a claim-bearing provider export:
+
+1. regenerate point-uncertainty calibration on disjoint sequence families;
+2. bind the fold count, cluster size, seed rule, and sampling cap into the
+   calibration compatibility record;
+3. compare in-sample and cross-fitted coverage, likelihood, and selective risk;
+4. preserve provider-v1 and frozen provider-v2 artifact reproduction.
+
+Until those gates pass, this API is a diagnostic and development surface rather
+than a new production default.

--- a/src/prob4d/__init__.py
+++ b/src/prob4d/__init__.py
@@ -14,6 +14,10 @@ from .calibration import (
     save_gauge_covariance_calibration,
     save_point_uncertainty_calibration,
 )
+from .cross_fitted_disagreement import (
+    CrossFittedDisagreementReport,
+    accumulate_cross_fitted_disagreement,
+)
 from .data import PredictionWindow
 from .evaluation_modes import (
     EvaluationModeResult,
@@ -59,6 +63,7 @@ __all__ = [
     "OBSERVATION_BELIEF_VERSION",
     "POINT_UNCERTAINTY_CALIBRATION_SCHEMA",
     "POINT_UNCERTAINTY_CALIBRATION_VERSION",
+    "CrossFittedDisagreementReport",
     "EvaluationModeResult",
     "EvaluationModes",
     "GaugeCovarianceCalibrationV1",
@@ -72,6 +77,7 @@ __all__ = [
     "PredictionWindow",
     "Sim3",
     "StackedObservationFactors",
+    "accumulate_cross_fitted_disagreement",
     "build_prob4d_observation_belief",
     "deterministic_covariance_root",
     "estimate_joint_gauge_tree",

--- a/src/prob4d/cross_fitted_disagreement.py
+++ b/src/prob4d/cross_fitted_disagreement.py
@@ -1,0 +1,434 @@
+"""Cluster-cross-fitted overlap disagreement for uncertainty diagnostics.
+
+The ordinary overlap disagreement is evaluated with the same correspondences that
+fit each relative ``Sim(3)`` gauge.  This module provides an additive diagnostic
+that holds out whole frame-by-spatial-tile clusters, refits the gauge on the
+remaining clusters, and scores only the held-out rows.
+
+No in-sample transform is substituted when a fold cannot be fitted.  Rows from a
+failed fold therefore retain zero evidence count, making missing cross-fitted
+support auditable instead of optimistic.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .alignment import WindowAlignment, estimate_sim3_robust
+from .data import PredictionWindow
+from .sim3 import Sim3
+from .uncertainty import DisagreementEvidence
+
+IntArray = NDArray[np.integer]
+
+
+@dataclass(frozen=True)
+class CrossFittedDisagreementReport:
+    """Audit information for one cross-fitted disagreement calculation."""
+
+    alignment_count: int
+    requested_folds: int
+    candidate_folds: int
+    fitted_folds: int
+    skipped_folds: int
+    skipped_alignments: int
+    overlap_points: int
+    evaluated_points: int
+    cluster_size: int
+    maximum_training_correspondences: int
+    seed: int
+
+    def __post_init__(self) -> None:
+        integer_fields = {
+            "alignment_count": self.alignment_count,
+            "requested_folds": self.requested_folds,
+            "candidate_folds": self.candidate_folds,
+            "fitted_folds": self.fitted_folds,
+            "skipped_folds": self.skipped_folds,
+            "skipped_alignments": self.skipped_alignments,
+            "overlap_points": self.overlap_points,
+            "evaluated_points": self.evaluated_points,
+            "cluster_size": self.cluster_size,
+            "maximum_training_correspondences": (
+                self.maximum_training_correspondences
+            ),
+            "seed": self.seed,
+        }
+        for name, value in integer_fields.items():
+            normalized = int(value)
+            if normalized != value:
+                raise ValueError(f"{name} must be an integer")
+            object.__setattr__(self, name, normalized)
+        if self.alignment_count < 0:
+            raise ValueError("alignment_count must be non-negative")
+        if self.requested_folds < 2:
+            raise ValueError("requested_folds must be at least two")
+        if self.candidate_folds < 0 or self.fitted_folds < 0:
+            raise ValueError("fold counts must be non-negative")
+        if self.skipped_folds < 0 or self.skipped_alignments < 0:
+            raise ValueError("skipped counts must be non-negative")
+        if self.fitted_folds + self.skipped_folds != self.candidate_folds:
+            raise ValueError("fitted and skipped folds must sum to candidate_folds")
+        if self.overlap_points < 0 or self.evaluated_points < 0:
+            raise ValueError("point counts must be non-negative")
+        if self.evaluated_points > self.overlap_points:
+            raise ValueError("evaluated_points cannot exceed overlap_points")
+        if self.cluster_size < 1:
+            raise ValueError("cluster_size must be positive")
+        if self.maximum_training_correspondences < 4:
+            raise ValueError(
+                "maximum_training_correspondences must be at least four"
+            )
+
+    @property
+    def evaluated_fraction(self) -> float:
+        """Fraction of overlap rows scored strictly out of fold."""
+
+        if self.overlap_points == 0:
+            return 0.0
+        return self.evaluated_points / self.overlap_points
+
+    def to_dict(self) -> dict[str, int | float]:
+        """Return a JSON-compatible audit summary."""
+
+        return {
+            "alignment_count": self.alignment_count,
+            "requested_folds": self.requested_folds,
+            "candidate_folds": self.candidate_folds,
+            "fitted_folds": self.fitted_folds,
+            "skipped_folds": self.skipped_folds,
+            "skipped_alignments": self.skipped_alignments,
+            "overlap_points": self.overlap_points,
+            "evaluated_points": self.evaluated_points,
+            "evaluated_fraction": self.evaluated_fraction,
+            "cluster_size": self.cluster_size,
+            "maximum_training_correspondences": (
+                self.maximum_training_correspondences
+            ),
+            "seed": self.seed,
+        }
+
+
+@dataclass(frozen=True)
+class _OverlapRows:
+    reference_index: int
+    moving_index: int
+    rows: IntArray
+    columns: IntArray
+    cluster_ids: IntArray
+
+
+def _validated_integer(
+    value: int,
+    *,
+    name: str,
+    minimum: int,
+) -> int:
+    normalized = int(value)
+    if normalized != value or normalized < minimum:
+        raise ValueError(f"{name} must be an integer of at least {minimum}")
+    return normalized
+
+
+def _clustered_overlap_rows(
+    reference: PredictionWindow,
+    moving: PredictionWindow,
+    alignment: WindowAlignment,
+    *,
+    cluster_size: int,
+) -> tuple[list[_OverlapRows], int, int]:
+    if reference.shape[1:] != moving.shape[1:]:
+        raise ValueError("overlapping windows must use the same spatial resolution")
+    records: list[_OverlapRows] = []
+    cluster_offset = 0
+    overlap_points = 0
+    width = reference.shape[2]
+    tile_columns = int(np.ceil(width / cluster_size))
+    for frame in alignment.common_frames:
+        reference_index = reference.local_index(int(frame))
+        moving_index = moving.local_index(int(frame))
+        mask = (
+            reference.valid_mask[reference_index]
+            & moving.valid_mask[moving_index]
+        )
+        rows, columns = np.nonzero(mask)
+        if not rows.size:
+            continue
+        tile_ids = (
+            rows // cluster_size * tile_columns
+            + columns // cluster_size
+        )
+        _, compact = np.unique(tile_ids, return_inverse=True)
+        cluster_ids = compact.astype(np.int64) + cluster_offset
+        cluster_offset += int(np.max(compact) + 1)
+        overlap_points += int(rows.size)
+        records.append(
+            _OverlapRows(
+                reference_index=reference_index,
+                moving_index=moving_index,
+                rows=rows.astype(np.int64),
+                columns=columns.astype(np.int64),
+                cluster_ids=cluster_ids,
+            )
+        )
+    return records, cluster_offset, overlap_points
+
+
+def _fold_assignment(
+    cluster_count: int,
+    fold_count: int,
+    *,
+    seed: int,
+) -> IntArray:
+    generator = np.random.default_rng(seed)
+    order = generator.permutation(cluster_count)
+    result = np.empty(cluster_count, dtype=np.int64)
+    result[order] = np.arange(cluster_count, dtype=np.int64) % fold_count
+    return result
+
+
+def _training_correspondences(
+    reference: PredictionWindow,
+    moving: PredictionWindow,
+    records: list[_OverlapRows],
+    cluster_folds: IntArray,
+    *,
+    held_out_fold: int,
+) -> tuple[np.ndarray, np.ndarray]:
+    source_parts: list[np.ndarray] = []
+    target_parts: list[np.ndarray] = []
+    for record in records:
+        selected = cluster_folds[record.cluster_ids] != held_out_fold
+        if not np.any(selected):
+            continue
+        rows = record.rows[selected]
+        columns = record.columns[selected]
+        source_parts.append(
+            moving.point_map[record.moving_index][rows, columns]
+        )
+        target_parts.append(
+            reference.point_map[record.reference_index][rows, columns]
+        )
+    if not source_parts:
+        return np.empty((0, 3)), np.empty((0, 3))
+    return np.concatenate(source_parts), np.concatenate(target_parts)
+
+
+def _residual_energy(
+    reference_points: np.ndarray,
+    moving_points: np.ndarray,
+    reference_rays: np.ndarray,
+    moving_rays: np.ndarray,
+    transform: Sim3,
+) -> tuple[np.ndarray, np.ndarray]:
+    source_aligned = transform.transform_points(moving_points)
+    residual = reference_points - source_aligned
+    rays = reference_rays + transform.rotate_directions(moving_rays)
+    ray_norm = np.linalg.norm(rays, axis=-1, keepdims=True)
+    rays = np.divide(
+        rays,
+        ray_norm,
+        out=reference_rays.copy(),
+        where=ray_norm > 1e-12,
+    )
+    parallel = np.sum(residual * rays, axis=-1) ** 2
+    total = np.sum(residual**2, axis=-1)
+    lateral = 0.5 * np.maximum(total - parallel, 0.0)
+    return parallel, lateral
+
+
+def _accumulate_rows(
+    evidence: dict[str, DisagreementEvidence],
+    reference: PredictionWindow,
+    moving: PredictionWindow,
+    record: _OverlapRows,
+    selected: np.ndarray,
+    transform: Sim3,
+    reference_rays: np.ndarray,
+    moving_rays: np.ndarray,
+) -> int:
+    rows = record.rows[selected]
+    columns = record.columns[selected]
+    if not rows.size:
+        return 0
+    parallel, lateral = _residual_energy(
+        reference.point_map[record.reference_index][rows, columns],
+        moving.point_map[record.moving_index][rows, columns],
+        reference_rays[record.reference_index][rows, columns],
+        moving_rays[record.moving_index][rows, columns],
+        transform,
+    )
+    for window_id, local_index in (
+        (reference.window_id, record.reference_index),
+        (moving.window_id, record.moving_index),
+    ):
+        item = evidence[window_id]
+        item.parallel_sum[local_index][rows, columns] += parallel
+        item.lateral_sum[local_index][rows, columns] += lateral
+        item.count[local_index][rows, columns] += 1.0
+    return int(rows.size)
+
+
+def accumulate_cross_fitted_disagreement(
+    windows: dict[str, PredictionWindow],
+    alignments: list[WindowAlignment],
+    *,
+    folds: int = 4,
+    cluster_size: int = 32,
+    maximum_training_correspondences: int = 100_000,
+    seed: int = 0,
+) -> tuple[
+    dict[str, DisagreementEvidence],
+    CrossFittedDisagreementReport,
+]:
+    """Estimate overlap disagreement without scoring gauge-fit correspondences.
+
+    Each alignment is partitioned into deterministic frame-by-spatial-tile
+    clusters.  For every fold, the relative gauge is fitted on all other
+    clusters and residual energy is accumulated only for the held-out clusters.
+
+    A fold that has too few or rank-deficient training correspondences is skipped.
+    The original in-sample alignment is never substituted.  Consequently, rows
+    from skipped folds retain zero evidence count and are visible in the returned
+    report.
+
+    The resulting evidence changes the uncertainty model's semantics.  Existing
+    point-uncertainty calibrations must therefore be regenerated before this
+    diagnostic is promoted into a claim-bearing provider export.
+    """
+
+    fold_count = _validated_integer(folds, name="folds", minimum=2)
+    cluster_width = _validated_integer(
+        cluster_size,
+        name="cluster_size",
+        minimum=1,
+    )
+    maximum = _validated_integer(
+        maximum_training_correspondences,
+        name="maximum_training_correspondences",
+        minimum=4,
+    )
+    normalized_seed = int(seed)
+    if normalized_seed != seed:
+        raise ValueError("seed must be an integer")
+    required_window_ids = {
+        window_id
+        for alignment in alignments
+        for window_id in (alignment.reference_id, alignment.moving_id)
+    }
+    missing = required_window_ids.difference(windows)
+    if missing:
+        raise KeyError(f"alignment windows are missing: {sorted(missing)}")
+
+    evidence = {
+        window_id: DisagreementEvidence.empty(window.shape)
+        for window_id, window in windows.items()
+    }
+    candidate_folds = 0
+    fitted_folds = 0
+    skipped_folds = 0
+    skipped_alignments = 0
+    overlap_points = 0
+    evaluated_points = 0
+
+    for alignment_index, alignment in enumerate(alignments):
+        reference = windows[alignment.reference_id]
+        moving = windows[alignment.moving_id]
+        records, cluster_count, alignment_points = _clustered_overlap_rows(
+            reference,
+            moving,
+            alignment,
+            cluster_size=cluster_width,
+        )
+        overlap_points += alignment_points
+        effective_folds = min(fold_count, cluster_count)
+        if effective_folds < 2 or not records:
+            skipped_alignments += 1
+            continue
+        candidate_folds += effective_folds
+        cluster_folds = _fold_assignment(
+            cluster_count,
+            effective_folds,
+            seed=normalized_seed + 1_000_003 * alignment_index,
+        )
+        reference_rays = reference.rays()
+        moving_rays = moving.rays()
+        alignment_fitted_folds = 0
+
+        for held_out_fold in range(effective_folds):
+            source, target = _training_correspondences(
+                reference,
+                moving,
+                records,
+                cluster_folds,
+                held_out_fold=held_out_fold,
+            )
+            if source.shape[0] > maximum:
+                generator = np.random.default_rng(
+                    normalized_seed
+                    + 1_000_003 * alignment_index
+                    + 97_409 * held_out_fold
+                )
+                selected = np.sort(
+                    generator.choice(
+                        source.shape[0],
+                        size=maximum,
+                        replace=False,
+                    )
+                )
+                source = source[selected]
+                target = target[selected]
+            if source.shape[0] < 4:
+                skipped_folds += 1
+                continue
+            try:
+                transform = estimate_sim3_robust(source, target).transform
+            except (ValueError, np.linalg.LinAlgError):
+                skipped_folds += 1
+                continue
+
+            fold_points = 0
+            for record in records:
+                held_out = (
+                    cluster_folds[record.cluster_ids] == held_out_fold
+                )
+                fold_points += _accumulate_rows(
+                    evidence,
+                    reference,
+                    moving,
+                    record,
+                    held_out,
+                    transform,
+                    reference_rays,
+                    moving_rays,
+                )
+            fitted_folds += 1
+            alignment_fitted_folds += 1
+            evaluated_points += fold_points
+
+        if alignment_fitted_folds == 0:
+            skipped_alignments += 1
+
+    report = CrossFittedDisagreementReport(
+        alignment_count=len(alignments),
+        requested_folds=fold_count,
+        candidate_folds=candidate_folds,
+        fitted_folds=fitted_folds,
+        skipped_folds=skipped_folds,
+        skipped_alignments=skipped_alignments,
+        overlap_points=overlap_points,
+        evaluated_points=evaluated_points,
+        cluster_size=cluster_width,
+        maximum_training_correspondences=maximum,
+        seed=normalized_seed,
+    )
+    return evidence, report
+
+
+__all__ = [
+    "CrossFittedDisagreementReport",
+    "accumulate_cross_fitted_disagreement",
+]

--- a/src/prob4d/cross_fitted_disagreement.py
+++ b/src/prob4d/cross_fitted_disagreement.py
@@ -12,6 +12,7 @@ support auditable instead of optimistic.
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import dataclass
 
 import numpy as np
@@ -177,6 +178,22 @@ def _clustered_overlap_rows(
     return records, cluster_offset, overlap_points
 
 
+def _stable_alignment_seed(
+    seed: int,
+    alignment: WindowAlignment,
+) -> int:
+    digest = hashlib.sha256()
+    digest.update(str(seed).encode("ascii"))
+    digest.update(b"\0")
+    digest.update(alignment.reference_id.encode("utf-8"))
+    digest.update(b"\0")
+    digest.update(alignment.moving_id.encode("utf-8"))
+    digest.update(b"\0")
+    frames = np.asarray(alignment.common_frames, dtype="<i8")
+    digest.update(frames.tobytes())
+    return int.from_bytes(digest.digest()[:8], "big")
+
+
 def _fold_assignment(
     cluster_count: int,
     fold_count: int,
@@ -334,7 +351,7 @@ def accumulate_cross_fitted_disagreement(
     overlap_points = 0
     evaluated_points = 0
 
-    for alignment_index, alignment in enumerate(alignments):
+    for alignment in alignments:
         reference = windows[alignment.reference_id]
         moving = windows[alignment.moving_id]
         records, cluster_count, alignment_points = _clustered_overlap_rows(
@@ -349,10 +366,11 @@ def accumulate_cross_fitted_disagreement(
             skipped_alignments += 1
             continue
         candidate_folds += effective_folds
+        alignment_seed = _stable_alignment_seed(normalized_seed, alignment)
         cluster_folds = _fold_assignment(
             cluster_count,
             effective_folds,
-            seed=normalized_seed + 1_000_003 * alignment_index,
+            seed=alignment_seed,
         )
         reference_rays = reference.rays()
         moving_rays = moving.rays()
@@ -368,9 +386,7 @@ def accumulate_cross_fitted_disagreement(
             )
             if source.shape[0] > maximum:
                 generator = np.random.default_rng(
-                    normalized_seed
-                    + 1_000_003 * alignment_index
-                    + 97_409 * held_out_fold
+                    alignment_seed + 97_409 * held_out_fold
                 )
                 selected = np.sort(
                     generator.choice(

--- a/tests/test_cross_fitted_disagreement.py
+++ b/tests/test_cross_fitted_disagreement.py
@@ -68,6 +68,51 @@ def _tile_bias_fixture() -> tuple[
     )
 
 
+def _two_alignment_fixture() -> tuple[
+    dict[str, PredictionWindow],
+    list[WindowAlignment],
+]:
+    windows, alignments = _tile_bias_fixture()
+    reference = windows["reference"]
+    second_points = reference.point_map[0].copy()
+    second_offsets = np.asarray(
+        [
+            [-0.03, 0.06, 0.01],
+            [0.07, -0.01, -0.03],
+            [-0.02, -0.05, 0.04],
+            [0.01, 0.03, -0.02],
+        ]
+    )
+    offset_index = 0
+    for tile_row in range(2):
+        for tile_column in range(2):
+            second_points[
+                2 * tile_row : 2 * (tile_row + 1),
+                2 * tile_column : 2 * (tile_column + 1),
+            ] -= second_offsets[offset_index]
+            offset_index += 1
+    second = PredictionWindow(
+        "moving-second",
+        np.asarray([0]),
+        second_points[None],
+        np.ones((1, 4, 4), dtype=bool),
+    )
+    result = estimate_sim3_robust(
+        second_points.reshape(-1, 3),
+        reference.point_map[0].reshape(-1, 3),
+    )
+    windows["moving-second"] = second
+    alignments.append(
+        WindowAlignment(
+            reference_id="reference",
+            moving_id="moving-second",
+            common_frames=np.asarray([0]),
+            result=result,
+        )
+    )
+    return windows, alignments
+
+
 def test_cross_fitted_disagreement_exposes_fit_optimism() -> None:
     windows, alignments = _tile_bias_fixture()
     in_sample = accumulate_disagreement(windows, alignments)
@@ -129,6 +174,39 @@ def test_cross_fitted_disagreement_is_deterministic() -> None:
         np.testing.assert_array_equal(
             first[window_id].count,
             second[window_id].count,
+        )
+
+
+def test_cross_fitted_disagreement_is_alignment_order_invariant() -> None:
+    windows, alignments = _two_alignment_fixture()
+    forward, forward_report = accumulate_cross_fitted_disagreement(
+        windows,
+        alignments,
+        folds=2,
+        cluster_size=2,
+        seed=31,
+    )
+    reverse, reverse_report = accumulate_cross_fitted_disagreement(
+        windows,
+        list(reversed(alignments)),
+        folds=2,
+        cluster_size=2,
+        seed=31,
+    )
+
+    assert forward_report == reverse_report
+    for window_id in windows:
+        np.testing.assert_array_equal(
+            forward[window_id].parallel_sum,
+            reverse[window_id].parallel_sum,
+        )
+        np.testing.assert_array_equal(
+            forward[window_id].lateral_sum,
+            reverse[window_id].lateral_sum,
+        )
+        np.testing.assert_array_equal(
+            forward[window_id].count,
+            reverse[window_id].count,
         )
 
 

--- a/tests/test_cross_fitted_disagreement.py
+++ b/tests/test_cross_fitted_disagreement.py
@@ -1,0 +1,152 @@
+import numpy as np
+
+from prob4d.alignment import WindowAlignment, estimate_sim3_robust
+from prob4d.cross_fitted_disagreement import (
+    accumulate_cross_fitted_disagreement,
+)
+from prob4d.data import PredictionWindow
+from prob4d.uncertainty import accumulate_disagreement
+
+
+def _tile_bias_fixture() -> tuple[
+    dict[str, PredictionWindow],
+    list[WindowAlignment],
+]:
+    rows, columns = np.mgrid[0:4, 0:4]
+    reference_points = np.stack(
+        (
+            0.30 * columns,
+            0.25 * rows,
+            1.0 + 0.20 * rows + 0.10 * columns + 0.05 * rows * columns,
+        ),
+        axis=-1,
+    )
+    tile_offsets = np.asarray(
+        [
+            [0.08, 0.00, 0.02],
+            [-0.05, 0.04, -0.01],
+            [0.02, -0.07, 0.03],
+            [-0.04, -0.02, -0.04],
+        ]
+    )
+    moving_points = reference_points.copy()
+    offset_index = 0
+    for tile_row in range(2):
+        for tile_column in range(2):
+            moving_points[
+                2 * tile_row : 2 * (tile_row + 1),
+                2 * tile_column : 2 * (tile_column + 1),
+            ] -= tile_offsets[offset_index]
+            offset_index += 1
+
+    valid = np.ones((1, 4, 4), dtype=bool)
+    reference = PredictionWindow(
+        "reference",
+        np.asarray([0]),
+        reference_points[None],
+        valid,
+    )
+    moving = PredictionWindow(
+        "moving",
+        np.asarray([0]),
+        moving_points[None],
+        valid,
+    )
+    result = estimate_sim3_robust(
+        moving_points.reshape(-1, 3),
+        reference_points.reshape(-1, 3),
+    )
+    alignment = WindowAlignment(
+        reference_id="reference",
+        moving_id="moving",
+        common_frames=np.asarray([0]),
+        result=result,
+    )
+    return (
+        {"reference": reference, "moving": moving},
+        [alignment],
+    )
+
+
+def test_cross_fitted_disagreement_exposes_fit_optimism() -> None:
+    windows, alignments = _tile_bias_fixture()
+    in_sample = accumulate_disagreement(windows, alignments)
+    cross_fitted, report = accumulate_cross_fitted_disagreement(
+        windows,
+        alignments,
+        folds=4,
+        cluster_size=2,
+        seed=7,
+    )
+
+    in_sample_energy = (
+        in_sample["reference"].parallel_mean
+        + in_sample["reference"].lateral_mean
+    )
+    cross_fitted_energy = (
+        cross_fitted["reference"].parallel_mean
+        + cross_fitted["reference"].lateral_mean
+    )
+
+    assert report.fitted_folds == 4
+    assert report.skipped_folds == 0
+    assert report.evaluated_points == 16
+    assert report.evaluated_fraction == 1.0
+    np.testing.assert_allclose(
+        cross_fitted["reference"].count,
+        np.ones((1, 4, 4)),
+    )
+    assert np.mean(cross_fitted_energy) > 1.5 * np.mean(in_sample_energy)
+
+
+def test_cross_fitted_disagreement_is_deterministic() -> None:
+    windows, alignments = _tile_bias_fixture()
+    first, first_report = accumulate_cross_fitted_disagreement(
+        windows,
+        alignments,
+        folds=4,
+        cluster_size=2,
+        seed=19,
+    )
+    second, second_report = accumulate_cross_fitted_disagreement(
+        windows,
+        alignments,
+        folds=4,
+        cluster_size=2,
+        seed=19,
+    )
+
+    assert first_report == second_report
+    for window_id in windows:
+        np.testing.assert_array_equal(
+            first[window_id].parallel_sum,
+            second[window_id].parallel_sum,
+        )
+        np.testing.assert_array_equal(
+            first[window_id].lateral_sum,
+            second[window_id].lateral_sum,
+        )
+        np.testing.assert_array_equal(
+            first[window_id].count,
+            second[window_id].count,
+        )
+
+
+def test_cross_fitted_disagreement_fails_closed_without_two_clusters() -> None:
+    windows, alignments = _tile_bias_fixture()
+    evidence, report = accumulate_cross_fitted_disagreement(
+        windows,
+        alignments,
+        folds=4,
+        cluster_size=16,
+    )
+
+    assert report.candidate_folds == 0
+    assert report.fitted_folds == 0
+    assert report.skipped_alignments == 1
+    assert report.overlap_points == 16
+    assert report.evaluated_points == 0
+    for item in evidence.values():
+        assert not np.any(item.count)
+        assert not np.any(item.parallel_sum)
+        assert not np.any(item.lateral_sum)


### PR DESCRIPTION
## Summary

- add `accumulate_cross_fitted_disagreement` as a public additive API;
- partition overlap rows into deterministic frame-by-spatial-tile folds;
- derive each fold assignment from a stable alignment identity rather than caller list order;
- refit each relative `Sim(3)` gauge without the held-out fold and score only held-out rows;
- fail closed when a fold is too small, rank deficient, or numerically unfittable instead of substituting the in-sample transform;
- return a structured report with fitted/skipped folds, skipped alignments, overlap rows, and the strictly out-of-fold evaluated fraction;
- add regressions for fit optimism, deterministic repetition, alignment-order invariance, and insufficient-cluster fallback;
- document that existing point-uncertainty calibrations must be regenerated before this diagnostic enters a claim-bearing provider export.

## Why

The current overlap-disagreement feature is evaluated on the same correspondences used to fit each window gauge. That is a valid online consistency cue, but it can understate prediction error because the alignment has already adapted to those rows. Cross-fitting exposes this optimism without changing frozen provider-v1/v2 artifact semantics.

## Compatibility and scientific boundary

- Existing `accumulate_disagreement` behavior is unchanged.
- Provider-v1 and provider-v2 observation artifacts are unchanged.
- The new API is diagnostic and additive; it is not a new claim-bearing default.
- Promotion requires independently regenerated calibration artifacts that bind the fold count, cluster size, stable seed rule, and correspondence cap.

## Validation

- Python compilation passed for the new module, tests, and root export.
- A local lightweight execution of all four proposed regressions passed.
- Repository CI runs Ruff, the complete Python 3.10/3.12/3.14 test matrix, distribution builds, and isolated wheel/sdist command smoke tests.