### PR TITLE
Add group-balanced point-uncertainty calibration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to Prob4D are documented here.
 - A public cluster-cross-fitted overlap-disagreement diagnostic that holds out
   frame-by-spatial-tile clusters, refits the relative gauge without them, fails
   closed on unfittable folds, and reports the strictly out-of-fold evaluated fraction.
+- Equal-group point-uncertainty calibration with canonical group ordering,
+  within-group trimming, per-group diagnostics, and row-order-invariant aggregate
+  scales so dense sequences cannot dominate solely through sample count.
 - `prob4d.provider_v2` as a safe-by-default Python surface with distinct
   exploratory and claim-bearing export functions.
 - Strict prediction/calibration compatibility checks covering MotionCrafter

--- a/docs/group-balanced-calibration.md
+++ b/docs/group-balanced-calibration.md
@@ -1,0 +1,60 @@
+# Group-balanced point-uncertainty calibration
+
+Dense calibration sets often contain very different numbers of valid rows per
+sequence, object, camera, or acquisition session. Pooling all rows gives every
+pixel equal mass, which can let one long or densely valid group determine nearly
+the entire variance scale.
+
+`DepthDisagreementModel.calibrate_group_balanced` provides an explicit
+alternative:
+
+```python
+calibrated, report = model.calibrate_group_balanced(
+    errors,
+    covariance,
+    sequence_ids,
+    mask=valid,
+    trim_quantile=0.99,
+)
+```
+
+For every declared group, Prob4D independently computes the along-ray and
+per-lateral-axis normalized squared errors, trims those ratios at the requested
+within-group quantile, and obtains one parallel and one lateral scale update.
+The final update is the arithmetic mean of the per-group updates. Thus each
+sequence contributes one calibration unit regardless of how many sampled rows
+it contains.
+
+The returned `GroupBalancedCalibrationReport` records:
+
+- the total valid row count and number of groups;
+- the common trim quantile;
+- equal-group aggregate scale updates and normalized MSE;
+- canonical sorted group IDs;
+- every group's row count, scale update, and untrimmed normalized MSE.
+
+`report.to_dict()` emits the explicit semantics identifier
+`equal-group-mean-of-within-group-trimmed-ratios-v1`.
+
+## Choosing the statistical unit
+
+The grouping must match the intended transfer claim. Typical choices are:
+
+- scene sequence for sequence-family-held-out reconstruction;
+- physical object or acquisition session for deformable-object transfer;
+- camera only when cameras are the independent deployment units;
+- simulation run for controlled Monte Carlo evidence.
+
+Neighboring pixels, overlapping windows, or repeated frames from one sequence
+are not independent calibration units merely because they are separate rows.
+
+## Compatibility and claim boundary
+
+`DepthDisagreementModel.calibrate` remains unchanged and retains pooled-point
+weighting for frozen reproduction. Group-balanced calibration is additive and
+must be selected explicitly.
+
+Changing the calibration aggregation changes the fitted covariance model.
+Claim-bearing artifacts must therefore record the grouping definition and exact
+calibration method, use disjoint calibration and target groups, and regenerate
+content-addressed calibration artifacts rather than relabeling pooled results.

--- a/src/prob4d/__init__.py
+++ b/src/prob4d/__init__.py
@@ -50,6 +50,7 @@ from .observation_factors import (
 )
 from .observation_validation import load_observation_belief_export
 from .sim3 import Sim3
+from .uncertainty import GroupBalancedCalibrationReport
 
 try:
     __version__ = version("prob4d")
