### PR TITLE
Add content-addressed memory-mapped prediction execution stores

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,6 +59,9 @@ jobs:
           src/prob4d/composition_jacobian.py
           src/prob4d/covariance_root.py
           src/prob4d/observation_factor_stream.py
+          src/prob4d/prediction_store.py
+          src/prob4d/prediction_store_benchmark.py
+          src/prob4d/prediction_store_cli.py
           src/prob4d/project_identity.py
           src/prob4d/provider_attestation.py
           src/prob4d/provider_manifest.py
@@ -140,6 +143,9 @@ jobs:
           import prob4d.composition_jacobian
           import prob4d.covariance_root
           import prob4d.observation_factor_stream
+          import prob4d.prediction_store
+          import prob4d.prediction_store_benchmark
+          import prob4d.prediction_store_cli
           import prob4d.project_identity
           import prob4d.provider_attestation
           import prob4d.provider_evaluation
@@ -232,6 +238,7 @@ jobs:
           import prob4d.provider_v1 as provider_v1
           import prob4d.provider_v2 as provider_v2
           from prob4d.composition_jacobian import current_composition_jacobian_mode
+          from prob4d.prediction_store import load_prediction_bundle_store
           from prob4d.project_identity import prob4d_project_identity
 
           print(prob4d.__version__)
@@ -240,6 +247,7 @@ jobs:
           assert provider_v2.PROVIDER_API_VERSION == 2
           assert provider_v2.OBSERVATION_FACTOR_STREAM_VERSION == 1
           assert callable(provider_v2.load_claim_bearing_observation_belief)
+          assert callable(load_prediction_bundle_store)
           assert resources.files("prob4d").joinpath("py.typed").is_file()
           assert current_composition_jacobian_mode() == "legacy_finite_difference"
           assert prob4d_project_identity()["canonical_repository"] == "IPS-Stuttgart/Prob4D"
@@ -258,6 +266,9 @@ jobs:
           "$bin/prob4d" observation export-calibrated --help
           "$bin/prob4d" observation export-exploratory --help
           "$bin/prob4d" motioncrafter --help
+          "$bin/prob4d" storage benchmark --help
+          "$bin/prob4d" storage materialize --help
+          "$bin/prob4d" storage validate --help
           "$bin/prob4d-provider-manifest" --help
           "$bin/prob4d-ablate" --help
           "$bin/prob4d-ablate-provider-v2-gauge" --help

--- a/docs/prediction-store.md
+++ b/docs/prediction-store.md
@@ -1,0 +1,92 @@
+# Memory-mapped prediction execution stores
+
+MotionCrafter prediction members are portable compressed NPZ artifacts. NumPy
+cannot memory-map arrays inside a compressed NPZ archive, so repeated large
+experiments otherwise decompress and retain complete windows in process memory.
+Prob4D now provides a separate, explicit execution-cache format based on
+uncompressed NPY members.
+
+The execution store does **not** replace or reinterpret the portable prediction,
+provider-v1, provider-v2, calibration, or observation artifacts. It binds the
+exact source prediction-manifest SHA-256 and records that provider semantics are
+unchanged.
+
+## Materialize once
+
+```bash
+prob4d storage materialize \
+  outputs/sequence/predictions.json \
+  outputs/sequence/prediction-store \
+  --dense-storage-dtype float32
+```
+
+Materialization first verifies the MotionCrafter bundle and every registered
+member. It then processes overlap windows and baselines one at a time, writes
+NPY members into a temporary tree, hashes every file, writes content-addressed
+window and bundle manifests, fsyncs them, and atomically publishes the complete
+directory. An existing destination is rejected instead of being partially
+updated.
+
+## Load and validate
+
+```python
+from prob4d import load_prediction_bundle_store
+
+bundle = load_prediction_bundle_store(
+    "outputs/sequence/prediction-store",
+    verify_hashes=True,
+)
+```
+
+The loader rejects:
+
+- manifest or member symlinks and path escapes;
+- missing, extra, aliased, or malformed fields;
+- byte-count, SHA-256, dtype, shape, or content-address mismatches;
+- inconsistent scene-flow/deformation-mask pairs;
+- invalid frame identities, masks, vectors, or non-normalized stored rays; and
+- any store that does not declare execution-cache-only semantics.
+
+Dense arrays are opened read-only with `mmap_mode="r"`. The returned
+`MMapPredictionWindow` is a `PredictionWindow` subclass, so existing alignment,
+uncertainty, and fusion routines consume it without changing estimator
+semantics. Validation is chunked and no second retained dense copy is created.
+
+Validate and summarize a store independently with:
+
+```bash
+prob4d storage validate outputs/sequence/prediction-store
+```
+
+## Matched process benchmark
+
+Run each backend in a separate fresh process:
+
+```bash
+prob4d storage benchmark outputs/sequence/predictions.json \
+  --backend eager_npz \
+  --dense-storage-dtype float32 \
+  --output-json outputs/sequence/eager-loading.json
+
+prob4d storage benchmark outputs/sequence/prediction-store \
+  --backend mmap_npy \
+  --dense-storage-dtype float32 \
+  --output-json outputs/sequence/mmap-loading.json
+```
+
+The reports bind the source-manifest identity, store ID where applicable,
+backend, dtype, Python/NumPy/platform versions, loading-and-validation time,
+retained dense-vector accounting, and peak process RSS. Compare only matched
+fresh processes on the same host and repository revision.
+
+The benchmark is engineering evidence. It does not establish reconstruction
+accuracy, calibration, BayesianPhysTwin benefit, or Causal4D performance.
+
+## Integrity and lifecycle
+
+The original verified NPZ bundle remains the portable source of truth. The NPY
+store may be deleted and regenerated from that exact bundle. It should be placed
+under an ignored output or cache directory rather than committed. New provider
+or paper evidence must continue to bind the original source manifest and the
+normal Prob4D provider artifacts; the execution-store ID is additional runtime
+provenance only.

--- a/src/prob4d/__init__.py
+++ b/src/prob4d/__init__.py
@@ -73,6 +73,18 @@ from .observation_factors import (
     write_observation_factor_bundle,
 )
 from .observation_validation import load_observation_belief_export
