### PR TITLE
Add source-only observation reliability calibration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ All notable changes to Prob4D are documented here.
 - A directed gauge-cycle audit that compares direct overlap alignments with
   two-edge paths in representative observation displacement, preserves deterministic
   thresholds, and explicitly avoids chi-square claims under unknown edge dependence.
+- A content-addressed, equal-group logistic source-reliability calibration with a
+  source-only feature contract, canonical row ordering, exact label/group semantics,
+  probability clipping, immutable metadata, and tamper-checked JSON round trips.
 - `prob4d.provider_v2` as a safe-by-default Python surface with distinct
   exploratory and claim-bearing export functions.
 - Strict prediction/calibration compatibility checks covering MotionCrafter

--- a/docs/source-reliability-calibration.md
+++ b/docs/source-reliability-calibration.md
@@ -1,0 +1,120 @@
+# Source-only observation reliability calibration
+
+Prob4D keeps four different concepts separate:
+
+- association probability: support for a named entity or track identity;
+- prior reliability: source-side evidence that an observation row is nominal;
+- posterior nominal responsibility: a downstream robust-likelihood quantity;
+- composite weight: a cap for correlated or repeated evidence.
+
+`prob4d.source_reliability` adds an opt-in calibration path for the second
+quantity. It does not alter the current provider-v1/v2 export defaults.
+
+## Source-only features
+
+```python
+from prob4d import build_source_reliability_features
+
+features = build_source_reliability_features(
+    prediction_window,
+    structured_covariance,
+    overlap_disagreement,
+)
+```
+
+The built-in feature contract contains:
+
+1. whether overlap evidence is present;
+2. log normalized overlap disagreement;
+3. proximity to a temporal window edge;
+4. log total predictive variance relative to the window median;
+5. whether valid scene flow is present;
+6. log scene-flow magnitude relative to the window median;
+7. local validity-mask deficit in a 3 by 3 neighborhood.
+
+These values use only the prediction source, its declared covariance, and overlap
+consistency. They do not use target truth at inference time, a physical-twin
+innovation, association probability, or a downstream posterior decision.
+
+The explicit `has_overlap` feature lets calibration learn a finite reliability
+for rows without duplicate-window evidence. Absence of disagreement is therefore
+not hard-coded as reliability one.
+
+## Equal-group logistic calibration
+
+```python
+from prob4d import fit_group_balanced_source_reliability
+
+model = fit_group_balanced_source_reliability(
+    calibration_features,
+    source_nominal_labels,
+    sequence_ids,
+    feature_names=feature_names,
+    label_definition="3-D source error below the frozen 20 mm threshold",
+    group_definition="physical sequence",
+    ridge=1e-3,
+)
+```
+
+Every declared group receives equal total optimization weight. A sequence with
+many valid pixels cannot dominate only because it contributes more rows. Within a
+group, rows retain equal weight. Inputs are canonically ordered before fitting,
+so row permutation does not change model bytes or the artifact ID.
+
+The fitted artifact records:
+
+- feature names, centering, scaling, intercept, and coefficients;
+- probability clipping limits;
+- exact label and group definitions;
+- canonical calibration group IDs;
+- group-balanced nominal fraction;
+- weighted log loss and Brier score;
+- optimization convergence and ridge strength;
+- finite JSON metadata and a SHA-256 content address.
+
+Save and load with:
+
+```python
+from prob4d import (
+    load_source_reliability_model,
+    save_source_reliability_model,
+)
+
+save_source_reliability_model(model, "source-reliability.json")
+loaded = load_source_reliability_model("source-reliability.json")
+```
+
+## Label boundary
+
+The label must be defined before opening target outcomes and generated from an
+independent source/calibration unit. Examples include a predeclared 3-D error
+threshold, an independently registered depth check, or a held-out source tracker
+competence label.
+
+Invalid labels include:
+
+- whether Bayesian-PhysTwin accepted the row;
+- the physical innovation magnitude;
+- a future target metric;
+- the robust likelihood's posterior nominal responsibility;
+- the track association probability itself.
+
+Using any of those would leak downstream evidence back into the prior.
+
+## Promotion boundary
+
+The model is additive and is not yet a claim-bearing provider-v2 default. Before
+promotion:
+
+1. freeze feature, label, group, clipping, and ridge definitions;
+2. fit on source/calibration objects or sessions disjoint from targets;
+3. bind prediction and calibration artifact digests in metadata;
+4. compare pooled and equal-group calibration, worst-group coverage, selective
+   risk, and harmful-update acceptance under the same Bayesian-PhysTwin guard;
+5. retain the previous provider semantics for frozen reproduction;
+6. require a new content-addressed calibration artifact rather than silently
+   reusing the current point-uncertainty calibration.
+
+A calibrated source nominality probability is still not proof that assimilating
+the observation improves a physical twin. The downstream baseline-relative guard
+and exact fallback remain necessary.

--- a/src/prob4d/__init__.py
+++ b/src/prob4d/__init__.py
@@ -62,6 +62,17 @@ from .observation_factors import (
 )
 from .observation_validation import load_observation_belief_export
 from .sim3 import Sim3
+from .source_reliability import (
+    SOURCE_RELIABILITY_SCHEMA,
+    SOURCE_RELIABILITY_VERSION,
+    SourceReliabilityCalibrationReport,
+    SourceReliabilityFeatures,
+    SourceReliabilityModelV1,
+    build_source_reliability_features,
+    fit_group_balanced_source_reliability,
+    load_source_reliability_model,
+    save_source_reliability_model,
+)
 from .uncertainty import GroupBalancedCalibrationReport
 
 try:
