### PR TITLE
Add gauge alignment cycle audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ All notable changes to Prob4D are documented here.
 - Prefix-only scene-flow tracklets with persistent within-window point IDs,
   deterministic collision handling, cumulative association probabilities,
   termination diagnostics, and conversion to unfused observation factors.
+- A directed gauge-cycle audit that compares direct overlap alignments with
+  two-edge paths in representative observation displacement, preserves deterministic
+  thresholds, and explicitly avoids chi-square claims under unknown edge dependence.
 - `prob4d.provider_v2` as a safe-by-default Python surface with distinct
   exploratory and claim-bearing export functions.
 - Strict prediction/calibration compatibility checks covering MotionCrafter

--- a/docs/alignment-cycle-audit.md
+++ b/docs/alignment-cycle-audit.md
@@ -1,0 +1,82 @@
+# Gauge alignment cycle audit
+
+The strict Prob4D observation provider uses one causal spanning tree to propagate
+the joint window-gauge covariance. This avoids multiplying dense overlap edges
+as though they were independent. The remaining non-tree alignments are still
+valuable as diagnostics.
+
+`prob4d.alignment_cycles` compares a direct edge
+
+```text
+A <- C
+```
+
+with every available two-edge path
+
+```text
+A <- B <- C.
+```
+
+```python
+from prob4d import audit_alignment_cycles
+
+audit = audit_alignment_cycles(
+    alignments,
+    representative_radius=0.25,
+    maximum_representative_displacement=0.01,
+)
+print(audit.to_dict())
+```
+
+## Reported quantities
+
+For each directed triangle, Prob4D composes `A <- B` and `B <- C`, compares the
+result with `A <- C`, and reports:
+
+- absolute log-scale disagreement;
+- shortest-axis-angle rotation disagreement in radians;
+- translation disagreement in the moving window's coordinates;
+- root-mean-square displacement of the origin and the six signed coordinate-axis
+  points at the declared representative radius;
+- direct and path-edge residual RMS diagnostics;
+- the minimum correspondence count across the three alignments.
+
+The representative-point displacement combines scale, rotation, and translation
+in the observation geometry rather than comparing mixed-unit `Sim(3)` parameters
+with one arbitrary norm. Its units are those of the local alignment coordinates.
+
+An optional displacement threshold creates a deterministic pass/fail result. The
+threshold is a registered engineering diagnostic, not a probability statement.
+
+## Statistical boundary
+
+Overlap alignments share frames, pixels, a model backbone, and often upstream
+window uncertainty. Their cross-covariance is not available. The audit therefore
+does **not** whiten the cycle residual by the three marginal edge covariances and
+does not label its result NIS, NEES, chi-square, or a calibrated p-value.
+
+A large cycle residual can indicate:
+
+- a bad direct or path alignment;
+- local deformation that violates the rigid/similarity overlap approximation;
+- shared or spatially varying model bias;
+- insufficient geometry or occlusion;
+- a threshold or correspondence-selection problem.
+
+It does not by itself identify which edge is wrong.
+
+## Intended use
+
+The audit is additive and does not change provider-v1/v2 gauge estimation. It can
+be used to:
+
+1. stratify held-out gauge-calibration results by cycle consistency;
+2. reduce source-side prior reliability for visibly inconsistent alignment
+   groups after an independently frozen calibration rule is established;
+3. compare alternative causal spanning-tree edge scores;
+4. diagnose whether a prospective Prob4D-to-Bayesian-PhysTwin failure originates
+   in the observation gauge graph.
+
+Using cycle residuals to remove target examples, tune a threshold after opening
+target outcomes, or multiply redundant edges as independent likelihood factors
+would violate the intended evidence boundary.

--- a/src/prob4d/__init__.py
+++ b/src/prob4d/__init__.py
@@ -2,6 +2,12 @@
 
 from importlib.metadata import PackageNotFoundError, version
 
