### PR TITLE
Harden claim-bearing observation loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to Prob4D are documented here.
 
 ### Added
 
+- `load_claim_bearing_observation_belief` and
+  `validate_claim_bearing_observation_belief` as explicit
+  `prob4d.provider_v2_loading` admission boundaries for calibrated, causal,
+  independently attested observations.
+- `ValidatedClaimBearingObservation` with the validated provider manifest,
+  calibration, runtime-revision, and observation artifact identities.
 - `ObservationFactorBundle` schema v4 with an ordered joint `7K x 7K` gauge
   covariance, explicit joint-versus-marginal covariance semantics, fail-closed
   marginal-block validation, and conservative schema-v2/v3 migration.
@@ -38,6 +44,10 @@ All notable changes to Prob4D are documented here.
 
 ### Changed
 
+- `ObservationBeliefExportV1.metadata` is now recursively immutable after finite-JSON
+  normalization. Ordinary `dict`/`list` checks and mutable `copy`/`deepcopy` workflows
+  remain supported, while caller-owned or nested mutation cannot change an existing
+  content address.
 - Stacked unfused factors now retain cross-window gauge covariance rather than
   reconstructing a block-diagonal prior from per-gauge marginals. The frozen
   provider-v1 writer remains schema v3 and rejects joint covariance it cannot encode.

--- a/docs/claim-bearing-observation-loading.md
+++ b/docs/claim-bearing-observation-loading.md
@@ -1,0 +1,54 @@
+# Strict claim-bearing observation loading
+
+`prob4d.provider_v2_loading` separates ordinary contract loading from admission into a
+claim-bearing experiment. `load_observation_belief_export` continues to validate the
+neutral `ObservationBeliefV1` content address and remains appropriate for frozen or
+exploratory artifacts. New prospective experiments should instead use:
+
+```python
+from prob4d.provider_v2_loading import load_claim_bearing_observation_belief
+
+validated = load_claim_bearing_observation_belief(
+    "outputs/held-out/observation_belief.npz"
+)
+observation = validated.observation
+```
+
+The strict loader rejects the artifact unless all of the following agree:
+
+- the source repository and strict Prob4D causal stream identity;
+- causal-stream contract version 2 and the exclusive frame cutoff;
+- selected source-window lineage with no future payload access;
+- canonical shared joint-gauge factor names and one factor group;
+- the sequential joint spanning-tree gauge model with preserved cross-window
+  covariance and no approximate fixed-lag boundary;
+- calibrated covariance metadata and the same two calibration artifact IDs in the
+  provider attestation;
+- a calibrated provider-v2 attestation using canonical covariance roots and analytic
+  composition Jacobians; and
+- an independently verified runtime revision equal to the observation source
+  revision.
+
+The returned `ValidatedClaimBearingObservation` also exposes the validated provider
+manifest ID, gauge and point calibration IDs, runtime revision, and observation
+artifact ID. It does not replace downstream Bayesian-PhysTwin validation or its
+baseline-relative accept/fallback decision.
+
+## Immutable metadata
+
+`ObservationBeliefExportV1.metadata` is normalized as finite JSON and recursively
+frozen after construction. Nested values remain compatible with ordinary
+`isinstance(value, dict)` and `isinstance(value, list)` checks, but every in-place
+mutation raises `TypeError`. Caller-owned inputs are defensively copied, so modifying
+the original metadata cannot change an existing observation or its content address.
+
+`copy.copy` and `copy.deepcopy` return ordinary mutable JSON containers. This keeps
+existing workflows such as `metadata = deepcopy(observation.metadata)` followed by
+`dataclasses.replace(...)` available without weakening the immutable artifact.
+
+## Compatibility
+
+The neutral observation schema and provider-v1 behavior are unchanged. Artifact IDs
+for unchanged metadata remain byte-for-byte stable because descriptors still contain
+ordinary canonical JSON. The strict loader is additive and must be selected
+explicitly by new claim-bearing workflows.