+from .prediction_store import (
+    PREDICTION_BUNDLE_STORE_SCHEMA,
+    PREDICTION_BUNDLE_STORE_VERSION,
+    PREDICTION_WINDOW_STORE_SCHEMA,
+    PREDICTION_WINDOW_STORE_VERSION,
+    MMapPredictionWindow,
+    load_prediction_bundle_store,
+    load_prediction_window_store,
+    materialize_prediction_bundle_store,
+    prediction_bundle_store_summary,
+    write_prediction_window_store,
+)
 from .project_identity import (
     PROB4D_CANONICAL_REPOSITORY,
     PROB4D_FROZEN_ARTIFACT_REPOSITORY,
@@ -120,6 +132,10 @@ __all__ = [
     "OBSERVATION_FACTOR_STREAM_VERSION",
     "POINT_UNCERTAINTY_CALIBRATION_SCHEMA",
     "POINT_UNCERTAINTY_CALIBRATION_VERSION",
+    "PREDICTION_BUNDLE_STORE_SCHEMA",
+    "PREDICTION_BUNDLE_STORE_VERSION",
+    "PREDICTION_WINDOW_STORE_SCHEMA",
+    "PREDICTION_WINDOW_STORE_VERSION",
     "PROB4D_CANONICAL_REPOSITORY",
     "PROB4D_FROZEN_ARTIFACT_REPOSITORY",
     "PROB4D_GITHUB_REPOSITORY_ID",
@@ -140,6 +156,7 @@ __all__ = [
     "GroupBalancedCalibrationReport",
     "JointGaugePosterior",
     "LinearizedObservationFactor",
+    "MMapPredictionWindow",
     "MetricGaugeAnchor",
     "ObservationBeliefExportV1",
     "ObservationFactor",
@@ -179,7 +196,11 @@ __all__ = [
     "load_observation_factor_bundle",
     "load_observation_factor_stream",
     "load_point_uncertainty_calibration",
+    "load_prediction_bundle_store",
+    "load_prediction_window_store",
     "load_source_reliability_model",
+    "materialize_prediction_bundle_store",
+    "prediction_bundle_store_summary",
     "prob4d_project_identity",
     "save_gauge_covariance_calibration",
     "save_metric_gauge_anchor",
@@ -191,4 +212,5 @@ __all__ = [
     "validate_prob4d_project_identity",
     "write_observation_factor_bundle",
     "write_observation_factor_stream",
+    "write_prediction_window_store",
 ]

--- a/src/prob4d/cli.py
+++ b/src/prob4d/cli.py
@@ -79,6 +79,21 @@ _ROUTES: Final[dict[Route, tuple[str, str, str]]] = {
         "main",
         "run the held-out Sintel uncertainty analysis",
     ),
+    ("storage", "benchmark"): (
+        "prob4d.prediction_store_benchmark",
+        "main",
+        "profile eager or memory-mapped prediction loading",
+    ),
+    ("storage", "materialize"): (
+        "prob4d.prediction_store_cli",
+        "main_materialize",
+        "create a content-addressed memory-mapped prediction store",
+    ),
+    ("storage", "validate"): (
+        "prob4d.prediction_store_cli",
+        "main_validate",
+        "validate and summarize a memory-mapped prediction store",
+    ),
     ("vggt", "baseline"): (
         "prob4d.vggt_baseline",
         "main",

--- a/src/prob4d/prediction_store.py
+++ b/src/prob4d/prediction_store.py
@@ -1,0 +1,739 @@
+"""Content-addressed memory-mapped execution storage for prediction bundles.
+
+Portable MotionCrafter and provider artifacts remain unchanged. This module
+materializes verified NPZ prediction bundles into uncompressed NPY members that
+NumPy can open read-only with ``mmap_mode='r'``. The store is an explicit
+execution cache: each member and manifest is hashed, source-manifest identity is
+retained, and existing fusion/alignment code can consume the resulting
+``MMapPredictionWindow`` because it preserves the ``PredictionWindow`` interface.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import tempfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path, PurePosixPath
+from typing import Any, Final, cast
+
+import numpy as np
+
+from ._immutable_json import plain_json
+from .data import DENSE_STORAGE_DTYPES, DenseStorageDType, PredictionWindow
+
+PREDICTION_WINDOW_STORE_SCHEMA: Final = "prob4d.prediction-window-store"
+PREDICTION_WINDOW_STORE_VERSION: Final = 1
+PREDICTION_BUNDLE_STORE_SCHEMA: Final = "prob4d.prediction-bundle-store"
+PREDICTION_BUNDLE_STORE_VERSION: Final = 1
+PREDICTION_STORE_MANIFEST: Final = "manifest.json"
+
+_WINDOW_MANIFEST_FIELDS: Final = frozenset(
+    {
+        "schema_name",
+        "schema_version",
+        "store_id",
+        "window_id",
+        "dense_storage_dtype",
+        "shape",
+        "fields",
+        "metadata",
+    }
+)
+_BUNDLE_MANIFEST_FIELDS: Final = frozenset(
+    {
+        "schema_name",
+        "schema_version",
+        "store_id",
+        "source_manifest_sha256",
+        "dense_storage_dtype",
+        "source_metadata",
+        "overlap_windows",
+        "disjoint_baseline",
+        "latent_linear_baseline",
+    }
+)
+_FIELD_DESCRIPTOR_FIELDS: Final = frozenset(
+    {"path", "sha256", "bytes", "dtype", "shape"}
+)
+_REQUIRED_WINDOW_FIELDS: Final = frozenset(
+    {"frame_indices", "point_map", "valid_mask"}
+)
+_OPTIONAL_WINDOW_FIELDS: Final = frozenset(
+    {"scene_flow", "deform_mask", "ray_directions"}
+)
+
+
+def _canonical_json(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        plain_json(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _sha256_bytes(value: bytes) -> str:
+    return hashlib.sha256(value).hexdigest()
+
+
+def _require_sha256(value: object, *, name: str) -> str:
+    digest = str(value)
+    if len(digest) != 64 or any(
+        character not in "0123456789abcdef" for character in digest
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return digest
+
+
+def _require_nonnegative_integer(value: object, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{name} must be a non-negative integer")
+    return value
+
+
+def _validated_dense_storage_dtype(value: object) -> DenseStorageDType:
+    normalized = str(value)
+    if normalized not in DENSE_STORAGE_DTYPES:
+        raise ValueError(
+            "dense_storage_dtype must be one of " + ", ".join(DENSE_STORAGE_DTYPES)
+        )
+    return cast(DenseStorageDType, normalized)
+
+
+def _dense_dtype(value: DenseStorageDType) -> np.dtype[np.floating]:
+    return np.dtype(np.float32 if value == "float32" else np.float64)
+
+
+def _safe_relative_path(value: object, *, name: str) -> str:
+    if not isinstance(value, str) or not value or "\\" in value:
+        raise ValueError(f"{name} must be a safe POSIX relative path")
+    path = PurePosixPath(value)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError(f"{name} must be a safe POSIX relative path")
+    return path.as_posix()
+
+
+def _resolve_member(root: Path, value: object, *, name: str) -> Path:
+    relative = _safe_relative_path(value, name=name)
+    root_resolved = root.resolve()
+    if root.is_symlink():
+        raise ValueError(f"{name} root must not be a symlink")
+    candidate = root_resolved.joinpath(*PurePosixPath(relative).parts)
+    if candidate.is_symlink():
+        raise ValueError(f"{name} must not be a symlink")
+    resolved = candidate.resolve()
+    try:
+        resolved.relative_to(root_resolved)
+    except ValueError as error:
+        raise ValueError(f"{name} escapes the prediction store") from error
+    return resolved
+
+
+def _fsync_directory(path: Path) -> None:
+    try:
+        descriptor = os.open(path, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(descriptor)
+    except OSError:
+        pass
+    finally:
+        os.close(descriptor)
+
+
+def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    descriptor, temporary = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(payload, stream, indent=2, sort_keys=True, allow_nan=False)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        _fsync_directory(path.parent)
+    finally:
+        if os.path.exists(temporary):
+            os.unlink(temporary)
+
+
+def _write_npy(path: Path, value: np.ndarray) -> None:
+    with path.open("wb") as stream:
+        np.save(stream, value, allow_pickle=False)
+        stream.flush()
+        os.fsync(stream.fileno())
+
+
+def _field_descriptor(path: Path, *, root: Path) -> dict[str, object]:
+    relative = path.relative_to(root).as_posix()
+    array = np.load(path, mmap_mode="r", allow_pickle=False)
+    return {
+        "path": relative,
+        "sha256": _sha256_file(path),
+        "bytes": path.stat().st_size,
+        "dtype": array.dtype.str,
+        "shape": list(array.shape),
+    }
+
+
+def _compute_store_id(manifest: Mapping[str, Any]) -> str:
+    payload = dict(manifest)
+    payload.pop("store_id", None)
+    return _sha256_bytes(_canonical_json(payload))
+
+
+def _validate_exact_fields(
+    value: Mapping[str, Any], expected: frozenset[str], *, name: str
+) -> None:
+    missing = sorted(expected - set(value))
+    extra = sorted(set(value) - expected)
+    if missing or extra:
+        raise ValueError(f"{name} fields changed; missing={missing}, extra={extra}")
+
+
+def _validate_finite_vectors(
+    value: np.ndarray,
+    active_mask: np.ndarray,
+    *,
+    name: str,
+    chunk_size: int = 65_536,
+) -> None:
+    flat_value = value.reshape(-1, value.shape[-1])
+    flat_mask = active_mask.reshape(-1)
+    for start in range(0, flat_value.shape[0], chunk_size):
+        stop = min(start + chunk_size, flat_value.shape[0])
+        selected = flat_mask[start:stop]
+        if np.any(selected) and not np.all(np.isfinite(flat_value[start:stop][selected])):
+            raise ValueError(f"active {name} entries must be finite")
+
+
+class MMapPredictionWindow(PredictionWindow):
+    """Validated read-only prediction window backed by NPY memory maps.
+
+    Unlike the public ``PredictionWindow`` constructor, this execution-cache
+    subclass does not defensively copy dense arrays. Files are hash-verified
+    before opening, arrays are read-only, and validation is chunked. Portable
+    artifacts and content-addressed provider semantics remain owned by the
+    original NPZ prediction bundle.
+    """
+
+    def __post_init__(self) -> None:
+        window_id = str(self.window_id)
+        dense_storage_dtype = _validated_dense_storage_dtype(self.dense_storage_dtype)
+        expected_dense_dtype = _dense_dtype(dense_storage_dtype)
+        frame_indices = np.asarray(self.frame_indices)
+        point_map = np.asarray(self.point_map)
+        valid_mask = np.asarray(self.valid_mask)
+
+        if not window_id:
+            raise ValueError("window_id must not be empty")
+        if frame_indices.dtype != np.dtype(np.int64):
+            raise ValueError("stored frame_indices must use int64")
+        if frame_indices.ndim != 1 or frame_indices.size == 0:
+            raise ValueError("frame_indices must be a non-empty one-dimensional array")
+        if np.any(frame_indices < 0) or np.any(np.diff(frame_indices) <= 0):
+            raise ValueError("frame_indices must be non-negative and strictly increasing")
+        if point_map.dtype != expected_dense_dtype:
+            raise ValueError("stored point_map dtype differs from dense_storage_dtype")
+        if point_map.ndim != 4 or point_map.shape[-1] != 3:
+            raise ValueError("point_map must have shape (T, H, W, 3)")
+        if valid_mask.dtype != np.dtype(bool) or valid_mask.shape != point_map.shape[:-1]:
+            raise ValueError("valid_mask must be Boolean with shape (T, H, W)")
+        if point_map.shape[0] != frame_indices.size:
+            raise ValueError("frame_indices length must match point_map time dimension")
+        _validate_finite_vectors(point_map, valid_mask, name="point_map")
+
+        scene_flow = None if self.scene_flow is None else np.asarray(self.scene_flow)
+        deform_mask = None if self.deform_mask is None else np.asarray(self.deform_mask)
+        rays = None if self.ray_directions is None else np.asarray(self.ray_directions)
+        if (scene_flow is None) != (deform_mask is None):
+            raise ValueError("scene_flow and deform_mask must either both be present or absent")
+        if scene_flow is not None and deform_mask is not None:
+            if scene_flow.dtype != expected_dense_dtype or scene_flow.shape != point_map.shape:
+                raise ValueError("stored scene_flow must match point_map shape and dtype")
+            if deform_mask.dtype != np.dtype(bool) or deform_mask.shape != valid_mask.shape:
+                raise ValueError("stored deform_mask must match valid_mask")
+            if np.any(deform_mask & ~valid_mask):
+                raise ValueError("deform_mask must be a subset of valid_mask")
+            _validate_finite_vectors(scene_flow, deform_mask, name="scene_flow")
+        if rays is not None:
+            if rays.dtype != expected_dense_dtype or rays.shape != point_map.shape:
+                raise ValueError("stored ray_directions must match point_map shape and dtype")
+            _validate_finite_vectors(rays, valid_mask, name="ray_directions")
+            flat_rays = rays.reshape(-1, 3)
+            flat_valid = valid_mask.reshape(-1)
+            for start in range(0, flat_rays.shape[0], 65_536):
+                stop = min(start + 65_536, flat_rays.shape[0])
+                selected = flat_valid[start:stop]
+                if not np.any(selected):
+                    continue
+                norms = np.linalg.norm(flat_rays[start:stop][selected], axis=-1)
+                if not np.allclose(norms, 1.0, atol=1e-6, rtol=1e-5):
+                    raise ValueError("stored ray_directions must already be normalized")
+
+        arrays = (frame_indices, point_map, valid_mask, scene_flow, deform_mask, rays)
+        for array in arrays:
+            if array is not None:
+                array.setflags(write=False)
+        object.__setattr__(self, "window_id", window_id)
+        object.__setattr__(self, "dense_storage_dtype", dense_storage_dtype)
+        object.__setattr__(self, "frame_indices", frame_indices)
+        object.__setattr__(self, "point_map", point_map)
+        object.__setattr__(self, "valid_mask", valid_mask)
+        object.__setattr__(self, "scene_flow", scene_flow)
+        object.__setattr__(self, "deform_mask", deform_mask)
+        object.__setattr__(self, "ray_directions", rays)
+
+
+def _window_arrays(
+    window: PredictionWindow, dense_storage_dtype: DenseStorageDType
+) -> dict[str, np.ndarray]:
+    dense_dtype = _dense_dtype(dense_storage_dtype)
+    arrays: dict[str, np.ndarray] = {
+        "frame_indices": np.asarray(window.frame_indices, dtype=np.int64),
+        "point_map": np.asarray(window.point_map, dtype=dense_dtype),
+        "valid_mask": np.asarray(window.valid_mask, dtype=bool),
+    }
+    if window.scene_flow is not None:
+        assert window.deform_mask is not None
+        arrays["scene_flow"] = np.asarray(window.scene_flow, dtype=dense_dtype)
+        arrays["deform_mask"] = np.asarray(window.deform_mask, dtype=bool)
+    if window.ray_directions is not None:
+        arrays["ray_directions"] = np.asarray(window.ray_directions, dtype=dense_dtype)
+    return arrays
+
+
+def write_prediction_window_store(
+    window: PredictionWindow,
+    destination: str | Path,
+    *,
+    dense_storage_dtype: DenseStorageDType | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> Path:
+    """Atomically materialize one prediction window as hash-bound NPY members."""
+
+    target = Path(destination)
+    if target.exists():
+        raise ValueError(f"prediction-window store already exists: {target}")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    storage_dtype = _validated_dense_storage_dtype(
+        window.dense_storage_dtype if dense_storage_dtype is None else dense_storage_dtype
+    )
+    temporary = Path(tempfile.mkdtemp(prefix=f".{target.name}.", dir=target.parent))
+    try:
+        descriptors: dict[str, dict[str, object]] = {}
+        for field, array in _window_arrays(window, storage_dtype).items():
+            path = temporary / f"{field}.npy"
+            _write_npy(path, array)
+            descriptors[field] = _field_descriptor(path, root=temporary)
+        payload: dict[str, Any] = {
+            "schema_name": PREDICTION_WINDOW_STORE_SCHEMA,
+            "schema_version": PREDICTION_WINDOW_STORE_VERSION,
+            "window_id": window.window_id,
+            "dense_storage_dtype": storage_dtype,
+            "shape": list(window.shape),
+            "fields": descriptors,
+            "metadata": {
+                **({} if metadata is None else plain_json(metadata)),
+                "execution_cache_only": True,
+                "portable_provider_artifact_semantics_unchanged": True,
+            },
+        }
+        payload["store_id"] = _compute_store_id(payload)
+        _atomic_write_json(temporary / PREDICTION_STORE_MANIFEST, payload)
+        _fsync_directory(temporary)
+        os.replace(temporary, target)
+        _fsync_directory(target.parent)
+    except Exception:
+        shutil.rmtree(temporary, ignore_errors=True)
+        raise
+    return target / PREDICTION_STORE_MANIFEST
+
+
+def _load_json_object(path: Path, *, name: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot read {name} {path}") from error
+    if not isinstance(value, dict):
+        raise ValueError(f"{name} must contain a JSON object")
+    return value
+
+
+def _load_field(
+    root: Path,
+    descriptor: Mapping[str, Any],
+    *,
+    name: str,
+    verify_hashes: bool,
+) -> np.ndarray:
+    _validate_exact_fields(descriptor, _FIELD_DESCRIPTOR_FIELDS, name=name)
+    path = _resolve_member(root, descriptor.get("path"), name=f"{name} path")
+    if not path.is_file():
+        raise ValueError(f"{name} file is missing")
+    expected_bytes = _require_nonnegative_integer(
+        descriptor.get("bytes"), name=f"{name} bytes"
+    )
+    if path.stat().st_size != expected_bytes:
+        raise ValueError(f"{name} byte count mismatch")
+    expected_sha = _require_sha256(descriptor.get("sha256"), name=f"{name} sha256")
+    if verify_hashes and _sha256_file(path) != expected_sha:
+        raise ValueError(f"{name} SHA-256 mismatch")
+    array = np.load(path, mmap_mode="r", allow_pickle=False)
+    expected_dtype = str(descriptor.get("dtype", ""))
+    if array.dtype.str != expected_dtype:
+        raise ValueError(f"{name} dtype differs from its descriptor")
+    expected_shape = descriptor.get("shape")
+    if not isinstance(expected_shape, list) or any(
+        isinstance(value, bool) or not isinstance(value, int) or value < 0
+        for value in expected_shape
+    ):
+        raise ValueError(f"{name} shape descriptor is invalid")
+    if list(array.shape) != expected_shape:
+        raise ValueError(f"{name} shape differs from its descriptor")
+    array.setflags(write=False)
+    return array
+
+
+def load_prediction_window_store(
+    directory: str | Path, *, verify_hashes: bool = True
+) -> MMapPredictionWindow:
+    """Verify and open one prediction-window execution store read-only."""
+
+    root = Path(directory)
+    if root.is_symlink() or not root.is_dir():
+        raise ValueError(f"prediction-window store is not a regular directory: {root}")
+    manifest_path = root / PREDICTION_STORE_MANIFEST
+    if manifest_path.is_symlink():
+        raise ValueError("prediction-window store manifest must not be a symlink")
+    manifest = _load_json_object(
+        manifest_path, name="prediction-window store manifest"
+    )
+    _validate_exact_fields(
+        manifest, _WINDOW_MANIFEST_FIELDS, name="prediction-window store manifest"
+    )
+    if manifest.get("schema_name") != PREDICTION_WINDOW_STORE_SCHEMA:
+        raise ValueError("unsupported prediction-window store schema")
+    if manifest.get("schema_version") != PREDICTION_WINDOW_STORE_VERSION:
+        raise ValueError("unsupported prediction-window store version")
+    declared_id = _require_sha256(manifest.get("store_id"), name="window store_id")
+    if _compute_store_id(manifest) != declared_id:
+        raise ValueError("prediction-window store ID does not match its manifest")
+    storage_dtype = _validated_dense_storage_dtype(manifest.get("dense_storage_dtype"))
+    metadata = manifest.get("metadata")
+    if not isinstance(metadata, Mapping):
+        raise ValueError("prediction-window store metadata must be a mapping")
+    if metadata.get("execution_cache_only") is not True:
+        raise ValueError("prediction-window store must declare execution-cache-only semantics")
+    if metadata.get("portable_provider_artifact_semantics_unchanged") is not True:
+        raise ValueError("prediction-window store must preserve provider artifact semantics")
+    fields = manifest.get("fields")
+    if not isinstance(fields, Mapping):
+        raise ValueError("prediction-window store fields must be a mapping")
+    field_names = set(fields)
+    if not _REQUIRED_WINDOW_FIELDS.issubset(field_names):
+        raise ValueError("prediction-window store lacks required fields")
+    unknown = field_names - _REQUIRED_WINDOW_FIELDS - _OPTIONAL_WINDOW_FIELDS
+    if unknown:
+        raise ValueError(f"prediction-window store has unknown fields: {sorted(unknown)}")
+    if ("scene_flow" in fields) != ("deform_mask" in fields):
+        raise ValueError("stored scene_flow and deform_mask must be present together")
+    paths: list[str] = []
+    for name in fields:
+        descriptor = fields[name]
+        if not isinstance(descriptor, Mapping):
+            raise ValueError(f"prediction field {name} descriptor must be a mapping")
+        paths.append(
+            _safe_relative_path(
+                descriptor.get("path"),
+                name=f"prediction field {name} path",
+            )
+        )
+    if len(paths) != len(set(paths)):
+        raise ValueError("prediction-window store field paths must be unique")
+    arrays = {
+        name: _load_field(
+            root,
+            cast(Mapping[str, Any], fields[name]),
+            name=f"prediction field {name}",
+            verify_hashes=verify_hashes,
+        )
+        for name in fields
+    }
+    shape = manifest.get("shape")
+    if not isinstance(shape, list) or len(shape) != 3:
+        raise ValueError("prediction-window store shape must contain T, H, W")
+    window = MMapPredictionWindow(
+        window_id=str(manifest.get("window_id", "")),
+        frame_indices=arrays["frame_indices"],
+        point_map=arrays["point_map"],
+        valid_mask=arrays["valid_mask"],
+        scene_flow=arrays.get("scene_flow"),
+        deform_mask=arrays.get("deform_mask"),
+        ray_directions=arrays.get("ray_directions"),
+        dense_storage_dtype=storage_dtype,
+    )
+    if list(window.shape) != shape:
+        raise ValueError("prediction-window store shape differs from loaded arrays")
+    return window
+
+
+def _store_reference(path: Path, *, root: Path, window: PredictionWindow) -> dict[str, Any]:
+    manifest = _load_json_object(path / PREDICTION_STORE_MANIFEST, name="window manifest")
+    return {
+        "window_id": window.window_id,
+        "path": path.relative_to(root).as_posix(),
+        "store_id": manifest["store_id"],
+    }
+
+
+def materialize_prediction_bundle_store(
+    source_manifest: str | Path,
+    destination: str | Path,
+    *,
+    dense_storage_dtype: DenseStorageDType = "float32",
+) -> Path:
+    """Convert one verified NPZ bundle into an atomic memory-mapped execution store."""
+
+    from .motioncrafter_integrity import (
+        resolve_motioncrafter_member,
+        verify_motioncrafter_prediction_manifest,
+    )
+
+    source = Path(source_manifest).resolve()
+    verify_motioncrafter_prediction_manifest(source, verify_hashes=True)
+    source_bytes = source.read_bytes()
+    source_metadata = _load_json_object(source, name="prediction source manifest")
+    root = source.parent
+    target = Path(destination)
+    if target.exists():
+        raise ValueError(f"prediction-bundle store already exists: {target}")
+    target.parent.mkdir(parents=True, exist_ok=True)
+    temporary = Path(tempfile.mkdtemp(prefix=f".{target.name}.", dir=target.parent))
+    try:
+        overlap_values = source_metadata.get("overlap_windows")
+        if not isinstance(overlap_values, list) or not overlap_values:
+            raise ValueError("prediction source manifest requires overlap windows")
+        overlap_references: list[dict[str, Any]] = []
+        for index, item in enumerate(overlap_values):
+            if not isinstance(item, Mapping):
+                raise ValueError(f"prediction overlap window {index} must be a mapping")
+            window_id = str(item.get("window_id", ""))
+            source_path = resolve_motioncrafter_member(
+                root,
+                item.get("path"),
+                name=f"overlap window {window_id!r} path",
+            )
+            window = PredictionWindow.from_npz(
+                source_path,
+                start_frame=item.get("start_frame"),
+                window_id=window_id,
+                dense_storage_dtype=dense_storage_dtype,
+            )
+            relative = Path("overlap") / f"{index:04d}"
+            write_prediction_window_store(
+                window,
+                temporary / relative,
+                dense_storage_dtype=dense_storage_dtype,
+                metadata={
+                    "source_manifest_sha256": _sha256_bytes(source_bytes),
+                    "source_role": "overlap_window",
+                    "source_index": index,
+                },
+            )
+            overlap_references.append(
+                _store_reference(temporary / relative, root=temporary, window=window)
+            )
+            del window
+        baseline_references: dict[str, dict[str, Any]] = {}
+        baseline_specs = (
+            ("disjoint_baseline", "baseline_disjoint"),
+            ("latent_linear_baseline", "baseline_latent_linear"),
+        )
+        for role, window_id in baseline_specs:
+            source_path = resolve_motioncrafter_member(
+                root,
+                source_metadata.get(role),
+                name=f"{role} path",
+            )
+            window = PredictionWindow.from_npz(
+                source_path,
+                start_frame=0,
+                window_id=window_id,
+                dense_storage_dtype=dense_storage_dtype,
+            )
+            relative = Path(role)
+            write_prediction_window_store(
+                window,
+                temporary / relative,
+                dense_storage_dtype=dense_storage_dtype,
+                metadata={
+                    "source_manifest_sha256": _sha256_bytes(source_bytes),
+                    "source_role": role,
+                },
+            )
+            baseline_references[role] = _store_reference(
+                temporary / relative, root=temporary, window=window
+            )
+            del window
+        payload: dict[str, Any] = {
+            "schema_name": PREDICTION_BUNDLE_STORE_SCHEMA,
+            "schema_version": PREDICTION_BUNDLE_STORE_VERSION,
+            "source_manifest_sha256": _sha256_bytes(source_bytes),
+            "dense_storage_dtype": _validated_dense_storage_dtype(
+                dense_storage_dtype
+            ),
+            "source_metadata": plain_json(source_metadata),
+            "overlap_windows": overlap_references,
+            "disjoint_baseline": baseline_references["disjoint_baseline"],
+            "latent_linear_baseline": baseline_references[
+                "latent_linear_baseline"
+            ],
+        }
+        payload["store_id"] = _compute_store_id(payload)
+        _atomic_write_json(temporary / PREDICTION_STORE_MANIFEST, payload)
+        _fsync_directory(temporary)
+        os.replace(temporary, target)
+        _fsync_directory(target.parent)
+    except Exception:
+        shutil.rmtree(temporary, ignore_errors=True)
+        raise
+    return target / PREDICTION_STORE_MANIFEST
+
+
+def _load_store_reference(
+    root: Path,
+    value: object,
+    *,
+    name: str,
+    verify_hashes: bool,
+) -> MMapPredictionWindow:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{name} must be a mapping")
+    _validate_exact_fields(
+        value, frozenset({"window_id", "path", "store_id"}), name=name
+    )
+    path = _resolve_member(root, value.get("path"), name=f"{name} path")
+    window = load_prediction_window_store(path, verify_hashes=verify_hashes)
+    if window.window_id != value.get("window_id"):
+        raise ValueError(f"{name} window ID differs from its store")
+    manifest = _load_json_object(path / PREDICTION_STORE_MANIFEST, name=name)
+    if manifest.get("store_id") != _require_sha256(
+        value.get("store_id"), name=f"{name} store_id"
+    ):
+        raise ValueError(f"{name} store ID differs from its reference")
+    return window
+
+
+def load_prediction_bundle_store(
+    directory: str | Path, *, verify_hashes: bool = True
+):
+    """Verify and open a complete bundle through read-only NPY memory maps."""
+
+    from .io import PredictionBundle
+
+    root = Path(directory)
+    if root.is_symlink() or not root.is_dir():
+        raise ValueError(f"prediction-bundle store is not a regular directory: {root}")
+    manifest_path = root / PREDICTION_STORE_MANIFEST
+    if manifest_path.is_symlink():
+        raise ValueError("prediction-bundle store manifest must not be a symlink")
+    manifest = _load_json_object(manifest_path, name="prediction-bundle store manifest")
+    _validate_exact_fields(
+        manifest, _BUNDLE_MANIFEST_FIELDS, name="prediction-bundle store manifest"
+    )
+    if manifest.get("schema_name") != PREDICTION_BUNDLE_STORE_SCHEMA:
+        raise ValueError("unsupported prediction-bundle store schema")
+    if manifest.get("schema_version") != PREDICTION_BUNDLE_STORE_VERSION:
+        raise ValueError("unsupported prediction-bundle store version")
+    declared_id = _require_sha256(manifest.get("store_id"), name="bundle store_id")
+    if _compute_store_id(manifest) != declared_id:
+        raise ValueError("prediction-bundle store ID does not match its manifest")
+    source_sha = _require_sha256(
+        manifest.get("source_manifest_sha256"), name="source manifest sha256"
+    )
+    storage_dtype = _validated_dense_storage_dtype(manifest.get("dense_storage_dtype"))
+    overlap_values = manifest.get("overlap_windows")
+    if not isinstance(overlap_values, list) or not overlap_values:
+        raise ValueError("prediction-bundle store requires overlap windows")
+    overlap = [
+        _load_store_reference(
+            root,
+            value,
+            name=f"overlap window {index}",
+            verify_hashes=verify_hashes,
+        )
+        for index, value in enumerate(overlap_values)
+    ]
+    overlap.sort(key=lambda window: window.start_frame)
+    disjoint = _load_store_reference(
+        root,
+        manifest.get("disjoint_baseline"),
+        name="disjoint baseline",
+        verify_hashes=verify_hashes,
+    )
+    latent = _load_store_reference(
+        root,
+        manifest.get("latent_linear_baseline"),
+        name="latent-linear baseline",
+        verify_hashes=verify_hashes,
+    )
+    source_metadata = manifest.get("source_metadata")
+    if not isinstance(source_metadata, Mapping):
+        raise ValueError("prediction-bundle source_metadata must be a mapping")
+    metadata = dict(plain_json(source_metadata))
+    metadata["prediction_execution_store"] = {
+        "schema_name": PREDICTION_BUNDLE_STORE_SCHEMA,
+        "schema_version": PREDICTION_BUNDLE_STORE_VERSION,
+        "store_id": declared_id,
+        "source_manifest_sha256": source_sha,
+        "dense_storage_dtype": storage_dtype,
+        "verify_hashes": bool(verify_hashes),
+    }
+    return PredictionBundle(
+        manifest_path=manifest_path,
+        overlap_windows=overlap,
+        disjoint_baseline=disjoint,
+        latent_linear_baseline=latent,
+        metadata=metadata,
+    )
+
+
+def prediction_bundle_store_summary(directory: str | Path) -> dict[str, object]:
+    """Return validated execution-store identity and retained-array accounting."""
+
+    bundle = load_prediction_bundle_store(directory, verify_hashes=True)
+    store = bundle.metadata["prediction_execution_store"]
+    return {
+        **store,
+        **bundle.dense_storage_summary(),
+        "manifest_path": str(bundle.manifest_path),
+    }
+
+
+__all__ = [
+    "MMapPredictionWindow",
+    "PREDICTION_BUNDLE_STORE_SCHEMA",
+    "PREDICTION_BUNDLE_STORE_VERSION",
+    "PREDICTION_STORE_MANIFEST",
+    "PREDICTION_WINDOW_STORE_SCHEMA",
+    "PREDICTION_WINDOW_STORE_VERSION",
+    "load_prediction_bundle_store",
+    "load_prediction_window_store",
+    "materialize_prediction_bundle_store",
+    "prediction_bundle_store_summary",
+    "write_prediction_window_store",
+]

--- a/src/prob4d/prediction_store_benchmark.py
+++ b/src/prob4d/prediction_store_benchmark.py
@@ -1,0 +1,125 @@
+"""Profile eager NPZ versus read-only memory-mapped prediction loading."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import platform
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from .data import DENSE_STORAGE_DTYPES
+from .io import load_prediction_bundle
+from .prediction_store import load_prediction_bundle_store
+
+
+def _peak_rss_bytes() -> int | None:
+    try:
+        import resource
+    except ImportError:
+        return None
+    value = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+    return value if sys.platform == "darwin" else 1024 * value
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def run_benchmark(arguments: argparse.Namespace) -> dict[str, Any]:
+    started = time.perf_counter()
+    if arguments.backend == "eager_npz":
+        bundle = load_prediction_bundle(
+            arguments.input,
+            dense_storage_dtype=arguments.dense_storage_dtype,
+        )
+        manifest_path = Path(arguments.input)
+        identity = {
+            "source_manifest_sha256": _sha256_file(manifest_path),
+            "store_id": None,
+        }
+    else:
+        bundle = load_prediction_bundle_store(arguments.input, verify_hashes=True)
+        manifest_path = bundle.manifest_path
+        store = bundle.metadata["prediction_execution_store"]
+        identity = {
+            "source_manifest_sha256": store["source_manifest_sha256"],
+            "store_id": store["store_id"],
+        }
+    loading_seconds = time.perf_counter() - started
+    summary = bundle.dense_storage_summary()
+    return {
+        "schema": "prob4d.prediction-store-memory-benchmark",
+        "version": 1,
+        "python_version": platform.python_version(),
+        "numpy_version": np.__version__,
+        "platform": platform.platform(),
+        "configuration": {
+            "backend": arguments.backend,
+            "input": str(arguments.input),
+            "dense_storage_dtype": arguments.dense_storage_dtype,
+            "full_member_hash_verification": True,
+        },
+        "identity": identity,
+        "timing_seconds": {"loading_and_validation": loading_seconds},
+        "memory_bytes": {
+            "peak_process_rss": _peak_rss_bytes(),
+            "retained_dense_vectors": summary["retained_bytes"],
+            "float64_equivalent": summary["float64_equivalent_bytes"],
+        },
+        "bundle": {
+            "window_count": summary["window_count"],
+            "dense_vector_field_count": summary["dense_vector_field_count"],
+            "storage_dtypes": summary["storage_dtypes"],
+            "manifest_path": str(manifest_path),
+        },
+        "claim_boundary": (
+            "Process-level engineering profile only. Compare backends in separate "
+            "fresh processes with the same host, revision, source bundle, and dtype."
+        ),
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path)
+    parser.add_argument(
+        "--backend",
+        choices=("eager_npz", "mmap_npy"),
+        required=True,
+    )
+    parser.add_argument(
+        "--dense-storage-dtype",
+        choices=DENSE_STORAGE_DTYPES,
+        default="float32",
+    )
+    parser.add_argument("--output-json", type=Path)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    arguments = parser.parse_args(argv)
+    try:
+        result = run_benchmark(arguments)
+    except ValueError as error:
+        parser.error(str(error))
+    encoded = json.dumps(result, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    if arguments.output_json is not None:
+        arguments.output_json.parent.mkdir(parents=True, exist_ok=True)
+        arguments.output_json.write_text(encoded, encoding="utf-8")
+    print(encoded, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/prob4d/prediction_store_benchmark.py
+++ b/src/prob4d/prediction_store_benchmark.py
@@ -6,6 +6,7 @@ import argparse
 import hashlib
 import json
 import platform
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -16,6 +17,18 @@ import numpy as np
 from .data import DENSE_STORAGE_DTYPES
 from .io import load_prediction_bundle
 from .prediction_store import load_prediction_bundle_store
+
+
+def _git_revision(repository_root: Path) -> str | None:
+    completed = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=repository_root,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    value = completed.stdout.strip()
+    return value if completed.returncode == 0 and len(value) == 40 else None
 
 
 def _peak_rss_bytes() -> int | None:
@@ -57,9 +70,18 @@ def run_benchmark(arguments: argparse.Namespace) -> dict[str, Any]:
         }
     loading_seconds = time.perf_counter() - started
     summary = bundle.dense_storage_summary()
+    actual_storage_dtypes = summary["storage_dtypes"]
+    expected_storage_dtypes = [arguments.dense_storage_dtype]
+    if actual_storage_dtypes != expected_storage_dtypes:
+        raise ValueError(
+            "prediction backend storage dtype differs from the requested benchmark "
+            f"contract: requested={expected_storage_dtypes}, actual={actual_storage_dtypes}"
+        )
+    repository_root = Path(__file__).resolve().parents[2]
     return {
         "schema": "prob4d.prediction-store-memory-benchmark",
         "version": 1,
+        "repository_revision": _git_revision(repository_root),
         "python_version": platform.python_version(),
         "numpy_version": np.__version__,
         "platform": platform.platform(),
@@ -79,7 +101,7 @@ def run_benchmark(arguments: argparse.Namespace) -> dict[str, Any]:
         "bundle": {
             "window_count": summary["window_count"],
             "dense_vector_field_count": summary["dense_vector_field_count"],
-            "storage_dtypes": summary["storage_dtypes"],
+            "storage_dtypes": actual_storage_dtypes,
             "manifest_path": str(manifest_path),
         },
         "claim_boundary": (

--- a/src/prob4d/prediction_store_cli.py
+++ b/src/prob4d/prediction_store_cli.py
@@ -1,0 +1,61 @@
+"""CLI for content-addressed memory-mapped prediction execution stores."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+from pathlib import Path
+
+from .data import DENSE_STORAGE_DTYPES
+from .prediction_store import (
+    materialize_prediction_bundle_store,
+    prediction_bundle_store_summary,
+)
+
+
+def main_materialize(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="prob4d storage materialize",
+        description=(
+            "Convert a verified NPZ prediction bundle into an atomic, "
+            "content-addressed NPY execution store."
+        ),
+    )
+    parser.add_argument("source_manifest", type=Path)
+    parser.add_argument("destination", type=Path)
+    parser.add_argument(
+        "--dense-storage-dtype",
+        choices=DENSE_STORAGE_DTYPES,
+        default="float32",
+    )
+    arguments = parser.parse_args(list(argv) if argv is not None else None)
+    try:
+        materialize_prediction_bundle_store(
+            arguments.source_manifest,
+            arguments.destination,
+            dense_storage_dtype=arguments.dense_storage_dtype,
+        )
+        summary = prediction_bundle_store_summary(arguments.destination)
+    except ValueError as error:
+        parser.error(str(error))
+    print(json.dumps(summary, indent=2, sort_keys=True, allow_nan=False))
+    return 0
+
+
+def main_validate(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="prob4d storage validate",
+        description="Hash-verify and summarize a memory-mapped prediction store.",
+    )
+    parser.add_argument("directory", type=Path)
+    arguments = parser.parse_args(list(argv) if argv is not None else None)
+    try:
+        summary = prediction_bundle_store_summary(arguments.directory)
+    except ValueError as error:
+        parser.error(str(error))
+    print(json.dumps(summary, indent=2, sort_keys=True, allow_nan=False))
+    return 0
+
+
+__all__ = ["main_materialize", "main_validate"]

--- a/tests/test_prediction_store.py
+++ b/tests/test_prediction_store.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from prob4d.benchmark import fuse_prediction_bundle_methods
+from prob4d.data import PredictionWindow
+from prob4d.fusion import FusedSequence, fuse_windows
+from prob4d.io import load_prediction_bundle
+from prob4d.prediction_store import (
+    MMapPredictionWindow,
+    load_prediction_bundle_store,
+    load_prediction_window_store,
+    materialize_prediction_bundle_store,
+    prediction_bundle_store_summary,
+    write_prediction_window_store,
+)
+from prob4d.sim3 import Sim3
+from prob4d.synthetic import SyntheticProblem, make_synthetic_problem
+from prob4d.uncertainty import DepthDisagreementModel
+
+
+def _write_sequence(path: Path, sequence: FusedSequence) -> None:
+    payload: dict[str, np.ndarray] = {
+        "frame_indices": sequence.frame_indices,
+        "point_map": sequence.point_map,
+        "valid_mask": sequence.valid_mask,
+    }
+    if sequence.scene_flow is not None:
+        payload["scene_flow"] = sequence.scene_flow
+        payload["deform_mask"] = sequence.deform_mask
+    np.savez_compressed(path, **payload)
+
+
+def _write_problem_bundle(root: Path, problem: SyntheticProblem) -> Path:
+    root.mkdir(parents=True)
+    windows_directory = root / "windows"
+    windows_directory.mkdir()
+    manifest_windows: list[dict[str, object]] = []
+    for window in problem.overlap_windows:
+        relative = Path("windows") / f"{window.window_id}.npz"
+        window.to_npz(root / relative)
+        manifest_windows.append(
+            {
+                "window_id": window.window_id,
+                "path": relative.as_posix(),
+                "start_frame": window.start_frame,
+                "stop_frame": window.stop_frame,
+            }
+        )
+    model = DepthDisagreementModel()
+    disjoint = fuse_windows(
+        problem.disjoint_windows,
+        {window.window_id: Sim3.identity() for window in problem.disjoint_windows},
+        {window.window_id: model.predict(window) for window in problem.disjoint_windows},
+        method="uniform",
+    )
+    latent = fuse_windows(
+        problem.overlap_windows,
+        {window.window_id: Sim3.identity() for window in problem.overlap_windows},
+        {window.window_id: model.predict(window) for window in problem.overlap_windows},
+        method="uniform",
+    )
+    _write_sequence(root / "baseline_disjoint.npz", disjoint)
+    _write_sequence(root / "baseline_latent_linear.npz", latent)
+    manifest = {
+        "format_version": 1,
+        "motioncrafter_commit": "synthetic-test",
+        "overlap_windows": manifest_windows,
+        "disjoint_baseline": "baseline_disjoint.npz",
+        "latent_linear_baseline": "baseline_latent_linear.npz",
+    }
+    manifest_path = root / "predictions.json"
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    return manifest_path
+
+
+def test_prediction_window_store_opens_read_only_memory_maps(tmp_path: Path) -> None:
+    point_map = np.arange(72, dtype=np.float64).reshape(2, 3, 4, 3)
+    valid = np.ones((2, 3, 4), dtype=bool)
+    window = PredictionWindow(
+        window_id="window-a",
+        frame_indices=np.asarray([3, 4], dtype=np.int64),
+        point_map=point_map,
+        valid_mask=valid,
+    )
+
+    manifest = write_prediction_window_store(
+        window,
+        tmp_path / "window-store",
+        dense_storage_dtype="float32",
+    )
+    loaded = load_prediction_window_store(tmp_path / "window-store")
+
+    assert manifest.is_file()
+    assert isinstance(loaded, MMapPredictionWindow)
+    assert loaded.dense_storage_dtype == "float32"
+    assert isinstance(loaded.point_map.base, np.memmap)
+    assert not loaded.point_map.flags.writeable
+    np.testing.assert_array_equal(loaded.frame_indices, window.frame_indices)
+    np.testing.assert_allclose(loaded.point_map, window.point_map)
+
+
+def test_prediction_window_store_detects_member_tampering(tmp_path: Path) -> None:
+    window = PredictionWindow(
+        window_id="window-a",
+        frame_indices=np.asarray([0], dtype=np.int64),
+        point_map=np.ones((1, 1, 1, 3), dtype=np.float64),
+        valid_mask=np.ones((1, 1, 1), dtype=bool),
+    )
+    write_prediction_window_store(window, tmp_path / "window-store")
+    member = tmp_path / "window-store" / "point_map.npy"
+    payload = bytearray(member.read_bytes())
+    payload[-1] ^= 1
+    member.write_bytes(payload)
+
+    with pytest.raises(ValueError, match="SHA-256 mismatch"):
+        load_prediction_window_store(tmp_path / "window-store")
+
+
+def test_prediction_bundle_store_matches_eager_fusion(tmp_path: Path) -> None:
+    problem = make_synthetic_problem(
+        seed=31,
+        num_frames=30,
+        height=2,
+        width=3,
+        overlap=10,
+    )
+    source_manifest = _write_problem_bundle(tmp_path / "bundle", problem)
+    source_digest = hashlib.sha256(source_manifest.read_bytes()).hexdigest()
+    eager = load_prediction_bundle(source_manifest, dense_storage_dtype="float32")
+
+    store_manifest = materialize_prediction_bundle_store(
+        source_manifest,
+        tmp_path / "bundle-store",
+        dense_storage_dtype="float32",
+    )
+    stored = load_prediction_bundle_store(tmp_path / "bundle-store")
+
+    assert store_manifest.is_file()
+    assert stored.metadata["prediction_execution_store"][
+        "source_manifest_sha256"
+    ] == source_digest
+    assert all(
+        isinstance(window.point_map.base, np.memmap)
+        for window in stored.overlap_windows
+    )
+    assert stored.dense_storage_summary() == eager.dense_storage_summary()
+
+    methods = ("prob4d_uniform", "prob4d_ci")
+    eager_fused = fuse_prediction_bundle_methods(eager, method_names=methods)
+    stored_fused = fuse_prediction_bundle_methods(stored, method_names=methods)
+    for method in methods:
+        np.testing.assert_allclose(
+            stored_fused[method].point_map,
+            eager_fused[method].point_map,
+        )
+        np.testing.assert_allclose(
+            stored_fused[method].point_covariance,
+            eager_fused[method].point_covariance,
+        )
+        np.testing.assert_array_equal(
+            stored_fused[method].contributors,
+            eager_fused[method].contributors,
+        )
+
+    summary = prediction_bundle_store_summary(tmp_path / "bundle-store")
+    assert summary["source_manifest_sha256"] == source_digest
+    assert summary["storage_dtypes"] == ["float32"]
+
+
+def test_prediction_bundle_store_is_create_once(tmp_path: Path) -> None:
+    problem = make_synthetic_problem(
+        seed=32,
+        num_frames=20,
+        height=1,
+        width=2,
+        overlap=5,
+    )
+    source_manifest = _write_problem_bundle(tmp_path / "bundle", problem)
+    destination = tmp_path / "bundle-store"
+    materialize_prediction_bundle_store(source_manifest, destination)
+
+    with pytest.raises(ValueError, match="already exists"):
+        materialize_prediction_bundle_store(source_manifest, destination)
+
+
+def test_prediction_store_grouped_cli_materializes_and_validates(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    from prob4d.cli import main as cli_main
+
+    problem = make_synthetic_problem(
+        seed=33,
+        num_frames=20,
+        height=1,
+        width=2,
+        overlap=5,
+    )
+    source_manifest = _write_problem_bundle(tmp_path / "bundle", problem)
+    destination = tmp_path / "bundle-store"
+
+    assert (
+        cli_main(
+            [
+                "storage",
+                "materialize",
+                str(source_manifest),
+                str(destination),
+            ]
+        )
+        == 0
+    )
+    materialized = json.loads(capsys.readouterr().out)
+    assert materialized["storage_dtypes"] == ["float32"]
+
+    assert cli_main(["storage", "validate", str(destination)]) == 0
+    validated = json.loads(capsys.readouterr().out)
+    assert validated["store_id"] == materialized["store_id"]
+
+
+def test_prediction_store_benchmark_reports_explicit_backends(tmp_path: Path) -> None:
+    from argparse import Namespace
+
+    from prob4d.prediction_store_benchmark import run_benchmark
+
+    problem = make_synthetic_problem(
+        seed=34,
+        num_frames=20,
+        height=1,
+        width=2,
+        overlap=5,
+    )
+    source_manifest = _write_problem_bundle(tmp_path / "bundle", problem)
+    destination = tmp_path / "bundle-store"
+    materialize_prediction_bundle_store(source_manifest, destination)
+
+    eager = run_benchmark(
+        Namespace(
+            backend="eager_npz",
+            input=source_manifest,
+            dense_storage_dtype="float32",
+        )
+    )
+    mapped = run_benchmark(
+        Namespace(
+            backend="mmap_npy",
+            input=destination,
+            dense_storage_dtype="float32",
+        )
+    )
+
+    assert eager["configuration"]["backend"] == "eager_npz"
+    assert mapped["configuration"]["backend"] == "mmap_npy"
+    assert eager["identity"]["source_manifest_sha256"] == mapped["identity"][
+        "source_manifest_sha256"
+    ]
+    assert mapped["identity"]["store_id"] is not None
+    assert eager["memory_bytes"]["retained_dense_vectors"] == mapped[
+        "memory_bytes"
+    ]["retained_dense_vectors"]

--- a/tests/test_prediction_store_benchmark_contract.py
+++ b/tests/test_prediction_store_benchmark_contract.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from prob4d import prediction_store_benchmark
+
+
+class _FakeMappedBundle:
+    manifest_path = Path("/tmp/fake-store/manifest.json")
+    metadata = {
+        "prediction_execution_store": {
+            "source_manifest_sha256": "a" * 64,
+            "store_id": "b" * 64,
+        }
+    }
+
+    @staticmethod
+    def dense_storage_summary() -> dict[str, object]:
+        return {
+            "retained_bytes": 128,
+            "float64_equivalent_bytes": 256,
+            "window_count": 3,
+            "dense_vector_field_count": 6,
+            "storage_dtypes": ["float32"],
+        }
+
+
+def test_mmap_benchmark_rejects_requested_dtype_mismatch(monkeypatch) -> None:
+    monkeypatch.setattr(
+        prediction_store_benchmark,
+        "load_prediction_bundle_store",
+        lambda *_args, **_kwargs: _FakeMappedBundle(),
+    )
+
+    with pytest.raises(ValueError, match="storage dtype differs"):
+        prediction_store_benchmark.run_benchmark(
+            Namespace(
+                backend="mmap_npy",
+                input=Path("/tmp/fake-store"),
+                dense_storage_dtype="float64",
+            )
+        )
+
+
+def test_mmap_benchmark_records_actual_dtype_and_revision(monkeypatch) -> None:
+    monkeypatch.setattr(
+        prediction_store_benchmark,
+        "load_prediction_bundle_store",
+        lambda *_args, **_kwargs: _FakeMappedBundle(),
+    )
+    monkeypatch.setattr(
+        prediction_store_benchmark,
+        "_git_revision",
+        lambda _root: "c" * 40,
+    )
+
+    result = prediction_store_benchmark.run_benchmark(
+        Namespace(
+            backend="mmap_npy",
+            input=Path("/tmp/fake-store"),
+            dense_storage_dtype="float32",
+        )
+    )
+
+    assert result["repository_revision"] == "c" * 40
+    assert result["configuration"]["dense_storage_dtype"] == "float32"
+    assert result["bundle"]["storage_dtypes"] == ["float32"]


### PR DESCRIPTION
## What changed

- add atomic, content-addressed NPY execution stores for verified MotionCrafter prediction windows and complete bundles;
- materialize windows one at a time so cache creation does not retain the complete source bundle;
- open dense arrays read-only through NumPy memory maps while preserving the `PredictionWindow` interface used by alignment, uncertainty, and fusion;
- bind every member's path, byte count, dtype, shape, and SHA-256 plus the exact source prediction-manifest digest;
- reject symlinks, path escapes, malformed/aliased fields, mismatched content addresses, invalid masks/vectors/rays, and partial existing destinations;
- add grouped materialize, validate, and fresh-process benchmark commands;
- prove eager-NPZ versus mmap-NPY fusion parity for uniform and covariance-intersection paths;
- bind benchmark reports to the executing repository revision and fail closed when the requested dtype differs from the mapped store;
- document that the store is an execution cache and does not replace or reinterpret portable provider artifacts.

## Usage

```bash
prob4d storage materialize predictions.json prediction-store \
  --dense-storage-dtype float32
prob4d storage validate prediction-store
prob4d storage benchmark prediction-store --backend mmap_npy
```

For a matched process-memory comparison, run the benchmark separately with `--backend eager_npz` on the original prediction manifest.

## Validation

The PR adds tamper, immutability, fusion-parity, CLI, create-once, benchmark-provenance, and dtype-contract tests and routes the new stable modules through Ruff, mypy, Python 3.10/3.12/3.14, distribution builds, isolated wheel/sdist installs, and grouped CLI smoke tests.

## Claim boundary

This is runtime and storage engineering. It does not alter gauge estimation, uncertainty semantics, provider-v1/v2 artifacts, reconstruction results, BayesianPhysTwin updates, or Causal4D claims. Full production-host, phase-wise `25 x 320 x 640` profiling remains separate work.

Advances #50.