### PR TITLE
Add append-only factor streams and explicit provider-v2 surfaces

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,12 +56,14 @@ jobs:
           src/prob4d/calibration_compatibility.py
           src/prob4d/composition_jacobian.py
           src/prob4d/covariance_root.py
+          src/prob4d/observation_factor_stream.py
           src/prob4d/provider_attestation.py
           src/prob4d/provider_manifest.py
           src/prob4d/provider_manifest_cli.py
           src/prob4d/provider_v1.py
           src/prob4d/provider_v2.py
           src/prob4d/provider_v2_cli.py
+          src/prob4d/provider_v2_loading.py
           src/prob4d/runtime_revision.py
           2>&1 | tee mypy-output.txt
       - name: Upload mypy diagnostics
@@ -129,11 +131,13 @@ jobs:
           import prob4d.cli
           import prob4d.composition_jacobian
           import prob4d.covariance_root
+          import prob4d.observation_factor_stream
           import prob4d.provider_attestation
           import prob4d.provider_manifest
           import prob4d.provider_v1
           import prob4d.provider_v2
           import prob4d.provider_v2_cli
+          import prob4d.provider_v2_loading
           import prob4d.runtime_revision
 
           forbidden = {"torch", "diffusers", "decord"}
@@ -209,14 +213,20 @@ jobs:
           "$python_bin" -m pip install "$artifact"
           "$python_bin" -m pip check
           "$python_bin" - <<'PY'
+          from importlib import resources
+
           import prob4d
           import prob4d.provider_v1 as provider_v1
           import prob4d.provider_v2 as provider_v2
           from prob4d.composition_jacobian import current_composition_jacobian_mode
 
           print(prob4d.__version__)
+          assert prob4d.__version__ == "0.3.0"
           assert provider_v1.PROVIDER_API_VERSION == 1
           assert provider_v2.PROVIDER_API_VERSION == 2
+          assert provider_v2.OBSERVATION_FACTOR_STREAM_VERSION == 1
+          assert callable(provider_v2.load_claim_bearing_observation_belief)
+          assert resources.files("prob4d").joinpath("py.typed").is_file()
           assert current_composition_jacobian_mode() == "legacy_finite_difference"
           PY
       - name: Exercise grouped and legacy command help
@@ -227,6 +237,7 @@ jobs:
           "$bin/prob4d" provider manifest --help
           "$bin/prob4d" provider manifest --api-version 2 --help
           "$bin/prob4d" observation export --help
+          "$bin/prob4d" observation export-v1 --help
           "$bin/prob4d" observation export-calibrated --help
           "$bin/prob4d" observation export-exploratory --help
           "$bin/prob4d" motioncrafter --help

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,28 @@ All notable changes to Prob4D are documented here.
 
 ## Unreleased
 
+## 0.3.0 — 2026-07-30
+
 ### Added
 
+- `ObservationFactorStreamV1`, a portable append-only chain of causally disjoint
+  schema-v4 factor bundles with bundle/payload checksums, stable observation
+  identity digests, contiguous frame intervals, and previous-update hash binding.
+- Direct provider-v2 exports of `load_claim_bearing_observation_belief`,
+  `validate_claim_bearing_observation_belief`, and
+  `ValidatedClaimBearingObservation` so safe export and admission live on one
+  versioned public surface.
+- A PEP 561 `py.typed` marker for downstream static type checking.
 - `load_claim_bearing_observation_belief` and
-  `validate_claim_bearing_observation_belief` as explicit
-  `prob4d.provider_v2_loading` admission boundaries for calibrated, causal,
-  independently attested observations.
-- `ValidatedClaimBearingObservation` with the validated provider manifest,
-  calibration, runtime-revision, and observation artifact identities.
+  `validate_claim_bearing_observation_belief` as explicit admission boundaries for
+  calibrated, causal, independently attested observations.
 - `ObservationFactorBundle` schema v4 with an ordered joint `7K x 7K` gauge
   covariance, explicit joint-versus-marginal covariance semantics, fail-closed
   marginal-block validation, and conservative schema-v2/v3 migration.
 - A public cluster-cross-fitted overlap-disagreement diagnostic that holds out
   frame-by-spatial-tile clusters, refits the relative gauge without them, fails
-  closed on unfittable folds, and reports the strictly out-of-fold evaluated fraction.
+  closed on unfittable folds, and reports the strictly out-of-fold evaluated
+  fraction.
 - Equal-group point-uncertainty calibration with canonical group ordering,
   within-group trimming, per-group diagnostics, and row-order-invariant aggregate
   scales so dense sequences cannot dominate solely through sample count.
@@ -28,56 +36,63 @@ All notable changes to Prob4D are documented here.
   deterministic collision handling, cumulative association probabilities,
   termination diagnostics, and conversion to unfused observation factors.
 - A directed gauge-cycle audit that compares direct overlap alignments with
-  two-edge paths in representative observation displacement, preserves deterministic
-  thresholds, and explicitly avoids chi-square claims under unknown edge dependence.
+  two-edge paths in representative observation displacement, preserves
+  deterministic thresholds, and avoids chi-square claims under unknown edge
+  dependence.
 - A content-addressed, equal-group logistic source-reliability calibration with a
-  source-only feature contract, canonical row ordering, exact label/group semantics,
-  probability clipping, immutable metadata, and tamper-checked JSON round trips.
+  source-only feature contract, canonical row ordering, exact label/group
+  semantics, probability clipping, immutable metadata, and tamper-checked JSON
+  round trips.
 - `prob4d.provider_v2` as a safe-by-default Python surface with distinct
   exploratory and claim-bearing export functions.
 - Strict prediction/calibration compatibility checks covering MotionCrafter
   revision, canonical model settings, resolution, window geometry, covariance
   cluster size, and gauge/point covariance methods before payload loading.
 - A context-local canonical covariance-root basis for repeated eigenspaces in
-  provider v2, with fail-closed rank boundaries and unchanged provider-v1 defaults.
+  provider v2, with fail-closed rank boundaries and unchanged provider-v1
+  defaults.
 - Context-local analytic `Sim(3)` composition Jacobians for provider-v2 sequential
   covariance propagation, with fail-closed handling at the SO(3) logarithm branch
   cut and exact provider-v1 finite-difference compatibility.
-- Explicit `prob4d observation export-calibrated` and
-  `prob4d observation export-exploratory` commands, plus installed legacy-style
-  entry points for scripted use.
+- Explicit `prob4d observation export-calibrated`,
+  `prob4d observation export-exploratory`, and
+  `prob4d observation export-v1` grouped commands, plus installed legacy-style
+  entry points for scripted reproduction.
 - Runtime source-revision attestation for provider-v2 export. Claim-bearing runs
   require independent VCS metadata or a clean source checkout; an environment-only
   `PROB4D_RUNTIME_REVISION` assertion is recorded only for exploratory deployments.
 - A versioned self-contained provider-attestation schema that embeds the complete
-  content-addressed provider manifest, export mode, calibration IDs, covariance-root
-  and composition-Jacobian modes, and runtime revision evidence. Consumers can
-  recompute and validate it without importing Prob4D.
+  content-addressed provider manifest, export mode, calibration IDs,
+  covariance-root and composition-Jacobian modes, and runtime revision evidence.
 - Version-selectable provider manifest emission through
   `prob4d provider manifest --api-version {1,2}`.
 - A provider-v2 gauge-backend ablation runner that preserves the seven-row
-  reconstruction contract while using the production causal spanning tree, analytic
-  composition Jacobians, and joint-covariance marginal adapter.
-- Provider-v2 unit, type, import, wheel, and source-distribution coverage.
+  reconstruction contract while using the production causal spanning tree,
+  analytic composition Jacobians, and joint-covariance marginal adapter.
 
 ### Changed
 
-- `ObservationBeliefExportV1.metadata` is now recursively immutable after finite-JSON
-  normalization. Ordinary `dict`/`list` checks and mutable `copy`/`deepcopy` workflows
-  remain supported, while caller-owned or nested mutation cannot change an existing
-  content address.
-- Stacked unfused factors now retain cross-window gauge covariance rather than
+- The grouped `prob4d observation export` route now fails closed with migration
+  guidance instead of silently selecting provider v1. The historical standalone
+  `prob4d-export-observation-belief` executable remains unchanged.
+- Claim-bearing loading now requires complete alignment-level covariance
+  calibration, rejects uncalibrated or pointwise-fallback permission, and rejects
+  recorded covariance fallback use.
+- `ObservationBeliefExportV1.metadata` is recursively immutable after finite-JSON
+  normalization. Ordinary `dict`/`list` checks and mutable `copy`/`deepcopy`
+  workflows remain supported.
+- Stacked unfused factors retain cross-window gauge covariance rather than
   reconstructing a block-diagonal prior from per-gauge marginals. The frozen
-  provider-v1 writer remains schema v3 and rejects joint covariance it cannot encode.
-- Fixed-lag gauge smoothing now Schur-marginalizes expired gauges into an
+  provider-v1 writer remains schema v3 and rejects joint covariance it cannot
+  encode.
+- Fixed-lag gauge smoothing Schur-marginalizes expired gauges into an
   uncertainty-bearing boundary prior. Portable historical covariance remains an
   explicit block-diagonal reconstruction approximation.