--- a/src/prob4d/_immutable_json.py
+++ b/src/prob4d/_immutable_json.py
@@ -1,0 +1,131 @@
+"""Finite JSON normalization with recursively immutable dict/list values."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any
+
+
+def plain_json(value: Any) -> Any:
+    """Return ordinary JSON-compatible containers for a frozen JSON value."""
+
+    if isinstance(value, Mapping):
+        return {str(key): plain_json(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [plain_json(item) for item in value]
+    return value
+
+
+class FrozenJsonDict(dict[str, Any]):
+    """A ``dict``-compatible mapping that rejects every in-place mutation."""
+
+    __slots__ = ()
+    _MUTATORS = frozenset({"clear", "pop", "popitem", "setdefault", "update"})
+
+    def __getattribute__(self, name: str) -> Any:
+        if name in type(self)._MUTATORS:
+            return self._immutable
+        return super().__getattribute__(name)
+
+    @staticmethod
+    def _immutable(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise TypeError("metadata is immutable")
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self._immutable(key, value)
+
+    def __delitem__(self, key: str) -> None:
+        self._immutable(key)
+
+    def __ior__(self, other: object) -> FrozenJsonDict:
+        self._immutable(other)
+        return self
+
+    def __copy__(self) -> dict[str, Any]:
+        return plain_json(self)
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> dict[str, Any]:
+        del memo
+        return plain_json(self)
+
+
+class FrozenJsonList(list[Any]):
+    """A ``list``-compatible sequence that rejects every in-place mutation."""
+
+    __slots__ = ()
+    _MUTATORS = frozenset(
+        {"append", "clear", "extend", "insert", "pop", "remove", "reverse", "sort"}
+    )
+
+    def __getattribute__(self, name: str) -> Any:
+        if name in type(self)._MUTATORS:
+            return self._immutable
+        return super().__getattribute__(name)
+
+    @staticmethod
+    def _immutable(*args: object, **kwargs: object) -> None:
+        del args, kwargs
+        raise TypeError("metadata is immutable")
+
+    def __setitem__(self, key: int | slice, value: Any) -> None:
+        self._immutable(key, value)
+
+    def __delitem__(self, key: int | slice) -> None:
+        self._immutable(key)
+
+    def __iadd__(self, other: object) -> FrozenJsonList:
+        self._immutable(other)
+        return self
+
+    def __imul__(self, other: object) -> FrozenJsonList:
+        self._immutable(other)
+        return self
+
+    def __copy__(self) -> list[Any]:
+        return plain_json(self)
+
+    def __deepcopy__(self, memo: dict[int, Any]) -> list[Any]:
+        del memo
+        return plain_json(self)
+
+
+def _freeze_json(value: Any) -> Any:
+    if isinstance(value, dict):
+        return FrozenJsonDict(
+            {str(key): _freeze_json(item) for key, item in value.items()}
+        )
+    if isinstance(value, list):
+        return FrozenJsonList(_freeze_json(item) for item in value)
+    return value
+
+
+def frozen_finite_json_mapping(
+    values: Mapping[str, Any],
+    *,
+    name: str = "metadata",
+) -> Mapping[str, Any]:
+    """Normalize finite JSON data and freeze every nested mapping and sequence."""
+
+    try:
+        normalized = json.loads(
+            json.dumps(
+                plain_json(values),
+                sort_keys=True,
+                allow_nan=False,
+            )
+        )
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"{name} must be finite JSON data") from error
+    if not isinstance(normalized, dict):
+        raise ValueError(f"{name} must be a JSON object")
+    return _freeze_json(normalized)
+
+
+__all__ = [
+    "FrozenJsonDict",
+    "FrozenJsonList",
+    "frozen_finite_json_mapping",
+    "plain_json",
+]

--- a/src/prob4d/observation_contract.py
+++ b/src/prob4d/observation_contract.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import numpy as np
 
+from ._immutable_json import frozen_finite_json_mapping, plain_json
 from .observation_contract_bundle import (
     observation_contract_array_sha256,
     observation_contract_artifact_id,
@@ -65,11 +66,8 @@ def _validate_sha256(value: str, *, name: str) -> None:
         raise ValueError(f"{name} must be a lowercase SHA-256 digest")
 
 
-def _validated_metadata(values: Mapping[str, Any]) -> dict[str, Any]:
-    try:
-        return json.loads(json.dumps(dict(values), sort_keys=True, allow_nan=False))
-    except (TypeError, ValueError) as error:
-        raise ValueError("metadata must be finite JSON data") from error
+def _validated_metadata(values: Mapping[str, Any]) -> Mapping[str, Any]:
+    return frozen_finite_json_mapping(values, name="metadata")
 
 
 def _readonly(
@@ -317,7 +315,7 @@ class ObservationBeliefExportV1:
             "source_repository": self.source_repository,
             "source_revision": self.source_revision,
             "source_artifact_sha256": self.source_artifact_sha256,
-            "metadata": self.metadata,
+            "metadata": plain_json(self.metadata),
         }
 
     def arrays(self) -> dict[str, np.ndarray]:

--- a/src/prob4d/provider_v2_loading.py
+++ b/src/prob4d/provider_v2_loading.py
@@ -1,0 +1,236 @@
+"""Strict loading boundary for claim-bearing Prob4D provider-v2 observations."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import cast
+
+from .causal_stream_contract import (
+    PROB4D_CAUSAL_STREAM_CONTRACT_VERSION,
+    PROB4D_CAUSAL_STREAM_ID,
+    PROB4D_SOURCE_REPOSITORY,
+)
+from .observation_contract import ObservationBeliefExportV1
+from .observation_validation import load_observation_belief_export
+from .provider_attestation import validate_provider_attestation
+
+
+def _required_mapping(value: object, *, name: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{name} must be a mapping")
+    return cast(Mapping[str, object], value)
+
+
+def _require_sha256(value: object, *, name: str) -> str:
+    digest = str(value)
+    if len(digest) != 64 or any(
+        character not in "0123456789abcdef" for character in digest
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return digest
+
+
+def _require_revision(value: object, *, name: str) -> str:
+    revision = str(value)
+    if len(revision) not in {40, 64} or any(
+        character not in "0123456789abcdef" for character in revision
+    ):
+        raise ValueError(f"{name} must be an exact lowercase Git commit")
+    return revision
+
+
+@dataclass(frozen=True)
+class ValidatedClaimBearingObservation:
+    """A strict provider-v2 observation plus its validated producer identities."""
+
+    observation: ObservationBeliefExportV1
+    provider_manifest_id: str
+    gauge_calibration_id: str
+    point_calibration_id: str
+    runtime_revision: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "provider_manifest_id",
+            _require_sha256(
+                self.provider_manifest_id,
+                name="provider_manifest_id",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "gauge_calibration_id",
+            _require_sha256(
+                self.gauge_calibration_id,
+                name="gauge_calibration_id",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "point_calibration_id",
+            _require_sha256(
+                self.point_calibration_id,
+                name="point_calibration_id",
+            ),
+        )
+        runtime_revision = _require_revision(
+            self.runtime_revision,
+            name="runtime_revision",
+        )
+        if runtime_revision != self.observation.source_revision:
+            raise ValueError(
+                "validated runtime revision differs from the observation source revision"
+            )
+        object.__setattr__(self, "runtime_revision", runtime_revision)
+
+    @property
+    def artifact_id(self) -> str:
+        """Return the immutable observation content address."""
+
+        return self.observation.artifact_id
+
+
+def validate_claim_bearing_observation_belief(
+    artifact: ObservationBeliefExportV1,
+) -> ValidatedClaimBearingObservation:
+    """Require the complete causal, calibrated, and attested provider-v2 boundary."""
+
+    if artifact.source_repository != PROB4D_SOURCE_REPOSITORY:
+        raise ValueError("claim-bearing observation must be produced by Prob4D")
+    if artifact.stream_id != PROB4D_CAUSAL_STREAM_ID:
+        raise ValueError("claim-bearing observation must use the strict Prob4D stream")
+
+    metadata = artifact.metadata
+    if (
+        metadata.get("prob4d_causal_stream_contract_version")
+        != PROB4D_CAUSAL_STREAM_CONTRACT_VERSION
+    ):
+        raise ValueError("claim-bearing observation requires causal stream contract v2")
+    stream_contract = _required_mapping(
+        metadata.get("prob4d_causal_stream_contract"),
+        name="Prob4D causal stream contract",
+    )
+    if stream_contract.get("version") != PROB4D_CAUSAL_STREAM_CONTRACT_VERSION:
+        raise ValueError("Prob4D causal stream contract metadata changed version")
+    if metadata.get("gauge_mode") != "sequential":
+        raise ValueError("claim-bearing observation requires sequential gauge mode")
+    if metadata.get("joint_cross_window_gauge_covariance_represented") is not True:
+        raise ValueError(
+            "claim-bearing observation requires joint cross-window gauge covariance"
+        )
+    if metadata.get("metric_anchor_covariance_in_joint_factor") is not True:
+        raise ValueError(
+            "claim-bearing observation requires metric-anchor covariance in the joint factor"
+        )
+    expected_factor_names = tuple(
+        f"joint_gauge_latent_{index:04d}" for index in range(len(artifact.factor_names))
+    )
+    if not expected_factor_names or artifact.factor_names != expected_factor_names:
+        raise ValueError("claim-bearing observation requires canonical joint gauge factors")
+    if {int(value) for value in artifact.factor_group_ids} != {0}:
+        raise ValueError("claim-bearing observation requires one shared joint factor group")
+
+    lineage = _required_mapping(
+        metadata.get("causal_source_lineage"),
+        name="Prob4D causal source lineage",
+    )
+    if lineage.get("causal_frame_stop_exclusive") != artifact.causal_frame_stop:
+        raise ValueError("causal source lineage differs from the observation cutoff")
+    if lineage.get("future_prediction_payloads_opened") != 0:
+        raise ValueError("claim-bearing observation opened future prediction payloads")
+    selected_windows = lineage.get("selected_windows")
+    if not isinstance(selected_windows, list) or not selected_windows:
+        raise ValueError("claim-bearing observation requires selected source-window lineage")
+    for selected_window in selected_windows:
+        window = _required_mapping(selected_window, name="selected source window")
+        source_frame_max = window.get("source_frame_max")
+        if isinstance(source_frame_max, bool) or not isinstance(source_frame_max, int):
+            raise ValueError("selected source-window frame maximum must be an integer")
+        if source_frame_max >= artifact.causal_frame_stop:
+            raise ValueError("selected source window crosses the causal frame boundary")
+
+    posterior = _required_mapping(
+        metadata.get("gauge_posterior"),
+        name="Prob4D gauge posterior",
+    )
+    if posterior.get("model") != "sequential_joint_spanning_tree_v1":
+        raise ValueError("claim-bearing observation requires the sequential joint gauge tree")
+    if posterior.get("cross_window_covariance_preserved") is not True:
+        raise ValueError("claim-bearing gauge posterior lost cross-window covariance")
+    if posterior.get("fixed_lag_boundary_covariance_is_approximate") is not False:
+        raise ValueError("claim-bearing observation cannot use approximate fixed-lag covariance")
+    if posterior.get("exported_factor_rank") != len(artifact.factor_names):
+        raise ValueError("claim-bearing gauge rank differs from the exported factor rank")
+
+    calibration = _required_mapping(
+        metadata.get("covariance_calibration"),
+        name="Prob4D covariance calibration metadata",
+    )
+    if calibration.get("status") != "calibrated":
+        raise ValueError("claim-bearing observation requires both covariance calibrations")
+
+    raw_attestation = _required_mapping(
+        metadata.get("prob4d_provider_attestation"),
+        name="Prob4D provider attestation",
+    )
+    validated_attestation = validate_provider_attestation(
+        raw_attestation,
+        source_revision=artifact.source_revision,
+        require_claim_bearing=True,
+    )
+    attested_calibration = _required_mapping(
+        validated_attestation["calibration_artifact_ids"],
+        name="attested calibration identities",
+    )
+    gauge_calibration_id = _require_sha256(
+        attested_calibration.get("gauge_artifact_id"),
+        name="attested gauge calibration ID",
+    )
+    point_calibration_id = _require_sha256(
+        attested_calibration.get("point_artifact_id"),
+        name="attested point calibration ID",
+    )
+    if calibration.get("gauge_artifact_id") != gauge_calibration_id:
+        raise ValueError("gauge calibration metadata differs from provider attestation")
+    if calibration.get("point_artifact_id") != point_calibration_id:
+        raise ValueError("point calibration metadata differs from provider attestation")
+
+    runtime = _required_mapping(
+        validated_attestation["runtime_revision"],
+        name="validated runtime revision",
+    )
+    runtime_revision = _require_revision(
+        runtime.get("observed_revision"),
+        name="validated runtime revision",
+    )
+    provider_manifest_id = _require_sha256(
+        validated_attestation["provider_manifest_id"],
+        name="provider manifest ID",
+    )
+    return ValidatedClaimBearingObservation(
+        observation=artifact,
+        provider_manifest_id=provider_manifest_id,
+        gauge_calibration_id=gauge_calibration_id,
+        point_calibration_id=point_calibration_id,
+        runtime_revision=runtime_revision,
+    )
+
+
+def load_claim_bearing_observation_belief(
+    path: str | Path,
+) -> ValidatedClaimBearingObservation:
+    """Load one artifact and require all claim-bearing provider-v2 invariants."""
+
+    return validate_claim_bearing_observation_belief(
+        load_observation_belief_export(path)
+    )
+
+
+__all__ = [
+    "ValidatedClaimBearingObservation",
+    "load_claim_bearing_observation_belief",
+    "validate_claim_bearing_observation_belief",
+]

--- a/tests/test_claim_bearing_observation.py
+++ b/tests/test_claim_bearing_observation.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+from copy import copy, deepcopy
+from dataclasses import replace
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from prob4d.observation_contract import (
+    ObservationBeliefExportV1,
+    save_observation_belief_export,
+)
+from prob4d.provider_v2 import build_provider_attestation, prob4d_provider_manifest
+from prob4d.provider_v2_loading import (
+    ValidatedClaimBearingObservation,
+    load_claim_bearing_observation_belief,
+    validate_claim_bearing_observation_belief,
+)
+
+REVISION = "a" * 40
+GAUGE_CALIBRATION_ID = "1" * 64
+POINT_CALIBRATION_ID = "2" * 64
+
+
+def _attestation() -> dict[str, object]:
+    return build_provider_attestation(
+        provider_manifest=prob4d_provider_manifest(provider_revision=REVISION),
+        provider_revision=REVISION,
+        export_mode="calibrated",
+        calibration_compatibility_validated=True,
+        calibration_artifact_ids={
+            "gauge_artifact_id": GAUGE_CALIBRATION_ID,
+            "point_artifact_id": POINT_CALIBRATION_ID,
+        },
+        covariance_root_mode="canonical_eigenspaces",
+        composition_jacobian_mode="analytic",
+        runtime_revision={
+            "expected_revision": REVISION,
+            "observed_revision": REVISION,
+            "source": "source_checkout",
+            "clean_checkout": True,
+            "matched": True,
+            "independently_verified": True,
+        },
+    )
+
+
+def _artifact(*, caller_metadata: dict[str, object] | None = None) -> ObservationBeliefExportV1:
+    metadata: dict[str, object] = {
+        "coordinate_frame": "phystwin-world",
+        "gauge_mode": "sequential",
+        "joint_cross_window_gauge_covariance_represented": True,
+        "metric_anchor_covariance_in_joint_factor": True,
+        "prob4d_causal_stream_contract_version": 2,
+        "prob4d_causal_stream_contract": {
+            "version": 2,
+            "causal_frame_stop_convention": "exclusive",
+        },
+        "causal_source_lineage": {
+            "causal_frame_stop_exclusive": 2,
+            "future_prediction_payloads_opened": 0,
+            "selected_windows": [
+                {
+                    "window_id": "window0",
+                    "source_frame_max": 0,
+                    "payload_sha256": "b" * 64,
+                }
+            ],
+        },
+        "gauge_posterior": {
+            "model": "sequential_joint_spanning_tree_v1",
+            "cross_window_covariance_preserved": True,
+            "fixed_lag_boundary_covariance_is_approximate": False,
+            "exported_factor_rank": 1,
+        },
+        "covariance_calibration": {
+            "status": "calibrated",
+            "gauge_artifact_id": GAUGE_CALIBRATION_ID,
+            "point_artifact_id": POINT_CALIBRATION_ID,
+        },
+        "prob4d_provider_attestation": _attestation(),
+        "nested": {"values": [1, {"label": "stable"}]},
+    }
+    if caller_metadata is not None:
+        metadata.update(caller_metadata)
+    return ObservationBeliefExportV1(
+        case_id="case-a",
+        stream_id="prob4d:causal-overlap-window-points",
+        causal_frame_stop=2,
+        view_names=("camera0",),
+        window_names=("window0",),
+        factor_names=("joint_gauge_latent_0000",),
+        source_repository="FlorianPfaff/Prob4D",
+        source_revision=REVISION,
+        source_artifact_sha256="c" * 64,
+        declared_frame_ids=np.asarray([0], dtype=np.int64),
+        mean_xyz_m=np.asarray([[0.0, 0.0, 1.0]], dtype=np.float64),
+        frame_ids=np.asarray([0], dtype=np.int64),
+        entity_ids=np.asarray([0], dtype=np.int64),
+        view_indices=np.asarray([0], dtype=np.int64),
+        window_indices=np.asarray([0], dtype=np.int64),
+        correlation_group_ids=np.asarray([0], dtype=np.int64),
+        factor_group_ids=np.asarray([0], dtype=np.int64),
+        prior_reliability=np.asarray([1.0], dtype=np.float64),
+        association_probability=np.asarray([1.0], dtype=np.float64),
+        local_covariance_m2=np.asarray([np.eye(3)], dtype=np.float64),
+        low_rank_factor_m=np.asarray([[[0.1], [0.0], [0.0]]], dtype=np.float64),
+        group_ids=np.asarray([0], dtype=np.int64),
+        group_prior_nominal_probability=np.asarray([1.0], dtype=np.float64),
+        group_composite_weight=np.asarray([1.0], dtype=np.float64),
+        metadata=metadata,
+    )
+
+
+def test_observation_metadata_is_recursively_immutable_and_hash_stable() -> None:
+    caller_metadata = {"caller_owned": {"items": [{"value": 1}]}}
+    artifact = _artifact(caller_metadata=caller_metadata)
+    artifact_id = artifact.artifact_id
+
+    caller_metadata["caller_owned"]["items"][0]["value"] = 99  # type: ignore[index]
+    assert artifact.metadata["caller_owned"]["items"][0]["value"] == 1  # type: ignore[index]
+    assert isinstance(artifact.metadata, dict)
+    assert isinstance(artifact.metadata["nested"]["values"], list)  # type: ignore[index]
+
+    with pytest.raises(TypeError, match="metadata is immutable"):
+        artifact.metadata["new"] = "value"  # type: ignore[index]
+    with pytest.raises(TypeError, match="metadata is immutable"):
+        artifact.metadata["nested"]["values"].append(2)  # type: ignore[index,union-attr]
+    with pytest.raises(TypeError, match="metadata is immutable"):
+        artifact.metadata["nested"]["values"][1]["label"] = "changed"  # type: ignore[index]
+
+    shallow = copy(artifact.metadata)
+    deep = deepcopy(artifact.metadata)
+    assert type(shallow) is dict
+    assert type(deep) is dict
+    assert type(deep["nested"]["values"]) is list
+    deep["nested"]["values"].append("mutable")
+    assert artifact.artifact_id == artifact_id
+
+
+def test_strict_claim_bearing_loader_returns_validated_identity(tmp_path: Path) -> None:
+    artifact = _artifact()
+    path = tmp_path / "observation.npz"
+    save_observation_belief_export(path, artifact)
+
+    validated = load_claim_bearing_observation_belief(path)
+
+    assert isinstance(validated, ValidatedClaimBearingObservation)
+    assert validated.artifact_id == artifact.artifact_id
+    assert validated.provider_manifest_id == _attestation()["provider_manifest_id"]
+    assert validated.gauge_calibration_id == GAUGE_CALIBRATION_ID
+    assert validated.point_calibration_id == POINT_CALIBRATION_ID
+    assert validated.runtime_revision == REVISION
+
+
+def test_strict_validation_rejects_calibration_identity_drift() -> None:
+    artifact = _artifact()
+    metadata = deepcopy(artifact.metadata)
+    metadata["covariance_calibration"]["gauge_artifact_id"] = "3" * 64
+    changed = replace(artifact, metadata=metadata)
+
+    with pytest.raises(ValueError, match="differs from provider attestation"):
+        validate_claim_bearing_observation_belief(changed)
+
+
+def test_strict_validation_rejects_exploratory_or_noncausal_artifacts() -> None:
+    artifact = _artifact()
+    metadata = deepcopy(artifact.metadata)
+    metadata.pop("prob4d_provider_attestation")
+    changed = replace(artifact, metadata=metadata)
+
+    with pytest.raises(ValueError, match="provider attestation"):
+        validate_claim_bearing_observation_belief(changed)
+
+    metadata = deepcopy(artifact.metadata)
+    metadata["causal_source_lineage"]["selected_windows"][0]["source_frame_max"] = 2
+    changed = replace(artifact, metadata=metadata)
+    with pytest.raises(ValueError, match="crosses the causal frame boundary"):
+        validate_claim_bearing_observation_belief(changed)


### PR DESCRIPTION
## Summary

- recursively freeze `ObservationBeliefExportV1.metadata` after finite-JSON normalization while preserving ordinary `dict`/`list` runtime checks and mutable `copy`/`deepcopy` workflows;
- prevent caller-owned or nested metadata mutation from changing an existing content address;
- add `prob4d.provider_v2_loading` with an explicit strict loader, validator, and typed `ValidatedClaimBearingObservation` result;
- require causal stream v2, sealed source-window lineage, canonical shared joint-gauge factors, sequential full cross-window covariance, calibrated covariance identities, a claim-bearing provider-v2 attestation, and independently verified runtime provenance;
- document the new admission boundary and add focused mutation, round-trip, provenance-drift, exploratory-artifact, and causal-boundary regressions.

## Root cause

Observation arrays were defensively copied and read-only, but metadata was only JSON-normalized into ordinary mutable dictionaries and lists. A caller could mutate nested metadata after construction and thereby change the content address of an already validated observation. Separately, the neutral artifact loader verifies schema and content integrity but intentionally does not distinguish claim-bearing provider-v2 artifacts from exploratory or frozen provider-v1 artifacts.

## Compatibility and evidence boundary

- The neutral observation schema, descriptor bytes for unchanged metadata, and provider-v1 behavior remain unchanged.
- Frozen metadata values retain ordinary `dict` and `list` compatibility; `copy.copy` and `copy.deepcopy` return mutable plain JSON containers for existing `dataclasses.replace` workflows.
- The strict loader is additive and opt-in. Existing exploratory and reproduction paths continue to use `load_observation_belief_export`.
- This change establishes a safer admission boundary; it is not an empirical accuracy, calibration, or physical-prediction result.

## Validation

- focused observation/provider suite: 27 passed;
- distribution-available repository suite: 239 passed;
- source compilation: passed;
- wheel build and package-content smoke check: passed.

The source distribution intentionally omits the repository-only joint-observation fixture and two repository scripts. GitHub Actions on the full checkout remains authoritative for Ruff, mypy, the complete Python 3.10/3.12/3.14 matrix, distribution builds, and installed wheel/sdist command smoke tests.