### PR TITLE
Pin immutable MotionCrafter model sources

### DIFF
--- a/docs/motioncrafter-artifact-integrity.md
+++ b/docs/motioncrafter-artifact-integrity.md
@@ -1,8 +1,9 @@
 # MotionCrafter artifact integrity and resume contract
 
 `prob4d-motioncrafter` publishes prediction bundles through the crash-safe runner
-in `prob4d.motioncrafter_safe`. The low-level GPU adapter remains unchanged; the
-runner adds an evidence boundary around each expensive inference call.
+in `prob4d.motioncrafter_safe`. The public route adds an evidence boundary around
+each expensive inference call and loads models only through an immutable,
+portable model-set contract.
 
 ## Publication rules
 
@@ -18,35 +19,58 @@ The hidden `.motioncrafter-progress.json` journal binds:
 - the input-video SHA-256 digest and byte count;
 - the MotionCrafter Git object ID, clean/dirty state, and status digest;
 - all output-affecting inference settings and the stochastic seed policy;
+- the immutable UNet, geometry/motion VAE, and base-pipeline model-set identity;
+- the exact model-loader module hash and size; and
 - every completed member's safe relative path, product kind, byte count, and
   SHA-256 digest.
 
-The cache directory and retrieval paths are excluded from the portable run
-identity. Model repository references are recorded exactly as supplied; callers
-remain responsible for using immutable local snapshots or otherwise pinned model
-revisions for claim-bearing execution.
+The cache directory and machine-local retrieval paths are excluded from the
+portable run identity.
+
+## Immutable model sources
+
+Every public run must identify each of its three model components as either:
+
+- a local directory whose complete regular-file tree is content-addressed; or
+- a Hugging Face repository with an exact lowercase 40- or 64-character
+  revision.
+
+Mutable branch or tag names and omitted remote revisions fail closed. The three
+sources and the loader implementation form one
+`prob4d.motioncrafter-model-set.v1` identity. Changing the base Stable Video
+Diffusion pipeline therefore invalidates the run and calibration identity just as
+changing the MotionCrafter UNet or VAE does.
+
+See [immutable MotionCrafter model sources](motioncrafter-model-sources.md) for
+the exact local and remote invocation forms.
 
 ## Resume
 
-Resume only the identical recorded run:
+Resume only the identical recorded run, supplying the same local snapshots or
+exact remote revisions used initially:
 
 ```bash
 prob4d-motioncrafter input.mp4 \
   --upstream-root ../MotionCrafter \
   --output-dir outputs/sequence_name \
+  --unet-path TencentARC/MotionCrafter \
+  --unet-revision <exact-commit> \
+  --vae-path TencentARC/MotionCrafter \
+  --vae-revision <exact-commit> \
+  --base-pipeline-revision <exact-commit> \
   --resume
 ```
 
 Before loading MotionCrafter, resume recomputes the input-video hash, checks the
-upstream checkout state, recomputes the run-spec digest, and verifies every
-journaled member. Valid members are skipped. Missing, corrupted, path-escaping,
-or configuration-incompatible evidence fails closed rather than being silently
-reused. A completed bundle is verified and returned without loading the GPU
-models.
+upstream checkout state, reconstructs the model-set identity, recomputes the
+run-spec digest, and verifies every journaled member. Valid members are skipped.
+Missing, corrupted, path-escaping, model-drifted, or configuration-incompatible
+evidence fails closed rather than being silently reused. A completed bundle is
+verified and returned without loading the GPU models.
 
 ## Verification-only operation
 
-Verify a portable bundle without the MotionCrafter environment:
+Verify a portable bundle without the MotionCrafter environment or model sources:
 
 ```bash
 prob4d-motioncrafter \
@@ -60,6 +84,9 @@ performs this verification before opening arrays. Legacy format-version-1
 manifests remain readable, but they are marked as integrity-unbound and still
 receive strict relative-path and bundle-root containment checks.
 
+Verification confirms the model-set identity recorded at execution time. It does
+not redownload remote repositories or establish observation competence.
+
 ## Dirty upstream checkouts
 
 A dirty MotionCrafter checkout is rejected by default. Exploratory runs may opt
@@ -69,8 +96,12 @@ in explicitly:
 prob4d-motioncrafter input.mp4 \
   --upstream-root ../MotionCrafter \
   --output-dir outputs/exploratory \
+  --unet-path /snapshots/motioncrafter \
+  --vae-path /snapshots/motioncrafter \
+  --base-pipeline-path /snapshots/stable-video-diffusion \
   --allow-dirty-upstream
 ```
 
 The dirty-state digest is then part of the run identity, so a later resume must
-match the same checkout state.
+match the same checkout state. The model sources remain immutable even for this
+explicit dirty-upstream diagnostic.