+from .alignment_cycles import (
+    AlignmentCycleAudit,
+    AlignmentCycleResidual,
+    alignment_edge_id,
+    audit_alignment_cycles,
+)
 from .calibration import (
     GAUGE_COVARIANCE_CALIBRATION_SCHEMA,
     GAUGE_COVARIANCE_CALIBRATION_VERSION,
@@ -70,6 +76,8 @@ __all__ = [
     "OBSERVATION_BELIEF_VERSION",
     "POINT_UNCERTAINTY_CALIBRATION_SCHEMA",
     "POINT_UNCERTAINTY_CALIBRATION_VERSION",
+    "AlignmentCycleAudit",
+    "AlignmentCycleResidual",
     "CausalTrackletReport",
     "CausalTrackletSet",
     "CrossFittedDisagreementReport",
@@ -88,6 +96,8 @@ __all__ = [
     "Sim3",
     "StackedObservationFactors",
     "accumulate_cross_fitted_disagreement",
+    "alignment_edge_id",
+    "audit_alignment_cycles",
     "build_causal_scene_flow_tracklets",
     "build_prob4d_observation_belief",
     "deterministic_covariance_root",

--- a/src/prob4d/alignment_cycles.py
+++ b/src/prob4d/alignment_cycles.py
@@ -1,0 +1,338 @@
+"""Deterministic cycle-consistency audits for overlapping-window gauges.
+
+Prob4D's strict observation provider uses a causal spanning tree so correlated
+alignment edges are not multiplied as if independent. Non-tree edges still
+contain useful diagnostic information: a direct alignment can be compared with
+the transform obtained through one intermediate window. This module reports
+that disagreement without assigning a chi-square interpretation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+
+import numpy as np
+
+from .alignment import WindowAlignment
+
+
+@dataclass(frozen=True)
+class AlignmentCycleResidual:
+    """One directed triangle ``reference <- middle <- moving``."""
+
+    reference_id: str
+    middle_id: str
+    moving_id: str
+    direct_edge_id: str
+    first_path_edge_id: str
+    second_path_edge_id: str
+    log_scale_error: float
+    rotation_error_rad: float
+    translation_error: float
+    representative_displacement: float
+    direct_residual_rms: float
+    maximum_path_residual_rms: float
+    minimum_correspondences: int
+    passed: bool | None = None
+
+    def __post_init__(self) -> None:
+        identifiers = (
+            self.reference_id,
+            self.middle_id,
+            self.moving_id,
+            self.direct_edge_id,
+            self.first_path_edge_id,
+            self.second_path_edge_id,
+        )
+        if any(not str(value) for value in identifiers):
+            raise ValueError("cycle identifiers must not be empty")
+        if len({self.reference_id, self.middle_id, self.moving_id}) != 3:
+            raise ValueError("a gauge cycle requires three distinct windows")
+        diagnostics = np.asarray(
+            [
+                self.log_scale_error,
+                self.rotation_error_rad,
+                self.translation_error,
+                self.representative_displacement,
+                self.direct_residual_rms,
+                self.maximum_path_residual_rms,
+            ],
+            dtype=np.float64,
+        )
+        if not np.all(np.isfinite(diagnostics)) or np.any(diagnostics < 0.0):
+            raise ValueError("cycle diagnostics must be finite and non-negative")
+        minimum_correspondences = int(self.minimum_correspondences)
+        if (
+            minimum_correspondences != self.minimum_correspondences
+            or minimum_correspondences < 0
+        ):
+            raise ValueError("minimum_correspondences must be a non-negative integer")
+        if self.passed is not None and not isinstance(self.passed, (bool, np.bool_)):
+            raise ValueError("passed must be boolean or None")
+        object.__setattr__(self, "minimum_correspondences", minimum_correspondences)
+        if self.passed is not None:
+            object.__setattr__(self, "passed", bool(self.passed))
+
+    @property
+    def cycle_id(self) -> str:
+        return f"{self.reference_id}<-{self.middle_id}<-{self.moving_id}"
+
+    def to_dict(self) -> dict[str, object]:
+        result = asdict(self)
+        result["cycle_id"] = self.cycle_id
+        return result
+
+
+@dataclass(frozen=True)
+class AlignmentCycleAudit:
+    """Aggregate audit over every available directed three-window cycle."""
+
+    alignment_count: int
+    window_count: int
+    cycle_count: int
+    representative_radius: float
+    maximum_representative_displacement: float | None
+    failed_cycle_count: int
+    mean_representative_displacement: float
+    median_representative_displacement: float
+    maximum_observed_representative_displacement: float
+    maximum_rotation_error_rad: float
+    maximum_translation_error: float
+    maximum_log_scale_error: float
+    cycles: tuple[AlignmentCycleResidual, ...]
+
+    def __post_init__(self) -> None:
+        integer_fields = (
+            "alignment_count",
+            "window_count",
+            "cycle_count",
+            "failed_cycle_count",
+        )
+        for name in integer_fields:
+            value = int(getattr(self, name))
+            if value != getattr(self, name) or value < 0:
+                raise ValueError(f"{name} must be a non-negative integer")
+            object.__setattr__(self, name, value)
+        cycles = tuple(self.cycles)
+        if len(cycles) != self.cycle_count:
+            raise ValueError("cycle_count differs from the cycle records")
+        if self.failed_cycle_count > self.cycle_count:
+            raise ValueError("failed_cycle_count cannot exceed cycle_count")
+        if not np.isfinite(self.representative_radius) or self.representative_radius <= 0.0:
+            raise ValueError("representative_radius must be finite and positive")
+        threshold = self.maximum_representative_displacement
+        if threshold is not None and (not np.isfinite(threshold) or threshold <= 0.0):
+            raise ValueError(
+                "maximum_representative_displacement must be positive when supplied"
+            )
+        diagnostics = np.asarray(
+            [
+                self.mean_representative_displacement,
+                self.median_representative_displacement,
+                self.maximum_observed_representative_displacement,
+                self.maximum_rotation_error_rad,
+                self.maximum_translation_error,
+                self.maximum_log_scale_error,
+            ],
+            dtype=np.float64,
+        )
+        if not np.all(np.isfinite(diagnostics)) or np.any(diagnostics < 0.0):
+            raise ValueError("aggregate cycle diagnostics must be finite and non-negative")
+        expected_failed = sum(cycle.passed is False for cycle in cycles)
+        if expected_failed != self.failed_cycle_count:
+            raise ValueError("failed_cycle_count differs from cycle pass flags")
+        if threshold is None and any(cycle.passed is not None for cycle in cycles):
+            raise ValueError("cycles cannot carry pass flags without a threshold")
+        if threshold is not None and any(cycle.passed is None for cycle in cycles):
+            raise ValueError("every cycle must carry a pass flag when a threshold is used")
+        ordered = tuple(sorted(cycles, key=lambda item: item.cycle_id))
+        if cycles != ordered:
+            raise ValueError("cycles must use canonical cycle-ID ordering")
+        object.__setattr__(self, "cycles", cycles)
+
+    @property
+    def passed(self) -> bool | None:
+        if self.maximum_representative_displacement is None:
+            return None
+        return self.failed_cycle_count == 0
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "semantics": "direct-versus-two-edge-sim3-cycle-displacement-v1",
+            "statistical_interpretation": "unnormalized diagnostic; edge dependence unknown",
+            "alignment_count": self.alignment_count,
+            "window_count": self.window_count,
+            "cycle_count": self.cycle_count,
+            "representative_radius": self.representative_radius,
+            "maximum_representative_displacement": (
+                self.maximum_representative_displacement
+            ),
+            "failed_cycle_count": self.failed_cycle_count,
+            "passed": self.passed,
+            "mean_representative_displacement": self.mean_representative_displacement,
+            "median_representative_displacement": self.median_representative_displacement,
+            "maximum_observed_representative_displacement": (
+                self.maximum_observed_representative_displacement
+            ),
+            "maximum_rotation_error_rad": self.maximum_rotation_error_rad,
+            "maximum_translation_error": self.maximum_translation_error,
+            "maximum_log_scale_error": self.maximum_log_scale_error,
+            "cycles": [cycle.to_dict() for cycle in self.cycles],
+        }
+
+
+def alignment_edge_id(alignment: WindowAlignment) -> str:
+    """Return the canonical directed edge identity ``reference<-moving``."""
+
+    return f"{alignment.reference_id}<-{alignment.moving_id}"
+
+
+def _representative_points(radius: float) -> np.ndarray:
+    axes = radius * np.eye(3, dtype=np.float64)
+    return np.concatenate((np.zeros((1, 3)), axes, -axes), axis=0)
+
+
+def _cycle_residual(
+    direct: WindowAlignment,
+    first: WindowAlignment,
+    second: WindowAlignment,
+    *,
+    representative_radius: float,
+    threshold: float | None,
+) -> AlignmentCycleResidual:
+    direct_transform = direct.result.transform
+    composed = first.result.transform.compose(second.result.transform)
+    residual = direct_transform.inverse().compose(composed).as_vector()
+    points = _representative_points(representative_radius)
+    direct_points = direct_transform.transform_points(points)
+    composed_points = composed.transform_points(points)
+    displacement = float(
+        np.sqrt(np.mean(np.sum((direct_points - composed_points) ** 2, axis=1)))
+    )
+    passed = None if threshold is None else displacement <= threshold
+    return AlignmentCycleResidual(
+        reference_id=direct.reference_id,
+        middle_id=first.moving_id,
+        moving_id=direct.moving_id,
+        direct_edge_id=alignment_edge_id(direct),
+        first_path_edge_id=alignment_edge_id(first),
+        second_path_edge_id=alignment_edge_id(second),
+        log_scale_error=abs(float(residual[0])),
+        rotation_error_rad=float(np.linalg.norm(residual[1:4])),
+        translation_error=float(np.linalg.norm(residual[4:7])),
+        representative_displacement=displacement,
+        direct_residual_rms=float(direct.result.residual_rms),
+        maximum_path_residual_rms=max(
+            float(first.result.residual_rms),
+            float(second.result.residual_rms),
+        ),
+        minimum_correspondences=min(
+            direct.result.num_correspondences,
+            first.result.num_correspondences,
+            second.result.num_correspondences,
+        ),
+        passed=passed,
+    )
+
+
+def audit_alignment_cycles(
+    alignments: list[WindowAlignment] | tuple[WindowAlignment, ...],
+    *,
+    representative_radius: float = 1.0,
+    maximum_representative_displacement: float | None = None,
+) -> AlignmentCycleAudit:
+    """Compare direct edges with every available directed two-edge path.
+
+    The audit intentionally reports raw transform disagreement. It does not
+    whiten the residual with edge covariances because overlapping-window edges
+    generally share frames, pixels, and a model backbone, and their unavailable
+    cross-covariance prevents a valid chi-square interpretation.
+    """
+
+    radius = float(representative_radius)
+    if not np.isfinite(radius) or radius <= 0.0:
+        raise ValueError("representative_radius must be finite and positive")
+    threshold = maximum_representative_displacement
+    if threshold is not None:
+        threshold = float(threshold)
+        if not np.isfinite(threshold) or threshold <= 0.0:
+            raise ValueError(
+                "maximum_representative_displacement must be positive when supplied"
+            )
+
+    edges: dict[tuple[str, str], WindowAlignment] = {}
+    windows: set[str] = set()
+    for alignment in alignments:
+        key = (alignment.reference_id, alignment.moving_id)
+        if key in edges:
+            raise ValueError(f"duplicate directed alignment edge {alignment_edge_id(alignment)!r}")
+        edges[key] = alignment
+        windows.update(key)
+
+    cycles: list[AlignmentCycleResidual] = []
+    for reference_id, moving_id in sorted(edges):
+        direct = edges[(reference_id, moving_id)]
+        for middle_id in sorted(windows - {reference_id, moving_id}):
+            first = edges.get((reference_id, middle_id))
+            second = edges.get((middle_id, moving_id))
+            if first is None or second is None:
+                continue
+            cycles.append(
+                _cycle_residual(
+                    direct,
+                    first,
+                    second,
+                    representative_radius=radius,
+                    threshold=threshold,
+                )
+            )
+    cycles.sort(key=lambda item: item.cycle_id)
+    displacements = np.asarray(
+        [cycle.representative_displacement for cycle in cycles],
+        dtype=np.float64,
+    )
+    rotations = np.asarray(
+        [cycle.rotation_error_rad for cycle in cycles],
+        dtype=np.float64,
+    )
+    translations = np.asarray(
+        [cycle.translation_error for cycle in cycles],
+        dtype=np.float64,
+    )
+    scales = np.asarray(
+        [cycle.log_scale_error for cycle in cycles],
+        dtype=np.float64,
+    )
+
+    def mean_or_zero(values: np.ndarray) -> float:
+        return 0.0 if not len(values) else float(np.mean(values))
+
+    def median_or_zero(values: np.ndarray) -> float:
+        return 0.0 if not len(values) else float(np.median(values))
+
+    def max_or_zero(values: np.ndarray) -> float:
+        return 0.0 if not len(values) else float(np.max(values))
+
+    return AlignmentCycleAudit(
+        alignment_count=len(edges),
+        window_count=len(windows),
+        cycle_count=len(cycles),
+        representative_radius=radius,
+        maximum_representative_displacement=threshold,
+        failed_cycle_count=sum(cycle.passed is False for cycle in cycles),
+        mean_representative_displacement=mean_or_zero(displacements),
+        median_representative_displacement=median_or_zero(displacements),
+        maximum_observed_representative_displacement=max_or_zero(displacements),
+        maximum_rotation_error_rad=max_or_zero(rotations),
+        maximum_translation_error=max_or_zero(translations),
+        maximum_log_scale_error=max_or_zero(scales),
+        cycles=tuple(cycles),
+    )
+
+
+__all__ = [
+    "AlignmentCycleAudit",
+    "AlignmentCycleResidual",
+    "alignment_edge_id",
+    "audit_alignment_cycles",
+]

--- a/tests/test_alignment_cycles.py
+++ b/tests/test_alignment_cycles.py
@@ -1,0 +1,117 @@
+import itertools
+
+import numpy as np
+import pytest
+
+from prob4d.alignment import AlignmentResult, WindowAlignment
+from prob4d.alignment_cycles import audit_alignment_cycles
+from prob4d.sim3 import Sim3
+
+
+def edge(
+    reference_id: str,
+    moving_id: str,
+    transform: Sim3,
+    *,
+    residual_rms: float = 0.01,
+    correspondences: int = 100,
+) -> WindowAlignment:
+    return WindowAlignment(
+        reference_id=reference_id,
+        moving_id=moving_id,
+        common_frames=np.array([3, 4], dtype=np.int64),
+        result=AlignmentResult(
+            transform=transform,
+            covariance=np.eye(7) * 1e-4,
+            residual_rms=residual_rms,
+            inlier_fraction=0.95,
+            num_correspondences=correspondences,
+        ),
+    )
+
+
+def exact_triangle() -> list[WindowAlignment]:
+    a_from_b = Sim3.from_vector(
+        np.array([0.03, 0.02, -0.01, 0.04, 0.2, -0.1, 0.05])
+    )
+    b_from_c = Sim3.from_vector(
+        np.array([-0.02, -0.03, 0.01, 0.02, -0.1, 0.08, 0.03])
+    )
+    a_from_c = a_from_b.compose(b_from_c)
+    return [
+        edge("a", "b", a_from_b),
+        edge("b", "c", b_from_c),
+        edge("a", "c", a_from_c),
+    ]
+
+
+def test_exact_triangle_has_zero_cycle_residual() -> None:
+    audit = audit_alignment_cycles(exact_triangle(), representative_radius=0.5)
+
+    assert audit.cycle_count == 1
+    cycle = audit.cycles[0]
+    assert cycle.cycle_id == "a<-b<-c"
+    assert cycle.representative_displacement < 1e-12
+    assert cycle.rotation_error_rad < 1e-12
+    assert cycle.translation_error < 1e-12
+    assert audit.passed is None
+
+
+def test_translation_inconsistency_fails_declared_displacement_gate() -> None:
+    alignments = exact_triangle()
+    direct = alignments[-1]
+    transform = direct.result.transform
+    perturbed = Sim3(
+        scale=transform.scale,
+        rotation=transform.rotation,
+        translation=transform.translation + np.array([0.1, 0.0, 0.0]),
+    )
+    alignments[-1] = edge("a", "c", perturbed)
+
+    audit = audit_alignment_cycles(
+        alignments,
+        representative_radius=0.5,
+        maximum_representative_displacement=0.05,
+    )
+
+    assert audit.failed_cycle_count == 1
+    assert audit.passed is False
+    assert audit.cycles[0].passed is False
+    np.testing.assert_allclose(
+        audit.cycles[0].representative_displacement,
+        0.1,
+        atol=1e-12,
+    )
+
+
+def test_cycle_audit_is_invariant_to_alignment_order() -> None:
+    alignments = exact_triangle()
+    expected = audit_alignment_cycles(alignments).to_dict()
+
+    for permutation in itertools.permutations(alignments):
+        assert audit_alignment_cycles(permutation).to_dict() == expected
+
+
+def test_duplicate_directed_edges_are_rejected() -> None:
+    alignments = exact_triangle()
+    alignments.append(alignments[0])
+
+    with pytest.raises(ValueError, match="duplicate directed alignment edge"):
+        audit_alignment_cycles(alignments)
+
+
+def test_graph_without_triangle_returns_empty_audit() -> None:
+    alignments = exact_triangle()[:2]
+
+    audit = audit_alignment_cycles(
+        alignments,
+        maximum_representative_displacement=0.01,
+    )
+
+    assert audit.cycle_count == 0
+    assert audit.failed_cycle_count == 0
+    assert audit.passed is True
+    assert audit.maximum_observed_representative_displacement == 0.0
+    assert audit.to_dict()["statistical_interpretation"].startswith(
+        "unnormalized diagnostic"
+    )


### PR DESCRIPTION
## Summary

- add `audit_alignment_cycles` for every available directed triangle `reference <- middle <- moving`;
- compare a direct overlap transform with the corresponding two-edge composition;
- report log-scale, shortest-axis-angle rotation, translation, and representative-point displacement disagreement;
- combine mixed-unit `Sim(3)` effects through the RMS displacement of the origin and six signed coordinate-axis points at a declared radius;
- provide deterministic optional pass/fail thresholds, canonical ordering, duplicate-edge rejection, and empty-graph behavior;
- retain direct/path residual RMS and minimum correspondence diagnostics for triage;
- export the new API, document the unknown-dependence boundary, and add exact-cycle, perturbed-cycle, permutation, duplicate-edge, and no-cycle regressions.

## Why

The strict provider correctly propagates one causal gauge tree rather than multiplying dense overlap edges as independent factors. Non-tree alignments should not be discarded entirely: a direct edge can be compared with a two-edge path to identify bad alignments, spatially varying model bias, deformation, or weak overlap geometry.

## Statistical and compatibility boundary

- Existing gauge estimation, provider-v1/v2 artifacts, and spanning-tree selection are unchanged.
- The audit is additive and source-side.
- Edge covariances are not used to create NIS, NEES, chi-square, or p-value claims because overlapping-window edges share frames, pixels, and backbone errors and their cross-covariance is unavailable.
- A displacement threshold is an explicitly registered engineering diagnostic, not a calibrated probability statement.
- A large cycle residual does not uniquely identify which of the three edges is wrong.

## Validation

- focused tests cover exact consistency, a controlled translation inconsistency, input-order invariance, duplicate directed edges, and graphs without triangles;
- repository CI runs Ruff, stable-interface mypy checks, the complete Python 3.10/3.12/3.14 test matrix, distribution builds, and isolated wheel/sdist command smoke tests.