### PR TITLE
Add correlation-aware causal multi-edge gauge graph ablation

### DIFF
--- a/docs/causal-gauge-graph.md
+++ b/docs/causal-gauge-graph.md
@@ -1,0 +1,106 @@
+# Correlation-aware causal multi-edge gauge graph
+
+The claim-bearing provider-v2 estimator retains one causal parent edge for every
+new MotionCrafter window. That spanning tree is transparent and preserves a full
+joint cross-window covariance, but it discards other prefix-valid overlap edges.
+Prob4D now provides a separately labelled experimental graph that admits all such
+edges without treating their shared frames or shared visual backbone as
+independent evidence.
+
+## Full-joint covariance intersection
+
+Assume the first `k` gauges have one joint Gaussian approximation
+
+```text
+x_0:k-1 ~ N(m, P).
+```
+
+Each prefix-valid edge from an earlier parent `p` to the new child `k` produces
+an augmented candidate
+
+```text
+[x_0:k-1, x_k] ~ N(m_p, P_p).
+```
+
+`P_p` carries the complete previous covariance `P`, the analytic Sim(3)
+composition cross-covariance between the parent and every previous gauge, and
+the edge covariance propagated through the relative transform. Candidates share
+prior, frames, weights, and often most correspondences, so the graph fuses the
+**complete augmented distributions** with covariance intersection:
+
+```text
+P_CI^-1 = sum_j w_j P_j^-1,
+sum_j w_j = 1,
+w_j >= 0.
+```
+
+The weights minimize joint log determinant through deterministic simplex
+coordinate searches. Information matrices are explicitly symmetrized and every
+candidate and posterior covariance is validated positive semidefinite. Sim(3)
+axis-angle coordinates fail closed near the SO(3) logarithm branch cut.
+
+This is materially different from treating edge residuals as independent graph
+factors. Repeated shared prior information is not summed with unit weight, and no
+independence assumption is made between edges.
+
+## API
+
+```python
+from prob4d import estimate_causal_multi_edge_gauge_graph
+
+posterior, report = estimate_causal_multi_edge_gauge_graph(
+    windows,
+    alignments,
+    initial_transform=metric_anchor.mean,
+    initial_covariance=metric_anchor.covariance,
+)
+```
+
+The posterior contains all gauge means and the complete joint covariance. The
+report records every admitted edge, its parent, alignment index, CI weight,
+analytic-Jacobian mode, and dependence semantics.
+
+The graph mode is `causal_full_joint_ci_graph_v1`. It is not accepted by the
+claim-bearing provider-v2 loader and must not be relabelled as the production
+`sequential_joint_spanning_tree_v1` model.
+
+## Paired diagnostic
+
+Run the registered four-method comparison with:
+
+```bash
+prob4d diagnostic gauge-graph \
+  --predictions outputs/test/predictions.json \
+  --truth data/test_truth.npz \
+  --calibration-predictions outputs/calibration/predictions.json \
+  --calibration-truth data/calibration_truth.npz \
+  --output-dir outputs/gauge-graph-ablation
+```
+
+It compares:
+
+1. the provider-v2 causal spanning tree;
+2. marginal multi-parent gauge CI;
+3. the full-joint causal multi-edge graph; and
+4. fixed-lag reconstruction control.
+
+All four use the same independently calibrated dense uncertainty model and the
+same covariance-intersection dense fusion. The output retains point, endpoint,
+seam, drift, coverage, NLL, covariance-width, and gauge metrics from the normal
+ablation contract, plus the complete graph report.
+
+## Promotion rule
+
+The production spanning tree remains the default. The graph may be considered
+for a future provider version only after a frozen held-out, group-balanced study
+shows lower seam, drift, endpoint, or point error without material regression in:
+
+- one-sided coverage shortfall;
+- covariance width;
+- worst-group calibration;
+- BayesianPhysTwin harmful accepted updates; or
+- exact-fallback behavior.
+
+A negative result is complete and retains the simpler tree. Passing unit tests or
+producing a smaller covariance is infrastructure or diagnostic evidence, not a
+scientific benefit claim.

--- a/src/prob4d/__init__.py
+++ b/src/prob4d/__init__.py
@@ -22,6 +22,13 @@ from .calibration import (
     save_gauge_covariance_calibration,
     save_point_uncertainty_calibration,
 )
