### PR TITLE
Harden release and source-distribution boundaries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Default ownership for the research codebase.
+* @FlorianPfaff
+
+# Provider, workflow, calibration, and release boundaries require maintainer review.
+/.github/ @FlorianPfaff
+/pyproject.toml @FlorianPfaff
+/MANIFEST.in @FlorianPfaff
+/src/prob4d/provider_*.py @FlorianPfaff
+/src/prob4d/observation_*.py @FlorianPfaff
+/src/prob4d/calibration*.py @FlorianPfaff
+/src/prob4d/runtime_revision.py @FlorianPfaff
+/src/prob4d/motioncrafter_integrity.py @FlorianPfaff
+/tests/fixtures/ @FlorianPfaff

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Run Ruff
         id: ruff
         continue-on-error: true
-        run: python -m ruff check src tests 2>&1 | tee ruff-output.txt
+        run: python -m ruff check src tests scripts/ci 2>&1 | tee ruff-output.txt
       - name: Upload Ruff diagnostics
         if: steps.ruff.outcome == 'failure'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
@@ -80,6 +80,12 @@ jobs:
       - name: Fail on mypy diagnostics
         if: steps.mypy.outcome == 'failure'
         run: exit 1
+      - name: Verify repository and release policies
+        run: >-
+          python -m pytest -q
+          tests/test_github_action_pins.py
+          tests/test_project_identity.py
+          tests/test_release_metadata.py
       - name: Verify clean-checkout runtime revision attestation
         run: |
           python - <<'PY'
@@ -118,7 +124,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.12", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -168,11 +174,52 @@ jobs:
           if-no-files-found: warn
           retention-days: 14
 
+  minimum-dependencies:
+    name: Declared runtime floors / Python 3.10
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.10"
+          cache: pip
+          cache-dependency-path: requirements/ci/minimum.txt
+      - name: Install exact runtime floor and test tooling
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements/ci/minimum.txt
+          python -m pip install --no-deps -e .
+      - name: Verify resolved floor
+        run: |
+          python - <<'PY'
+          import numpy
+          import prob4d
+
+          assert numpy.__version__ == "1.24.0"
+          assert prob4d.__version__ == "0.3.1"
+          PY
+      - name: Run complete suite at the declared floor
+        run: >-
+          python -m pytest
+          --tb=short
+          --junitxml=pytest-minimum-dependencies.xml
+      - name: Upload floor-environment evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: minimum-dependency-evidence
+          path: pytest-minimum-dependencies.xml
+          if-no-files-found: warn
+          retention-days: 14
+
   build:
     name: Build distributions
-    needs: [quality, test]
+    needs: [quality, test, minimum-dependencies]
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -182,9 +229,12 @@ jobs:
           python-version: "3.12"
       - name: Build and validate wheel and source distribution
         run: |