-- Documentation now recommends the calibrated provider-v2 command for new
-  claim-bearing experiments and labels provider-v1 commands as frozen compatibility
-  surfaces.
-- CI verifies analytic-versus-finite-difference derivative parity, provider-manifest
-  and attestation hashing, clean-checkout runtime provenance, and every provider-v2
-  command from installed wheel and source artifacts.
+- Documentation recommends calibrated provider v2 for new claim-bearing work and
+  labels provider-v1 routes as frozen compatibility surfaces.
+- CI verifies analytic-versus-finite-difference derivative parity, provider
+  manifest and attestation hashing, clean-checkout runtime provenance, and every
+  provider-v2 command from installed wheel and source artifacts.
 
 ## 0.2.0 — 2026-07-26
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,17 @@ prob4d-validate-observation \
   outputs/sequence_name/observation_belief.npz
 ```
 
+Claim-bearing consumers should use the strict loader from the same provider-v2
+namespace:
+
+```python
+from prob4d.provider_v2 import load_claim_bearing_observation_belief
+
+validated = load_claim_bearing_observation_belief(
+    "outputs/sequence_name/observation_belief.npz"
+)
+```
+
 Provider v2 verifies the executing Prob4D revision and prediction/calibration
 compatibility before decoded prediction payloads are opened. The final artifact
 binds the provider-v2 manifest identity, export mode, covariance-root mode,
@@ -106,9 +117,10 @@ checkout. `PROB4D_RUNTIME_REVISION` can annotate an exploratory packaged
 deployment, but an environment assertion is not accepted as independent evidence.
 
 Use `prob4d observation export-exploratory` for labelled uncalibrated,
-pointwise-fallback, legacy-root, or fixed-lag reconstruction controls. The older
-`prob4d observation export` and `prob4d-export-observation-belief` commands remain
-frozen provider-v1 compatibility surfaces.
+pointwise-fallback, legacy-root, or fixed-lag reconstruction controls. Use
+`prob4d observation export-v1` for the frozen grouped provider-v1 route. The bare
+`prob4d observation export` command prints migration guidance and runs no exporter;
+the historical `prob4d-export-observation-belief` executable remains unchanged.
 
 The exporter opens only independently decoded windows wholly before the
 exclusive cutoff. It recomputes alignment, gauge estimation, overlap
@@ -127,6 +139,13 @@ with zero uncertainty. Its portable all-window covariance still contains only
 historical marginal blocks, so it remains an opt-in reconstruction ablation. See
 [the causal observation export contract](docs/observation-belief-export.md) and
 [provider API version 2](docs/provider-v2.md).
+
+For recursive experiments with several causal observation times, provider v2 also
+exposes an append-only `ObservationFactorStreamV1`. Each update references one
+schema-v4 unfused factor bundle, admits a new non-overlapping frame interval, and
+binds bundle/payload hashes, observation identities, and the previous update ID.
+See [append-only observation-factor streams](docs/observation-factor-stream.md)
+and the [compatibility matrix](docs/compatibility.md).
 
 Prepare a separate calibration sequence and world-coordinate truth files, then
 run the real ablation:

--- a/docs/claim-bearing-observation-loading.md
+++ b/docs/claim-bearing-observation-loading.md
@@ -1,18 +1,23 @@
 # Strict claim-bearing observation loading
 
-`prob4d.provider_v2_loading` separates ordinary contract loading from admission into a
-claim-bearing experiment. `load_observation_belief_export` continues to validate the
-neutral `ObservationBeliefV1` content address and remains appropriate for frozen or
-exploratory artifacts. New prospective experiments should instead use:
+`prob4d.provider_v2` separates ordinary contract loading from admission into a
+claim-bearing experiment. `load_observation_belief_export` continues to validate
+the neutral `ObservationBeliefV1` content address and remains appropriate for
+frozen or explicitly exploratory artifacts. New prospective experiments should
+instead use:
 
 ```python
-from prob4d.provider_v2_loading import load_claim_bearing_observation_belief
+from prob4d.provider_v2 import load_claim_bearing_observation_belief
 
 validated = load_claim_bearing_observation_belief(
     "outputs/held-out/observation_belief.npz"
 )
 observation = validated.observation
 ```
+
+The implementation remains in `prob4d.provider_v2_loading`, but the canonical
+public import is the safe-by-default provider-v2 namespace. This keeps export and
+admission semantics discoverable from one versioned surface.
 
 The strict loader rejects the artifact unless all of the following agree:
 
@@ -22,33 +27,44 @@ The strict loader rejects the artifact unless all of the following agree:
 - canonical shared joint-gauge factor names and one factor group;
 - the sequential joint spanning-tree gauge model with preserved cross-window
   covariance and no approximate fixed-lag boundary;
-- calibrated covariance metadata and the same two calibration artifact IDs in the
-  provider attestation;
-- a calibrated provider-v2 attestation using canonical covariance roots and analytic
-  composition Jacobians; and
+- complete gauge and point calibration metadata;
+- calibration of every admitted gauge alignment;
+- no permission for uncalibrated covariance or pointwise fallback;
+- no recorded covariance-fallback use;
+- the same calibration artifact IDs in the observation and provider attestation;
+- canonical covariance roots and analytic composition Jacobians; and
 - an independently verified runtime revision equal to the observation source
   revision.
 
-The returned `ValidatedClaimBearingObservation` also exposes the validated provider
-manifest ID, gauge and point calibration IDs, runtime revision, and observation
-artifact ID. It does not replace downstream Bayesian-PhysTwin validation or its
-baseline-relative accept/fallback decision.
+The returned `ValidatedClaimBearingObservation` also exposes the validated
+provider manifest ID, gauge and point calibration IDs, runtime revision, and
+observation artifact ID. It does not replace independent validation in
+Bayesian-PhysTwin, nor the baseline-relative accept/fallback decision.
+
+## Incremental factor streams
+
+For repeated causal observation times, use
+`ObservationFactorStreamV1` from the same provider-v2 namespace. The stream binds
+non-overlapping schema-v4 factor bundles through a previous-update hash chain and
+revalidates every referenced manifest and payload. See
+[append-only observation-factor streams](observation-factor-stream.md).
 
 ## Immutable metadata
 
 `ObservationBeliefExportV1.metadata` is normalized as finite JSON and recursively
 frozen after construction. Nested values remain compatible with ordinary
 `isinstance(value, dict)` and `isinstance(value, list)` checks, but every in-place
-mutation raises `TypeError`. Caller-owned inputs are defensively copied, so modifying
-the original metadata cannot change an existing observation or its content address.
+mutation raises `TypeError`. Caller-owned inputs are defensively copied, so
+modifying the original metadata cannot change an existing observation or its
+content address.
 
-`copy.copy` and `copy.deepcopy` return ordinary mutable JSON containers. This keeps
-existing workflows such as `metadata = deepcopy(observation.metadata)` followed by
+`copy.copy` and `copy.deepcopy` return ordinary mutable JSON containers. This
+keeps workflows such as `metadata = deepcopy(observation.metadata)` followed by
 `dataclasses.replace(...)` available without weakening the immutable artifact.
 
 ## Compatibility
 
-The neutral observation schema and provider-v1 behavior are unchanged. Artifact IDs
-for unchanged metadata remain byte-for-byte stable because descriptors still contain
-ordinary canonical JSON. The strict loader is additive and must be selected
-explicitly by new claim-bearing workflows.
+The neutral observation schema and provider-v1 behavior are unchanged. Artifact
+IDs for unchanged metadata remain byte-for-byte stable because descriptors still
+contain ordinary canonical JSON. Strict provider-v2 loading and factor streams
+are additive and must be selected explicitly by new claim-bearing workflows.

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,0 +1,60 @@
+# Version and compatibility boundaries
+
+Prob4D versions its Python providers separately from its portable artifact
+contracts. Exact repository revisions and artifact digests remain mandatory for
+frozen evidence even when package-version ranges are compatible.
+
+## Prob4D 0.3.x surfaces
+
+| Surface | Version | Intended use |
+| --- | ---: | --- |
+| `prob4d.provider_v1` | 1 | Frozen reproduction and provider-v1 compatibility |
+| `prob4d.provider_v2` | 2 | New calibrated or explicitly exploratory development |
+| `phys4d.observation_belief` | 1 | Portable fused observation container |
+| Prob4D causal stream contract | 2 | Strict causal lineage and joint-gauge semantics |
+| `ObservationFactorBundle` | 4 | Unfused factors with ordered joint gauge covariance |
+| `ObservationFactorStreamV1` | 1 | Append-only sequence of causal schema-v4 delta bundles |
+
+Provider-v1 behavior and the standalone
+`prob4d-export-observation-belief` executable remain available for frozen run
+manifests. New work should choose an explicit provider-v2 export mode and use the
+strict loader re-exported by `prob4d.provider_v2`.
+
+## Grouped CLI migration
+
+| Command | Meaning |
+| --- | --- |
+| `prob4d observation export-calibrated` | Claim-bearing provider-v2 export |
+| `prob4d observation export-exploratory` | Labelled provider-v2 control |
+| `prob4d observation export-v1` | Frozen provider-v1 grouped compatibility route |
+| `prob4d observation export` | Migration guidance only; no exporter is run |
+
+The deliberately ambiguous grouped command fails closed. Historical scripts may
+continue using the unchanged standalone provider-v1 executable.
+
+## Companion projects
+
+At the time Prob4D 0.3.0 was prepared, the companion package versions on their
+main branches were:
+
+- Bayesian-PhysTwin 0.4.0;
+- Causal4D 0.4.1.
+
+These numbers are development reference points, not substitutes for the
+three-repository installed-wheel golden path. Claim-bearing runs must bind exact
+Prob4D, Bayesian-PhysTwin, and Causal4D commits, wheel hashes, provider
+manifests, artifacts, and protocol identifiers.
+
+## Upgrade rules
+
+- A breaking Python signature requires a new provider module.
+- A breaking Prob4D-specific interpretation of an observation artifact requires
+  a new causal-stream contract version.
+- A breaking factor-bundle representation requires a new bundle schema.
+- A changed stream hash or interval interpretation requires a new factor-stream
+  schema.
+- A changed covariance or reliability fitting method requires regenerated,
+  content-addressed calibration artifacts.
+
+Passing compatibility tests is infrastructure evidence. It does not establish
+accuracy, calibration, transfer, intervention benefit, or safety.

--- a/docs/observation-factor-stream.md
+++ b/docs/observation-factor-stream.md
@@ -1,0 +1,102 @@
+# Append-only observation-factor streams
+
+`ObservationFactorStreamV1` records a sequence of causal, unfused Prob4D
+observation updates without rewriting or reopening previously admitted frame
+intervals. It is intended for recursive Bayesian-PhysTwin experiments that need
+several observation times rather than one persisted endpoint correction.
+
+The stream is an orchestration artifact. Every update references a normal
+schema-v4 `ObservationFactorBundle`; it does not introduce another point,
+covariance, or gauge representation.
+
+## Contract
+
+Each update must reference a bundle that:
+
+- uses observation-factor schema version 4;
+- declares `joint-cross-window` gauge covariance semantics;
+- contains only factors in the newly admitted frame interval;
+- uses the same sequence, case, stream, source repository, and source revision as
+  all previous updates; and
+- lies inside the directory containing the stream manifest.
+
+The first update declares `admitted_frame_start`. Every subsequent update starts
+exactly at the preceding exclusive `causal_frame_stop`. Empty temporal regions
+inside an admitted interval are allowed, but a later update may not reintroduce
+a frame from an earlier interval.
+
+## Portable identity
+
+For every update, Prob4D records and validates:
+
+- the bundle-manifest SHA-256 digest;
+- the referenced NPZ payload SHA-256 digest;
+- a digest of the ordered `(frame, view, window, point_id)` observations;
+- the factor, observation, and persistent-identity counts;
+- the ordered gauge IDs; and
+- the preceding update ID.
+
+The update ID excludes the local bundle path. Moving an unchanged stream tree
+therefore preserves its content identity, while changing a bundle, payload,
+identity, frame boundary, or chain predecessor changes the update and stream
+IDs. Relative paths are still validated as retrieval metadata and may not escape
+the stream directory.
+
+## Python example
+
+```python
+from prob4d.provider_v2 import (
+    append_observation_factor_bundle,
+    load_observation_factor_stream,
+    write_observation_factor_stream,
+)
+
+stream_path = "outputs/case-a/prob4d-factor-stream.json"
+
+stream = append_observation_factor_bundle(
+    None,
+    "outputs/case-a/update-000/factors.json",
+    stream_manifest_path=stream_path,
+    admitted_frame_start=100,
+    metadata={"protocol": "prob4d-bpt-recursive-prefix-v1"},
+)
+stream = append_observation_factor_bundle(
+    stream,
+    "outputs/case-a/update-001/factors.json",
+    stream_manifest_path=stream_path,
+)
+write_observation_factor_stream(stream, stream_path)
+
+validated = load_observation_factor_stream(stream_path)
+assert validated.updates[1].previous_update_id == validated.updates[0].update_id
+```
+
+`load_observation_factor_stream` reopens and validates every referenced bundle by
+default. Passing `validate_bundles=False` validates only the stream manifest and
+its hash chain; it is useful for metadata inspection, not evidence admission.
+
+## Identity semantics
+
+Persistent identities are scoped by `(view_id, window_id, point_id)`. The
+existing causal scene-flow tracklet builder can provide such point IDs inside a
+window. A producer that changes identity semantics must use a distinct stream ID
+or protocol identifier rather than silently reinterpreting an existing stream.
+
+The stream does not assert that points from different windows or cameras denote
+the same material point. Such associations remain explicit downstream model
+inputs.
+
+## Scientific boundary
+
+A valid stream proves that the referenced factor updates are immutable,
+causally ordered, non-overlapping, and checksum-bound. It does not prove that:
+
+- the visual uncertainty is calibrated on a target cohort;
+- the observations identify a physical state rather than a nuisance mode;
+- an update should be accepted; or
+- Prob4D improves future physical prediction.
+
+Bayesian-PhysTwin remains responsible for nuisance-aware inference, the
+baseline-relative regret guard, and exact fallback. Causal4D should consume only
+a content-bound accepted twin belief rather than reinterpret the raw factor
+stream.

--- a/docs/provider-contract.md
+++ b/docs/provider-contract.md
@@ -8,24 +8,29 @@ explicit nonclaims.
 
 ```bash
 prob4d provider manifest \
