### PR TITLE
Bound dense prediction storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,3 +318,11 @@ The implementation has been exercised at full `25 x 320 x 640` window size on
 an RTX 6000 Ada host. Frame-level covariance intersection is the production
 default; the more expensive per-pixel CI weight search remains available for
 small diagnostic experiments.
+
+The pinned benchmark loads serialized MotionCrafter point and flow fields in
+`float32` by default and records `dense_storage_dtype` in every fused artifact.
+Low-dimensional gauge estimation and covariance calculations still use
+`float64`. Stable provider loaders retain the historical `float64` default unless
+the caller explicitly selects another storage mode. Frame-local ray access also
+avoids full-window normalization temporaries in cross-fitted overlap diagnostics.
+See [dense-memory execution](docs/dense-memory.md).

--- a/docs/dense-memory.md
+++ b/docs/dense-memory.md
@@ -1,0 +1,60 @@
+# Dense-memory execution
+
+Prob4D separates **dense storage precision** from **estimation precision**. The
+serialized MotionCrafter arrays are already `float32`; eagerly converting every
+point map, scene-flow field, and optional ray field to `float64` can double the
+retained prediction memory without adding information.
+
+## Explicit storage mode
+
+`PredictionWindow` and `load_prediction_bundle` accept
+`dense_storage_dtype="float32"` or `"float64"`. The default on the reusable
+provider-facing loader remains `float64` for frozen compatibility. The pinned
+benchmark deliberately selects `float32` and binds that choice into its config
+and every fused prediction artifact:
+
+```bash
+prob4d benchmark \
+  --dataset-dir /data/Sintel_video \
+  --output-dir outputs/benchmark \
+  --upstream-root /opt/MotionCrafter \
+  --cache-dir /models/cache \
+  --unet-path TencentARC/MotionCrafter \
+  --unet-revision <exact-revision> \
+  --vae-path TencentARC/MotionCrafter \
+  --vae-revision <exact-revision> \
+  --base-pipeline-revision <exact-revision> \
+  --dense-storage-dtype float32
+```
+
+The benchmark report stores a deterministic `prediction_dense_storage` summary
+for each completed sample: retained bytes, the all-`float64` equivalent, field
+count, window count, and retained fraction. This is storage accounting rather
+than a process-RSS measurement; allocator, decompression, and NumPy temporaries
+still depend on the host runtime.
+
+## Numerical boundary
+
+Dense point and flow payloads may remain `float32`, while low-dimensional
+alignment, gauge, and fusion routines continue to promote their selected inputs
+to `float64`. The mode changes retained storage rather than the declared gauge
+or covariance model. Fused artifacts nevertheless record the mode so held-out
+evaluation cannot silently combine benchmark runs produced under different
+execution contracts.
+
+## Frame-local ray access
+
+Use `PredictionWindow.rays_at(local_index)` when only one frame is needed.
+`rays()` remains available for compatibility, but builds its output frame by
+frame rather than creating another full-size normalization temporary.
+Cross-fitted overlap disagreement retains only rays for valid overlap rows and
+does not materialize complete ray fields for both windows.
+
+## Remaining measurement work
+
+These changes halve retained point/flow storage in the benchmark and bound ray
+temporaries in cross-fitted disagreement. Follow-up work under issue #50 should
+preserve structured covariance until selected slices are required, add optional
+memory-mapped loading, and record peak RSS, loading time, disagreement time,
+gauge estimation time, fusion time, and export time for the production
+`25 x 320 x 640` setting before making a runtime or process-memory claim.

--- a/src/prob4d/_provider_evaluation_compute.py
+++ b/src/prob4d/_provider_evaluation_compute.py
@@ -12,6 +12,7 @@ from typing import Any
 import numpy as np
 
 from ._provider_evaluation_manifest import ProviderEvaluationCase
+from .data import DENSE_STORAGE_DTYPES
 from .evaluation_modes import EvaluationModes, evaluate_sequence_modes
 from .io import FusedPredictionMetadata, load_fused_prediction_artifact, load_truth
 
