### PR TITLE
Add preregistered provider competence decisions

### DIFF
--- a/.github/workflows/provider-evaluation-decision.yml
+++ b/.github/workflows/provider-evaluation-decision.yml
@@ -1,0 +1,68 @@
+name: Provider evaluation decision contract
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/provider-evaluation-decision.yml"
+      - "docs/provider-evaluation-decisions.md"
+      - "src/prob4d/_provider_evaluation_decision.py"
+      - "src/prob4d/_provider_evaluation_manifest.py"
+      - "src/prob4d/_provider_evaluation_output.py"
+      - "src/prob4d/provider_evaluation.py"
+      - "tests/test_provider_evaluation.py"
+      - "tests/test_provider_evaluation_decision.py"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/provider-evaluation-decision.yml"
+      - "docs/provider-evaluation-decisions.md"
+      - "src/prob4d/_provider_evaluation_decision.py"
+      - "src/prob4d/_provider_evaluation_manifest.py"
+      - "src/prob4d/_provider_evaluation_output.py"
+      - "src/prob4d/provider_evaluation.py"
+      - "tests/test_provider_evaluation.py"
+      - "tests/test_provider_evaluation_decision.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: provider-decision-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  provider-decision:
+    name: Provider decision manifest and report
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install development environment
+        run: python -m pip install -e ".[dev]"
+      - name: Check focused source quality
+        run: |
+          python -m ruff check \
+            src/prob4d/_provider_evaluation_decision.py \
+            src/prob4d/_provider_evaluation_manifest.py \
+            src/prob4d/_provider_evaluation_output.py \
+            src/prob4d/provider_evaluation.py \
+            tests/test_provider_evaluation.py \
+            tests/test_provider_evaluation_decision.py
+          python -m mypy \
+            src/prob4d/_provider_evaluation_decision.py \
+            src/prob4d/_provider_evaluation_manifest.py \
+            src/prob4d/provider_evaluation.py
+      - name: Run decision and compatibility regressions
+        run: >-
+          python -m pytest -q
+          tests/test_provider_evaluation.py
+          tests/test_provider_evaluation_decision.py

--- a/.github/workflows/provider-evaluation-decision.yml
+++ b/.github/workflows/provider-evaluation-decision.yml
@@ -47,7 +47,9 @@ jobs:
           cache: pip
           cache-dependency-path: pyproject.toml
       - name: Install development environment
-        run: python -m pip install -e ".[dev]"
+        run: |
+          python -m pip install -e ".[dev]"
+          python -m pip install "numpy>=1.24,<2.3"
       - name: Check focused source quality
         run: |
           python -m ruff check \

--- a/docs/provider-evaluation-decisions.md
+++ b/docs/provider-evaluation-decisions.md
@@ -1,0 +1,135 @@
+# Preregistered provider-evaluation decisions
+
+Provider-evaluation manifest version 2 adds a target-frozen decision policy to the
+paired held-out evaluator. Manifest version 1 and report version 2 remain unchanged
+for frozen reproduction.
+
+The decision policy answers one narrow question: whether a registered Prob4D
+observation method passes declared held-out provider-competence gates relative to the
+manifest's reference method. It does not authorize a Bayesian-PhysTwin update and it
+does not establish Causal4D intervention benefit.
+
+## Manifest
+
+A decision-bearing manifest uses schema version 2 and adds exactly one
+`decision_policy` object:
+
+```json
+{
+  "schema_name": "prob4d.provider-evaluation",
+  "schema_version": 2,
+  "primary_mode": "metric",
+  "reference_method": "prob4d_uniform",
+  "cases": [
+    {
+      "case_id": "object-01-session-02",
+      "group_id": "object-01",
+      "truth": "truth/object-01-session-02.npz",
+      "predictions": {
+        "prob4d_uniform": "predictions/uniform/object-01-session-02.npz",
+        "prob4d_ci": "predictions/ci/object-01-session-02.npz"
+      },
+      "boundary_frames": [25, 42, 59],
+      "prefix_frame_stop_exclusive": 25
+    }
+  ],
+  "metadata": {
+    "split_id": "held-out-objects-v1",
+    "target_access_seal": "<registered-seal-id>"
+  },
+  "decision_policy": {
+    "policy_id": "prob4d-provider-gate-v1",
+    "minimum_group_count": 9,
+    "rules": [
+      {
+        "rule_id": "point-rmse-superiority",
+        "candidate_method": "prob4d_ci",
+        "metric": "metric_point_rmse",
+        "direction": "lower",
+        "criterion": "superiority",
+        "margin": 0.0
+      },
+      {
+        "rule_id": "coverage-noninferiority",
+        "candidate_method": "prob4d_ci",
+        "metric": "coverage_95",
+        "direction": "higher",
+        "criterion": "noninferiority",
+        "margin": 0.03
+      }
+    ]
+  }
+}
+```
+
+All candidate methods must be present in every case and must differ from the
+registered reference. Rule IDs are unique. `metric` is one unqualified metric field
+from the selected primary evaluation mode. A decision-bearing manifest cannot use
+`oracle_aligned`, because a truth-fitted full-sequence alignment is a reconstruction
+diagnostic rather than a prospective observation gate.
+
+## Bound interpretation
+
+Every rule consumes the paired `candidate - reference` group-bootstrap summary. The
+bound is selected by the rule semantics rather than by the observed result:
+
+| Direction | Criterion | Passing condition |
+| --- | --- | --- |
+| lower is better | superiority | upper 95% bound <= `-margin` |
+| lower is better | non-inferiority | upper 95% bound <= `margin` |
+| higher is better | superiority | lower 95% bound >= `margin` |
+| higher is better | non-inferiority | lower 95% bound >= `-margin` |
+
+The complete policy passes only when every rule passes and the observed independent
+`group_id` count is at least `minimum_group_count`. An insufficient group count is
+reported as a failed gate; it does not discard the evaluated cases or suppress the
+negative result.
+
+Report schema version 3 binds the exact policy and emits:
+
+- observed and required independent-group counts;
+- every metric path, estimate, interval, selected decision bound, and threshold;
+- per-rule pass/fail results;
+- the complete policy pass/fail result; and
+- the unchanged provider-only claim boundary.
+
+## Fail-closed command use
+
+The ordinary command always writes the report, including a failed decision:
+
+```bash
+prob4d evaluate provider protocols/provider-evaluation-v2.json \
+  --output-dir outputs/provider-evaluation
+```
+
+For automation, require the registered policy to pass:
+
+```bash
+prob4d evaluate provider protocols/provider-evaluation-v2.json \
+  --output-dir outputs/provider-evaluation \
+  --require-decision-pass
+```
+
+The command returns:
+
+- exit code `0` when the schema-v2 decision policy passes;
+- exit code `3` when the report is valid but the group or metric gates fail; and
+- argparse exit code `2` when `--require-decision-pass` is requested for a manifest
+  without a decision policy.
+
+The JSON, CSV, and Markdown outputs are written before exit code 3 is returned, so a
+well-powered negative or underpowered result remains inspectable and archivable.
+
+## Information boundary
+
+The policy, split, grouping unit, reference method, metric directions, criteria,
+margins, minimum group count, bootstrap configuration, model identities, and complete
+prediction artifacts must be sealed before target outcomes are opened. Changing a rule
+after scoring creates a new exploratory method rather than repairing the registered
+one.
+
+A passing provider decision remains only an observation-quality gate. Bayesian-PhysTwin
+must separately evaluate identifiability, guarded acceptance, harmful accepted updates,
+physical prediction, uncertainty width, and exact fallback. Causal4D may consume only
+an accepted, content-bound twin belief and must not assimilate the same Prob4D evidence
+a second time.