@@ -67,6 +68,7 @@ __all__ = [
     "EvaluationModeResult",
     "EvaluationModes",
     "GaugeCovarianceCalibrationV1",
+    "GroupBalancedCalibrationReport",
     "JointGaugePosterior",
     "LinearizedObservationFactor",
     "MetricGaugeAnchor",

--- a/src/prob4d/uncertainty.py
+++ b/src/prob4d/uncertainty.py
@@ -130,6 +130,127 @@ class CalibrationReport:
 
 
 @dataclass(frozen=True)
+class GroupBalancedCalibrationReport:
+    """Equal-group calibration audit with per-group scale diagnostics."""
+
+    count: int
+    trim_quantile: float
+    parallel_scale_update: float
+    lateral_scale_update: float
+    parallel_normalized_mse: float
+    lateral_normalized_mse: float
+    group_ids: tuple[str, ...]
+    group_counts: tuple[int, ...]
+    group_parallel_scale_updates: tuple[float, ...]
+    group_lateral_scale_updates: tuple[float, ...]
+    group_parallel_normalized_mse: tuple[float, ...]
+    group_lateral_normalized_mse: tuple[float, ...]
+
+    def __post_init__(self) -> None:
+        count = int(self.count)
+        trim_quantile = float(self.trim_quantile)
+        group_ids = tuple(map(str, self.group_ids))
+        group_counts = tuple(map(int, self.group_counts))
+        group_values = tuple(
+            tuple(map(float, values))
+            for values in (
+                self.group_parallel_scale_updates,
+                self.group_lateral_scale_updates,
+                self.group_parallel_normalized_mse,
+                self.group_lateral_normalized_mse,
+            )
+        )
+        lengths = {
+            len(group_ids),
+            len(group_counts),
+            *(len(values) for values in group_values),
+        }
+        if lengths != {len(group_ids)} or not group_ids:
+            raise ValueError("group calibration fields must have one non-empty shared length")
+        if len(set(group_ids)) != len(group_ids) or any(not value for value in group_ids):
+            raise ValueError("group calibration IDs must be non-empty and unique")
+        if group_ids != tuple(sorted(group_ids)):
+            raise ValueError("group calibration IDs must use canonical sorted order")
+        if any(value < 1 for value in group_counts) or sum(group_counts) != count:
+            raise ValueError("group calibration counts must be positive and sum to count")
+        if not 0.0 < trim_quantile <= 1.0:
+            raise ValueError("trim_quantile must lie in (0, 1]")
+        aggregate = np.asarray(
+            [
+                self.parallel_scale_update,
+                self.lateral_scale_update,
+                self.parallel_normalized_mse,
+                self.lateral_normalized_mse,
+            ],
+            dtype=np.float64,
+        )
+        if not np.all(np.isfinite(aggregate)) or np.any(aggregate < 0.0):
+            raise ValueError("group calibration aggregates must be finite and non-negative")
+        if aggregate[0] <= 0.0 or aggregate[1] <= 0.0:
+            raise ValueError("group calibration scale updates must be strictly positive")
+        for index, values in enumerate(group_values):
+            array = np.asarray(values, dtype=np.float64)
+            if not np.all(np.isfinite(array)) or np.any(array < 0.0):
+                raise ValueError("per-group calibration values must be finite and non-negative")
+            if index < 2 and np.any(array <= 0.0):
+                raise ValueError("per-group calibration scale updates must be positive")
+        object.__setattr__(self, "count", count)
+        object.__setattr__(self, "trim_quantile", trim_quantile)
+        object.__setattr__(self, "parallel_scale_update", float(aggregate[0]))
+        object.__setattr__(self, "lateral_scale_update", float(aggregate[1]))
+        object.__setattr__(self, "parallel_normalized_mse", float(aggregate[2]))
+        object.__setattr__(self, "lateral_normalized_mse", float(aggregate[3]))
+        object.__setattr__(self, "group_ids", group_ids)
+        object.__setattr__(self, "group_counts", group_counts)
+        object.__setattr__(self, "group_parallel_scale_updates", group_values[0])
+        object.__setattr__(self, "group_lateral_scale_updates", group_values[1])
+        object.__setattr__(self, "group_parallel_normalized_mse", group_values[2])
+        object.__setattr__(self, "group_lateral_normalized_mse", group_values[3])
+
+    @property
+    def group_count(self) -> int:
+        return len(self.group_ids)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "aggregation": "equal-group-mean-of-within-group-trimmed-ratios-v1",
+            "count": self.count,
+            "group_count": self.group_count,
+            "trim_quantile": self.trim_quantile,
+            "parallel_scale_update": self.parallel_scale_update,
+            "lateral_scale_update": self.lateral_scale_update,
+            "parallel_normalized_mse": self.parallel_normalized_mse,
+            "lateral_normalized_mse": self.lateral_normalized_mse,
+            "groups": [
+                {
+                    "group_id": group_id,
+                    "count": count,
+                    "parallel_scale_update": parallel_update,
+                    "lateral_scale_update": lateral_update,
+                    "parallel_normalized_mse": parallel_mse,
+                    "lateral_normalized_mse": lateral_mse,
+                }
+                for (
+                    group_id,
+                    count,
+                    parallel_update,
+                    lateral_update,
+                    parallel_mse,
+                    lateral_mse,
+                ) in zip(
+                    self.group_ids,
+                    self.group_counts,
+                    self.group_parallel_scale_updates,
+                    self.group_lateral_scale_updates,
+                    self.group_parallel_normalized_mse,
+                    self.group_lateral_normalized_mse,
+                    strict=True,
+                )
+            ],
+        }
+
+
+@dataclass(frozen=True)
 class DepthDisagreementModel:
     """Depth-aware variance model augmented with online overlap disagreement."""
 