@@ -95,6 +96,12 @@ def _validate_method_metadata(
         raise ValueError(
             f"{path} metadata.includes_covariance must be true for provider evaluation"
         )
+    dense_storage_dtype = details.get("dense_storage_dtype", "float64")
+    if dense_storage_dtype not in DENSE_STORAGE_DTYPES:
+        raise ValueError(
+            f"{path} metadata.dense_storage_dtype must be one of "
+            + ", ".join(DENSE_STORAGE_DTYPES)
+        )
     for field in ("gauge_estimator", "uncertainty_calibration"):
         value = details.get(field)
         if not isinstance(value, str) or not value.strip():
@@ -140,6 +147,7 @@ def _method_signature(metadata: FusedPredictionMetadata) -> tuple[object, ...]:
         details.get("motioncrafter_revision"),
         details.get("motioncrafter_seed_policy"),
         details.get("motioncrafter_model_set_sha256"),
+        details.get("dense_storage_dtype", "float64"),
         details.get("gauge_estimator"),
         details.get("uncertainty_calibration"),
         details.get("gauge_covariance_calibration_artifact_id"),

--- a/src/prob4d/benchmark_safe.py
+++ b/src/prob4d/benchmark_safe.py
@@ -20,6 +20,7 @@ from .benchmark import (
     benchmark_method_semantics,
     fuse_prediction_bundle_methods,
 )
+from .data import DENSE_STORAGE_DTYPES, DenseStorageDType
 from .io import (
     load_fused_prediction_artifact,
     load_fused_prediction_metadata,
@@ -58,10 +59,18 @@ class BenchmarkExportConfig:
     overlap: int = 8
     seed: int = 42
     seed_policy: MotionCrafterSeedPolicy = MOTIONCRAFTER_SEED_POLICY_LEGACY_COMMON
+    dense_storage_dtype: DenseStorageDType = "float32"
     max_sequences: int | None = None
     skip_existing: bool = False
     include_covariance: bool = False
     fusion_methods: tuple[str, ...] = FUSION_METHOD_NAMES
+
+    def __post_init__(self) -> None:
+        if self.dense_storage_dtype not in DENSE_STORAGE_DTYPES:
+            raise ValueError(
+                "dense_storage_dtype must be one of "
+                + ", ".join(DENSE_STORAGE_DTYPES)
+            )
 
 
 def _sha256_file(path: Path) -> str:
@@ -93,7 +102,8 @@ def _existing_prediction_manifest(
     motioncrafter_commit: str,
     seed_policy: str,
     model_set_sha256: str,
-) -> tuple[Path, int]:
+    dense_storage_dtype: DenseStorageDType,
+) -> tuple[Path, int, dict[str, object]]:
     manifest_path = artifact_directory / "predictions.json"
     try:
         manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
@@ -123,9 +133,12 @@ def _existing_prediction_manifest(
             "existing benchmark prediction bundle belongs to another MotionCrafter "
             f"configuration: expected={expected}, actual={actual}"
         )
-    bundle = load_prediction_bundle(manifest_path)
+    bundle = load_prediction_bundle(
+        manifest_path,
+        dense_storage_dtype=dense_storage_dtype,
+    )
     frame_count = int(bundle.disjoint_baseline.frame_indices.size)
-    return manifest_path, frame_count
+    return manifest_path, frame_count, bundle.dense_storage_summary()
 
 
 def _validate_existing_outputs(
@@ -138,14 +151,16 @@ def _validate_existing_outputs(
     seed_policy: str,
     model_set_sha256: str,
     include_covariance: bool,
-) -> tuple[Path, int]:
+    dense_storage_dtype: DenseStorageDType,
+) -> tuple[Path, int, dict[str, object]]:
     """Validate every skipped output against the current exact producer identity."""
 
-    manifest_path, frame_count = _existing_prediction_manifest(
+    manifest_path, frame_count, dense_storage_summary = _existing_prediction_manifest(
         artifact_directory,
         motioncrafter_commit=motioncrafter_commit,
         seed_policy=seed_policy,
         model_set_sha256=model_set_sha256,
+        dense_storage_dtype=dense_storage_dtype,
     )
     prediction_manifest_sha256 = _sha256_file(manifest_path)
     baseline_pairs = (
@@ -174,6 +189,7 @@ def _validate_existing_outputs(
         "motioncrafter_model_set_sha256": model_set_sha256,
         "prediction_manifest_sha256": prediction_manifest_sha256,
         "includes_covariance": include_covariance,
+        "dense_storage_dtype": dense_storage_dtype,
     }
     for method in fusion_methods:
         path = destinations[method]
@@ -203,7 +219,7 @@ def _validate_existing_outputs(
             )
         if include_covariance:
             load_fused_prediction_artifact(path)
-    return manifest_path, frame_count
+    return manifest_path, frame_count, dense_storage_summary
 
 
 def _validate_existing_benchmark_manifest(
@@ -274,7 +290,7 @@ def run_benchmark_export(config: BenchmarkExportConfig) -> Path:
             path for path in destinations.values() if path.exists()
         ]
         if config.skip_existing and len(existing_destinations) == len(destinations):
-            _, frame_count = _validate_existing_outputs(
+            _, frame_count, dense_storage_summary = _validate_existing_outputs(
                 artifact_directory=artifact_directory,
                 destinations=destinations,
                 fusion_methods=fusion_methods,
@@ -283,6 +299,7 @@ def run_benchmark_export(config: BenchmarkExportConfig) -> Path:
                 seed_policy=config.seed_policy,
                 model_set_sha256=model_set.set_sha256,
                 include_covariance=config.include_covariance,
+                dense_storage_dtype=config.dense_storage_dtype,
             )
             samples.append(
                 {
@@ -290,6 +307,7 @@ def run_benchmark_export(config: BenchmarkExportConfig) -> Path:
                     "status": "existing_validated",
                     "frames": frame_count,
                     "index": sample_index,
+                    "prediction_dense_storage": dense_storage_summary,
                 }
             )
             continue
@@ -328,7 +346,11 @@ def run_benchmark_export(config: BenchmarkExportConfig) -> Path:
         prediction_manifest_sha256 = _sha256_file(manifest_path)
 
         loading_started = time.perf_counter()
-        bundle = load_prediction_bundle(manifest_path)
+        bundle = load_prediction_bundle(
+            manifest_path,
+            dense_storage_dtype=config.dense_storage_dtype,
+        )
+        dense_storage_summary = bundle.dense_storage_summary()
         loading_seconds = time.perf_counter() - loading_started
 
         fusion_started = time.perf_counter()
@@ -351,6 +373,7 @@ def run_benchmark_export(config: BenchmarkExportConfig) -> Path:
             "motioncrafter_model_set_sha256": model_set.set_sha256,
             "prediction_manifest_sha256": prediction_manifest_sha256,
             "includes_covariance": config.include_covariance,
+            "dense_storage_dtype": config.dense_storage_dtype,
         }
         for method, sequence in fused_methods.items():
             _write_fused_prediction(
@@ -376,6 +399,7 @@ def run_benchmark_export(config: BenchmarkExportConfig) -> Path:
                 "frames": int(next(iter(fused_methods.values())).frame_indices.size),
                 "index": sample_index,
                 "prediction_manifest_sha256": prediction_manifest_sha256,
+                "prediction_dense_storage": dense_storage_summary,
             }
         )
         del bundle, fused_methods
@@ -454,6 +478,15 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--skip-existing", action="store_true")
     parser.add_argument("--include-covariance", action="store_true")
     parser.add_argument(
+        "--dense-storage-dtype",
+        choices=DENSE_STORAGE_DTYPES,
+        default="float32",
+        help=(
+            "in-memory point/flow storage; float32 halves dense prediction storage "
+            "while gauge and covariance calculations remain float64"
+        ),
+    )
+    parser.add_argument(
         "--fusion-method",
         dest="fusion_methods",
         action="append",
@@ -488,6 +521,7 @@ def main(argv: list[str] | None = None) -> int:
         max_sequences=arguments.max_sequences,
         skip_existing=arguments.skip_existing,
         include_covariance=arguments.include_covariance,
+        dense_storage_dtype=arguments.dense_storage_dtype,
         fusion_methods=tuple(arguments.fusion_methods or FUSION_METHOD_NAMES),
     )
     try:

--- a/src/prob4d/cross_fitted_disagreement.py
+++ b/src/prob4d/cross_fitted_disagreement.py
@@ -120,6 +120,8 @@ class _OverlapRows:
     rows: IntArray
     columns: IntArray
     cluster_ids: IntArray
+    reference_rays: NDArray[np.floating]
+    moving_rays: NDArray[np.floating]
 
 
 def _validated_integer(
@@ -173,6 +175,14 @@ def _clustered_overlap_rows(
                 rows=rows.astype(np.int64),
                 columns=columns.astype(np.int64),
                 cluster_ids=cluster_ids,
+                reference_rays=reference.rays_at(
+                    reference_index,
+                    dtype=np.float64,
+                )[rows, columns],
+                moving_rays=moving.rays_at(
+                    moving_index,
+                    dtype=np.float64,
+                )[rows, columns],
             )
         )
     return records, cluster_offset, overlap_points
@@ -264,8 +274,6 @@ def _accumulate_rows(
     record: _OverlapRows,
     selected: np.ndarray,
     transform: Sim3,
-    reference_rays: np.ndarray,
-    moving_rays: np.ndarray,
 ) -> int:
     rows = record.rows[selected]
     columns = record.columns[selected]
@@ -274,8 +282,8 @@ def _accumulate_rows(
     parallel, lateral = _residual_energy(
         reference.point_map[record.reference_index][rows, columns],
         moving.point_map[record.moving_index][rows, columns],
-        reference_rays[record.reference_index][rows, columns],
-        moving_rays[record.moving_index][rows, columns],
+        record.reference_rays[selected],
+        record.moving_rays[selected],
         transform,
     )
     for window_id, local_index in (
@@ -372,8 +380,6 @@ def accumulate_cross_fitted_disagreement(
             effective_folds,
             seed=alignment_seed,
         )
-        reference_rays = reference.rays()
-        moving_rays = moving.rays()
         alignment_fitted_folds = 0
 
         for held_out_fold in range(effective_folds):
@@ -418,8 +424,6 @@ def accumulate_cross_fitted_disagreement(
                     record,
                     held_out,
                     transform,
-                    reference_rays,
-                    moving_rays,
                 )
             fitted_folds += 1
             alignment_fitted_folds += 1

--- a/src/prob4d/data.py
+++ b/src/prob4d/data.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Final, Literal, cast
 
 import numpy as np
 from numpy.typing import NDArray
@@ -11,6 +12,11 @@ from numpy.typing import NDArray
 FloatArray = NDArray[np.floating]
 BoolArray = NDArray[np.bool_]
 IntArray = NDArray[np.integer]
+DenseStorageDType = Literal["float32", "float64"]
+DENSE_STORAGE_DTYPES: Final[tuple[DenseStorageDType, ...]] = (
+    "float32",
+    "float64",
+)
 
 
 def _readonly_owned(value: np.ndarray) -> np.ndarray:
@@ -18,6 +24,19 @@ def _readonly_owned(value: np.ndarray) -> np.ndarray:
 
     value.setflags(write=False)
     return value
+
+
+def _validated_dense_storage_dtype(value: object) -> DenseStorageDType:
+    normalized = str(value)
+    if normalized not in DENSE_STORAGE_DTYPES:
+        raise ValueError(
+            "dense_storage_dtype must be one of " + ", ".join(DENSE_STORAGE_DTYPES)
+        )
+    return cast(DenseStorageDType, normalized)
+
+
+def _numpy_dense_dtype(value: DenseStorageDType) -> np.dtype[np.floating]:
+    return np.dtype(np.float32 if value == "float32" else np.float64)
 
 
 @dataclass(frozen=True)
@@ -37,11 +56,16 @@ class PredictionWindow:
     scene_flow: FloatArray | None = None
     deform_mask: BoolArray | None = None
     ray_directions: FloatArray | None = None
+    dense_storage_dtype: DenseStorageDType = "float64"
 
     def __post_init__(self) -> None:
         window_id = str(self.window_id)
+        dense_storage_dtype = _validated_dense_storage_dtype(
+            self.dense_storage_dtype
+        )
+        dense_dtype = _numpy_dense_dtype(dense_storage_dtype)
         frame_indices = np.asarray(self.frame_indices, dtype=np.int64).copy()
-        point_map = np.asarray(self.point_map, dtype=np.float64).copy()
+        point_map = np.asarray(self.point_map, dtype=dense_dtype).copy()
         valid_mask = np.asarray(self.valid_mask, dtype=bool).copy()
 
         if not window_id:
@@ -81,6 +105,7 @@ class PredictionWindow:
             rays[valid_mask] /= ray_norm[valid_mask, None]
 
         object.__setattr__(self, "window_id", window_id)
+        object.__setattr__(self, "dense_storage_dtype", dense_storage_dtype)
         object.__setattr__(self, "frame_indices", _readonly_owned(frame_indices))
         object.__setattr__(self, "point_map", _readonly_owned(point_map))
         object.__setattr__(self, "valid_mask", _readonly_owned(valid_mask))
@@ -106,7 +131,7 @@ class PredictionWindow:
     ) -> np.ndarray | None:
         if value is None:
             return None
-        array = np.asarray(value, dtype=np.float64).copy()
+        array = np.asarray(value, dtype=reference.dtype).copy()
         if array.shape != reference.shape:
             raise ValueError(f"{name} must have shape {reference.shape}")
         return array
@@ -147,18 +172,60 @@ class PredictionWindow:
     def common_frames(self, other: PredictionWindow) -> IntArray:
         return np.intersect1d(self.frame_indices, other.frame_indices, assume_unique=True)
 
-    def rays(self) -> FloatArray:
-        """Return normalized rays, falling back to directions from the local origin."""
+    @property
+    def dense_vector_storage_bytes(self) -> int:
+        """Return bytes retained by dense three-vector prediction fields."""
 
+        arrays = (self.point_map, self.scene_flow, self.ray_directions)
+        return sum(array.nbytes for array in arrays if array is not None)
+
+    def rays_at(
+        self,
+        local_index: int,
+        *,
+        dtype: type[np.floating] | np.dtype[np.floating] | None = None,
+    ) -> FloatArray:
+        """Return normalized rays for one frame without copying the full window."""
+
+        index = int(local_index)
+        if index != local_index or not 0 <= index < self.shape[0]:
+            raise IndexError("local ray frame index is out of range")
+        target_dtype = self.point_map.dtype if dtype is None else np.dtype(dtype)
+        if target_dtype not in {np.dtype(np.float32), np.dtype(np.float64)}:
+            raise ValueError("ray dtype must be float32 or float64")
         if self.ray_directions is not None:
-            return self.ray_directions.copy()
-        norms = np.linalg.norm(self.point_map, axis=-1, keepdims=True)
+            return np.array(
+                self.ray_directions[index],
+                dtype=target_dtype,
+                copy=True,
+            )
+
+        points = np.asarray(self.point_map[index], dtype=target_dtype)
+        norms = np.linalg.norm(points, axis=-1, keepdims=True)
         return np.divide(
-            self.point_map,
+            points,
             norms,
-            out=np.zeros_like(self.point_map),
+            out=np.zeros(points.shape, dtype=target_dtype),
             where=norms > np.finfo(np.float64).eps,
         )
+
+    def rays(
+        self,
+        *,
+        dtype: type[np.floating] | np.dtype[np.floating] | None = None,
+    ) -> FloatArray:
+        """Return all normalized rays, using frame-local temporary storage."""
+
+        if self.ray_directions is not None:
+            target_dtype = self.ray_directions.dtype if dtype is None else np.dtype(dtype)
+            if target_dtype not in {np.dtype(np.float32), np.dtype(np.float64)}:
+                raise ValueError("ray dtype must be float32 or float64")
+            return np.array(self.ray_directions, dtype=target_dtype, copy=True)
+        target_dtype = self.point_map.dtype if dtype is None else np.dtype(dtype)
+        output = np.empty(self.point_map.shape, dtype=target_dtype)
+        for local_index in range(self.shape[0]):
+            output[local_index] = self.rays_at(local_index, dtype=target_dtype)
+        return output
 
     def to_npz(self, path: str | Path) -> None:
         """Write a portable, self-describing prediction window."""
@@ -166,14 +233,17 @@ class PredictionWindow:
         payload: dict[str, np.ndarray] = {
             "window_id": np.asarray(self.window_id),
             "frame_indices": self.frame_indices,
-            "point_map": self.point_map.astype(np.float32),
+            "point_map": self.point_map.astype(np.float32, copy=False),
             "valid_mask": self.valid_mask,
         }
         if self.scene_flow is not None:
-            payload["scene_flow"] = self.scene_flow.astype(np.float32)
+            payload["scene_flow"] = self.scene_flow.astype(np.float32, copy=False)
             payload["deform_mask"] = self.deform_mask
         if self.ray_directions is not None:
-            payload["ray_directions"] = self.ray_directions.astype(np.float32)
+            payload["ray_directions"] = self.ray_directions.astype(
+                np.float32,
+                copy=False,
+            )
         np.savez_compressed(Path(path), **payload)
 
     @classmethod
@@ -183,6 +253,7 @@ class PredictionWindow:
         *,
         start_frame: int | None = None,
         window_id: str | None = None,
+        dense_storage_dtype: DenseStorageDType = "float64",
     ) -> PredictionWindow:
         """Read a window, requiring explicit frame metadata when absent upstream."""
 
@@ -209,4 +280,12 @@ class PredictionWindow:
                 scene_flow=data["scene_flow"] if "scene_flow" in data else None,
                 deform_mask=data["deform_mask"] if "deform_mask" in data else None,
                 ray_directions=data["ray_directions"] if "ray_directions" in data else None,
+                dense_storage_dtype=dense_storage_dtype,
             )
+
+
+__all__ = [
+    "DENSE_STORAGE_DTYPES",
+    "DenseStorageDType",
+    "PredictionWindow",
+]

--- a/src/prob4d/io.py
+++ b/src/prob4d/io.py
@@ -11,7 +11,7 @@ from typing import Any, Literal
 import numpy as np
 
 from ._immutable_json import frozen_finite_json_mapping, plain_json
-from .data import PredictionWindow
+from .data import DenseStorageDType, PredictionWindow
 from .fusion import FusedSequence
 from .metrics import TruthSequence
 from .motioncrafter_integrity import (
@@ -335,8 +335,50 @@ class PredictionBundle:
     latent_linear_baseline: PredictionWindow
     metadata: dict
 
+    def dense_storage_summary(self) -> dict[str, object]:
+        """Summarize retained dense vector storage without sampling process RSS."""
 
-def load_prediction_bundle(path: str | Path) -> PredictionBundle:
+        windows = [
+            *self.overlap_windows,
+            self.disjoint_baseline,
+            self.latent_linear_baseline,
+        ]
+        retained_bytes = sum(window.dense_vector_storage_bytes for window in windows)
+        float64_equivalent_bytes = 0
+        dense_vector_field_count = 0
+        for window in windows:
+            for array in (
+                window.point_map,
+                window.scene_flow,
+                window.ray_directions,
+            ):
+                if array is None:
+                    continue
+                dense_vector_field_count += 1
+                float64_equivalent_bytes += array.size * np.dtype(np.float64).itemsize
+        return {
+            "window_count": len(windows),
+            "dense_vector_field_count": dense_vector_field_count,
+            "storage_dtypes": sorted(
+                {window.dense_storage_dtype for window in windows}
+            ),
+            "retained_bytes": retained_bytes,
+            "float64_equivalent_bytes": float64_equivalent_bytes,
+            "retained_fraction_of_float64": (
+                0.0
+                if float64_equivalent_bytes == 0
+                else retained_bytes / float64_equivalent_bytes
+            ),
+        }
+
+
+def load_prediction_bundle(
+    path: str | Path,
+    *,
+    dense_storage_dtype: DenseStorageDType = "float64",
+) -> PredictionBundle:
+    """Load a verified bundle with an explicit dense in-memory storage mode."""
+
     path = Path(path).resolve()
     verify_motioncrafter_prediction_manifest(path, verify_hashes=True)
     payload = json.loads(path.read_text(encoding="utf-8"))
@@ -350,6 +392,7 @@ def load_prediction_bundle(path: str | Path) -> PredictionBundle:
             member(item["path"], name=f"overlap window {item['window_id']!r} path"),
             start_frame=item.get("start_frame"),
             window_id=item["window_id"],
+            dense_storage_dtype=dense_storage_dtype,
         )
         for item in payload["overlap_windows"]
     ]
