### PR TITLE
Make MotionCrafter stochastic seed semantics explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Prob4D are documented here.
 
 ## Unreleased
 
+### Added
+
+- Explicit MotionCrafter `legacy-common` and `derived-per-call` stochastic seed
+  policies, with a versioned source-bound call schedule recorded in every new
+  prediction manifest.
+- Fail-closed seed-schedule validation that recomputes effective seeds and
+  rejects missing, reordered, inconsistent, duplicated, or colliding derived
+  calls.
+
+### Changed
+
+- Claim-bearing prediction/calibration compatibility now retains the historical
+  version-1 model identifier for legacy common-seed runs and uses a version-2
+  identifier for `derived-per-call` runs, preventing silent calibration reuse
+  across stochastic semantics.
+- `prob4d-benchmark` forwards and records the selected MotionCrafter seed policy.
+
 ## 0.3.0 — 2026-07-30
 
 ### Added

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -14,11 +14,19 @@ frozen evidence even when package-version ranges are compatible.
 | Prob4D causal stream contract | 2 | Strict causal lineage and joint-gauge semantics |
 | `ObservationFactorBundle` | 4 | Unfused factors with ordered joint gauge covariance |
 | `ObservationFactorStreamV1` | 1 | Append-only sequence of causal schema-v4 delta bundles |
+| MotionCrafter model identifier | 1 / 2 | Legacy common seed / derived per-call seed semantics |
 
 Provider-v1 behavior and the standalone
 `prob4d-export-observation-belief` executable remain available for frozen run
 manifests. New work should choose an explicit provider-v2 export mode and use the
 strict loader re-exported by `prob4d.provider_v2`.
+
+The historical `prob4d.motioncrafter-model.v1` identifier covers the original
+common-seed behavior, whether the manifest omits `seed_policy` or explicitly
+uses `legacy-common`. A run using `derived-per-call` receives a
+`prob4d.motioncrafter-model.v2` identifier, and its source-bound seed schedule is
+validated before claim-bearing calibration compatibility is accepted. See
+[the stochastic seed policy](stochastic-seed-policy.md).
 
 ## Grouped CLI migration
 
@@ -55,6 +63,8 @@ manifests, artifacts, and protocol identifiers.
   schema.
 - A changed covariance or reliability fitting method requires regenerated,
   content-addressed calibration artifacts.
+- A changed stochastic seed derivation requires a new MotionCrafter model
+  identifier schema and regenerated calibration artifacts.
 
 Passing compatibility tests is infrastructure evidence. It does not establish
 accuracy, calibration, transfer, intervention benefit, or safety.

--- a/docs/data-format.md
+++ b/docs/data-format.md
@@ -10,7 +10,29 @@
   "motioncrafter_commit": "<git sha>",
   "config": {
     "window_size": 25,
-    "overlap": 8
+    "overlap": 8,
+    "seed": 42,
+    "seed_policy": "derived-per-call"
+  },
+  "stochastic_seed_schedule": {
+    "schema": "prob4d.motioncrafter-seed-schedule.v1",
+    "policy": "derived-per-call",
+    "root_seed": 42,
+    "calls": [
+      {
+        "call_id": "baseline-disjoint",
+        "product": "disjoint_baseline",
+        "effective_seed": 123456789
+      },
+      {
+        "call_id": "overlap-window:window_0000:0:25",
+        "product": "independently_decoded_overlap_window",
+        "window_id": "window_0000",
+        "source_frame_start": 0,
+        "source_frame_stop_exclusive": 25,
+        "effective_seed": 987654321
+      }
+    ]
   },
   "temporal_lineage": {
     "schema_version": 1,
@@ -47,6 +69,15 @@ must require `source_frame_max < cutoff_frame`. Unknown lineage schemas or
 manifests without enough legacy configuration fail closed. Version-1 manifests
 created before this field was added can be audited without rerunning the GPU
 model when their `config.window_size` and `config.overlap` fields are present.
+
+The stochastic-seed section records the effective seed of every baseline and
+independently decoded window. `legacy-common` preserves the historical behavior
+of reusing the root seed for every call. `derived-per-call` hashes the root seed
+and source-bound call identity into a deterministic 32-bit seed. Claim-bearing
+compatibility validation recomputes this schedule and rejects missing or altered
+records. Manifests created before the field existed are interpreted as implicit
+`legacy-common`; a new `derived-per-call` manifest without a complete schedule
+fails closed. See [the stochastic seed policy](stochastic-seed-policy.md).
 
 Every prediction archive contains:
 

--- a/docs/data-format.md
+++ b/docs/data-format.md
@@ -22,7 +22,12 @@
       {
         "call_id": "baseline-disjoint",
         "product": "disjoint_baseline",
-        "effective_seed": 123456789
+        "effective_seed": 1402652322
+      },
+      {
+        "call_id": "baseline-latent-linear",
+        "product": "latent_linear_baseline",
+        "effective_seed": 4164824660
       },
       {
         "call_id": "overlap-window:window_0000:0:25",
@@ -30,7 +35,7 @@
         "window_id": "window_0000",
         "source_frame_start": 0,
         "source_frame_stop_exclusive": 25,
-        "effective_seed": 987654321
+        "effective_seed": 659168348
       }
     ]
   },