+  --api-version 2 \
   --provider-revision 0123456789abcdef0123456789abcdef01234567 \
-  --output outputs/prob4d-provider.json
+  --output outputs/prob4d-provider-v2.json
 ```
 
 ## Python import boundary
 
-Downstream development code should import `prob4d.provider_v1` instead of
-underscore-prefixed modules or experiment helpers. The Python call surface and
-the produced stream contract are versioned independently:
+Use the provider surface matching the experiment:
 
-- `provider_v1` identifies the stable Python signatures;
-- `prob4d_causal_stream_contract_version` identifies the provider-specific
-  interpretation of a strict observation artifact.
+- `prob4d.provider_v1` is frozen for exact reproduction and historical artifacts;
+- `prob4d.provider_v2` is the safe-by-default surface for new calibrated or
+  explicitly exploratory development.
 
-A breaking Python signature change requires a new provider module. A breaking
-gauge, factor-group, or lineage interpretation requires a new stream-contract
-version. Exact Git revisions and artifact hashes remain mandatory for frozen
-experiments.
+Provider v2 directly exposes its strict claim-bearing loader, explicit export
+functions, schema-v4 factor bundle, and append-only factor-stream contract.
+Downstream code should not import underscore-prefixed implementation modules or
+Prob4D experiment helpers.
+
+The Python call surface and the produced stream contract are versioned
+independently. A breaking Python signature requires another provider module. A
+breaking gauge, factor-group, covariance, reliability, or lineage interpretation
+requires the corresponding artifact or stream-contract version to change. Exact
+Git revisions and artifact hashes remain mandatory for frozen experiments.
 
 ## Artifact semantics
 
@@ -44,47 +49,50 @@ can:
 - retain association probability separately from residual-independent prior
   reliability; and
 - bind metric coordinates to a content-addressed anchor that identifies the
-  exact first prediction payload, exact external calibration artifact, case, and
-  world frame.
+  exact first prediction payload, external calibration artifact, case, and world
+  frame.
 
 A zero anchor covariance is declared as `fixed_external_calibration`. A nonzero
 anchor covariance is declared as `propagated_external_prior` and is included in
-the same joint latent factor as the relative-gauge uncertainty. The producer and
+the same joint latent factor as relative-gauge uncertainty. The producer and
 both consumers reject an explicit v2 artifact when this treatment, calibration
 digest, or inclusion flag is absent or inconsistent.
 
 The production default is a causal sequential spanning tree. It preserves the
-uncertainty of the selected causal constraints without pretending that redundant
-dense alignment edges are independent. Fixed-lag smoothing now carries a
+uncertainty of selected causal constraints without pretending that redundant
+dense alignment edges are independent. Fixed-lag smoothing carries a
 Schur-complement information prior across the moving boundary, but its portable
 all-window covariance contains only block-diagonal historical marginals. It
 therefore remains an explicit reconstruction control and is not labelled as
 strict stream contract v2.
 
-Prob4D 0.2.0 artifacts that already contain canonical
-`joint_gauge_latent_####` factors but predate the explicit version field can be
-recognized by updated Bayesian-PhysTwin and Causal4D validators. Their validation
-report marks the version as inferred. Newly exported production artifacts carry
-the version, complete metric-anchor schema, calibration digest, and covariance
-treatment explicitly.
-
-The manifest does **not** claim that exported covariance has passed prospective
-target calibration, that redundant dense-edge fusion is validated, or that a
-valid observation artifact by itself improves a Bayesian physical twin.
-
-Use `prob4d-validate-observation` to reject schema drift, array drift, malformed
-archives, and content-address mismatches. Strict causal export writes through a
-temporary archive, reloads and validates its content address, then atomically
-replaces the requested output. `PredictionWindow` inputs are copied and frozen
-after validation so caller-side mutation cannot alter a sealed source object.
+## Unfused and incremental observations
 
 Provider v2 exposes `ObservationFactorBundle` schema v4 for consumers that keep
 explicit gauge nuisance variables. It stores one ordered joint `7K x 7K` gauge
-covariance and distinguishes `joint-cross-window` from
-`marginal-blocks-only` semantics. Schema-v2/v3 bundles upgrade conservatively as
-marginal-only because their missing off-diagonal blocks cannot be reconstructed.
-The frozen provider-v1 surface continues to advertise and write schema v3.
+covariance and distinguishes `joint-cross-window` from `marginal-blocks-only`
+semantics. Schema-v2/v3 bundles upgrade conservatively as marginal-only because
+missing off-diagonal blocks cannot be reconstructed. The frozen provider-v1
+surface continues to advertise and write schema v3.
 
-The grouped `prob4d` command is the preferred discoverable interface. Existing
-`prob4d-*` commands remain available so historical run manifests and frozen
-experiments retain their exact command lines.
+`ObservationFactorStreamV1` binds several causally disjoint schema-v4 delta
+bundles without rewriting old intervals. Update IDs cover bundle and payload
+hashes, frame boundaries, observation-identity digests, gauge IDs, and the
+previous update ID. See [append-only observation-factor streams](observation-factor-stream.md).
+
+## Validation and nonclaims
+
+Use `prob4d-validate-observation` to reject observation-schema drift, malformed
+archives, and content-address mismatches. Use
+`load_claim_bearing_observation_belief` from `prob4d.provider_v2` to require the
+complete calibrated provider-v2 admission boundary.
+
+The manifest does **not** claim that exported covariance has passed prospective
+target calibration, that redundant dense-edge fusion is validated, or that a
+valid observation artifact improves a Bayesian physical twin.
+
+The grouped `prob4d` command is the preferred discoverable interface. New callers
+must choose `export-calibrated`, `export-exploratory`, or `export-v1`. The bare
+`prob4d observation export` route prints migration guidance and runs no exporter.
+Existing standalone `prob4d-*` commands remain available for historical run
+manifests.

--- a/docs/provider-v2.md
+++ b/docs/provider-v2.md
@@ -1,25 +1,25 @@
 # Provider API version 2
 
 `prob4d.provider_v2` is the safe-by-default Python surface for new claim-bearing
-experiments. It does not change `ObservationBeliefV1`, the causal observation
-stream contract, or the frozen `prob4d.provider_v1` behavior.
+experiments. It preserves the neutral `ObservationBeliefV1` schema, the Prob4D
+causal-stream-v2 contract, and frozen `prob4d.provider_v1` behavior.
 
 ## Explicit export modes
 
-Version 2 removes the ambiguous general export entry point. Callers must choose
-one of two functions:
+Callers must choose one of two provider-v2 functions:
 
 - `export_exploratory_observation_belief` permits uncalibrated or partially
-  calibrated covariance and can explicitly enable the pointwise covariance
-  fallback.
+  calibrated covariance and can explicitly enable pointwise covariance fallback;
 - `export_calibrated_observation_belief` requires both content-addressed
   calibration artifacts, an exact Prob4D source revision, sequential gauge
-  covariance propagation, and the fail-closed spatial-cluster covariance path.
+  propagation, canonical covariance roots, analytic composition Jacobians, and
+  the fail-closed spatial-cluster covariance path.
 
 The calibrated function verifies the executing Prob4D revision and validates
-calibration compatibility before any decoded prediction payload is opened.
+prediction/calibration compatibility before any decoded prediction payload is
+opened.
 
-The grouped CLI exposes the same distinction:
+The grouped CLI makes the selection explicit:
 
 ```bash
 prob4d observation export-calibrated \
@@ -34,139 +34,118 @@ prob4d observation export-calibrated \
   --summary-json outputs/test/observation_belief_summary.json
 ```
 
-Use `prob4d observation export-exploratory` for labelled reconstruction controls.
-The older `prob4d observation export` and
-`prob4d-export-observation-belief` commands remain frozen provider-v1
-compatibility surfaces.
+Use `prob4d observation export-exploratory` for labelled reconstruction controls
+and `prob4d observation export-v1` for the frozen grouped provider-v1 route. The
+bare `prob4d observation export` command is intentionally ambiguous: it prints
+migration guidance and does not execute an exporter. The historical
+`prob4d-export-observation-belief` executable remains unchanged.
+
+## Strict claim-bearing loading
+
+Provider v2 also exposes the corresponding admission boundary:
+
+```python
+from prob4d.provider_v2 import load_claim_bearing_observation_belief
+
+validated = load_claim_bearing_observation_belief(
+    "outputs/test/observation_belief.npz"
+)
+observation = validated.observation
+```
+
+This validates causal stream version 2, joint cross-window covariance, complete
+alignment-level covariance calibration, zero fallback permission/use, canonical
+numerical modes, calibration identities, and independently verified runtime
+provenance. The neutral `load_observation_belief_export` remains available for
+frozen and exploratory artifacts.
 
 ## Provider and runtime attestation
 
 Every provider-v2 artifact contains `metadata.prob4d_provider_attestation`. The
 record binds:
 