@@ -361,11 +404,13 @@ def load_prediction_bundle(path: str | Path) -> PredictionBundle:
             member(payload["disjoint_baseline"], name="disjoint baseline path"),
             start_frame=0,
             window_id="baseline_disjoint",
+            dense_storage_dtype=dense_storage_dtype,
         ),
         latent_linear_baseline=PredictionWindow.from_npz(
             member(payload["latent_linear_baseline"], name="latent-linear baseline path"),
             start_frame=0,
             window_id="baseline_latent_linear",
+            dense_storage_dtype=dense_storage_dtype,
         ),
         metadata=payload,
     )

--- a/tests/test_benchmark_safe.py
+++ b/tests/test_benchmark_safe.py
@@ -96,6 +96,8 @@ def test_existing_benchmark_outputs_are_validated_before_skip(tmp_path: Path) ->
 
     assert manifest_path == artifact_directory / "predictions.json"
     assert frame_count == 40
+    assert storage_summary["storage_dtypes"] == ["float32"]
+    assert storage_summary["retained_fraction_of_float64"] == 0.5
 
     baseline = destinations["motioncrafter_disjoint"]
     baseline.write_bytes(baseline.read_bytes() + b"tampered")

--- a/tests/test_benchmark_safe.py
+++ b/tests/test_benchmark_safe.py
@@ -53,7 +53,10 @@ def _existing_outputs(tmp_path: Path) -> tuple[Path, dict[str, Path]]:
         destination.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy2(artifact_directory / source_name, destination)
 
