### PR TITLE
Fail closed on incomplete claim-bearing calibration

### DIFF
--- a/src/prob4d/provider_v2_loading.py
+++ b/src/prob4d/provider_v2_loading.py
@@ -41,6 +41,12 @@ def _require_revision(value: object, *, name: str) -> str:
     return revision
 
 
+def _require_nonnegative_integer(value: object, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{name} must be a non-negative integer")
+    return value
+
+
 @dataclass(frozen=True)
 class ValidatedClaimBearingObservation:
     """A strict provider-v2 observation plus its validated producer identities."""
@@ -171,6 +177,30 @@ def validate_claim_bearing_observation_belief(
     )
     if calibration.get("status") != "calibrated":
         raise ValueError("claim-bearing observation requires both covariance calibrations")
+    if calibration.get("uncalibrated_exploratory_covariance_allowed") is not False:
+        raise ValueError(
+            "claim-bearing observation cannot allow uncalibrated covariance"
+        )
+    if calibration.get("pointwise_covariance_fallback_allowed") is not False:
+        raise ValueError(
+            "claim-bearing observation cannot allow pointwise covariance fallback"
+        )
+    alignment_count = _require_nonnegative_integer(
+        calibration.get("alignment_count"),
+        name="claim-bearing alignment_count",
+    )
+    calibrated_alignment_count = _require_nonnegative_integer(
+        calibration.get("gauge_calibrated_alignment_count"),
+        name="claim-bearing gauge_calibrated_alignment_count",
+    )
+    if calibrated_alignment_count != alignment_count:
+        raise ValueError("claim-bearing observation has uncalibrated gauge alignments")
+    fallback_counts = _required_mapping(
+        calibration.get("covariance_fallback_counts"),
+        name="claim-bearing covariance fallback counts",
+    )
+    if fallback_counts:
+        raise ValueError("claim-bearing observation reports covariance fallback use")
 
     raw_attestation = _required_mapping(
         metadata.get("prob4d_provider_attestation"),

--- a/tests/test_claim_bearing_observation.py
+++ b/tests/test_claim_bearing_observation.py
@@ -46,7 +46,10 @@ def _attestation() -> dict[str, object]:
     )
 
 
-def _artifact(*, caller_metadata: dict[str, object] | None = None) -> ObservationBeliefExportV1:
+def _artifact(
+    *,
+    caller_metadata: dict[str, object] | None = None,
+) -> ObservationBeliefExportV1:
     metadata: dict[str, object] = {
         "coordinate_frame": "phystwin-world",
         "gauge_mode": "sequential",
@@ -78,6 +81,11 @@ def _artifact(*, caller_metadata: dict[str, object] | None = None) -> Observatio
             "status": "calibrated",
             "gauge_artifact_id": GAUGE_CALIBRATION_ID,
             "point_artifact_id": POINT_CALIBRATION_ID,
+            "alignment_count": 1,
+            "gauge_calibrated_alignment_count": 1,
+            "covariance_fallback_counts": {},
+            "uncalibrated_exploratory_covariance_allowed": False,
+            "pointwise_covariance_fallback_allowed": False,
         },
         "prob4d_provider_attestation": _attestation(),
         "nested": {"values": [1, {"label": "stable"}]},
@@ -161,6 +169,65 @@ def test_strict_validation_rejects_calibration_identity_drift() -> None:
     changed = replace(artifact, metadata=metadata)
 
     with pytest.raises(ValueError, match="differs from provider attestation"):
+        validate_claim_bearing_observation_belief(changed)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        (
+            "gauge_calibrated_alignment_count",
+            0,
+            "uncalibrated gauge alignments",
+        ),
+        (
+            "covariance_fallback_counts",
+            {"pointwise": 1},
+            "reports covariance fallback use",
+        ),
+        (
+            "uncalibrated_exploratory_covariance_allowed",
+            True,
+            "cannot allow uncalibrated covariance",
+        ),
+        (
+            "pointwise_covariance_fallback_allowed",
+            True,
+            "cannot allow pointwise covariance fallback",
+        ),
+    ],
+)
+def test_strict_validation_rejects_incomplete_or_fallback_calibration(
+    field: str,
+    value: object,
+    message: str,
+) -> None:
+    artifact = _artifact()
+    metadata = deepcopy(artifact.metadata)
+    metadata["covariance_calibration"][field] = value
+    changed = replace(artifact, metadata=metadata)
+
+    with pytest.raises(ValueError, match=message):
+        validate_claim_bearing_observation_belief(changed)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [
+        "alignment_count",
+        "gauge_calibrated_alignment_count",
+        "covariance_fallback_counts",
+        "uncalibrated_exploratory_covariance_allowed",
+        "pointwise_covariance_fallback_allowed",
+    ],
+)
+def test_strict_validation_requires_complete_calibration_metadata(field: str) -> None:
+    artifact = _artifact()
+    metadata = deepcopy(artifact.metadata)
+    metadata["covariance_calibration"].pop(field)
+    changed = replace(artifact, metadata=metadata)
+
+    with pytest.raises(ValueError):
         validate_claim_bearing_observation_belief(changed)
 
 


### PR DESCRIPTION
## Summary

- require claim-bearing provider-v2 observations to declare complete gauge and point covariance calibration metadata;
- require every gauge alignment to be calibrated;
- reject permission for uncalibrated covariance or pointwise fallback;
- reject any recorded covariance fallback use;
- add focused regressions for partial calibration, fallback permission/use, and missing calibration fields.

## Root cause

The strict provider-v2 loader checked calibrated status and attested calibration identities, but it did not enforce the alignment-count and fallback invariants already required by downstream Bayesian-PhysTwin and Causal4D consumers. A producer artifact could therefore pass Prob4D's strict loader while being rejected later at the physical-update boundary.

## Compatibility and scientific boundary

- provider-v1 and exploratory loading are unchanged;
- the stricter behavior applies only to the explicit claim-bearing provider-v2 loader;
- this is an evidence-admission and provenance consistency fix, not an empirical calibration or prediction result.

## Validation

GitHub Actions is authoritative for Ruff, typing, the Python 3.10/3.12/3.14 suites, package builds, and installed-artifact smoke checks. The downstream Causal4D three-repository workflow includes adversarial variants for every new rejection.