--- a/src/prob4d/_provider_evaluation_decision.py
+++ b/src/prob4d/_provider_evaluation_decision.py
@@ -1,0 +1,151 @@
+"""Preregistered decision rules for held-out provider competence reports."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from ._provider_evaluation_manifest import (
+    EvaluationModeName,
+    ProviderEvaluationDecisionPolicy,
+    ProviderEvaluationDecisionRule,
+)
+
+
+def _group_count(
+    aggregate: Mapping[str, Any],
+    *,
+    reference_method: str,
+) -> int:
+    reference = aggregate.get(reference_method)
+    if not isinstance(reference, Mapping):
+        raise ValueError("decision policy reference method is missing from aggregate results")
+    count = reference.get("group_count")
+    if isinstance(count, bool) or not isinstance(count, int) or count < 1:
+        raise ValueError("aggregate reference group_count must be a positive integer")
+    for method_id, summary in aggregate.items():
+        if not isinstance(summary, Mapping) or summary.get("group_count") != count:
+            raise ValueError(
+                f"method {method_id!r} does not share the reference group count"
+            )
+    return count
+
+
+def _rule_result(
+    rule: ProviderEvaluationDecisionRule,
+    *,
+    comparison: Mapping[str, Any],
+    primary_mode: EvaluationModeName,
+) -> dict[str, Any]:
+    metrics = comparison.get("metrics")
+    if not isinstance(metrics, Mapping):
+        raise ValueError(
+            f"candidate {rule.candidate_method!r} has no paired comparison metrics"
+        )
+    metric_path = f"{primary_mode}.metrics.{rule.metric}"
+    summary = metrics.get(metric_path)
+    if not isinstance(summary, Mapping):
+        raise ValueError(
+            f"decision rule {rule.rule_id!r} references unavailable metric "
+            f"{metric_path!r}"
+        )
+    required = ("mean", "ci95_lower", "ci95_upper", "group_count")
+    if any(name not in summary for name in required):
+        raise ValueError(
+            f"decision metric {metric_path!r} lacks a complete bootstrap summary"
+        )
+    estimate = float(summary["mean"])
+    lower = float(summary["ci95_lower"])
+    upper = float(summary["ci95_upper"])
+
+    if rule.direction == "lower":
+        bound_name = "ci95_upper"
+        bound_value = upper
+        threshold = -rule.margin if rule.criterion == "superiority" else rule.margin
+        passed = bound_value <= threshold
+    else:
+        bound_name = "ci95_lower"
+        bound_value = lower
+        threshold = rule.margin if rule.criterion == "superiority" else -rule.margin
+        passed = bound_value >= threshold
+
+    return {
+        "rule_id": rule.rule_id,
+        "candidate_method": rule.candidate_method,
+        "reference_method": comparison.get("reference_method"),
+        "metric": rule.metric,
+        "metric_path": metric_path,
+        "direction": rule.direction,
+        "criterion": rule.criterion,
+        "margin": rule.margin,
+        "difference_semantics": "candidate_minus_reference",
+        "estimate": estimate,
+        "ci95_lower": lower,
+        "ci95_upper": upper,
+        "decision_bound": bound_name,
+        "decision_bound_value": bound_value,
+        "pass_threshold": threshold,
+        "passed": passed,
+    }
+
+
+def evaluate_provider_decision_policy(
+    policy: ProviderEvaluationDecisionPolicy,
+    *,
+    aggregate: Mapping[str, Any],
+    comparisons: Mapping[str, Any],
+    primary_mode: EvaluationModeName,
+    reference_method: str,
+) -> dict[str, Any]:
+    """Evaluate one target-frozen policy without selecting metrics after scoring."""
+
+    observed_group_count = _group_count(
+        aggregate,
+        reference_method=reference_method,
+    )
+    group_count_passed = observed_group_count >= policy.minimum_group_count
+    results: list[dict[str, Any]] = []
+    for rule in policy.rules:
+        comparison = comparisons.get(rule.candidate_method)
+        if not isinstance(comparison, Mapping):
+            raise ValueError(
+                f"decision candidate {rule.candidate_method!r} has no paired comparison"
+            )
+        if comparison.get("reference_method") != reference_method:
+            raise ValueError(
+                f"decision candidate {rule.candidate_method!r} changed reference method"
+            )
+        results.append(
+            _rule_result(
+                rule,
+                comparison=comparison,
+                primary_mode=primary_mode,
+            )
+        )
+
+    passed_rule_count = sum(bool(result["passed"]) for result in results)
+    return {
+        "policy_id": policy.policy_id,
+        "primary_mode": primary_mode,
+        "reference_method": reference_method,
+        "minimum_group_count": policy.minimum_group_count,
+        "observed_group_count": observed_group_count,
+        "group_count_passed": group_count_passed,
+        "rule_count": len(results),
+        "passed_rule_count": passed_rule_count,
+        "rules": results,
+        "overall_passed": group_count_passed and passed_rule_count == len(results),
+        "decision_semantics": (
+            "All preregistered rules and the minimum independent-group gate must pass. "
+            "Lower-is-better rules use the upper paired-bootstrap bound; "
+            "higher-is-better rules use the lower bound."
+        ),
+        "claim_boundary": (
+            "A passing policy establishes only held-out provider competence under the "
+            "registered observation protocol. It does not establish Bayesian-PhysTwin "
+            "acceptance or Causal4D intervention benefit."
+        ),
+    }
+
+
+__all__ = ["evaluate_provider_decision_policy"]

--- a/src/prob4d/_provider_evaluation_manifest.py
+++ b/src/prob4d/_provider_evaluation_manifest.py
@@ -434,11 +434,15 @@ def load_provider_evaluation_plan(
 def load_provider_evaluation_cases(
     manifest_path: Path,
 ) -> tuple[list[ProviderEvaluationCase], EvaluationModeName, str, dict[str, Any]]:
-    """Load the frozen v1-compatible paired-case surface."""
+    """Load only the frozen manifest-v1 paired-case surface."""
 
-    cases, primary_mode, reference_method, metadata, _ = (
+    cases, primary_mode, reference_method, metadata, policy = (
         load_provider_evaluation_plan(manifest_path)
     )
+    if policy is not None:
+        raise ValueError(
+            "decision-bearing manifest requires load_provider_evaluation_plan"
+        )
     return cases, primary_mode, reference_method, metadata
 
 

--- a/src/prob4d/_provider_evaluation_manifest.py
+++ b/src/prob4d/_provider_evaluation_manifest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import math
+import re
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -13,8 +14,14 @@ import numpy as np
 
 PROVIDER_EVALUATION_SCHEMA = "prob4d.provider-evaluation"
 PROVIDER_EVALUATION_VERSION = 1
+PROVIDER_EVALUATION_DECISION_VERSION = 2
 EvaluationModeName = Literal["metric", "prefix_aligned", "oracle_aligned"]
+DecisionDirection = Literal["lower", "higher"]
+DecisionCriterion = Literal["superiority", "noninferiority"]
 _EVALUATION_MODES = {"metric", "prefix_aligned", "oracle_aligned"}
+_DECISION_DIRECTIONS = {"lower", "higher"}
+_DECISION_CRITERIA = {"superiority", "noninferiority"}
+_METRIC_NAME = re.compile(r"^[A-Za-z][A-Za-z0-9_]*$")
 
 
 @dataclass(frozen=True)
@@ -65,6 +72,95 @@ class ProviderEvaluationCase:
         object.__setattr__(self, "prefix_frame_stop_exclusive", prefix_stop)
 
 
+@dataclass(frozen=True)
+class ProviderEvaluationDecisionRule:
+    """One preregistered paired comparison against the manifest reference method."""
+
+    rule_id: str
+    candidate_method: str
+    metric: str
+    direction: DecisionDirection
+    criterion: DecisionCriterion
+    margin: float = 0.0
+
+    def __post_init__(self) -> None:
+        rule_id = str(self.rule_id).strip()
+        candidate_method = str(self.candidate_method).strip()
+        metric = str(self.metric).strip()
+        direction = str(self.direction).strip()
+        criterion = str(self.criterion).strip()
+        margin = float(self.margin)
+        if not rule_id or not candidate_method:
+            raise ValueError("decision rule and candidate IDs must be nonempty")
+        if _METRIC_NAME.fullmatch(metric) is None:
+            raise ValueError(
+                "decision metric must be one unqualified evaluation metric name"
+            )
+        if direction not in _DECISION_DIRECTIONS:
+            raise ValueError(
+                f"decision direction must be one of {sorted(_DECISION_DIRECTIONS)}"
+            )
+        if criterion not in _DECISION_CRITERIA:
+            raise ValueError(
+                f"decision criterion must be one of {sorted(_DECISION_CRITERIA)}"
+            )
+        if not math.isfinite(margin) or margin < 0.0:
+            raise ValueError("decision margin must be finite and nonnegative")
+        object.__setattr__(self, "rule_id", rule_id)
+        object.__setattr__(self, "candidate_method", candidate_method)
+        object.__setattr__(self, "metric", metric)
+        object.__setattr__(self, "direction", direction)
+        object.__setattr__(self, "criterion", criterion)
+        object.__setattr__(self, "margin", margin)
+
+    def to_dict(self) -> dict[str, str | float]:
+        return {
+            "rule_id": self.rule_id,
+            "candidate_method": self.candidate_method,
+            "metric": self.metric,
+            "direction": self.direction,
+            "criterion": self.criterion,
+            "margin": self.margin,
+        }
+
+
+@dataclass(frozen=True)
+class ProviderEvaluationDecisionPolicy:
+    """Target-frozen provider competence rule set."""
+
+    policy_id: str
+    minimum_group_count: int
+    rules: tuple[ProviderEvaluationDecisionRule, ...]
+
+    def __post_init__(self) -> None:
+        policy_id = str(self.policy_id).strip()
+        if not policy_id:
+            raise ValueError("decision policy_id must be nonempty")
+        minimum_group_count = self.minimum_group_count
+        if (
+            isinstance(minimum_group_count, bool)
+            or not isinstance(minimum_group_count, int)
+            or minimum_group_count < 1
+        ):
+            raise ValueError("decision minimum_group_count must be a positive integer")
+        rules = tuple(self.rules)
+        if not rules:
+            raise ValueError("decision policy must contain at least one rule")
+        rule_ids = tuple(rule.rule_id for rule in rules)
+        if len(set(rule_ids)) != len(rule_ids):
+            raise ValueError("decision rule IDs must be unique")
+        object.__setattr__(self, "policy_id", policy_id)
+        object.__setattr__(self, "minimum_group_count", minimum_group_count)
+        object.__setattr__(self, "rules", rules)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "policy_id": self.policy_id,
+            "minimum_group_count": self.minimum_group_count,
+            "rules": [rule.to_dict() for rule in self.rules],
+        }
+
+
 def _reject_constant(value: str) -> None:
     raise ValueError(f"non-standard JSON constant is forbidden: {value}")
 
@@ -112,10 +208,92 @@ def _resolve_path(root: Path, value: object, *, name: str) -> Path:
     return resolved
 
 
-def load_provider_evaluation_cases(
+def _decision_policy(
+    value: object,
+    *,
+    methods: tuple[str, ...],
+    reference_method: str,
+) -> ProviderEvaluationDecisionPolicy:
+    policy = _mapping(value, name="decision_policy")
+    if set(policy) != {"policy_id", "minimum_group_count", "rules"}:
+        raise ValueError("decision_policy fields changed")
+    raw_rules = policy.get("rules")
+    if not isinstance(raw_rules, list) or not raw_rules:
+        raise ValueError("decision_policy.rules must be a nonempty array")
+    rules: list[ProviderEvaluationDecisionRule] = []
+    for index, raw_rule in enumerate(raw_rules):
+        item = _mapping(raw_rule, name=f"decision_policy.rules[{index}]")
+        fields = {
+            "rule_id",
+            "candidate_method",
+            "metric",
+            "direction",
+            "criterion",
+            "margin",
+        }
+        if set(item) != fields:
+            raise ValueError(f"decision_policy.rules[{index}] fields changed")
+        direction = _text(
+            item.get("direction"),
+            name=f"decision_policy.rules[{index}].direction",
+        )
+        criterion = _text(
+            item.get("criterion"),
+            name=f"decision_policy.rules[{index}].criterion",
+        )
+        margin_value = item.get("margin")
+        if isinstance(margin_value, bool) or not isinstance(
+            margin_value, (int, float)
+        ):
+            raise ValueError(
+                f"decision_policy.rules[{index}].margin must be numeric"
+            )
+        rule = ProviderEvaluationDecisionRule(
+            rule_id=_text(
+                item.get("rule_id"),
+                name=f"decision_policy.rules[{index}].rule_id",
+            ),
+            candidate_method=_text(
+                item.get("candidate_method"),
+                name=f"decision_policy.rules[{index}].candidate_method",
+            ),
+            metric=_text(
+                item.get("metric"),
+                name=f"decision_policy.rules[{index}].metric",
+            ),
+            direction=cast(DecisionDirection, direction),
+            criterion=cast(DecisionCriterion, criterion),
+            margin=float(margin_value),
+        )
+        if rule.candidate_method == reference_method:
+            raise ValueError("decision candidate must differ from reference_method")
+        if rule.candidate_method not in methods:
+            raise ValueError(
+                f"decision candidate {rule.candidate_method!r} is not a registered method"
+            )
+        rules.append(rule)
+    minimum_group_count = policy.get("minimum_group_count")
+    if isinstance(minimum_group_count, bool) or not isinstance(
+        minimum_group_count, int
+    ):
+        raise ValueError("decision_policy.minimum_group_count must be an integer")
+    return ProviderEvaluationDecisionPolicy(
+        policy_id=_text(policy.get("policy_id"), name="decision_policy.policy_id"),
+        minimum_group_count=minimum_group_count,
+        rules=tuple(rules),
+    )
+
+
+def load_provider_evaluation_plan(
     manifest_path: Path,
-) -> tuple[list[ProviderEvaluationCase], EvaluationModeName, str, dict[str, Any]]:
-    """Load a strict paired-case manifest and resolve all input paths."""
+) -> tuple[
+    list[ProviderEvaluationCase],
+    EvaluationModeName,
+    str,
+    dict[str, Any],
+    ProviderEvaluationDecisionPolicy | None,
+]:
+    """Load paired cases and an optional target-frozen decision policy."""
 
     try:
         manifest = _mapping(
@@ -129,6 +307,14 @@ def load_provider_evaluation_cases(
         raise ValueError(
             f"cannot read provider-evaluation manifest: {manifest_path}"
         ) from error
+    if manifest.get("schema_name") != PROVIDER_EVALUATION_SCHEMA:
+        raise ValueError("unsupported provider-evaluation manifest schema")
+    schema_version = manifest.get("schema_version")
+    if isinstance(schema_version, bool) or schema_version not in {
+        PROVIDER_EVALUATION_VERSION,
+        PROVIDER_EVALUATION_DECISION_VERSION,
+    }:
+        raise ValueError("unsupported provider-evaluation manifest version")
     expected_fields = {
         "schema_name",
         "schema_version",
@@ -137,6 +323,8 @@ def load_provider_evaluation_cases(
         "cases",
         "metadata",
     }
+    if schema_version == PROVIDER_EVALUATION_DECISION_VERSION:
+        expected_fields.add("decision_policy")
     actual_fields = set(manifest)
     if actual_fields != expected_fields:
         raise ValueError(
@@ -144,14 +332,15 @@ def load_provider_evaluation_cases(
             f"missing={sorted(expected_fields - actual_fields)}, "
             f"extra={sorted(actual_fields - expected_fields)}"
         )
-    if manifest.get("schema_name") != PROVIDER_EVALUATION_SCHEMA:
-        raise ValueError("unsupported provider-evaluation manifest schema")
-    if manifest.get("schema_version") != PROVIDER_EVALUATION_VERSION:
-        raise ValueError("unsupported provider-evaluation manifest version")
     primary_mode_value = _text(manifest.get("primary_mode"), name="primary_mode")
     if primary_mode_value not in _EVALUATION_MODES:
         raise ValueError(f"primary_mode must be one of {sorted(_EVALUATION_MODES)}")
     primary_mode = cast(EvaluationModeName, primary_mode_value)
+    if (
+        schema_version == PROVIDER_EVALUATION_DECISION_VERSION
+        and primary_mode == "oracle_aligned"
+    ):
+        raise ValueError("decision-bearing evaluation cannot use oracle_aligned mode")
     reference_method = _text(
         manifest.get("reference_method"),
         name="reference_method",
@@ -232,14 +421,38 @@ def load_provider_evaluation_cases(
         raise ValueError(
             "reference_method must identify one prediction method in every case"
         )
+    policy = None
+    if schema_version == PROVIDER_EVALUATION_DECISION_VERSION:
+        policy = _decision_policy(
+            manifest.get("decision_policy"),
+            methods=expected_methods,
+            reference_method=reference_method,
+        )
+    return cases, primary_mode, reference_method, metadata, policy
+
+
+def load_provider_evaluation_cases(
+    manifest_path: Path,
+) -> tuple[list[ProviderEvaluationCase], EvaluationModeName, str, dict[str, Any]]:
+    """Load the frozen v1-compatible paired-case surface."""
+
+    cases, primary_mode, reference_method, metadata, _ = (
+        load_provider_evaluation_plan(manifest_path)
+    )
     return cases, primary_mode, reference_method, metadata
 
 
 __all__ = [
+    "PROVIDER_EVALUATION_DECISION_VERSION",
     "PROVIDER_EVALUATION_SCHEMA",
     "PROVIDER_EVALUATION_VERSION",
+    "DecisionCriterion",
+    "DecisionDirection",
     "EvaluationModeName",
     "ProviderEvaluationCase",
+    "ProviderEvaluationDecisionPolicy",
+    "ProviderEvaluationDecisionRule",
     "load_provider_evaluation_cases",
+    "load_provider_evaluation_plan",
     "validate_finite_json",
 ]

--- a/src/prob4d/_provider_evaluation_output.py
+++ b/src/prob4d/_provider_evaluation_output.py
@@ -92,6 +92,59 @@ def _table_rows(
     return rows
 
 
+def _decision_lines(decision: Mapping[str, Any] | None) -> list[str]:
+    if decision is None:
+        return []
+    overall = "PASS" if decision.get("overall_passed") is True else "FAIL"
+    group_result = "PASS" if decision.get("group_count_passed") is True else "FAIL"
+    lines = [
+        "",
+        "## Preregistered provider decision",
+        "",
+        f"Policy: `{decision['policy_id']}`. Overall result: **{overall}**.",
+        "",
+        "Independent-group gate: "
+        f"{decision['observed_group_count']} observed / "
+        f"{decision['minimum_group_count']} required — **{group_result}**.",
+        "",
+        "All values use paired `candidate - reference` group-bootstrap intervals.",
+        "",
+        "| Rule | Candidate | Metric | Criterion | Margin | Decision bound | "
+        "Threshold | Result |",
+        "| --- | --- | --- | --- | ---: | ---: | ---: | --- |",
+    ]
+    rules = decision.get("rules")
+    if not isinstance(rules, list):
+        raise ValueError("decision rules must be an array")
+    for rule in rules:
+        if not isinstance(rule, Mapping):
+            raise ValueError("decision rule result must be an object")
+        result = "PASS" if rule.get("passed") is True else "FAIL"
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(rule["rule_id"]),
+                    str(rule["candidate_method"]),
+                    str(rule["metric"]),
+                    f"{rule['direction']} {rule['criterion']}",
+                    f"{float(rule['margin']):.6g}",
+                    f"{float(rule['decision_bound_value']):.6g}",
+                    f"{float(rule['pass_threshold']):.6g}",
+                    result,
+                ]
+            )
+            + " |"
+        )
+    lines.extend(
+        [
+            "",
+            str(decision["claim_boundary"]),
+        ]
+    )
+    return lines
+
+
 def _write_markdown(
     path: Path,
     *,
@@ -99,6 +152,7 @@ def _write_markdown(
     reference_method: str,
     aggregate: Mapping[str, Any],
     comparisons: Mapping[str, Any],
+    decision: Mapping[str, Any] | None,
 ) -> None:
     selected = (
         "metric_point_rmse",
@@ -156,6 +210,7 @@ def _write_markdown(
         "| " + " | ".join(headers) + " |",
         separator,
         *_table_rows(comparisons, primary_mode=primary_mode, selected=selected),
+        *_decision_lines(decision),
         "",
         "Covariance semantics are read from each prediction archive and must remain "
         "consistent within a method. Legacy archives are rejected by default.",
@@ -173,6 +228,7 @@ def write_provider_evaluation_outputs(
     reference_method: str,
     aggregate: Mapping[str, Any],
     comparisons: Mapping[str, Any],
+    decision: Mapping[str, Any] | None = None,
 ) -> None:
     """Write the complete report and compact human- and table-readable views."""
 
@@ -189,6 +245,7 @@ def write_provider_evaluation_outputs(
         reference_method=reference_method,
         aggregate=aggregate,
         comparisons=comparisons,
+        decision=decision,
     )
 
 

--- a/src/prob4d/provider_evaluation.py
+++ b/src/prob4d/provider_evaluation.py
@@ -11,11 +11,15 @@ from ._provider_evaluation_compute import (
     aggregate_provider_records,
     evaluate_provider_cases,
 )
+from ._provider_evaluation_decision import evaluate_provider_decision_policy
 from ._provider_evaluation_manifest import (
+    PROVIDER_EVALUATION_DECISION_VERSION,
     PROVIDER_EVALUATION_SCHEMA,
     PROVIDER_EVALUATION_VERSION,
     ProviderEvaluationCase,
-    load_provider_evaluation_cases,
+    ProviderEvaluationDecisionPolicy,
+    ProviderEvaluationDecisionRule,
+    load_provider_evaluation_plan,
     validate_finite_json,
 )
 from ._provider_evaluation_output import write_provider_evaluation_outputs
@@ -39,8 +43,8 @@ def run_provider_evaluation(
     if normalized_seed != seed:
         raise ValueError("seed must be an integer")
     source = Path(manifest_path).resolve()
-    cases, primary_mode, reference_method, manifest_metadata = (
-        load_provider_evaluation_cases(source)
+    cases, primary_mode, reference_method, manifest_metadata, decision_policy = (
+        load_provider_evaluation_plan(source)
     )
     records, method_metadata = evaluate_provider_cases(
         cases,
@@ -52,13 +56,24 @@ def run_provider_evaluation(
         bootstrap_resamples=bootstrap_resamples,
         seed=normalized_seed,
     )
+    decision = (
+        None
+        if decision_policy is None
+        else evaluate_provider_decision_policy(
+            decision_policy,
+            aggregate=aggregate,
+            comparisons=comparisons,
+            primary_mode=primary_mode,
+            reference_method=reference_method,
+        )
+    )
     clean_records = [
         {key: value for key, value in record.items() if key != "_numeric"}
         for record in records
     ]
     report: dict[str, Any] = {
         "schema_name": "prob4d.provider-evaluation-report",
-        "schema_version": 2,
+        "schema_version": 2 if decision_policy is None else 3,
         "source_manifest": str(source),
         "source_manifest_sha256": hashlib.sha256(source.read_bytes()).hexdigest(),
         "primary_mode": primary_mode,
@@ -85,6 +100,9 @@ def run_provider_evaluation(
             "Causal4D intervention benefit."
         ),
     }
+    if decision_policy is not None:
+        report["decision_policy"] = decision_policy.to_dict()
+        report["decision"] = decision
     validate_finite_json(report, name="provider-evaluation report")
     write_provider_evaluation_outputs(
         output_directory,
@@ -94,6 +112,7 @@ def run_provider_evaluation(
         reference_method=reference_method,
         aggregate=aggregate,
         comparisons=comparisons,
+        decision=decision,
     )
     return report
 
@@ -112,8 +131,16 @@ def main(argv: list[str] | None = None) -> int:
             "semantics were not embedded; use only for labelled diagnostics"
         ),
     )
+    parser.add_argument(
+        "--require-decision-pass",
+        action="store_true",
+        help=(
+            "require a schema-v2 preregistered decision policy and return exit code "
+            "3 when its independent-group or paired metric gates do not pass"
+        ),
+    )
     arguments = parser.parse_args(argv)
-    run_provider_evaluation(
+    report = run_provider_evaluation(
         arguments.manifest,
         arguments.output_dir,
         bootstrap_resamples=arguments.bootstrap_resamples,
@@ -121,6 +148,14 @@ def main(argv: list[str] | None = None) -> int:
         allow_legacy_artifacts=arguments.allow_legacy_artifacts,
     )
     print(arguments.output_dir / "provider_evaluation.json")
+    if arguments.require_decision_pass:
+        decision = report.get("decision")
+        if not isinstance(decision, dict):
+            parser.error(
+                "--require-decision-pass requires a schema-v2 manifest decision_policy"
+            )
+        if decision.get("overall_passed") is not True:
+            return 3
     return 0
 
 
@@ -129,8 +164,11 @@ if __name__ == "__main__":
 
 
 __all__ = [
+    "PROVIDER_EVALUATION_DECISION_VERSION",
     "PROVIDER_EVALUATION_SCHEMA",
     "PROVIDER_EVALUATION_VERSION",
     "ProviderEvaluationCase",
+    "ProviderEvaluationDecisionPolicy",
+    "ProviderEvaluationDecisionRule",
     "run_provider_evaluation",
 ]

--- a/tests/test_provider_evaluation_decision.py
+++ b/tests/test_provider_evaluation_decision.py
@@ -1,0 +1,393 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from prob4d._provider_evaluation_decision import evaluate_provider_decision_policy
+from prob4d._provider_evaluation_manifest import (
+    ProviderEvaluationDecisionPolicy,
+    ProviderEvaluationDecisionRule,
+    load_provider_evaluation_plan,
+)
+from prob4d.fusion import FusedSequence
+from prob4d.io import save_fused_prediction, save_truth
+from prob4d.metrics import TruthSequence
+from prob4d.provider_evaluation import main, run_provider_evaluation
+
+
+def _rule(
+    *,
+    rule_id: str = "rmse-superiority",
+    metric: str = "point_rmse",
+    direction: str = "lower",
+    criterion: str = "superiority",
+    margin: float = 0.05,
+) -> ProviderEvaluationDecisionRule:
+    return ProviderEvaluationDecisionRule(
+        rule_id=rule_id,
+        candidate_method="ci",
+        metric=metric,
+        direction=direction,  # type: ignore[arg-type]
+        criterion=criterion,  # type: ignore[arg-type]
+        margin=margin,
+    )
+
+
+def _comparison_summary() -> tuple[dict[str, object], dict[str, object]]:
+    aggregate: dict[str, object] = {
+        "uniform": {"group_count": 9},
+        "ci": {"group_count": 9},
+    }
+    comparisons: dict[str, object] = {
+        "ci": {
+            "reference_method": "uniform",
+            "group_count": 9,
+            "metrics": {
+                "metric.metrics.point_rmse": {
+                    "mean": -0.20,
+                    "ci95_lower": -0.30,
+                    "ci95_upper": -0.10,
+                    "group_count": 9,
+                },
+                "metric.metrics.coverage_95": {
+                    "mean": -0.01,
+                    "ci95_lower": -0.02,
+                    "ci95_upper": 0.01,
+                    "group_count": 9,
+                },
+            },
+        }
+    }
+    return aggregate, comparisons
+
+
+def test_decision_policy_applies_directional_bootstrap_bounds() -> None:
+    aggregate, comparisons = _comparison_summary()
+    policy = ProviderEvaluationDecisionPolicy(
+        policy_id="provider-gate-v1",
+        minimum_group_count=9,
+        rules=(
+            _rule(),
+            _rule(
+                rule_id="coverage-noninferiority",
+                metric="coverage_95",
+                direction="higher",
+                criterion="noninferiority",
+                margin=0.03,
+            ),
+        ),
+    )
+
+    result = evaluate_provider_decision_policy(
+        policy,
+        aggregate=aggregate,
+        comparisons=comparisons,
+        primary_mode="metric",
+        reference_method="uniform",
+    )
+
+    assert result["overall_passed"] is True
+    assert result["group_count_passed"] is True
+    assert result["passed_rule_count"] == 2
+    first, second = result["rules"]
+    assert first["decision_bound"] == "ci95_upper"
+    assert first["pass_threshold"] == pytest.approx(-0.05)
+    assert second["decision_bound"] == "ci95_lower"
+    assert second["pass_threshold"] == pytest.approx(-0.03)
+
+
+def test_decision_policy_retains_failed_independent_group_gate() -> None:
+    aggregate, comparisons = _comparison_summary()
+    policy = ProviderEvaluationDecisionPolicy(
+        policy_id="provider-gate-v1",
+        minimum_group_count=10,
+        rules=(_rule(),),
+    )
+
+    result = evaluate_provider_decision_policy(
+        policy,
+        aggregate=aggregate,
+        comparisons=comparisons,
+        primary_mode="metric",
+        reference_method="uniform",
+    )
+
+    assert result["rules"][0]["passed"] is True
+    assert result["group_count_passed"] is False
+    assert result["overall_passed"] is False
+
+
+def test_decision_policy_rejects_unavailable_registered_metric() -> None:
+    aggregate, comparisons = _comparison_summary()
+    policy = ProviderEvaluationDecisionPolicy(
+        policy_id="provider-gate-v1",
+        minimum_group_count=9,
+        rules=(_rule(metric="not_a_metric"),),
+    )
+
+    with pytest.raises(ValueError, match="unavailable metric"):
+        evaluate_provider_decision_policy(
+            policy,
+            aggregate=aggregate,
+            comparisons=comparisons,
+            primary_mode="metric",
+            reference_method="uniform",
+        )
+
+
+def _manifest_case(tmp_path: Path) -> dict[str, object]:
+    truth = tmp_path / "truth.npz"
+    uniform = tmp_path / "uniform.npz"
+    ci = tmp_path / "ci.npz"
+    for path in (truth, uniform, ci):
+        path.write_bytes(b"placeholder")
+    return {
+        "case_id": "case-1",
+        "group_id": "group-1",
+        "truth": truth.name,
+        "predictions": {"uniform": uniform.name, "ci": ci.name},
+        "boundary_frames": [],
+        "prefix_frame_stop_exclusive": None,
+    }
+
+
+def test_manifest_v2_loads_strict_decision_policy(tmp_path: Path) -> None:
+    manifest = {
+        "schema_name": "prob4d.provider-evaluation",
+        "schema_version": 2,
+        "primary_mode": "metric",
+        "reference_method": "uniform",
+        "cases": [_manifest_case(tmp_path)],
+        "metadata": {"split_id": "held-out-v1"},
+        "decision_policy": {
+            "policy_id": "provider-gate-v1",
+            "minimum_group_count": 9,
+            "rules": [
+                {
+                    "rule_id": "rmse-superiority",
+                    "candidate_method": "ci",
+                    "metric": "point_rmse",
+                    "direction": "lower",
+                    "criterion": "superiority",
+                    "margin": 0.05,
+                }
+            ],
+        },
+    }
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    _, mode, reference, metadata, policy = load_provider_evaluation_plan(path)
+
+    assert mode == "metric"
+    assert reference == "uniform"
+    assert metadata["split_id"] == "held-out-v1"
+    assert policy is not None
+    assert policy.policy_id == "provider-gate-v1"
+    assert policy.rules[0].metric == "point_rmse"
+
+
+def test_manifest_v2_rejects_oracle_decision_mode(tmp_path: Path) -> None:
+    manifest = {
+        "schema_name": "prob4d.provider-evaluation",
+        "schema_version": 2,
+        "primary_mode": "oracle_aligned",
+        "reference_method": "uniform",
+        "cases": [_manifest_case(tmp_path)],
+        "metadata": {},
+        "decision_policy": {
+            "policy_id": "provider-gate-v1",
+            "minimum_group_count": 1,
+            "rules": [
+                {
+                    "rule_id": "rmse-superiority",
+                    "candidate_method": "ci",
+                    "metric": "point_rmse",
+                    "direction": "lower",
+                    "criterion": "superiority",
+                    "margin": 0.0,
+                }
+            ],
+        },
+    }
+    path = tmp_path / "manifest.json"
+    path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="cannot use oracle_aligned"):
+        load_provider_evaluation_plan(path)
+
+
+def _truth() -> TruthSequence:
+    points = np.array(
+        [
+            [[[0.0, 0.0, 1.0]]],
+            [[[1.0, 0.0, 1.0]]],
+        ]
+    )
+    return TruthSequence(
+        frame_indices=np.array([0, 1]),
+        point_map=points,
+        valid_mask=np.ones((2, 1, 1), dtype=bool),
+    )
+
+
+def _prediction(truth: TruthSequence, error: float) -> FusedSequence:
+    points = truth.point_map.copy()
+    points[..., 0] += error
+    covariance = np.broadcast_to(np.eye(3), points.shape + (3,)).copy()
+    return FusedSequence(
+        frame_indices=truth.frame_indices,
+        point_map=points,
+        valid_mask=truth.valid_mask,
+        point_covariance=covariance,
+        contributors=np.ones(truth.valid_mask.shape, dtype=np.uint16),
+    )
+
+
+def _artifact_metadata() -> dict[str, object]:
+    return {
+        "prob4d_revision": "a" * 40,
+        "motioncrafter_revision": "b" * 40,
+        "motioncrafter_seed_policy": "derived-per-call",
+        "motioncrafter_model_set_sha256": "c" * 64,
+        "prediction_manifest_sha256": "d" * 64,
+        "includes_covariance": True,
+        "gauge_estimator": "sequential",
+        "uncertainty_calibration": "held_out",
+    }
+
+
+def _write_case(
+    root: Path,
+    case_id: str,
+    group_id: str,
+    *,
+    uniform_error: float,
+    ci_error: float,
+) -> dict[str, object]:
+    truth = _truth()
+    truth_path = root / f"{case_id}-truth.npz"
+    uniform_path = root / f"{case_id}-uniform.npz"
+    ci_path = root / f"{case_id}-ci.npz"
+    save_truth(truth_path, truth)
+    save_fused_prediction(
+        uniform_path,
+        _prediction(truth, uniform_error),
+        method_id="uniform",
+        fusion_method="uniform",
+        metadata=_artifact_metadata(),
+    )
+    save_fused_prediction(
+        ci_path,
+        _prediction(truth, ci_error),
+        method_id="ci",
+        fusion_method="covariance_intersection",
+        metadata=_artifact_metadata(),
+    )
+    return {
+        "case_id": case_id,
+        "group_id": group_id,
+        "truth": truth_path.name,
+        "predictions": {"uniform": uniform_path.name, "ci": ci_path.name},
+        "boundary_frames": [1],
+        "prefix_frame_stop_exclusive": 1,
+    }
+
+
+def _evaluation_manifest(tmp_path: Path, *, minimum_group_count: int) -> Path:
+    cases = [
+        _write_case(
+            tmp_path,
+            "c1",
+            "g1",
+            uniform_error=1.0,
+            ci_error=0.5,
+        ),
+        _write_case(
+            tmp_path,
+            "c2",
+            "g1",
+            uniform_error=3.0,
+            ci_error=1.0,
+        ),
+        _write_case(
+            tmp_path,
+            "c3",
+            "g2",
+            uniform_error=5.0,
+            ci_error=2.0,
+        ),
+    ]
+    manifest = {
+        "schema_name": "prob4d.provider-evaluation",
+        "schema_version": 2,
+        "primary_mode": "metric",
+        "reference_method": "uniform",
+        "cases": cases,
+        "metadata": {"split": "held-out-objects"},
+        "decision_policy": {
+            "policy_id": "provider-gate-v1",
+            "minimum_group_count": minimum_group_count,
+            "rules": [
+                {
+                    "rule_id": "rmse-superiority",
+                    "candidate_method": "ci",
+                    "metric": "metric_point_rmse",
+                    "direction": "lower",
+                    "criterion": "superiority",
+                    "margin": 0.5,
+                }
+            ],
+        },
+    }
+    path = tmp_path / f"evaluation-{minimum_group_count}.json"
+    path.write_text(json.dumps(manifest), encoding="utf-8")
+    return path
+
+
+def test_provider_evaluation_v2_reports_registered_decision(tmp_path: Path) -> None:
+    path = _evaluation_manifest(tmp_path, minimum_group_count=2)
+    output = tmp_path / "report"
+
+    report = run_provider_evaluation(
+        path,
+        output,
+        bootstrap_resamples=200,
+        seed=17,
+    )
+
+    assert report["schema_version"] == 3
+    assert report["decision"]["overall_passed"] is True
+    assert report["decision"]["rules"][0]["decision_bound"] == "ci95_upper"
+    markdown = output.joinpath("provider_evaluation.md").read_text(encoding="utf-8")
+    assert "Preregistered provider decision" in markdown
+    assert "Overall result: **PASS**" in markdown
+
+
+def test_cli_returns_three_after_writing_failed_registered_decision(
+    tmp_path: Path,
+) -> None:
+    path = _evaluation_manifest(tmp_path, minimum_group_count=3)
+    output = tmp_path / "report-failed"
+
+    assert (
+        main(
+            [
+                str(path),
+                "--output-dir",
+                str(output),
+                "--bootstrap-resamples",
+                "100",
+                "--require-decision-pass",
+            ]
+        )
+        == 3
+    )
+    report = json.loads(
+        output.joinpath("provider_evaluation.json").read_text(encoding="utf-8")
+    )
+    assert report["decision"]["group_count_passed"] is False
+    assert report["decision"]["overall_passed"] is False


### PR DESCRIPTION
## Summary

Add an opt-in provider-evaluation manifest version 2 that turns target-frozen paired metrics into an auditable pass/fail decision without changing frozen manifest-v1 or report-v2 behavior.

### Decision policy contract

- add strict `ProviderEvaluationDecisionPolicy` and `ProviderEvaluationDecisionRule` contracts;
- bind one policy ID, a minimum independent-group count, unique rule IDs, candidate methods, primary-mode metric fields, direction, superiority/non-inferiority criterion, and nonnegative margin;
- reject unknown candidates, reference-as-candidate rules, malformed metrics, duplicate rules, changed fields, and non-finite margins;
- prohibit `oracle_aligned` as a decision-bearing primary mode;
- preserve `load_provider_evaluation_cases` as a manifest-v1-only surface and fail closed rather than silently discarding a v2 policy.

### Deterministic paired decisions

Each rule consumes the existing paired `candidate - reference` group-bootstrap summary:

- lower-is-better superiority: upper 95% bound <= `-margin`;
- lower-is-better non-inferiority: upper 95% bound <= `margin`;
- higher-is-better superiority: lower 95% bound >= `margin`;
- higher-is-better non-inferiority: lower 95% bound >= `-margin`.

The complete policy passes only when every registered rule passes and the observed `group_id` count reaches the frozen minimum. Insufficient groups produce a retained failed decision rather than suppressing the report.

### Reporting and automation

- emit report schema version 3 only for decision-bearing manifests, including the exact policy, observed/required groups, estimates, intervals, selected bounds, thresholds, rule results, and overall result;
- add a compact Markdown decision table;
- add `--require-decision-pass`, returning exit code 3 after writing a valid failed report and argparse exit code 2 when no policy is present;
- document preregistration, exit codes, rule interpretation, and the provider-only claim boundary;
- add a focused immutable-action workflow covering Ruff, Python-3.10-targeted mypy, manifest-v1 compatibility, decision contracts, report output, and CLI behavior.

## Compatibility and scientific boundary

- manifest version 1 and report version 2 remain unchanged;
- prediction, covariance, provider, factor, and observation schemas are unchanged;
- evaluation metrics and paired bootstrap calculations are unchanged;
- no target split, margin, or metric is selected by this implementation;
- a passing policy establishes only provider observation competence, not Bayesian-PhysTwin acceptance, safe state assimilation, physical-prediction benefit, or Causal4D intervention benefit.

## Validation

Both required workflows passed on head `7087a62ec93b9dfddc09700d7d3b2e0aa9f2603e`:

- **Provider evaluation decision contract #2** — Ruff, Python-3.10-targeted mypy, the complete legacy evaluator slice, and every new decision-policy regression passed;
- **Tests #441** — repository-wide Ruff and stable-interface mypy, complete suites on Python 3.10, 3.11, 3.12, 3.13, and 3.14, the exact Python 3.10 / NumPy 1.24.0 floor, provider manifests and runtime attestation, safe wheel/sdist builds, extracted-sdist validation, and isolated wheel/sdist CLI smoke tests all passed.

The first focused run exposed a tooling incompatibility rather than a product defect: NumPy 2.5 stubs use Python-3.12-only type syntax while Prob4D intentionally type-checks against Python 3.10. The focused static-check environment now uses `numpy>=1.24,<2.3`; runtime compatibility remains covered independently through the complete unconstrained Python matrix and exact NumPy floor.