### PR TITLE
Add source-only diagnostics for common-mode observation failures

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,6 +68,7 @@ jobs:
           src/prob4d/provider_v2_cli.py
           src/prob4d/provider_v2_loading.py
           src/prob4d/runtime_revision.py
+          src/prob4d/source_diagnostics.py
           2>&1 | tee mypy-output.txt
       - name: Upload mypy diagnostics
         if: steps.mypy.outcome == 'failure'
@@ -148,6 +149,7 @@ jobs:
           import prob4d.provider_v2_cli
           import prob4d.provider_v2_loading
           import prob4d.runtime_revision
+          import prob4d.source_diagnostics
 
           forbidden = {"torch", "diffusers", "decord"}
           loaded = sorted(forbidden & set(sys.modules))

--- a/docs/source-only-diagnostics.md
+++ b/docs/source-only-diagnostics.md
@@ -1,0 +1,69 @@
+# Source-only diagnostics for common-mode failures
+
+Overlap disagreement is useful when independently decoded windows disagree, but
+it cannot by itself identify a visual backbone that is consistently wrong in all
+windows. Prob4D therefore provides opt-in source-side diagnostics that can augment
+reliability features without reading Bayesian-PhysTwin innovations or target
+truth.
+
+## Flow/geometry consistency
+
+`build_flow_point_consistency_diagnostic` compares the decoded displacement
+
+```text
+point_map[t + 1] - point_map[t]
+```
+
+with `scene_flow[t]` wherever both frames and the deforming-flow row are valid.
+It exports an availability indicator, a scale-free relative residual, and a
+bounded direction disagreement. The function records the assumed one-step flow
+semantics in metadata; producers with a different flow convention must not reuse
+it silently.
+
+## Independent-seed dispersion
+
+`build_common_gauge_seed_dispersion_diagnostic` estimates empirical point
+spread across two or more independently seeded predictions. Inputs must already
+share exactly the same frame grid and an explicitly named common gauge. The
+diagnostic does not perform alignment itself, because target-informed or
+sample-specific alignment would change the interpretation of dispersion.
+
+The metadata binds the common-gauge identity, immutable model-set identity,
+window IDs, frame IDs, and the fact that no alignment was performed inside the
+diagnostic.
+
+## Reliability augmentation
+
+Use `augment_source_reliability_features` to append one or more diagnostic grids
+to an existing `SourceReliabilityFeatures` object. It preserves the base valid-row
+set and rejects feature-name or grid mismatches. Every diagnostic must explicitly
+declare:
+
+```text
+uses_truth = false
+uses_downstream_physical_innovation = false
+uses_association_probability = false
+```
+
+Changing the feature set requires a newly fitted, content-addressed source
+reliability calibration. Existing calibration artifacts remain unchanged.
+
+## Common-mode evaluation audit
+
+`audit_common_mode_failures` partitions opened evaluation rows into four cells:
+
+| Disagreement | Error | Interpretation |
+| --- | --- | --- |
+| low | low | nominal agreement |
+| high | low | conservative or benign disagreement |
+| low | high | common-mode failure candidate |
+| high | high | detected failure |
+
+The disagreement and error thresholds are explicit inputs and should be frozen
+from development or calibration units. The low-disagreement/high-error rate and
+severity are evaluation outputs only; they must not be used to refit reliability
+on the same target outcomes.
+
+These diagnostics do not establish that Prob4D observations improve a physical
+twin. Provider competence, BayesianPhysTwin acceptance, harmful accepted updates,
+and future physical prediction remain separate prospective gates.

--- a/src/prob4d/__init__.py
+++ b/src/prob4d/__init__.py
@@ -85,6 +85,14 @@ from .project_identity import (
     validate_prob4d_project_identity,
 )
 from .sim3 import Sim3