+from .causal_gauge_graph import (
+    CAUSAL_GAUGE_GRAPH_DEPENDENCE,
+    CAUSAL_GAUGE_GRAPH_MODE,
+    CausalGaugeGraphReport,
+    CausalGaugeGraphStep,
+    estimate_causal_multi_edge_gauge_graph,
+)
 from .causal_tracklets import (
     CausalTrackletReport,
     CausalTrackletSet,
@@ -124,6 +131,8 @@ except PackageNotFoundError:  # Source tree without installed distribution metad
     __version__ = "0.3.1"
 
 __all__ = [
+    "CAUSAL_GAUGE_GRAPH_DEPENDENCE",
+    "CAUSAL_GAUGE_GRAPH_MODE",
     "GAUGE_COVARIANCE_CALIBRATION_SCHEMA",
     "GAUGE_COVARIANCE_CALIBRATION_VERSION",
     "OBSERVATION_BELIEF_SCHEMA",
@@ -145,6 +154,8 @@ __all__ = [
     "SOURCE_RELIABILITY_VERSION",
     "AlignmentCycleAudit",
     "AlignmentCycleResidual",
+    "CausalGaugeGraphReport",
+    "CausalGaugeGraphStep",
     "CausalTrackletReport",
     "CausalTrackletSet",
     "CommonModeFailureAudit",
@@ -184,6 +195,7 @@ __all__ = [
     "build_source_reliability_features",
     "canonical_prob4d_repository",
     "deterministic_covariance_root",
+    "estimate_causal_multi_edge_gauge_graph",
     "estimate_joint_gauge_tree",
     "evaluate_sequence_modes",
     "fit_group_balanced_point_uncertainty_calibration",

--- a/src/prob4d/causal_gauge_graph.py
+++ b/src/prob4d/causal_gauge_graph.py
@@ -1,0 +1,417 @@
+"""Correlation-aware causal multi-edge gauge graph by full-joint CI.
+
+The claim-bearing provider-v2 estimator deliberately retains a transparent
+single-parent spanning tree. This module is a separately labelled experimental
+mode: every prefix-valid overlap edge predicts an augmented joint state
+containing all previously admitted gauges and the new child gauge. Covariance
+intersection fuses those augmented distributions while treating their unknown
+shared-backbone and shared-frame correlation conservatively.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Final
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .alignment import WindowAlignment
+from .composition_jacobian import analytic_sim3_compose_jacobians
+from .covariance import regularized_inverse_psd, validated_covariance_psd
+from .data import PredictionWindow
+from .observation_export import JointGaugePosterior
+from .sim3 import Sim3
+
+FloatArray = NDArray[np.floating]
+CAUSAL_GAUGE_GRAPH_MODE: Final = "causal_full_joint_ci_graph_v1"
+CAUSAL_GAUGE_GRAPH_DEPENDENCE: Final = (
+    "unknown_cross_edge_correlation_full_joint_covariance_intersection_v1"
+)
+
+
+@dataclass(frozen=True)
+class CausalGaugeGraphStep:
+    """One child admission and the conservative edge weights used for it."""
+
+    child_window_id: str
+    candidate_parent_ids: tuple[str, ...]
+    candidate_alignment_indices: tuple[int, ...]
+    covariance_intersection_weights: FloatArray
+
+    def __post_init__(self) -> None:
+        child = str(self.child_window_id)
+        parents = tuple(str(value) for value in self.candidate_parent_ids)
+        indices = tuple(int(value) for value in self.candidate_alignment_indices)
+        weights = np.asarray(
+            self.covariance_intersection_weights,
+            dtype=np.float64,
+        ).copy()
+        if not child or not parents or any(not value for value in parents):
+            raise ValueError("causal gauge-graph step requires nonempty window IDs")
+        if len(parents) != len(indices) or weights.shape != (len(parents),):
+            raise ValueError("causal gauge-graph step fields changed length")
+        if len(set(indices)) != len(indices) or any(value < 0 for value in indices):
+            raise ValueError("causal gauge-graph alignment indices must be unique")
+        if not np.all(np.isfinite(weights)) or np.any(weights < 0.0):
+            raise ValueError(
+                "causal gauge-graph CI weights must be finite and nonnegative"
+            )
+        if not np.isclose(float(np.sum(weights)), 1.0, atol=1e-10, rtol=0.0):
+            raise ValueError("causal gauge-graph CI weights must sum to one")
+        weights.setflags(write=False)
+        object.__setattr__(self, "child_window_id", child)
+        object.__setattr__(self, "candidate_parent_ids", parents)
+        object.__setattr__(self, "candidate_alignment_indices", indices)
+        object.__setattr__(self, "covariance_intersection_weights", weights)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "child_window_id": self.child_window_id,
+            "candidate_parent_ids": list(self.candidate_parent_ids),
+            "candidate_alignment_indices": list(self.candidate_alignment_indices),
+            "covariance_intersection_weights": [
+                float(value) for value in self.covariance_intersection_weights
+            ],
+        }
+
+
+@dataclass(frozen=True)
+class CausalGaugeGraphReport:
+    """Auditable edge admission and dependence semantics for one graph run."""
+
+    window_ids: tuple[str, ...]
+    steps: tuple[CausalGaugeGraphStep, ...]
+    dependence_semantics: str = CAUSAL_GAUGE_GRAPH_DEPENDENCE
+    composition_jacobian_mode: str = "analytic"
+    claim_bearing_provider_export: bool = False
+
+    def __post_init__(self) -> None:
+        windows = tuple(str(value) for value in self.window_ids)
+        if not windows or len(set(windows)) != len(windows):
+            raise ValueError("causal gauge-graph report requires unique window IDs")
+        if len(self.steps) != len(windows) - 1:
+            raise ValueError("causal gauge-graph report requires one step per child")
+        if tuple(step.child_window_id for step in self.steps) != windows[1:]:
+            raise ValueError("causal gauge-graph steps differ from window order")
+        if self.dependence_semantics != CAUSAL_GAUGE_GRAPH_DEPENDENCE:
+            raise ValueError("causal gauge-graph dependence semantics changed")
+        if self.composition_jacobian_mode != "analytic":
+            raise ValueError(
+                "causal gauge graph requires analytic composition Jacobians"
+            )
+        if self.claim_bearing_provider_export is not False:
+            raise ValueError("experimental causal gauge graph cannot be claim-bearing")
+        object.__setattr__(self, "window_ids", windows)
+        object.__setattr__(self, "steps", tuple(self.steps))
+
+    @property
+    def admitted_edge_count(self) -> int:
+        return sum(len(step.candidate_alignment_indices) for step in self.steps)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "mode": CAUSAL_GAUGE_GRAPH_MODE,
+            "window_ids": list(self.window_ids),
+            "steps": [step.to_dict() for step in self.steps],
+            "admitted_edge_count": self.admitted_edge_count,
+            "dependence_semantics": self.dependence_semantics,
+            "composition_jacobian_mode": self.composition_jacobian_mode,
+            "claim_bearing_provider_export": self.claim_bearing_provider_export,
+        }
+
+
+def _validate_rotation_coordinates(vector: FloatArray, *, name: str) -> None:
+    values = np.asarray(vector, dtype=np.float64)
+    if values.ndim != 1 or values.size % 7 != 0 or not np.all(np.isfinite(values)):
+        raise ValueError(f"{name} must contain finite ordered Sim(3) coordinates")
+    rotations = values.reshape(-1, 7)[:, 1:4]
+    if np.any(np.linalg.norm(rotations, axis=1) >= np.pi - 1e-7):
+        raise ValueError(f"{name} reaches the SO(3) axis-angle branch cut")
+
+
+def _candidate_joint_distribution(
+    *,
+    previous_window_ids: tuple[str, ...],
+    estimates: dict[str, Sim3],
+    joint_covariance: FloatArray,
+    child_id: str,
+    alignment: WindowAlignment,
+) -> tuple[FloatArray, FloatArray, Sim3]:
+    parent_id = alignment.reference_id
+    parent_index = previous_window_ids.index(parent_id)
+    parent = estimates[parent_id]
+    relative = alignment.result.transform
+    child = parent.compose(relative)
+    parent_jacobian, relative_jacobian = analytic_sim3_compose_jacobians(
+        parent,
+        relative,
+    )
+    previous_dimension = 7 * len(previous_window_ids)
+    parent_slice = slice(7 * parent_index, 7 * (parent_index + 1))
+    cross = parent_jacobian @ joint_covariance[parent_slice, :]
+    relative_covariance = validated_covariance_psd(
+        alignment.result.covariance,
+        name=f"relative gauge covariance {parent_id}->{child_id}",
+        shape=(7, 7),
+        readonly=False,
+    )
+    child_covariance = (
+        parent_jacobian
+        @ joint_covariance[parent_slice, parent_slice]
+        @ parent_jacobian.T
+        + relative_jacobian @ relative_covariance @ relative_jacobian.T
+    )
+    covariance = np.empty(
+        (previous_dimension + 7, previous_dimension + 7),
+        dtype=np.float64,
+    )
+    covariance[:previous_dimension, :previous_dimension] = joint_covariance
+    covariance[previous_dimension:, :previous_dimension] = cross
+    covariance[:previous_dimension, previous_dimension:] = cross.T
+    covariance[previous_dimension:, previous_dimension:] = child_covariance
+    covariance = validated_covariance_psd(
+        covariance,
+        name=f"augmented gauge candidate {parent_id}->{child_id}",
+        readonly=False,
+    )
+    mean = np.concatenate(
+        [
+            *(estimates[window_id].as_vector() for window_id in previous_window_ids),
+            child.as_vector(),
+        ]
+    )
+    _validate_rotation_coordinates(mean, name="causal gauge-graph candidate mean")
+    return mean, covariance, child
+
+
+def _symmetric_inverse(value: FloatArray, *, name: str) -> FloatArray:
+    inverse = regularized_inverse_psd(
+        value,
+        name=name,
+        eigenvalue_floor=1e-12,
+    )
+    return 0.5 * (inverse + inverse.T)
+
+
+def _ci_objective(weights: FloatArray, information: FloatArray) -> float:
+    combined = np.einsum("k,kij->ij", weights, information, optimize=True)
+    combined = 0.5 * (combined + combined.T)
+    covariance = _symmetric_inverse(
+        combined,
+        name="causal gauge-graph CI information",
+    )
+    sign, log_determinant = np.linalg.slogdet(covariance)
+    if sign <= 0.0 or not np.isfinite(log_determinant):
+        raise ValueError("causal gauge-graph CI lost positive definiteness")
+    return float(log_determinant)
+
+
+def _optimize_ci_weights(
+    information: FloatArray,
+    *,
+    minimum_weight: float,
+    grid_size: int = 21,
+    maximum_sweeps: int = 32,
+) -> FloatArray:
+    count = information.shape[0]
+    if count == 1:
+        return np.ones(1, dtype=np.float64)
+    if not 0.0 <= minimum_weight < 1.0 / count:
+        raise ValueError("minimum_edge_weight must lie in [0, 1 / edge_count)")
+    if grid_size < 3 or maximum_sweeps < 1:
+        raise ValueError("CI grid size and sweep count must be positive")
+    weights = np.full(count, 1.0 / count, dtype=np.float64)
+    score = _ci_objective(weights, information)
+    for _ in range(maximum_sweeps):
+        improved = False
+        for first in range(count - 1):
+            for second in range(first + 1, count):
+                pair_mass = float(weights[first] + weights[second])
+                lower = minimum_weight / pair_mass
+                upper = 1.0 - lower
+                candidates = np.linspace(lower, upper, grid_size)
+                candidates = candidates[
+                    np.argsort(
+                        np.abs(candidates - weights[first] / pair_mass),
+                        kind="stable",
+                    )
+                ]
+                best_weights = weights
+                best_score = score
+                for fraction in candidates:
+                    candidate = weights.copy()
+                    candidate[first] = pair_mass * float(fraction)
+                    candidate[second] = pair_mass * (1.0 - float(fraction))
+                    candidate_score = _ci_objective(candidate, information)
+                    if candidate_score < best_score - 1e-12:
+                        best_weights = candidate
+                        best_score = candidate_score
+                if best_score < score - 1e-12:
+                    weights = best_weights
+                    score = best_score
+                    improved = True
+        if not improved:
+            break
+    weights /= float(np.sum(weights))
+    return weights
+
+
+def _fuse_augmented_candidates(
+    means: FloatArray,
+    covariances: FloatArray,
+    *,
+    minimum_edge_weight: float,
+) -> tuple[FloatArray, FloatArray, FloatArray]:
+    count = means.shape[0]
+    if count == 1:
+        return means[0].copy(), covariances[0].copy(), np.ones(1, dtype=np.float64)
+    information = np.stack(
+        [
+            _symmetric_inverse(
+                covariance,
+                name=f"causal gauge-graph candidate covariance {index}",
+            )
+            for index, covariance in enumerate(covariances)
+        ]
+    )
+    weights = _optimize_ci_weights(
+        information,
+        minimum_weight=minimum_edge_weight,
+    )
+    combined_information = np.einsum(
+        "k,kij->ij",
+        weights,
+        information,
+        optimize=True,
+    )
+    combined_information = 0.5 * (combined_information + combined_information.T)
+    covariance = _symmetric_inverse(
+        combined_information,
+        name="causal gauge-graph combined information",
+    )
+    information_vector = np.einsum(
+        "k,kij,kj->i",
+        weights,
+        information,
+        means,
+        optimize=True,
+    )
+    mean = covariance @ information_vector
+    return mean, covariance, weights
+
+
+def estimate_causal_multi_edge_gauge_graph(
+    windows: Sequence[PredictionWindow],
+    alignments: Sequence[WindowAlignment],
+    *,
+    initial_transform: Sim3,
+    initial_covariance: FloatArray,
+    minimum_edge_weight: float = 0.0,
+) -> tuple[JointGaugePosterior, CausalGaugeGraphReport]:
+    """Fuse all prefix-valid gauge edges with full-joint covariance intersection.
+
+    Every candidate contains the same complete previously admitted joint gauge
+    posterior plus one child prediction from a different overlap edge. CI is
+    applied to that augmented state, so shared prior, frame, and backbone
+    dependence is never treated as independence. The method is experimental and
+    is not an accepted claim-bearing provider-v2 gauge model.
+    """
+
+    if not windows:
+        raise ValueError("causal gauge graph requires at least one window")
+    window_ids = tuple(window.window_id for window in windows)
+    if len(set(window_ids)) != len(window_ids):
+        raise ValueError("causal gauge-graph window IDs must be unique")
+    position = {window_id: index for index, window_id in enumerate(window_ids)}
+    covariance = validated_covariance_psd(
+        initial_covariance,
+        name="causal gauge-graph anchor covariance",
+        shape=(7, 7),
+        readonly=False,
+    )
+    joint = covariance.copy()
+    estimates: dict[str, Sim3] = {window_ids[0]: initial_transform}
+    steps: list[CausalGaugeGraphStep] = []
+
+    for child_index, child_id in enumerate(window_ids[1:], start=1):
+        candidates = [
+            (index, alignment)
+            for index, alignment in enumerate(alignments)
+            if alignment.moving_id == child_id
+            and alignment.reference_id in estimates
+            and position[alignment.reference_id] < child_index
+        ]
+        candidates.sort(
+            key=lambda item: (
+                position[item[1].reference_id],
+                item[0],
+            )
+        )
+        if not candidates:
+            raise ValueError(
+                f"window {child_id!r} has no causal overlap with an earlier window"
+            )
+        previous_ids = window_ids[:child_index]
+        candidate_means: list[FloatArray] = []
+        candidate_covariances: list[FloatArray] = []
+        for _, alignment in candidates:
+            mean, candidate_covariance, _ = _candidate_joint_distribution(
+                previous_window_ids=previous_ids,
+                estimates=estimates,
+                joint_covariance=joint,
+                child_id=child_id,
+                alignment=alignment,
+            )
+            candidate_means.append(mean)
+            candidate_covariances.append(candidate_covariance)
+        fused_mean, fused_covariance, weights = _fuse_augmented_candidates(
+            np.stack(candidate_means),
+            np.stack(candidate_covariances),
+            minimum_edge_weight=minimum_edge_weight,
+        )
+        _validate_rotation_coordinates(
+            fused_mean,
+            name="causal gauge-graph fused mean",
+        )
+        joint = validated_covariance_psd(
+            fused_covariance,
+            name=f"causal gauge-graph posterior through {child_id}",
+            readonly=False,
+        )
+        for index, window_id in enumerate(window_ids[: child_index + 1]):
+            estimates[window_id] = Sim3.from_vector(
+                fused_mean[7 * index : 7 * (index + 1)]
+            )
+        steps.append(
+            CausalGaugeGraphStep(
+                child_window_id=child_id,
+                candidate_parent_ids=tuple(
+                    alignment.reference_id for _, alignment in candidates
+                ),
+                candidate_alignment_indices=tuple(index for index, _ in candidates),
+                covariance_intersection_weights=weights,
+            )
+        )
+
+    posterior = JointGaugePosterior(
+        window_ids=window_ids,
+        estimates=estimates,
+        joint_covariance=joint,
+        mode=CAUSAL_GAUGE_GRAPH_MODE,
+        cross_window_covariance_preserved=True,
+        parent_window_ids=tuple(None for _ in window_ids),
+        selected_alignment_indices=tuple(None for _ in window_ids),
+    )
+    report = CausalGaugeGraphReport(window_ids=window_ids, steps=tuple(steps))
+    return posterior, report
+
+
+__all__ = [
+    "CAUSAL_GAUGE_GRAPH_DEPENDENCE",
+    "CAUSAL_GAUGE_GRAPH_MODE",
+    "CausalGaugeGraphReport",
+    "CausalGaugeGraphStep",
+    "estimate_causal_multi_edge_gauge_graph",
+]

--- a/src/prob4d/causal_gauge_graph_ablation.py
+++ b/src/prob4d/causal_gauge_graph_ablation.py
@@ -1,0 +1,208 @@
+"""Held-out diagnostic comparing causal gauge graph alternatives.
+
+This runner is intentionally separate from the frozen seven-row ablations and
+from claim-bearing provider-v2 export. It compares the production causal spanning
+tree, marginal multi-parent CI initialization, full-joint multi-edge CI graph,
+and fixed-lag reconstruction control under one calibrated dense uncertainty
+model and one paired evaluation contract.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from .causal_gauge_graph import estimate_causal_multi_edge_gauge_graph
+from .experiments import (
+    AblationRow,
+    _dataset_calibration,
+    _evaluate,
+    _uncertainties,
+    _window_truth_gauge,
+    _write_results,
+)
+from .fusion import fuse_windows
+from .gauge import (
+    FixedLagGaugeSmoother,
+    RelativeGaugeConstraint,
+    SequentialGaugeEstimator,
+)
+from .io import load_prediction_bundle, load_truth
+from .observation_export import _build_alignments
+from .provider_v2_gauge_ablation import (
+    estimate_provider_v2_gauge_backend,
+    marginal_gauge_estimates,
+)
+from .sim3 import Sim3
+from .uncertainty import CalibrationReport, DepthDisagreementModel
+
+
+def _transform_and_covariance_maps(estimates):
+    return (
+        {
+            window_id: estimate.global_from_local
+            for window_id, estimate in estimates.items()
+        },
+        {
+            window_id: estimate.covariance
+            for window_id, estimate in estimates.items()
+        },
+    )
+
+
+def run_causal_gauge_graph_ablation(
+    *,
+    predictions: str | Path,
+    truth_path: str | Path,
+    calibration_predictions: str | Path,
+    calibration_truth_path: str | Path,
+    fixed_lag: int = 4,
+    minimum_edge_weight: float = 0.0,
+) -> tuple[list[AblationRow], CalibrationReport, dict[str, Any]]:
+    """Compare four gauge estimators with paired CI dense fusion."""
+
+    if fixed_lag < 2:
+        raise ValueError("fixed_lag must be at least two")
+    test_bundle = load_prediction_bundle(predictions)
+    truth = load_truth(truth_path)
+    calibration_bundle = load_prediction_bundle(calibration_predictions)
+    calibration_truth = load_truth(calibration_truth_path)
+    model, report, _ = _dataset_calibration(
+        calibration_bundle,
+        calibration_truth,
+        DepthDisagreementModel(),
+    )
+    windows = test_bundle.overlap_windows
+    alignments = _build_alignments(windows)
+    constraints = [
+        RelativeGaugeConstraint.from_window_alignment(alignment)
+        for alignment in alignments
+    ]
+    ordered_ids = [window.window_id for window in windows]
+    anchor_covariance = np.diag(np.full(7, 1e-10, dtype=np.float64))
+
+    tree_posterior, tree = estimate_provider_v2_gauge_backend(
+        windows,
+        alignments,
+        initial_transform=Sim3.identity(),
+        initial_covariance=anchor_covariance,
+    )
+    marginal_ci = SequentialGaugeEstimator().estimate(
+        ordered_ids,
+        constraints,
+        initial_transform=Sim3.identity(),
+        initial_covariance=anchor_covariance,
+    )
+    graph_posterior, graph_report = estimate_causal_multi_edge_gauge_graph(
+        windows,
+        alignments,
+        initial_transform=Sim3.identity(),
+        initial_covariance=anchor_covariance,
+        minimum_edge_weight=minimum_edge_weight,
+    )
+    graph = marginal_gauge_estimates(graph_posterior)
+    fixed_lag_estimates = FixedLagGaugeSmoother(lag=fixed_lag).smooth(
+        ordered_ids,
+        marginal_ci,
+        constraints,
+    )
+
+    uncertainties = _uncertainties(windows, alignments, model)
+    estimators = {
+        "tree_ci": tree,
+        "sequential_multi_parent_ci": marginal_ci,
+        "causal_graph_ci": graph,
+        "fixed_lag_ci": fixed_lag_estimates,
+    }
+    sequences = {}
+    for key, estimates in estimators.items():
+        transforms, gauge_covariances = _transform_and_covariance_maps(estimates)
+        sequences[key] = fuse_windows(
+            windows,
+            transforms,
+            uncertainties,
+            method="covariance_intersection",
+            gauge_covariances=gauge_covariances,
+        )
+
+    true_gauges = {
+        window.window_id: _window_truth_gauge(window, truth)
+        for window in windows
+    }
+    boundaries = [window.start_frame for window in windows[1:]]
+    labels = {
+        "tree_ci": "Causal single-parent spanning tree + CI",
+        "sequential_multi_parent_ci": "Marginal multi-parent gauge CI + dense CI",
+        "causal_graph_ci": "Full-joint causal multi-edge graph CI + dense CI",
+        "fixed_lag_ci": "Fixed-lag gauge reconstruction control + dense CI",
+    }
+    rows = [
+        _evaluate(
+            key,
+            labels[key],
+            sequences[key],
+            truth,
+            gauges=estimators[key],
+            true_gauges=true_gauges,
+            boundary_frames=boundaries,
+            baseline_source="prob4d_causal_gauge_graph_diagnostic",
+        )
+        for key in labels
+    ]
+    metadata: dict[str, Any] = {
+        "benchmark": "prob4d_causal_gauge_graph_ablation_v1",
+        "predictions": str(Path(predictions).resolve()),
+        "truth": str(Path(truth_path).resolve()),
+        "calibration_predictions": str(Path(calibration_predictions).resolve()),
+        "calibration_truth": str(Path(calibration_truth_path).resolve()),
+        "motioncrafter_commit": test_bundle.metadata.get("motioncrafter_commit"),
+        "paired_method_order": list(labels),
+        "dense_fusion_method": "covariance_intersection",
+        "fixed_lag": fixed_lag,
+        "minimum_edge_weight": minimum_edge_weight,
+        "tree_posterior_mode": tree_posterior.mode,
+        "graph": graph_report.to_dict(),
+        "graph_joint_covariance_dimension": int(
+            graph_posterior.joint_covariance.shape[0]
+        ),
+        "provider_v2_claim_bearing_export": False,
+        "target_truth_used_only_for_evaluation": True,
+        "promotion_rule": (
+            "retain the production tree unless a frozen held-out grouped result "
+            "improves seam, drift, or point error without material coverage or "
+            "harmful-update regression"
+        ),
+    }
+    return rows, report, metadata
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--predictions", type=Path, required=True)
+    parser.add_argument("--truth", type=Path, required=True)
+    parser.add_argument("--calibration-predictions", type=Path, required=True)
+    parser.add_argument("--calibration-truth", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--fixed-lag", type=int, default=4)
+    parser.add_argument("--minimum-edge-weight", type=float, default=0.0)
+    arguments = parser.parse_args(argv)
+    try:
+        rows, calibration, metadata = run_causal_gauge_graph_ablation(
+            predictions=arguments.predictions,
+            truth_path=arguments.truth,
+            calibration_predictions=arguments.calibration_predictions,
+            calibration_truth_path=arguments.calibration_truth,
+            fixed_lag=arguments.fixed_lag,
+            minimum_edge_weight=arguments.minimum_edge_weight,
+        )
+    except ValueError as error:
+        parser.error(str(error))
+    _write_results(arguments.output_dir, rows, calibration, metadata)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/prob4d/cli.py
+++ b/src/prob4d/cli.py
@@ -19,6 +19,11 @@ _ROUTES: Final[dict[Route, tuple[str, str, str]]] = {
         "main",
         "run the pinned recursive-fusion benchmark",
     ),
+    ("diagnostic", "gauge-graph"): (
+        "prob4d.causal_gauge_graph_ablation",
+        "main",
+        "compare causal gauge-tree, multi-parent, graph, and fixed-lag modes",
+    ),
     ("evaluate", "provider"): (
         "prob4d.provider_evaluation",
         "main",

--- a/tests/test_causal_gauge_graph.py
+++ b/tests/test_causal_gauge_graph.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import numpy as np
+
+from prob4d.causal_gauge_graph import (
+    CAUSAL_GAUGE_GRAPH_DEPENDENCE,
+    CAUSAL_GAUGE_GRAPH_MODE,
+    estimate_causal_multi_edge_gauge_graph,
+)
+from prob4d.composition_jacobian import composition_jacobian_mode
+from prob4d.observation_export import _build_alignments, estimate_joint_gauge_tree
+from prob4d.sim3 import Sim3
+from prob4d.synthetic import make_synthetic_problem
+
+
+def _problem():
+    return make_synthetic_problem(
+        seed=171,
+        num_frames=45,
+        height=4,
+        width=6,
+        overlap=15,
+    )
+
+
+def test_single_edge_per_child_matches_analytic_spanning_tree() -> None:
+    problem = _problem()
+    alignments = _build_alignments(problem.overlap_windows)
+    anchor_covariance = np.diag(np.linspace(1e-7, 7e-7, 7))
+    with composition_jacobian_mode("analytic"):
+        tree = estimate_joint_gauge_tree(
+            problem.overlap_windows,
+            alignments,
+            initial_transform=Sim3.identity(),
+            initial_covariance=anchor_covariance,
+        )
+    selected = [
+        alignments[index]
+        for index in tree.selected_alignment_indices[1:]
+        if index is not None
+    ]
+
+    graph, report = estimate_causal_multi_edge_gauge_graph(
+        problem.overlap_windows,
+        selected,
+        initial_transform=Sim3.identity(),
+        initial_covariance=anchor_covariance,
+    )
+
+    np.testing.assert_allclose(
+        graph.joint_covariance,
+        tree.joint_covariance,
+        atol=1e-10,
+    )
+    for window_id in graph.window_ids:
+        np.testing.assert_allclose(
+            graph.estimates[window_id].as_vector(),
+            tree.estimates[window_id].as_vector(),
+            atol=1e-10,
+        )
+    assert all(
+        np.array_equal(step.covariance_intersection_weights, [1.0])
+        for step in report.steps
+    )
+
+
+def test_multi_edge_graph_admits_every_prefix_valid_edge_and_is_psd() -> None:
+    problem = _problem()
+    alignments = _build_alignments(problem.overlap_windows)
+    graph, report = estimate_causal_multi_edge_gauge_graph(
+        problem.overlap_windows,
+        alignments,
+        initial_transform=Sim3.identity(),
+        initial_covariance=np.eye(7) * 1e-6,
+    )
+
+    assert graph.mode == CAUSAL_GAUGE_GRAPH_MODE
+    assert graph.cross_window_covariance_preserved
+    assert report.dependence_semantics == CAUSAL_GAUGE_GRAPH_DEPENDENCE
+    assert report.claim_bearing_provider_export is False
+    assert report.admitted_edge_count == len(alignments)
+    assert len(report.steps[-1].candidate_parent_ids) >= 2
+    assert np.min(np.linalg.eigvalsh(graph.joint_covariance)) >= -1e-9
+    assert np.any(np.abs(graph.joint_covariance[:7, 7:]) > 0.0)
+    for step in report.steps:
+        assert np.all(step.covariance_intersection_weights >= 0.0)
+        np.testing.assert_allclose(
+            np.sum(step.covariance_intersection_weights),
+            1.0,
+        )
+
+
+def test_graph_posterior_is_invariant_to_alignment_input_order() -> None:
+    problem = _problem()
+    alignments = _build_alignments(problem.overlap_windows)
+    kwargs = {
+        "initial_transform": Sim3.identity(),
+        "initial_covariance": np.eye(7) * 1e-6,
+    }
+
+    first, first_report = estimate_causal_multi_edge_gauge_graph(
+        problem.overlap_windows,
+        alignments,
+        **kwargs,
+    )
+    second, second_report = estimate_causal_multi_edge_gauge_graph(
+        problem.overlap_windows,
+        list(reversed(alignments)),
+        **kwargs,
+    )
+
+    np.testing.assert_allclose(
+        first.joint_covariance,
+        second.joint_covariance,
+        atol=1e-10,
+    )
+    for window_id in first.window_ids:
+        np.testing.assert_allclose(
+            first.estimates[window_id].as_vector(),
+            second.estimates[window_id].as_vector(),
+            atol=1e-10,
+        )
+    assert [step.candidate_parent_ids for step in first_report.steps] == [
+        step.candidate_parent_ids for step in second_report.steps
+    ]
+
+
+def test_graph_report_is_json_compatible() -> None:
+    problem = _problem()
+    alignments = _build_alignments(problem.overlap_windows)
+    _, report = estimate_causal_multi_edge_gauge_graph(
+        problem.overlap_windows,
+        alignments,
+        initial_transform=Sim3.identity(),
+        initial_covariance=np.eye(7) * 1e-6,
+    )
+
+    payload = report.to_dict()
+    assert payload["mode"] == CAUSAL_GAUGE_GRAPH_MODE
+    assert payload["admitted_edge_count"] == len(alignments)
+    assert payload["claim_bearing_provider_export"] is False

--- a/tests/test_causal_gauge_graph_ablation.py
+++ b/tests/test_causal_gauge_graph_ablation.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from test_io import write_problem_bundle
+
+from prob4d.causal_gauge_graph import CAUSAL_GAUGE_GRAPH_MODE
+from prob4d.causal_gauge_graph_ablation import run_causal_gauge_graph_ablation
+from prob4d.synthetic import make_synthetic_problem
+
+
+def test_causal_gauge_graph_ablation_preserves_paired_four_method_contract(
+    tmp_path,
+) -> None:
+    test_problem = make_synthetic_problem(
+        seed=181,
+        num_frames=45,
+        height=4,
+        width=6,
+        overlap=15,
+    )
+    calibration_problem = make_synthetic_problem(
+        seed=182,
+        num_frames=45,
+        height=4,
+        width=6,
+        overlap=15,
+    )
+    predictions, truth = write_problem_bundle(tmp_path / "test", test_problem)
+    calibration_predictions, calibration_truth = write_problem_bundle(
+        tmp_path / "calibration",
+        calibration_problem,
+    )
+
+    rows, calibration, metadata = run_causal_gauge_graph_ablation(
+        predictions=predictions,
+        truth_path=truth,
+        calibration_predictions=calibration_predictions,
+        calibration_truth_path=calibration_truth,
+    )
+
+    assert [row.key for row in rows] == [
+        "tree_ci",
+        "sequential_multi_parent_ci",
+        "causal_graph_ci",
+        "fixed_lag_ci",
+    ]
+    assert calibration.count > 0
+    assert all(
+        row.baseline_source == "prob4d_causal_gauge_graph_diagnostic"
+        for row in rows
+    )
+    assert metadata["benchmark"] == "prob4d_causal_gauge_graph_ablation_v1"
+    assert metadata["graph"]["mode"] == CAUSAL_GAUGE_GRAPH_MODE
+    assert metadata["graph"]["admitted_edge_count"] >= len(
+        test_problem.overlap_windows
+    ) - 1
+    assert metadata["provider_v2_claim_bearing_export"] is False
+    assert metadata["target_truth_used_only_for_evaluation"] is True

--- a/tests/test_causal_gauge_graph_cli.py
+++ b/tests/test_causal_gauge_graph_cli.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from prob4d.cli import main as cli_main
+
+
+def test_grouped_causal_gauge_graph_help(capsys) -> None:
+    assert cli_main(["diagnostic", "gauge-graph", "--help"]) == 0
+    output = capsys.readouterr().out
+    assert "--predictions" in output
+    assert "--calibration-predictions" in output
+    assert "--minimum-edge-weight" in output

--- a/tests/test_causal_gauge_graph_cli.py
+++ b/tests/test_causal_gauge_graph_cli.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import pytest
+
 from prob4d.cli import main as cli_main
 
 
 def test_grouped_causal_gauge_graph_help(capsys) -> None:
-    assert cli_main(["diagnostic", "gauge-graph", "--help"]) == 0
+    with pytest.raises(SystemExit) as error:
+        cli_main(["diagnostic", "gauge-graph", "--help"])
+    assert error.value.code == 0
     output = capsys.readouterr().out
     assert "--predictions" in output
     assert "--calibration-predictions" in output


### PR DESCRIPTION
## What changed

- add an experimental causal gauge graph that admits every prefix-valid overlap edge;
- form one augmented distribution over all previously admitted gauges plus the new child for each edge;
- fuse those complete joint distributions with covariance intersection, so shared prior, frames, correspondences, and backbone dependence are never treated as independent evidence;
- propagate analytic Sim(3) composition Jacobians, preserve the complete joint cross-window covariance, validate every covariance fail-closed, and reject SO(3) branch-cut cases;
- record every admitted parent edge, alignment index, CI weight, and dependence semantics in an immutable graph report;
- add a paired four-method diagnostic comparing the provider-v2 tree, marginal multi-parent CI, full-joint graph, and fixed-lag reconstruction control;
- add grouped CLI, documentation, single-edge parity, order-invariance, PSD, audit, and end-to-end ablation tests.

## Usage

```bash
prob4d diagnostic gauge-graph \
  --predictions outputs/test/predictions.json \
  --truth data/test_truth.npz \
  --calibration-predictions outputs/calibration/predictions.json \
  --calibration-truth data/calibration_truth.npz \
  --output-dir outputs/gauge-graph-ablation
```

## Dependence treatment

Each candidate contains the same full previous joint posterior and one edge-derived child. CI weights sum to one across the complete augmented states. The implementation does not sum edge information under an independence assumption and does not use downstream physical innovations to score edges.

## Compatibility and claim boundary

The production provider-v2 mode remains `sequential_joint_spanning_tree_v1`. The new `causal_full_joint_ci_graph_v1` mode is not admitted by claim-bearing export or consumer loaders. It is a diagnostic candidate only.

Promotion requires a frozen held-out, group-balanced result that improves seam, drift, endpoint, or point error without material coverage, covariance-width, harmful-update, or fallback regression. A negative result retains the tree.

Advances #49.