-- provider API version 2 and the content-addressed provider-v2 manifest;
+- provider API version 2 and its content-addressed manifest;
 - the artifact's exact Prob4D source revision;
 - calibrated versus exploratory export mode;
 - whether prediction/calibration compatibility was validated;
 - gauge and point calibration artifact identifiers;
 - covariance-root and composition-Jacobian modes; and
-- the observed runtime revision, its evidence source, checkout cleanliness, and
-  whether the observation was independently verified from VCS metadata.
+- the observed runtime revision, evidence source, checkout cleanliness, and
+  independent-verification status.
 
 Claim-bearing export fails closed when runtime provenance is unavailable,
-mismatched, dirty, or not independently verified. It accepts only a VCS-installed
-package whose PEP 610 metadata identifies the commit or a clean source checkout at
-the declared revision.
+mismatched, dirty, or not independently verified. It accepts a VCS-installed
+package whose PEP 610 metadata identifies the commit or a clean source checkout
+at the declared revision.
 
-`PROB4D_RUNTIME_REVISION` may annotate a packaged exploratory deployment. It is
-recorded as `deployment_environment`, but an unauthenticated environment variable
-cannot prove which code bytes are executing and therefore never satisfies the
-claim-bearing entry point.
+`PROB4D_RUNTIME_REVISION` may annotate an exploratory packaged deployment. An
+unauthenticated environment variable cannot prove the executing code bytes and
+never satisfies the claim-bearing entry point.
 
-CI emits both provider manifests with:
+CI emits both manifests with:
 
 ```bash
 prob4d provider manifest --api-version 1 --provider-revision "<commit>"
 prob4d provider manifest --api-version 2 --provider-revision "<commit>"
 ```
 
-## Analytic Sim(3) composition Jacobians
+## Analytic `Sim(3)` composition Jacobians
 
-Sequential gauge covariance propagation composes a parent gauge with an uncertain
-relative gauge. Provider v2 now differentiates that composition analytically in
-the repository's seven-coordinate convention:
+Sequential gauge covariance propagation composes a parent gauge with an
+uncertain relative gauge in coordinates
 
 ```text
 [log scale, axis-angle rotation (3), translation (3)].
 ```
 
-For `G = G_parent compose G_relative`, the derivatives account for:
+Provider v2 accounts for additive log scale, SO(3) right Jacobians, scale and
+rotation transport of relative translation, and direct translation blocks. The
+SO(3) logarithm is nondifferentiable at its pi branch cut; provider-v2 sequential
+export fails closed there rather than exporting platform-dependent covariance.
 
-- additive log scale;
-- the SO(3) right Jacobians of the parent, relative, and composed rotations;
-- scale and rotation transport of the relative translation; and
-- the direct parent and relative translation blocks.
+A task-local dispatcher preserves compatibility:
 
-The SO(3) logarithm is not differentiable at its pi branch cut. Provider-v2
-sequential export fails closed at that numerically ambiguous boundary instead of
-exporting a platform-dependent covariance. Random-transform, near-identity, and
-right-Jacobian inverse tests compare the analytic result with the frozen
-central-difference implementation.
-
-A task-local dispatcher keeps the compatibility boundary explicit:
-
-- provider-v2 sequential joint-gauge export uses `analytic`;
-- provider v1 defaults to `legacy_finite_difference` even after provider v2 has
-  been imported;
-- the exploratory fixed-lag reconstruction path retains
-  `legacy_finite_difference`, because its rolling smoother has separate nonlinear
-  derivatives; and
-- nested or concurrent export contexts cannot leak the provider-v2 sequential
-  choice into a frozen provider-v1 run.
-
-The selected mode is recorded in the provider-v2 artifact attestation.
+- provider-v2 sequential export uses `analytic`;
+- provider v1 defaults to `legacy_finite_difference`;
+- exploratory fixed-lag reconstruction retains its frozen derivative path; and
+- nested or concurrent contexts cannot leak modes across provider versions.
 
 ## Canonical covariance-root basis
 
-Provider version 1 retains the frozen eigenvector/sign convention used by existing
-artifacts. Version 2 selects a context-local canonical basis for numerically
-repeated covariance eigenspaces. The basis is derived from each eigenspace
-projector rather than from an arbitrary orthonormal basis returned by the linear
-algebra backend.
+Provider v1 retains its frozen eigenvector/sign convention. Provider v2 derives a
+canonical basis from repeated-eigenspace projectors and fails closed when an
+eigenvalue floor or rank boundary would split a numerically repeated eigenspace.
+The claim-bearing entry point always uses `canonical_eigenspaces`; exploratory
+callers can request legacy roots for reproduction.
 
-Version 2 also fails closed when an eigenvalue floor or `max_gauge_rank` boundary
-would split a numerically repeated eigenspace. Such a split would make the retained
-subspace depend on an arbitrary eigensolver basis. Exploratory callers can request
-`gauge_root_mode="legacy_eigenvectors"` when reproducing a version-1 factor basis;
-the claim-bearing entry point always uses `canonical_eigenspaces`.
-
-The mode is context-local, so concurrent version-1 and version-2 exports retain
-their declared semantics without process-global mode leakage. The low-rank factor
-bytes remain covered by the observation artifact ID.
-
-## Canonical MotionCrafter model identifier
-
-Calibration artifacts used through version 2 must set `model_identifier` to the
-value returned by:
-
-```python
-import json
-
-from prob4d.provider_v2 import motioncrafter_model_identifier
-
-manifest = json.loads(open("predictions.json", encoding="utf-8").read())
-model_identifier = motioncrafter_model_identifier(manifest)
-```
-
-The identifier hashes the model type, UNet and VAE identifiers, inference-step
-configuration, guidance scale, decode chunk size, low-memory mode, random seed,
-and temporal frame stride. Image resolution and window geometry remain separate
-compatibility fields so mismatch diagnostics identify them directly. The exact
-MotionCrafter source commit is checked separately.
-
-## Compatibility fields
+## Calibration compatibility
 
 For a claim-bearing export, each calibration must match the prediction manifest
-and runtime settings in all of the following fields:
+and runtime in:
 
-- source repository;
-- MotionCrafter revision;
+- source repository and MotionCrafter revision;
 - canonical model identifier, including seed and temporal stride;
 - image resolution;
 - window size and overlap;
 - covariance cluster size; and
-- the expected gauge or point covariance method.
+- expected gauge or point covariance method.
 
-The default methods are
-`frame_spatial_cluster_robust_v1` for gauge covariance and
-`depth_disagreement_anisotropic_v1` for conditional point covariance. A mismatch
-raises `CalibrationCompatibilityError` with field-level diagnostics.
+The default methods are `frame_spatial_cluster_robust_v1` for gauge covariance
+and `depth_disagreement_anisotropic_v1` for conditional point covariance. A
+mismatch raises `CalibrationCompatibilityError` with field-level diagnostics.
+Calibration case identifiers and input digests intentionally identify independent
+calibration data and normally differ from the target artifact.
 
-The calibration case identifiers and input digests are deliberately not compared
-to the target sequence. They identify the independent calibration data and should
-normally differ from the target artifact.
+## Append-only factor streams
 
-## Python example
+`ObservationFactorStreamV1` is an additive provider-v2 artifact for recursive
+observation times. It references causally disjoint schema-v4
+`ObservationFactorBundle` deltas and binds them through portable update IDs and a
+previous-update hash chain. Paths are retrieval metadata; bundle and payload
+hashes, frame intervals, observation identities, and gauge IDs determine content
+identity. See [append-only observation-factor streams](observation-factor-stream.md).
+
+## Python export example
 
 ```python
 from prob4d.provider_v2 import (
@@ -191,5 +170,6 @@ artifact = export_calibrated_observation_belief(
 )
 ```
 
-Version 1 remains available for frozen runs. New experiments should use version 2
-unless they intentionally reproduce the earlier API semantics.
+Provider v1 remains available for frozen runs. New experiments should use
+provider v2 unless they intentionally reproduce earlier API semantics. See the
+[compatibility boundaries](compatibility.md) for the complete matrix.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "prob4d"
-version = "0.2.0"
+version = "0.3.0"
 description = "Probabilistic recursive fusion for long-horizon 4D reconstruction"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -49,6 +49,7 @@ where = ["src"]
 
 [tool.setuptools.package-data]
 prob4d = [
+    "py.typed",
     "contract_data/observation_belief_v1/*.json",
     "contract_data/observation_belief_v1/vectors/*.json",
 ]

--- a/src/prob4d/__init__.py
+++ b/src/prob4d/__init__.py
@@ -53,6 +53,15 @@ from .observation_export import (
     load_metric_gauge_anchor,
     save_metric_gauge_anchor,
 )