--- a/docs/stochastic-seed-policy.md
+++ b/docs/stochastic-seed-policy.md
@@ -59,7 +59,12 @@ New prediction manifests contain:
       {
         "call_id": "baseline-disjoint",
         "product": "disjoint_baseline",
-        "effective_seed": 123456789
+        "effective_seed": 1402652322
+      },
+      {
+        "call_id": "baseline-latent-linear",
+        "product": "latent_linear_baseline",
+        "effective_seed": 4164824660
       },
       {
         "call_id": "overlap-window:window_0000:0:25",
@@ -67,14 +72,16 @@ New prediction manifests contain:
         "window_id": "window_0000",
         "source_frame_start": 0,
         "source_frame_stop_exclusive": 25,
-        "effective_seed": 987654321
+        "effective_seed": 659168348
       }
     ]
   }
 }
 ```
 
-The validator recomputes every effective seed and rejects:
+The example seeds above are the actual values produced by the version-1 schedule
+for root seed 42 and the displayed call identities. The validator recomputes
+every effective seed and rejects:
 
 - unsupported policies or schedule schemas;
 - a root seed or policy that differs from `config`;

--- a/docs/stochastic-seed-policy.md
+++ b/docs/stochastic-seed-policy.md
@@ -1,0 +1,105 @@
+# MotionCrafter stochastic seed policy
+
+MotionCrafter can be run in deterministic or diffusion mode, but the same
+adapter code creates several logically distinct prediction products:
+
+- the disjoint-window baseline;
+- the latent overlap baseline; and
+- every independently decoded overlap window used by Prob4D.
+
+Before Prob4D 0.3.1, every call received the same configured seed. This is kept
+as an explicit compatibility mode rather than silently changing frozen runs.
+
+## Policies
+
+`prob4d-motioncrafter` and `prob4d-benchmark` accept:
+
+```text
+--seed-policy legacy-common
+--seed-policy derived-per-call
+```
+
+### `legacy-common`
+
+Every inference call receives the root `--seed` unchanged. This exactly
+preserves historical behavior and may create common-random-number dependence
+between products. Manifests created before the policy field existed are
+interpreted as `legacy-common`.
+
+### `derived-per-call`
+
+Every call receives a deterministic 32-bit seed obtained from a versioned hash
+of:
+
+```text
+(root seed, stable call identity)
+```
+
+The call identity binds the prediction product and, for an independently
+decoded window, its window ID and exclusive source-frame interval. Changing the
+window schedule therefore changes the effective seed schedule. Distinct seeds
+avoid an implicit shared seed; they do not prove statistical independence of
+predictions produced by a shared model and checkpoint.
+
+## Manifest contract
+
+New prediction manifests contain:
+
+```json
+{
+  "config": {
+    "seed": 42,
+    "seed_policy": "derived-per-call"
+  },
+  "stochastic_seed_schedule": {
+    "schema": "prob4d.motioncrafter-seed-schedule.v1",
+    "policy": "derived-per-call",
+    "root_seed": 42,
+    "calls": [
+      {
+        "call_id": "baseline-disjoint",
+        "product": "disjoint_baseline",
+        "effective_seed": 123456789
+      },
+      {
+        "call_id": "overlap-window:window_0000:0:25",
+        "product": "independently_decoded_overlap_window",
+        "window_id": "window_0000",
+        "source_frame_start": 0,
+        "source_frame_stop_exclusive": 25,
+        "effective_seed": 987654321
+      }
+    ]
+  }
+}
+```
+
+The validator recomputes every effective seed and rejects:
+
+- unsupported policies or schedule schemas;
+- a root seed or policy that differs from `config`;
+- missing, reordered, duplicated, or source-inconsistent calls;
+- an incorrect effective seed; and
+- a derived-per-call seed collision.
+
+A new `derived-per-call` manifest without a schedule fails closed. A legacy
+manifest without a schedule remains admissible only as implicit
+`legacy-common` evidence.
+
+## Calibration compatibility
+
+The historical common-seed behavior retains the version-1 MotionCrafter model
+identifier, including when `legacy-common` is written explicitly. This keeps
+frozen calibration artifacts reproducible.
+
+`derived-per-call` uses `prob4d.motioncrafter-model.v2` and includes the policy
+in the canonical model identifier. Gauge and point covariance calibrations
+therefore cannot be reused silently across the two stochastic semantics.
+
+## Recommended use
+
+Use `legacy-common` only for exact reproduction of an existing run. For new
+stochastic experiments, use `derived-per-call`, regenerate all covariance and
+source-reliability calibration artifacts, and treat distinct root seeds as
+separate sequence-level replicates. Do not count windows from one root-seed run
+as independent Monte Carlo replicates.

--- a/docs/stochastic-seed-policy.md
+++ b/docs/stochastic-seed-policy.md
@@ -7,8 +7,9 @@ adapter code creates several logically distinct prediction products:
 - the latent overlap baseline; and
 - every independently decoded overlap window used by Prob4D.
 
-Before Prob4D 0.3.1, every call received the same configured seed. This is kept
-as an explicit compatibility mode rather than silently changing frozen runs.
+Before this policy was introduced, every call received the same configured seed.
+That behavior is kept as an explicit compatibility mode rather than silently
+changing frozen runs.
 
 ## Policies
 

--- a/src/prob4d/benchmark.py
+++ b/src/prob4d/benchmark.py
@@ -18,7 +18,13 @@ from .alignment import WindowAlignment, align_windows
 from .fusion import FusedSequence, fuse_windows
 from .gauge import FixedLagGaugeSmoother, RelativeGaugeConstraint, SequentialGaugeEstimator
 from .io import PredictionBundle, load_prediction_bundle, pack_symmetric_covariance
-from .motioncrafter import MotionCrafterAdapter, MotionCrafterRunConfig
+from .motioncrafter import (
+    MOTIONCRAFTER_SEED_POLICIES,
+    MOTIONCRAFTER_SEED_POLICY_LEGACY_COMMON,
+    MotionCrafterAdapter,
+    MotionCrafterRunConfig,
+    MotionCrafterSeedPolicy,
+)
 from .uncertainty import DepthDisagreementModel, accumulate_disagreement
 
 FUSION_METHOD_NAMES = (
@@ -43,6 +49,7 @@ class BenchmarkExportConfig:
     window_size: int = 25
     overlap: int = 8
     seed: int = 42
+    seed_policy: MotionCrafterSeedPolicy = MOTIONCRAFTER_SEED_POLICY_LEGACY_COMMON
     max_sequences: int | None = None
     skip_existing: bool = False
     include_covariance: bool = False
@@ -226,6 +233,7 @@ def run_benchmark_export(config: BenchmarkExportConfig) -> Path:
             window_size=config.window_size,
             overlap=config.overlap,
             seed=config.seed,
+            seed_policy=config.seed_policy,
         )
     )
     fusion_methods = tuple(dict.fromkeys(config.fusion_methods))
@@ -322,6 +330,15 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--window-size", type=int, default=25)
     parser.add_argument("--overlap", type=int, default=8)
     parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--seed-policy",
+        choices=MOTIONCRAFTER_SEED_POLICIES,
+        default=MOTIONCRAFTER_SEED_POLICY_LEGACY_COMMON,
+        help=(
+            "legacy-common preserves historical common random numbers; "
+            "derived-per-call records deterministic source-bound seeds"
+        ),
+    )
     parser.add_argument("--max-sequences", type=int)
     parser.add_argument("--skip-existing", action="store_true")
     parser.add_argument("--include-covariance", action="store_true")
@@ -346,6 +363,7 @@ def main(argv: list[str] | None = None) -> int:
             window_size=arguments.window_size,
             overlap=arguments.overlap,
             seed=arguments.seed,
+            seed_policy=arguments.seed_policy,
             max_sequences=arguments.max_sequences,
             skip_existing=arguments.skip_existing,
             include_covariance=arguments.include_covariance,

--- a/src/prob4d/calibration_compatibility.py
+++ b/src/prob4d/calibration_compatibility.py
@@ -21,8 +21,9 @@ from .motioncrafter import (
 from .observation_contract import file_sha256
 
 PROB4D_SOURCE_REPOSITORY = "FlorianPfaff/Prob4D"
-MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA_V1 = "prob4d.motioncrafter-model.v1"
-MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA = "prob4d.motioncrafter-model.v2"
+MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA = "prob4d.motioncrafter-model.v1"
+MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA_V1 = MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA
+MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA_V2 = "prob4d.motioncrafter-model.v2"
 POINT_UNCERTAINTY_COVARIANCE_METHOD = "depth_disagreement_anisotropic_v1"
 
 _MODEL_CONFIG_KEYS_V1 = (
@@ -104,7 +105,7 @@ def motioncrafter_model_identifier(manifest: Mapping[str, Any]) -> str:
         schema = MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA_V1
         config_keys = _MODEL_CONFIG_KEYS_V1
     elif seed_policy == MOTIONCRAFTER_SEED_POLICY_DERIVED_PER_CALL:
-        schema = MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA
+        schema = MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA_V2
         config_keys = _MODEL_CONFIG_KEYS_V2
     else:
         raise ValueError(f"unsupported MotionCrafter seed policy {seed_policy!r}")
@@ -314,6 +315,7 @@ def assert_calibration_pair_compatible(
 __all__ = [
     "MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA",
     "MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA_V1",
+    "MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA_V2",
     "POINT_UNCERTAINTY_COVARIANCE_METHOD",
     "PROB4D_SOURCE_REPOSITORY",
     "CalibrationCompatibilityError",

--- a/src/prob4d/calibration_compatibility.py
+++ b/src/prob4d/calibration_compatibility.py
@@ -13,13 +13,19 @@ from .alignment import (
     DEFAULT_COVARIANCE_CLUSTER_SIZE,
     DENSE_ALIGNMENT_COVARIANCE_METHOD,
 )
+from .motioncrafter import (
+    MOTIONCRAFTER_SEED_POLICY_DERIVED_PER_CALL,
+    MOTIONCRAFTER_SEED_POLICY_LEGACY_COMMON,
+    validate_motioncrafter_seed_schedule,
+)
 from .observation_contract import file_sha256
 
 PROB4D_SOURCE_REPOSITORY = "FlorianPfaff/Prob4D"
-MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA = "prob4d.motioncrafter-model.v1"
+MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA_V1 = "prob4d.motioncrafter-model.v1"
+MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA = "prob4d.motioncrafter-model.v2"
 POINT_UNCERTAINTY_COVARIANCE_METHOD = "depth_disagreement_anisotropic_v1"
 
-_MODEL_CONFIG_KEYS = (
+_MODEL_CONFIG_KEYS_V1 = (
     "model_type",
     "unet_path",
     "vae_path",
@@ -30,6 +36,7 @@ _MODEL_CONFIG_KEYS = (
     "seed",
     "frame_stride",
 )
+_MODEL_CONFIG_KEYS_V2 = (*_MODEL_CONFIG_KEYS_V1, "seed_policy")
 
 
 class CalibrationCompatibilityError(ValueError):
@@ -79,23 +86,40 @@ def _required_mapping(value: object, *, name: str) -> Mapping[str, Any]:
 
 
 def motioncrafter_model_identifier(manifest: Mapping[str, Any]) -> str:
-    """Return a canonical identifier for prediction-affecting model settings."""
+    """Return a canonical identifier for prediction-affecting model settings.
+
+    Historical manifests without ``seed_policy`` and new manifests that explicitly
+    request ``legacy-common`` retain the version-1 identifier because their inference
+    behavior is identical. ``derived-per-call`` uses a version-2 descriptor that binds
+    the seed policy into covariance-calibration compatibility.
+    """
 
     if manifest.get("format_version") != 1:
         raise ValueError("unsupported prediction-manifest format_version")
     config = _required_mapping(manifest.get("config"), name="prediction manifest config")
-    missing = [key for key in _MODEL_CONFIG_KEYS if key not in config]
+    seed_policy = str(
+        config.get("seed_policy", MOTIONCRAFTER_SEED_POLICY_LEGACY_COMMON)
+    )
+    if seed_policy == MOTIONCRAFTER_SEED_POLICY_LEGACY_COMMON:
+        schema = MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA_V1
+        config_keys = _MODEL_CONFIG_KEYS_V1
+    elif seed_policy == MOTIONCRAFTER_SEED_POLICY_DERIVED_PER_CALL:
+        schema = MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA
+        config_keys = _MODEL_CONFIG_KEYS_V2
+    else:
+        raise ValueError(f"unsupported MotionCrafter seed policy {seed_policy!r}")
+    missing = [key for key in config_keys if key not in config]
     if missing:
         raise ValueError(
             "prediction manifest is missing model-identifier settings: "
             + ", ".join(missing)
         )
     descriptor = {
-        "schema": MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA,
-        "config": {key: config[key] for key in _MODEL_CONFIG_KEYS},
+        "schema": schema,
+        "config": {key: config[key] for key in config_keys},
     }
     digest = hashlib.sha256(_canonical_json(descriptor)).hexdigest()
-    return f"{MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA}:{digest}"
+    return f"{schema}:{digest}"
 
 
 @dataclass(frozen=True)
@@ -185,6 +209,7 @@ def load_prediction_calibration_target(
     if manifest.get("format_version") != 1:
         raise ValueError("unsupported prediction-manifest format_version")
     config = _required_mapping(manifest.get("config"), name="prediction manifest config")
+    validate_motioncrafter_seed_schedule(manifest)
     try:
         resolution = (int(config["height"]), int(config["width"]))
         window_size = int(config["window_size"])
@@ -288,6 +313,7 @@ def assert_calibration_pair_compatible(
 
 __all__ = [
     "MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA",
+    "MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA_V1",
     "POINT_UNCERTAINTY_COVARIANCE_METHOD",
     "PROB4D_SOURCE_REPOSITORY",
     "CalibrationCompatibilityError",

--- a/src/prob4d/io.py
+++ b/src/prob4d/io.py
@@ -11,6 +11,7 @@ import numpy as np
 from .data import PredictionWindow
 from .fusion import FusedSequence
 from .metrics import TruthSequence
+from .motioncrafter import validate_motioncrafter_seed_schedule
 
 
 def pack_symmetric_covariance(covariance: np.ndarray) -> np.ndarray:
@@ -83,6 +84,11 @@ def load_prediction_bundle(path: str | Path) -> PredictionBundle:
     payload = json.loads(path.read_text(encoding="utf-8"))
     if payload.get("format_version") != 1:
         raise ValueError("unsupported prediction-manifest format_version")
+    config = payload.get("config")
+    if "stochastic_seed_schedule" in payload or (
+        isinstance(config, dict) and "seed_policy" in config
+    ):
+        validate_motioncrafter_seed_schedule(payload)
     root = path.parent
     windows = [
         PredictionWindow.from_npz(

--- a/src/prob4d/motioncrafter.py
+++ b/src/prob4d/motioncrafter.py
@@ -8,17 +8,180 @@ large upstream inference environment.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import subprocess
 import sys
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Final, Literal
 
 import numpy as np
 
 from .data import PredictionWindow
 from .lineage import motioncrafter_temporal_lineage_manifest
+
+MotionCrafterSeedPolicy = Literal["legacy-common", "derived-per-call"]
+MOTIONCRAFTER_SEED_POLICY_LEGACY_COMMON: Final[MotionCrafterSeedPolicy] = (
+    "legacy-common"
+)
+MOTIONCRAFTER_SEED_POLICY_DERIVED_PER_CALL: Final[MotionCrafterSeedPolicy] = (
+    "derived-per-call"
+)
+MOTIONCRAFTER_SEED_POLICIES: Final[tuple[MotionCrafterSeedPolicy, ...]] = (
+    MOTIONCRAFTER_SEED_POLICY_LEGACY_COMMON,
+    MOTIONCRAFTER_SEED_POLICY_DERIVED_PER_CALL,
+)
+MOTIONCRAFTER_SEED_SCHEDULE_SCHEMA: Final = "prob4d.motioncrafter-seed-schedule.v1"
+_NUMPY_SEED_MODULUS: Final = 2**32
+
+
+def motioncrafter_seed_for_call(
+    root_seed: int,
+    *,
+    policy: MotionCrafterSeedPolicy,
+    call_id: str,
+) -> int:
+    """Return the deterministic effective seed for one inference call.
+
+    ``legacy-common`` preserves the historical behavior in which every baseline
+    and independently decoded window receives the same seed. ``derived-per-call``
+    hashes the root seed and stable call identity into NumPy's accepted 32-bit
+    seed range. Distinct seeds avoid an implicit common-random-number coupling;
+    they do not by themselves establish statistical independence.
+    """
+
+    seed = int(root_seed)
+    if not 0 <= seed < _NUMPY_SEED_MODULUS:
+        raise ValueError("seed must lie in [0, 2**32)")
+    normalized_call_id = str(call_id).strip()
+    if not normalized_call_id:
+        raise ValueError("call_id must be non-empty")
+    if policy == MOTIONCRAFTER_SEED_POLICY_LEGACY_COMMON:
+        return seed
+    if policy != MOTIONCRAFTER_SEED_POLICY_DERIVED_PER_CALL:
+        raise ValueError(f"unsupported MotionCrafter seed policy {policy!r}")
+    descriptor = json.dumps(
+        {
+            "schema": MOTIONCRAFTER_SEED_SCHEDULE_SCHEMA,
+            "root_seed": seed,
+            "call_id": normalized_call_id,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return int.from_bytes(hashlib.sha256(descriptor).digest()[:4], "big")
+
+
+def validate_motioncrafter_seed_schedule(
+    manifest: Mapping[str, Any],
+) -> dict[str, object]:
+    """Validate a prediction manifest's recorded inference-seed schedule.
+
+    Manifests created before the schedule existed are accepted only under the
+    historical ``legacy-common`` policy. New ``derived-per-call`` runs must carry
+    the complete source-bound call list, and every effective seed is recomputed.
+    """
+
+    config = manifest.get("config")
+    if not isinstance(config, Mapping):
+        raise ValueError("prediction manifest config must be a mapping")
+    root_seed = int(config.get("seed", -1))
+    policy = str(
+        config.get("seed_policy", MOTIONCRAFTER_SEED_POLICY_LEGACY_COMMON)
+    )
+    if policy not in MOTIONCRAFTER_SEED_POLICIES:
+        raise ValueError(f"unsupported MotionCrafter seed policy {policy!r}")
+    motioncrafter_seed_for_call(root_seed, policy=policy, call_id="validation")
+
+    schedule = manifest.get("stochastic_seed_schedule")
+    if schedule is None:
+        if policy != MOTIONCRAFTER_SEED_POLICY_LEGACY_COMMON:
+            raise ValueError("derived-per-call prediction manifest lacks a seed schedule")
+        return {
+            "schema": MOTIONCRAFTER_SEED_SCHEDULE_SCHEMA,
+            "policy": policy,
+            "root_seed": root_seed,
+            "call_count": 0,
+            "source": "implicit-legacy-common",
+        }
+    if not isinstance(schedule, Mapping):
+        raise ValueError("stochastic_seed_schedule must be a mapping")
+    if schedule.get("schema") != MOTIONCRAFTER_SEED_SCHEDULE_SCHEMA:
+        raise ValueError("unsupported stochastic seed-schedule schema")
+    if schedule.get("policy") != policy:
+        raise ValueError("seed schedule policy differs from prediction config")
+    if int(schedule.get("root_seed", -1)) != root_seed:
+        raise ValueError("seed schedule root_seed differs from prediction config")
+    calls = schedule.get("calls")
+    if not isinstance(calls, list):
+        raise ValueError("seed schedule calls must be a list")
+    windows = manifest.get("overlap_windows")
+    if not isinstance(windows, list):
+        raise ValueError("seed-scheduled manifest must contain overlap_windows")
+
+    expected: list[dict[str, object]] = [
+        {"call_id": "baseline-disjoint", "product": "disjoint_baseline"},
+        {
+            "call_id": "baseline-latent-linear",
+            "product": "latent_linear_baseline",
+        },
+    ]
+    for item in windows:
+        if not isinstance(item, Mapping):
+            raise ValueError("overlap window records must be mappings")
+        window_id = str(item.get("window_id", "")).strip()
+        if not window_id:
+            raise ValueError("overlap window_id must be non-empty")
+        start = int(item.get("start_frame", -1))
+        stop = int(item.get("stop_frame", -1))
+        if start < 0 or stop <= start:
+            raise ValueError("overlap window frame bounds are invalid")
+        expected.append(
+            {
+                "call_id": f"overlap-window:{window_id}:{start}:{stop}",
+                "product": "independently_decoded_overlap_window",
+                "window_id": window_id,
+                "source_frame_start": start,
+                "source_frame_stop_exclusive": stop,
+            }
+        )
+    if len(calls) != len(expected):
+        raise ValueError("seed schedule call count does not match prediction products")
+
+    call_ids: list[str] = []
+    for index, (actual, required) in enumerate(zip(calls, expected, strict=True)):
+        if not isinstance(actual, Mapping):
+            raise ValueError(f"seed schedule call {index} must be a mapping")
+        for key, value in required.items():
+            if actual.get(key) != value:
+                raise ValueError(f"seed schedule call {index} has inconsistent {key}")
+        call_id = str(required["call_id"])
+        effective_seed = int(actual.get("effective_seed", -1))
+        expected_seed = motioncrafter_seed_for_call(
+            root_seed,
+            policy=policy,
+            call_id=call_id,
+        )
+        if effective_seed != expected_seed:
+            raise ValueError(f"seed schedule call {call_id!r} has an invalid effective seed")
+        call_ids.append(call_id)
+    if len(set(call_ids)) != len(call_ids):
+        raise ValueError("seed schedule call IDs must be unique")
+    if (
+        policy == MOTIONCRAFTER_SEED_POLICY_DERIVED_PER_CALL
+        and len({int(item["effective_seed"]) for item in calls}) != len(calls)
+    ):
+        raise ValueError("derived-per-call seed schedule contains a seed collision")
+    return {
+        "schema": MOTIONCRAFTER_SEED_SCHEDULE_SCHEMA,
+        "policy": policy,
+        "root_seed": root_seed,
+        "call_count": len(calls),
+        "source": "manifest",
+    }
 
 
 @dataclass(frozen=True)
@@ -38,6 +201,7 @@ class MotionCrafterRunConfig:
     guidance_scale: float = 1.0
     decode_chunk_size: int = 25
     seed: int = 42
+    seed_policy: MotionCrafterSeedPolicy = MOTIONCRAFTER_SEED_POLICY_LEGACY_COMMON
     low_memory_usage: bool = False
     frame_start: int = 0
     frame_stop: int | None = None
@@ -50,6 +214,12 @@ class MotionCrafterRunConfig:
             raise ValueError("MotionCrafter height and width must be divisible by 64")
         if not 0 <= self.overlap < self.window_size:
             raise ValueError("overlap must be non-negative and smaller than window_size")
+        if not 0 <= int(self.seed) < _NUMPY_SEED_MODULUS:
+            raise ValueError("seed must lie in [0, 2**32)")
+        if self.seed_policy not in MOTIONCRAFTER_SEED_POLICIES:
+            raise ValueError(
+                "seed_policy must be one of " + ", ".join(MOTIONCRAFTER_SEED_POLICIES)
+            )
         if self.frame_start < 0:
             raise ValueError("frame_start must be non-negative")
         if self.frame_stop is not None and self.frame_stop <= self.frame_start:
@@ -225,13 +395,44 @@ class MotionCrafterAdapter:
             config.frame_stride,
             dtype=np.int64,
         )[:num_frames]
+        seed_schedule: list[dict[str, object]] = []
+
+        def effective_seed(
+            call_id: str,
+            *,
+            product: str,
+            window_id: str | None = None,
+            source_frame_start: int | None = None,
+            source_frame_stop_exclusive: int | None = None,
+        ) -> int:
+            seed = motioncrafter_seed_for_call(
+                config.seed,
+                policy=config.seed_policy,
+                call_id=call_id,
+            )
+            record: dict[str, object] = {
+                "call_id": call_id,
+                "product": product,
+                "effective_seed": seed,
+            }
+            if window_id is not None:
+                record["window_id"] = window_id
+            if source_frame_start is not None:
+                record["source_frame_start"] = source_frame_start
+            if source_frame_stop_exclusive is not None:
+                record["source_frame_stop_exclusive"] = source_frame_stop_exclusive
+            seed_schedule.append(record)
+            return seed
 
         disjoint_path = output / "baseline_disjoint.npz"
         disjoint = self.infer(
             frames,
             window_size=config.window_size,
             overlap=0,
-            seed=config.seed,
+            seed=effective_seed(
+                "baseline-disjoint",
+                product="disjoint_baseline",
+            ),
         )
         self._write_baseline(disjoint_path, disjoint, frame_indices)
 
@@ -240,7 +441,10 @@ class MotionCrafterAdapter:
             frames,
             window_size=config.window_size,
             overlap=config.overlap,
-            seed=config.seed,
+            seed=effective_seed(
+                "baseline-latent-linear",
+                product="latent_linear_baseline",
+            ),
         )
         self._write_baseline(latent_path, latent, frame_indices)
 
@@ -254,11 +458,19 @@ class MotionCrafterAdapter:
         for index, start in enumerate(starts):
             stop = min(start + config.window_size, num_frames)
             window_id = f"window_{index:04d}"
+            start_frame = int(frame_indices[start])
+            stop_frame = int(frame_indices[stop - 1]) + config.frame_stride
             results = self.infer(
                 frames[start:stop],
                 window_size=stop - start,
                 overlap=0,
-                seed=config.seed,
+                seed=effective_seed(
+                    f"overlap-window:{window_id}:{start_frame}:{stop_frame}",
+                    product="independently_decoded_overlap_window",
+                    window_id=window_id,
+                    source_frame_start=start_frame,
+                    source_frame_stop_exclusive=stop_frame,
+                ),
             )
             arrays = self._arrays(results)
             window = PredictionWindow(
@@ -275,8 +487,8 @@ class MotionCrafterAdapter:
                 {
                     "window_id": window_id,
                     "path": relative_path.as_posix(),
-                    "start_frame": int(frame_indices[start]),
-                    "stop_frame": int(frame_indices[stop - 1]) + config.frame_stride,
+                    "start_frame": start_frame,
+                    "stop_frame": stop_frame,
                 }
             )
 
@@ -288,6 +500,17 @@ class MotionCrafterAdapter:
                 key: str(value) if isinstance(value, Path) else value
                 for key, value in asdict(config).items()
             },
+            "stochastic_seed_schedule": {
+                "schema": MOTIONCRAFTER_SEED_SCHEDULE_SCHEMA,
+                "policy": config.seed_policy,
+                "root_seed": config.seed,
+                "calls": seed_schedule,
+                "interpretation": (
+                    "legacy-common exactly preserves the historical common seed; "
+                    "derived-per-call deterministically assigns a source-bound seed to "
+                    "each inference call without claiming statistical independence"
+                ),
+            },
             "temporal_lineage": motioncrafter_temporal_lineage_manifest(
                 window_size=config.window_size,
                 overlap=config.overlap,
@@ -298,6 +521,7 @@ class MotionCrafterAdapter:
         }
         manifest["config"]["video_path"] = str(actual_video_path)
         manifest["config"]["output_directory"] = str(output.resolve())
+        validate_motioncrafter_seed_schedule(manifest)
         manifest_path = output / "predictions.json"
         manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
         return manifest_path
@@ -330,6 +554,15 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--guidance-scale", type=float, default=1.0)
     parser.add_argument("--decode-chunk-size", type=int, default=25)
     parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--seed-policy",
+        choices=MOTIONCRAFTER_SEED_POLICIES,
+        default=MOTIONCRAFTER_SEED_POLICY_LEGACY_COMMON,
+        help=(
+            "legacy-common reuses one seed for exact historical behavior; "
+            "derived-per-call records deterministic source-bound seeds"
+        ),
+    )
     parser.add_argument("--low-memory-usage", action="store_true")
     parser.add_argument("--frame-start", type=int, default=0)
     parser.add_argument("--frame-stop", type=int)
@@ -351,6 +584,7 @@ def main(argv: list[str] | None = None) -> int:
         guidance_scale=arguments.guidance_scale,
         decode_chunk_size=arguments.decode_chunk_size,
         seed=arguments.seed,
+        seed_policy=arguments.seed_policy,
         low_memory_usage=arguments.low_memory_usage,
         frame_start=arguments.frame_start,
         frame_stop=arguments.frame_stop,

--- a/src/prob4d/provider_manifest.py
+++ b/src/prob4d/provider_manifest.py
@@ -9,7 +9,7 @@ from importlib.metadata import PackageNotFoundError, distribution, version
 from typing import Any
 
 PROB4D_PROVIDER_API_VERSION = 1
-PROB4D_PROVIDER_PACKAGE_VERSION = "0.2.0"
+PROB4D_PROVIDER_PACKAGE_VERSION = "0.3.0"
 PROB4D_CAUSAL_STREAM_CONTRACT_VERSION = 2
 PROB4D_PROVIDER_CAPABILITIES = (
     "append_invariant_causal_source_digest",

--- a/tests/test_calibration_compatibility.py
+++ b/tests/test_calibration_compatibility.py
@@ -14,6 +14,7 @@ from prob4d.calibration import (
 from prob4d.calibration_compatibility import (
     MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA,
     MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA_V1,
+    MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA_V2,
     POINT_UNCERTAINTY_COVARIANCE_METHOD,
     CalibrationCompatibilityError,
     assert_calibration_pair_compatible,
@@ -132,10 +133,13 @@ def test_model_identifier_preserves_legacy_seed_semantics_and_binds_new_policy()
     derived["config"]["seed_policy"] = MOTIONCRAFTER_SEED_POLICY_DERIVED_PER_CALL
 
     legacy_identifier = motioncrafter_model_identifier(implicit_legacy)
+    assert MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA == (
+        MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA_V1
+    )
     assert legacy_identifier == motioncrafter_model_identifier(explicit_legacy)
-    assert legacy_identifier.startswith(f"{MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA_V1}:")
+    assert legacy_identifier.startswith(f"{MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA}:")
     assert motioncrafter_model_identifier(derived).startswith(
-        f"{MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA}:"
+        f"{MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA_V2}:"
     )
     assert motioncrafter_model_identifier(derived) != legacy_identifier
 

--- a/tests/test_calibration_compatibility.py
+++ b/tests/test_calibration_compatibility.py
@@ -12,12 +12,18 @@ from prob4d.calibration import (
     PointUncertaintyCalibrationV1,
 )
 from prob4d.calibration_compatibility import (
+    MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA,
+    MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA_V1,
     POINT_UNCERTAINTY_COVARIANCE_METHOD,
     CalibrationCompatibilityError,
     assert_calibration_pair_compatible,
     calibration_compatibility_mismatches,
     load_prediction_calibration_target,
     motioncrafter_model_identifier,
+)
+from prob4d.motioncrafter import (
+    MOTIONCRAFTER_SEED_POLICY_DERIVED_PER_CALL,
+    MOTIONCRAFTER_SEED_POLICY_LEGACY_COMMON,
 )
 from prob4d.uncertainty import CalibrationReport, DepthDisagreementModel
 
@@ -114,6 +120,29 @@ def test_model_identifier_is_canonical_and_sensitive_to_model_settings() -> None
     assert motioncrafter_model_identifier(first) != motioncrafter_model_identifier(
         changed
     )
+
+
+def test_model_identifier_preserves_legacy_seed_semantics_and_binds_new_policy() -> None:
+    implicit_legacy = _manifest()
+    explicit_legacy = json.loads(json.dumps(implicit_legacy))
+    explicit_legacy["config"]["seed_policy"] = (
+        MOTIONCRAFTER_SEED_POLICY_LEGACY_COMMON
+    )
+    derived = json.loads(json.dumps(implicit_legacy))
+    derived["config"]["seed_policy"] = MOTIONCRAFTER_SEED_POLICY_DERIVED_PER_CALL
+
+    legacy_identifier = motioncrafter_model_identifier(implicit_legacy)
+    assert legacy_identifier == motioncrafter_model_identifier(explicit_legacy)
+    assert legacy_identifier.startswith(f"{MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA_V1}:")
+    assert motioncrafter_model_identifier(derived).startswith(
+        f"{MOTIONCRAFTER_MODEL_IDENTIFIER_SCHEMA}:"
+    )
+    assert motioncrafter_model_identifier(derived) != legacy_identifier
+
+    invalid = json.loads(json.dumps(implicit_legacy))
+    invalid["config"]["seed_policy"] = "unknown"
+    with pytest.raises(ValueError, match="seed policy"):
+        motioncrafter_model_identifier(invalid)
 
 
 def test_calibration_pair_matches_prediction_manifest(tmp_path: Path) -> None:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 from prob4d.fusion import FusedSequence, fuse_windows
 from prob4d.io import (
@@ -85,10 +86,25 @@ def test_prediction_bundle_and_truth_round_trip(tmp_path: Path) -> None:
     np.testing.assert_allclose(truth.point_map, problem.truth.point_map, rtol=1e-6)
 
 
+def test_prediction_bundle_rejects_explicit_derived_policy_without_schedule(
+    tmp_path: Path,
+) -> None:
+    problem = make_synthetic_problem(seed=22, num_frames=40, height=4, width=6, overlap=15)
+    manifest_path, _ = write_problem_bundle(tmp_path / "bundle", problem)
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["config"] = {
+        "seed": 42,
+        "seed_policy": "derived-per-call",
+    }
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="lacks a seed schedule"):
+        load_prediction_bundle(manifest_path)
+
+
 def test_symmetric_covariance_pack_round_trip() -> None:
     covariance = np.arange(18, dtype=np.float64).reshape(2, 3, 3)
     covariance = covariance + np.swapaxes(covariance, -1, -2)
 
     restored = unpack_symmetric_covariance(pack_symmetric_covariance(covariance))
-
     np.testing.assert_array_equal(restored, covariance)

--- a/tests/test_motioncrafter.py
+++ b/tests/test_motioncrafter.py
@@ -1,8 +1,34 @@
+from __future__ import annotations
+
+import json
 from pathlib import Path
 
+import numpy as np
 import pytest
 
-from prob4d.motioncrafter import MotionCrafterRunConfig
+from prob4d.motioncrafter import (
+    MOTIONCRAFTER_SEED_POLICY_DERIVED_PER_CALL,
+    MOTIONCRAFTER_SEED_POLICY_LEGACY_COMMON,
+    MOTIONCRAFTER_SEED_SCHEDULE_SCHEMA,
+    MotionCrafterAdapter,
+    MotionCrafterRunConfig,
+    motioncrafter_seed_for_call,
+    validate_motioncrafter_seed_schedule,
+)
+
+
+class _FakeTensor:
+    def __init__(self, values: np.ndarray) -> None:
+        self.values = values
+
+    def detach(self) -> _FakeTensor:
+        return self
+
+    def cpu(self) -> _FakeTensor:
+        return self
+
+    def numpy(self) -> np.ndarray:
+        return self.values
 
 
 def test_motioncrafter_config_validates_window_geometry() -> None:
@@ -36,3 +62,118 @@ def test_motioncrafter_config_validates_source_frame_selection() -> None:
         MotionCrafterRunConfig(**base, frame_start=10, frame_stop=10)
     with pytest.raises(ValueError, match="frame_stride"):
         MotionCrafterRunConfig(**base, frame_stride=0)
+    with pytest.raises(ValueError, match="seed must"):
+        MotionCrafterRunConfig(**base, seed=-1)
+    with pytest.raises(ValueError, match="seed_policy"):
+        MotionCrafterRunConfig(**base, seed_policy="implicit")  # type: ignore[arg-type]
+
+
+def test_motioncrafter_seed_policy_is_deterministic_and_call_sensitive() -> None:
+    assert (
+        motioncrafter_seed_for_call(
+            42,
+            policy=MOTIONCRAFTER_SEED_POLICY_LEGACY_COMMON,
+            call_id="window-a",
+        )
+        == 42
+    )
+
+    first = motioncrafter_seed_for_call(
+        42,
+        policy=MOTIONCRAFTER_SEED_POLICY_DERIVED_PER_CALL,
+        call_id="window-a",
+    )
+    assert first == motioncrafter_seed_for_call(
+        42,
+        policy=MOTIONCRAFTER_SEED_POLICY_DERIVED_PER_CALL,
+        call_id="window-a",
+    )
+    assert first != motioncrafter_seed_for_call(
+        42,
+        policy=MOTIONCRAFTER_SEED_POLICY_DERIVED_PER_CALL,
+        call_id="window-b",
+    )
+    assert first != motioncrafter_seed_for_call(
+        43,
+        policy=MOTIONCRAFTER_SEED_POLICY_DERIVED_PER_CALL,
+        call_id="window-a",
+    )
+    assert 0 <= first < 2**32
+
+
+def test_motioncrafter_run_records_source_bound_seed_schedule(tmp_path: Path) -> None:
+    output = tmp_path / "output"
+    config = MotionCrafterRunConfig(
+        upstream_root=tmp_path / "upstream",
+        video_path=tmp_path / "video.mp4",
+        output_directory=output,
+        window_size=25,
+        overlap=8,
+        seed=71,
+        seed_policy=MOTIONCRAFTER_SEED_POLICY_DERIVED_PER_CALL,
+    )
+    adapter = object.__new__(MotionCrafterAdapter)
+    adapter.config = config
+
+    def fake_read_video(_: Path | None = None) -> np.ndarray:
+        return np.zeros((30, 3, 64, 64), dtype=np.float32)
+
+    adapter.read_video = fake_read_video
+
+    def fake_infer(
+        frames: np.ndarray,
+        *,
+        window_size: int,
+        overlap: int,
+        seed: int,
+    ) -> tuple[_FakeTensor, _FakeTensor]:
+        del window_size, overlap, seed
+        count = int(frames.shape[0])
+        points = np.zeros((count, 2, 2, 3), dtype=np.float32)
+        points[..., 2] = 1.0
+        valid = np.ones((count, 2, 2), dtype=bool)
+        return _FakeTensor(points), _FakeTensor(valid)
+
+    adapter.infer = fake_infer
+
+    def fake_upstream_commit() -> str:
+        return "a" * 40
+
+    adapter._upstream_commit = fake_upstream_commit
+
+    manifest_path = adapter.run()
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    schedule = manifest["stochastic_seed_schedule"]
+    validation = validate_motioncrafter_seed_schedule(manifest)
+
+    assert validation["call_count"] == 4
+    assert validation["source"] == "manifest"
+    assert schedule["schema"] == MOTIONCRAFTER_SEED_SCHEDULE_SCHEMA
+    assert schedule["policy"] == MOTIONCRAFTER_SEED_POLICY_DERIVED_PER_CALL
+    assert schedule["root_seed"] == 71
+    assert manifest["config"]["seed_policy"] == MOTIONCRAFTER_SEED_POLICY_DERIVED_PER_CALL
+    calls = schedule["calls"]
+    assert [record["product"] for record in calls[:2]] == [
+        "disjoint_baseline",
+        "latent_linear_baseline",
+    ]
+    assert len(calls) == 4
+    assert len({record["call_id"] for record in calls}) == len(calls)
+    assert len({record["effective_seed"] for record in calls}) == len(calls)
+    for record in calls:
+        assert record["effective_seed"] == motioncrafter_seed_for_call(
+            71,
+            policy=MOTIONCRAFTER_SEED_POLICY_DERIVED_PER_CALL,
+            call_id=record["call_id"],
+        )
+
+
+def test_derived_seed_policy_fails_closed_without_a_schedule() -> None:
+    manifest = {
+        "config": {
+            "seed": 42,
+            "seed_policy": MOTIONCRAFTER_SEED_POLICY_DERIVED_PER_CALL,
+        }
+    }
+    with pytest.raises(ValueError, match="lacks a seed schedule"):
+        validate_motioncrafter_seed_schedule(manifest)

--- a/tests/test_motioncrafter.py
+++ b/tests/test_motioncrafter.py
@@ -167,6 +167,17 @@ def test_motioncrafter_run_records_source_bound_seed_schedule(tmp_path: Path) ->
             call_id=record["call_id"],
         )
 
+    tampered = json.loads(json.dumps(manifest))
+    tampered["stochastic_seed_schedule"]["calls"][2]["effective_seed"] += 1
+    with pytest.raises(ValueError, match="invalid effective seed"):
+        validate_motioncrafter_seed_schedule(tampered)
+
+    reordered = json.loads(json.dumps(manifest))
+    reordered_calls = reordered["stochastic_seed_schedule"]["calls"]
+    reordered_calls[0], reordered_calls[1] = reordered_calls[1], reordered_calls[0]
+    with pytest.raises(ValueError, match="inconsistent call_id"):
+        validate_motioncrafter_seed_schedule(reordered)
+
 
 def test_derived_seed_policy_fails_closed_without_a_schedule() -> None:
     manifest = {

--- a/tests/test_provider_manifest.py
+++ b/tests/test_provider_manifest.py
@@ -4,13 +4,17 @@ import hashlib
 import json
 from pathlib import Path
 
-from prob4d.provider_manifest import prob4d_provider_manifest
+from prob4d.provider_manifest import (
+    PROB4D_PROVIDER_PACKAGE_VERSION,
+    prob4d_provider_manifest,
+)
 from prob4d.provider_manifest_cli import main
 
 
 def test_provider_manifest_declares_covariance_boundary() -> None:
     manifest = prob4d_provider_manifest(provider_revision="a" * 40)
 
+    assert PROB4D_PROVIDER_PACKAGE_VERSION == "0.3.0"
     assert manifest["provider_revision"] == "a" * 40
     assert manifest["artifact_schema_versions"] == {
         "GaugeCovarianceCalibrationV1": 1,


### PR DESCRIPTION
## What changed

- add explicit `legacy-common` and `derived-per-call` MotionCrafter seed policies;
- record a versioned, source-bound effective-seed schedule for both baselines and every independently decoded overlap window;
- validate the complete schedule before ordinary prediction-bundle loading and before claim-bearing calibration compatibility is accepted;
- preserve the historical public version-1 model-identifier constant and identifier bytes for implicit or explicit legacy common-seed runs;
- use a separate version-2 model identifier for derived per-call seeds so covariance calibrations cannot be reused silently across stochastic semantics;
- expose the policy in `prob4d-motioncrafter` and `prob4d-benchmark`;
- add CPU-only schedule, tamper, ordering, bundle-admission, and compatibility regression tests plus documentation;
- correct the source-tree provider-version fallback from `0.2.0` to the current `0.3.0`.

## Why

The adapter previously reset every logically distinct MotionCrafter inference call to the same configured seed. That preserved reproducibility, but it made the resulting common-random-number dependence implicit and could make overlap disagreement or stochastic covariance evidence difficult to interpret.

The default remains `legacy-common`, so frozen behavior does not change. New stochastic experiments can opt into `derived-per-call`, where each seed is a deterministic hash of the root seed and a source-bound call identity. This removes the implicit shared seed without claiming that outputs from a shared model are statistically independent.

## User and scientific impact

- Historical prediction manifests remain valid and are interpreted as implicit `legacy-common` runs.
- Explicitly seed-versioned manifests are validated before prediction payloads are opened.
- New derived-policy manifests fail closed if their schedule is missing, reordered, inconsistent, tampered with, or colliding.
- Gauge and point covariance calibration artifacts must be regenerated when moving from legacy common seeds to derived per-call seeds.
- Distinct root-seed sequence runs remain the correct Monte Carlo unit; windows from one run must not be counted as independent replicates.

## Validation

GitHub Actions run **#386** passed on the final head:

- Ruff and mypy;
- provider-manifest emission and clean-checkout runtime attestation;
- stable-import checks proving the lightweight interfaces do not load Torch, Diffusers, or Decord;
- the complete test suite on Python 3.10, 3.12, and 3.14;
- wheel and source-distribution build/validation;
- isolated installation and grouped/legacy CLI smoke tests for both wheel and sdist.

GPU MotionCrafter inference and the prospective Prob4D-to-Bayesian-PhysTwin experiment are deliberately outside this PR; this change hardens their statistical and provenance contract.