-    bundle = load_prediction_bundle(manifest_path)
+    bundle = load_prediction_bundle(
+        manifest_path,
+        dense_storage_dtype="float32",
+    )
     sequence = fuse_prediction_bundle_methods(
         bundle,
         method_names={"prob4d_uniform"},
@@ -70,6 +73,7 @@ def _existing_outputs(tmp_path: Path) -> tuple[Path, dict[str, Path]]:
             "motioncrafter_model_set_sha256": "c" * 64,
             "prediction_manifest_sha256": _sha256_file(manifest_path),
             "includes_covariance": True,
+            "dense_storage_dtype": "float32",
         },
     )
     return artifact_directory, destinations
@@ -78,7 +82,7 @@ def _existing_outputs(tmp_path: Path) -> tuple[Path, dict[str, Path]]:
 def test_existing_benchmark_outputs_are_validated_before_skip(tmp_path: Path) -> None:
     artifact_directory, destinations = _existing_outputs(tmp_path)
 
-    manifest_path, frame_count = _validate_existing_outputs(
+    manifest_path, frame_count, storage_summary = _validate_existing_outputs(
         artifact_directory=artifact_directory,
         destinations=destinations,
         fusion_methods=("prob4d_uniform",),
@@ -87,6 +91,7 @@ def test_existing_benchmark_outputs_are_validated_before_skip(tmp_path: Path) ->
         seed_policy="legacy-common",
         model_set_sha256="c" * 64,
         include_covariance=True,
+        dense_storage_dtype="float32",
     )
 
     assert manifest_path == artifact_directory / "predictions.json"
@@ -104,6 +109,7 @@ def test_existing_benchmark_outputs_are_validated_before_skip(tmp_path: Path) ->
             seed_policy="legacy-common",
             model_set_sha256="c" * 64,
             include_covariance=True,
+            dense_storage_dtype="float32",
         )
 
 