+from .observation_factor_stream import (
+    OBSERVATION_FACTOR_STREAM_SCHEMA,
+    OBSERVATION_FACTOR_STREAM_VERSION,
+    ObservationFactorStreamUpdateV1,
+    ObservationFactorStreamV1,
+    append_observation_factor_bundle,
+    load_observation_factor_stream,
+    write_observation_factor_stream,
+)
 from .observation_factors import (
     LinearizedObservationFactor,
     ObservationFactor,
@@ -80,13 +89,15 @@ from .uncertainty import GroupBalancedCalibrationReport
 try:
     __version__ = version("prob4d")
 except PackageNotFoundError:  # Source tree without installed distribution metadata.
-    __version__ = "0.2.0"
+    __version__ = "0.3.0"
 
 __all__ = [
     "GAUGE_COVARIANCE_CALIBRATION_SCHEMA",
     "GAUGE_COVARIANCE_CALIBRATION_VERSION",
     "OBSERVATION_BELIEF_SCHEMA",
     "OBSERVATION_BELIEF_VERSION",
+    "OBSERVATION_FACTOR_STREAM_SCHEMA",
+    "OBSERVATION_FACTOR_STREAM_VERSION",
     "POINT_UNCERTAINTY_CALIBRATION_SCHEMA",
     "POINT_UNCERTAINTY_CALIBRATION_VERSION",
     "SOURCE_RELIABILITY_SCHEMA",
@@ -106,6 +117,8 @@ __all__ = [
     "ObservationBeliefExportV1",
     "ObservationFactor",
     "ObservationFactorBundle",
+    "ObservationFactorStreamUpdateV1",
+    "ObservationFactorStreamV1",
     "PointUncertaintyCalibrationV1",
     "PredictionWindow",
     "Sim3",
@@ -115,6 +128,7 @@ __all__ = [
     "StackedObservationFactors",
     "accumulate_cross_fitted_disagreement",
     "alignment_edge_id",
+    "append_observation_factor_bundle",
     "audit_alignment_cycles",
     "build_causal_scene_flow_tracklets",
     "build_prob4d_observation_belief",
@@ -129,6 +143,7 @@ __all__ = [
     "load_metric_gauge_anchor",
     "load_observation_belief_export",
     "load_observation_factor_bundle",
+    "load_observation_factor_stream",
     "load_point_uncertainty_calibration",
     "load_source_reliability_model",
     "save_gauge_covariance_calibration",
@@ -139,4 +154,5 @@ __all__ = [
     "stack_observation_factors",
     "tracklets_to_observation_factors",
     "write_observation_factor_bundle",
+    "write_observation_factor_stream",
 ]

--- a/src/prob4d/cli.py
+++ b/src/prob4d/cli.py
@@ -25,6 +25,11 @@ _ROUTES: Final[dict[Route, tuple[str, str, str]]] = {
         "generate MotionCrafter prediction products",
     ),
     ("observation", "export"): (
+        "prob4d.cli",
+        "_ambiguous_observation_export",
+        "choose an explicit calibrated, exploratory, or provider-v1 export mode",
+    ),
+    ("observation", "export-v1"): (
         "prob4d.causal_stream_cli",
         "main",
         "export through the frozen provider-v1 compatibility CLI",
@@ -70,6 +75,30 @@ _ROUTES: Final[dict[Route, tuple[str, str, str]]] = {
         "export the matched VGGT baseline",
     ),
 }
+
+
+def _ambiguous_observation_export(argv: Sequence[str] | None = None) -> int:
+    """Require callers to select an observation-export contract explicitly."""
+
+    arguments = list(() if argv is None else argv)
+    help_requested = any(value in {"-h", "--help"} for value in arguments)
+    lines = [
+        "usage: prob4d observation <export-calibrated|export-exploratory|export-v1> "
+        "[arguments]",
+        "",
+        "'prob4d observation export' is intentionally ambiguous and does not run "
+        "an exporter.",
+        "",
+        "Choose one explicit contract:",
+        "  export-calibrated   claim-bearing provider-v2 export",
+        "  export-exploratory  labelled provider-v2 control",
+        "  export-v1           frozen provider-v1 compatibility export",
+        "",
+        "The legacy 'prob4d-export-observation-belief' executable remains unchanged.",
+    ]
+    output = sys.stdout if help_requested else sys.stderr
+    print("\n".join(lines), file=output)
+    return 0 if help_requested else 2
 
 
 def _children(prefix: Route) -> list[str]:

--- a/src/prob4d/observation_factor_stream.py
+++ b/src/prob4d/observation_factor_stream.py
@@ -1,0 +1,592 @@
+"""Append-only, content-addressed streams of unfused observation-factor bundles.
+
+Each update references one schema-v4 :class:`ObservationFactorBundle` on disk,
+adds observations from one non-overlapping causal frame interval, and binds the
+previous update ID.  Bundle paths are retrieval metadata; hashes, identities,
+and frame boundaries determine the portable update and stream content addresses.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass, field, replace
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+import numpy as np
+
+from ._immutable_json import frozen_finite_json_mapping, plain_json
+from .observation_factors import (
+    OBSERVATION_FACTOR_SCHEMA,
+    OBSERVATION_FACTOR_SCHEMA_VERSION,
+    ObservationFactorBundle,
+    load_observation_factor_bundle,
+)
+
+OBSERVATION_FACTOR_STREAM_SCHEMA = "prob4d.observation-factor-stream"
+OBSERVATION_FACTOR_STREAM_VERSION = 1
+
+
+def _canonical_json(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        plain_json(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _sha256_json(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json(value)).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as stream:
+            for block in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(block)
+    except OSError as error:
+        raise ValueError(f"cannot read stream member {path.name!r}") from error
+    return digest.hexdigest()
+
+
+def _require_sha256(value: object, *, name: str) -> str:
+    digest = str(value)
+    if len(digest) != 64 or any(
+        character not in "0123456789abcdef" for character in digest
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return digest
+
+
+def _require_nonnegative_integer(value: object, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{name} must be a non-negative integer")
+    return value
+
+
+def _safe_relative_path(value: object, *, name: str) -> str:
+    path = str(value)
+    if not path or "\\" in path:
+        raise ValueError(f"{name} must be a safe POSIX relative path")
+    pure = PurePosixPath(path)
+    if pure.is_absolute() or any(part in {"", ".", ".."} for part in pure.parts):
+        raise ValueError(f"{name} must be a safe POSIX relative path")
+    return pure.as_posix()
+
+
+def _resolved_member(root: Path, relative_path: str, *, name: str) -> Path:
+    safe = _safe_relative_path(relative_path, name=name)
+    root_resolved = root.resolve()
+    candidate = (root_resolved / Path(*PurePosixPath(safe).parts)).resolve()
+    try:
+        candidate.relative_to(root_resolved)
+    except ValueError as error:
+        raise ValueError(f"{name} escapes the stream directory") from error
+    return candidate
+
+
+def _relative_member(path: Path, *, root: Path, name: str) -> str:
+    root_resolved = root.resolve()
+    path_resolved = path.resolve()
+    try:
+        relative = path_resolved.relative_to(root_resolved)
+    except ValueError as error:
+        raise ValueError(f"{name} must lie inside the stream directory") from error
+    return _safe_relative_path(relative.as_posix(), name=name)
+
+
+def _observation_identity_summary(
+    bundle: ObservationFactorBundle,
+) -> tuple[int, int, str]:
+    persistent_identities: set[tuple[str, str, int]] = set()
+    observation_identities: list[tuple[int, str, str, int]] = []
+    for factor in bundle.factors:
+        for point_id in np.asarray(factor.point_ids, dtype=np.int64):
+            persistent = (factor.view_id, factor.window_id, int(point_id))
+            observation = (factor.frame_index, *persistent)
+            persistent_identities.add(persistent)
+            observation_identities.append(observation)
+    if len(set(observation_identities)) != len(observation_identities):
+        raise ValueError(
+            "an observation-factor stream update contains duplicate frame identities"
+        )
+    ordered = sorted(observation_identities)
+    digest = hashlib.sha256(_canonical_json({"observations": ordered})).hexdigest()
+    return len(persistent_identities), len(observation_identities), digest
+
+
+@dataclass(frozen=True)
+class ObservationFactorStreamUpdateV1:
+    """One causally disjoint, hash-chained observation-factor update."""
+
+    update_index: int
+    admitted_frame_start: int
+    causal_frame_stop: int
+    bundle_manifest_path: str
+    bundle_manifest_sha256: str
+    bundle_payload_sha256: str
+    bundle_sequence_id: str
+    case_id: str
+    stream_id: str
+    source_repository: str
+    source_revision: str
+    factor_count: int
+    observation_count: int
+    persistent_identity_count: int
+    observation_identity_sha256: str
+    gauge_ids: tuple[str, ...]
+    previous_update_id: str | None = None
+    update_id: str | None = None
+
+    def __post_init__(self) -> None:
+        update_index = _require_nonnegative_integer(
+            self.update_index,
+            name="update_index",
+        )
+        frame_start = _require_nonnegative_integer(
+            self.admitted_frame_start,
+            name="admitted_frame_start",
+        )
+        frame_stop = _require_nonnegative_integer(
+            self.causal_frame_stop,
+            name="causal_frame_stop",
+        )
+        if frame_stop <= frame_start:
+            raise ValueError("causal_frame_stop must exceed admitted_frame_start")
+        factor_count = _require_nonnegative_integer(
+            self.factor_count,
+            name="factor_count",
+        )
+        observation_count = _require_nonnegative_integer(
+            self.observation_count,
+            name="observation_count",
+        )
+        identity_count = _require_nonnegative_integer(
+            self.persistent_identity_count,
+            name="persistent_identity_count",
+        )
+        if factor_count < 1 or observation_count < 1 or identity_count < 1:
+            raise ValueError("stream updates must contain factors and observations")
+
+        identifiers = {
+            "bundle_sequence_id": str(self.bundle_sequence_id),
+            "case_id": str(self.case_id),
+            "stream_id": str(self.stream_id),
+            "source_repository": str(self.source_repository),
+            "source_revision": str(self.source_revision),
+        }
+        if any(not value for value in identifiers.values()):
+            raise ValueError("stream update identifiers must be non-empty")
+        gauge_ids = tuple(str(value) for value in self.gauge_ids)
+        if not gauge_ids or any(not value for value in gauge_ids):
+            raise ValueError("gauge_ids must be non-empty")
+        if len(set(gauge_ids)) != len(gauge_ids):
+            raise ValueError("gauge_ids must be unique")
+
+        previous = self.previous_update_id
+        if previous is not None:
+            previous = _require_sha256(previous, name="previous_update_id")
+        manifest_path = _safe_relative_path(
+            self.bundle_manifest_path,
+            name="bundle_manifest_path",
+        )
+        manifest_sha = _require_sha256(
+            self.bundle_manifest_sha256,
+            name="bundle_manifest_sha256",
+        )
+        payload_sha = _require_sha256(
+            self.bundle_payload_sha256,
+            name="bundle_payload_sha256",
+        )
+        identity_sha = _require_sha256(
+            self.observation_identity_sha256,
+            name="observation_identity_sha256",
+        )
+
+        object.__setattr__(self, "update_index", update_index)
+        object.__setattr__(self, "admitted_frame_start", frame_start)
+        object.__setattr__(self, "causal_frame_stop", frame_stop)
+        object.__setattr__(self, "factor_count", factor_count)
+        object.__setattr__(self, "observation_count", observation_count)
+        object.__setattr__(self, "persistent_identity_count", identity_count)
+        object.__setattr__(self, "bundle_manifest_path", manifest_path)
+        object.__setattr__(self, "bundle_manifest_sha256", manifest_sha)
+        object.__setattr__(self, "bundle_payload_sha256", payload_sha)
+        object.__setattr__(self, "observation_identity_sha256", identity_sha)
+        object.__setattr__(self, "gauge_ids", gauge_ids)
+        object.__setattr__(self, "previous_update_id", previous)
+        for name, value in identifiers.items():
+            object.__setattr__(self, name, value)
+
+        expected = _sha256_json(self.identity_record())
+        supplied = self.update_id
+        if supplied is not None and _require_sha256(supplied, name="update_id") != expected:
+            raise ValueError("observation-factor stream update ID mismatch")
+        object.__setattr__(self, "update_id", expected)
+
+    def identity_record(self) -> dict[str, object]:
+        """Return the portable path-independent update identity payload."""
+
+        return {
+            "update_index": self.update_index,
+            "admitted_frame_start": self.admitted_frame_start,
+            "causal_frame_stop": self.causal_frame_stop,
+            "bundle_manifest_sha256": self.bundle_manifest_sha256,
+            "bundle_payload_sha256": self.bundle_payload_sha256,
+            "bundle_sequence_id": self.bundle_sequence_id,
+            "case_id": self.case_id,
+            "stream_id": self.stream_id,
+            "source_repository": self.source_repository,
+            "source_revision": self.source_revision,
+            "factor_count": self.factor_count,
+            "observation_count": self.observation_count,
+            "persistent_identity_count": self.persistent_identity_count,
+            "observation_identity_sha256": self.observation_identity_sha256,
+            "gauge_ids": list(self.gauge_ids),
+            "previous_update_id": self.previous_update_id,
+        }
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            **self.identity_record(),
+            "bundle_manifest_path": self.bundle_manifest_path,
+            "update_id": self.update_id,
+        }
+
+
+@dataclass(frozen=True)
+class ObservationFactorStreamV1:
+    """A portable append-only chain of causal observation-factor updates."""
+
+    sequence_id: str
+    case_id: str
+    stream_id: str
+    source_repository: str
+    source_revision: str
+    updates: tuple[ObservationFactorStreamUpdateV1, ...]
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    artifact_id: str | None = None
+
+    def __post_init__(self) -> None:
+        identifiers = {
+            "sequence_id": str(self.sequence_id),
+            "case_id": str(self.case_id),
+            "stream_id": str(self.stream_id),
+            "source_repository": str(self.source_repository),
+            "source_revision": str(self.source_revision),
+        }
+        if any(not value for value in identifiers.values()):
+            raise ValueError("stream identifiers must be non-empty")
+        updates = tuple(self.updates)
+        if not updates:
+            raise ValueError("an observation-factor stream must contain updates")
+        previous: ObservationFactorStreamUpdateV1 | None = None
+        for index, update in enumerate(updates):
+            if update.update_index != index:
+                raise ValueError("stream update indices must be contiguous from zero")
+            if update.bundle_sequence_id != identifiers["sequence_id"]:
+                raise ValueError("stream update sequence_id changed")
+            for name in ("case_id", "stream_id", "source_repository", "source_revision"):
+                if getattr(update, name) != identifiers[name]:
+                    raise ValueError(f"stream update {name} changed")
+            expected_previous = None if previous is None else previous.update_id
+            if update.previous_update_id != expected_previous:
+                raise ValueError("stream update hash chain is broken")
+            if previous is not None and (
+                update.admitted_frame_start != previous.causal_frame_stop
+            ):
+                raise ValueError("stream frame intervals must be contiguous")
+            previous = update
+
+        metadata = frozen_finite_json_mapping(
+            self.metadata,
+            name="observation-factor stream metadata",
+        )
+        object.__setattr__(self, "updates", updates)
+        object.__setattr__(self, "metadata", metadata)
+        for name, value in identifiers.items():
+            object.__setattr__(self, name, value)
+
+        expected = _sha256_json(self.identity_record())
+        supplied = self.artifact_id
+        if supplied is not None and _require_sha256(supplied, name="artifact_id") != expected:
+            raise ValueError("observation-factor stream artifact ID mismatch")
+        object.__setattr__(self, "artifact_id", expected)
+
+    @property
+    def admitted_frame_start(self) -> int:
+        return self.updates[0].admitted_frame_start
+
+    @property
+    def causal_frame_stop(self) -> int:
+        return self.updates[-1].causal_frame_stop
+
+    @property
+    def factor_count(self) -> int:
+        return sum(update.factor_count for update in self.updates)
+
+    @property
+    def observation_count(self) -> int:
+        return sum(update.observation_count for update in self.updates)
+
+    def identity_record(self) -> dict[str, object]:
+        return {
+            "schema": OBSERVATION_FACTOR_STREAM_SCHEMA,
+            "schema_version": OBSERVATION_FACTOR_STREAM_VERSION,
+            "sequence_id": self.sequence_id,
+            "case_id": self.case_id,
+            "stream_id": self.stream_id,
+            "source_repository": self.source_repository,
+            "source_revision": self.source_revision,
+            "metadata": plain_json(self.metadata),
+            "updates": [
+                update.identity_record() | {"update_id": update.update_id}
+                for update in self.updates
+            ],
+        }
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            **self.identity_record(),
+            "artifact_id": self.artifact_id,
+            "updates": [update.to_record() for update in self.updates],
+        }
+
+
+def _bundle_update(
+    bundle_manifest_path: Path,
+    *,
+    stream_directory: Path,
+    update_index: int,
+    admitted_frame_start: int,
+    previous_update_id: str | None,
+) -> ObservationFactorStreamUpdateV1:
+    manifest = bundle_manifest_path.resolve()
+    relative_manifest = _relative_member(
+        manifest,
+        root=stream_directory,
+        name="bundle_manifest_path",
+    )
+    try:
+        record = json.loads(manifest.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ValueError("observation-factor bundle manifest is unreadable") from error
+    if not isinstance(record, dict):
+        raise ValueError("observation-factor bundle manifest must be a JSON object")
+    if record.get("schema") != OBSERVATION_FACTOR_SCHEMA:
+        raise ValueError("stream updates require an observation-factor bundle")
+    if int(record.get("schema_version", -1)) != OBSERVATION_FACTOR_SCHEMA_VERSION:
+        raise ValueError("stream updates require observation-factor schema v4")
+    covariance = record.get("gauge_covariance")
+    if not isinstance(covariance, dict) or (
+        covariance.get("semantics") != "joint-cross-window"
+        or covariance.get("cross_window_covariance_preserved") is not True
+    ):
+        raise ValueError("stream updates require joint cross-window gauge covariance")
+
+    payload_record = record.get("payload")
+    if not isinstance(payload_record, dict):
+        raise ValueError("observation-factor bundle payload record is missing")
+    payload_relative = _safe_relative_path(
+        payload_record.get("path"),
+        name="observation-factor payload path",
+    )
+    payload_path = _resolved_member(
+        manifest.parent,
+        payload_relative,
+        name="observation-factor payload path",
+    )
+    payload_sha = _require_sha256(
+        payload_record.get("sha256"),
+        name="observation-factor payload SHA-256",
+    )
+    if _sha256_file(payload_path) != payload_sha:
+        raise ValueError("observation-factor payload checksum mismatch")
+
+    bundle = load_observation_factor_bundle(manifest)
+    frame_indices = [factor.frame_index for factor in bundle.factors]
+    if not frame_indices:
+        raise ValueError("stream updates require at least one factor")
+    if min(frame_indices) < admitted_frame_start:
+        raise ValueError("stream update reintroduces an already admitted frame")
+    if max(frame_indices) >= bundle.causal_frame_stop:
+        raise ValueError("stream update crosses its exclusive causal frame stop")
+    persistent_count, observation_count, identity_sha = _observation_identity_summary(
+        bundle
+    )
+    case_id = bundle.case_id
+    stream_id = bundle.stream_id
+    if case_id is None or stream_id is None:  # Normalized by ObservationFactorBundle.
+        raise RuntimeError("validated observation-factor bundle lost case or stream ID")
+
+    return ObservationFactorStreamUpdateV1(
+        update_index=update_index,
+        admitted_frame_start=admitted_frame_start,
+        causal_frame_stop=bundle.causal_frame_stop,
+        bundle_manifest_path=relative_manifest,
+        bundle_manifest_sha256=_sha256_file(manifest),
+        bundle_payload_sha256=payload_sha,
+        bundle_sequence_id=bundle.sequence_id,
+        case_id=case_id,
+        stream_id=stream_id,
+        source_repository=bundle.source_repository,
+        source_revision=bundle.source_revision,
+        factor_count=len(bundle.factors),
+        observation_count=observation_count,
+        persistent_identity_count=persistent_count,
+        observation_identity_sha256=identity_sha,
+        gauge_ids=tuple(gauge.window_id for gauge in bundle.gauges),
+        previous_update_id=previous_update_id,
+    )
+
+
+def append_observation_factor_bundle(
+    stream: ObservationFactorStreamV1 | None,
+    bundle_manifest_path: str | Path,
+    *,
+    stream_manifest_path: str | Path,
+    admitted_frame_start: int | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> ObservationFactorStreamV1:
+    """Append one schema-v4 delta bundle without reopening prior frame intervals."""
+
+    stream_path = Path(stream_manifest_path)
+    stream_directory = stream_path.resolve().parent
+    manifest = Path(bundle_manifest_path)
+    if stream is None:
+        update_index = 0
+        previous_update_id = None
+        if admitted_frame_start is None:
+            preview = load_observation_factor_bundle(manifest)
+            admitted_start = min(factor.frame_index for factor in preview.factors)
+        else:
+            admitted_start = _require_nonnegative_integer(
+                admitted_frame_start,
+                name="admitted_frame_start",
+            )
+    else:
+        update_index = len(stream.updates)
+        previous_update_id = stream.updates[-1].update_id
+        expected_start = stream.causal_frame_stop
+        admitted_start = (
+            expected_start
+            if admitted_frame_start is None
+            else _require_nonnegative_integer(
+                admitted_frame_start,
+                name="admitted_frame_start",
+            )
+        )
+        if admitted_start != expected_start:
+            raise ValueError("the next stream interval must start at the prior causal stop")
+
+    update = _bundle_update(
+        manifest,
+        stream_directory=stream_directory,
+        update_index=update_index,
+        admitted_frame_start=admitted_start,
+        previous_update_id=previous_update_id,
+    )
+    if stream is None:
+        return ObservationFactorStreamV1(
+            sequence_id=update.bundle_sequence_id,
+            case_id=update.case_id,
+            stream_id=update.stream_id,
+            source_repository=update.source_repository,
+            source_revision=update.source_revision,
+            updates=(update,),
+            metadata={} if metadata is None else metadata,
+        )
+    if metadata is not None and plain_json(metadata) != plain_json(stream.metadata):
+        raise ValueError("stream metadata cannot change while appending")
+    return replace(
+        stream,
+        updates=(*stream.updates, update),
+        artifact_id=None,
+    )
+
+
+def write_observation_factor_stream(
+    stream: ObservationFactorStreamV1,
+    path: str | Path,
+) -> Path:
+    """Atomically write a content-addressed stream manifest."""
+
+    output = Path(path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = output.with_name(f".{output.name}.tmp")
+    temporary.write_text(
+        json.dumps(stream.to_record(), indent=2, sort_keys=True, allow_nan=False)
+        + "\n",
+        encoding="utf-8",
+    )
+    os.replace(temporary, output)
+    return output
+
+
+def load_observation_factor_stream(
+    path: str | Path,
+    *,
+    validate_bundles: bool = True,
+) -> ObservationFactorStreamV1:
+    """Load a stream and optionally revalidate every referenced bundle and payload."""
+
+    manifest = Path(path)
+    try:
+        record = json.loads(manifest.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ValueError("observation-factor stream manifest is unreadable") from error
+    if not isinstance(record, dict):
+        raise ValueError("observation-factor stream manifest must be a JSON object")
+    if record.get("schema") != OBSERVATION_FACTOR_STREAM_SCHEMA:
+        raise ValueError("manifest is not an observation-factor stream")
+    if int(record.get("schema_version", -1)) != OBSERVATION_FACTOR_STREAM_VERSION:
+        raise ValueError("unsupported observation-factor stream version")
+    raw_updates = record.get("updates")
+    if not isinstance(raw_updates, list) or not raw_updates:
+        raise ValueError("observation-factor stream has no updates")
+    if any(not isinstance(value, dict) for value in raw_updates):
+        raise ValueError("observation-factor stream updates must be JSON objects")
+    updates = tuple(ObservationFactorStreamUpdateV1(**value) for value in raw_updates)
+    stream = ObservationFactorStreamV1(
+        sequence_id=str(record.get("sequence_id", "")),
+        case_id=str(record.get("case_id", "")),
+        stream_id=str(record.get("stream_id", "")),
+        source_repository=str(record.get("source_repository", "")),
+        source_revision=str(record.get("source_revision", "")),
+        updates=updates,
+        metadata=record.get("metadata", {}),
+        artifact_id=record.get("artifact_id"),
+    )
+    if validate_bundles:
+        for update in stream.updates:
+            bundle_path = _resolved_member(
+                manifest.parent,
+                update.bundle_manifest_path,
+                name="bundle_manifest_path",
+            )
+            recomputed = _bundle_update(
+                bundle_path,
+                stream_directory=manifest.parent,
+                update_index=update.update_index,
+                admitted_frame_start=update.admitted_frame_start,
+                previous_update_id=update.previous_update_id,
+            )
+            if recomputed != update:
+                raise ValueError("observation-factor stream update no longer matches its bundle")
+    return stream
+
+
+__all__ = [
+    "OBSERVATION_FACTOR_STREAM_SCHEMA",
+    "OBSERVATION_FACTOR_STREAM_VERSION",
+    "ObservationFactorStreamUpdateV1",
+    "ObservationFactorStreamV1",
+    "append_observation_factor_bundle",
+    "load_observation_factor_stream",
+    "write_observation_factor_stream",
+]

--- a/src/prob4d/provider_v2.py
+++ b/src/prob4d/provider_v2.py
@@ -27,6 +27,15 @@ from .composition_jacobian import (
     composition_jacobian_mode,
 )
 from .covariance_root import CovarianceRootMode, covariance_root_mode
+from .observation_factor_stream import (
+    OBSERVATION_FACTOR_STREAM_SCHEMA,
+    OBSERVATION_FACTOR_STREAM_VERSION,
+    ObservationFactorStreamUpdateV1,
+    ObservationFactorStreamV1,
+    append_observation_factor_bundle,
+    load_observation_factor_stream,
+    write_observation_factor_stream,
+)
 from .observation_factors import (
     OBSERVATION_FACTOR_SCHEMA,
     OBSERVATION_FACTOR_SCHEMA_VERSION,
@@ -70,6 +79,11 @@ from .provider_v1 import (
     save_point_uncertainty_calibration,
     select_causal_source,
 )
+from .provider_v2_loading import (
+    ValidatedClaimBearingObservation,
+    load_claim_bearing_observation_belief,
+    validate_claim_bearing_observation_belief,
+)
 from .runtime_revision import (
     RuntimeRevisionAttestation,
     assert_runtime_revision,
@@ -103,11 +117,13 @@ def prob4d_provider_manifest(
     capabilities = list(cast(list[str], inherited["capabilities"]))
     for capability in (
         "analytic_sim3_composition_jacobians",
+        "append_only_observation_factor_streams",
         "canonical_repeated_eigenspace_covariance_root",
         "explicit_exploratory_and_claim_bearing_exports",
         "joint_cross_window_sim3_gauge_covariance_in_factor_bundle",
         "provider_attested_observation_artifacts",
         "runtime_revision_attestation",
+        "strict_claim_bearing_observation_loading",
         "strict_prediction_calibration_compatibility",
     ):
         if capability not in capabilities:
@@ -145,11 +161,21 @@ def prob4d_provider_manifest(
                 "joint-cross-window and marginal-blocks-only semantics are distinct, "
                 "while schema-v2/v3 inputs upgrade conservatively as marginal-only"
             ),
+            "observation_factor_stream_semantics": (
+                "schema-v1 stream manifests bind causally disjoint schema-v4 delta "
+                "bundles through portable update IDs, a previous-update hash chain, "
+                "stable observation-identity digests, and verified file checksums"
+            ),
             "provider_attestation_semantics": (
                 "every provider-v2 export embeds the complete content-addressed "
                 "provider manifest, export mode, covariance-root and composition-"
                 "Jacobian modes, and runtime-revision evidence; downstream consumers "
                 "can validate the attestation without importing Prob4D"
+            ),
+            "claim_bearing_loading_semantics": (
+                "prob4d.provider_v2 re-exports a strict loader that requires causal "
+                "stream-v2 joint covariance, complete calibration metadata, and an "
+                "independently verified provider-v2 attestation before admission"
             ),
         }
     )
@@ -163,6 +189,9 @@ def prob4d_provider_manifest(
         cast(dict[str, int], inherited["artifact_schema_versions"])
     )
     artifact_schema_versions["ObservationFactorBundle"] = OBSERVATION_FACTOR_SCHEMA_VERSION
+    artifact_schema_versions["ObservationFactorStreamV1"] = (
+        OBSERVATION_FACTOR_STREAM_VERSION
+    )
     descriptor: dict[str, object] = {
         **inherited,
         "provider_api_version": PROVIDER_API_VERSION,
@@ -350,6 +379,8 @@ __all__ = [
     "OBSERVATION_BELIEF_VERSION",
     "OBSERVATION_FACTOR_SCHEMA",
     "OBSERVATION_FACTOR_SCHEMA_VERSION",
+    "OBSERVATION_FACTOR_STREAM_SCHEMA",
+    "OBSERVATION_FACTOR_STREAM_VERSION",
     "POINT_UNCERTAINTY_CALIBRATION_SCHEMA",
     "POINT_UNCERTAINTY_CALIBRATION_VERSION",
     "PROB4D_CAUSAL_STREAM_CONTRACT_VERSION",
@@ -365,12 +396,16 @@ __all__ = [
     "MetricGaugeAnchor",
     "ObservationBeliefExportV1",
     "ObservationFactorBundle",
+    "ObservationFactorStreamUpdateV1",
+    "ObservationFactorStreamV1",
     "PointUncertaintyCalibrationV1",
     "PredictionCalibrationTargetV1",
     "RuntimeRevisionAttestation",
     "SamplingMode",
+    "ValidatedClaimBearingObservation",
     "SelectedOverlapWindow",
     "assert_calibration_pair_compatible",
+    "append_observation_factor_bundle",
     "assert_runtime_revision",
     "bind_causal_stream_contract_v2",
     "build_provider_attestation",
@@ -378,10 +413,12 @@ __all__ = [
     "export_calibrated_observation_belief",
     "export_exploratory_observation_belief",
     "inspect_runtime_revision",
+    "load_claim_bearing_observation_belief",
     "load_gauge_covariance_calibration",
     "load_metric_gauge_anchor",
     "load_observation_belief_export",
     "load_observation_factor_bundle",
+    "load_observation_factor_stream",
     "load_point_uncertainty_calibration",
     "load_prediction_calibration_target",
     "motioncrafter_model_identifier",
@@ -391,7 +428,9 @@ __all__ = [
     "save_observation_belief_export",
     "save_point_uncertainty_calibration",
     "select_causal_source",
+    "validate_claim_bearing_observation_belief",
     "validate_provider_attestation",
     "validate_provider_manifest",
     "write_observation_factor_bundle",
+    "write_observation_factor_stream",
 ]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,6 +17,23 @@ def test_grouped_cli_lists_explicit_provider_v2_exports(capsys) -> None:
     assert "export" in output
     assert "export-calibrated" in output
     assert "export-exploratory" in output
+    assert "export-v1" in output
+
+
+def test_grouped_cli_requires_explicit_observation_export_mode(capsys) -> None:
+    assert main(["observation", "export"]) == 2
+    error = capsys.readouterr().err
+    assert "intentionally ambiguous" in error
+    assert "export-calibrated" in error
+    assert "export-exploratory" in error
+    assert "export-v1" in error
+
+
+def test_ambiguous_observation_export_help_is_informational(capsys) -> None:
+    assert main(["observation", "export", "--help"]) == 0
+    output = capsys.readouterr().out
+    assert "Choose one explicit contract" in output
+    assert "prob4d-export-observation-belief" in output
 
 
 def test_grouped_cli_rejects_unknown_command(capsys) -> None:

--- a/tests/test_observation_factor_stream.py
+++ b/tests/test_observation_factor_stream.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from prob4d.gauge import GaugeEstimate
+from prob4d.observation_factor_stream import (
+    OBSERVATION_FACTOR_STREAM_SCHEMA,
+    append_observation_factor_bundle,
+    load_observation_factor_stream,
+    write_observation_factor_stream,
+)
+from prob4d.observation_factors import (
+    ObservationFactor,
+    ObservationFactorBundle,
+    write_observation_factor_bundle,
+)
+from prob4d.sim3 import Sim3
+
+
+def _write_delta_bundle(
+    root: Path,
+    *,
+    name: str,
+    frame_index: int,
+    causal_frame_stop: int,
+    point_id: int,
+) -> Path:
+    gauge = GaugeEstimate(
+        "window-0",
+        Sim3.identity(),
+        np.eye(7, dtype=np.float64) * 1e-4,
+    )
+    factor = ObservationFactor(
+        factor_id=f"{name}:frame-{frame_index}",
+        frame_index=frame_index,
+        view_id="camera-0",
+        window_id="window-0",
+        gauge_id="window-0",
+        point_ids=np.asarray([point_id], dtype=np.int64),
+        points_local_m=np.asarray([[0.0, 0.0, 1.0]], dtype=np.float64),
+        valid_mask=np.asarray([True]),
+        local_covariance_m2=np.asarray([np.eye(3) * 1e-3]),
+        association_probability=np.asarray([0.9]),
+        prior_reliability=np.asarray([0.8]),
+        prior_nominal_probability=0.95,
+        composite_weight=1.0,
+        correlation_group_id=f"camera-0:frame-{frame_index}",
+        causal_frame_stop=causal_frame_stop,
+    )
+    bundle = ObservationFactorBundle(
+        sequence_id="sequence-a",
+        case_id="case-a",
+        stream_id="prob4d:tracklets:camera-0",
+        factors=(factor,),
+        gauges=(gauge,),
+        source_repository="FlorianPfaff/Prob4D",
+        source_revision="a" * 40,
+        causal_frame_stop=causal_frame_stop,
+        joint_gauge_covariance=gauge.covariance,
+        gauge_covariance_semantics="joint-cross-window",
+    )
+    manifest, _ = write_observation_factor_bundle(bundle, root / f"{name}.json")
+    return manifest
+
+
+def test_stream_roundtrip_binds_disjoint_bundle_updates(tmp_path: Path) -> None:
+    stream_path = tmp_path / "stream.json"
+    first = _write_delta_bundle(
+        tmp_path,
+        name="update-0",
+        frame_index=1,
+        causal_frame_stop=3,
+        point_id=7,
+    )
+    second = _write_delta_bundle(
+        tmp_path,
+        name="update-1",
+        frame_index=4,
+        causal_frame_stop=6,
+        point_id=7,
+    )
+
+    stream = append_observation_factor_bundle(
+        None,
+        first,
+        stream_manifest_path=stream_path,
+        admitted_frame_start=0,
+        metadata={"protocol": "prefix-updates-v1"},
+    )
+    stream = append_observation_factor_bundle(
+        stream,
+        second,
+        stream_manifest_path=stream_path,
+    )
+    write_observation_factor_stream(stream, stream_path)
+    loaded = load_observation_factor_stream(stream_path)
+    record = json.loads(stream_path.read_text(encoding="utf-8"))
+
+    assert record["schema"] == OBSERVATION_FACTOR_STREAM_SCHEMA
+    assert loaded.artifact_id == stream.artifact_id
+    assert loaded.admitted_frame_start == 0
+    assert loaded.causal_frame_stop == 6
+    assert loaded.factor_count == 2
+    assert loaded.observation_count == 2
+    assert loaded.updates[0].previous_update_id is None
+    assert loaded.updates[1].previous_update_id == loaded.updates[0].update_id
+    assert loaded.updates[0].persistent_identity_count == 1
+    assert loaded.updates[0].bundle_manifest_path == "update-0.json"
+    assert loaded.updates[1].bundle_manifest_path == "update-1.json"
+
+
+def test_stream_rejects_reintroduced_frame(tmp_path: Path) -> None:
+    stream_path = tmp_path / "stream.json"
+    first = _write_delta_bundle(
+        tmp_path,
+        name="update-0",
+        frame_index=1,
+        causal_frame_stop=3,
+        point_id=7,
+    )
+    overlapping = _write_delta_bundle(
+        tmp_path,
+        name="overlap",
+        frame_index=2,
+        causal_frame_stop=5,
+        point_id=7,
+    )
+    stream = append_observation_factor_bundle(
+        None,
+        first,
+        stream_manifest_path=stream_path,
+        admitted_frame_start=0,
+    )
+
+    with pytest.raises(ValueError, match="already admitted frame"):
+        append_observation_factor_bundle(
+            stream,
+            overlapping,
+            stream_manifest_path=stream_path,
+        )
+
+
+def test_stream_rejects_changed_bundle_after_sealing(tmp_path: Path) -> None:
+    stream_path = tmp_path / "stream.json"
+    bundle = _write_delta_bundle(
+        tmp_path,
+        name="update-0",
+        frame_index=1,
+        causal_frame_stop=3,
+        point_id=7,
+    )
+    stream = append_observation_factor_bundle(
+        None,
+        bundle,
+        stream_manifest_path=stream_path,
+        admitted_frame_start=0,
+    )
+    write_observation_factor_stream(stream, stream_path)
+    bundle.write_text(bundle.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="no longer matches its bundle"):
+        load_observation_factor_stream(stream_path)
+
+
+def test_stream_rejects_path_traversal_even_when_identity_is_unchanged(
+    tmp_path: Path,
+) -> None:
+    stream_path = tmp_path / "stream.json"
+    bundle = _write_delta_bundle(
+        tmp_path,
+        name="update-0",
+        frame_index=1,
+        causal_frame_stop=3,
+        point_id=7,
+    )
+    stream = append_observation_factor_bundle(
+        None,
+        bundle,
+        stream_manifest_path=stream_path,
+        admitted_frame_start=0,
+    )
+    write_observation_factor_stream(stream, stream_path)
+    record = json.loads(stream_path.read_text(encoding="utf-8"))
+    record["updates"][0]["bundle_manifest_path"] = "../update-0.json"
+    stream_path.write_text(json.dumps(record), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="safe POSIX relative path"):
+        load_observation_factor_stream(stream_path)
+
+
+def test_stream_rejects_broken_update_chain(tmp_path: Path) -> None:
+    stream_path = tmp_path / "stream.json"
+    first = _write_delta_bundle(
+        tmp_path,
+        name="update-0",
+        frame_index=1,
+        causal_frame_stop=3,
+        point_id=7,
+    )
+    second = _write_delta_bundle(
+        tmp_path,
+        name="update-1",
+        frame_index=4,
+        causal_frame_stop=6,
+        point_id=7,
+    )
+    stream = append_observation_factor_bundle(
+        None,
+        first,
+        stream_manifest_path=stream_path,
+        admitted_frame_start=0,
+    )
+    stream = append_observation_factor_bundle(
+        stream,
+        second,
+        stream_manifest_path=stream_path,
+    )
+    write_observation_factor_stream(stream, stream_path)
+    record = json.loads(stream_path.read_text(encoding="utf-8"))
+    record["updates"][1]["previous_update_id"] = "0" * 64
+    stream_path.write_text(json.dumps(record), encoding="utf-8")
+
+    with pytest.raises(ValueError):
+        load_observation_factor_stream(stream_path, validate_bundles=False)

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from importlib import resources
 from importlib.metadata import version
 
 import prob4d
@@ -7,3 +8,7 @@ import prob4d
 
 def test_runtime_version_matches_installed_distribution() -> None:
     assert prob4d.__version__ == version("prob4d")
+
+
+def test_distribution_marks_inline_types() -> None:
+    assert resources.files("prob4d").joinpath("py.typed").is_file()

--- a/tests/test_provider_v2.py
+++ b/tests/test_provider_v2.py
@@ -79,14 +79,36 @@ def test_provider_v2_exposes_safe_capabilities() -> None:
         "canonical_repeated_eigenspace_covariance_root" in manifest["capabilities"]
     )
     assert "analytic_sim3_composition_jacobians" in manifest["capabilities"]
+    assert "append_only_observation_factor_streams" in manifest["capabilities"]
     assert "runtime_revision_attestation" in manifest["capabilities"]
+    assert "strict_claim_bearing_observation_loading" in manifest["capabilities"]
     assert "provider_attested_observation_artifacts" in manifest["capabilities"]
     assert manifest["metadata"]["python_import_boundary"] == "prob4d.provider_v2"
+    assert manifest["artifact_schema_versions"]["ObservationFactorStreamV1"] == 1
     assert "canonical basis" in manifest["metadata"]["covariance_root_semantics"]
     assert "closed-form derivatives" in manifest["metadata"][
         "composition_jacobian_semantics"
     ]
     assert manifest["limitations"]["uncalibrated_export_is_default"] is False
+
+
+def test_provider_v2_reexports_strict_claim_bearing_loader() -> None:
+    from prob4d.provider_v2_loading import (
+        ValidatedClaimBearingObservation,
+        load_claim_bearing_observation_belief,
+        validate_claim_bearing_observation_belief,
+    )
+
+    assert provider.ValidatedClaimBearingObservation is ValidatedClaimBearingObservation
+    assert provider.OBSERVATION_FACTOR_STREAM_VERSION == 1
+    assert (
+        provider.load_claim_bearing_observation_belief
+        is load_claim_bearing_observation_belief
+    )
+    assert (
+        provider.validate_claim_bearing_observation_belief
+        is validate_claim_bearing_observation_belief
+    )
 
 
 def test_exploratory_export_is_explicit_context_local_and_attested(


### PR DESCRIPTION
## Summary

- add `ObservationFactorStreamV1`, a content-addressed append-only chain of causally disjoint schema-v4 observation-factor bundles;
- bind every update to bundle and payload SHA-256 digests, stable observation identities, causal frame intervals, ordered gauges, and the preceding update ID;
- re-export strict claim-bearing loading from `prob4d.provider_v2`, so calibrated export and admission share one versioned public surface;
- make the grouped observation export mode explicit: `export-calibrated`, `export-exploratory`, or `export-v1`; the ambiguous bare route now fails closed while the historical standalone provider-v1 executable remains unchanged;
- prepare Prob4D 0.3.0, ship a PEP 561 `py.typed` marker, add a compatibility matrix, and extend installed-wheel/sdist CI smoke coverage.

## Motivation

The existing evidence rejects static endpoint persistence and one-dimensional action scaling as broadly transferable predictive updates. The next admissible experiment needs multiple causal observation times. This PR provides that producer-side infrastructure without moving physical-state inference or update acceptance into Prob4D.

Each stream update remains a normal unfused `ObservationFactorBundle`; Bayesian-PhysTwin continues to own nuisance-aware recursive inference, the baseline-relative regret guard, and exact fallback. Causal4D continues to consume only an accepted, content-bound twin belief.

## Compatibility

- `prob4d.provider_v1` and its historical standalone CLI remain frozen for reproduction;
- `prob4d.provider_v2` gains additive strict-loading and factor-stream APIs;
- `ObservationBeliefV1`, causal stream contract v2, and `ObservationFactorBundle` schema v4 are unchanged;
- the new factor-stream schema is version 1;
- the grouped `prob4d observation export` command no longer silently selects provider v1; `prob4d observation export-v1` is the explicit compatibility route.

## Validation

Local validation against the latest successful packaged source:

- 287 NumPy/package tests passed;
- the omitted repository-only tests import `scripts/` or cross-repository fixture files that are not included in the source distribution;
- the 0.3.0 wheel built and installed in an isolated environment;
- installed-wheel smoke verified provider v1/v2, strict loading, the factor-stream API, `py.typed`, and explicit CLI migration behavior.

GitHub Actions is authoritative for Ruff, mypy, all repository tests on Python 3.10/3.12/3.14, distribution builds, and isolated wheel/sdist command smoke tests.

## Scientific boundary

This is an infrastructure and evidence-admission change. It does not establish target calibration, state identifiability, accepted-update safety, or physical-prediction improvement.