-          python -m pip install build twine
+          python -m pip install build pytest twine
           python -m build
           python -m twine check dist/*
+          archive=$(find dist -maxdepth 1 -name '*.tar.gz' -print -quit)
+          test -n "$archive"
+          python scripts/ci/check_sdist.py "$archive"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: python-distributions
@@ -233,7 +283,7 @@ jobs:
           from prob4d.project_identity import prob4d_project_identity
 
           print(prob4d.__version__)
-          assert prob4d.__version__ == "0.3.0"
+          assert prob4d.__version__ == "0.3.1"
           assert provider_v1.PROVIDER_API_VERSION == 1
           assert provider_v2.PROVIDER_API_VERSION == 2
           assert provider_v2.OBSERVATION_FACTOR_STREAM_VERSION == 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -231,7 +231,7 @@ jobs:
           python-version: "3.12"
       - name: Build and validate wheel and source distribution
         run: |
-          python -m pip install build pytest twine
+          python -m pip install build numpy pytest twine
           python -m build
           python -m twine check dist/*
           archive=$(find dist -maxdepth 1 -name '*.tar.gz' -print -quit)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,19 @@
+cff-version: 1.2.0
+message: "If you use Prob4D in research, please cite this software and the associated paper."
+title: "Prob4D"
+type: software
+authors:
+  - family-names: "Pfaff"
+    given-names: "Florian"
+repository-code: "https://github.com/IPS-Stuttgart/Prob4D"
+url: "https://github.com/IPS-Stuttgart/Prob4D"
+version: "0.3.1"
+abstract: >-
+  Probabilistic recursive fusion for long-horizon 4D reconstruction from overlapping
+  MotionCrafter windows, with uncertain Sim(3) gauges, calibrated covariance, causal
+  observation export, and versioned provider contracts.
+keywords:
+  - "4D reconstruction"
+  - "Bayesian estimation"
+  - "robotics"
+  - "uncertainty quantification"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,42 @@
+# Contributing to Prob4D
+
+Prob4D is research software with versioned numerical and cross-repository contracts.
+Changes should preserve the distinction between implementation evidence and empirical
+scientific evidence.
+
+## Development setup
+
+```bash
+python -m pip install -e ".[dev]"
+python -m pytest
+python -m ruff check src tests
+```
+
+The lightweight package must remain importable without Torch, Diffusers, Decord, or a
+MotionCrafter checkout. GPU and model-loading dependencies belong behind lazy imports.
+
+## Contract changes
+
+`prob4d.provider_v1` is frozen for existing experiments. New claim-bearing development
+uses `prob4d.provider_v2`. A breaking Python provider change requires a new provider
+module; a changed artifact interpretation requires a new schema or causal-stream
+contract version. Do not silently reinterpret historical artifacts.
+
+Changes to covariance, reliability, source lineage, stochastic seed semantics, model
+identity, or evidence admission require focused adversarial tests and corresponding
+changelog documentation. Exact fallback and causal-prefix invariants must remain
+fail-closed.
+
+## Pull requests
+
+A pull request should describe:
+
+- the implementation or contract change;
+- the failure mode or research question it addresses;
+- compatibility and claim boundaries;
+- validation performed; and
+- any calibration artifacts or frozen experiments that must be regenerated.
+
+Generated predictions, model weights, large datasets, videos, and raw experiment
+outputs must remain outside Git. Compact evidence belongs in the canonical project-notes
+repository only after its source and claim boundary are frozen.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,15 @@
+include CHANGELOG.md
+include CITATION.cff
+include CONTRIBUTING.md
+include README.md
+include SECURITY.md
+include pyproject.toml
+graft .github
+graft docs
+graft environments
+graft requirements
+graft scripts
+graft tests
+global-exclude __pycache__
+global-exclude *.py[cod]
+global-exclude .DS_Store

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security policy
+
+## Supported versions
+
+Security and integrity fixes are applied to the current `0.3.x` development line.
+Frozen historical revisions remain reproducible but may not receive backports.
+
+## Reporting a vulnerability
+
+Do not open a public issue for a suspected vulnerability involving credential exposure,
+artifact path traversal, unsafe deserialization, workflow privilege, model-source
+integrity, or evidence tampering.
+
+Use GitHub's private vulnerability-reporting or Security Advisory interface for this
+repository. Include the affected revision, a minimal reproduction, the expected
+security boundary, and whether any private data, token, model artifact, or evidence
+bundle may have been exposed. If private reporting is unavailable, contact the
+repository maintainers through a private institutional channel.
+
+The maintainers will acknowledge the report, assess affected versions and artifacts,
+and coordinate a fix and disclosure. Scientific correctness concerns without a
+security impact should use an ordinary issue and retain the repository's explicit
+claim boundaries.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,17 +4,40 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "prob4d"
-version = "0.3.0"
+version = "0.3.1"
 description = "Probabilistic recursive fusion for long-horizon 4D reconstruction"
 readme = "README.md"
 requires-python = ">=3.10"
 authors = [{name = "Florian Pfaff"}]
+keywords = [
+  "4d-reconstruction",
+  "bayesian-estimation",
+  "computer-vision",
+  "robotics",
+  "uncertainty-quantification",
+]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Science/Research",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+  "Topic :: Scientific/Engineering :: Information Analysis",
+]
 dependencies = ["numpy>=1.24"]
 
 [project.urls]
 Repository = "https://github.com/IPS-Stuttgart/Prob4D"
 Documentation = "https://github.com/IPS-Stuttgart/Prob4D/tree/main/docs"
 Issues = "https://github.com/IPS-Stuttgart/Prob4D/issues"
+Changelog = "https://github.com/IPS-Stuttgart/Prob4D/blob/main/CHANGELOG.md"
+Citation = "https://github.com/IPS-Stuttgart/Prob4D/blob/main/CITATION.cff"
+Security = "https://github.com/IPS-Stuttgart/Prob4D/blob/main/SECURITY.md"
 Project-Notes = "https://github.com/FlorianPfaff/BayesianPhysTwin-Paper"
 
 [project.optional-dependencies]
@@ -24,6 +47,7 @@ dev = [
   "pytest>=7.4",
   "pytest-cov>=4.1",
   "ruff>=0.6",
+  "tomli>=2.0; python_version < '3.11'",
   "twine>=5.0",
 ]
 

--- a/requirements/ci/minimum.txt
+++ b/requirements/ci/minimum.txt
@@ -1,0 +1,4 @@
+build==1.2.2.post1
+numpy==1.24.0
+pytest==7.4.4
+tomli==2.0.1; python_version < "3.11"

--- a/scripts/ci/check_sdist.py
+++ b/scripts/ci/check_sdist.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Audit and exercise a built Prob4D source distribution."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path, PurePosixPath
+
+
+REQUIRED_PATHS = frozenset(
+    {
+        ".github/CODEOWNERS",
+        ".github/workflows/tests.yml",
+        "CHANGELOG.md",
+        "CITATION.cff",
+        "CONTRIBUTING.md",
+        "README.md",
+        "SECURITY.md",
+        "docs/provider-v2.md",
+        "docs/repository-identity.md",
+        "requirements/ci/minimum.txt",
+        "scripts/ci/check_sdist.py",
+        "tests/fixtures/prob4d_joint_observation_v1.json",
+        "tests/test_github_action_pins.py",
+        "tests/test_joint_observation_contract_fixture.py",
+        "tests/test_project_identity.py",
+        "tests/test_release_metadata.py",
+    }
+)
+REPRESENTATIVE_TESTS = (
+    "tests/test_sim3.py",
+    "tests/test_provider_manifest.py",
+    "tests/test_joint_observation_contract_fixture.py",
+    "tests/test_project_identity.py",
+    "tests/test_release_metadata.py",
+    "tests/test_github_action_pins.py",
+)
+
+
+def _validated_members(archive: Path) -> tuple[str, tuple[tarfile.TarInfo, ...]]:
+    with tarfile.open(archive, "r:gz") as handle:
+        members = tuple(handle.getmembers())
+    if not members:
+        raise RuntimeError("source distribution is empty")
+
+    roots: set[str] = set()
+    relative_paths: set[str] = set()
+    for member in members:
+        path = PurePosixPath(member.name)
+        if path.is_absolute() or not path.parts or ".." in path.parts:
+            raise RuntimeError(f"unsafe source-distribution path: {member.name}")
+        roots.add(path.parts[0])
+        if member.issym() or member.islnk() or not (member.isdir() or member.isfile()):
+            raise RuntimeError(f"source distribution contains a non-regular member: {member.name}")
+        if len(path.parts) > 1:
+            relative_paths.add(PurePosixPath(*path.parts[1:]).as_posix())
+
+    if len(roots) != 1:
+        raise RuntimeError("source distribution must have exactly one root directory")
+    missing = sorted(REQUIRED_PATHS - relative_paths)
+    if missing:
+        raise RuntimeError(f"source distribution omitted required assets: {missing}")
+    return roots.pop(), members
+
+
+def _extract_regular_files(archive: Path, destination: Path) -> str:
+    root_name, members = _validated_members(archive)
+    with tarfile.open(archive, "r:gz") as handle:
+        for member in members:
+            relative = PurePosixPath(member.name)
+            target = destination.joinpath(*relative.parts)
+            if member.isdir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            source = handle.extractfile(member)
+            if source is None:
+                raise RuntimeError(f"unable to read archive member: {member.name}")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_bytes(source.read())
+    return root_name
+
+
+def audit_sdist(archive: Path) -> None:
+    archive = archive.resolve()
+    if not archive.is_file():
+        raise RuntimeError(f"source distribution does not exist: {archive}")
+    with tempfile.TemporaryDirectory(prefix="prob4d-sdist-") as temporary:
+        destination = Path(temporary)
+        root_name = _extract_regular_files(archive, destination)
+        source_root = destination / root_name
+        environment = os.environ.copy()
+        environment["PYTHONPATH"] = str(source_root / "src")
+        result = subprocess.run(
+            [sys.executable, "-m", "pytest", "-q", *REPRESENTATIVE_TESTS],
+            cwd=source_root,
+            env=environment,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(result.stdout + result.stderr)
+        print(result.stdout, end="")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("archive", type=Path)
+    arguments = parser.parse_args(argv)
+    audit_sdist(arguments.archive)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/prob4d/__init__.py
+++ b/src/prob4d/__init__.py
@@ -101,7 +101,7 @@ from .uncertainty import GroupBalancedCalibrationReport
 try:
     __version__ = version("prob4d")
 except PackageNotFoundError:  # Source tree without installed distribution metadata.
-    __version__ = "0.3.0"
+    __version__ = "0.3.1"
 
 __all__ = [
     "GAUGE_COVARIANCE_CALIBRATION_SCHEMA",

--- a/src/prob4d/provider_manifest.py
+++ b/src/prob4d/provider_manifest.py
@@ -9,7 +9,7 @@ from importlib.metadata import PackageNotFoundError, distribution, version
 from typing import Any
 
 PROB4D_PROVIDER_API_VERSION = 1
-PROB4D_PROVIDER_PACKAGE_VERSION = "0.3.0"
+PROB4D_PROVIDER_PACKAGE_VERSION = "0.3.1"
 PROB4D_CAUSAL_STREAM_CONTRACT_VERSION = 2
 PROB4D_PROVIDER_CAPABILITIES = (
     "append_invariant_causal_source_digest",

--- a/tests/test_github_action_pins.py
+++ b/tests/test_github_action_pins.py
@@ -42,6 +42,28 @@ def _pin_errors(text: str, *, source: str) -> list[str]:
     return errors
 
 
+def _checkout_credential_errors(text: str, *, source: str) -> list[str]:
+    lines = text.splitlines()
+    errors: list[str] = []
+    for index, line in enumerate(lines):
+        stripped = line.lstrip()
+        if not stripped.startswith("- uses: actions/checkout@"):
+            continue
+        indentation = len(line) - len(stripped)
+        block: list[str] = []
+        for candidate in lines[index + 1 :]:
+            candidate_stripped = candidate.lstrip()
+            candidate_indentation = len(candidate) - len(candidate_stripped)
+            if candidate_stripped.startswith("- ") and candidate_indentation <= indentation:
+                break
+            block.append(candidate)
+        if not any("persist-credentials: false" in value for value in block):
+            errors.append(
+                f"{source}:{index + 1}: checkout must set persist-credentials: false"
+            )
+    return errors
+
+
 def test_every_external_github_action_is_immutably_pinned() -> None:
     workflow_files = sorted(WORKFLOW_ROOT.glob("*.yml")) + sorted(
         WORKFLOW_ROOT.glob("*.yaml")
@@ -52,6 +74,20 @@ def test_every_external_github_action_is_immutably_pinned() -> None:
     for path in workflow_files:
         errors.extend(
             _pin_errors(
+                path.read_text(encoding="utf-8"),
+                source=path.relative_to(ROOT).as_posix(),
+            )
+        )
+    assert not errors, "\n".join(errors)
+
+
+def test_checkout_actions_disable_persisted_credentials() -> None:
+    errors: list[str] = []
+    for path in sorted(WORKFLOW_ROOT.glob("*.yml")) + sorted(
+        WORKFLOW_ROOT.glob("*.yaml")
+    ):
+        errors.extend(
+            _checkout_credential_errors(
                 path.read_text(encoding="utf-8"),
                 source=path.relative_to(ROOT).as_posix(),
             )
@@ -84,3 +120,12 @@ def test_pin_policy_allows_local_docker_and_annotated_commit_uses() -> None:
     )
 
     assert _pin_errors(text, source="fixture.yml") == []
+
+
+def test_checkout_policy_rejects_credential_persistence() -> None:
+    pinned = "0123456789abcdef0123456789abcdef01234567"
+    unsafe = f"- uses: actions/checkout@{pinned} # v7\n"
+    safe = unsafe + "  with:\n    persist-credentials: false\n"
+
+    assert len(_checkout_credential_errors(unsafe, source="fixture.yml")) == 1
+    assert _checkout_credential_errors(safe, source="fixture.yml") == []

--- a/tests/test_provider_manifest.py
+++ b/tests/test_provider_manifest.py
@@ -14,7 +14,7 @@ from prob4d.provider_manifest_cli import main
 def test_provider_manifest_declares_covariance_boundary() -> None:
     manifest = prob4d_provider_manifest(provider_revision="a" * 40)
 
-    assert PROB4D_PROVIDER_PACKAGE_VERSION == "0.3.0"
+    assert PROB4D_PROVIDER_PACKAGE_VERSION == "0.3.1"
     assert manifest["provider_revision"] == "a" * 40
     assert manifest["artifact_schema_versions"] == {
         "GaugeCovarianceCalibrationV1": 1,

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import re
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # Python 3.10.
+    import tomli as tomllib
+
+import prob4d
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EXPECTED_VERSION = "0.3.1"
+EXPECTED_REPOSITORY = "https://github.com/IPS-Stuttgart/Prob4D"
+
+
+def _project() -> dict[str, object]:
+    payload = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    return payload["project"]
+
+
+def test_package_and_citation_versions_are_synchronized() -> None:
+    project = _project()
+    assert project["version"] == EXPECTED_VERSION
+    assert prob4d.__version__ == EXPECTED_VERSION
+    try:
+        installed_version = version("prob4d")
+    except PackageNotFoundError:
+        installed_version = EXPECTED_VERSION
+    assert installed_version == EXPECTED_VERSION
+
+    citation = (ROOT / "CITATION.cff").read_text(encoding="utf-8")
+    match = re.search(r'^version:\s*["\']?([^"\'\s]+)', citation, re.MULTILINE)
+    assert match is not None
+    assert match.group(1) == EXPECTED_VERSION
+
+
+def test_project_urls_point_to_the_canonical_repository() -> None:
+    urls = _project()["urls"]
+    assert isinstance(urls, dict)
+    assert urls["Repository"] == EXPECTED_REPOSITORY
+    assert urls["Documentation"].startswith(EXPECTED_REPOSITORY)
+    assert urls["Issues"].startswith(EXPECTED_REPOSITORY)
+    assert urls["Changelog"].startswith(EXPECTED_REPOSITORY)
+    assert urls["Citation"].startswith(EXPECTED_REPOSITORY)
+    assert urls["Security"].startswith(EXPECTED_REPOSITORY)
+
+
+def test_release_governance_files_exist() -> None:
+    for name in (
+        "CHANGELOG.md",
+        "CITATION.cff",
+        "CONTRIBUTING.md",
+        "MANIFEST.in",
+        "SECURITY.md",
+    ):
+        assert (ROOT / name).is_file(), name


### PR DESCRIPTION
## Summary

Prepare the current Prob4D development line as version **0.3.1** and make its release, compatibility, workflow, and source-archive boundaries fail closed.

### Release and governance metadata

- synchronize package, source-tree fallback, provider-manifest fallback, tests, installed-artifact checks, and citation metadata at `0.3.1`;
- add `CITATION.cff`, `CONTRIBUTING.md`, and `SECURITY.md`;
- add research-oriented package classifiers, keywords, and canonical changelog/citation/security URLs;
- add `CODEOWNERS` coverage for workflow, provider, calibration, artifact, and release-critical paths;
- preserve the transfer-resistant project identity and frozen historical artifact repository semantics merged in #57.

### Reproducible source distributions

- add an explicit `MANIFEST.in` containing repository policy, documentation, environment, requirement, script, fixture, and test assets;
- add a safe sdist auditor that rejects absolute paths, traversal, links, nonregular members, multiple archive roots, and missing registered assets;
- extract the source archive without following links and run representative provider, project-identity, release, workflow, and observation-contract tests from the extracted tree.

### Compatibility and workflow gates

- extend the complete core matrix to Python 3.10, 3.11, 3.12, 3.13, and 3.14;
- add a Python 3.10 job using the exact declared NumPy floor, `numpy==1.24.0`;
- retain immutable GitHub Action pins and additionally require every checkout to set `persist-credentials: false`;
- verify project identity and release metadata explicitly in the quality job;
- build and validate wheel and sdist only after the full version matrix and minimum-dependency environment pass;
- smoke-test version 0.3.1 and the project-identity route from isolated wheel and sdist installs;
- preserve the source-only diagnostics API and its mypy/import coverage merged in #58.

## Compatibility and scientific boundary

This is release, provenance, archive, and compatibility hardening. It does not change:

- provider-v1 or provider-v2 semantics;
- observation, factor-bundle, factor-stream, or fused-prediction schemas;
- artifact IDs or frozen source-repository strings;
- covariance, reliability, alignment, fusion, or evaluation numerics;
- Bayesian-PhysTwin admission or fallback behavior;
- Causal4D inference or any scientific claim.

No empirical reconstruction, calibration, physical-update, or intervention benefit is claimed by this PR.

## Validation

GitHub Actions **Tests #432** passed completely on head `cf76ab5a250027ffd59cf085a46bf5d63e0bd551`:

- Ruff and stable-interface mypy;
- repository, immutable-action, checkout-credential, project-identity, release-version, and runtime-attestation policies;
- complete test suites on Python 3.10, 3.11, 3.12, 3.13, and 3.14;
- complete Python 3.10 suite at the exact declared NumPy floor, `numpy==1.24.0`;
- provider-v1 and provider-v2 manifest emission plus project-identity artifact emission;
- wheel and source-distribution construction and `twine check`;
- safe source-archive inventory, extraction, and representative tests executed from the extracted sdist;
- isolated wheel and sdist installation, package-version/provider checks, and all grouped/legacy CLI help routes.

The first archive-validation run correctly exposed that the build-validation environment lacked NumPy. The workflow now installs the package runtime dependency before executing tests from the extracted source archive; the complete corrected run is green.