### PR TITLE
Add full-resolution production memory profiling

### DIFF
--- a/.github/workflows/production-memory-profile.yml
+++ b/.github/workflows/production-memory-profile.yml
@@ -1,0 +1,276 @@
+name: Production memory profile
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/production-memory-profile.yml"
+      - "docs/production-memory-profile.md"
+      - "src/prob4d/evaluation_memory_benchmark.py"
+      - "src/prob4d/fusion_memory_benchmark.py"
+      - "src/prob4d/prediction_store_benchmark.py"
+      - "tests/test_fusion_memory_benchmark.py"
+  workflow_dispatch:
+    inputs:
+      frames:
+        description: "Number of full-resolution frames"
+        required: true
+        default: "25"
+        type: string
+      height:
+        description: "Frame height"
+        required: true
+        default: "320"
+        type: string
+      width:
+        description: "Frame width"
+        required: true
+        default: "640"
+        type: string
+      contributors:
+        description: "Overlapping fusion contributors"
+        required: true
+        default: "3"
+        type: string
+      include_flow:
+        description: "Include dense scene flow in evaluation"
+        required: true
+        default: true
+        type: boolean
+      fusion_tile_size:
+        description: "Fusion tile size"
+        required: true
+        default: "16384"
+        type: string
+      evaluation_chunk_size:
+        description: "Evaluation chunk size"
+        required: true
+        default: "65536"
+        type: string
+      prediction_manifest:
+        description: "Optional absolute NPZ-bundle manifest path on the runner"
+        required: false
+        default: ""
+        type: string
+      prediction_store:
+        description: "Optional absolute mmap-store directory on the runner"
+        required: false
+        default: ""
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-memory-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PROFILE_FRAMES: ${{ inputs.frames }}
+  PROFILE_HEIGHT: ${{ inputs.height }}
+  PROFILE_WIDTH: ${{ inputs.width }}
+  PROFILE_CONTRIBUTORS: ${{ inputs.contributors }}
+  PROFILE_INCLUDE_FLOW: ${{ inputs.include_flow }}
+  PROFILE_FUSION_TILE_SIZE: ${{ inputs.fusion_tile_size }}
+  PROFILE_EVALUATION_CHUNK_SIZE: ${{ inputs.evaluation_chunk_size }}
+  PROFILE_PREDICTION_MANIFEST: ${{ inputs.prediction_manifest }}
+  PROFILE_PREDICTION_STORE: ${{ inputs.prediction_store }}
+
+jobs:
+  profile:
+    name: Full-resolution memory profile
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install lightweight package
+        run: python -m pip install -e .
+      - name: Resolve profile configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          {
+            echo "PROFILE_FRAMES=${PROFILE_FRAMES:-25}"
+            echo "PROFILE_HEIGHT=${PROFILE_HEIGHT:-320}"
+            echo "PROFILE_WIDTH=${PROFILE_WIDTH:-640}"
+            echo "PROFILE_CONTRIBUTORS=${PROFILE_CONTRIBUTORS:-3}"
+            echo "PROFILE_INCLUDE_FLOW=${PROFILE_INCLUDE_FLOW:-true}"
+            echo "PROFILE_FUSION_TILE_SIZE=${PROFILE_FUSION_TILE_SIZE:-16384}"
+            echo "PROFILE_EVALUATION_CHUNK_SIZE=${PROFILE_EVALUATION_CHUNK_SIZE:-65536}"
+            echo "PROFILE_PREDICTION_MANIFEST=${PROFILE_PREDICTION_MANIFEST:-}"
+            echo "PROFILE_PREDICTION_STORE=${PROFILE_PREDICTION_STORE:-}"
+          } >> "${GITHUB_ENV}"
+      - name: Record host identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p outputs/production-memory
+          {
+            echo "github_repository=${GITHUB_REPOSITORY}"
+            echo "github_sha=${GITHUB_SHA}"
+            echo "github_run_id=${GITHUB_RUN_ID}"
+            echo "runner_name=${RUNNER_NAME}"
+            echo "runner_os=${RUNNER_OS}"
+            echo "runner_arch=${RUNNER_ARCH}"
+            echo
+            uname -a
+            echo
+            lscpu
+            echo
+            free -b
+            echo
+            nvidia-smi
+            echo
+            python -VV
+            python -c 'import numpy; print("numpy=" + numpy.__version__)'
+          } > outputs/production-memory/host.txt 2>&1
+      - name: Profile full-window dense fusion
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m prob4d.fusion_memory_benchmark \
+            --frames "${PROFILE_FRAMES}" \
+            --height "${PROFILE_HEIGHT}" \
+            --width "${PROFILE_WIDTH}" \
+            --contributors "${PROFILE_CONTRIBUTORS}" \
+            --method covariance_intersection \
+            --fusion-tile-size "${PROFILE_FUSION_TILE_SIZE}" \
+            --output-json outputs/production-memory/fusion.json \
+            > outputs/production-memory/fusion.stdout.json
+      - name: Profile bounded provider evaluation
+        shell: bash
+        run: |
+          set -euo pipefail
+          flow_flag=()
+          if [[ "${PROFILE_INCLUDE_FLOW}" == "true" ]]; then
+            flow_flag+=(--include-flow)
+          fi
+          python -m prob4d.evaluation_memory_benchmark \
+            --frames "${PROFILE_FRAMES}" \
+            --height "${PROFILE_HEIGHT}" \
+            --width "${PROFILE_WIDTH}" \
+            --evaluation-chunk-size "${PROFILE_EVALUATION_CHUNK_SIZE}" \
+            "${flow_flag[@]}" \
+            --output-json outputs/production-memory/evaluation.json \
+            > outputs/production-memory/evaluation.stdout.json
+      - name: Profile optional prediction backends
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -n "${PROFILE_PREDICTION_MANIFEST}" ]]; then
+            python -m prob4d.prediction_store_benchmark \
+              "${PROFILE_PREDICTION_MANIFEST}" \
+              --backend eager_npz \
+              --dense-storage-dtype float32 \
+              --output-json outputs/production-memory/prediction-eager.json \
+              > outputs/production-memory/prediction-eager.stdout.json
+          fi
+          if [[ -n "${PROFILE_PREDICTION_STORE}" ]]; then
+            python -m prob4d.prediction_store_benchmark \
+              "${PROFILE_PREDICTION_STORE}" \
+              --backend mmap_npy \
+              --dense-storage-dtype float32 \
+              --output-json outputs/production-memory/prediction-mmap.json \
+              > outputs/production-memory/prediction-mmap.stdout.json
+          fi
+      - name: Validate and summarize reports
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from __future__ import annotations
+
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          root = Path("outputs/production-memory")
+          reports = {}
+          for name in ("fusion", "evaluation", "prediction-eager", "prediction-mmap"):
+              path = root / f"{name}.json"
+              if not path.is_file():
+                  continue
+              report = json.loads(path.read_text(encoding="utf-8"))
+              if report["repository_revision"] != os.environ["GITHUB_SHA"]:
+                  raise RuntimeError(f"{name} revision does not match GITHUB_SHA")
+              peak = report["memory_bytes"]["peak_process_rss"]
+              if peak is None or int(peak) <= 0:
+                  raise RuntimeError(f"{name} did not report positive peak RSS")
+              reports[name] = report
+
+          if set(reports) < {"fusion", "evaluation"}:
+              raise RuntimeError("fusion and evaluation reports are required")
+
+          summary = {
+              "schema": "prob4d.production-memory-profile",
+              "version": 1,
+              "repository_revision": os.environ["GITHUB_SHA"],
+              "run_id": os.environ["GITHUB_RUN_ID"],
+              "runner_name": os.environ["RUNNER_NAME"],
+              "reports": {
+                  name: {
+                      "schema": value["schema"],
+                      "configuration": value["configuration"],
+                      "timing_seconds": value["timing_seconds"],
+                      "memory_bytes": value["memory_bytes"],
+                      "output": value["output"],
+                  }
+                  for name, value in sorted(reports.items())
+              },
+              "claim_boundary": (
+                  "Hardware-specific engineering evidence only. This report does not "
+                  "establish reconstruction accuracy, uncertainty calibration, "
+                  "Bayesian-PhysTwin benefit, or Causal4D benefit."
+              ),
+          }
+          encoded = json.dumps(summary, indent=2, sort_keys=True, allow_nan=False) + "\n"
+          (root / "summary.json").write_text(encoded, encoding="utf-8")
+
+          for path in sorted(root.iterdir()):
+              if path.is_file():
+                  digest = hashlib.sha256(path.read_bytes()).hexdigest()
+                  with (root / "SHA256SUMS").open("a", encoding="utf-8") as stream:
+                      stream.write(f"{digest}  {path.name}\n")
+
+          mib = 1024 * 1024
+          fusion = reports["fusion"]
+          evaluation = reports["evaluation"]
+          lines = [
+              "## Production memory profile",
+              "",
+              "| Phase | Peak RSS | Runtime |",
+              "| --- | ---: | ---: |",
+              (
+                  f"| Dense fusion | "
+                  f"{fusion['memory_bytes']['peak_process_rss'] / mib:.2f} MiB | "
+                  f"{fusion['timing_seconds']['fusion']:.3f} s |"
+              ),
+              (
+                  f"| Provider evaluation | "
+                  f"{evaluation['memory_bytes']['peak_process_rss'] / mib:.2f} MiB | "
+                  f"{evaluation['timing_seconds']['evaluation']:.3f} s |"
+              ),
+              "",
+              f"Runner: `{os.environ['RUNNER_NAME']}`; revision: `{os.environ['GITHUB_SHA']}`.",
+          ]
+          with Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a", encoding="utf-8") as stream:
+              stream.write("\n".join(lines) + "\n")
+          PY
+      - name: Upload profile evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: production-memory-profile-${{ github.run_id }}
+          path: outputs/production-memory
+          if-no-files-found: error
+          retention-days: 30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,10 @@ All notable changes to Prob4D are documented here.
 - Bounded-memory metric, prefix-aligned, and oracle-aligned evaluation with an
   explicit chunk-size execution contract and deterministic process-level memory,
   timing, retained-storage, and numerical-agreement benchmark.
