### PR TITLE
Tile dense fusion without changing CI semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ All notable changes to Prob4D are documented here.
   access, and deterministic retained-storage accounting for benchmark runs.
 - `FusedSequence` as a public immutable dense-output contract with canonical
   dtypes, bounded active covariance validation, and read-only arrays.
+- Bounded spatial-tile dense fusion that preserves structured covariance until a
+  representative covariance-intersection sample or active tile is required, plus
+  a deterministic process-level memory and timing benchmark.
 
 ### Changed
 
@@ -41,6 +44,9 @@ All notable changes to Prob4D are documented here.
   states, or dense-storage execution semantics across cases.
 - Fusion and fused-artifact loading transfer ownership of private arrays into the
   immutable `FusedSequence` contract without an unnecessary second dense copy.
+- Dense covariance-intersection weights remain optimized once per complete
+  frame/contributor-mask pattern and are reused across bounded application tiles,
+  so the tile size changes temporary memory rather than estimator semantics.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -333,3 +333,11 @@ covariances fail closed on asymmetry or indefiniteness, and every retained array
 is read-only. Internal fusion and artifact-loading paths can transfer ownership of
 private arrays to avoid a second dense copy while preserving the same validation.
 See [the fused-sequence contract](docs/fused-sequence-contract.md).
+
+
+Dense fusion now preserves structured ray-parallel/lateral covariance until a
+representative CI sample or active spatial tile is needed. Covariance-intersection
+weights are still optimized once per complete frame/mask pattern and reused for
+all tiles, so `fusion_tile_size` changes temporary memory rather than estimator
+semantics. A deterministic process-level benchmark records peak RSS, timing, and
+an output digest. See [tiled dense fusion](docs/tiled-fusion.md).

--- a/docs/tiled-fusion.md
+++ b/docs/tiled-fusion.md
@@ -1,0 +1,90 @@
+# Tiled dense fusion
+
+Prob4D retains dense fused means and marginal covariance because they are part of
+its reconstruction and evaluation interfaces. It does not need to retain one
+fully transformed dense covariance field for every contributing MotionCrafter
+window at the same time.
+
+## Execution model
+
+`fuse_windows` processes each output frame and validity-mask pattern in bounded
+spatial tiles. The default tile contains 16,384 pixels and can be changed with
+`fusion_tile_size` for engineering benchmarks.
+
+For each contributing window, the implementation materializes only the selected
+rows of:
+
+- the point map or scene-flow field transformed into the global gauge;
+- the ray-parallel/lateral conditional covariance expanded into dense `3 x 3`
+  matrices; and
+- the optional gauge-induced covariance propagated through the local `Sim(3)`
+  Jacobian.
+
+The complete fused output remains dense and immutable. Tiling bounds
+contributor-sized temporaries; it does not change output artifact schemas or
+provider-v1/provider-v2 observation semantics.
+
+## Covariance-intersection semantics
+
+Prob4D's production dense covariance-intersection mode uses one weight vector for
+all pixels with the same contributor mask in one frame. Tiled application must
+not accidentally optimize a different weight in every tile.
+
+The implementation therefore:
+
+1. selects the same deterministic, evenly spaced sample of at most 4,096 rows as
+   the previous dense path;
+2. optimizes one pairwise or generalized-CI weight vector on that complete
+   pattern sample; and
+3. reuses the frozen weights while applying CI to each spatial tile.
+
+Uniform and independent-precision fusion are point-separable and are evaluated
+in the same bounded tile loop. Regression tests compare large and one-pixel
+tiles for all three methods and verify that structured covariance is never
+expanded for a complete 5,000-row contributor field.
+
+## Benchmark
+
+Run the installed package benchmark with:
+
+```bash
+python -m prob4d.fusion_memory_benchmark \
+  --height 320 \
+  --width 640 \
+  --contributors 3 \
+  --method covariance_intersection \
+  --fusion-tile-size 16384 \
+  --output-json outputs/dense-fusion-memory.json
+```
+
+The benchmark records the exact repository revision, Python and NumPy versions,
+platform, configuration, retained-array accounting, process peak RSS, timing,
+and a deterministic digest of the fused arrays. Peak RSS includes construction
+of the synthetic inputs and should be compared only between otherwise matched
+fresh processes.
+
+A matched local synthetic run compared commit
+`9496a36b9fe9f80a13396e0c65ce06841636a249` with the tiled implementation at one
+`320 x 640` frame, three contributors, conditional structured covariance, gauge
+covariance, and frame-global covariance intersection:
+
+| Measurement | Eager baseline | Tiled candidate | Change |
+| --- | ---: | ---: | ---: |
+| Peak RSS | 579,784 KiB | 219,132 KiB | -62.2% |
+| Fusion time | 3.718 s | 3.083 s | -17.1% |
+| Point sum | 819,319.9940782051 | 819,319.9940782051 | exact match |
+| Covariance-trace sum | 12,191.715942554092 | 12,191.715942554092 | exact match |
+| Contributor-count sum | 614,400 | 614,400 | exact match |
+
+The run used NumPy 2.3.5 on Linux 6.12.13 x86-64 with an Intel Xeon Platinum
+8370C. These numbers are engineering evidence for that process and host, not a
+runtime guarantee or a reconstruction-accuracy, uncertainty-calibration,
+Bayesian-PhysTwin, or Causal4D result.
+
+## Remaining work
+
+Tiling does not eliminate the dense fused output covariance. Issue #50 still
+tracks optional memory-mapped prediction loading, end-to-end production-host
+profiling, export-stage memory, and hardware-recorded benchmarks at the full
+25-frame setting. Those changes must remain explicit execution modes and must
+not alter frozen provider artifacts silently.