--- a/docs/motioncrafter-model-sources.md
+++ b/docs/motioncrafter-model-sources.md
@@ -1,0 +1,90 @@
+# Immutable MotionCrafter model sources
+
+The public `prob4d motioncrafter` and `prob4d-motioncrafter` routes require an
+immutable identity for every model component used during inference:
+
+1. the MotionCrafter UNet;
+2. the geometry/motion VAE; and
+3. the base Stable Video Diffusion pipeline.
+
+A mutable repository name such as `TencentARC/MotionCrafter` or a branch name such
+as `main` is not sufficient for a claim-bearing run.
+
+## Supported source forms
+
+Each component may be supplied in one of two forms.
+
+### Exact remote revision
+
+Pass a Hugging Face repository and an exact lowercase 40- or 64-character commit
+revision:
+
+```bash
+prob4d-motioncrafter input.mp4 \
+  --upstream-root ../MotionCrafter \
+  --output-dir outputs/sequence \
+  --unet-path TencentARC/MotionCrafter \
+  --unet-revision <exact-commit> \
+  --vae-path TencentARC/MotionCrafter \
+  --vae-revision <exact-commit> \
+  --base-pipeline-path stabilityai/stable-video-diffusion-img2vid-xt \
+  --base-pipeline-revision <exact-commit>
+```
+
+The exact revision is forwarded to every `from_pretrained` call. Tags, branches,
+short revisions, and omitted revisions fail closed.
+
+### Local content-addressed snapshot
+
+Pass a local directory and omit the corresponding revision option:
+
+```bash
+prob4d-motioncrafter input.mp4 \
+  --upstream-root ../MotionCrafter \
+  --output-dir outputs/sequence \
+  --unet-path /snapshots/motioncrafter \
+  --vae-path /snapshots/motioncrafter \
+  --base-pipeline-path /snapshots/stable-video-diffusion
+```
+
+The producer recursively hashes every regular file, following file symlinks and
+excluding only `.git` metadata. The portable source descriptor records the tree
+SHA-256, file count, and total byte count without recording the machine-local
+snapshot path.
+
+The local UNet snapshot must contain `unet_determ` or `unet_diff`, according to
+`--model-type`. The VAE snapshot must contain `geometry_motion_vae`, and the base
+pipeline must contain `model_index.json`.
+
+## Portable model-set identity
+
+The three source descriptors, selected model type, and SHA-256/byte identity of
+the executed `prob4d.motioncrafter_models` loader are canonicalized into:
+
+```text
+prob4d.motioncrafter-model-set.v1:<sha256>
+```
+
+The public run config stores role-specific identities derived from this value
+rather than mutable paths. Consequently:
+
+- changing any model revision or local file changes the run-spec digest;
+- `--resume` refuses a different model set before loading GPU models;
+- the existing MotionCrafter calibration model identifier changes as well,
+  preventing covariance calibration from being reused silently across model
+  bytes or base-pipeline revisions;
+- a moved but byte-identical local snapshot retains the same portable identity.
+
+The full compact model-source manifest is embedded in the run configuration and
+therefore in `artifact_integrity.run_spec`.
+
+## Verification boundary
+
+`--verify-only` validates a completed bundle without requiring model access. It
+confirms the model-set identity that was bound at execution time, but it does not
+redownload or rehash remote model repositories after the fact.
+
+This contract establishes execution provenance, not model competence. A
+content-valid model set can still produce inaccurate or poorly calibrated
+observations; held-out provider evaluation and the separate Bayesian-PhysTwin
+guard remain required.