--- a/tests/test_cross_fitted_disagreement.py
+++ b/tests/test_cross_fitted_disagreement.py
@@ -228,3 +228,22 @@ def test_cross_fitted_disagreement_fails_closed_without_two_clusters() -> None:
         assert not np.any(item.count)
         assert not np.any(item.parallel_sum)
         assert not np.any(item.lateral_sum)
+
+
+def test_cross_fitted_path_does_not_materialize_full_window_rays(monkeypatch) -> None:
+    windows, alignments = _tile_bias_fixture()
+
+    def forbidden_full_rays(*args, **kwargs):
+        raise AssertionError("full-window rays were materialized")
+
+    monkeypatch.setattr(PredictionWindow, "rays", forbidden_full_rays)
+    cross_fitted, report = accumulate_cross_fitted_disagreement(
+        windows,
+        alignments,
+        folds=4,
+        cluster_size=2,
+        seed=7,
+    )
+
+    assert report.evaluated_points == 16
+    assert np.any(cross_fitted["reference"].count)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -106,3 +106,66 @@ def test_window_rejects_invalid_active_ray_directions(bad_value: float) -> None:
             valid_mask=np.ones((1, 1, 1), dtype=bool),
             ray_directions=rays,
         )
+
+
+def test_explicit_float32_storage_halves_dense_vectors_and_keeps_ray_parity(
+    tmp_path: Path,
+) -> None:
+    points = np.arange(2 * 3 * 4 * 3, dtype=np.float32).reshape(2, 3, 4, 3)
+    points[..., 2] += 1.0
+    flow = np.ones_like(points)
+    valid = np.ones((2, 3, 4), dtype=bool)
+    deform = np.ones_like(valid)
+    legacy = PredictionWindow(
+        "legacy",
+        np.array([0, 1]),
+        points,
+        valid,
+        scene_flow=flow,
+        deform_mask=deform,
+    )
+    compact = PredictionWindow(
+        "compact",
+        np.array([0, 1]),
+        points,
+        valid,
+        scene_flow=flow,
+        deform_mask=deform,
+        dense_storage_dtype="float32",
+    )
+
+    assert compact.point_map.dtype == np.float32
+    assert compact.scene_flow.dtype == np.float32
+    assert legacy.point_map.dtype == np.float64
+    assert compact.dense_vector_storage_bytes * 2 == legacy.dense_vector_storage_bytes
+    np.testing.assert_array_equal(
+        compact.rays_at(1, dtype=np.float64),
+        legacy.rays_at(1, dtype=np.float64),
+    )
+    np.testing.assert_array_equal(
+        compact.rays(dtype=np.float64)[1],
+        compact.rays_at(1, dtype=np.float64),
+    )
+    with pytest.raises(ValueError):
+        compact.point_map[0, 0, 0, 0] = 1.0
+
+    path = tmp_path / "compact.npz"
+    compact.to_npz(path)
+    restored = PredictionWindow.from_npz(
+        path,
+        dense_storage_dtype="float32",
+    )
+    assert restored.point_map.dtype == np.float32
+    assert restored.scene_flow.dtype == np.float32
+    np.testing.assert_array_equal(restored.point_map, compact.point_map)
+
+
+def test_window_rejects_unknown_dense_storage_dtype() -> None:
+    with pytest.raises(ValueError, match="dense_storage_dtype"):
+        PredictionWindow(
+            window_id="bad-storage",
+            frame_indices=np.array([0]),
+            point_map=np.ones((1, 1, 1, 3)),
+            valid_mask=np.ones((1, 1, 1), dtype=bool),
+            dense_storage_dtype="float16",  # type: ignore[arg-type]
+        )

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -157,3 +157,37 @@ def test_legacy_fused_prediction_is_explicitly_unspecified(tmp_path: Path) -> No
 
     assert metadata.legacy_unspecified
     assert metadata.fusion_method == "unspecified"