--- a/scripts/benchmark_dense_fusion_memory.py
+++ b/scripts/benchmark_dense_fusion_memory.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""Run the installed Prob4D dense-fusion memory benchmark."""
+
+from prob4d.fusion_memory_benchmark import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/prob4d/fusion.py
+++ b/src/prob4d/fusion.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Literal
 
@@ -15,6 +16,12 @@ from .uncertainty import StructuredCovariance
 
 FloatArray = NDArray[np.floating]
 FusionMethod = Literal["uniform", "precision", "covariance_intersection"]
+DEFAULT_FUSION_TILE_SIZE = 16_384
+DEFAULT_CI_WEIGHT_SAMPLE_SIZE = 4_096
+FrameFieldLoader = Callable[
+    [int, NDArray[np.int64]],
+    tuple[FloatArray, FloatArray],
+]
 
 
 @dataclass(frozen=True)
@@ -571,44 +578,346 @@ def _fuse_contributor_stack(
     raise ValueError(f"unknown fusion method {method!r}")
 
 
-def _fuse_frame_fields(
-    means: list[FloatArray],
-    covariances: list[FloatArray],
+def _covariance_intersection_weights(
+    means: FloatArray,
+    covariances: FloatArray,
+) -> FloatArray:
+    """Optimize one global CI weight vector for a bounded representative sample."""
+
+    contributor_count = means.shape[0]
+    if contributor_count < 2:
+        return np.ones(1, dtype=np.float64)
+    if contributor_count == 2:
+        _, _, first_weight = fuse_gaussians_covariance_intersection(
+            means[0],
+            covariances[0],
+            means[1],
+            covariances[1],
+            weight_sample_size=means.shape[1],
+        )
+        value = float(np.ravel(first_weight)[0])
+        return np.asarray([value, 1.0 - value], dtype=np.float64)
+
+    from ._generalized_ci import fuse_nway_covariance_intersection
+
+    _, _, weights = fuse_nway_covariance_intersection(
+        means,
+        covariances,
+        weight_sample_size=means.shape[1],
+        canonicalize=False,
+    )
+    return weights
+
+
+def _fuse_contributor_stack_fixed_ci(
+    means: FloatArray,
+    covariances: FloatArray,
+    weights: FloatArray,
+) -> tuple[FloatArray, FloatArray]:
+    """Apply already optimized CI weights to one bounded spatial tile."""
+
+    contributor_count = means.shape[0]
+    normalized_weights = np.asarray(weights, dtype=np.float64)
+    if normalized_weights.shape != (contributor_count,):
+        raise ValueError("CI weights must match the contributor count")
+    if contributor_count == 1:
+        return means[0], covariances[0]
+
+    information = _regularized_inverse(covariances)
+    if contributor_count == 2:
+        first_weight = float(normalized_weights[0])
+        second_weight = float(normalized_weights[1])
+        fused_covariance = _regularized_inverse(
+            first_weight * information[0] + second_weight * information[1]
+        )
+        information_vector = first_weight * np.einsum(
+            "nij,nj->ni", information[0], means[0]
+        ) + second_weight * np.einsum(
+            "nij,nj->ni", information[1], means[1]
+        )
+    else:
+        fused_covariance = _regularized_inverse(
+            np.einsum(
+                "k,knij->nij",
+                normalized_weights,
+                information,
+                optimize=True,
+            )
+        )
+        information_vector = np.einsum(
+            "k,knij,knj->ni",
+            normalized_weights,
+            information,
+            means,
+            optimize=True,
+        )
+    fused_mean = np.einsum(
+        "nij,nj->ni",
+        fused_covariance,
+        information_vector,
+        optimize=True,
+    )
+    return fused_mean, fused_covariance
+
+
+def _representative_positions(sample_count: int) -> NDArray[np.int64]:
+    """Match the existing deterministic CI sampling policy without dense copies."""
+
+    if sample_count < 1:
+        raise ValueError("CI weight optimization requires at least one sample")
+    if sample_count <= DEFAULT_CI_WEIGHT_SAMPLE_SIZE:
+        return np.arange(sample_count, dtype=np.int64)
+    return np.linspace(
+        0,
+        sample_count - 1,
+        DEFAULT_CI_WEIGHT_SAMPLE_SIZE,
+        dtype=np.int64,
+    )
+
+
+def _validated_loaded_tile(
+    loader: FrameFieldLoader,
+    contributor_index: int,
+    indices: NDArray[np.int64],
+) -> tuple[np.ndarray, np.ndarray]:
+    """Load one contributor tile and validate its compact dense shapes."""
+
+    means, covariances = loader(contributor_index, indices)
+    mean_array = np.asarray(means, dtype=np.float64)
+    covariance_array = np.asarray(covariances, dtype=np.float64)
+    expected_mean_shape = (indices.size, 3)
+    expected_covariance_shape = (indices.size, 3, 3)
+    if mean_array.shape != expected_mean_shape:
+        raise ValueError(f"frame tile means must have shape {expected_mean_shape}")
+    if covariance_array.shape != expected_covariance_shape:
+        raise ValueError(
+            f"frame tile covariances must have shape {expected_covariance_shape}"
+        )
+    return mean_array, covariance_array
+
+
+def _fuse_frame_field_loader(
     masks: list[NDArray[np.bool_]],
     *,
     method: FusionMethod,
+    loader: FrameFieldLoader,
+    tile_size: int,
 ) -> tuple[FloatArray, FloatArray, NDArray[np.bool_], NDArray[np.uint16]]:
-    """Fuse all contributors to one frame without pairwise ordering effects."""
+    """Fuse one frame from a tile loader while retaining frame-global CI weights."""
 
-    stacked_means = np.stack(means)
-    stacked_covariances = np.stack(covariances)
-    stacked_masks = np.stack(masks)
+    if tile_size < 1:
+        raise ValueError("fusion tile_size must be positive")
+    if not masks:
+        raise ValueError("frame fusion requires at least one contributor")
+    if len(masks) > np.iinfo(np.uint16).max:
+        raise ValueError("frame fusion contributor count exceeds uint16 storage")
+
+    normalized_masks = [np.asarray(mask, dtype=bool) for mask in masks]
+    first_shape = normalized_masks[0].shape
+    if len(first_shape) != 2:
+        raise ValueError("frame masks must have shape (H, W)")
+    if any(mask.shape != first_shape for mask in normalized_masks):
+        raise ValueError(f"frame masks must have shape {first_shape}")
+
+    stacked_masks = np.stack(normalized_masks)
     contributor_count, height, width = stacked_masks.shape
     active_rows = stacked_masks.reshape(contributor_count, -1).T
     patterns, inverse = np.unique(active_rows, axis=0, return_inverse=True)
     output_mean = np.zeros((height * width, 3), dtype=np.float64)
     output_covariance = np.zeros((height * width, 3, 3), dtype=np.float64)
     output_count = np.sum(active_rows, axis=1, dtype=np.uint16)
-    flat_means = stacked_means.reshape(contributor_count, -1, 3)
-    flat_covariances = stacked_covariances.reshape(contributor_count, -1, 3, 3)
+
     for pattern_index, pattern in enumerate(patterns):
         active = np.flatnonzero(pattern)
-        if len(active) == 0:
+        if active.size == 0:
             continue
-        selected = inverse == pattern_index
-        fused_mean, fused_covariance = _fuse_contributor_stack(
-            flat_means[active][:, selected],
-            flat_covariances[active][:, selected],
-            method=method,
-        )
-        output_mean[selected] = fused_mean
-        output_covariance[selected] = fused_covariance
+        selected_indices = np.flatnonzero(inverse == pattern_index)
+
+        ci_weights: FloatArray | None = None
+        if method == "covariance_intersection" and active.size > 1:
+            sample_positions = _representative_positions(selected_indices.size)
+            sample_indices = selected_indices[sample_positions]
+            loaded_sample = [
+                _validated_loaded_tile(loader, int(index), sample_indices)
+                for index in active
+            ]
+            sample_means = np.stack([values[0] for values in loaded_sample])
+            sample_covariances = np.stack([values[1] for values in loaded_sample])
+            ci_weights = _covariance_intersection_weights(
+                sample_means,
+                sample_covariances,
+            )
+
+        for start in range(0, selected_indices.size, tile_size):
+            stop = min(start + tile_size, selected_indices.size)
+            tile_indices = selected_indices[start:stop]
+            loaded_tile = [
+                _validated_loaded_tile(loader, int(index), tile_indices)
+                for index in active
+            ]
+            tile_means = np.stack([values[0] for values in loaded_tile])
+            tile_covariances = np.stack([values[1] for values in loaded_tile])
+            if ci_weights is None:
+                fused_mean, fused_covariance = _fuse_contributor_stack(
+                    tile_means,
+                    tile_covariances,
+                    method=method,
+                )
+            else:
+                fused_mean, fused_covariance = _fuse_contributor_stack_fixed_ci(
+                    tile_means,
+                    tile_covariances,
+                    ci_weights,
+                )
+            output_mean[tile_indices] = fused_mean
+            output_covariance[tile_indices] = fused_covariance
+
     valid = output_count > 0
     return (
         output_mean.reshape(height, width, 3),
         output_covariance.reshape(height, width, 3, 3),
         valid.reshape(height, width),
         output_count.reshape(height, width),
+    )
+
+
+def _fuse_frame_fields(
+    means: list[FloatArray],
+    covariances: list[FloatArray],
+    masks: list[NDArray[np.bool_]],
+    *,
+    method: FusionMethod,
+    tile_size: int = DEFAULT_FUSION_TILE_SIZE,
+) -> tuple[FloatArray, FloatArray, NDArray[np.bool_], NDArray[np.uint16]]:
+    """Fuse already materialized frame fields in bounded spatial tiles."""
+
+    if not means or len(means) != len(covariances) or len(means) != len(masks):
+        raise ValueError("frame fusion requires matching nonempty contributor lists")
+
+    first_mask = np.asarray(masks[0], dtype=bool)
+    if first_mask.ndim != 2:
+        raise ValueError("frame masks must have shape (H, W)")
+    height, width = first_mask.shape
+    expected_mean_shape = (height, width, 3)
+    expected_covariance_shape = (height, width, 3, 3)
+    normalized_means: list[np.ndarray] = []
+    normalized_covariances: list[np.ndarray] = []
+    for mean, covariance in zip(means, covariances, strict=True):
+        mean_array = np.asarray(mean, dtype=np.float64)
+        covariance_array = np.asarray(covariance, dtype=np.float64)
+        if mean_array.shape != expected_mean_shape:
+            raise ValueError(f"frame means must have shape {expected_mean_shape}")
+        if covariance_array.shape != expected_covariance_shape:
+            raise ValueError(
+                f"frame covariances must have shape {expected_covariance_shape}"
+            )
+        normalized_means.append(mean_array.reshape(-1, 3))
+        normalized_covariances.append(covariance_array.reshape(-1, 3, 3))
+
+    def loader(
+        contributor_index: int,
+        indices: NDArray[np.int64],
+    ) -> tuple[FloatArray, FloatArray]:
+        return (
+            normalized_means[contributor_index][indices],
+            normalized_covariances[contributor_index][indices],
+        )
+
+    return _fuse_frame_field_loader(
+        masks,
+        method=method,
+        loader=loader,
+        tile_size=tile_size,
+    )
+
+
+@dataclass(frozen=True)
+class _WindowFrameField:
+    """One local point or flow field with lazily materialized world covariance."""
+
+    values: FloatArray
+    uncertainty: StructuredCovariance
+    transform: Sim3
+    local_index: int
+    gauge_covariance: FloatArray | None
+    include_translation: bool
+
+
+def _structured_covariance_rows(
+    uncertainty: StructuredCovariance,
+    transform: Sim3,
+    local_index: int,
+    flat_indices: NDArray[np.int64],
+) -> FloatArray:
+    """Expand structured covariance only for selected spatial rows."""
+
+    rays = uncertainty.ray_directions[local_index].reshape(-1, 3)[flat_indices]
+    rays = transform.rotate_directions(rays)
+    parallel = (
+        transform.scale**2
+        * uncertainty.parallel_variance[local_index].reshape(-1)[flat_indices]
+    )
+    lateral = (
+        transform.scale**2
+        * uncertainty.lateral_variance[local_index].reshape(-1)[flat_indices]
+    )
+    outer = np.einsum("ni,nj->nij", rays, rays)
+    return lateral[:, None, None] * np.eye(3) + (
+        parallel - lateral
+    )[:, None, None] * outer
+
+
+def _load_window_frame_tile(
+    field: _WindowFrameField,
+    flat_indices: NDArray[np.int64],
+) -> tuple[FloatArray, FloatArray]:
+    """Transform one compact tile and add local plus gauge-induced covariance."""
+
+    local_values = np.asarray(field.values).reshape(-1, 3)[flat_indices]
+    transformed = (
+        field.transform.transform_points(local_values)
+        if field.include_translation
+        else field.transform.transform_vectors(local_values)
+    )
+    covariance = _structured_covariance_rows(
+        field.uncertainty,
+        field.transform,
+        field.local_index,
+        flat_indices,
+    )
+    if field.gauge_covariance is not None:
+        covariance += _gauge_induced_covariance(
+            local_values,
+            field.transform,
+            field.gauge_covariance,
+            include_translation=field.include_translation,
+        )
+    return transformed, covariance
+
+
+def _fuse_window_frame_fields(
+    fields: list[_WindowFrameField],
+    masks: list[NDArray[np.bool_]],
+    *,
+    method: FusionMethod,
+    tile_size: int,
+) -> tuple[FloatArray, FloatArray, NDArray[np.bool_], NDArray[np.uint16]]:
+    """Fuse local window fields without materializing contributor-sized matrices."""
+
+    if len(fields) != len(masks) or not fields:
+        raise ValueError("window-frame fusion requires matching nonempty fields and masks")
+
+    def loader(
+        contributor_index: int,
+        indices: NDArray[np.int64],
+    ) -> tuple[FloatArray, FloatArray]:
+        return _load_window_frame_tile(fields[contributor_index], indices)
+
+    return _fuse_frame_field_loader(
+        masks,
+        method=method,
+        loader=loader,
+        tile_size=tile_size,
     )
 
 
@@ -679,12 +988,14 @@ def fuse_windows(
     method: FusionMethod,
     flow_uncertainties: dict[str, StructuredCovariance] | None = None,
     gauge_covariances: dict[str, FloatArray] | None = None,
+    fusion_tile_size: int = DEFAULT_FUSION_TILE_SIZE,
 ) -> FusedSequence:
     """Transform and jointly fuse duplicate pixels in canonical window order.
 