--- a/src/prob4d/motioncrafter_models.py
+++ b/src/prob4d/motioncrafter_models.py
@@ -1,0 +1,531 @@
+"""Immutable model-source binding for MotionCrafter inference."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final, Literal
+
+from .motioncrafter import MotionCrafterAdapter, MotionCrafterRunConfig
+
+MOTIONCRAFTER_MODEL_SOURCE_SCHEMA: Final = "prob4d.motioncrafter-model-source.v1"
+MOTIONCRAFTER_MODEL_SET_SCHEMA: Final = "prob4d.motioncrafter-model-set.v1"
+DEFAULT_BASE_PIPELINE: Final = "stabilityai/stable-video-diffusion-img2vid-xt"
+
+ModelSourceKind = Literal["local_snapshot", "huggingface_revision"]
+
+
+def _canonical_json(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        dict(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as stream:
+            for block in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(block)
+    except OSError as error:
+        raise ValueError(f"cannot read model snapshot member {path}") from error
+    return digest.hexdigest()
+
+
+def _require_sha256(value: object, *, name: str) -> str:
+    digest = str(value)
+    if len(digest) != 64 or any(
+        character not in "0123456789abcdef" for character in digest
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return digest
+
+
+def _require_revision(value: object, *, name: str) -> str:
+    revision = str(value)
+    if len(revision) not in {40, 64} or any(
+        character not in "0123456789abcdef" for character in revision
+    ):
+        raise ValueError(
+            f"{name} must be an exact lowercase 40- or 64-character revision"
+        )
+    return revision
+
+
+def _positive_integer(value: object, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 1:
+        raise ValueError(f"{name} must be a positive integer")
+    return value
+
+
+def _module_descriptor() -> dict[str, object]:
+    path = Path(__file__).resolve()
+    return {
+        "module": "prob4d.motioncrafter_models",
+        "sha256": _sha256_file(path),
+        "bytes": path.stat().st_size,
+    }
+
+
+def _local_tree_descriptor(
+    root: Path,
+    *,
+    role: str,
+    required_members: tuple[str, ...],
+) -> dict[str, object]:
+    root = root.expanduser().resolve()
+    if not root.is_dir():
+        raise ValueError(f"{role} model source is not a local directory: {root}")
+    for relative in required_members:
+        required = root / relative
+        if not required.exists():
+            raise ValueError(
+                f"{role} local snapshot lacks required member {relative!r}"
+            )
+
+    members: list[dict[str, object]] = []
+    for candidate in sorted(
+        root.rglob("*"),
+        key=lambda path: path.relative_to(root).as_posix(),
+    ):
+        relative = candidate.relative_to(root)
+        if ".git" in relative.parts:
+            continue
+        if candidate.is_dir():
+            continue
+        if not candidate.is_file():
+            raise ValueError(
+                f"{role} local snapshot contains a non-regular member: {relative}"
+            )
+        members.append(
+            {
+                "path": relative.as_posix(),
+                "sha256": _sha256_file(candidate),
+                "bytes": candidate.stat().st_size,
+            }
+        )
+    if not members:
+        raise ValueError(f"{role} local snapshot contains no regular files")
+
+    portable = {
+        "schema": MOTIONCRAFTER_MODEL_SOURCE_SCHEMA,
+        "role": role,
+        "kind": "local_snapshot",
+        "members": members,
+    }
+    return {
+        "tree_sha256": hashlib.sha256(_canonical_json(portable)).hexdigest(),
+        "file_count": len(members),
+        "bytes": sum(int(member["bytes"]) for member in members),
+    }
+
+
+@dataclass(frozen=True)
+class PinnedModelSource:
+    """One local content-addressed snapshot or exact remote revision."""
+
+    role: str
+    kind: ModelSourceKind
+    runtime_reference: str
+    revision: str | None = None
+    tree_sha256: str | None = None
+    file_count: int | None = None
+    bytes: int | None = None
+
+    def __post_init__(self) -> None:
+        role = str(self.role).strip()
+        reference = str(self.runtime_reference).strip()
+        if not role or not reference:
+            raise ValueError("model-source role and reference must be nonempty")
+        if self.kind == "local_snapshot":
+            if self.revision is not None:
+                raise ValueError("local model snapshots cannot declare a remote revision")
+            tree_sha = _require_sha256(
+                self.tree_sha256,
+                name=f"{role} local snapshot tree_sha256",
+            )
+            file_count = _positive_integer(
+                self.file_count,
+                name=f"{role} local snapshot file_count",
+            )
+            byte_count = _positive_integer(
+                self.bytes,
+                name=f"{role} local snapshot bytes",
+            )
+            object.__setattr__(self, "tree_sha256", tree_sha)
+            object.__setattr__(self, "file_count", file_count)
+            object.__setattr__(self, "bytes", byte_count)
+        elif self.kind == "huggingface_revision":
+            object.__setattr__(
+                self,
+                "revision",
+                _require_revision(
+                    self.revision,
+                    name=f"{role} Hugging Face revision",
+                ),
+            )
+            if any(
+                value is not None
+                for value in (self.tree_sha256, self.file_count, self.bytes)
+            ):
+                raise ValueError(
+                    "remote model revisions cannot carry local-tree statistics"
+                )
+        else:
+            raise ValueError(f"unsupported model-source kind {self.kind!r}")
+        object.__setattr__(self, "role", role)
+        object.__setattr__(self, "runtime_reference", reference)
+
+    @classmethod
+    def inspect(
+        cls,
+        reference: str | Path,
+        *,
+        role: str,
+        revision: str | None,
+        required_members: tuple[str, ...] = (),
+    ) -> PinnedModelSource:
+        """Resolve a local snapshot or require an exact remote revision."""
+
+        candidate = Path(reference).expanduser()
+        if candidate.exists():
+            if revision is not None:
+                raise ValueError(
+                    f"{role} is local; do not combine a local snapshot with --{role}-revision"
+                )
+            descriptor = _local_tree_descriptor(
+                candidate,
+                role=role,
+                required_members=required_members,
+            )
+            return cls(
+                role=role,
+                kind="local_snapshot",
+                runtime_reference=str(candidate.resolve()),
+                tree_sha256=str(descriptor["tree_sha256"]),
+                file_count=int(descriptor["file_count"]),
+                bytes=int(descriptor["bytes"]),
+            )
+        if revision is None:
+            raise ValueError(
+                f"{role} source {str(reference)!r} is not a local snapshot and lacks "
+                "an exact remote revision"
+            )
+        return cls(
+            role=role,
+            kind="huggingface_revision",
+            runtime_reference=str(reference),
+            revision=revision,
+        )
+
+    def portable_record(self) -> dict[str, object]:
+        record: dict[str, object] = {
+            "schema": MOTIONCRAFTER_MODEL_SOURCE_SCHEMA,
+            "role": self.role,
+            "kind": self.kind,
+        }
+        if self.kind == "local_snapshot":
+            record.update(
+                tree_sha256=self.tree_sha256,
+                file_count=self.file_count,
+                bytes=self.bytes,
+            )
+        else:
+            record.update(
+                repository=self.runtime_reference,
+                revision=self.revision,
+            )
+        return record
+
+    def from_pretrained_arguments(self) -> tuple[str, dict[str, object]]:
+        kwargs: dict[str, object] = {}
+        if self.kind == "huggingface_revision":
+            kwargs["revision"] = self.revision
+        return self.runtime_reference, kwargs
+
+
+@dataclass(frozen=True)
+class PinnedMotionCrafterRunConfig(MotionCrafterRunConfig):
+    """MotionCrafter configuration with a portable immutable model-set identity."""
+
+    base_pipeline_path: str = ""
+    model_source_schema: str = MOTIONCRAFTER_MODEL_SET_SCHEMA
+    model_source_set_sha256: str = ""
+    model_source_manifest_json: str = ""
+    model_loader_module_sha256: str = ""
+    model_loader_module_bytes: int = 0
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        if self.model_source_schema != MOTIONCRAFTER_MODEL_SET_SCHEMA:
+            raise ValueError("unsupported MotionCrafter model-set schema")
+        set_sha = _require_sha256(
+            self.model_source_set_sha256,
+            name="MotionCrafter model-set SHA-256",
+        )
+        loader_sha = _require_sha256(
+            self.model_loader_module_sha256,
+            name="MotionCrafter model-loader module SHA-256",
+        )
+        loader_bytes = _positive_integer(
+            self.model_loader_module_bytes,
+            name="MotionCrafter model-loader module bytes",
+        )
+        try:
+            manifest = json.loads(self.model_source_manifest_json)
+        except json.JSONDecodeError as error:
+            raise ValueError("MotionCrafter model-source manifest is invalid JSON") from error
+        if not isinstance(manifest, dict):
+            raise ValueError("MotionCrafter model-source manifest must be an object")
+        if manifest.get("schema") != MOTIONCRAFTER_MODEL_SET_SCHEMA:
+            raise ValueError("MotionCrafter model-source manifest schema changed")
+        if manifest.get("model_type") != self.model_type:
+            raise ValueError("MotionCrafter model-source manifest model_type changed")
+        loader = manifest.get("loader_module")
+        if not isinstance(loader, Mapping):
+            raise ValueError("MotionCrafter model-source manifest lacks loader metadata")
+        if (
+            loader.get("sha256") != loader_sha
+            or loader.get("bytes") != loader_bytes
+        ):
+            raise ValueError("MotionCrafter model-loader identity changed")
+        if hashlib.sha256(_canonical_json(manifest)).hexdigest() != set_sha:
+            raise ValueError("MotionCrafter model-set digest mismatch")
+        identity = f"{MOTIONCRAFTER_MODEL_SET_SCHEMA}:{set_sha}"
+        if self.unet_path != f"{identity}#unet":
+            raise ValueError("MotionCrafter UNet identity changed")
+        if self.vae_path != f"{identity}#geometry-motion-vae":
+            raise ValueError("MotionCrafter VAE identity changed")
+        if self.base_pipeline_path != f"{identity}#base-video-pipeline":
+            raise ValueError("MotionCrafter base-pipeline identity changed")
+        object.__setattr__(self, "model_source_set_sha256", set_sha)
+        object.__setattr__(self, "model_loader_module_sha256", loader_sha)
+        object.__setattr__(self, "model_loader_module_bytes", loader_bytes)
+        object.__setattr__(
+            self,
+            "model_source_manifest_json",
+            _canonical_json(manifest).decode("utf-8"),
+        )
+
+
+@dataclass(frozen=True)
+class PinnedMotionCrafterModelSet:
+    """The three immutable model sources used by one MotionCrafter run."""
+
+    model_type: str
+    unet: PinnedModelSource
+    vae: PinnedModelSource
+    base_pipeline: PinnedModelSource
+    loader_module_sha256: str
+    loader_module_bytes: int
+    set_sha256: str
+    manifest_json: str
+
+    @classmethod
+    def inspect(
+        cls,
+        *,
+        model_type: str,
+        unet_reference: str | Path,
+        unet_revision: str | None,
+        vae_reference: str | Path,
+        vae_revision: str | None,
+        base_pipeline_reference: str | Path,
+        base_pipeline_revision: str | None,
+    ) -> PinnedMotionCrafterModelSet:
+        """Inspect all model sources and derive one portable set identity."""
+
+        if model_type not in {"determ", "diff"}:
+            raise ValueError("model_type must be 'determ' or 'diff'")
+        unet = PinnedModelSource.inspect(
+            unet_reference,
+            role="unet",
+            revision=unet_revision,
+            required_members=(f"unet_{model_type}",),
+        )
+        vae = PinnedModelSource.inspect(
+            vae_reference,
+            role="vae",
+            revision=vae_revision,
+            required_members=("geometry_motion_vae",),
+        )
+        base = PinnedModelSource.inspect(
+            base_pipeline_reference,
+            role="base-pipeline",
+            revision=base_pipeline_revision,
+            required_members=("model_index.json",),
+        )
+        loader = _module_descriptor()
+        manifest = {
+            "schema": MOTIONCRAFTER_MODEL_SET_SCHEMA,
+            "model_type": model_type,
+            "sources": {
+                "unet": unet.portable_record(),
+                "vae": vae.portable_record(),
+                "base_pipeline": base.portable_record(),
+            },
+            "loader_module": loader,
+        }
+        manifest_json = _canonical_json(manifest).decode("utf-8")
+        set_sha = hashlib.sha256(manifest_json.encode("utf-8")).hexdigest()
+        return cls(
+            model_type=model_type,
+            unet=unet,
+            vae=vae,
+            base_pipeline=base,
+            loader_module_sha256=str(loader["sha256"]),
+            loader_module_bytes=int(loader["bytes"]),
+            set_sha256=set_sha,
+            manifest_json=manifest_json,
+        )
+
+    def build_config(self, **kwargs: Any) -> PinnedMotionCrafterRunConfig:
+        """Create the portable config consumed by the crash-safe runner."""
+
+        identity = f"{MOTIONCRAFTER_MODEL_SET_SCHEMA}:{self.set_sha256}"
+        forbidden = {"model_type", "unet_path", "vae_path", "base_pipeline_path"} & set(
+            kwargs
+        )
+        if forbidden:
+            raise ValueError(
+                "pinned model identities are derived, not caller supplied: "
+                + ", ".join(sorted(forbidden))
+            )
+        return PinnedMotionCrafterRunConfig(
+            **kwargs,
+            model_type=self.model_type,
+            unet_path=f"{identity}#unet",
+            vae_path=f"{identity}#geometry-motion-vae",
+            base_pipeline_path=f"{identity}#base-video-pipeline",
+            model_source_set_sha256=self.set_sha256,
+            model_source_manifest_json=self.manifest_json,
+            model_loader_module_sha256=self.loader_module_sha256,
+            model_loader_module_bytes=self.loader_module_bytes,
+        )
+
+    def adapter_factory(
+        self,
+    ) -> Callable[[MotionCrafterRunConfig], MotionCrafterAdapter]:
+        """Return a factory that refuses a config from another model set."""
+
+        expected = self.set_sha256
+
+        def factory(config: MotionCrafterRunConfig) -> MotionCrafterAdapter:
+            if not isinstance(config, PinnedMotionCrafterRunConfig):
+                raise ValueError("pinned model adapter requires a pinned run config")
+            if config.model_source_set_sha256 != expected:
+                raise ValueError("pinned model adapter/config identity mismatch")
+            return PinnedMotionCrafterAdapter(config, model_set=self)
+
+        return factory
+
+
+class PinnedMotionCrafterAdapter(MotionCrafterAdapter):
+    """MotionCrafter adapter loading only the model sources bound above."""
+
+    def __init__(
+        self,
+        config: PinnedMotionCrafterRunConfig,
+        *,
+        model_set: PinnedMotionCrafterModelSet,
+    ) -> None:
+        if model_set.set_sha256 != config.model_source_set_sha256:
+            raise ValueError("model-set identity differs from the pinned run config")
+        self.config = config
+        upstream_root = config.upstream_root.resolve()
+        if not (upstream_root / "motioncrafter").is_dir():
+            raise ValueError(f"{upstream_root} is not a MotionCrafter checkout")
+        sys.path.insert(0, str(upstream_root))
+
+        try:
+            import torch
+            import torch.nn.functional as functional
+            from decord import VideoReader, cpu
+            from diffusers import AutoencoderKL
+            from diffusers.training_utils import set_seed
+            from motioncrafter import (
+                MotionCrafterDetermPipeline,
+                MotionCrafterDiffPipeline,
+                UNetSpatioTemporalConditionModelVid2vid,
+                UnifyAutoencoderKL,
+            )
+        except ImportError as error:
+            raise RuntimeError(
+                "Run prob4d-motioncrafter inside the upstream MotionCrafter environment"
+            ) from error
+
+        self.torch = torch
+        self.functional = functional
+        self.VideoReader = VideoReader
+        self.cpu = cpu
+        self.set_seed = set_seed
+
+        vae_reference, vae_kwargs = model_set.vae.from_pretrained_arguments()
+        self.geometry_motion_vae = (
+            UnifyAutoencoderKL.from_pretrained(
+                vae_reference,
+                subfolder="geometry_motion_vae",
+                low_cpu_mem_usage=True,
+                torch_dtype=torch.float32,
+                cache_dir=config.cache_directory,
+                **vae_kwargs,
+            )
+            .requires_grad_(False)
+            .to("cuda", dtype=torch.float32)
+        )
+
+        unet_reference, unet_kwargs = model_set.unet.from_pretrained_arguments()
+        unet = (
+            UNetSpatioTemporalConditionModelVid2vid.from_pretrained(
+                unet_reference,
+                subfolder=(
+                    "unet_diff" if config.model_type == "diff" else "unet_determ"
+                ),
+                low_cpu_mem_usage=True,
+                torch_dtype=torch.float16,
+                cache_dir=config.cache_directory,
+                **unet_kwargs,
+            )
+            .requires_grad_(False)
+            .to("cuda", dtype=torch.float16)
+        )
+        pipeline_class = (
+            MotionCrafterDiffPipeline
+            if config.model_type == "diff"
+            else MotionCrafterDetermPipeline
+        )
+        base_reference, base_kwargs = (
+            model_set.base_pipeline.from_pretrained_arguments()
+        )
+        self.pipeline = pipeline_class.from_pretrained(
+            base_reference,
+            unet=unet,
+            torch_dtype=torch.float16,
+            variant="fp16",
+            cache_dir=config.cache_directory,
+            **base_kwargs,
+        ).to("cuda")
+        try:
+            self.pipeline.enable_xformers_memory_efficient_attention()
+        except Exception:
+            pass
+        self.pipeline.enable_attention_slicing()
+        self.video_vae_class = AutoencoderKL
+
+
+__all__ = [
+    "DEFAULT_BASE_PIPELINE",
+    "MOTIONCRAFTER_MODEL_SET_SCHEMA",
+    "MOTIONCRAFTER_MODEL_SOURCE_SCHEMA",
+    "PinnedModelSource",
+    "PinnedMotionCrafterAdapter",
+    "PinnedMotionCrafterModelSet",
+    "PinnedMotionCrafterRunConfig",
+]

--- a/src/prob4d/motioncrafter_safe.py
+++ b/src/prob4d/motioncrafter_safe.py
@@ -9,11 +9,14 @@ from pathlib import Path
 from .motioncrafter import (
     MOTIONCRAFTER_SEED_POLICIES,
     MOTIONCRAFTER_SEED_POLICY_LEGACY_COMMON,
-    MotionCrafterRunConfig,
 )
 from .motioncrafter_integrity import (
     MOTIONCRAFTER_MANIFEST_FILENAME,
     verify_motioncrafter_prediction_manifest,
+)
+from .motioncrafter_models import (
+    DEFAULT_BASE_PIPELINE,
+    PinnedMotionCrafterModelSet,
 )
 from .motioncrafter_runner import SafeMotionCrafterRunner
 
@@ -25,7 +28,23 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--output-dir", type=Path, required=True)
     parser.add_argument("--model-type", choices=["determ", "diff"], default="determ")
     parser.add_argument("--unet-path", default="TencentARC/MotionCrafter")
+    parser.add_argument(
+        "--unet-revision",
+        help="exact remote revision; omit only when --unet-path is a local snapshot",
+    )
     parser.add_argument("--vae-path", default="TencentARC/MotionCrafter")
+    parser.add_argument(
+        "--vae-revision",
+        help="exact remote revision; omit only when --vae-path is a local snapshot",
+    )
+    parser.add_argument("--base-pipeline-path", default=DEFAULT_BASE_PIPELINE)
+    parser.add_argument(
+        "--base-pipeline-revision",
+        help=(
+            "exact remote revision; omit only when --base-pipeline-path is "
+            "a local snapshot"
+        ),
+    )
     parser.add_argument("--cache-dir", default="workspace/pretrained_models")
     parser.add_argument("--height", type=int, default=320)
     parser.add_argument("--width", type=int, default=640)
@@ -75,13 +94,26 @@ def main(argv: list[str] | None = None) -> int:
     if arguments.upstream_root is None:
         parser.error("--upstream-root is required unless --verify-only is used")
 
-    config = MotionCrafterRunConfig(
+    try:
+        model_set = PinnedMotionCrafterModelSet.inspect(
+            model_type=arguments.model_type,
+            unet_reference=arguments.unet_path,
+            unet_revision=arguments.unet_revision,
+            vae_reference=arguments.vae_path,
+            vae_revision=arguments.vae_revision,
+            base_pipeline_reference=arguments.base_pipeline_path,
+            base_pipeline_revision=arguments.base_pipeline_revision,
+        )
+    except ValueError as error:
+        parser.error(
+            f"{error}. Claim-bearing inference requires local content-addressed "
+            "snapshots or exact remote revisions."
+        )
+
+    config = model_set.build_config(
         upstream_root=arguments.upstream_root,
         video_path=arguments.video_path,
         output_directory=arguments.output_dir,
-        model_type=arguments.model_type,
-        unet_path=arguments.unet_path,
-        vae_path=arguments.vae_path,
         cache_directory=arguments.cache_dir,
         height=arguments.height,
         width=arguments.width,
@@ -99,6 +131,7 @@ def main(argv: list[str] | None = None) -> int:
     )
     manifest = SafeMotionCrafterRunner(
         config,
+        adapter_factory=model_set.adapter_factory(),
         allow_dirty_upstream=arguments.allow_dirty_upstream,
     ).run(resume=arguments.resume)
     print(manifest)

--- a/tests/test_motioncrafter_models.py
+++ b/tests/test_motioncrafter_models.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from prob4d.calibration_compatibility import motioncrafter_model_identifier
+from prob4d.motioncrafter import MOTIONCRAFTER_SEED_POLICY_DERIVED_PER_CALL
+from prob4d.motioncrafter_models import (
+    MOTIONCRAFTER_MODEL_SET_SCHEMA,
+    PinnedMotionCrafterModelSet,
+    PinnedMotionCrafterRunConfig,
+)
+from prob4d.motioncrafter_safe import main as motioncrafter_main
+
+
+def _local_model_roots(tmp_path: Path) -> tuple[Path, Path, Path]:
+    unet = tmp_path / "unet"
+    vae = tmp_path / "vae"
+    base = tmp_path / "base"
+    (unet / "unet_determ").mkdir(parents=True)
+    (unet / "unet_determ" / "config.json").write_text(
+        '{"kind":"unet"}',
+        encoding="utf-8",
+    )
+    (unet / "weights.bin").write_bytes(b"unet weights")
+    (vae / "geometry_motion_vae").mkdir(parents=True)
+    (vae / "geometry_motion_vae" / "config.json").write_text(
+        '{"kind":"vae"}',
+        encoding="utf-8",
+    )
+    base.mkdir()
+    (base / "model_index.json").write_text(
+        '{"kind":"base"}',
+        encoding="utf-8",
+    )
+    (base / "model.bin").write_bytes(b"base weights")
+    return unet, vae, base
+
+
+def _build_config(
+    model_set: PinnedMotionCrafterModelSet,
+    tmp_path: Path,
+) -> PinnedMotionCrafterRunConfig:
+    return model_set.build_config(
+        upstream_root=tmp_path / "MotionCrafter",
+        video_path=tmp_path / "input.mp4",
+        output_directory=tmp_path / "output",
+        window_size=25,
+        overlap=8,
+        seed=11,
+        seed_policy=MOTIONCRAFTER_SEED_POLICY_DERIVED_PER_CALL,
+    )
+
+
+def _manifest_config(config: PinnedMotionCrafterRunConfig) -> dict[str, object]:
+    return {
+        key: str(value) if isinstance(value, Path) else value
+        for key, value in asdict(config).items()
+    }
+
+
+def test_local_model_set_is_path_independent_and_content_sensitive(
+    tmp_path: Path,
+) -> None:
+    first_roots = _local_model_roots(tmp_path / "first")
+    second_roots = _local_model_roots(tmp_path / "second")
+
+    first = PinnedMotionCrafterModelSet.inspect(
+        model_type="determ",
+        unet_reference=first_roots[0],
+        unet_revision=None,
+        vae_reference=first_roots[1],
+        vae_revision=None,
+        base_pipeline_reference=first_roots[2],
+        base_pipeline_revision=None,
+    )
+    second = PinnedMotionCrafterModelSet.inspect(
+        model_type="determ",
+        unet_reference=second_roots[0],
+        unet_revision=None,
+        vae_reference=second_roots[1],
+        vae_revision=None,
+        base_pipeline_reference=second_roots[2],
+        base_pipeline_revision=None,
+    )
+
+    assert first.set_sha256 == second.set_sha256
+    assert json.loads(first.manifest_json)["schema"] == MOTIONCRAFTER_MODEL_SET_SCHEMA
+
+    (second_roots[2] / "model.bin").write_bytes(b"changed base weights")
+    changed = PinnedMotionCrafterModelSet.inspect(
+        model_type="determ",
+        unet_reference=second_roots[0],
+        unet_revision=None,
+        vae_reference=second_roots[1],
+        vae_revision=None,
+        base_pipeline_reference=second_roots[2],
+        base_pipeline_revision=None,
+    )
+    assert changed.set_sha256 != first.set_sha256
+
+
+def test_remote_model_sources_require_exact_revisions(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="lacks an exact remote revision"):
+        PinnedMotionCrafterModelSet.inspect(
+            model_type="determ",
+            unet_reference="TencentARC/MotionCrafter",
+            unet_revision=None,
+            vae_reference="TencentARC/MotionCrafter",
+            vae_revision="a" * 40,
+            base_pipeline_reference="stabilityai/stable-video-diffusion-img2vid-xt",
+            base_pipeline_revision="b" * 40,
+        )
+
+    with pytest.raises(ValueError, match="40- or 64-character"):
+        PinnedMotionCrafterModelSet.inspect(
+            model_type="determ",
+            unet_reference="TencentARC/MotionCrafter",
+            unet_revision="main",
+            vae_reference="TencentARC/MotionCrafter",
+            vae_revision="a" * 40,
+            base_pipeline_reference="stabilityai/stable-video-diffusion-img2vid-xt",
+            base_pipeline_revision="b" * 40,
+        )
+
+
+def test_pinned_model_set_binds_base_pipeline_into_calibration_identity(
+    tmp_path: Path,
+) -> None:
+    first = PinnedMotionCrafterModelSet.inspect(
+        model_type="determ",
+        unet_reference="TencentARC/MotionCrafter",
+        unet_revision="a" * 40,
+        vae_reference="TencentARC/MotionCrafter",
+        vae_revision="b" * 40,
+        base_pipeline_reference="stabilityai/stable-video-diffusion-img2vid-xt",
+        base_pipeline_revision="c" * 40,
+    )
+    changed_base = PinnedMotionCrafterModelSet.inspect(
+        model_type="determ",
+        unet_reference="TencentARC/MotionCrafter",
+        unet_revision="a" * 40,
+        vae_reference="TencentARC/MotionCrafter",
+        vae_revision="b" * 40,
+        base_pipeline_reference="stabilityai/stable-video-diffusion-img2vid-xt",
+        base_pipeline_revision="d" * 40,
+    )
+    first_config = _build_config(first, tmp_path)
+    changed_config = _build_config(changed_base, tmp_path)
+
+    first_manifest = {
+        "format_version": 1,
+        "config": _manifest_config(first_config),
+    }
+    changed_manifest = {
+        "format_version": 1,
+        "config": _manifest_config(changed_config),
+    }
+    assert first_config.unet_path.startswith(
+        f"{MOTIONCRAFTER_MODEL_SET_SCHEMA}:"
+    )
+    assert motioncrafter_model_identifier(first_manifest) != (
+        motioncrafter_model_identifier(changed_manifest)
+    )
+
+
+def test_adapter_factory_rejects_another_model_set_before_gpu_imports(
+    tmp_path: Path,
+) -> None:
+    first_roots = _local_model_roots(tmp_path / "first")
+    second_roots = _local_model_roots(tmp_path / "second")
+    (second_roots[0] / "weights.bin").write_bytes(b"different unet weights")
+    first = PinnedMotionCrafterModelSet.inspect(
+        model_type="determ",
+        unet_reference=first_roots[0],
+        unet_revision=None,
+        vae_reference=first_roots[1],
+        vae_revision=None,
+        base_pipeline_reference=first_roots[2],
+        base_pipeline_revision=None,
+    )
+    second = PinnedMotionCrafterModelSet.inspect(
+        model_type="determ",
+        unet_reference=second_roots[0],
+        unet_revision=None,
+        vae_reference=second_roots[1],
+        vae_revision=None,
+        base_pipeline_reference=second_roots[2],
+        base_pipeline_revision=None,
+    )
+    config = _build_config(second, tmp_path)
+
+    with pytest.raises(ValueError, match="adapter/config identity mismatch"):
+        first.adapter_factory()(config)
+
+
+def test_safe_cli_fails_closed_on_mutable_default_model_refs(
+    tmp_path: Path,
+    capsys: Any,
+) -> None:
+    video = tmp_path / "input.mp4"
+    video.write_bytes(b"video")
+    with pytest.raises(SystemExit) as error:
+        motioncrafter_main(
+            [
+                str(video),
+                "--upstream-root",
+                str(tmp_path / "MotionCrafter"),
+                "--output-dir",
+                str(tmp_path / "output"),
+            ]
+        )
+    assert error.value.code == 2
+    assert "exact remote revision" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

Close the remaining model/checkpoint provenance gap in the crash-safe public MotionCrafter producer routes.

### Immutable source contract

- require `prob4d motioncrafter` and `prob4d-motioncrafter` to bind the MotionCrafter UNet, geometry/motion VAE, and base Stable Video Diffusion pipeline;
- accept either a local snapshot with a recursive regular-file content digest or a Hugging Face repository with an exact lowercase 40/64-character revision;
- reject mutable branches, tags, short revisions, and omitted remote revisions;
- combine the three sources, selected model type, and exact loader-module bytes into one portable `prob4d.motioncrafter-model-set.v1` identity;
- exclude machine-local snapshot paths while retaining local tree SHA-256, file count, and byte count.

### Execution and compatibility

- forward exact remote revisions to every `from_pretrained` call;
- load local paths directly without network resolution;
- bind the compact model-source manifest and loader identity into the existing run specification;
- make `--resume` reconstruct the same model-set identity before GPU loading;
- encode the complete model-set digest in the existing UNet/VAE model-identifier fields, so changing the base pipeline also invalidates covariance-calibration compatibility;
- keep `--verify-only` independent of model availability.

### Validation

- path-independent and content-sensitive local snapshot identity;
- exact remote revision enforcement;
- base-pipeline changes invalidate the calibration model identifier;
- adapter/config mismatches fail before optional GPU imports;
- the public CLI fails closed on its former mutable defaults;
- Ruff, stable-interface mypy, and clean-checkout revision attestation passed;
- complete suites passed on Python 3.10, 3.12, and 3.14;
- wheel/sdist builds and isolated installed CLI smoke tests passed.

## Scope boundary

`prob4d-benchmark` remains a separate batch orchestration path and will be migrated to this same pinning contract independently, preserving its model-reuse behavior.

## Claim boundary

This is execution-provenance infrastructure. It does not establish model accuracy, covariance calibration, safe Bayesian-PhysTwin assimilation, or Causal4D benefit. Those remain held-out empirical gates.