+from .source_diagnostics import (
+    CommonModeFailureAudit,
+    SourceOnlyDiagnosticGrid,
+    audit_common_mode_failures,
+    augment_source_reliability_features,
+    build_common_gauge_seed_dispersion_diagnostic,
+    build_flow_point_consistency_diagnostic,
+)
 from .source_reliability import (
     SOURCE_RELIABILITY_SCHEMA,
     SOURCE_RELIABILITY_VERSION,
@@ -123,6 +131,7 @@ __all__ = [
     "AlignmentCycleResidual",
     "CausalTrackletReport",
     "CausalTrackletSet",
+    "CommonModeFailureAudit",
     "CrossFittedDisagreementReport",
     "EvaluationModeResult",
     "EvaluationModes",
@@ -140,6 +149,7 @@ __all__ = [
     "PointUncertaintyCalibrationV1",
     "PredictionWindow",
     "Sim3",
+    "SourceOnlyDiagnosticGrid",
     "SourceReliabilityCalibrationReport",
     "SourceReliabilityFeatures",
     "SourceReliabilityModelV1",
@@ -148,7 +158,11 @@ __all__ = [
     "alignment_edge_id",
     "append_observation_factor_bundle",
     "audit_alignment_cycles",
+    "audit_common_mode_failures",
+    "augment_source_reliability_features",
     "build_causal_scene_flow_tracklets",
+    "build_common_gauge_seed_dispersion_diagnostic",
+    "build_flow_point_consistency_diagnostic",
     "build_prob4d_observation_belief",
     "build_source_reliability_features",
     "canonical_prob4d_repository",

--- a/src/prob4d/source_diagnostics.py
+++ b/src/prob4d/source_diagnostics.py
@@ -1,0 +1,454 @@
+"""Source-side diagnostics for common-mode observation failures.
+
+Overlap disagreement detects mutually inconsistent windows, but a shared visual
+backbone can be confidently wrong in every window.  This module adds diagnostics
+that remain independent of Bayesian-PhysTwin innovations and target labels:
+
+- one-step consistency between decoded point motion and predicted scene flow;
+- empirical dispersion across independently seeded predictions in an explicitly
+  common gauge; and
+- an evaluation-only quadrant audit that reports low-disagreement/high-error
+  failures without feeding target truth back into reliability calibration.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ._immutable_json import frozen_finite_json_mapping, plain_json
+from .data import PredictionWindow
+from .source_reliability import SourceReliabilityFeatures
+
+FloatArray = NDArray[np.floating]
+BoolArray = NDArray[np.bool_]
+
+
+def _readonly(value: np.ndarray, *, dtype: Any) -> np.ndarray:
+    result = np.asarray(value, dtype=dtype).copy()
+    result.setflags(write=False)
+    return result
+
+
+@dataclass(frozen=True)
+class SourceOnlyDiagnosticGrid:
+    """Finite source-only diagnostic features on one prediction grid."""
+
+    feature_names: tuple[str, ...]
+    values: FloatArray
+    available_mask: BoolArray
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        names = tuple(str(value).strip() for value in self.feature_names)
+        if not names or any(not value for value in names):
+            raise ValueError("diagnostic feature_names must be non-empty")
+        if len(set(names)) != len(names):
+            raise ValueError("diagnostic feature_names must be unique")
+        values = np.asarray(self.values, dtype=np.float64)
+        available = np.asarray(self.available_mask, dtype=bool)
+        if values.ndim < 2 or values.shape[-1] != len(names):
+            raise ValueError("diagnostic values must have shape (..., feature_count)")
+        if available.shape != values.shape[:-1]:
+            raise ValueError("diagnostic available_mask must match the feature grid")
+        if not np.all(np.isfinite(values)):
+            raise ValueError("source-only diagnostic values must be finite")
+
+        normalized_metadata = frozen_finite_json_mapping(
+            self.metadata,
+            name="source-only diagnostic metadata",
+        )
+        required_false = (
+            "uses_truth",
+            "uses_downstream_physical_innovation",
+            "uses_association_probability",
+        )
+        for name in required_false:
+            if normalized_metadata.get(name) is not False:
+                raise ValueError(f"source-only diagnostic metadata must declare {name}=false")
+
+        masked_values = np.where(available[..., None], values, 0.0)
+        object.__setattr__(self, "feature_names", names)
+        object.__setattr__(self, "values", _readonly(masked_values, dtype=np.float64))
+        object.__setattr__(self, "available_mask", _readonly(available, dtype=bool))
+        object.__setattr__(self, "metadata", normalized_metadata)
+
+    @property
+    def grid_shape(self) -> tuple[int, ...]:
+        return self.available_mask.shape
+
+    @property
+    def available_count(self) -> int:
+        return int(np.count_nonzero(self.available_mask))
+
+    def summary(self) -> dict[str, object]:
+        return {
+            "feature_names": list(self.feature_names),
+            "grid_shape": list(self.grid_shape),
+            "available_count": self.available_count,
+            "metadata": plain_json(self.metadata),
+        }
+
+
+def augment_source_reliability_features(
+    base: SourceReliabilityFeatures,
+    diagnostics: Sequence[SourceOnlyDiagnosticGrid],
+) -> SourceReliabilityFeatures:
+    """Append source-only diagnostics without changing the base valid-row set."""
+
+    diagnostic_list = list(diagnostics)
+    if not diagnostic_list:
+        raise ValueError("at least one source-only diagnostic is required")
+
+    names = list(base.feature_names)
+    arrays = [np.asarray(base.values, dtype=np.float64)]
+    summaries: list[dict[str, object]] = []
+    for diagnostic in diagnostic_list:
+        if diagnostic.grid_shape != base.valid_mask.shape:
+            raise ValueError("source-only diagnostic grid differs from base features")
+        duplicates = sorted(set(names) & set(diagnostic.feature_names))
+        if duplicates:
+            raise ValueError(f"source-only diagnostic feature names collide: {duplicates}")
+        names.extend(diagnostic.feature_names)
+        arrays.append(np.asarray(diagnostic.values, dtype=np.float64))
+        summaries.append(diagnostic.summary())
+
+    metadata = plain_json(base.metadata)
+    metadata.update(
+        {
+            "semantics": "prob4d-source-only-reliability-features-augmented-v1",
+            "uses_truth": False,
+            "uses_downstream_physical_innovation": False,
+            "uses_association_probability": False,
+            "source_only_diagnostics": summaries,
+        }
+    )
+    return SourceReliabilityFeatures(
+        feature_names=tuple(names),
+        values=np.concatenate(arrays, axis=-1),
+        valid_mask=base.valid_mask,
+        metadata=metadata,
+    )
+
+
+def build_flow_point_consistency_diagnostic(
+    window: PredictionWindow,
+) -> SourceOnlyDiagnosticGrid:
+    """Compare one-step decoded point displacement with predicted scene flow.
+
+    The diagnostic assumes that ``scene_flow[t]`` predicts motion from local frame
+    ``t`` to local frame ``t + 1``.  It is opt-in and records this assumption in
+    metadata so a producer with different flow semantics cannot silently reuse it.
+    """
+
+    shape = window.shape
+    available = np.zeros(shape, dtype=bool)
+    relative_residual = np.zeros(shape, dtype=np.float64)
+    direction_disagreement = np.zeros(shape, dtype=np.float64)
+
+    if (
+        window.scene_flow is not None
+        and window.deform_mask is not None
+        and shape[0] > 1
+    ):
+        current = np.asarray(window.point_map[:-1], dtype=np.float64)
+        following = np.asarray(window.point_map[1:], dtype=np.float64)
+        flow = np.asarray(window.scene_flow[:-1], dtype=np.float64)
+        active = (
+            np.asarray(window.valid_mask[:-1], dtype=bool)
+            & np.asarray(window.valid_mask[1:], dtype=bool)
+            & np.asarray(window.deform_mask[:-1], dtype=bool)
+        )
+        displacement = following - current
+        residual_norm = np.linalg.norm(displacement - flow, axis=-1)
+        displacement_norm = np.linalg.norm(displacement, axis=-1)
+        flow_norm = np.linalg.norm(flow, axis=-1)
+        scale = displacement_norm + flow_norm
+        epsilon = np.finfo(np.float64).eps
+        local_relative = np.divide(
+            residual_norm,
+            scale,
+            out=np.zeros_like(residual_norm),
+            where=scale > epsilon,
+        )
+        both_nonzero = (displacement_norm > epsilon) & (flow_norm > epsilon)
+        cosine = np.divide(
+            np.einsum("...i,...i->...", displacement, flow),
+            displacement_norm * flow_norm,
+            out=np.ones_like(displacement_norm),
+            where=both_nonzero,
+        )
+        local_direction = np.where(
+            both_nonzero,
+            0.5 * (1.0 - np.clip(cosine, -1.0, 1.0)),
+            0.0,
+        )
+        available[:-1] = active
+        relative_residual[:-1] = np.where(active, local_relative, 0.0)
+        direction_disagreement[:-1] = np.where(active, local_direction, 0.0)
+
+    values = np.stack(
+        (
+            available.astype(np.float64),
+            np.log1p(relative_residual),
+            direction_disagreement,
+        ),
+        axis=-1,
+    )
+    return SourceOnlyDiagnosticGrid(
+        feature_names=(
+            "has_flow_point_consistency",
+            "log1p_relative_flow_point_residual",
+            "flow_point_direction_disagreement",
+        ),
+        values=values,
+        available_mask=available,
+        metadata={
+            "semantics": "prob4d-flow-point-consistency-v1",
+            "flow_semantics": "scene_flow[t] predicts point_map[t+1] - point_map[t]",
+            "uses_truth": False,
+            "uses_downstream_physical_innovation": False,
+            "uses_association_probability": False,
+            "window_id": window.window_id,
+            "frame_indices": [int(value) for value in window.frame_indices],
+            "scene_flow_available": window.scene_flow is not None,
+        },
+    )
+
+
+def build_common_gauge_seed_dispersion_diagnostic(
+    windows: Sequence[PredictionWindow],
+    *,
+    common_gauge_id: str,
+    model_set_id: str,
+) -> SourceOnlyDiagnosticGrid:
+    """Measure empirical point dispersion across independently seeded predictions.
+
+    Every input must already be represented in the same declared gauge.  The
+    function deliberately does not align samples itself because target-informed or
+    differently fitted gauges would change the meaning of empirical dispersion.
+    """
+
+    samples = list(windows)
+    if len(samples) < 2:
+        raise ValueError("seed dispersion requires at least two prediction windows")
+    gauge_id = str(common_gauge_id).strip()
+    model_identity = str(model_set_id).strip()
+    if not gauge_id or not model_identity:
+        raise ValueError("common_gauge_id and model_set_id must be non-empty")
+    window_ids = [window.window_id for window in samples]
+    if len(set(window_ids)) != len(window_ids):
+        raise ValueError("seed-dispersion window IDs must be unique")
+
+    reference = samples[0]
+    for window in samples[1:]:
+        if window.shape != reference.shape:
+            raise ValueError("seed-dispersion prediction grids differ")
+        if not np.array_equal(window.frame_indices, reference.frame_indices):
+            raise ValueError("seed-dispersion frame indices differ")
+
+    count = np.zeros(reference.shape, dtype=np.int64)
+    point_sum = np.zeros(reference.shape + (3,), dtype=np.float64)
+    squared_norm_sum = np.zeros(reference.shape, dtype=np.float64)
+    for window in samples:
+        mask = np.asarray(window.valid_mask, dtype=bool)
+        points = np.asarray(window.point_map, dtype=np.float64)
+        count[mask] += 1
+        point_sum[mask] += points[mask]
+        squared_norm_sum[mask] += np.einsum(
+            "...i,...i->...",
+            points[mask],
+            points[mask],
+        )
+
+    available = count >= 2
+    safe_count = np.maximum(count, 1)
+    mean = point_sum / safe_count[..., None]
+    second_moment = squared_norm_sum / safe_count
+    variance_trace = np.maximum(
+        second_moment - np.einsum("...i,...i->...", mean, mean),
+        0.0,
+    )
+    dispersion = np.sqrt(variance_trace)
+    mean_radius = np.linalg.norm(mean, axis=-1)
+    positive_radius = mean_radius[available & (mean_radius > 0.0)]
+    radius_scale = float(np.median(positive_radius)) if positive_radius.size else 1.0
+    denominator = np.maximum(mean_radius, max(radius_scale, 1.0) * 1e-9)
+    relative_dispersion = np.where(available, dispersion / denominator, 0.0)
+    contributor_fraction = np.where(
+        available,
+        count / float(len(samples)),
+        0.0,
+    )
+
+    values = np.stack(
+        (
+            available.astype(np.float64),
+            contributor_fraction,
+            np.log1p(relative_dispersion),
+        ),
+        axis=-1,
+    )
+    return SourceOnlyDiagnosticGrid(
+        feature_names=(
+            "has_independent_seed_dispersion",
+            "independent_seed_contributor_fraction",
+            "log1p_relative_independent_seed_dispersion",
+        ),
+        values=values,
+        available_mask=available,
+        metadata={
+            "semantics": "prob4d-common-gauge-seed-dispersion-v1",
+            "uses_truth": False,
+            "uses_downstream_physical_innovation": False,
+            "uses_association_probability": False,
+            "common_gauge_id": gauge_id,
+            "model_set_id": model_identity,
+            "seed_count": len(samples),
+            "window_ids": window_ids,
+            "frame_indices": [int(value) for value in reference.frame_indices],
+            "alignment_performed_by_diagnostic": False,
+            "radius_scale": radius_scale,
+        },
+    )
+
+
+@dataclass(frozen=True)
+class CommonModeFailureAudit:
+    """Evaluation-only disagreement/error quadrant accounting."""
+
+    disagreement_threshold: float
+    error_threshold: float
+    valid_count: int
+    low_disagreement_low_error_count: int
+    high_disagreement_low_error_count: int
+    low_disagreement_high_error_count: int
+    high_disagreement_high_error_count: int
+    low_disagreement_high_error_mean: float
+    low_disagreement_high_error_max: float
+
+    def __post_init__(self) -> None:
+        thresholds = np.asarray(
+            [self.disagreement_threshold, self.error_threshold],
+            dtype=np.float64,
+        )
+        if not np.all(np.isfinite(thresholds)) or np.any(thresholds < 0.0):
+            raise ValueError("common-mode audit thresholds must be finite and non-negative")
+        count_names = (
+            "valid_count",
+            "low_disagreement_low_error_count",
+            "high_disagreement_low_error_count",
+            "low_disagreement_high_error_count",
+            "high_disagreement_high_error_count",
+        )
+        for name in count_names:
+            value = getattr(self, name)
+            if isinstance(value, bool) or int(value) != value or value < 0:
+                raise ValueError(f"{name} must be a non-negative integer")
+            object.__setattr__(self, name, int(value))
+        if self.valid_count < 1:
+            raise ValueError("common-mode audit requires at least one valid row")
+        total = sum(getattr(self, name) for name in count_names[1:])
+        if total != self.valid_count:
+            raise ValueError("common-mode quadrant counts do not sum to valid_count")
+        severity = np.asarray(
+            [
+                self.low_disagreement_high_error_mean,
+                self.low_disagreement_high_error_max,
+            ],
+            dtype=np.float64,
+        )
+        if not np.all(np.isfinite(severity)) or np.any(severity < 0.0):
+            raise ValueError("common-mode failure severity must be finite and non-negative")
+
+    @property
+    def low_disagreement_high_error_rate(self) -> float:
+        return self.low_disagreement_high_error_count / self.valid_count
+
+    def to_dict(self) -> dict[str, int | float]:
+        return {
+            **asdict(self),
+            "low_disagreement_high_error_rate": (
+                self.low_disagreement_high_error_rate
+            ),
+        }
+
+
+def audit_common_mode_failures(
+    disagreement_score: FloatArray,
+    error: FloatArray,
+    *,
+    disagreement_threshold: float,
+    error_threshold: float,
+    valid_mask: BoolArray | None = None,
+) -> CommonModeFailureAudit:
+    """Report the low-disagreement/high-error quadrant on opened evaluation data.
+
+    Thresholds are explicit inputs and should be frozen from development or
+    calibration units.  This function is evaluation-only: its result must not be
+    used to refit a source-reliability model on the same target outcomes.
+    """
+
+    disagreement = np.asarray(disagreement_score, dtype=np.float64)
+    errors = np.asarray(error, dtype=np.float64)
+    if disagreement.shape != errors.shape:
+        raise ValueError("common-mode disagreement and error arrays must match")
+    if not np.all(np.isfinite(disagreement)) or np.any(disagreement < 0.0):
+        raise ValueError("common-mode disagreement scores must be finite and non-negative")
+    if not np.all(np.isfinite(errors)) or np.any(errors < 0.0):
+        raise ValueError("common-mode errors must be finite and non-negative")
+    if valid_mask is None:
+        valid = np.ones(disagreement.shape, dtype=bool)
+    else:
+        valid = np.asarray(valid_mask, dtype=bool)
+        if valid.shape != disagreement.shape:
+            raise ValueError("common-mode valid_mask must match the score arrays")
+    if not np.any(valid):
+        raise ValueError("common-mode audit has no valid rows")
+
+    disagreement_limit = float(disagreement_threshold)
+    error_limit = float(error_threshold)
+    if (
+        not np.isfinite(disagreement_limit)
+        or disagreement_limit < 0.0
+        or not np.isfinite(error_limit)
+        or error_limit < 0.0
+    ):
+        raise ValueError("common-mode thresholds must be finite and non-negative")
+
+    high_disagreement = disagreement > disagreement_limit
+    high_error = errors > error_limit
+    low_low = valid & ~high_disagreement & ~high_error
+    high_low = valid & high_disagreement & ~high_error
+    low_high = valid & ~high_disagreement & high_error
+    high_high = valid & high_disagreement & high_error
+    low_high_errors = errors[low_high]
+    return CommonModeFailureAudit(
+        disagreement_threshold=disagreement_limit,
+        error_threshold=error_limit,
+        valid_count=int(np.count_nonzero(valid)),
+        low_disagreement_low_error_count=int(np.count_nonzero(low_low)),
+        high_disagreement_low_error_count=int(np.count_nonzero(high_low)),
+        low_disagreement_high_error_count=int(np.count_nonzero(low_high)),
+        high_disagreement_high_error_count=int(np.count_nonzero(high_high)),
+        low_disagreement_high_error_mean=(
+            float(np.mean(low_high_errors)) if low_high_errors.size else 0.0
+        ),
+        low_disagreement_high_error_max=(
+            float(np.max(low_high_errors)) if low_high_errors.size else 0.0
+        ),
+    )
+
+
+__all__ = [
+    "CommonModeFailureAudit",
+    "SourceOnlyDiagnosticGrid",
+    "audit_common_mode_failures",
+    "augment_source_reliability_features",
+    "build_common_gauge_seed_dispersion_diagnostic",
+    "build_flow_point_consistency_diagnostic",
+]

--- a/tests/test_source_diagnostics.py
+++ b/tests/test_source_diagnostics.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from prob4d.data import PredictionWindow
+from prob4d.source_diagnostics import (
+    audit_common_mode_failures,
+    augment_source_reliability_features,
+    build_common_gauge_seed_dispersion_diagnostic,
+    build_flow_point_consistency_diagnostic,
+)
+from prob4d.source_reliability import SourceReliabilityFeatures
+
+
+def _window(
+    window_id: str,
+    *,
+    offset: float = 0.0,
+    flow_scale: float = 1.0,
+    frame_indices: np.ndarray | None = None,
+) -> PredictionWindow:
+    points = np.zeros((3, 1, 2, 3), dtype=np.float64)
+    for local_index in range(3):
+        points[local_index, ..., 0] = 10.0 + offset + local_index
+    flow = np.zeros_like(points)
+    flow[:-1, ..., 0] = flow_scale
+    valid = np.ones(points.shape[:-1], dtype=bool)
+    deform = np.zeros_like(valid)
+    deform[:-1] = True
+    return PredictionWindow(
+        window_id=window_id,
+        frame_indices=(
+            np.arange(3, dtype=np.int64)
+            if frame_indices is None
+            else frame_indices
+        ),
+        point_map=points,
+        valid_mask=valid,
+        scene_flow=flow,
+        deform_mask=deform,
+    )
+
+
+def test_flow_point_consistency_is_zero_for_matching_one_step_flow() -> None:
+    diagnostic = build_flow_point_consistency_diagnostic(_window("seed-1"))
+
+    assert diagnostic.feature_names == (
+        "has_flow_point_consistency",
+        "log1p_relative_flow_point_residual",
+        "flow_point_direction_disagreement",
+    )
+    assert np.all(diagnostic.available_mask[:-1])
+    assert not np.any(diagnostic.available_mask[-1])
+    assert np.allclose(diagnostic.values[:-1, ..., 1:], 0.0)
+    assert diagnostic.metadata["uses_truth"] is False
+
+
+def test_flow_point_consistency_detects_magnitude_and_direction_mismatch() -> None:
+    diagnostic = build_flow_point_consistency_diagnostic(
+        _window("seed-1", flow_scale=-1.0)
+    )
+
+    assert np.all(diagnostic.values[:-1, ..., 1] > 0.0)
+    assert np.allclose(diagnostic.values[:-1, ..., 2], 1.0)
+
+
+def test_seed_dispersion_requires_common_grid_and_reports_sample_spread() -> None:
+    first = _window("seed-1")
+    identical = _window("seed-2")
+    shifted = _window("seed-3", offset=2.0)
+
+    zero = build_common_gauge_seed_dispersion_diagnostic(
+        [first, identical],
+        common_gauge_id="metric-anchor-a",
+        model_set_id="model-set-a",
+    )
+    spread = build_common_gauge_seed_dispersion_diagnostic(
+        [first, shifted],
+        common_gauge_id="metric-anchor-a",
+        model_set_id="model-set-a",
+    )
+
+    assert np.all(zero.available_mask)
+    assert np.allclose(zero.values[..., 2], 0.0)
+    assert np.all(spread.values[..., 2] > 0.0)
+    assert np.allclose(spread.values[..., 1], 1.0)
+    assert spread.metadata["alignment_performed_by_diagnostic"] is False
+
+
+def test_seed_dispersion_rejects_different_frame_identity() -> None:
+    with pytest.raises(ValueError, match="frame indices differ"):
+        build_common_gauge_seed_dispersion_diagnostic(
+            [
+                _window("seed-1"),
+                _window(
+                    "seed-2",
+                    frame_indices=np.asarray([1, 2, 3], dtype=np.int64),
+                ),
+            ],
+            common_gauge_id="metric-anchor-a",
+            model_set_id="model-set-a",
+        )
+
+
+def test_diagnostics_augment_source_reliability_without_using_target_data() -> None:
+    window = _window("seed-1")
+    base = SourceReliabilityFeatures(
+        feature_names=("base",),
+        values=np.zeros(window.shape + (1,), dtype=np.float64),
+        valid_mask=window.valid_mask,
+        metadata={
+            "uses_truth": False,
+            "uses_downstream_physical_innovation": False,
+            "uses_association_probability": False,
+        },
+    )
+    diagnostic = build_flow_point_consistency_diagnostic(window)
+
+    augmented = augment_source_reliability_features(base, [diagnostic])
+
+    assert augmented.feature_names == ("base", *diagnostic.feature_names)
+    assert np.array_equal(augmented.valid_mask, base.valid_mask)
+    assert augmented.values.shape[-1] == 4
+    assert augmented.metadata["uses_truth"] is False
+    assert len(augmented.metadata["source_only_diagnostics"]) == 1
+
+
+def test_common_mode_audit_reports_all_four_quadrants() -> None:
+    audit = audit_common_mode_failures(
+        np.asarray([0.1, 0.9, 0.1, 0.9]),
+        np.asarray([0.1, 0.1, 0.9, 0.9]),
+        disagreement_threshold=0.5,
+        error_threshold=0.5,
+    )
+
+    assert audit.low_disagreement_low_error_count == 1
+    assert audit.high_disagreement_low_error_count == 1
+    assert audit.low_disagreement_high_error_count == 1
+    assert audit.high_disagreement_high_error_count == 1
+    assert audit.low_disagreement_high_error_rate == pytest.approx(0.25)
+    assert audit.low_disagreement_high_error_mean == pytest.approx(0.9)
+    assert audit.to_dict()["low_disagreement_high_error_rate"] == pytest.approx(0.25)


### PR DESCRIPTION
## What changed

- add an immutable `SourceOnlyDiagnosticGrid` contract whose metadata must explicitly exclude truth, downstream physical innovations, and association probabilities;
- add one-step point-map/scene-flow consistency diagnostics;
- add empirical dispersion across independently seeded predictions that are already in one declared common gauge and model-set identity;
- allow these source-only grids to augment the existing content-addressed reliability feature surface without changing its valid-row set;
- add an evaluation-only four-quadrant audit for the important low-disagreement/high-error common-mode failure cell;
- expose the API publicly, document its information boundary, and exercise it in Ruff, mypy, Python 3.10/3.12/3.14, and installed-artifact tests.

## Why

Window-overlap disagreement cannot detect a shared visual backbone that is consistently wrong in every window. These diagnostics provide independent source-side evidence while preserving BayesianPhysTwin's ownership of physical innovations and the final accept/fallback decision.

## Scientific boundary

The common-mode audit may read error only after an evaluation outcome is opened. Its thresholds must be frozen from development or calibration units, and the target audit must not be fed back into reliability fitting. This PR adds diagnostic and calibration inputs; it does not claim held-out provider competence or physical-twin improvement.

## Validation

The pull request runs the complete repository CI, including Ruff, stable-surface mypy, all tests on Python 3.10/3.12/3.14, distribution builds, and isolated wheel/sdist installation.