@@ -241,6 +362,105 @@ class DepthDisagreementModel:
             parallel_normalized_mse=float(np.mean(parallel_ratio)),
             lateral_normalized_mse=float(np.mean(lateral_ratio)),
         )
+
+    def calibrate_group_balanced(
+        self,
+        errors: FloatArray,
+        covariance: StructuredCovariance,
+        group_ids: np.ndarray,
+        *,
+        mask: NDArray[np.bool_] | None = None,
+        trim_quantile: float = 0.99,
+    ) -> tuple[DepthDisagreementModel, GroupBalancedCalibrationReport]:
+        """Scale variances while assigning equal mass to each declared group.
+
+        Ratios are trimmed independently inside every group. The final parallel
+        and lateral updates are arithmetic means of those per-group values, so a
+        long or densely sampled sequence cannot dominate merely by contributing
+        more rows. Group IDs are canonicalized to sorted strings, and rows with
+        invalid errors or a false mask value contribute to no group.
+        """
+
+        errors = np.asarray(errors, dtype=np.float64)
+        if errors.shape != covariance.ray_directions.shape:
+            raise ValueError("errors and covariance rays must have matching shapes")
+        if not np.isfinite(trim_quantile) or not 0.0 < trim_quantile <= 1.0:
+            raise ValueError("trim_quantile must lie in (0, 1]")
+        groups = np.asarray(group_ids)
+        if groups.shape != errors.shape[:-1]:
+            raise ValueError("group_ids must match the calibration sample grid")
+        active = np.all(np.isfinite(errors), axis=-1)
+        if mask is not None:
+            supplied_mask = np.asarray(mask, dtype=bool)
+            if supplied_mask.shape != active.shape:
+                raise ValueError("calibration mask shape does not match errors")
+            active &= supplied_mask
+        if not np.any(active):
+            raise ValueError("calibration set has no valid residuals")
+
+        active_groups = tuple(
+            "" if value is None else str(value).strip()
+            for value in groups[active].reshape(-1)
+        )
+        if any(not value for value in active_groups):
+            raise ValueError("active group IDs must be non-empty")
+        group_array = np.asarray(active_groups, dtype=str)
+        canonical_group_ids = tuple(sorted(set(active_groups)))
+
+        ray = covariance.ray_directions
+        parallel_error = np.sum(errors * ray, axis=-1)
+        total_squared = np.sum(errors**2, axis=-1)
+        lateral_squared = np.maximum(total_squared - parallel_error**2, 0.0)
+        parallel_ratio = (
+            parallel_error[active] ** 2 / covariance.parallel_variance[active]
+        ).reshape(-1)
+        lateral_ratio = (
+            lateral_squared[active] / (2.0 * covariance.lateral_variance[active])
+        ).reshape(-1)
+
+        def ordered_mean(values: np.ndarray) -> float:
+            return float(np.mean(np.sort(np.asarray(values, dtype=np.float64))))
+
+        def trimmed_mean(values: np.ndarray) -> float:
+            ordered = np.sort(np.asarray(values, dtype=np.float64))
+            upper = float(np.quantile(ordered, trim_quantile))
+            return max(float(np.mean(np.minimum(ordered, upper))), 1e-6)
+
+        counts: list[int] = []
+        parallel_updates: list[float] = []
+        lateral_updates: list[float] = []
+        parallel_mse: list[float] = []
+        lateral_mse: list[float] = []
+        for group_id in canonical_group_ids:
+            selected = group_array == group_id
+            counts.append(int(np.count_nonzero(selected)))
+            parallel_updates.append(trimmed_mean(parallel_ratio[selected]))
+            lateral_updates.append(trimmed_mean(lateral_ratio[selected]))
+            parallel_mse.append(ordered_mean(parallel_ratio[selected]))
+            lateral_mse.append(ordered_mean(lateral_ratio[selected]))
+
+        parallel_update = ordered_mean(np.asarray(parallel_updates))
+        lateral_update = ordered_mean(np.asarray(lateral_updates))
+        calibrated = replace(
+            self,
+            parallel_scale=self.parallel_scale * parallel_update,
+            lateral_scale=self.lateral_scale * lateral_update,
+        )
+        report = GroupBalancedCalibrationReport(
+            count=int(np.count_nonzero(active)),
+            trim_quantile=trim_quantile,
+            parallel_scale_update=parallel_update,
+            lateral_scale_update=lateral_update,
+            parallel_normalized_mse=ordered_mean(np.asarray(parallel_mse)),
+            lateral_normalized_mse=ordered_mean(np.asarray(lateral_mse)),
+            group_ids=canonical_group_ids,
+            group_counts=tuple(counts),
+            group_parallel_scale_updates=tuple(parallel_updates),
+            group_lateral_scale_updates=tuple(lateral_updates),
+            group_parallel_normalized_mse=tuple(parallel_mse),
+            group_lateral_normalized_mse=tuple(lateral_mse),
+        )
+        return calibrated, report
 
 
 def accumulate_disagreement(

--- a/tests/test_uncertainty.py
+++ b/tests/test_uncertainty.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from prob4d.data import PredictionWindow
-from prob4d.uncertainty import DepthDisagreementModel
+from prob4d.uncertainty import DepthDisagreementModel, StructuredCovariance
 
 
 def make_window() -> PredictionWindow:
@@ -13,6 +13,27 @@ def make_window() -> PredictionWindow:
         point_map,
         np.ones((2, 2, 3), dtype=bool),
     )