+
+
+def test_prediction_bundle_explicit_float32_storage_is_auditable(
+    tmp_path: Path,
+) -> None:
+    problem = make_synthetic_problem(
+        seed=23,
+        num_frames=40,
+        height=4,
+        width=6,
+        overlap=15,
+    )
+    manifest_path, _ = write_problem_bundle(tmp_path / "bundle", problem)
+
+    legacy = load_prediction_bundle(manifest_path)
+    compact = load_prediction_bundle(
+        manifest_path,
+        dense_storage_dtype="float32",
+    )
+    legacy_summary = legacy.dense_storage_summary()
+    compact_summary = compact.dense_storage_summary()
+
+    assert legacy_summary["storage_dtypes"] == ["float64"]
+    assert compact_summary["storage_dtypes"] == ["float32"]
+    assert compact_summary["retained_fraction_of_float64"] == 0.5
+    assert compact_summary["retained_bytes"] * 2 == legacy_summary["retained_bytes"]
+    for expected, actual in zip(
+        legacy.overlap_windows,
+        compact.overlap_windows,
+        strict=True,
+    ):
+        np.testing.assert_array_equal(actual.point_map, expected.point_map)
+        if expected.scene_flow is not None:
+            np.testing.assert_array_equal(actual.scene_flow, expected.scene_flow)

