### PR TITLE
Harden repository identity and CI action provenance

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,8 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
           cache: pip
@@ -38,7 +40,7 @@ jobs:
         run: python -m ruff check src tests 2>&1 | tee ruff-output.txt
       - name: Upload Ruff diagnostics
         if: steps.ruff.outcome == 'failure'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: ruff-diagnostics
           path: ruff-output.txt
@@ -57,6 +59,7 @@ jobs:
           src/prob4d/composition_jacobian.py
           src/prob4d/covariance_root.py
           src/prob4d/observation_factor_stream.py
+          src/prob4d/project_identity.py
           src/prob4d/provider_attestation.py
           src/prob4d/provider_manifest.py
           src/prob4d/provider_manifest_cli.py
@@ -68,7 +71,7 @@ jobs:
           2>&1 | tee mypy-output.txt
       - name: Upload mypy diagnostics
         if: steps.mypy.outcome == 'failure'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: mypy-diagnostics
           path: mypy-output.txt
@@ -98,12 +101,14 @@ jobs:
             --api-version 2 \
             --provider-revision "${GITHUB_SHA}" \
             --output provider-manifest-v2.json
-      - uses: actions/upload-artifact@v7
+          prob4d project identity --compact > project-identity.json
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: prob4d-provider-manifests
           path: |
             provider-manifest.json
             provider-manifest-v2.json
+            project-identity.json
           retention-days: 14
 
   test:
@@ -115,8 +120,10 @@ jobs:
       matrix:
         python-version: ["3.10", "3.12", "3.14"]
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -132,6 +139,7 @@ jobs:
           import prob4d.composition_jacobian
           import prob4d.covariance_root
           import prob4d.observation_factor_stream
+          import prob4d.project_identity
           import prob4d.provider_attestation
           import prob4d.provider_evaluation
           import prob4d.provider_manifest
@@ -153,7 +161,7 @@ jobs:
           --junitxml=pytest-results-${{ matrix.python-version }}.xml
       - name: Upload pytest report
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: pytest-results-${{ matrix.python-version }}
           path: pytest-results-${{ matrix.python-version }}.xml
@@ -166,8 +174,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
       - name: Build and validate wheel and source distribution