+
+
+def _imbalanced_group_calibration() -> tuple[np.ndarray, StructuredCovariance, np.ndarray]:
+    small_count = 4
+    large_count = 400
+    count = small_count + large_count
+    rays = np.zeros((count, 3))
+    rays[:, 2] = 1.0
+    covariance = StructuredCovariance(
+        ray_directions=rays,
+        parallel_variance=np.ones(count),
+        lateral_variance=np.ones(count),
+    )
+    errors = np.zeros((count, 3))
+    errors[:small_count] = np.array([1.0, 1.0, 1.0])
+    errors[small_count:] = np.array([3.0, 3.0, 3.0])
+    groups = np.asarray(
+        ["small"] * small_count + ["large"] * large_count,
+        dtype=object,
+    )
+    return errors, covariance, groups
 
 
 def test_depth_model_grows_along_ray_uncertainty() -> None:
@@ -60,3 +81,66 @@ def test_calibration_scales_disagreement_variance_too() -> None:
 
     np.testing.assert_allclose(scaled.parallel_variance, 3.0 * unscaled.parallel_variance)
     np.testing.assert_allclose(scaled.lateral_variance, 5.0 * unscaled.lateral_variance)
+
+
+def test_group_balanced_calibration_assigns_equal_mass_to_sequences() -> None:
+    errors, covariance, groups = _imbalanced_group_calibration()
+    model = DepthDisagreementModel()
+
+    balanced, report = model.calibrate_group_balanced(
+        errors,
+        covariance,
+        groups,
+        trim_quantile=1.0,
+    )
+    pooled, _ = model.calibrate(errors, covariance, trim_quantile=1.0)
+
+    np.testing.assert_allclose(balanced.parallel_scale, 5.0)
+    np.testing.assert_allclose(balanced.lateral_scale, 5.0)
+    assert pooled.parallel_scale > 8.9
+    assert pooled.lateral_scale > 8.9
+    assert report.group_ids == ("large", "small")
+    assert report.group_counts == (400, 4)
+    assert report.group_count == 2
+    assert report.to_dict()["aggregation"] == (
+        "equal-group-mean-of-within-group-trimmed-ratios-v1"
+    )
+
+
+def test_group_balanced_calibration_is_row_order_invariant() -> None:
+    errors, covariance, groups = _imbalanced_group_calibration()
+    model = DepthDisagreementModel()
+    forward, forward_report = model.calibrate_group_balanced(
+        errors,
+        covariance,
+        groups,
+        trim_quantile=1.0,
+    )
+    permutation = np.arange(len(errors))[::-1]
+    reversed_covariance = StructuredCovariance(
+        ray_directions=covariance.ray_directions[permutation],
+        parallel_variance=covariance.parallel_variance[permutation],
+        lateral_variance=covariance.lateral_variance[permutation],
+    )
+    reverse, reverse_report = model.calibrate_group_balanced(
+        errors[permutation],
+        reversed_covariance,
+        groups[permutation],
+        trim_quantile=1.0,
+    )
+
+    assert forward == reverse
+    assert forward_report == reverse_report
+
+
+def test_group_balanced_calibration_rejects_empty_active_group() -> None:
+    errors, covariance, groups = _imbalanced_group_calibration()
+    groups = groups.copy()
+    groups[0] = ""
+
+    with np.testing.assert_raises_regex(ValueError, "group IDs must be non-empty"):
+        DepthDisagreementModel().calibrate_group_balanced(
+            errors,
+            covariance,
+            groups,
+        )