--- a/tests/test_provider_evaluation.py
+++ b/tests/test_provider_evaluation.py
@@ -253,3 +253,46 @@ def test_provider_evaluation_rejects_legacy_unspecified_artifacts(
 
     with pytest.raises(ValueError, match="legacy unspecified"):
         run_provider_evaluation(manifest_path, tmp_path / "output")
+
+
+def test_provider_evaluation_rejects_dense_storage_mode_drift(
+    tmp_path: Path,
+) -> None:
+    first = _write_case(
+        tmp_path,
+        "c1",
+        "g1",
+        uniform_error=1.0,
+        ci_error=0.5,
+    )
+    second = _write_case(
+        tmp_path,
+        "c2",
+        "g2",
+        uniform_error=2.0,
+        ci_error=1.0,
+    )
+    truth = _truth()
+    changed_metadata = _artifact_metadata()
+    changed_metadata["dense_storage_dtype"] = "float32"
+    save_fused_prediction(
+        tmp_path / "c2-uniform.npz",
+        _prediction(truth, 2.0),
+        method_id="uniform",
+        fusion_method="uniform",
+        metadata=changed_metadata,
+    )
+
+    manifest = {
+        "schema_name": "prob4d.provider-evaluation",
+        "schema_version": 1,
+        "primary_mode": "metric",
+        "reference_method": "uniform",
+        "cases": [first, second],
+        "metadata": {},
+    }
+    path = tmp_path / "evaluation.json"
+    path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="mixes covariance, model"):
+        run_provider_evaluation(path, tmp_path / "output")