+- An opt-in self-hosted full-resolution memory-profile workflow that runs fusion
+  and provider evaluation in fresh processes, optionally profiles verified eager
+  and mmap prediction loading, binds host and revision identity, and uploads
+  checksummed machine-readable evidence.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -349,3 +349,9 @@ fitted transforms during accumulation instead of materializing complete
 transformed sequences. The provider report records the selected chunk size, and
 a deterministic process benchmark measures peak RSS and numerical agreement. See
 [bounded-memory provider evaluation](docs/streaming-evaluation.md).
+
+A separate opt-in workflow runs the fusion and evaluation benchmarks at the full
+`25 x 320 x 640` shape on the IPS self-hosted `nvidia-smi` runner. It captures
+CPU, RAM, GPU, software, revision, timing, RSS, retained-storage, and output-digest
+evidence, with optional eager-versus-mmap loading for runner-local prediction
+bundles. See [production memory profiling](docs/production-memory-profile.md).

--- a/docs/production-memory-profile.md
+++ b/docs/production-memory-profile.md
@@ -1,0 +1,74 @@
+# Production memory profiling
+
+Prob4D provides an opt-in self-hosted workflow for reproducible, fresh-process
+memory measurements at the production `25 x 320 x 640` window shape. It is an
+engineering evidence surface for issue #50, not a reconstruction or downstream
+physics experiment.
+
+## Covered phases
+
+The workflow runs each measured phase in a separate Python process:
+
+1. dense covariance-intersection fusion with configurable contributor and tile
+   counts;
+2. metric, prefix-aligned, and oracle-aligned provider evaluation with optional
+   dense scene flow and configurable evaluation chunks;
+3. optional eager-NPZ and read-only mmap-NPY loading for an actual prediction
+   bundle already present on the runner.
+
+Separate processes prevent an earlier phase's high-water RSS mark from being
+attributed to a later phase. Every JSON report records the exact repository
+revision, Python and NumPy versions, host platform, configuration, timing, peak
+process RSS, retained-array accounting, and a deterministic output digest.
+
+## Runner and invocation
+
+The checked-in workflow targets the IPS self-hosted labels:
+
+```text
+self-hosted, Linux, X64, nvidia-smi
+```
+
+A pull request that changes the workflow or one of its benchmark surfaces runs
+the full synthetic profile automatically. For a manual run, open **Actions →
+Production memory profile → Run workflow**. The defaults are:
+
+```text
+frames: 25
+height: 320
+width: 640
+contributors: 3
+fusion tile size: 16384
+evaluation chunk size: 65536
+include flow: true
+```
+
+The optional `prediction_manifest` and `prediction_store` inputs are absolute
+paths on the self-hosted runner. When supplied, the workflow additionally runs
+the verified eager and mmap loading benchmarks in fresh processes. These paths
+are never uploaded; only their content-addressed identities and measurements are
+included in the JSON evidence.
+
+## Evidence artifact
+
+Each run uploads one `production-memory-profile-<run-id>` artifact containing:
+
+- `host.txt`, including CPU, RAM, GPU, driver, Python, and NumPy identity;
+- one JSON and captured stdout file per executed phase;
+- `summary.json`, binding the phase reports to the workflow revision and runner;
+- `SHA256SUMS` for every evidence file.
+
+The workflow fails closed when a required phase does not report positive peak
+RSS or when a report revision differs from `GITHUB_SHA`.
+
+## Claim boundary and remaining work
+
+Synthetic full-resolution runs establish only resource behavior for the selected
+host and configuration. Optional actual-bundle loading adds storage evidence but
+does not establish visual accuracy, calibration, Bayesian-PhysTwin acceptance,
+or Causal4D benefit.
+
+Issue #50 remains open until one frozen real multi-overlap bundle is profiled
+phase by phase through loading, disagreement, gauge estimation, fusion,
+provider export, and evaluation. The workflow is the repeatable hardware and
+artifact substrate for that final evidence gate.