@@ -175,7 +185,7 @@ jobs:
           python -m pip install build twine
           python -m build
           python -m twine check dist/*
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: python-distributions
           path: dist/
@@ -192,11 +202,11 @@ jobs:
       matrix:
         kind: [wheel, sdist]
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: python-distributions
           path: dist
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
       - name: Install isolated artifact
@@ -220,6 +230,7 @@ jobs:
           import prob4d.provider_v1 as provider_v1
           import prob4d.provider_v2 as provider_v2
           from prob4d.composition_jacobian import current_composition_jacobian_mode
+          from prob4d.project_identity import prob4d_project_identity
 
           print(prob4d.__version__)
           assert prob4d.__version__ == "0.3.0"
@@ -229,12 +240,14 @@ jobs:
           assert callable(provider_v2.load_claim_bearing_observation_belief)
           assert resources.files("prob4d").joinpath("py.typed").is_file()
           assert current_composition_jacobian_mode() == "legacy_finite_difference"
+          assert prob4d_project_identity()["canonical_repository"] == "IPS-Stuttgart/Prob4D"
           PY
       - name: Exercise grouped and legacy command help
         shell: bash
         run: |
           bin="$RUNNER_TEMP/prob4d-artifact-smoke/bin"
           "$bin/prob4d" --help
+          "$bin/prob4d" project identity --help
           "$bin/prob4d" provider manifest --help
           "$bin/prob4d" provider manifest --api-version 2 --help
           "$bin/prob4d" evaluate provider --help

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -40,6 +40,24 @@ validated before claim-bearing calibration compatibility is accepted. See
 The deliberately ambiguous grouped command fails closed. Historical scripts may
 continue using the unchanged standalone provider-v1 executable.
 
+## Repository transfer identity
+
+The canonical repository is `IPS-Stuttgart/Prob4D`, but frozen artifacts may
+correctly retain `FlorianPfaff/Prob4D`. Repository owner/name strings must not be
+rewritten inside content-addressed provider or observation artifacts.
+
+Use:
+
+```bash
+prob4d project identity --compact
+```
+
+for the additive stable project descriptor. New orchestration metadata should
+bind `github-repository-id:1295794737` as the durable project identity and record
+the canonical repository separately for navigation. Existing provider-v1,
+causal-stream, and provider-v2 artifact schemas retain their exact historical
+repository semantics. See [repository identity](repository-identity.md).
+
 ## Companion projects
 
 At the time Prob4D 0.3.0 was prepared, the companion package versions on their
@@ -65,6 +83,8 @@ manifests, artifacts, and protocol identifiers.
   content-addressed calibration artifacts.
 - A changed stochastic seed derivation requires a new MotionCrafter model
   identifier schema and regenerated calibration artifacts.
+- A repository transfer alone does not permit rewriting a frozen artifact's
+  source-repository field.
 
 Passing compatibility tests is infrastructure evidence. It does not establish
 accuracy, calibration, transfer, intervention benefit, or safety.

--- a/docs/repository-identity.md
+++ b/docs/repository-identity.md
@@ -1,0 +1,49 @@
+# Repository identity and transfer compatibility
+
+The canonical Prob4D repository is now `IPS-Stuttgart/Prob4D`. GitHub repository
+names are mutable display coordinates: a repository may be transferred without
+changing the project or its commit history. New integrations should therefore use
+Prob4D's stable project identity rather than treating the current owner/name pair
+as the sole identity.
+
+Print the machine-readable descriptor with:
+
+```bash
+prob4d project identity --compact
+```
+
+The descriptor currently contains:
+
+- stable project ID `github-repository-id:1295794737`;
+- canonical repository `IPS-Stuttgart/Prob4D`;
+- historical alias `FlorianPfaff/Prob4D`; and
+- the repository string retained by frozen observation artifacts.
+
+## Frozen artifact boundary
+
+Provider-v1 artifacts, causal-stream-v1/v2 artifacts, conformance vectors, and
+historical provider-v2 attestations may contain
+`source_repository = "FlorianPfaff/Prob4D"`. That field is part of their frozen
+content-addressed semantics. It must not be rewritten merely because the GitHub
+repository was transferred.
+
+The stable project-identity API is additive. It does not change any existing
+artifact schema, provider manifest, artifact ID, calibration ID, or causal source
+digest. Consumers can accept both current and historical repository aliases for
+repository discovery while continuing to validate the exact legacy string when a
+frozen schema requires it.
+
+## Consumer migration rule
+
+For new, non-frozen orchestration metadata:
+
+1. bind `project_id` as the durable identity;
+2. record the canonical repository for human navigation;
+3. retain the exact repository string already embedded in frozen artifacts;
+4. never rewrite old content-addressed artifacts to normalize a repository name;
+5. update cross-repository fixtures before making a future schema require the
+   stable project ID.
+
+The Python helpers `canonical_prob4d_repository`, `is_prob4d_repository`, and
+`validate_prob4d_project_identity` provide the same rules to programmatic
+consumers.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,9 @@ authors = [{name = "Florian Pfaff"}]
 dependencies = ["numpy>=1.24"]
 
 [project.urls]
-Repository = "https://github.com/FlorianPfaff/Prob4D"
-Documentation = "https://github.com/FlorianPfaff/Prob4D/tree/main/docs"
-Issues = "https://github.com/FlorianPfaff/Prob4D/issues"
+Repository = "https://github.com/IPS-Stuttgart/Prob4D"
+Documentation = "https://github.com/IPS-Stuttgart/Prob4D/tree/main/docs"
+Issues = "https://github.com/IPS-Stuttgart/Prob4D/issues"
 Project-Notes = "https://github.com/FlorianPfaff/BayesianPhysTwin-Paper"
 
 [project.optional-dependencies]

--- a/src/prob4d/__init__.py
+++ b/src/prob4d/__init__.py
@@ -73,6 +73,17 @@ from .observation_factors import (
     write_observation_factor_bundle,
 )
 from .observation_validation import load_observation_belief_export
+from .project_identity import (
+    PROB4D_CANONICAL_REPOSITORY,
+    PROB4D_FROZEN_ARTIFACT_REPOSITORY,
+    PROB4D_GITHUB_REPOSITORY_ID,
+    PROB4D_PROJECT_ID,
+    PROB4D_REPOSITORY_ALIASES,
+    canonical_prob4d_repository,
+    is_prob4d_repository,
+    prob4d_project_identity,
+    validate_prob4d_project_identity,
+)
 from .sim3 import Sim3
 from .source_reliability import (
     SOURCE_RELIABILITY_SCHEMA,
@@ -101,6 +112,11 @@ __all__ = [
     "OBSERVATION_FACTOR_STREAM_VERSION",
     "POINT_UNCERTAINTY_CALIBRATION_SCHEMA",
     "POINT_UNCERTAINTY_CALIBRATION_VERSION",
+    "PROB4D_CANONICAL_REPOSITORY",
+    "PROB4D_FROZEN_ARTIFACT_REPOSITORY",
+    "PROB4D_GITHUB_REPOSITORY_ID",
+    "PROB4D_PROJECT_ID",
+    "PROB4D_REPOSITORY_ALIASES",
     "SOURCE_RELIABILITY_SCHEMA",
     "SOURCE_RELIABILITY_VERSION",
     "AlignmentCycleAudit",
@@ -135,12 +151,14 @@ __all__ = [
     "build_causal_scene_flow_tracklets",
     "build_prob4d_observation_belief",
     "build_source_reliability_features",
+    "canonical_prob4d_repository",
     "deterministic_covariance_root",
     "estimate_joint_gauge_tree",
     "evaluate_sequence_modes",
     "fit_group_balanced_point_uncertainty_calibration",
     "fit_group_balanced_source_reliability",
     "group_balanced_point_calibration_metadata",
+    "is_prob4d_repository",
     "load_gauge_covariance_calibration",
     "load_metric_gauge_anchor",
     "load_observation_belief_export",
@@ -148,6 +166,7 @@ __all__ = [
     "load_observation_factor_stream",
     "load_point_uncertainty_calibration",
     "load_source_reliability_model",
+    "prob4d_project_identity",
     "save_gauge_covariance_calibration",
     "save_metric_gauge_anchor",
     "save_observation_belief_export",
@@ -155,6 +174,7 @@ __all__ = [
     "save_source_reliability_model",
     "stack_observation_factors",
     "tracklets_to_observation_factors",
+    "validate_prob4d_project_identity",
     "write_observation_factor_bundle",
     "write_observation_factor_stream",
 ]

--- a/src/prob4d/cli.py
+++ b/src/prob4d/cli.py
@@ -49,6 +49,11 @@ _ROUTES: Final[dict[Route, tuple[str, str, str]]] = {
         "main_exploratory",
         "export an explicitly exploratory provider-v2 observation belief",
     ),
+    ("project", "identity"): (
+        "prob4d.project_identity",
+        "main",
+        "print the stable project ID and repository aliases",
+    ),
     ("provider", "manifest"): (
         "prob4d.provider_manifest_cli",
         "main",

--- a/src/prob4d/project_identity.py
+++ b/src/prob4d/project_identity.py
@@ -1,0 +1,143 @@
+"""Transfer-resistant identity for the Prob4D project.
+
+Historical observation artifacts deliberately retain the repository name that was
+current when their schemas were frozen.  Repository display names are therefore
+not suitable as the long-lived identity of the project.  This module publishes a
+stable GitHub repository ID, the current canonical name, and the accepted
+historical aliases without changing any frozen provider-v1 or causal-stream
+payload.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any, Final
+
+PROB4D_PROJECT_IDENTITY_SCHEMA: Final = "prob4d.project-identity"
+PROB4D_PROJECT_IDENTITY_VERSION: Final = 1
+PROB4D_GITHUB_REPOSITORY_ID: Final = 1_295_794_737
+PROB4D_PROJECT_ID: Final = f"github-repository-id:{PROB4D_GITHUB_REPOSITORY_ID}"
+PROB4D_CANONICAL_REPOSITORY: Final = "IPS-Stuttgart/Prob4D"
+PROB4D_FROZEN_ARTIFACT_REPOSITORY: Final = "FlorianPfaff/Prob4D"
+PROB4D_REPOSITORY_ALIASES: Final[tuple[str, ...]] = (
+    PROB4D_CANONICAL_REPOSITORY,
+    PROB4D_FROZEN_ARTIFACT_REPOSITORY,
+)
+
+_IDENTITY_FIELDS: Final = frozenset(
+    {
+        "schema_name",
+        "schema_version",
+        "project_id",
+        "github_repository_id",
+        "canonical_repository",
+        "frozen_artifact_repository",
+        "accepted_repository_aliases",
+    }
+)
+
+
+def canonical_prob4d_repository(value: object) -> str:
+    """Return the canonical repository name for a recognized Prob4D alias.
+
+    GitHub repository names are case-insensitive.  Whitespace and unrelated
+    repositories fail closed instead of being silently normalized.
+    """
+
+    repository = str(value).strip()
+    for alias in PROB4D_REPOSITORY_ALIASES:
+        if repository.casefold() == alias.casefold():
+            return PROB4D_CANONICAL_REPOSITORY
+    raise ValueError(f"unrecognized Prob4D repository identity: {repository!r}")
+
+
+def is_prob4d_repository(value: object) -> bool:
+    """Return whether *value* is a recognized current or historical alias."""
+
+    try:
+        canonical_prob4d_repository(value)
+    except ValueError:
+        return False
+    return True
+
+
+def prob4d_project_identity() -> dict[str, object]:
+    """Return the machine-readable stable project identity descriptor."""
+
+    return {
+        "schema_name": PROB4D_PROJECT_IDENTITY_SCHEMA,
+        "schema_version": PROB4D_PROJECT_IDENTITY_VERSION,
+        "project_id": PROB4D_PROJECT_ID,
+        "github_repository_id": PROB4D_GITHUB_REPOSITORY_ID,
+        "canonical_repository": PROB4D_CANONICAL_REPOSITORY,
+        "frozen_artifact_repository": PROB4D_FROZEN_ARTIFACT_REPOSITORY,
+        "accepted_repository_aliases": list(PROB4D_REPOSITORY_ALIASES),
+    }
+
+
+def validate_prob4d_project_identity(value: Mapping[str, Any]) -> dict[str, object]:
+    """Validate and normalize a project-identity descriptor."""
+
+    fields = set(value)
+    if fields != _IDENTITY_FIELDS:
+        missing = sorted(_IDENTITY_FIELDS - fields)
+        extra = sorted(fields - _IDENTITY_FIELDS)
+        raise ValueError(
+            "Prob4D project-identity fields changed; "
+            f"missing={missing}, extra={extra}"
+        )
+    normalized = dict(value)
+    expected = prob4d_project_identity()
+    if normalized != expected:
+        raise ValueError("Prob4D project-identity descriptor does not match this project")
+    return expected
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Print the transfer-resistant identity as JSON."""
+
+    parser = argparse.ArgumentParser(
+        prog="prob4d project identity",
+        description=(
+            "Print Prob4D's stable project ID, canonical repository, and frozen "
+            "artifact alias."
+        ),
+    )
+    parser.add_argument(
+        "--compact",
+        action="store_true",
+        help="emit canonical compact JSON instead of indented JSON",
+    )
+    arguments = parser.parse_args(list(argv) if argv is not None else None)
+    separators = (",", ":") if arguments.compact else None
+    print(
+        json.dumps(
+            prob4d_project_identity(),
+            sort_keys=True,
+            indent=None if arguments.compact else 2,
+            separators=separators,
+            allow_nan=False,
+        )
+    )
+    return 0
+
+
+__all__ = [
+    "PROB4D_CANONICAL_REPOSITORY",
+    "PROB4D_FROZEN_ARTIFACT_REPOSITORY",
+    "PROB4D_GITHUB_REPOSITORY_ID",
+    "PROB4D_PROJECT_ID",
+    "PROB4D_PROJECT_IDENTITY_SCHEMA",
+    "PROB4D_PROJECT_IDENTITY_VERSION",
+    "PROB4D_REPOSITORY_ALIASES",
+    "canonical_prob4d_repository",
+    "is_prob4d_repository",
+    "prob4d_project_identity",
+    "validate_prob4d_project_identity",
+]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_github_action_pins.py
+++ b/tests/test_github_action_pins.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_ROOT = ROOT / ".github" / "workflows"
+_USES_LINE = re.compile(
+    r"^\s*(?:-\s*)?uses:\s*(?P<value>[^#\s]+)\s*(?:#\s*(?P<comment>.+))?$"
+)
+_FULL_COMMIT = re.compile(r"^[0-9a-f]{40}$")
+_VERSION_COMMENT = re.compile(r"^v[0-9]+(?:\.[0-9]+){0,2}(?:[-+][A-Za-z0-9.-]+)?$")
+
+
+def _pin_errors(text: str, *, source: str) -> list[str]:
+    errors: list[str] = []
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        match = _USES_LINE.match(line)
+        if match is None:
+            continue
+        value = match.group("value").strip("\"'")
+        if value.startswith(("./", "docker://")):
+            continue
+        if "@" not in value:
+            errors.append(
+                f"{source}:{line_number}: external action has no ref: {value}"
+            )
+            continue
+        action, ref = value.rsplit("@", 1)
+        if "/" not in action or not _FULL_COMMIT.fullmatch(ref):
+            errors.append(
+                f"{source}:{line_number}: external action must use a full "
+                f"lowercase commit SHA: {value}"
+            )
+        comment = (match.group("comment") or "").strip().split(maxsplit=1)[0:1]
+        if not comment or _VERSION_COMMENT.fullmatch(comment[0]) is None:
+            errors.append(
+                f"{source}:{line_number}: immutable action pin needs a version "
+                f"annotation such as '# v7': {value}"
+            )
+    return errors
+
+
+def test_every_external_github_action_is_immutably_pinned() -> None:
+    workflow_files = sorted(WORKFLOW_ROOT.glob("*.yml")) + sorted(
+        WORKFLOW_ROOT.glob("*.yaml")
+    )
+    assert workflow_files, "no GitHub Actions workflows found"
+
+    errors: list[str] = []
+    for path in workflow_files:
+        errors.extend(
+            _pin_errors(
+                path.read_text(encoding="utf-8"),
+                source=path.relative_to(ROOT).as_posix(),
+            )
+        )
+    assert not errors, "\n".join(errors)
+
+
+def test_pin_policy_rejects_tags_branches_and_short_shas() -> None:
+    text = "\n".join(
+        (
+            "- uses: actions/checkout@v7",
+            "- uses: owner/action@main",
+            "- uses: owner/action@0123456789abcdef # v1",
+        )
+    )
+    errors = _pin_errors(text, source="fixture.yml")
+
+    assert len(errors) == 5
+    assert all("fixture.yml" in error for error in errors)
+
+
+def test_pin_policy_allows_local_docker_and_annotated_commit_uses() -> None:
+    pinned = "0123456789abcdef0123456789abcdef01234567"
+    text = "\n".join(
+        (
+            "- uses: ./local-action",
+            "- uses: docker://python:3.12",
+            f"- uses: owner/action@{pinned} # v1.2.3",
+        )
+    )
+
+    assert _pin_errors(text, source="fixture.yml") == []

--- a/tests/test_project_identity.py
+++ b/tests/test_project_identity.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from prob4d.cli import main as cli_main
+from prob4d.project_identity import (
+    PROB4D_CANONICAL_REPOSITORY,
+    PROB4D_FROZEN_ARTIFACT_REPOSITORY,
+    PROB4D_GITHUB_REPOSITORY_ID,
+    PROB4D_PROJECT_ID,
+    canonical_prob4d_repository,
+    is_prob4d_repository,
+    main,
+    prob4d_project_identity,
+    validate_prob4d_project_identity,
+)
+
+
+def test_project_identity_is_transfer_resistant_and_preserves_frozen_alias() -> None:
+    descriptor = prob4d_project_identity()
+
+    assert descriptor["project_id"] == PROB4D_PROJECT_ID
+    assert descriptor["github_repository_id"] == PROB4D_GITHUB_REPOSITORY_ID
+    assert descriptor["canonical_repository"] == PROB4D_CANONICAL_REPOSITORY
+    assert (
+        descriptor["frozen_artifact_repository"]
+        == PROB4D_FROZEN_ARTIFACT_REPOSITORY
+    )
+    assert descriptor["accepted_repository_aliases"] == [
+        PROB4D_CANONICAL_REPOSITORY,
+        PROB4D_FROZEN_ARTIFACT_REPOSITORY,
+    ]
+    assert validate_prob4d_project_identity(descriptor) == descriptor
+
+
+def test_current_and_historical_repository_names_resolve_to_canonical() -> None:
+    assert (
+        canonical_prob4d_repository("ips-stuttgart/prob4d")
+        == PROB4D_CANONICAL_REPOSITORY
+    )
+    assert (
+        canonical_prob4d_repository("FlorianPfaff/Prob4D")
+        == PROB4D_CANONICAL_REPOSITORY
+    )
+    assert is_prob4d_repository(PROB4D_CANONICAL_REPOSITORY)
+    assert is_prob4d_repository(PROB4D_FROZEN_ARTIFACT_REPOSITORY)
+    assert not is_prob4d_repository("other/Prob4D")
+    with pytest.raises(ValueError, match="unrecognized Prob4D repository"):
+        canonical_prob4d_repository("other/Prob4D")
+
+
+def test_project_identity_rejects_modified_descriptors() -> None:
+    descriptor = prob4d_project_identity()
+    descriptor["canonical_repository"] = "other/Prob4D"
+    with pytest.raises(ValueError, match="does not match"):
+        validate_prob4d_project_identity(descriptor)
+
+
+def test_project_identity_cli_emits_valid_json(capsys) -> None:
+    assert main(["--compact"]) == 0
+    assert json.loads(capsys.readouterr().out) == prob4d_project_identity()
+
+
+def test_grouped_cli_exposes_project_identity(capsys) -> None:
+    assert cli_main(["project", "identity", "--compact"]) == 0
+    assert json.loads(capsys.readouterr().out) == prob4d_project_identity()


### PR DESCRIPTION
## What changed

- add a stable, transfer-resistant Prob4D project identity based on the GitHub repository ID;
- expose it through `prob4d project identity` and the public Python API;
- preserve `FlorianPfaff/Prob4D` explicitly as the frozen artifact repository alias rather than rewriting historical content-addressed artifacts;
- point package metadata to the canonical `IPS-Stuttgart/Prob4D` repository;
- document repository-transfer and consumer migration rules;
- pin every external GitHub Action to a reviewed immutable commit SHA, disable persisted checkout credentials, and add a regression test that rejects tags, branches, and short SHAs;
- include the project-identity descriptor in CI artifacts and installed-wheel/sdist smoke tests.

## Why

The repository transfer made human-facing owner/name metadata stale, while frozen provider and observation contracts intentionally retain the historical repository string. This patch separates durable project identity from mutable repository navigation without changing any frozen provider-v1, causal-stream, calibration, or observation artifact semantics.

Pinning Actions removes mutable third-party workflow references and makes the supply-chain policy executable rather than documentary.

## Validation

The pull request runs Ruff, mypy on the new stable module, the complete Python 3.10/3.12/3.14 suite, provider/runtime checks, distribution builds, isolated wheel/sdist installs, grouped CLI smoke tests, and the immutable-action-pin policy.

## Claim boundary

This is repository and CI infrastructure. It does not change the estimator, calibration, provider artifact schemas, BayesianPhysTwin behavior, or any scientific claim.