### PR DESCRIPTION
## Summary

- add explicit `float32`/`float64` dense storage to `PredictionWindow` and prediction-bundle loading while preserving the stable provider-facing `float64` default;
- make the pinned benchmark use `float32` dense storage by default and bind the selected mode plus deterministic storage accounting into fused artifacts and benchmark reports;
- use frame-local rays in cross-fitted overlap diagnostics instead of materializing complete ray fields for both windows;
- reject held-out provider evaluations that silently mix dense-storage execution semantics for one method.

## Validation

- focused dense-memory/benchmark/evaluator suite: **28 passed**;
- all tests available in the downloaded source distribution: **319 passed**;
- Python compilation, 100-column checks, and `git diff --check` passed;
- GitHub CI remains authoritative for Ruff, mypy, the complete repository-only test set, distribution builds, and installed-artifact smoke tests.

Three tests were unavailable in the downloaded source distribution because their repository-only scripts/fixture are not packaged there: `test_sparse_gauge_anchor_script.py`, `test_vggt_prob4d_blends.py`, and `test_joint_observation_contract_fixture.py`.

## Scope and claim boundary

This PR reports deterministic retained-array storage, not measured peak RSS or runtime. It makes no reconstruction-accuracy, uncertainty-calibration, physical-update, or Causal4D-benefit claim. Structured-covariance slicing, optional memory-mapped loading, and a hardware-specific peak-RSS/timing benchmark remain follow-up work.

Progresses #50.