### PR DESCRIPTION
## Summary

- add `DepthDisagreementModel.calibrate_group_balanced` as an explicit alternative to pooled-row calibration;
- trim normalized along-ray and lateral error ratios independently within each declared group;
- assign equal aggregate mass to every group so long or densely valid sequences cannot dominate solely through sample count;
- canonicalize group ordering and sort ratio values before aggregation, making the result invariant to input-row order;
- add `GroupBalancedCalibrationReport` with total and per-group counts, scale updates, normalized MSE, and a JSON-compatible semantics identifier;
- retain the existing pooled `calibrate` method unchanged for frozen reproduction;
- add regressions for severe group-size imbalance, pooled-versus-balanced behavior, row-order invariance, and invalid group IDs;
- document how to choose the statistical unit and why calibration artifacts must be regenerated when aggregation changes.

## Why

A dense calibration set can contain hundreds of times more rows for one sequence than another. The current pooled estimator gives those rows proportionally more influence, even when the intended transfer claim treats sequence, object, or session as the statistical unit. The new method estimates one robust update per group and averages those updates equally.

In the regression fixture, a 400-row group with normalized error ratio 9 and a 4-row group with ratio 1 produce:

- pooled update: greater than 8.9;
- equal-group update: exactly 5.0.

## Compatibility and claim boundary

- Existing `DepthDisagreementModel.calibrate` behavior is unchanged.
- Existing provider-v1/v2 exports and calibration artifacts are unchanged.
- Group-balanced calibration is opt-in and additive.
- Claim-bearing use must bind the grouping definition and method, use disjoint calibration/target groups, and regenerate the content-addressed calibration artifact.

## Validation

- A lightweight local execution verified the 5.0 balanced update, canonical group ordering, and row-order invariance.
- Repository CI will run Ruff, mypy/provider checks, the full Python 3.10/3.12/3.14 suite, distribution builds, and isolated wheel/sdist CLI smoke tests.