@@ -76,6 +87,8 @@ __all__ = [
     "OBSERVATION_BELIEF_VERSION",
     "POINT_UNCERTAINTY_CALIBRATION_SCHEMA",
     "POINT_UNCERTAINTY_CALIBRATION_VERSION",
+    "SOURCE_RELIABILITY_SCHEMA",
+    "SOURCE_RELIABILITY_VERSION",
     "AlignmentCycleAudit",
     "AlignmentCycleResidual",
     "CausalTrackletReport",
@@ -94,24 +107,31 @@ __all__ = [
     "PointUncertaintyCalibrationV1",
     "PredictionWindow",
     "Sim3",
+    "SourceReliabilityCalibrationReport",
+    "SourceReliabilityFeatures",
+    "SourceReliabilityModelV1",
     "StackedObservationFactors",
     "accumulate_cross_fitted_disagreement",
     "alignment_edge_id",
     "audit_alignment_cycles",
     "build_causal_scene_flow_tracklets",
     "build_prob4d_observation_belief",
+    "build_source_reliability_features",
     "deterministic_covariance_root",
     "estimate_joint_gauge_tree",
     "evaluate_sequence_modes",
+    "fit_group_balanced_source_reliability",
     "load_gauge_covariance_calibration",
     "load_metric_gauge_anchor",
     "load_observation_belief_export",
     "load_observation_factor_bundle",
     "load_point_uncertainty_calibration",
+    "load_source_reliability_model",
     "save_gauge_covariance_calibration",
     "save_metric_gauge_anchor",
     "save_observation_belief_export",
     "save_point_uncertainty_calibration",
+    "save_source_reliability_model",
     "stack_observation_factors",
     "tracklets_to_observation_factors",
     "write_observation_factor_bundle",

--- a/src/prob4d/source_reliability.py
+++ b/src/prob4d/source_reliability.py
@@ -1,0 +1,684 @@
+"""Source-only, group-balanced calibration of observation prior reliability.
+
+The calibrated probability is a prior statement about source-side nominality. It
+must not use a Bayesian-PhysTwin physical innovation, a downstream posterior
+responsibility, or association probability as a substitute label.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ._immutable_json import frozen_finite_json_mapping, plain_json
+from .data import PredictionWindow
+from .uncertainty import DisagreementEvidence, StructuredCovariance
+
+FloatArray = NDArray[np.floating]
+BoolArray = NDArray[np.bool_]
+
+SOURCE_RELIABILITY_SCHEMA = "prob4d.source-reliability-calibration"
+SOURCE_RELIABILITY_VERSION = 1
+
+
+def _readonly(value: np.ndarray, *, dtype: Any) -> np.ndarray:
+    result = np.asarray(value, dtype=dtype).copy()
+    result.setflags(write=False)
+    return result
+
+
+def _canonical_json(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        plain_json(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _sigmoid(logits: np.ndarray) -> np.ndarray:
+    values = np.asarray(logits, dtype=np.float64)
+    result = np.empty_like(values)
+    positive = values >= 0.0
+    result[positive] = 1.0 / (1.0 + np.exp(-values[positive]))
+    exponent = np.exp(values[~positive])
+    result[~positive] = exponent / (1.0 + exponent)
+    return result
+
+
+@dataclass(frozen=True)
+class SourceReliabilityFeatures:
+    """Source-only feature grid and the rows eligible for calibration/use."""
+
+    feature_names: tuple[str, ...]
+    values: FloatArray
+    valid_mask: BoolArray
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        names = tuple(str(value) for value in self.feature_names)
+        if not names or any(not value for value in names):
+            raise ValueError("feature_names must be non-empty")
+        if len(set(names)) != len(names):
+            raise ValueError("feature_names must be unique")
+        values = np.asarray(self.values, dtype=np.float64)
+        mask = np.asarray(self.valid_mask, dtype=bool)
+        if values.ndim < 2 or values.shape[-1] != len(names):
+            raise ValueError("feature values must have shape (..., feature_count)")
+        if mask.shape != values.shape[:-1]:
+            raise ValueError("valid_mask must match the feature leading dimensions")
+        if not np.all(np.isfinite(values)):
+            raise ValueError("source reliability features must be finite")
+        if not np.any(mask):
+            raise ValueError("source reliability feature grid has no valid rows")
+        object.__setattr__(self, "feature_names", names)
+        object.__setattr__(self, "values", _readonly(values, dtype=np.float64))
+        object.__setattr__(self, "valid_mask", _readonly(mask, dtype=bool))
+        object.__setattr__(
+            self,
+            "metadata",
+            frozen_finite_json_mapping(
+                self.metadata,
+                name="source reliability feature metadata",
+            ),
+        )
+
+    @property
+    def feature_count(self) -> int:
+        return len(self.feature_names)
+
+    @property
+    def row_count(self) -> int:
+        return int(np.count_nonzero(self.valid_mask))
+
+    def flattened(self) -> FloatArray:
+        return self.values[self.valid_mask].copy()
+
+    def summary(self) -> dict[str, object]:
+        return {
+            "feature_names": list(self.feature_names),
+            "feature_count": self.feature_count,
+            "row_count": self.row_count,
+            "grid_shape": list(self.valid_mask.shape),
+        }
+
+
+def _local_validity_deficit(valid_mask: np.ndarray) -> np.ndarray:
+    valid = np.asarray(valid_mask, dtype=np.float64)
+    padded = np.pad(valid, ((0, 0), (1, 1), (1, 1)), mode="constant")
+    count = np.zeros_like(valid)
+    height, width = valid.shape[1:]
+    for row_offset in range(3):
+        for column_offset in range(3):
+            count += padded[
+                :,
+                row_offset : row_offset + height,
+                column_offset : column_offset + width,
+            ]
+    return 1.0 - count / 9.0
+
+
+def build_source_reliability_features(
+    window: PredictionWindow,
+    covariance: StructuredCovariance,
+    evidence: DisagreementEvidence | None = None,
+) -> SourceReliabilityFeatures:
+    """Build finite features without truth or downstream physical residuals."""
+
+    if covariance.parallel_variance.shape != window.shape:
+        raise ValueError("structured covariance shape differs from prediction window")
+    if evidence is not None and evidence.count.shape != window.shape:
+        raise ValueError("disagreement evidence shape differs from prediction window")
+
+    valid = np.asarray(window.valid_mask, dtype=bool)
+    parallel = covariance.parallel_variance
+    lateral = covariance.lateral_variance
+    total_variance = parallel + 2.0 * lateral
+    variance_scale = max(
+        float(np.median(total_variance[valid])),
+        np.finfo(np.float64).tiny,
+    )
+    log_relative_variance = np.log(
+        np.maximum(total_variance / variance_scale, np.finfo(np.float64).tiny)
+    )
+
+    if evidence is None:
+        has_overlap = np.zeros(window.shape, dtype=bool)
+        normalized_disagreement = np.zeros(window.shape, dtype=np.float64)
+    else:
+        has_overlap = evidence.count > 0.0
+        normalized_disagreement = (
+            evidence.parallel_mean / np.maximum(parallel, 1e-15)
+            + evidence.lateral_mean / np.maximum(lateral, 1e-15)
+        )
+        normalized_disagreement = np.where(
+            has_overlap,
+            normalized_disagreement,
+            0.0,
+        )
+    log_disagreement = np.log1p(np.maximum(normalized_disagreement, 0.0))
+
+    time_steps = window.shape[0]
+    if time_steps == 1:
+        temporal_edge = np.ones(1, dtype=np.float64)
+    else:
+        positions = np.arange(time_steps, dtype=np.float64)
+        distance = np.minimum(positions, time_steps - 1.0 - positions)
+        temporal_edge = 1.0 - distance / max((time_steps - 1.0) / 2.0, 1.0)
+        temporal_edge = np.clip(temporal_edge, 0.0, 1.0)
+    temporal_edge_grid = np.broadcast_to(
+        temporal_edge[:, None, None],
+        window.shape,
+    )
+
+    has_scene_flow = np.zeros(window.shape, dtype=bool)
+    log_relative_flow = np.zeros(window.shape, dtype=np.float64)
+    if window.scene_flow is not None and window.deform_mask is not None:
+        has_scene_flow = window.deform_mask & valid
+        flow_norm = np.linalg.norm(window.scene_flow, axis=-1)
+        positive_flow = flow_norm[has_scene_flow & (flow_norm > 0.0)]
+        flow_scale = (
+            float(np.median(positive_flow))
+            if len(positive_flow)
+            else 1.0
+        )
+        flow_scale = max(flow_scale, np.finfo(np.float64).tiny)
+        log_relative_flow = np.log1p(flow_norm / flow_scale)
+        log_relative_flow = np.where(has_scene_flow, log_relative_flow, 0.0)
+
+    validity_deficit = _local_validity_deficit(valid)
+    values = np.stack(
+        (
+            has_overlap.astype(np.float64),
+            log_disagreement,
+            temporal_edge_grid,
+            log_relative_variance,
+            has_scene_flow.astype(np.float64),
+            log_relative_flow,
+            validity_deficit,
+        ),
+        axis=-1,
+    )
+    return SourceReliabilityFeatures(
+        feature_names=(
+            "has_overlap",
+            "log1p_normalized_overlap_disagreement",
+            "temporal_edge_proximity",
+            "log_relative_total_variance",
+            "has_scene_flow",
+            "log1p_relative_scene_flow",
+            "local_validity_deficit",
+        ),
+        values=values,
+        valid_mask=valid,
+        metadata={
+            "semantics": "prob4d-source-only-reliability-features-v1",
+            "uses_truth": False,
+            "uses_downstream_physical_innovation": False,
+            "uses_association_probability": False,
+            "window_id": window.window_id,
+            "frame_indices": [int(value) for value in window.frame_indices],
+            "variance_scale": variance_scale,
+            "overlap_evidence_available": evidence is not None,
+            "scene_flow_available": window.scene_flow is not None,
+        },
+    )
+
+
+@dataclass(frozen=True)
+class SourceReliabilityCalibrationReport:
+    """Optimization and held-in calibration diagnostics."""
+
+    count: int
+    group_count: int
+    feature_count: int
+    iterations: int
+    converged: bool
+    group_balanced_nominal_fraction: float
+    weighted_log_loss: float
+    weighted_brier_score: float
+    ridge: float
+
+    def __post_init__(self) -> None:
+        integer_fields = ("count", "group_count", "feature_count", "iterations")
+        for name in integer_fields:
+            value = int(getattr(self, name))
+            if value != getattr(self, name) or value < 1:
+                raise ValueError(f"{name} must be a positive integer")
+            object.__setattr__(self, name, value)
+        diagnostics = np.asarray(
+            [
+                self.group_balanced_nominal_fraction,
+                self.weighted_log_loss,
+                self.weighted_brier_score,
+                self.ridge,
+            ],
+            dtype=np.float64,
+        )
+        if not np.all(np.isfinite(diagnostics)) or np.any(diagnostics < 0.0):
+            raise ValueError("source reliability diagnostics must be finite and non-negative")
+        if diagnostics[0] > 1.0:
+            raise ValueError("nominal fraction must lie in [0, 1]")
+        object.__setattr__(self, "converged", bool(self.converged))
+        object.__setattr__(
+            self,
+            "group_balanced_nominal_fraction",
+            float(diagnostics[0]),
+        )
+        object.__setattr__(self, "weighted_log_loss", float(diagnostics[1]))
+        object.__setattr__(self, "weighted_brier_score", float(diagnostics[2]))
+        object.__setattr__(self, "ridge", float(diagnostics[3]))
+
+    def to_dict(self) -> dict[str, int | float | bool]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class SourceReliabilityModelV1:
+    """Content-addressed group-balanced logistic source-reliability model."""
+
+    feature_names: tuple[str, ...]
+    feature_center: FloatArray
+    feature_scale: FloatArray
+    coefficients: FloatArray
+    minimum_probability: float
+    maximum_probability: float
+    label_definition: str
+    group_definition: str
+    calibration_group_ids: tuple[str, ...]
+    report: SourceReliabilityCalibrationReport
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        names = tuple(str(value) for value in self.feature_names)
+        if not names or any(not value for value in names):
+            raise ValueError("feature_names must be non-empty")
+        if len(set(names)) != len(names):
+            raise ValueError("feature_names must be unique")
+        center = np.asarray(self.feature_center, dtype=np.float64)
+        scale = np.asarray(self.feature_scale, dtype=np.float64)
+        coefficients = np.asarray(self.coefficients, dtype=np.float64)
+        feature_count = len(names)
+        if center.shape != (feature_count,) or scale.shape != (feature_count,):
+            raise ValueError("feature center and scale must match feature_names")
+        if coefficients.shape != (feature_count + 1,):
+            raise ValueError("coefficients must contain intercept plus one value per feature")
+        if not np.all(np.isfinite(center)) or not np.all(np.isfinite(coefficients)):
+            raise ValueError("source reliability model values must be finite")
+        if not np.all(np.isfinite(scale)) or np.any(scale <= 0.0):
+            raise ValueError("feature_scale must be finite and positive")
+        minimum = float(self.minimum_probability)
+        maximum = float(self.maximum_probability)
+        if not 0.0 < minimum < maximum < 1.0:
+            raise ValueError("probability limits must satisfy 0 < minimum < maximum < 1")
+        label_definition = str(self.label_definition).strip()
+        group_definition = str(self.group_definition).strip()
+        if not label_definition or not group_definition:
+            raise ValueError("label_definition and group_definition must be non-empty")
+        groups = tuple(sorted(str(value).strip() for value in self.calibration_group_ids))
+        if not groups or any(not value for value in groups) or len(set(groups)) != len(groups):
+            raise ValueError("calibration_group_ids must be non-empty and unique")
+        if self.report.feature_count != feature_count:
+            raise ValueError("calibration report feature count changed")
+        if self.report.group_count != len(groups):
+            raise ValueError("calibration report group count changed")
+        object.__setattr__(self, "feature_names", names)
+        object.__setattr__(self, "feature_center", _readonly(center, dtype=np.float64))
+        object.__setattr__(self, "feature_scale", _readonly(scale, dtype=np.float64))
+        object.__setattr__(
+            self,
+            "coefficients",
+            _readonly(coefficients, dtype=np.float64),
+        )
+        object.__setattr__(self, "minimum_probability", minimum)
+        object.__setattr__(self, "maximum_probability", maximum)
+        object.__setattr__(self, "label_definition", label_definition)
+        object.__setattr__(self, "group_definition", group_definition)
+        object.__setattr__(self, "calibration_group_ids", groups)
+        object.__setattr__(
+            self,
+            "metadata",
+            frozen_finite_json_mapping(
+                self.metadata,
+                name="source reliability calibration metadata",
+            ),
+        )
+
+    def predict(self, features: SourceReliabilityFeatures | FloatArray) -> FloatArray:
+        if isinstance(features, SourceReliabilityFeatures):
+            if features.feature_names != self.feature_names:
+                raise ValueError("source reliability feature names changed")
+            values = features.values
+        else:
+            values = np.asarray(features, dtype=np.float64)
+        if values.shape[-1:] != (len(self.feature_names),):
+            raise ValueError("feature array has changed final dimension")
+        if not np.all(np.isfinite(values)):
+            raise ValueError("prediction features must be finite")
+        standardized = (values - self.feature_center) / self.feature_scale
+        logits = self.coefficients[0] + np.einsum(
+            "...f,f->...",
+            standardized,
+            self.coefficients[1:],
+        )
+        probability = _sigmoid(logits)
+        probability = np.clip(
+            probability,
+            self.minimum_probability,
+            self.maximum_probability,
+        )
+        if isinstance(features, SourceReliabilityFeatures):
+            probability = np.where(features.valid_mask, probability, 0.0)
+        return probability
+
+    def descriptor(self) -> dict[str, Any]:
+        return {
+            "schema": SOURCE_RELIABILITY_SCHEMA,
+            "version": SOURCE_RELIABILITY_VERSION,
+            "feature_names": list(self.feature_names),
+            "feature_center": self.feature_center.tolist(),
+            "feature_scale": self.feature_scale.tolist(),
+            "coefficients": self.coefficients.tolist(),
+            "minimum_probability": self.minimum_probability,
+            "maximum_probability": self.maximum_probability,
+            "label_definition": self.label_definition,
+            "group_definition": self.group_definition,
+            "calibration_group_ids": list(self.calibration_group_ids),
+            "report": self.report.to_dict(),
+            "metadata": plain_json(self.metadata),
+        }
+
+    @property
+    def artifact_id(self) -> str:
+        return hashlib.sha256(_canonical_json(self.descriptor())).hexdigest()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"artifact_id": self.artifact_id, **self.descriptor()}
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> SourceReliabilityModelV1:
+        if payload.get("schema") != SOURCE_RELIABILITY_SCHEMA:
+            raise ValueError("unexpected source reliability schema")
+        if payload.get("version") != SOURCE_RELIABILITY_VERSION:
+            raise ValueError("unsupported source reliability version")
+        report_payload = payload.get("report")
+        if not isinstance(report_payload, Mapping):
+            raise ValueError("source reliability artifact is missing its report")
+        try:
+            report = SourceReliabilityCalibrationReport(
+                count=int(report_payload["count"]),
+                group_count=int(report_payload["group_count"]),
+                feature_count=int(report_payload["feature_count"]),
+                iterations=int(report_payload["iterations"]),
+                converged=bool(report_payload["converged"]),
+                group_balanced_nominal_fraction=float(
+                    report_payload["group_balanced_nominal_fraction"]
+                ),
+                weighted_log_loss=float(report_payload["weighted_log_loss"]),
+                weighted_brier_score=float(
+                    report_payload["weighted_brier_score"]
+                ),
+                ridge=float(report_payload["ridge"]),
+            )
+            artifact = cls(
+                feature_names=tuple(payload["feature_names"]),
+                feature_center=np.asarray(payload["feature_center"], dtype=np.float64),
+                feature_scale=np.asarray(payload["feature_scale"], dtype=np.float64),
+                coefficients=np.asarray(payload["coefficients"], dtype=np.float64),
+                minimum_probability=float(payload["minimum_probability"]),
+                maximum_probability=float(payload["maximum_probability"]),
+                label_definition=str(payload["label_definition"]),
+                group_definition=str(payload["group_definition"]),
+                calibration_group_ids=tuple(payload["calibration_group_ids"]),
+                report=report,
+                metadata=payload.get("metadata", {}),
+            )
+        except (KeyError, TypeError, ValueError) as error:
+            raise ValueError("invalid source reliability artifact") from error
+        if str(payload.get("artifact_id", "")) != artifact.artifact_id:
+            raise ValueError("source reliability artifact_id does not match content")
+        return artifact
+
+
+def _canonical_training_rows(
+    features: np.ndarray,
+    labels: np.ndarray,
+    groups: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    keys: list[np.ndarray] = [labels]
+    keys.extend(features[:, index] for index in reversed(range(features.shape[1])))
+    keys.append(groups)
+    order = np.lexsort(tuple(keys))
+    return features[order], labels[order], groups[order]
+
+
+def _weighted_objective(
+    design: np.ndarray,
+    labels: np.ndarray,
+    weights: np.ndarray,
+    parameters: np.ndarray,
+    ridge: float,
+) -> float:
+    logits = design @ parameters
+    data_loss = np.sum(weights * (np.logaddexp(0.0, logits) - labels * logits))
+    return float(data_loss + 0.5 * ridge * np.sum(parameters[1:] ** 2))
+
+
+def fit_group_balanced_source_reliability(
+    features: FloatArray,
+    nominal_labels: BoolArray | FloatArray,
+    group_ids: np.ndarray,
+    *,
+    feature_names: Sequence[str],
+    mask: BoolArray | None = None,
+    ridge: float = 1e-3,
+    maximum_iterations: int = 100,
+    convergence_tolerance: float = 1e-9,
+    minimum_probability: float = 0.01,
+    maximum_probability: float = 0.99,
+    label_definition: str,
+    group_definition: str,
+    metadata: Mapping[str, Any] | None = None,
+) -> SourceReliabilityModelV1:
+    """Fit deterministic logistic nominality with equal mass per group."""
+
+    values = np.asarray(features, dtype=np.float64)
+    labels = np.asarray(nominal_labels, dtype=np.float64)
+    groups = np.asarray(group_ids)
+    if values.ndim < 2 or values.shape[-1] < 1:
+        raise ValueError("features must have shape (..., feature_count)")
+    leading_shape = values.shape[:-1]
+    if labels.shape != leading_shape or groups.shape != leading_shape:
+        raise ValueError("labels and group_ids must match feature leading dimensions")
+    names = tuple(str(value) for value in feature_names)
+    if len(names) != values.shape[-1]:
+        raise ValueError("feature_names length differs from feature count")
+    active = np.ones(leading_shape, dtype=bool)
+    if mask is not None:
+        supplied_mask = np.asarray(mask, dtype=bool)
+        if supplied_mask.shape != leading_shape:
+            raise ValueError("mask must match feature leading dimensions")
+        active &= supplied_mask
+    if not np.any(active):
+        raise ValueError("source reliability calibration has no active rows")
+    active_values = values[active]
+    active_labels = labels[active]
+    raw_groups = groups[active].reshape(-1)
+    if not np.all(np.isfinite(active_values)):
+        raise ValueError("active calibration features must be finite")
+    if not np.all(np.isfinite(active_labels)) or not np.all(
+        (active_labels == 0.0) | (active_labels == 1.0)
+    ):
+        raise ValueError("nominal_labels must contain only zero or one")
+    if len(np.unique(active_labels)) != 2:
+        raise ValueError("source reliability calibration requires both label classes")
+    normalized_groups = np.asarray(
+        ["" if value is None else str(value).strip() for value in raw_groups],
+        dtype=str,
+    )
+    if np.any(normalized_groups == ""):
+        raise ValueError("active calibration group IDs must be non-empty")
+    active_values, active_labels, normalized_groups = _canonical_training_rows(
+        active_values,
+        active_labels,
+        normalized_groups,
+    )
+    canonical_groups = tuple(sorted(set(normalized_groups.tolist())))
+    group_count = len(canonical_groups)
+    weights = np.empty(len(active_labels), dtype=np.float64)
+    for group_id in canonical_groups:
+        selected = normalized_groups == group_id
+        weights[selected] = 1.0 / (group_count * int(np.count_nonzero(selected)))
+    if not np.isclose(np.sum(weights), 1.0, atol=1e-12):
+        raise RuntimeError("group-balanced calibration weights do not sum to one")
+
+    ridge = float(ridge)
+    tolerance = float(convergence_tolerance)
+    maximum_iterations = int(maximum_iterations)
+    if not np.isfinite(ridge) or ridge <= 0.0:
+        raise ValueError("ridge must be finite and positive")
+    if not np.isfinite(tolerance) or tolerance <= 0.0:
+        raise ValueError("convergence_tolerance must be finite and positive")
+    if maximum_iterations < 1:
+        raise ValueError("maximum_iterations must be positive")
+    if not 0.0 < minimum_probability < maximum_probability < 1.0:
+        raise ValueError("probability limits must satisfy 0 < minimum < maximum < 1")
+
+    center = np.sum(weights[:, None] * active_values, axis=0)
+    centered = active_values - center
+    scale = np.sqrt(np.sum(weights[:, None] * centered**2, axis=0))
+    scale = np.where(scale > 1e-12, scale, 1.0)
+    standardized = centered / scale
+    design = np.column_stack((np.ones(len(standardized)), standardized))
+    nominal_fraction = float(np.sum(weights * active_labels))
+    initial_probability = float(np.clip(nominal_fraction, 1e-6, 1.0 - 1e-6))
+    parameters = np.zeros(design.shape[1], dtype=np.float64)
+    parameters[0] = np.log(initial_probability / (1.0 - initial_probability))
+    regularizer = np.diag(np.r_[0.0, np.full(values.shape[-1], ridge)])
+    converged = False
+    iterations = 0
+    for iteration in range(1, maximum_iterations + 1):
+        iterations = iteration
+        logits = design @ parameters
+        probability = _sigmoid(logits)
+        curvature = weights * probability * (1.0 - probability)
+        gradient = design.T @ (weights * (probability - active_labels))
+        gradient[1:] += ridge * parameters[1:]
+        hessian = design.T @ (curvature[:, None] * design) + regularizer
+        hessian += 1e-12 * np.eye(hessian.shape[0])
+        try:
+            step = np.linalg.solve(hessian, gradient)
+        except np.linalg.LinAlgError:
+            step = np.linalg.lstsq(hessian, gradient, rcond=None)[0]
+        if np.linalg.norm(step) <= tolerance * (1.0 + np.linalg.norm(parameters)):
+            converged = True
+            break
+        current_objective = _weighted_objective(
+            design,
+            active_labels,
+            weights,
+            parameters,
+            ridge,
+        )
+        accepted = False
+        fraction = 1.0
+        for _ in range(20):
+            candidate = parameters - fraction * step
+            candidate_objective = _weighted_objective(
+                design,
+                active_labels,
+                weights,
+                candidate,
+                ridge,
+            )
+            if candidate_objective < current_objective - 1e-14:
+                parameters = candidate
+                accepted = True
+                break
+            fraction *= 0.5
+        if not accepted:
+            break
+        if np.linalg.norm(fraction * step) <= tolerance * (
+            1.0 + np.linalg.norm(parameters)
+        ):
+            converged = True
+            break
+
+    fitted_probability = np.clip(
+        _sigmoid(design @ parameters),
+        minimum_probability,
+        maximum_probability,
+    )
+    weighted_log_loss = float(
+        -np.sum(
+            weights
+            * (
+                active_labels * np.log(fitted_probability)
+                + (1.0 - active_labels) * np.log(1.0 - fitted_probability)
+            )
+        )
+    )
+    weighted_brier = float(
+        np.sum(weights * (fitted_probability - active_labels) ** 2)
+    )
+    report = SourceReliabilityCalibrationReport(
+        count=len(active_labels),
+        group_count=group_count,
+        feature_count=values.shape[-1],
+        iterations=iterations,
+        converged=converged,
+        group_balanced_nominal_fraction=nominal_fraction,
+        weighted_log_loss=weighted_log_loss,
+        weighted_brier_score=weighted_brier,
+        ridge=ridge,
+    )
+    return SourceReliabilityModelV1(
+        feature_names=names,
+        feature_center=center,
+        feature_scale=scale,
+        coefficients=parameters,
+        minimum_probability=minimum_probability,
+        maximum_probability=maximum_probability,
+        label_definition=label_definition,
+        group_definition=group_definition,
+        calibration_group_ids=canonical_groups,
+        report=report,
+        metadata={} if metadata is None else metadata,
+    )
+
+
+def save_source_reliability_model(
+    model: SourceReliabilityModelV1,
+    path: str | Path,
+) -> None:
+    Path(path).write_text(
+        json.dumps(model.to_dict(), sort_keys=True, indent=2, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def load_source_reliability_model(path: str | Path) -> SourceReliabilityModelV1:
+    payload = json.loads(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, Mapping):
+        raise ValueError("source reliability artifact must be a JSON object")
+    return SourceReliabilityModelV1.from_dict(payload)
+
+
+__all__ = [
+    "SOURCE_RELIABILITY_SCHEMA",
+    "SOURCE_RELIABILITY_VERSION",
+    "SourceReliabilityCalibrationReport",
+    "SourceReliabilityFeatures",
+    "SourceReliabilityModelV1",
+    "build_source_reliability_features",
+    "fit_group_balanced_source_reliability",
+    "load_source_reliability_model",
+    "save_source_reliability_model",
+]

--- a/tests/test_source_reliability.py
+++ b/tests/test_source_reliability.py
@@ -1,0 +1,217 @@
+import json
+
+import numpy as np
+import pytest
+
+from prob4d.data import PredictionWindow
+from prob4d.source_reliability import (
+    SourceReliabilityModelV1,
+    build_source_reliability_features,
+    fit_group_balanced_source_reliability,
+    load_source_reliability_model,
+    save_source_reliability_model,
+)
+from prob4d.uncertainty import DisagreementEvidence, StructuredCovariance
+
+
+def feature_window() -> PredictionWindow:
+    point_map = np.zeros((3, 2, 2, 3), dtype=np.float64)
+    point_map[..., 2] = np.array(
+        [
+            [[1.0, 2.0], [3.0, 4.0]],
+            [[1.5, 2.5], [3.5, 4.5]],
+            [[2.0, 3.0], [4.0, 5.0]],
+        ]
+    )
+    valid = np.ones((3, 2, 2), dtype=bool)
+    valid[1, 1, 1] = False
+    flow = np.zeros_like(point_map)
+    flow[..., 0] = 0.1
+    deform = valid.copy()
+    return PredictionWindow(
+        window_id="features",
+        frame_indices=np.array([10, 11, 12]),
+        point_map=point_map,
+        valid_mask=valid,
+        scene_flow=flow,
+        deform_mask=deform,
+    )
+
+
+def test_source_feature_builder_uses_only_source_side_inputs() -> None:
+    window = feature_window()
+    rays = window.rays()
+    covariance = StructuredCovariance(
+        ray_directions=rays,
+        parallel_variance=np.full(window.shape, 0.04),
+        lateral_variance=np.full(window.shape, 0.01),
+    )
+    parallel = np.zeros(window.shape)
+    lateral = np.zeros(window.shape)
+    count = np.zeros(window.shape)
+    parallel[0, 0, 0] = 0.08
+    lateral[0, 0, 0] = 0.01
+    count[0, 0, 0] = 1.0
+    evidence = DisagreementEvidence(parallel, lateral, count)
+
+    features = build_source_reliability_features(window, covariance, evidence)
+
+    assert features.values.shape == window.shape + (7,)
+    assert features.feature_names[0] == "has_overlap"
+    assert features.values[0, 0, 0, 0] == 1.0
+    assert features.values[0, 0, 1, 0] == 0.0
+    assert features.values[0, 0, 0, 1] > 0.0
+    assert features.values[0, 0, 0, 2] == 1.0
+    assert features.values[1, 0, 0, 2] == 0.0
+    assert features.values[2, 0, 0, 2] == 1.0
+    assert features.metadata["uses_truth"] is False
+    assert features.metadata["uses_downstream_physical_innovation"] is False
+    assert features.valid_mask[1, 1, 1] == 0
+
+
+def test_group_balance_prevents_dense_sequence_domination() -> None:
+    features = np.zeros((404, 1), dtype=np.float64)
+    labels = np.r_[np.ones(400), np.zeros(4)]
+    groups = np.asarray(["large"] * 400 + ["small"] * 4)
+
+    model = fit_group_balanced_source_reliability(
+        features,
+        labels,
+        groups,
+        feature_names=("constant",),
+        ridge=1e-3,
+        label_definition="source point error below frozen threshold",
+        group_definition="sequence",
+    )
+
+    probability = float(model.predict(np.zeros((1, 1)))[0])
+    np.testing.assert_allclose(probability, 0.5, atol=1e-12)
+    np.testing.assert_allclose(
+        model.report.group_balanced_nominal_fraction,
+        0.5,
+        atol=1e-12,
+    )
+    assert model.report.group_count == 2
+    assert model.report.converged is True
+
+
+def test_logistic_model_learns_source_feature_ranking() -> None:
+    generator = np.random.default_rng(42)
+    feature = np.linspace(-3.0, 3.0, 300)
+    latent = feature + generator.normal(scale=0.7, size=len(feature))
+    labels = (latent > 0.0).astype(np.float64)
+    groups = np.asarray([f"sequence-{index // 30}" for index in range(len(feature))])
+
+    model = fit_group_balanced_source_reliability(
+        feature[:, None],
+        labels,
+        groups,
+        feature_names=("source_score",),
+        ridge=1e-2,
+        label_definition="source-only nominal correspondence label",
+        group_definition="sequence",
+    )
+    predicted = model.predict(np.array([[-2.0], [0.0], [2.0]]))
+
+    assert predicted[0] < predicted[1] < predicted[2]
+    assert predicted[0] < 0.2
+    assert predicted[2] > 0.8
+    assert model.report.weighted_brier_score < 0.15
+
+
+def test_fit_and_artifact_are_invariant_to_row_order() -> None:
+    generator = np.random.default_rng(7)
+    features = generator.normal(size=(120, 3))
+    labels = (features[:, 0] - 0.5 * features[:, 1] > 0.0).astype(float)
+    groups = np.asarray([f"group-{index // 20}" for index in range(len(features))])
+    arguments = {
+        "feature_names": ("first", "second", "third"),
+        "ridge": 0.05,
+        "label_definition": "source-only binary nominality",
+        "group_definition": "object session",
+        "metadata": {"split": "calibration-only"},
+    }
+    first = fit_group_balanced_source_reliability(
+        features,
+        labels,
+        groups,
+        **arguments,
+    )
+    permutation = generator.permutation(len(features))
+    second = fit_group_balanced_source_reliability(
+        features[permutation],
+        labels[permutation],
+        groups[permutation],
+        **arguments,
+    )
+
+    assert first.artifact_id == second.artifact_id
+    assert first.to_dict() == second.to_dict()
+    np.testing.assert_array_equal(first.coefficients, second.coefficients)
+
+
+def test_source_reliability_artifact_round_trip_and_tamper_rejection(
+    tmp_path,
+) -> None:
+    features = np.array([[-1.0], [-0.5], [0.5], [1.0]])
+    labels = np.array([0.0, 0.0, 1.0, 1.0])
+    groups = np.array(["a", "a", "b", "b"])
+    model = fit_group_balanced_source_reliability(
+        features,
+        labels,
+        groups,
+        feature_names=("score",),
+        label_definition="source-only nominality",
+        group_definition="sequence",
+    )
+    path = tmp_path / "source-reliability.json"
+    save_source_reliability_model(model, path)
+
+    loaded = load_source_reliability_model(path)
+    assert loaded.artifact_id == model.artifact_id
+    np.testing.assert_array_equal(loaded.coefficients, model.coefficients)
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["coefficients"][0] += 0.1
+    with pytest.raises(ValueError, match="artifact_id"):
+        SourceReliabilityModelV1.from_dict(payload)
+
+
+def test_feature_contract_masks_invalid_rows_during_prediction() -> None:
+    window = feature_window()
+    covariance = StructuredCovariance(
+        ray_directions=window.rays(),
+        parallel_variance=np.full(window.shape, 0.04),
+        lateral_variance=np.full(window.shape, 0.01),
+    )
+    features = build_source_reliability_features(window, covariance)
+    active_values = features.flattened()
+    labels = (active_values[:, 3] < np.median(active_values[:, 3])).astype(float)
+    groups = np.asarray(
+        [f"frame-{index // 4}" for index in range(len(active_values))]
+    )
+    model = fit_group_balanced_source_reliability(
+        active_values,
+        labels,
+        groups,
+        feature_names=features.feature_names,
+        label_definition="source variance below frozen median threshold",
+        group_definition="frame",
+    )
+
+    probability = model.predict(features)
+    assert probability.shape == window.shape
+    assert probability[1, 1, 1] == 0.0
+    assert np.all(probability[features.valid_mask] > 0.0)
+
+
+def test_source_reliability_fit_requires_both_label_classes() -> None:
+    with pytest.raises(ValueError, match="both label classes"):
+        fit_group_balanced_source_reliability(
+            np.zeros((4, 1)),
+            np.ones(4),
+            np.asarray(["a", "a", "b", "b"]),
+            feature_names=("constant",),
+            label_definition="nominality",
+            group_definition="sequence",
+        )

--- a/tests/test_source_reliability.py
+++ b/tests/test_source_reliability.py
@@ -186,7 +186,7 @@ def test_feature_contract_masks_invalid_rows_during_prediction() -> None:
     )
     features = build_source_reliability_features(window, covariance)
     active_values = features.flattened()
-    labels = (active_values[:, 3] < np.median(active_values[:, 3])).astype(float)
+    labels = (active_values[:, 2] > 0.5).astype(float)
     groups = np.asarray(
         [f"frame-{index // 4}" for index in range(len(active_values))]
     )
@@ -195,7 +195,7 @@ def test_feature_contract_masks_invalid_rows_during_prediction() -> None:
         labels,
         groups,
         feature_names=features.feature_names,
-        label_definition="source variance below frozen median threshold",
+        label_definition="source temporal edge proximity above frozen threshold",
         group_definition="frame",
     )
 


### PR DESCRIPTION
## Summary

- add a finite source-only feature contract for observation prior reliability;
- include explicit missing-overlap and scene-flow-availability indicators so absence of disagreement is not treated as certainty;
- expose overlap disagreement, temporal-window edge proximity, relative predictive variance, scene-flow magnitude, and local validity deficit without using truth at inference time;
- fit deterministic ridge-logistic nominality with equal total mass per declared sequence/object/session group;
- canonicalize training-row and group ordering so input permutation does not change coefficients or artifact bytes;
- record feature normalization, coefficients, probability limits, exact label/group definitions, calibration groups, convergence, weighted log loss, Brier score, and immutable metadata;
- content-address the complete model and provide strict save/load/tamper validation;
- export the new APIs, document the label and promotion boundaries, and add source-feature, imbalance, ranking, row-order, round-trip, masking, and invalid-label regressions.

## Why

The current overlap-derived reliability path assigns reliability one where no overlap observation exists. More generally, shared model bias can be wrong while overlapping predictions agree. A claim-bearing feeder therefore needs a separately calibrated source-side prior nominality model rather than interpreting missing or small disagreement as certainty.

The calibration assigns equal aggregate weight to every declared statistical unit. A long or densely valid sequence cannot dominate merely because it contributes more pixels.

## Information and compatibility boundary

- Existing provider-v1/v2 exports and calibration artifacts are unchanged.
- The new feature/model API is additive and opt-in.
- Features may use prediction geometry, source covariance, overlap consistency, temporal location, masks, and scene flow; they do not use a Bayesian-PhysTwin innovation, target future metric, association probability, or posterior robust responsibility.
- Labels and grouping definitions must be frozen before target access and generated from independent source/calibration evidence.
- A calibrated source reliability does not authorize a physical update; Bayesian-PhysTwin's baseline-relative guard and exact fallback remain necessary.
- Promotion requires a new content-addressed calibration artifact and held-out sequence/object evaluation rather than silent reuse of the current point-uncertainty calibration.

## Validation

- focused tests cover source-only feature semantics, severe group-size imbalance, learned ranking, byte-level row-order invariance, artifact round-trip and tamper rejection, invalid-row masking, and the both-class requirement;
- repository CI runs Ruff, stable-interface mypy checks, the complete Python 3.10/3.12/3.14 test matrix, distribution builds, and isolated wheel/sdist command smoke tests.