### PR TITLE
Harden provider evaluation support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,13 @@ All notable changes to Prob4D are documented here.
   access, and deterministic retained-storage accounting for benchmark runs.
 - `FusedSequence` as a public immutable dense-output contract with canonical
   dtypes, bounded active covariance validation, and read-only arrays.
+- `TruthSequence` as an immutable, canonical, alias-safe truth-input contract with
+  strict frame ordering and active point/flow finiteness validation.
+- Common-support primary provider evaluation, native-support secondary results,
+  support-retention diagnostics, frame-balanced errors, multi-level coverage,
+  covariance-width summaries, uncertainty-error ranking, selective risk, and
+  worst-group coverage-shortfall reporting. Selective-risk metrics are invariant
+  to sample ordering when uncertainty scores tie.
 - Bounded spatial-tile dense fusion that preserves structured covariance until a
   representative covariance-intersection sample or active tile is required, plus
   a deterministic process-level memory and timing benchmark.
@@ -44,6 +51,11 @@ All notable changes to Prob4D are documented here.
   states, or dense-storage execution semantics across cases.
 - Fusion and fused-artifact loading transfer ownership of private arrays into the
   immutable `FusedSequence` contract without an unnecessary second dense copy.
+- Provider-evaluation report schema version 2 keeps the established unprefixed
+  metric paths for common-support primary results and adds explicit
+  `native_support` and `support` secondary diagnostics.
+- Evaluation modes rely on the immutable finite-active point/flow contracts
+  directly instead of rebuilding dense sequences solely to sanitize flow masks.
 - Dense covariance-intersection weights remain optimized once per complete
   frame/contributor-mask pattern and are reused across bounded application tiles,
   so the tile size changes temporary memory rather than estimator semantics.
@@ -55,6 +67,11 @@ All notable changes to Prob4D are documented here.
   covariance now fail closed on non-finite, asymmetric, or materially indefinite
   matrices, while tolerated floating-point-scale negative eigenvalues are
   projected to the positive-semidefinite boundary.
+- Truth arrays can no longer change after validation through caller-owned aliases,
+  and malformed frame indices or non-finite active truth geometry now fail before
+  evaluation.
+- Paired provider comparisons no longer reward methods for omitting difficult
+  frames or pixels from their primary score.
 
 ## 0.3.0 — 2026-07-30
 

--- a/docs/provider-evaluation.md
+++ b/docs/provider-evaluation.md
@@ -16,12 +16,22 @@ The evaluator is deliberately paired and fail-closed:
   that covariance fields are present;
 - historical archives without embedded semantics are rejected unless the run is
   explicitly labelled with `--allow-legacy-artifacts`;
+- primary metrics use only frames and pixels supported by truth and every
+  registered method in the case;
+- native per-method metrics and common/native support-retention fractions are
+  retained as secondary diagnostics, so selective missingness cannot silently
+  improve the primary score;
 - cases are first averaged within a registered `group_id`, then groups receive
   equal aggregate mass;
 - one registered reference method defines paired within-case differences for every
   candidate;
 - confidence intervals use a deterministic bootstrap over groups, not dense
   pixels or frames.
+
+Truth inputs are admitted through the immutable `TruthSequence` contract. Frame
+indices are canonical nonnegative, strictly increasing `int64` values; point and
+flow arrays are defensively copied; active geometry must be finite; and all
+retained arrays are read-only after validation.
 
 ## Prediction artifact semantics
 
@@ -128,6 +138,30 @@ identify one method present in every case. The report computes
 `candidate - reference` differences within case, averages them within group, and
 bootstraps groups.
 