-    Every frame/mask pattern is fused in one batch. Uniform and independent
-    precision fusion use their exact multi-input formulas; covariance intersection
-    solves one generalized simplex problem for all contributors.
+    Uniform and independent precision fusion use their exact multi-input formulas;
+    covariance intersection solves one generalized simplex problem for every full
+    frame/mask pattern. Dense application is then processed in bounded spatial
+    tiles without changing those global weights.
     """
 
     if not windows:
@@ -704,6 +1015,8 @@ def fuse_windows(
         raise ValueError("all windows must use the same spatial resolution")
     if method not in {"uniform", "precision", "covariance_intersection"}:
         raise ValueError(f"unknown fusion method {method!r}")
+    if fusion_tile_size < 1:
+        raise ValueError("fusion_tile_size must be positive")
     for window in ordered_windows:
         if window.window_id not in gauges or window.window_id not in point_uncertainties:
             raise KeyError(f"missing gauge or uncertainty for window {window.window_id!r}")
@@ -730,11 +1043,9 @@ def fuse_windows(
     flow_covariance = np.zeros_like(point_covariance) if has_flow else None
 
     for output_index, frame in enumerate(all_frames):
-        point_means: list[FloatArray] = []
-        point_covariances: list[FloatArray] = []
+        point_fields: list[_WindowFrameField] = []
         point_masks: list[NDArray[np.bool_]] = []
-        flow_means: list[FloatArray] = []
-        flow_covariances: list[FloatArray] = []
+        flow_fields: list[_WindowFrameField] = []
         flow_masks: list[NDArray[np.bool_]] = []
         for window in ordered_windows:
             try:
@@ -742,22 +1053,21 @@ def fuse_windows(
             except KeyError:
                 continue
             gauge = gauges[window.window_id]
-            local_points = window.point_map[local_index]
-            transformed_points = gauge.transform_points(local_points)
-            transformed_point_covariance = _structured_covariance_frame(
-                point_uncertainties[window.window_id],
-                gauge,
-                local_index,
+            gauge_covariance = (
+                None
+                if gauge_covariances is None
+                else gauge_covariances[window.window_id]
             )
-            if gauge_covariances is not None:
-                transformed_point_covariance += _gauge_induced_covariance(
-                    local_points,
-                    gauge,
-                    gauge_covariances[window.window_id],
+            point_fields.append(
+                _WindowFrameField(
+                    values=window.point_map[local_index],
+                    uncertainty=point_uncertainties[window.window_id],
+                    transform=gauge,
+                    local_index=local_index,
+                    gauge_covariance=gauge_covariance,
                     include_translation=True,
                 )
-            point_means.append(transformed_points)
-            point_covariances.append(transformed_point_covariance)
+            )
             point_masks.append(window.valid_mask[local_index])
 
             if window.scene_flow is None:
@@ -767,22 +1077,17 @@ def fuse_windows(
                 if flow_uncertainties is not None
                 else point_uncertainties[window.window_id]
             )
-            local_flow = window.scene_flow[local_index]
-            transformed_flow = gauge.transform_vectors(local_flow)
-            transformed_flow_covariance = _structured_covariance_frame(
-                uncertainty,
-                gauge,
-                local_index,
-            )
-            if gauge_covariances is not None:
-                transformed_flow_covariance += _gauge_induced_covariance(
-                    local_flow,
-                    gauge,
-                    gauge_covariances[window.window_id],
+            flow_fields.append(
+                _WindowFrameField(
+                    values=window.scene_flow[local_index],
+                    uncertainty=uncertainty,
+                    transform=gauge,
+                    local_index=local_index,
+                    gauge_covariance=gauge_covariance,
                     include_translation=False,
                 )
-            flow_means.append(transformed_flow)
-            flow_covariances.append(transformed_flow_covariance)
+            )
+            assert window.deform_mask is not None
             flow_masks.append(window.deform_mask[local_index])
 
         (
@@ -790,23 +1095,26 @@ def fuse_windows(
             point_covariance[output_index],
             valid_mask[output_index],
             contributors[output_index],
-        ) = _fuse_frame_fields(
-            point_means,
-            point_covariances,
+        ) = _fuse_window_frame_fields(
+            point_fields,
             point_masks,
             method=method,
+            tile_size=fusion_tile_size,
         )
-        if flow_means:
+        if flow_fields:
+            assert scene_flow is not None
+            assert flow_covariance is not None
+            assert deform_mask is not None
             (
                 scene_flow[output_index],
                 flow_covariance[output_index],
                 deform_mask[output_index],
                 _,
-            ) = _fuse_frame_fields(
-                flow_means,
-                flow_covariances,
+            ) = _fuse_window_frame_fields(
+                flow_fields,
                 flow_masks,
                 method=method,
+                tile_size=fusion_tile_size,
             )
 
     return FusedSequence._from_owned_arrays(

--- a/src/prob4d/fusion_memory_benchmark.py
+++ b/src/prob4d/fusion_memory_benchmark.py
@@ -1,0 +1,233 @@
+"""Profile dense Prob4D fusion with deterministic synthetic overlapping windows."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import platform
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from prob4d.data import PredictionWindow
+from prob4d.fusion import DEFAULT_FUSION_TILE_SIZE, fuse_windows
+from prob4d.sim3 import Sim3
+from prob4d.uncertainty import StructuredCovariance
+
+
+def _git_revision(repository_root: Path) -> str | None:
+    completed = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repository_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    value = completed.stdout.strip()
+    return value if completed.returncode == 0 and len(value) == 40 else None
+
+
+def _peak_rss_bytes() -> int | None:
+    try:
+        import resource
+    except ImportError:
+        return None
+    value = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+    return value if sys.platform == "darwin" else 1024 * value
+
+
+def _digest_arrays(*arrays: np.ndarray) -> str:
+    digest = hashlib.sha256()
+    for value in arrays:
+        contiguous = np.ascontiguousarray(value)
+        digest.update(contiguous.dtype.str.encode("ascii"))
+        digest.update(np.asarray(contiguous.shape, dtype=np.int64).tobytes())
+        digest.update(memoryview(contiguous).cast("B"))
+    return digest.hexdigest()
+
+
+def _build_inputs(
+    *,
+    height: int,
+    width: int,
+    contributor_count: int,
+    seed: int,
+) -> tuple[
+    list[PredictionWindow],
+    dict[str, Sim3],
+    dict[str, StructuredCovariance],
+    dict[str, np.ndarray],
+]:
+    generator = np.random.default_rng(seed)
+    base = generator.normal(size=(1, height, width, 3)).astype(np.float32)
+    base[..., 2] += np.float32(4.0)
+    mask = np.ones((1, height, width), dtype=bool)
+    windows: list[PredictionWindow] = []
+    gauges: dict[str, Sim3] = {}
+    uncertainties: dict[str, StructuredCovariance] = {}
+    gauge_covariances: dict[str, np.ndarray] = {}
+
+    for index in range(contributor_count):
+        values = base.copy()
+        values[..., 0] += np.float32(0.02 * index)
+        window_id = f"window-{index:02d}"
+        window = PredictionWindow(
+            window_id=window_id,
+            frame_indices=np.asarray([0]),
+            point_map=values,
+            valid_mask=mask,
+            dense_storage_dtype="float32",
+        )
+        rays = values.astype(np.float64)
+        rays /= np.linalg.norm(rays, axis=-1, keepdims=True)
+        parallel = np.full(window.shape, 0.01 * (index + 1), dtype=np.float64)
+        lateral = np.full(window.shape, 0.02 * (index + 1), dtype=np.float64)
+        windows.append(window)
+        gauges[window_id] = Sim3(
+            scale=1.0 + 0.01 * index,
+            translation=np.asarray([0.01 * index, -0.005 * index, 0.0]),
+        )
+        uncertainties[window_id] = StructuredCovariance(rays, parallel, lateral)
+        gauge_covariances[window_id] = np.diag(
+            [1e-4, 2e-4, 2e-4, 2e-4, 1e-5, 1e-5, 1e-5]
+        )
+    return windows, gauges, uncertainties, gauge_covariances
+
+
+def run_benchmark(arguments: argparse.Namespace) -> dict[str, Any]:
+    if arguments.height < 1 or arguments.width < 1:
+        raise ValueError("height and width must be positive")
+    if arguments.contributors < 1:
+        raise ValueError("contributors must be positive")
+    if arguments.fusion_tile_size < 1:
+        raise ValueError("fusion tile size must be positive")
+
+    construction_started = time.perf_counter()
+    windows, gauges, uncertainties, gauge_covariances = _build_inputs(
+        height=arguments.height,
+        width=arguments.width,
+        contributor_count=arguments.contributors,
+        seed=arguments.seed,
+    )
+    construction_seconds = time.perf_counter() - construction_started
+
+    fusion_started = time.perf_counter()
+    fused = fuse_windows(
+        windows,
+        gauges,
+        uncertainties,
+        method=arguments.method,
+        gauge_covariances=gauge_covariances,
+        fusion_tile_size=arguments.fusion_tile_size,
+    )
+    fusion_seconds = time.perf_counter() - fusion_started
+
+    retained_prediction_bytes = sum(window.dense_vector_storage_bytes for window in windows)
+    retained_structured_bytes = sum(
+        uncertainty.ray_directions.nbytes
+        + uncertainty.parallel_variance.nbytes
+        + uncertainty.lateral_variance.nbytes
+        for uncertainty in uncertainties.values()
+    )
+    output_bytes = sum(
+        value.nbytes
+        for value in (
+            fused.frame_indices,
+            fused.point_map,
+            fused.valid_mask,
+            fused.point_covariance,
+            fused.contributors,
+        )
+    )
+    repository_root = Path(__file__).resolve().parents[2]
+    return {
+        "schema": "prob4d.dense-fusion-memory-benchmark",
+        "version": 1,
+        "repository_revision": _git_revision(repository_root),
+        "python_version": platform.python_version(),
+        "numpy_version": np.__version__,
+        "platform": platform.platform(),
+        "configuration": {
+            "height": arguments.height,
+            "width": arguments.width,
+            "frames": 1,
+            "contributors": arguments.contributors,
+            "seed": arguments.seed,
+            "method": arguments.method,
+            "fusion_tile_size": arguments.fusion_tile_size,
+            "gauge_covariance": True,
+            "dense_storage_dtype": "float32",
+        },
+        "timing_seconds": {
+            "input_construction": construction_seconds,
+            "fusion": fusion_seconds,
+        },
+        "memory_bytes": {
+            "peak_process_rss": _peak_rss_bytes(),
+            "retained_prediction_vectors": retained_prediction_bytes,
+            "retained_structured_covariance": retained_structured_bytes,
+            "fused_output": output_bytes,
+        },
+        "output": {
+            "artifact_digest": _digest_arrays(
+                fused.frame_indices,
+                fused.point_map,
+                fused.valid_mask,
+                fused.point_covariance,
+                fused.contributors,
+            ),
+            "point_sum": float(np.sum(fused.point_map)),
+            "covariance_trace_sum": float(
+                np.trace(fused.point_covariance, axis1=-2, axis2=-1).sum()
+            ),
+            "contributors_sum": int(fused.contributors.sum()),
+        },
+        "claim_boundary": (
+            "Synthetic process-level engineering profile only; peak RSS includes input "
+            "construction and does not establish real-data accuracy or calibration."
+        ),
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--height", type=int, default=320)
+    parser.add_argument("--width", type=int, default=640)
+    parser.add_argument("--contributors", type=int, default=3)
+    parser.add_argument("--seed", type=int, default=17)
+    parser.add_argument(
+        "--method",
+        choices=("uniform", "precision", "covariance_intersection"),
+        default="covariance_intersection",
+    )
+    parser.add_argument(
+        "--fusion-tile-size",
+        type=int,
+        default=DEFAULT_FUSION_TILE_SIZE,
+    )
+    parser.add_argument("--output-json", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    arguments = parser.parse_args(argv)
+    try:
+        result = run_benchmark(arguments)
+    except ValueError as error:
+        parser.error(str(error))
+    encoded = json.dumps(result, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    if arguments.output_json is not None:
+        arguments.output_json.parent.mkdir(parents=True, exist_ok=True)
+        arguments.output_json.write_text(encoded, encoding="utf-8")
+    print(encoded, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_fusion.py
+++ b/tests/test_fusion.py
@@ -1,7 +1,9 @@
 from itertools import permutations
 
 import numpy as np
+import pytest
 
+import prob4d.fusion as fusion_module
 from prob4d.data import PredictionWindow
 from prob4d.fusion import (
     fuse_gaussians_covariance_intersection,
@@ -182,3 +184,192 @@ def test_covariance_intersection_fusion_is_invariant_to_window_input_order() -> 
             candidate.point_covariance,
             reference.point_covariance,
         )
+
+
+@pytest.mark.parametrize("method", ["uniform", "precision", "covariance_intersection"])
+def test_fuse_windows_spatial_tiling_preserves_all_fusion_methods(method: str) -> None:
+    frames = [0]
+    windows = [
+        make_window("first", frames, -0.5),
+        make_window("second", frames, 0.25),
+        make_window("third", frames, 1.0),
+    ]
+    windows = [
+        PredictionWindow(
+            window.window_id,
+            window.frame_indices,
+            np.tile(window.point_map, (1, 2, 3, 1)),
+            np.asarray(
+                [
+                    [
+                        [True, True, True, True, True, True],
+                        [True, True, True, True, True, True],
+                    ]
+                ]
+            ),
+        )
+        for window in windows
+    ]
+    windows[1] = PredictionWindow(
+        windows[1].window_id,
+        windows[1].frame_indices,
+        windows[1].point_map,
+        np.asarray(
+            [
+                [
+                    [True, True, True, False, False, False],
+                    [True, True, True, False, False, False],
+                ]
+            ]
+        ),
+    )
+    windows[2] = PredictionWindow(
+        windows[2].window_id,
+        windows[2].frame_indices,
+        windows[2].point_map,
+        np.asarray(
+            [
+                [
+                    [True, False, True, False, True, False],
+                    [True, False, True, False, True, False],
+                ]
+            ]
+        ),
+    )
+    gauges = {window.window_id: Sim3.identity() for window in windows}
+    uncertainties = {
+        window.window_id: make_uncertainty(window, float(index + 1))
+        for index, window in enumerate(windows)
+    }
+
+    untiled = fuse_windows(
+        windows,
+        gauges,
+        uncertainties,
+        method=method,
+        fusion_tile_size=10_000,
+    )
+    tiled = fuse_windows(
+        windows,
+        gauges,
+        uncertainties,
+        method=method,
+        fusion_tile_size=2,
+    )
+
+    np.testing.assert_array_equal(tiled.valid_mask, untiled.valid_mask)
+    np.testing.assert_array_equal(tiled.contributors, untiled.contributors)
+    np.testing.assert_allclose(tiled.point_map, untiled.point_map, rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(
+        tiled.point_covariance,
+        untiled.point_covariance,
+        rtol=1e-12,
+        atol=1e-12,
+    )
+
+
+def test_covariance_intersection_tiles_reuse_global_pattern_weights() -> None:
+    points = np.zeros((1, 1, 6, 3))
+    first = PredictionWindow(
+        "first",
+        np.asarray([0]),
+        points,
+        np.ones((1, 1, 6), dtype=bool),
+    )
+    second_points = points.copy()
+    second_points[..., 0] = 10.0
+    second = PredictionWindow(
+        "second",
+        np.asarray([0]),
+        second_points,
+        np.ones((1, 1, 6), dtype=bool),
+    )
+    rays = np.zeros_like(points)
+    rays[..., 2] = 1.0
+    first_variance = np.asarray([[[1.0, 1.0, 1.0, 100.0, 100.0, 100.0]]])
+    second_variance = first_variance[..., ::-1].copy()
+    uncertainties = {
+        "first": StructuredCovariance(rays, first_variance, first_variance),
+        "second": StructuredCovariance(rays, second_variance, second_variance),
+    }
+    gauges = {"first": Sim3.identity(), "second": Sim3.identity()}
+
+    global_batch = fuse_windows(
+        [first, second],
+        gauges,
+        uncertainties,
+        method="covariance_intersection",
+        fusion_tile_size=6,
+    )
+    one_pixel_tiles = fuse_windows(
+        [first, second],
+        gauges,
+        uncertainties,
+        method="covariance_intersection",
+        fusion_tile_size=1,
+    )
+
+    np.testing.assert_allclose(one_pixel_tiles.point_map, global_batch.point_map)
+    np.testing.assert_allclose(
+        one_pixel_tiles.point_covariance,
+        global_batch.point_covariance,
+    )
+    assert np.all(one_pixel_tiles.point_map[..., 0] > 0.0)
+    assert np.all(one_pixel_tiles.point_map[..., 0] < 10.0)
+
+
+def test_fuse_windows_rejects_nonpositive_tile_size() -> None:
+    window = make_window("window", [0], 0.0)
+
+    with pytest.raises(ValueError, match="fusion_tile_size must be positive"):
+        fuse_windows(
+            [window],
+            {window.window_id: Sim3.identity()},
+            {window.window_id: make_uncertainty(window, 1.0)},
+            method="uniform",
+            fusion_tile_size=0,
+        )
+
+
+def test_structured_covariance_expansion_is_bounded_by_sample_or_tile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    point_count = 5_000
+    points = np.zeros((1, 1, point_count, 3))
+    mask = np.ones((1, 1, point_count), dtype=bool)
+    first = PredictionWindow("first", np.asarray([0]), points, mask)
+    second_points = points.copy()
+    second_points[..., 0] = 1.0
+    second = PredictionWindow("second", np.asarray([0]), second_points, mask)
+    rays = np.zeros_like(points)
+    rays[..., 2] = 1.0
+    uncertainty = StructuredCovariance(
+        rays,
+        np.ones((1, 1, point_count)),
+        np.ones((1, 1, point_count)),
+    )
+    observed_sizes: list[int] = []
+    original = fusion_module._structured_covariance_rows
+
+    def tracked_rows(
+        structured: StructuredCovariance,
+        transform: Sim3,
+        local_index: int,
+        flat_indices: np.ndarray,
+    ) -> np.ndarray:
+        observed_sizes.append(int(flat_indices.size))
+        return original(structured, transform, local_index, flat_indices)
+
+    monkeypatch.setattr(fusion_module, "_structured_covariance_rows", tracked_rows)
+    result = fuse_windows(
+        [first, second],
+        {"first": Sim3.identity(), "second": Sim3.identity()},
+        {"first": uncertainty, "second": uncertainty},
+        method="covariance_intersection",
+        fusion_tile_size=64,
+    )
+
+    assert result.point_map.shape == (1, 1, point_count, 3)
+    assert observed_sizes
+    assert max(observed_sizes) == 4_096
+    assert point_count not in observed_sizes

--- a/tests/test_fusion_memory_benchmark.py
+++ b/tests/test_fusion_memory_benchmark.py
@@ -1,0 +1,52 @@
+from argparse import Namespace
+
+import pytest
+
+from prob4d.fusion_memory_benchmark import run_benchmark
+
+
+def _arguments(**overrides: object) -> Namespace:
+    values: dict[str, object] = {
+        "height": 8,
+        "width": 12,
+        "contributors": 3,
+        "seed": 17,
+        "method": "covariance_intersection",
+        "fusion_tile_size": 16,
+    }
+    values.update(overrides)
+    return Namespace(**values)
+
+
+def test_dense_fusion_memory_benchmark_emits_reproducible_contract() -> None:
+    first = run_benchmark(_arguments())
+    second = run_benchmark(_arguments())
+
+    assert first["schema"] == "prob4d.dense-fusion-memory-benchmark"
+    assert first["version"] == 1
+    assert first["configuration"] == second["configuration"]
+    assert first["output"] == second["output"]
+    assert len(first["output"]["artifact_digest"]) == 64
+    assert first["memory_bytes"]["retained_prediction_vectors"] > 0
+    assert first["memory_bytes"]["retained_structured_covariance"] > 0
+    assert first["memory_bytes"]["fused_output"] > 0
+    peak_rss = first["memory_bytes"]["peak_process_rss"]
+    assert peak_rss is None or peak_rss > 0
+    assert first["timing_seconds"]["fusion"] >= 0.0
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("height", 0, "height and width must be positive"),
+        ("contributors", 0, "contributors must be positive"),
+        ("fusion_tile_size", 0, "fusion tile size must be positive"),
+    ],
+)
+def test_dense_fusion_memory_benchmark_rejects_invalid_sizes(
+    field: str,
+    value: int,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        run_benchmark(_arguments(**{field: value}))


### PR DESCRIPTION
## Summary

- preserve ray-parallel/lateral structured covariance until a representative covariance-intersection sample or active spatial tile is required;
- optimize one covariance-intersection weight vector for the complete frame/contributor-mask pattern and reuse it across all application tiles, so tiling changes temporary memory rather than estimator semantics;
- add a deterministic process-level dense-fusion memory/timing benchmark with output digests, documentation, and regression coverage.

## Validation

- focused tiled-fusion and benchmark tests: **16 passed**;
- all tests available in the downloaded source distribution: **336 passed**;
- Python compilation and 100-column checks passed;
- GitHub Actions: **all green** — Ruff, mypy, runtime attestation, complete Python 3.10/3.12/3.14 suites, wheel/sdist builds, and isolated installed-artifact CLI smoke tests.

Three tests were unavailable in the downloaded source distribution because their repository-only scripts or fixture are not packaged there: `test_sparse_gauge_anchor_script.py`, `test_vggt_prob4d_blends.py`, and `test_joint_observation_contract_fixture.py`. All three were exercised by the complete GitHub repository suite.

## Matched synthetic memory benchmark

One `320 x 640` frame, three overlapping contributors, conditional structured covariance, gauge covariance, and frame-global covariance intersection:

| Measurement | Eager baseline | Tiled candidate | Change |
| --- | ---: | ---: | ---: |
| Peak RSS | 579,784 KiB | 219,132 KiB | -62.2% |
| Fusion time | 3.718 s | 3.083 s | -17.1% |
| Point sum | 819,319.9940782051 | 819,319.9940782051 | exact match |
| Covariance-trace sum | 12,191.715942554092 | 12,191.715942554092 | exact match |
| Contributor-count sum | 614,400 | 614,400 | exact match |

The matched run used NumPy 2.3.5 on Linux 6.12.13 x86-64 with an Intel Xeon Platinum 8370C. Peak RSS includes synthetic input construction and is meaningful only for otherwise matched fresh processes.

## Scope and claim boundary

This is engineering evidence for bounded contributor-sized fusion temporaries. It makes no reconstruction-accuracy, uncertainty-calibration, Bayesian-PhysTwin physical-update, or Causal4D claim. The dense fused output covariance remains allocated; optional memory-mapped prediction loading, export-stage profiling, and full 25-frame production-host measurement remain follow-up work.

Progresses #50.