--- a/src/prob4d/fusion_memory_benchmark.py
+++ b/src/prob4d/fusion_memory_benchmark.py
@@ -53,6 +53,7 @@ def _digest_arrays(*arrays: np.ndarray) -> str:
 
 def _build_inputs(
     *,
+    frames: int,
     height: int,
     width: int,
     contributor_count: int,
@@ -64,9 +65,10 @@ def _build_inputs(
     dict[str, np.ndarray],
 ]:
     generator = np.random.default_rng(seed)
-    base = generator.normal(size=(1, height, width, 3)).astype(np.float32)
+    base = generator.normal(size=(frames, height, width, 3)).astype(np.float32)
     base[..., 2] += np.float32(4.0)
-    mask = np.ones((1, height, width), dtype=bool)
+    mask = np.ones((frames, height, width), dtype=bool)
+    frame_indices = np.arange(frames, dtype=np.int64)
     windows: list[PredictionWindow] = []
     gauges: dict[str, Sim3] = {}
     uncertainties: dict[str, StructuredCovariance] = {}
@@ -78,7 +80,7 @@ def _build_inputs(
         window_id = f"window-{index:02d}"
         window = PredictionWindow(
             window_id=window_id,
-            frame_indices=np.asarray([0]),
+            frame_indices=frame_indices,
             point_map=values,
             valid_mask=mask,
             dense_storage_dtype="float32",
@@ -100,6 +102,8 @@ def _build_inputs(
 
 
 def run_benchmark(arguments: argparse.Namespace) -> dict[str, Any]:
+    if arguments.frames < 1:
+        raise ValueError("frames must be positive")
     if arguments.height < 1 or arguments.width < 1:
         raise ValueError("height and width must be positive")
     if arguments.contributors < 1:
@@ -109,6 +113,7 @@ def run_benchmark(arguments: argparse.Namespace) -> dict[str, Any]:
 
     construction_started = time.perf_counter()
     windows, gauges, uncertainties, gauge_covariances = _build_inputs(
+        frames=arguments.frames,
         height=arguments.height,
         width=arguments.width,
         contributor_count=arguments.contributors,
@@ -155,7 +160,7 @@ def run_benchmark(arguments: argparse.Namespace) -> dict[str, Any]:
         "configuration": {
             "height": arguments.height,
             "width": arguments.width,
-            "frames": 1,
+            "frames": arguments.frames,
             "contributors": arguments.contributors,
             "seed": arguments.seed,
             "method": arguments.method,
@@ -196,6 +201,7 @@ def run_benchmark(arguments: argparse.Namespace) -> dict[str, Any]:
 
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--frames", type=int, default=1)
     parser.add_argument("--height", type=int, default=320)
     parser.add_argument("--width", type=int, default=640)
     parser.add_argument("--contributors", type=int, default=3)

--- a/tests/test_fusion_memory_benchmark.py
+++ b/tests/test_fusion_memory_benchmark.py
@@ -7,6 +7,7 @@ from prob4d.fusion_memory_benchmark import run_benchmark
 
 def _arguments(**overrides: object) -> Namespace:
     values: dict[str, object] = {
+        "frames": 2,
         "height": 8,
         "width": 12,
         "contributors": 3,
@@ -25,6 +26,7 @@ def test_dense_fusion_memory_benchmark_emits_reproducible_contract() -> None:
     assert first["schema"] == "prob4d.dense-fusion-memory-benchmark"
     assert first["version"] == 1
     assert first["configuration"] == second["configuration"]
+    assert first["configuration"]["frames"] == 2
     assert first["output"] == second["output"]
     assert len(first["output"]["artifact_digest"]) == 64
     assert first["memory_bytes"]["retained_prediction_vectors"] > 0
@@ -38,6 +40,7 @@ def test_dense_fusion_memory_benchmark_emits_reproducible_contract() -> None:
 @pytest.mark.parametrize(
     ("field", "value", "message"),
     [
+        ("frames", 0, "frames must be positive"),
         ("height", 0, "height and width must be positive"),
         ("contributors", 0, "contributors must be positive"),
         ("fusion_tile_size", 0, "fusion tile size must be positive"),


### PR DESCRIPTION
## Summary

Add a reproducible self-hosted evidence surface for the remaining production-memory work in issue #50.

- extend the deterministic dense-fusion benchmark from one frame to configurable full windows while retaining the historical one-frame default;
- add a guarded same-repository workflow on the IPS `self-hosted`, `Linux`, `X64`, `nvidia-smi` runner;
- run full-resolution fusion and bounded provider evaluation in separate fresh processes at the default `25 x 320 x 640` shape;
- optionally profile verified eager-NPZ and mmap-NPY loading for runner-local prediction bundles;
- bind host, software, repository revision, configuration, timings, peak RSS, retained storage, and deterministic output digests into checksummed JSON evidence;
- document invocation, artifact contents, and the remaining real-data evidence boundary.

## Safety and compatibility

The workflow runs only for same-repository pull requests or explicit manual dispatch. External forks cannot consume the self-hosted runner. All third-party actions are pinned to immutable commit SHAs.

No provider, fused-prediction, observation, factor, decision-policy, or estimator schema changes are introduced. The workflow and benchmarks are engineering evidence only.

## Validation

Both authoritative workflows passed on head `b09eb88844159d621ab661f7af0bf2bca8e39087`:

- **Tests #462** — complete repository CI passed;
- **Production memory profile #1** — completed successfully on `workstation2`.

The production profile used the PR merge-ref revision `6bff16535d9aafbf6ce403e9bb13839b0d1505ec`, Python 3.12.13, NumPy 2.2.6, and Linux 6.17.0-23-generic.

### Full-window dense fusion

Configuration: 25 frames, 320 × 640, three contributors, float32 prediction storage, gauge covariance, covariance intersection, tile size 16,384.

- peak process RSS: **1,450,295,296 bytes** (1.35 GiB);
- fusion time: **40.93 s**;
- retained prediction vectors: **184,320,000 bytes**;
- retained structured covariance: **614,400,000 bytes**;
- fused output: **506,880,200 bytes**;
- deterministic output digest: `4eee96a355de938830bac851710548a9ca24008b340c3f71a05184b0b0588722`.

### Bounded provider evaluation

Configuration: 25 frames, 320 × 640, flow enabled, chunk size 65,536, metric/prefix/oracle modes.

- peak process RSS: **2,586,529,792 bytes** (2.41 GiB);
- evaluation time: **154.89 s**;
- evaluated points: **4,965,872**;
- retained prediction: **1,003,520,200 bytes**;
- retained truth: **256,000,200 bytes**;
- retained scalar-diagnostic upper bound: **119,180,928 bytes**;
- avoided historical point/covariance copies: **491,520,000 bytes**;
- avoided per-aligned-mode materialization: **983,040,000 bytes**;
- deterministic metric digest: `f038ce513ec7ab15137757536fc842e147c3249a7f011736b66e5ff60a5ab78b`.

The optional real eager-NPZ/mmap-NPY backend profiles were not run because runner-local bundle paths were not configured. The workflow retains those explicit inputs for a later real-bundle evidence run.

Local preparation also passed 405 tests, the action-pin and release-policy checks, wheel/sdist construction, the extracted-source audit, and small multi-frame benchmark smokes.

## Claim boundary

These measurements are hardware-specific synthetic engineering evidence. They do not establish reconstruction accuracy, uncertainty calibration, Bayesian-PhysTwin benefit, or Causal4D benefit.

The remaining issue #50 gate is a matched real multi-overlap bundle with phase-wise loading, disagreement, gauge-estimation, fusion, export, and evaluation measurements.

Advances #50.