+## Common-support primary and native-support secondary results
+
+Report schema version 2 preserves the existing primary metric paths, but their
+support semantics are now explicit:
+
+- `cases[*].evaluation` and the unprefixed aggregate metric paths use the
+  intersection of truth support and every registered method in that case;
+- `cases[*].native_support_evaluation` evaluates each method on its own available
+  support;
+- `cases[*].support` reports common frame/pixel counts, common/native retention,
+  truth-relative retention, and flow-support availability;
+- aggregate CSV columns prefixed with `native_support.` and `support.` retain the
+  corresponding secondary diagnostics.
+
+A case fails closed when the registered methods have no common frames, use
+incompatible spatial grids, or have no jointly valid common point support. Flow
+EPE is a paired common-support metric only when truth and every registered method
+provide flow. Otherwise native flow results remain secondary and the common flow
+support is empty.
+
+This distinction prevents a method from appearing more accurate merely because
+it abstains on difficult pixels or frames. Native-support results remain useful
+for diagnosing whether gains are purchased through reduced coverage.
+
 ## Command
 
 ```bash
@@ -146,14 +180,22 @@ prob4d-evaluate-provider protocols/provider-evaluation.json \
 
 Outputs are:
 
-- `provider_evaluation.json`: nested case results, artifact semantics, equal-group
+- `provider_evaluation.json`: nested common-support and native-support case
+  results, artifact semantics, support-retention diagnostics, equal-group
   aggregate intervals, and paired differences from the reference;
-- `provider_evaluation.csv`: one flat row per case and method;
-- `provider_evaluation.md`: a compact primary-mode table.
+- `provider_evaluation.csv`: one flat row per case and method, including native
+  metrics and support-retention columns;
+- `provider_evaluation.md`: a compact common-support primary-mode table.
 
-Reported metrics include metric and optionally aligned point RMSE, endpoint
-error, drift slope, seam error, flow endpoint error, 95% ellipsoid coverage,
-Gaussian negative log likelihood, and mean squared Mahalanobis error.
+Reported metrics include pooled and frame-balanced point RMSE, endpoint error,
+drift slope, seam error, flow endpoint error, 50%, 80%, 90%, and 95% ellipsoid
+coverage, 95% coverage shortfall, multi-level calibration error, Gaussian
+negative log likelihood, mean and median squared Mahalanobis error, covariance
+trace and log determinant, uncertainty-error Spearman correlation, fixed-retention
+selective risk, and risk-coverage area. Selective-risk summaries use the expected
+risk under random tie-breaking, so equal uncertainty scores cannot make results
+depend on pixel order. Aggregate coverage-shortfall summaries also identify the
+worst registered group.
 
 ## Claim boundary
 

--- a/src/prob4d/_provider_evaluation_compute.py
+++ b/src/prob4d/_provider_evaluation_compute.py
@@ -14,7 +14,14 @@ import numpy as np
 from ._provider_evaluation_manifest import ProviderEvaluationCase
 from .data import DENSE_STORAGE_DTYPES
 from .evaluation_modes import EvaluationModes, evaluate_sequence_modes
-from .io import FusedPredictionMetadata, load_fused_prediction_artifact, load_truth
+from .fusion import FusedSequence
+from .io import (
+    FusedPredictionArtifact,
+    FusedPredictionMetadata,
+    load_fused_prediction_artifact,
+    load_truth,
+)
+from .metrics import TruthSequence
 
 
 def _numeric_leaves(value: object, *, prefix: str = "") -> dict[str, float]:
@@ -156,6 +163,106 @@ def _method_signature(metadata: FusedPredictionMetadata) -> tuple[object, ...]:
     )
 
 
+def _paired_common_support(
+    truth: TruthSequence,
+    predictions: Mapping[str, FusedSequence],
+) -> tuple[np.ndarray, np.ndarray | None, dict[str, Any]]:
+    """Build truth-indexed support shared by every registered method in one case."""
+
+    if not predictions:
+        raise ValueError("provider evaluation requires at least one prediction method")
+    spatial_shape = truth.valid_mask.shape[1:]
+    common_frames = truth.frame_indices
+    for method_id, prediction in sorted(predictions.items()):
+        if prediction.valid_mask.shape[1:] != spatial_shape:
+            raise ValueError(
+                f"method {method_id!r} has spatial support "
+                f"{prediction.valid_mask.shape[1:]}, expected {spatial_shape}"
+            )
+        common_frames = np.intersect1d(common_frames, prediction.frame_indices)
+    if common_frames.size == 0:
+        raise ValueError("registered methods and truth have no common frames")
+
+    truth_indices = np.searchsorted(truth.frame_indices, common_frames)
+    common_point_support = np.zeros_like(truth.valid_mask, dtype=bool)
+    active_points = truth.valid_mask[truth_indices].copy()
+    prediction_indices: dict[str, np.ndarray] = {}
+    for method_id, prediction in sorted(predictions.items()):
+        indices = np.searchsorted(prediction.frame_indices, common_frames)
+        prediction_indices[method_id] = indices
+        active_points &= prediction.valid_mask[indices]
+    common_point_support[truth_indices] = active_points
+    common_point_count = int(np.count_nonzero(active_points))
+    if common_point_count == 0:
+        raise ValueError(
+            "registered methods and truth have no jointly valid common point support"
+        )
+
+    all_methods_have_flow = truth.scene_flow is not None and all(
+        prediction.scene_flow is not None for prediction in predictions.values()
+    )
+    common_flow_support: np.ndarray | None = None
+    common_flow_count = 0
+    if truth.scene_flow is not None:
+        common_flow_support = np.zeros_like(truth.valid_mask, dtype=bool)
+        if all_methods_have_flow:
+            assert truth.deform_mask is not None
+            active_flow = truth.deform_mask[truth_indices] & active_points
+            for method_id, prediction in sorted(predictions.items()):
+                assert prediction.deform_mask is not None
+                active_flow &= prediction.deform_mask[
+                    prediction_indices[method_id]
+                ]
+            common_flow_support[truth_indices] = active_flow
+            common_flow_count = int(np.count_nonzero(active_flow))
+
+    truth_valid_on_common_frames = int(
+        np.count_nonzero(truth.valid_mask[truth_indices])
+    )
+    return common_point_support, common_flow_support, {
+        "truth_frame_count": int(truth.frame_indices.size),
+        "common_frame_count": int(common_frames.size),
+        "common_frame_fraction_of_truth": float(
+            common_frames.size / truth.frame_indices.size
+        ),
+        "truth_valid_points_on_common_frames": truth_valid_on_common_frames,
+        "common_valid_points": common_point_count,
+        "common_point_fraction_of_truth_on_common_frames": float(
+            common_point_count / truth_valid_on_common_frames
+        ),
+        "all_methods_have_flow": all_methods_have_flow,
+        "common_valid_flow_points": common_flow_count,
+    }
+
+
+def _method_support_summary(
+    *,
+    common: EvaluationModes,
+    native: EvaluationModes,
+    paired: Mapping[str, Any],
+) -> dict[str, Any]:
+    common_metrics = common.metric.metrics
+    native_metrics = native.metric.metrics
+    common_points = common_metrics.evaluated_points
+    native_points = native_metrics.evaluated_points
+    common_frames = common_metrics.evaluated_frames
+    native_frames = native_metrics.evaluated_frames
+    common_flow = common_metrics.evaluated_flow_points
+    native_flow = native_metrics.evaluated_flow_points
+    return {
+        **paired,
+        "native_valid_points": native_points,
+        "common_point_fraction_of_native": float(common_points / native_points),
+        "native_evaluated_frames": native_frames,
+        "common_evaluated_frames": common_frames,
+        "common_frame_fraction_of_native": float(common_frames / native_frames),
+        "native_valid_flow_points": native_flow,
+        "common_flow_fraction_of_native": (
+            float(common_flow / native_flow) if native_flow > 0 else None
+        ),
+    }
+
+
 def evaluate_provider_cases(
     cases: list[ProviderEvaluationCase],
     *,
@@ -168,8 +275,10 @@ def evaluate_provider_cases(
     method_metadata: dict[str, dict[str, Any]] = {}
     for case in cases:
         truth = load_truth(case.truth_path)
+        artifacts: dict[str, FusedPredictionArtifact] = {}
         for method_id, prediction_path in sorted(case.predictions.items()):
             artifact = load_fused_prediction_artifact(prediction_path)
+            artifacts[method_id] = artifact
             metadata = artifact.metadata
             if metadata.legacy_unspecified and not allow_legacy_artifacts:
                 raise ValueError(
@@ -192,13 +301,47 @@ def evaluate_provider_cases(
                     "revision semantics"
                 )
             method_metadata.setdefault(method_id, metadata.to_dict())
-            modes: EvaluationModes = evaluate_sequence_modes(
+
+        common_point_support, common_flow_support, paired_support = (
+            _paired_common_support(
+                truth,
+                {
+                    method_id: artifact.sequence
+                    for method_id, artifact in artifacts.items()
+                },
+            )
+        )
+        for method_id, prediction_path in sorted(case.predictions.items()):
+            artifact = artifacts[method_id]
+            native_modes: EvaluationModes = evaluate_sequence_modes(
                 artifact.sequence,
                 truth,
                 boundary_frames=list(case.boundary_frames),
                 prefix_frame_stop_exclusive=case.prefix_frame_stop_exclusive,
             )
-            evaluation = modes.to_dict()
+            common_modes: EvaluationModes = evaluate_sequence_modes(
+                artifact.sequence,
+                truth,
+                boundary_frames=list(case.boundary_frames),
+                prefix_frame_stop_exclusive=case.prefix_frame_stop_exclusive,
+                truth_support_mask=common_point_support,
+                truth_flow_support_mask=common_flow_support,
+            )
+            evaluation = common_modes.to_dict()
+            native_evaluation = native_modes.to_dict()
+            support = _method_support_summary(
+                common=common_modes,
+                native=native_modes,
+                paired=paired_support,
+            )
+            numeric = _numeric_leaves(evaluation)
+            numeric.update(
+                _numeric_leaves(
+                    native_evaluation,
+                    prefix="native_support",
+                )
+            )
+            numeric.update(_numeric_leaves(support, prefix="support"))
             records.append(
                 {
                     "case_id": case.case_id,
@@ -206,9 +349,11 @@ def evaluate_provider_cases(
                     "method_id": method_id,
                     "prediction_path": str(prediction_path),
                     "truth_path": str(case.truth_path),
-                    "artifact": metadata.to_dict(),
+                    "artifact": artifact.metadata.to_dict(),
                     "evaluation": evaluation,
-                    "_numeric": _numeric_leaves(evaluation),
+                    "native_support_evaluation": native_evaluation,
+                    "support": support,
+                    "_numeric": numeric,
                 }
             )
     return records, method_metadata
@@ -251,15 +396,21 @@ def aggregate_provider_records(
         )
         metrics: dict[str, Any] = {}
         for metric in metric_names:
+            group_ids = sorted(groups)
             group_means = np.asarray(
-                [np.mean(groups[group_id][metric]) for group_id in sorted(groups)],
+                [np.mean(groups[group_id][metric]) for group_id in group_ids],
                 dtype=np.float64,
             )
-            metrics[metric] = _bootstrap_summary(
+            summary = _bootstrap_summary(
                 group_means,
                 resamples=bootstrap_resamples,
                 seed=_stable_seed(seed, method_id, metric),
             )
+            if metric.endswith("coverage_shortfall_95"):
+                worst_index = int(np.argmax(group_means))
+                summary["worst_group_mean"] = float(group_means[worst_index])
+                summary["worst_group_id"] = group_ids[worst_index]
+            metrics[metric] = summary
         aggregate[method_id] = {
             "case_count": method_case_counts[method_id],
             "group_count": len(groups),

--- a/src/prob4d/_provider_evaluation_output.py
+++ b/src/prob4d/_provider_evaluation_output.py
@@ -102,24 +102,32 @@ def _write_markdown(
 ) -> None:
     selected = (
         "metric_point_rmse",
-        "point_rmse",
+        "frame_balanced_point_rmse",
         "endpoint_point_rmse",
         "drift_slope",
         "seam_rmse",
         "coverage_95",
+        "coverage_shortfall_95",
+        "mean_covariance_trace",
         "gaussian_nll",
+        "uncertainty_error_spearman",
+        "risk_coverage_auc",
     )
     headers = [
         "Method",
         "Groups",
         "Cases",
         "Metric point RMSE",
-        "Point RMSE",
+        "Frame-balanced RMSE",
         "Endpoint RMSE",
         "Drift slope",
         "Seam RMSE",
         "Coverage 95%",
+        "Coverage shortfall",
+        "Mean covariance trace",
         "Gaussian NLL",
+        "UQ-error Spearman",
+        "Risk-coverage AUC",
     ]
     separator = "| " + " | ".join(["---"] + ["---:"] * (len(headers) - 1)) + " |"
     lines = [
@@ -127,6 +135,10 @@ def _write_markdown(
         "",
         f"Primary evaluation mode: `{primary_mode}`.",
         f"Registered reference method: `{reference_method}`.",
+        "",
+        "The primary table uses only frame/pixel support shared by truth and every "
+        "registered method in each case. Native per-method results and support "
+        "retention are retained in the JSON and CSV outputs.",
         "",
         "Intervals are deterministic group-bootstrap 95% intervals. Each physical "
         "object or independent acquisition session contributes equal aggregate mass.",

--- a/src/prob4d/evaluation_modes.py
+++ b/src/prob4d/evaluation_modes.py
@@ -68,47 +68,6 @@ class EvaluationModes:
         }
 
 
-def _sanitize_flow_support(
-    prediction: FusedSequence,
-    truth: TruthSequence,
-) -> tuple[FusedSequence, TruthSequence]:
-    """Exclude invalid or non-finite flow entries before legacy metric calls."""
-
-    sanitized_prediction = prediction
-    if prediction.scene_flow is not None:
-        prediction_flow_mask = (
-            np.asarray(prediction.deform_mask, dtype=bool)
-            & prediction.valid_mask
-            & np.all(np.isfinite(prediction.scene_flow), axis=-1)
-        )
-        sanitized_prediction = FusedSequence(
-            frame_indices=prediction.frame_indices,
-            point_map=prediction.point_map,
-            valid_mask=prediction.valid_mask,
-            point_covariance=prediction.point_covariance,
-            contributors=prediction.contributors,
-            scene_flow=prediction.scene_flow,
-            deform_mask=prediction_flow_mask,
-            flow_covariance=prediction.flow_covariance,
-        )
-
-    sanitized_truth = truth
-    if truth.scene_flow is not None:
-        truth_flow_mask = (
-            np.asarray(truth.deform_mask, dtype=bool)
-            & truth.valid_mask
-            & np.all(np.isfinite(truth.scene_flow), axis=-1)
-        )
-        sanitized_truth = TruthSequence(
-            frame_indices=truth.frame_indices,
-            point_map=truth.point_map,
-            valid_mask=truth.valid_mask,
-            scene_flow=truth.scene_flow,
-            deform_mask=truth_flow_mask,
-        )
-    return sanitized_prediction, sanitized_truth
-
-
 def _common_pairs(
     prediction: FusedSequence,
     truth: TruthSequence,
@@ -132,6 +91,7 @@ def _fit_scale_translation_streaming(
     truth: TruthSequence,
     *,
     frame_stop_exclusive: int | None,
+    truth_support_mask: np.ndarray | None,
 ) -> tuple[float, np.ndarray, int, int]:
     """Fit one isotropic scale and translation without stacking dense frames."""
 
@@ -155,6 +115,8 @@ def _fit_scale_translation_streaming(
             & np.all(np.isfinite(source_frame), axis=-1)
             & np.all(np.isfinite(target_frame), axis=-1)
         )
+        if truth_support_mask is not None:
+            active &= truth_support_mask[truth_index]
         if not np.any(active):
             continue
         source = source_frame[active]
@@ -230,6 +192,8 @@ def _evaluate_transformed(
     fit_point_count: int,
     fit_frame_stop_exclusive: int | None,
     boundary_frames: list[int] | None,
+    truth_support_mask: np.ndarray | None,
+    truth_flow_support_mask: np.ndarray | None,
 ) -> EvaluationModeResult:
     transformed = _transformed_prediction(
         prediction,
@@ -241,6 +205,8 @@ def _evaluate_transformed(
         truth,
         boundary_frames=boundary_frames,
         align_scale_translation=False,
+        truth_support_mask=truth_support_mask,
+        truth_flow_support_mask=truth_flow_support_mask,
     )
     metrics = replace(metrics, fitted_alignment_scale=scale)
     return EvaluationModeResult(
@@ -260,6 +226,8 @@ def evaluate_sequence_modes(
     *,
     boundary_frames: list[int] | None = None,
     prefix_frame_stop_exclusive: int | None = None,
+    truth_support_mask: np.ndarray | None = None,
+    truth_flow_support_mask: np.ndarray | None = None,
 ) -> EvaluationModes:
     """Evaluate metric, causal-prefix-aligned, and oracle-aligned interpretations.
 
@@ -270,7 +238,18 @@ def evaluate_sequence_modes(
     than a causal prediction result.
     """
 
-    prediction, truth = _sanitize_flow_support(prediction, truth)
+    support_mask = None
+    if truth_support_mask is not None:
+        support_mask = np.asarray(truth_support_mask, dtype=bool)
+        if support_mask.shape != truth.valid_mask.shape:
+            raise ValueError("truth_support_mask must match truth valid_mask shape")
+    flow_support_mask = None
+    if truth_flow_support_mask is not None:
+        flow_support_mask = np.asarray(truth_flow_support_mask, dtype=bool)
+        if flow_support_mask.shape != truth.valid_mask.shape:
+            raise ValueError(
+                "truth_flow_support_mask must match truth valid_mask shape"
+            )
     metric = _evaluate_transformed(
         "metric",
         prediction,
@@ -281,6 +260,8 @@ def evaluate_sequence_modes(
         fit_point_count=0,
         fit_frame_stop_exclusive=None,
         boundary_frames=boundary_frames,
+        truth_support_mask=support_mask,
+        truth_flow_support_mask=flow_support_mask,
     )
 
     oracle_scale, oracle_translation, oracle_frames, oracle_points = (
@@ -288,6 +269,7 @@ def evaluate_sequence_modes(
             prediction,
             truth,
             frame_stop_exclusive=None,
+            truth_support_mask=support_mask,
         )
     )
     oracle = _evaluate_transformed(
@@ -300,6 +282,8 @@ def evaluate_sequence_modes(
         fit_point_count=oracle_points,
         fit_frame_stop_exclusive=None,
         boundary_frames=boundary_frames,
+        truth_support_mask=support_mask,
+        truth_flow_support_mask=flow_support_mask,
     )
 
     prefix: EvaluationModeResult | None = None
@@ -309,6 +293,7 @@ def evaluate_sequence_modes(
                 prediction,
                 truth,
                 frame_stop_exclusive=prefix_frame_stop_exclusive,
+                truth_support_mask=support_mask,
             )
         )
         prefix = _evaluate_transformed(
@@ -321,6 +306,8 @@ def evaluate_sequence_modes(
             fit_point_count=prefix_points,
             fit_frame_stop_exclusive=prefix_frame_stop_exclusive,
             boundary_frames=boundary_frames,
+            truth_support_mask=support_mask,
+            truth_flow_support_mask=flow_support_mask,
         )
 
     return EvaluationModes(

--- a/src/prob4d/metrics.py
+++ b/src/prob4d/metrics.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import asdict, dataclass
 
 import numpy as np
-from numpy.typing import NDArray
+from numpy.typing import ArrayLike, DTypeLike, NDArray
 
 from .covariance import covariance_statistics
 from .fusion import FusedSequence
@@ -15,6 +15,14 @@ FloatArray = NDArray[np.floating]
 
 @dataclass(frozen=True)
 class TruthSequence:
+    """A validated immutable dense truth sequence.
+
+    Public construction defensively copies every NumPy field, normalizes it to
+    the canonical dtype, validates active geometry, and makes the retained arrays
+    read-only. Inactive point and flow entries may contain arbitrary sentinels;
+    only entries selected by their corresponding masks are required to be finite.
+    """
+
     frame_indices: NDArray[np.integer]
     point_map: FloatArray
     valid_mask: NDArray[np.bool_]
@@ -22,19 +30,60 @@ class TruthSequence:
     deform_mask: NDArray[np.bool_] | None = None
 
     def __post_init__(self) -> None:
-        frames = np.asarray(self.frame_indices, dtype=np.int64)
-        points = np.asarray(self.point_map, dtype=np.float64)
-        mask = np.asarray(self.valid_mask, dtype=bool)
-        if points.shape[:-1] != mask.shape or points.shape[-1] != 3:
-            raise ValueError("truth point-map and mask shapes are inconsistent")
+        raw_frames = np.asarray(self.frame_indices)
+        if not np.issubdtype(raw_frames.dtype, np.integer):
+            raise ValueError("truth frame_indices must contain integers")
+        if np.any(raw_frames < 0) or np.any(raw_frames > np.iinfo(np.int64).max):
+            raise ValueError("truth frame_indices must fit the non-negative int64 range")
+        frames = _readonly_copy(raw_frames, dtype=np.int64)
+        points = _readonly_copy(self.point_map, dtype=np.float64)
+        mask = _readonly_copy(self.valid_mask, dtype=bool)
+        if frames.ndim != 1 or frames.size == 0:
+            raise ValueError(
+                "truth frame_indices must be a non-empty one-dimensional array"
+            )
+        if np.any(np.diff(frames) <= 0):
+            raise ValueError("truth frame_indices must be strictly increasing")
+        if points.ndim != 4 or points.shape[-1] != 3:
+            raise ValueError("truth point_map must have shape (T, H, W, 3)")
+        if mask.shape != points.shape[:-1]:
+            raise ValueError("truth valid_mask must have shape (T, H, W)")
         if frames.shape != (points.shape[0],):
-            raise ValueError("truth frame indices do not match point-map length")
+            raise ValueError("truth frame_indices do not match point_map length")
+        _validate_finite_active_vectors(
+            points,
+            active_mask=mask,
+            name="active truth point_map",
+        )
         if (self.scene_flow is None) != (self.deform_mask is None):
             raise ValueError("truth scene_flow and deform_mask must be paired")
+
+        flow: np.ndarray | None = None
+        flow_mask: np.ndarray | None = None
+        if self.scene_flow is not None:
+            assert self.deform_mask is not None
+            flow = _readonly_copy(self.scene_flow, dtype=np.float64)
+            flow_mask = _readonly_copy(self.deform_mask, dtype=bool)
+            if flow.shape != points.shape:
+                raise ValueError("truth scene_flow must match point_map shape")
+            if flow_mask.shape != mask.shape:
+                raise ValueError("truth deform_mask must match valid_mask shape")
+            _validate_finite_active_vectors(
+                flow,
+                active_mask=flow_mask & mask,
+                name="active truth scene_flow",
+            )
+
+        object.__setattr__(self, "frame_indices", frames)
+        object.__setattr__(self, "point_map", points)
+        object.__setattr__(self, "valid_mask", mask)
+        object.__setattr__(self, "scene_flow", flow)
+        object.__setattr__(self, "deform_mask", flow_mask)
 
 
 @dataclass(frozen=True)
 class SequenceMetrics:
+    # Preserve the historical constructor order for downstream compatibility.
     metric_point_rmse: float
     metric_endpoint_point_rmse: float
     point_rmse: float
@@ -48,12 +97,34 @@ class SequenceMetrics:
     evaluated_points: int
     fitted_alignment_scale: float
 
+    # Extended provider scorecard.
+    metric_frame_balanced_point_rmse: float
+    frame_balanced_point_rmse: float
+    coverage_50: float
+    coverage_80: float
+    coverage_90: float
+    coverage_shortfall_95: float
+    coverage_calibration_error: float
+    median_mahalanobis_squared: float
+    mean_covariance_trace: float
+    mean_covariance_log_determinant: float
+    uncertainty_error_spearman: float
+    mean_relative_error: float
+    relative_error_retained_50: float
+    relative_error_retained_80: float
+    selective_gain_80: float
+    selective_oracle_fraction_80: float
+    risk_coverage_auc: float
+    evaluated_frames: int
+    evaluated_flow_points: int
+
     def to_dict(self) -> dict[str, float | int | None]:
         return asdict(self)
 
 
 @dataclass(frozen=True)
 class UncertaintyDiagnostics:
+    # Preserve the historical constructor order for downstream compatibility.
     count: int
     coverage_50: float
     coverage_80: float
@@ -71,6 +142,12 @@ class UncertaintyDiagnostics:
     selective_gain_80: float
     selective_oracle_fraction_80: float
 
+    # Extended width and selective-risk diagnostics.
+    mean_covariance_trace: float
+    mean_covariance_log_determinant: float
+    relative_error_retained_50: float
+    risk_coverage_auc: float
+
     def to_dict(self) -> dict[str, float | int]:
         return asdict(self)
 
@@ -81,6 +158,44 @@ _CHI_SQUARED_3 = {
     0.90: 6.251388631170325,
     0.95: 7.814727903251179,
 }
+
+
+def _readonly_copy(value: ArrayLike, *, dtype: DTypeLike) -> np.ndarray:
+    array = np.asarray(value, dtype=dtype).copy()
+    array.setflags(write=False)
+    return array
+
+
+def _validate_finite_active_vectors(
+    values: np.ndarray,
+    *,
+    active_mask: NDArray[np.bool_],
+    name: str,
+    chunk_size: int = 65_536,
+) -> None:
+    if chunk_size < 1:
+        raise ValueError("truth vector validation chunk_size must be positive")
+    flat_values = values.reshape(-1, values.shape[-1])
+    flat_active = np.asarray(active_mask, dtype=bool).reshape(-1)
+    for start in range(0, flat_values.shape[0], chunk_size):
+        stop = min(start + chunk_size, flat_values.shape[0])
+        selected = flat_active[start:stop]
+        if np.any(selected) and not np.all(np.isfinite(flat_values[start:stop][selected])):
+            raise ValueError(f"{name} entries must be finite")
+
+
+def _validated_support_mask(
+    value: NDArray[np.bool_] | None,
+    *,
+    truth: TruthSequence,
+    name: str,
+) -> NDArray[np.bool_] | None:
+    if value is None:
+        return None
+    mask = np.asarray(value, dtype=bool)
+    if mask.shape != truth.valid_mask.shape:
+        raise ValueError(f"{name} must match truth valid_mask shape")
+    return mask
 
 
 def _rankdata(values: FloatArray) -> FloatArray:
@@ -96,6 +211,68 @@ def _rankdata(values: FloatArray) -> FloatArray:
         ranks[order[start:stop]] = 0.5 * (start + stop - 1)
         start = stop
     return ranks
+
+
+def _expected_risk_at_count(
+    risks: FloatArray,
+    uncertainty_scores: FloatArray,
+    retain_count: int,
+) -> float:
+    """Return tie-invariant expected risk at one fixed retained sample count."""
+
+    risks = np.asarray(risks, dtype=np.float64)
+    scores = np.asarray(uncertainty_scores, dtype=np.float64)
+    if risks.shape != scores.shape or risks.ndim != 1:
+        raise ValueError("risks and uncertainty_scores must be equal-length vectors")
+    if not 1 <= retain_count <= risks.size:
+        raise ValueError("retain_count must select at least one and at most all samples")
+    threshold = np.partition(scores, retain_count - 1)[retain_count - 1]
+    lower = scores < threshold
+    tied = scores == threshold
+    lower_count = int(np.count_nonzero(lower))
+    tied_count = int(np.count_nonzero(tied))
+    tied_to_retain = retain_count - lower_count
+    if tied_count < tied_to_retain or tied_to_retain < 1:
+        raise RuntimeError("invalid uncertainty tie partition")
+    retained_sum = float(np.sum(risks[lower]))
+    retained_sum += float(tied_to_retain / tied_count) * float(np.sum(risks[tied]))
+    return retained_sum / retain_count
+
+
+def _tie_aware_risk_coverage_auc(
+    risks: FloatArray,
+    uncertainty_scores: FloatArray,
+) -> float:
+    """Integrate expected selective risk without depending on tie order."""
+
+    risks = np.asarray(risks, dtype=np.float64)
+    scores = np.asarray(uncertainty_scores, dtype=np.float64)
+    if risks.shape != scores.shape or risks.ndim != 1 or risks.size == 0:
+        raise ValueError("risks and uncertainty_scores must be nonempty equal vectors")
+    order = np.argsort(scores, kind="mergesort")
+    sorted_scores = scores[order]
+    sorted_risks = risks[order]
+    retained_count = 0
+    retained_sum = 0.0
+    integrated_risk = 0.0
+    start = 0
+    while start < risks.size:
+        stop = start + 1
+        while stop < risks.size and sorted_scores[stop] == sorted_scores[start]:
+            stop += 1
+        group = sorted_risks[start:stop]
+        group_mean = float(np.mean(group))
+        within_group_counts = np.arange(1, group.size + 1, dtype=np.float64)
+        integrated_risk += float(
+            np.sum(
+                (retained_sum + within_group_counts * group_mean)
+                / (retained_count + within_group_counts)
+            )
+        )
+        retained_count += group.size
+        retained_sum += float(np.sum(group))
+        start = stop
+    return integrated_risk / risks.size
 
 
 def uncertainty_diagnostics(
@@ -164,13 +341,25 @@ def uncertainty_diagnostics(
     else:
         spearman = float(np.corrcoef(uncertainty_rank, error_rank)[0, 1])
 
-    retain_count = max(1, int(np.floor(0.8 * relative_error.size)))
-    selected = np.argpartition(uncertainty_score, retain_count - 1)[:retain_count]
-    oracle = np.argpartition(relative_error, retain_count - 1)[:retain_count]
+    retain_count_50 = max(1, int(np.floor(0.5 * relative_error.size)))
+    retain_count_80 = max(1, int(np.floor(0.8 * relative_error.size)))
     risk_all = float(np.mean(relative_error))
-    risk_retained = float(np.mean(relative_error[selected]))
-    risk_oracle = float(np.mean(relative_error[oracle]))
-    gain = risk_all - risk_retained
+    risk_retained_50 = _expected_risk_at_count(
+        relative_error,
+        uncertainty_score,
+        retain_count_50,
+    )
+    risk_retained_80 = _expected_risk_at_count(
+        relative_error,
+        uncertainty_score,
+        retain_count_80,
+    )
+    risk_oracle = _expected_risk_at_count(
+        relative_error,
+        relative_error,
+        retain_count_80,
+    )
+    gain = risk_all - risk_retained_80
     oracle_gain = risk_all - risk_oracle
 
     return UncertaintyDiagnostics(
@@ -184,12 +373,21 @@ def uncertainty_diagnostics(
         mean_mahalanobis_squared=float(np.mean(mahalanobis_squared)),
         median_mahalanobis_squared=float(np.median(mahalanobis_squared)),
         gaussian_nll=float(np.mean(nll)),
+        mean_covariance_trace=float(
+            np.mean(np.trace(symmetric, axis1=-2, axis2=-1))
+        ),
+        mean_covariance_log_determinant=float(np.mean(log_determinant)),
         uncertainty_error_spearman=spearman,
         mean_relative_error=risk_all,
-        relative_error_retained_80=risk_retained,
+        relative_error_retained_50=risk_retained_50,
+        relative_error_retained_80=risk_retained_80,
         relative_error_oracle_80=risk_oracle,
         selective_gain_80=gain,
         selective_oracle_fraction_80=(gain / oracle_gain if oracle_gain > 1e-12 else 0.0),
+        risk_coverage_auc=_tie_aware_risk_coverage_auc(
+            relative_error,
+            uncertainty_score,
+        ),
     )
 
 
@@ -214,9 +412,21 @@ def evaluate_sequence(
     *,
     boundary_frames: list[int] | None = None,
     align_scale_translation: bool = True,
+    truth_support_mask: NDArray[np.bool_] | None = None,
+    truth_flow_support_mask: NDArray[np.bool_] | None = None,
 ) -> SequenceMetrics:
     """Evaluate one sequence after at most one global scale/translation alignment."""
 
+    support_mask = _validated_support_mask(
+        truth_support_mask,
+        truth=truth,
+        name="truth_support_mask",
+    )
+    flow_support_mask = _validated_support_mask(
+        truth_flow_support_mask,
+        truth=truth,
+        name="truth_flow_support_mask",
+    )
     common_frames = np.intersect1d(prediction.frame_indices, truth.frame_indices)
     if common_frames.size == 0:
         raise ValueError("prediction and truth have no common frames")
@@ -231,6 +441,8 @@ def evaluate_sequence(
     predicted_mask = prediction.valid_mask[prediction_indices]
     truth_points = truth.point_map[truth_indices]
     truth_mask = truth.valid_mask[truth_indices]
+    if support_mask is not None:
+        truth_mask = truth_mask & support_mask[truth_indices]
     active = predicted_mask & truth_mask
     if not np.any(active):
         raise ValueError("prediction and truth have no jointly valid points")
@@ -248,6 +460,9 @@ def evaluate_sequence(
     metric_finite_frames = np.flatnonzero(np.isfinite(metric_frame_rmse))
     metric_point_rmse = float(np.sqrt(np.mean(metric_squared_norm[active])))
     metric_endpoint_point_rmse = float(metric_frame_rmse[metric_finite_frames[-1]])
+    metric_frame_balanced_point_rmse = float(
+        np.mean(metric_frame_rmse[metric_finite_frames])
+    )
 
     scale = 1.0
     translation = np.zeros(3)
@@ -277,6 +492,7 @@ def evaluate_sequence(
     else:
         drift_slope = 0.0
     endpoint_point_rmse = float(frame_rmse[np.flatnonzero(finite_frames)[-1]])
+    frame_balanced_point_rmse = float(np.mean(frame_rmse[finite_frames]))
 
     seam_values: list[float] = []
     common_position = {int(frame): index for index, frame in enumerate(common_frames)}
@@ -293,16 +509,15 @@ def evaluate_sequence(
 
     active_covariance = predicted_covariance[active]
     active_error = errors[active]
-    _, inverse_covariance, log_determinant = covariance_statistics(
+    diagnostics = uncertainty_diagnostics(
+        active_error,
         active_covariance,
-        name="predicted point covariance",
+        np.linalg.norm(truth_points[active], axis=-1),
+        uncertainty_normalizers=np.linalg.norm(predicted_points[active], axis=-1),
     )
-    mahalanobis = np.einsum(
-        "...i,...ij,...j->...", active_error, inverse_covariance, active_error
-    )
-    nll = 0.5 * (3.0 * np.log(2.0 * np.pi) + log_determinant + mahalanobis)
 
     flow_epe: float | None = None
+    evaluated_flow_points = 0
     if prediction.scene_flow is not None and truth.scene_flow is not None:
         predicted_flow = scale * prediction.scene_flow[prediction_indices]
         truth_flow = truth.scene_flow[truth_indices]
@@ -314,7 +529,10 @@ def evaluate_sequence(
             & np.all(np.isfinite(predicted_flow), axis=-1)
             & np.all(np.isfinite(truth_flow), axis=-1)
         )
+        if flow_support_mask is not None:
+            flow_mask &= flow_support_mask[truth_indices]
         if np.any(flow_mask):
+            evaluated_flow_points = int(np.count_nonzero(flow_mask))
             flow_epe = float(
                 np.mean(
                     np.linalg.norm(
@@ -327,14 +545,35 @@ def evaluate_sequence(
     return SequenceMetrics(
         metric_point_rmse=metric_point_rmse,
         metric_endpoint_point_rmse=metric_endpoint_point_rmse,
+        metric_frame_balanced_point_rmse=metric_frame_balanced_point_rmse,
         point_rmse=point_rmse,
         endpoint_point_rmse=endpoint_point_rmse,
+        frame_balanced_point_rmse=frame_balanced_point_rmse,
         drift_slope=drift_slope,
         seam_rmse=seam_rmse,
         flow_epe=flow_epe,
-        coverage_95=float(np.mean(mahalanobis <= 7.814727903251179)),
-        gaussian_nll=float(np.mean(nll)),
-        mean_mahalanobis_squared=float(np.mean(mahalanobis)),
+        coverage_50=diagnostics.coverage_50,
+        coverage_80=diagnostics.coverage_80,
+        coverage_90=diagnostics.coverage_90,
+        coverage_95=diagnostics.coverage_95,
+        coverage_shortfall_95=diagnostics.coverage_shortfall_95,
+        coverage_calibration_error=diagnostics.coverage_calibration_error,
+        gaussian_nll=diagnostics.gaussian_nll,
+        mean_mahalanobis_squared=diagnostics.mean_mahalanobis_squared,
+        median_mahalanobis_squared=diagnostics.median_mahalanobis_squared,
+        mean_covariance_trace=diagnostics.mean_covariance_trace,
+        mean_covariance_log_determinant=(
+            diagnostics.mean_covariance_log_determinant
+        ),
+        uncertainty_error_spearman=diagnostics.uncertainty_error_spearman,
+        mean_relative_error=diagnostics.mean_relative_error,
+        relative_error_retained_50=diagnostics.relative_error_retained_50,
+        relative_error_retained_80=diagnostics.relative_error_retained_80,
+        selective_gain_80=diagnostics.selective_gain_80,
+        selective_oracle_fraction_80=diagnostics.selective_oracle_fraction_80,
+        risk_coverage_auc=diagnostics.risk_coverage_auc,
         evaluated_points=int(np.count_nonzero(active)),
+        evaluated_frames=int(np.count_nonzero(finite_frames)),
+        evaluated_flow_points=evaluated_flow_points,
         fitted_alignment_scale=scale,
     )

--- a/src/prob4d/provider_evaluation.py
+++ b/src/prob4d/provider_evaluation.py
@@ -58,10 +58,12 @@ def run_provider_evaluation(
     ]
     report: dict[str, Any] = {
         "schema_name": "prob4d.provider-evaluation-report",
-        "schema_version": 1,
+        "schema_version": 2,
         "source_manifest": str(source),
         "source_manifest_sha256": hashlib.sha256(source.read_bytes()).hexdigest(),
         "primary_mode": primary_mode,
+        "primary_support": "common_across_registered_methods",
+        "secondary_support": "native_per_method",
         "reference_method": reference_method,
         "bootstrap_resamples": bootstrap_resamples,
         "bootstrap_seed": normalized_seed,
@@ -71,6 +73,12 @@ def run_provider_evaluation(
         "cases": clean_records,
         "aggregate": aggregate,
         "comparisons": comparisons,
+        "support_semantics": (
+            "Primary metrics use the intersection of truth support and every "
+            "registered method within each case. Native per-method metrics and "
+            "retention fractions are reported separately to expose selective "
+            "missingness."
+        ),
         "claim_boundary": (
             "This report measures held-out observation competence. It does not by itself "
             "establish Bayesian-PhysTwin acceptance, physical-prediction benefit, or "

--- a/tests/test_provider_evaluation_support.py
+++ b/tests/test_provider_evaluation_support.py
@@ -1,0 +1,519 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from prob4d.evaluation_modes import evaluate_sequence_modes
+from prob4d.fusion import FusedSequence
+from prob4d.io import save_fused_prediction, save_truth
+from prob4d.metrics import TruthSequence, evaluate_sequence, uncertainty_diagnostics
+from prob4d.provider_evaluation import run_provider_evaluation
+
+
+def _prediction(
+    truth: TruthSequence,
+    error: float,
+    *,
+    valid_mask: np.ndarray | None = None,
+) -> FusedSequence:
+    points = truth.point_map.copy()
+    points[..., 0] += error
+    mask = truth.valid_mask if valid_mask is None else np.asarray(valid_mask, dtype=bool)
+    covariance = np.broadcast_to(np.eye(3), points.shape + (3,)).copy()
+    return FusedSequence(
+        frame_indices=truth.frame_indices,
+        point_map=points,
+        valid_mask=mask,
+        point_covariance=covariance,
+        contributors=np.ones(mask.shape, dtype=np.uint16),
+    )
+
+
+def _artifact_metadata() -> dict[str, object]:
+    return {
+        "prob4d_revision": "a" * 40,
+        "motioncrafter_revision": "b" * 40,
+        "motioncrafter_seed_policy": "derived-per-call",
+        "motioncrafter_model_set_sha256": "c" * 64,
+        "prediction_manifest_sha256": "d" * 64,
+        "includes_covariance": True,
+        "gauge_estimator": "sequential",
+        "uncertainty_calibration": "held_out",
+    }
+
+
+def test_truth_sequence_is_canonical_immutable_and_alias_safe() -> None:
+    frames = np.array([0, 2], dtype=np.int32)
+    points = np.zeros((2, 1, 2, 3), dtype=np.float32)
+    points[0, 0, 1] = np.nan
+    valid = np.array([[[True, False]], [[True, True]]], dtype=np.uint8)
+    flow = np.zeros_like(points)
+    flow[0, 0, 1] = np.inf
+    deform = np.array([[[True, False]], [[False, True]]], dtype=np.uint8)
+
+    truth = TruthSequence(frames, points, valid, flow, deform)
+
+    assert truth.frame_indices.dtype == np.int64
+    assert truth.point_map.dtype == np.float64
+    assert truth.valid_mask.dtype == np.bool_
+    assert truth.scene_flow is not None
+    assert truth.scene_flow.dtype == np.float64
+    assert truth.deform_mask is not None
+    assert truth.deform_mask.dtype == np.bool_
+    assert not np.shares_memory(truth.frame_indices, frames)
+    assert not np.shares_memory(truth.point_map, points)
+    assert not np.shares_memory(truth.valid_mask, valid)
+
+    frames[0] = 1
+    points[1, 0, 0, 0] = 9.0
+    valid[1, 0, 0] = 0
+    flow[1, 0, 1, 0] = 7.0
+    deform[1, 0, 1] = 0
+    np.testing.assert_array_equal(truth.frame_indices, [0, 2])
+    np.testing.assert_allclose(truth.point_map[1, 0, 0], 0.0)
+    assert truth.valid_mask[1, 0, 0]
+    np.testing.assert_allclose(truth.scene_flow[1, 0, 1], 0.0)
+    assert truth.deform_mask[1, 0, 1]
+
+    for array in (
+        truth.frame_indices,
+        truth.point_map,
+        truth.valid_mask,
+        truth.scene_flow,
+        truth.deform_mask,
+    ):
+        assert array is not None
+        assert not array.flags.writeable
+        with pytest.raises(ValueError):
+            array.flat[0] = 0
+
+
+@pytest.mark.parametrize(
+    ("frames", "message"),
+    [
+        (np.array([0.0, 1.0]), "contain integers"),
+        (np.array([-1, 0]), "non-negative int64"),
+        (np.array([0, 0]), "strictly increasing"),
+        (np.array([1, 0]), "strictly increasing"),
+    ],
+)
+def test_truth_sequence_rejects_invalid_frame_contract(
+    frames: np.ndarray,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        TruthSequence(
+            frame_indices=frames,
+            point_map=np.zeros((2, 1, 1, 3)),
+            valid_mask=np.ones((2, 1, 1), dtype=bool),
+        )
+
+
+def test_truth_sequence_rejects_nonfinite_active_geometry() -> None:
+    points = np.zeros((1, 1, 1, 3))
+    points[0, 0, 0, 0] = np.nan
+    with pytest.raises(ValueError, match="active truth point_map"):
+        TruthSequence(
+            frame_indices=np.array([0]),
+            point_map=points,
+            valid_mask=np.ones((1, 1, 1), dtype=bool),
+        )
+
+    points.fill(0.0)
+    flow = np.zeros_like(points)
+    flow[0, 0, 0, 0] = np.inf
+    with pytest.raises(ValueError, match="active truth scene_flow"):
+        TruthSequence(
+            frame_indices=np.array([0]),
+            point_map=points,
+            valid_mask=np.ones((1, 1, 1), dtype=bool),
+            scene_flow=flow,
+            deform_mask=np.ones((1, 1, 1), dtype=bool),
+        )
+
+
+def test_sequence_metrics_include_frame_balanced_and_uncertainty_scorecard() -> None:
+    truth_points = np.zeros((2, 1, 4, 3))
+    prediction_points = truth_points.copy()
+    prediction_points[1, 0, 0, 0] = 2.0
+    valid = np.array(
+        [
+            [[True, True, True, True]],
+            [[True, False, False, False]],
+        ]
+    )
+    covariance = np.broadcast_to(
+        np.eye(3) * 0.04,
+        prediction_points.shape + (3,),
+    ).copy()
+    prediction = FusedSequence(
+        np.arange(2),
+        prediction_points,
+        valid,
+        covariance,
+        np.ones_like(valid, dtype=np.uint16),
+    )
+    truth = TruthSequence(np.arange(2), truth_points, valid)
+
+    metrics = evaluate_sequence(
+        prediction,
+        truth,
+        align_scale_translation=False,
+    )
+
+    np.testing.assert_allclose(metrics.point_rmse, np.sqrt(4.0 / 5.0))
+    np.testing.assert_allclose(metrics.frame_balanced_point_rmse, 1.0)
+    np.testing.assert_allclose(metrics.mean_covariance_trace, 0.12)
+    np.testing.assert_allclose(
+        metrics.mean_covariance_log_determinant,
+        3.0 * np.log(0.04),
+    )
+    assert metrics.coverage_50 == pytest.approx(0.8)
+    assert metrics.coverage_95 == pytest.approx(0.8)
+    assert metrics.coverage_shortfall_95 == pytest.approx(0.15)
+    assert metrics.evaluated_frames == 2
+    assert metrics.evaluated_flow_points == 0
+    assert np.isfinite(metrics.risk_coverage_auc)
+
+
+def test_selective_risk_is_permutation_invariant_under_uncertainty_ties() -> None:
+    errors = np.array(
+        [
+            [0.1, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.2, 0.0, 0.0],
+            [0.8, 0.0, 0.0],
+        ]
+    )
+    covariances = np.broadcast_to(np.eye(3), (4, 3, 3)).copy()
+    norms = np.ones(4)
+    original = uncertainty_diagnostics(errors, covariances, norms)
+    permutation = np.array([3, 0, 2, 1])
+    permuted = uncertainty_diagnostics(
+        errors[permutation],
+        covariances[permutation],
+        norms[permutation],
+    )
+
+    np.testing.assert_allclose(
+        original.relative_error_retained_50,
+        original.mean_relative_error,
+    )
+    np.testing.assert_allclose(
+        permuted.relative_error_retained_50,
+        original.relative_error_retained_50,
+    )
+    np.testing.assert_allclose(
+        permuted.relative_error_retained_80,
+        original.relative_error_retained_80,
+    )
+    np.testing.assert_allclose(
+        permuted.risk_coverage_auc,
+        original.risk_coverage_auc,
+    )
+
+
+def test_truth_support_mask_controls_fit_and_evaluation_support() -> None:
+    truth_points = np.asarray(
+        [
+            [[[0.0, 0.0, 1.0], [1.0, 0.0, 1.0], [2.0, 0.0, 1.0]]],
+            [[[0.0, 1.0, 1.0], [1.0, 1.0, 1.0], [2.0, 1.0, 1.0]]],
+        ]
+    )
+    translation = np.asarray([1.0, -0.5, 0.25])
+    predicted_points = (truth_points - translation) / 2.0
+    prediction = _prediction(
+        TruthSequence(np.arange(2), predicted_points, np.ones((2, 1, 3), dtype=bool)),
+        0.0,
+    )
+    truth = TruthSequence(
+        np.arange(2),
+        truth_points,
+        np.ones((2, 1, 3), dtype=bool),
+    )
+    support = np.zeros_like(truth.valid_mask)
+    support[:, :, :2] = True
+
+    result = evaluate_sequence_modes(
+        prediction,
+        truth,
+        prefix_frame_stop_exclusive=1,
+        truth_support_mask=support,
+    )
+
+    assert result.prefix_aligned is not None
+    assert result.prefix_aligned.fit_point_count == 2
+    assert result.metric.metrics.evaluated_points == 4
+    assert result.metric.metrics.evaluated_frames == 2
+
+    with pytest.raises(ValueError, match="truth_support_mask"):
+        evaluate_sequence_modes(
+            prediction,
+            truth,
+            truth_support_mask=np.ones((1, 1, 1), dtype=bool),
+        )
+
+
+def test_provider_evaluation_uses_common_support_and_reports_native_retention(
+    tmp_path: Path,
+) -> None:
+    truth = TruthSequence(
+        frame_indices=np.array([0, 1]),
+        point_map=np.array(
+            [
+                [[[0.0, 0.0, 1.0], [1.0, 0.0, 1.0]]],
+                [[[0.0, 1.0, 1.0], [1.0, 1.0, 1.0]]],
+            ]
+        ),
+        valid_mask=np.ones((2, 1, 2), dtype=bool),
+    )
+    selective_truth = TruthSequence(
+        frame_indices=np.array([1]),
+        point_map=truth.point_map[1:],
+        valid_mask=np.array([[[True, False]]]),
+    )
+    truth_path = tmp_path / "truth.npz"
+    wide_path = tmp_path / "wide.npz"
+    selective_path = tmp_path / "selective.npz"
+    save_truth(truth_path, truth)
+    save_fused_prediction(
+        wide_path,
+        _prediction(truth, 0.5),
+        method_id="wide",
+        fusion_method="uniform",
+        metadata=_artifact_metadata(),
+    )
+    save_fused_prediction(
+        selective_path,
+        _prediction(selective_truth, 0.25),
+        method_id="selective",
+        fusion_method="uniform",
+        metadata=_artifact_metadata(),
+    )
+    manifest = {
+        "schema_name": "prob4d.provider-evaluation",
+        "schema_version": 1,
+        "primary_mode": "metric",
+        "reference_method": "wide",
+        "cases": [
+            {
+                "case_id": "case",
+                "group_id": "group",
+                "truth": truth_path.name,
+                "predictions": {
+                    "wide": wide_path.name,
+                    "selective": selective_path.name,
+                },
+                "boundary_frames": [],
+                "prefix_frame_stop_exclusive": None,
+            }
+        ],
+        "metadata": {},
+    }
+    manifest_path = tmp_path / "evaluation.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    output = tmp_path / "output"
+
+    report = run_provider_evaluation(
+        manifest_path,
+        output,
+        bootstrap_resamples=10,
+    )
+
+    records = {record["method_id"]: record for record in report["cases"]}
+    wide_record = records["wide"]
+    selective_record = records["selective"]
+    assert wide_record["evaluation"]["metric"]["metrics"]["evaluated_points"] == 1
+    assert (
+        selective_record["evaluation"]["metric"]["metrics"]["evaluated_points"]
+        == 1
+    )
+    assert (
+        wide_record["native_support_evaluation"]["metric"]["metrics"][
+            "evaluated_points"
+        ]
+        == 4
+    )
+    assert (
+        selective_record["native_support_evaluation"]["metric"]["metrics"][
+            "evaluated_points"
+        ]
+        == 1
+    )
+    assert wide_record["support"]["common_frame_count"] == 1
+    assert wide_record["support"]["common_point_fraction_of_native"] == 0.25
+    assert wide_record["support"]["common_frame_fraction_of_native"] == 0.5
+    assert selective_record["support"]["common_point_fraction_of_native"] == 1.0
+    assert selective_record["support"]["common_frame_fraction_of_native"] == 1.0
+    np.testing.assert_allclose(
+        report["aggregate"]["wide"]["metrics"][
+            "metric.metrics.metric_point_rmse"
+        ]["mean"],
+        0.5,
+    )
+    assert report["schema_version"] == 2
+    assert report["primary_support"] == "common_across_registered_methods"
+    csv_header = output.joinpath("provider_evaluation.csv").read_text(
+        encoding="utf-8"
+    ).splitlines()[0]
+    assert "native_support.metric.metrics.metric_point_rmse" in csv_header
+    assert "support.common_point_fraction_of_native" in csv_header
+    markdown = output.joinpath("provider_evaluation.md").read_text(encoding="utf-8")
+    assert "support shared by truth and every registered method" in markdown
+
+
+def test_provider_common_flow_requires_every_registered_method(tmp_path: Path) -> None:
+    point_map = np.array([[[[0.0, 0.0, 1.0]]]])
+    valid = np.ones((1, 1, 1), dtype=bool)
+    scene_flow = np.array([[[[1.0, 0.0, 0.0]]]])
+    truth = TruthSequence(
+        frame_indices=np.array([0]),
+        point_map=point_map,
+        valid_mask=valid,
+        scene_flow=scene_flow,
+        deform_mask=valid,
+    )
+    covariance = np.broadcast_to(np.eye(3), point_map.shape + (3,)).copy()
+    with_flow = FusedSequence(
+        frame_indices=np.array([0]),
+        point_map=point_map,
+        valid_mask=valid,
+        point_covariance=covariance,
+        contributors=np.ones_like(valid, dtype=np.uint16),
+        scene_flow=scene_flow,
+        deform_mask=valid,
+        flow_covariance=covariance,
+    )
+    without_flow = _prediction(truth, 0.0)
+    truth_path = tmp_path / "truth.npz"
+    with_flow_path = tmp_path / "with-flow.npz"
+    without_flow_path = tmp_path / "without-flow.npz"
+    save_truth(truth_path, truth)
+    save_fused_prediction(
+        with_flow_path,
+        with_flow,
+        method_id="with_flow",
+        fusion_method="uniform",
+        metadata=_artifact_metadata(),
+    )
+    save_fused_prediction(
+        without_flow_path,
+        without_flow,
+        method_id="without_flow",
+        fusion_method="uniform",
+        metadata=_artifact_metadata(),
+    )
+    manifest_path = tmp_path / "evaluation.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_name": "prob4d.provider-evaluation",
+                "schema_version": 1,
+                "primary_mode": "metric",
+                "reference_method": "without_flow",
+                "cases": [
+                    {
+                        "case_id": "case",
+                        "group_id": "group",
+                        "truth": truth_path.name,
+                        "predictions": {
+                            "with_flow": with_flow_path.name,
+                            "without_flow": without_flow_path.name,
+                        },
+                        "boundary_frames": [],
+                        "prefix_frame_stop_exclusive": None,
+                    }
+                ],
+                "metadata": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    report = run_provider_evaluation(
+        manifest_path,
+        tmp_path / "output",
+        bootstrap_resamples=10,
+    )
+
+    records = {record["method_id"]: record for record in report["cases"]}
+    with_flow_record = records["with_flow"]
+    assert with_flow_record["evaluation"]["metric"]["metrics"]["flow_epe"] is None
+    assert (
+        with_flow_record["native_support_evaluation"]["metric"]["metrics"][
+            "flow_epe"
+        ]
+        == 0.0
+    )
+    assert with_flow_record["support"]["all_methods_have_flow"] is False
+    assert with_flow_record["support"]["common_valid_flow_points"] == 0
+    assert with_flow_record["support"]["common_flow_fraction_of_native"] == 0.0
+    assert (
+        records["without_flow"]["support"]["common_flow_fraction_of_native"]
+        is None
+    )
+
+
+def test_provider_aggregate_records_worst_group_coverage_shortfall(
+    tmp_path: Path,
+) -> None:
+    truth = TruthSequence(
+        frame_indices=np.array([0]),
+        point_map=np.array([[[[0.0, 0.0, 1.0]]]]),
+        valid_mask=np.ones((1, 1, 1), dtype=bool),
+    )
+    cases = []
+    for case_id, group_id, error in (
+        ("c1", "g1", 0.0),
+        ("c2", "g1", 3.0),
+        ("c3", "g2", 5.0),
+    ):
+        truth_path = tmp_path / f"{case_id}-truth.npz"
+        prediction_path = tmp_path / f"{case_id}-prediction.npz"
+        save_truth(truth_path, truth)
+        save_fused_prediction(
+            prediction_path,
+            _prediction(truth, error),
+            method_id="method",
+            fusion_method="uniform",
+            metadata=_artifact_metadata(),
+        )
+        cases.append(
+            {
+                "case_id": case_id,
+                "group_id": group_id,
+                "truth": truth_path.name,
+                "predictions": {"method": prediction_path.name},
+                "boundary_frames": [],
+                "prefix_frame_stop_exclusive": None,
+            }
+        )
+    manifest_path = tmp_path / "evaluation.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_name": "prob4d.provider-evaluation",
+                "schema_version": 1,
+                "primary_mode": "metric",
+                "reference_method": "method",
+                "cases": cases,
+                "metadata": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    report = run_provider_evaluation(
+        manifest_path,
+        tmp_path / "output",
+        bootstrap_resamples=10,
+    )
+
+    summary = report["aggregate"]["method"]["metrics"][
+        "metric.metrics.coverage_shortfall_95"
+    ]
+    assert summary["worst_group_id"] == "g2"
+    assert summary["worst_group_mean"] == pytest.approx(0.95)


### PR DESCRIPTION
## Summary

- make `TruthSequence` an immutable, alias-safe, dtype-normalized truth-input contract with strict frame ordering and active point/flow finiteness checks;
- evaluate registered methods on common frame/pixel support for the primary paired comparison while retaining method-native results and support-retention diagnostics;
- add frame-balanced errors, multi-level coverage, covariance-width summaries, uncertainty-error ranking, tie-invariant selective risk, risk-coverage area, and worst-group coverage-shortfall reporting;
- publish provider-evaluation report schema version 2 while preserving established unprefixed primary metric paths;
- update documentation, changelog, and adversarial regression coverage.

## Rebase and scope

The implementation is a single commit based directly on current `main` at `e5347a553da9b61f1b0b4dd463285f8fff5cfb37`. The newer tiled dense-fusion implementation and its changelog entries are preserved.

The final diff contains exactly eight intended files; no patch payload or temporary workflow file remains.

## Validation

GitHub Actions **Tests #422** passed on final commit `4c2bbb7f6a553891f6fc9d7ffc3dca2d1a420c8e`:

- Ruff quality checks;
- mypy checks for stable provider interfaces;
- complete pytest suite on Python 3.10, 3.12, and 3.14;
- provider manifest and clean-checkout runtime-attestation checks;
- wheel and source-distribution builds with Twine validation;
- isolated installed-wheel and installed-sdist CLI smoke tests.

The prepared source-distribution patch had also passed its available suite with **338 tests passing** before rebasing.

## Claim boundary

This change hardens evaluation correctness and uncertainty reporting. It makes no new reconstruction-accuracy, Bayesian-PhysTwin, or Causal4D performance claim.