### PR TITLE
Add sparse explicit-gauge factor stacks

### DIFF
--- a/docs/sparse-observation-factor-stack.md
+++ b/docs/sparse-observation-factor-stack.md
@@ -1,0 +1,86 @@
+# Sparse explicit-gauge observation-factor stacks
+
+`ObservationFactorBundle` schema v4 preserves one local `Sim(3)` gauge per
+prediction window and one ordered joint gauge covariance over all windows. The
+historical in-memory `bundle.stack()` adapter expands every selected observation
+row into a dense gauge Jacobian with shape
+
+```text
+M x 3 x 7K
+```
+
+where `M` is the selected observation count and `K` is the number of gauges.
+Exactly one seven-column block is nonzero in each row. This is convenient for
+small experiments, but its Jacobian storage grows as `O(MK)`.
+
+`prob4d.sparse_observation_factors` provides an additive representation with:
+
+```text
+local_gauge_jacobian: M x 3 x 7
+gauge_indices:        M
+gauge_prior:           7K x 7K
+```
+
+The representation is mathematically equivalent to the dense stack and reduces
+the row-design storage to `O(M)`. It does not change the neutral serialized
+factor-bundle schema or its content identity.
+
+## Usage
+
+```python
+from prob4d.provider_v2 import load_observation_factor_bundle
+from prob4d.sparse_observation_factors import (
+    stack_sparse_observation_factors,
+)
+
+bundle = load_observation_factor_bundle("outputs/case-a/factors.json")
+stacked = stack_sparse_observation_factors(bundle)
+
+# Apply one explicit gauge perturbation without constructing zero blocks.
+predicted_gauge_displacement = stacked.apply_gauge_delta(gauge_delta)
+
+# Materialize the historical dense design only for a compatibility boundary.
+dense_design = stacked.dense_gauge_jacobian()
+```
+
+The sparse adapter preserves:
+
+- conditional and marginal world covariance separately;
+- the complete joint cross-window gauge prior;
+- association probability;
+- source-side prior reliability;
+- nominal-component probability;
+- composite information weight;
+- row, factor, view, correlation-group, frame, and gauge identities; and
+- the exclusive causal frame stop.
+
+## Covariance rule
+
+An estimator that keeps gauge errors explicit must use:
+
+```text
+conditional_world_covariance_m2
++ local_gauge_jacobian
++ gauge_indices
++ gauge_prior_covariance
+```
+
+It must not additionally use `marginal_world_covariance_m2`, because that would
+count `J Sigma_gg J^T` twice. The method
+`gauge_marginal_covariance_m2()` reconstructs that per-row contribution for
+parity tests and diagnostics.
+
+The full joint gauge prior remains dense in this additive adapter. It therefore
+removes the dominant zero-block row expansion but does not yet replace the
+`O(K^2)` prior with a sparse square-root factor graph. A future artifact or
+provider version is required before changing serialized gauge-prior semantics.
+
+## Compatibility and claim boundary
+
+The existing `StackedObservationFactors`, factor-bundle schema v4, provider-v1
+surface, provider-v2 artifacts, and content addresses remain unchanged. The new
+adapter is an in-memory execution representation only.
+
+Lower memory use and exact dense parity are engineering properties. They do not
+establish point-covariance calibration, physical-state identifiability, safe
+Bayesian-PhysTwin updates, or improved Causal4D predictions.

--- a/src/prob4d/sparse_observation_factors.py
+++ b/src/prob4d/sparse_observation_factors.py
@@ -1,0 +1,383 @@
+"""Sparse in-memory stacking for explicit-gauge observation-factor updates.
+
+The neutral schema-v4 :class:`~prob4d.observation_factors.ObservationFactorBundle`
+stores one local seven-dimensional ``Sim(3)`` gauge block per observation row and
+one joint prior over all gauges.  The historical dense stack expands every row
+to ``3 x 7K`` even though exactly one seven-column block is nonzero.  This module
+keeps the local block plus an integer gauge index, preserving the exact
+statistics while reducing Jacobian storage from ``O(MK)`` to ``O(M)``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .observation_factors import ObservationFactorBundle
+
+FloatArray = NDArray[np.floating]
+IntArray = NDArray[np.integer]
+
+
+def _readonly(value: np.ndarray, *, dtype: Any | None = None) -> np.ndarray:
+    result = np.asarray(value, dtype=dtype).copy()
+    result.setflags(write=False)
+    return result
+
+
+def _integer_vector(value: np.ndarray, *, name: str) -> np.ndarray:
+    raw = np.asarray(value)
+    if raw.ndim != 1:
+        raise ValueError(f"{name} must be a vector")
+    if raw.dtype.kind not in {"i", "u"}:
+        raise TypeError(f"{name} must contain genuine integers")
+    return np.asarray(raw, dtype=np.int64)
+
+
+def _require_psd(value: np.ndarray, *, name: str, tolerance: float = 1e-12) -> None:
+    symmetric = 0.5 * (value + value.T)
+    if not np.allclose(value, symmetric, atol=tolerance, rtol=1e-10):
+        raise ValueError(f"{name} must be symmetric")
+    if np.min(np.linalg.eigvalsh(symmetric), initial=0.0) < -tolerance:
+        raise ValueError(f"{name} must be positive semidefinite")
+
+
+@dataclass(frozen=True, slots=True)
+class SparseStackedObservationFactors:
+    """Flattened rows with one local gauge block and one gauge index per row.
+
+    ``conditional_world_covariance_m2`` is the covariance to use when gauge
+    errors remain explicit nuisance variables.  ``marginal_world_covariance_m2``
+    is retained for diagnostics and consumers that integrate gauges out; it must
+    not be added to the explicit gauge design.
+    """
+
+    world_mean_m: FloatArray
+    conditional_world_covariance_m2: FloatArray
+    marginal_world_covariance_m2: FloatArray
+    local_gauge_jacobian: FloatArray
+    gauge_indices: IntArray
+    gauge_prior_covariance: FloatArray
+    association_probability: FloatArray
+    prior_reliability: FloatArray
+    prior_nominal_probability: FloatArray
+    composite_weight: FloatArray
+    point_ids: IntArray
+    frame_indices: IntArray
+    view_ids: tuple[str, ...]
+    factor_ids: tuple[str, ...]
+    correlation_group_ids: tuple[str, ...]
+    gauge_ids: tuple[str, ...]
+    causal_frame_stop: int
+
+    def __post_init__(self) -> None:
+        mean = np.asarray(self.world_mean_m, dtype=np.float64)
+        conditional = np.asarray(
+            self.conditional_world_covariance_m2,
+            dtype=np.float64,
+        )
+        marginal = np.asarray(
+            self.marginal_world_covariance_m2,
+            dtype=np.float64,
+        )
+        local_jacobian = np.asarray(self.local_gauge_jacobian, dtype=np.float64)
+        gauge_indices = _integer_vector(self.gauge_indices, name="gauge_indices")
+        gauge_prior = np.asarray(self.gauge_prior_covariance, dtype=np.float64)
+        association = np.asarray(self.association_probability, dtype=np.float64)
+        reliability = np.asarray(self.prior_reliability, dtype=np.float64)
+        nominal = np.asarray(self.prior_nominal_probability, dtype=np.float64)
+        composite = np.asarray(self.composite_weight, dtype=np.float64)
+        point_ids = _integer_vector(self.point_ids, name="point_ids")
+        frame_indices = _integer_vector(self.frame_indices, name="frame_indices")
+        gauge_ids = tuple(str(value) for value in self.gauge_ids)
+        count = len(mean)
+        gauge_count = len(gauge_ids)
+        gauge_dimension = 7 * gauge_count
+
+        if count < 1:
+            raise ValueError("sparse observation-factor stack must contain rows")
+        if mean.shape != (count, 3):
+            raise ValueError("world_mean_m must have shape (M, 3)")
+        if conditional.shape != (count, 3, 3):
+            raise ValueError(
+                "conditional_world_covariance_m2 must have shape (M, 3, 3)"
+            )
+        if marginal.shape != (count, 3, 3):
+            raise ValueError("marginal_world_covariance_m2 must have shape (M, 3, 3)")
+        if local_jacobian.shape != (count, 3, 7):
+            raise ValueError("local_gauge_jacobian must have shape (M, 3, 7)")
+        if gauge_indices.shape != (count,):
+            raise ValueError("gauge_indices must have shape (M,)")
+        if not gauge_ids or any(not value for value in gauge_ids):
+            raise ValueError("gauge_ids must contain nonempty strings")
+        if len(set(gauge_ids)) != gauge_count:
+            raise ValueError("gauge_ids must be unique")
+        if np.any(gauge_indices < 0) or np.any(gauge_indices >= gauge_count):
+            raise ValueError("gauge_indices reference an unknown gauge")
+        if gauge_prior.shape != (gauge_dimension, gauge_dimension):
+            raise ValueError(
+                "gauge_prior_covariance must have shape "
+                f"({gauge_dimension}, {gauge_dimension})"
+            )
+        if not np.all(np.isfinite(gauge_prior)):
+            raise ValueError("gauge_prior_covariance must be finite")
+        _require_psd(gauge_prior, name="gauge_prior_covariance")
+
+        probabilities = (
+            ("association_probability", association, True),
+            ("prior_reliability", reliability, True),
+            ("prior_nominal_probability", nominal, True),
+            ("composite_weight", composite, False),
+        )
+        for name, values, allow_zero in probabilities:
+            if values.shape != (count,):
+                raise ValueError(f"{name} must have shape (M,)")
+            lower = values >= 0.0 if allow_zero else values > 0.0
+            if (
+                not np.all(np.isfinite(values))
+                or not np.all(lower)
+                or np.any(values > 1.0)
+            ):
+                interval = "[0, 1]" if allow_zero else "(0, 1]"
+                raise ValueError(f"{name} must lie in {interval}")
+
+        if point_ids.shape != (count,) or frame_indices.shape != (count,):
+            raise ValueError("row identity vectors must have shape (M,)")
+        raw_causal_frame_stop = self.causal_frame_stop
+        if (
+            isinstance(raw_causal_frame_stop, (bool, np.bool_))
+            or not isinstance(raw_causal_frame_stop, (int, np.integer))
+        ):
+            raise TypeError("causal_frame_stop must be a genuine integer")
+        causal_frame_stop = int(raw_causal_frame_stop)
+        if causal_frame_stop < 1:
+            raise ValueError("causal_frame_stop must be positive")
+        if np.any(frame_indices < 0) or np.any(frame_indices >= causal_frame_stop):
+            raise ValueError("stacked rows cross the exclusive causal frame stop")
+
+        string_fields = {
+            "view_ids": tuple(str(value) for value in self.view_ids),
+            "factor_ids": tuple(str(value) for value in self.factor_ids),
+            "correlation_group_ids": tuple(
+                str(value) for value in self.correlation_group_ids
+            ),
+        }
+        for name, values in string_fields.items():
+            if len(values) != count or any(not value for value in values):
+                raise ValueError(f"{name} must contain one nonempty string per row")
+
+        for name, value in (
+            ("world_mean_m", mean),
+            ("conditional_world_covariance_m2", conditional),
+            ("marginal_world_covariance_m2", marginal),
+            ("local_gauge_jacobian", local_jacobian),
+            ("gauge_indices", gauge_indices),
+            ("gauge_prior_covariance", gauge_prior),
+            ("association_probability", association),
+            ("prior_reliability", reliability),
+            ("prior_nominal_probability", nominal),
+            ("composite_weight", composite),
+            ("point_ids", point_ids),
+            ("frame_indices", frame_indices),
+        ):
+            object.__setattr__(self, name, _readonly(value))
+        for name, values in string_fields.items():
+            object.__setattr__(self, name, values)
+        object.__setattr__(self, "gauge_ids", gauge_ids)
+        object.__setattr__(self, "causal_frame_stop", causal_frame_stop)
+
+    @property
+    def observation_count(self) -> int:
+        return len(self.world_mean_m)
+
+    @property
+    def gauge_count(self) -> int:
+        return len(self.gauge_ids)
+
+    @property
+    def dense_gauge_dimension(self) -> int:
+        return 7 * self.gauge_count
+
+    @property
+    def sparse_gauge_design_nbytes(self) -> int:
+        """Bytes retained for the local Jacobians and row gauge indices."""
+
+        return int(self.local_gauge_jacobian.nbytes + self.gauge_indices.nbytes)
+
+    @property
+    def dense_gauge_design_nbytes(self) -> int:
+        """Bytes required by the equivalent float64 dense ``M x 3 x 7K`` design."""
+
+        return int(
+            self.observation_count
+            * 3
+            * self.dense_gauge_dimension
+            * np.dtype(np.float64).itemsize
+        )
+
+    def dense_gauge_jacobian(self) -> FloatArray:
+        """Materialize the historical dense design as a mutable compatibility copy."""
+
+        result = np.zeros(
+            (self.observation_count, 3, self.dense_gauge_dimension),
+            dtype=np.float64,
+        )
+        for gauge_index in range(self.gauge_count):
+            selected = self.gauge_indices == gauge_index
+            start = 7 * gauge_index
+            result[selected, :, start : start + 7] = self.local_gauge_jacobian[selected]
+        return result
+
+    def apply_gauge_delta(self, gauge_delta: FloatArray) -> FloatArray:
+        """Apply one stacked or block-shaped gauge perturbation to every row."""
+
+        delta = np.asarray(gauge_delta, dtype=np.float64)
+        if delta.shape == (self.dense_gauge_dimension,):
+            blocks = delta.reshape(self.gauge_count, 7)
+        elif delta.shape == (self.gauge_count, 7):
+            blocks = delta
+        else:
+            raise ValueError(
+                "gauge_delta must have shape "
+                f"({self.dense_gauge_dimension},) or ({self.gauge_count}, 7)"
+            )
+        if not np.all(np.isfinite(blocks)):
+            raise ValueError("gauge_delta must be finite")
+        return np.einsum(
+            "nij,nj->ni",
+            self.local_gauge_jacobian,
+            blocks[self.gauge_indices],
+            optimize=True,
+        )
+
+    def gauge_marginal_covariance_m2(self) -> FloatArray:
+        """Return each row's ``J Sigma_gg J^T`` contribution."""
+
+        blocks = np.empty((self.observation_count, 7, 7), dtype=np.float64)
+        for gauge_index in range(self.gauge_count):
+            selected = self.gauge_indices == gauge_index
+            start = 7 * gauge_index
+            blocks[selected] = self.gauge_prior_covariance[
+                start : start + 7,
+                start : start + 7,
+            ]
+        result = np.einsum(
+            "nia,nab,njb->nij",
+            self.local_gauge_jacobian,
+            blocks,
+            self.local_gauge_jacobian,
+            optimize=True,
+        )
+        return 0.5 * (result + result.swapaxes(1, 2))
+
+
+def stack_sparse_observation_factors(
+    bundle: ObservationFactorBundle,
+    *,
+    include_invalid: bool = False,
+) -> SparseStackedObservationFactors:
+    """Stack a factor bundle without expanding zero gauge-Jacobian blocks."""
+
+    if not isinstance(bundle, ObservationFactorBundle):
+        raise TypeError("bundle must be an ObservationFactorBundle")
+    gauge_ids = tuple(gauge.window_id for gauge in bundle.gauges)
+    gauge_positions = {gauge_id: index for index, gauge_id in enumerate(gauge_ids)}
+
+    means: list[np.ndarray] = []
+    conditional_covariances: list[np.ndarray] = []
+    marginal_covariances: list[np.ndarray] = []
+    local_jacobians: list[np.ndarray] = []
+    gauge_indices: list[np.ndarray] = []
+    association_probabilities: list[np.ndarray] = []
+    prior_reliabilities: list[np.ndarray] = []
+    prior_nominal_probabilities: list[np.ndarray] = []
+    composite_weights: list[np.ndarray] = []
+    point_ids: list[np.ndarray] = []
+    frame_indices: list[np.ndarray] = []
+    view_ids: list[str] = []
+    factor_ids: list[str] = []
+    correlation_group_ids: list[str] = []
+
+    for factor in bundle.factors:
+        linearized = bundle.linearize(factor)
+        selected = (
+            np.ones(len(factor.point_ids), dtype=bool)
+            if include_invalid
+            else (
+                factor.valid_mask
+                & (factor.association_probability > 0.0)
+                & (factor.prior_reliability > 0.0)
+            )
+        )
+        selected_count = int(np.count_nonzero(selected))
+        if selected_count == 0:
+            continue
+        gauge_index = gauge_positions[factor.gauge_id]
+        means.append(linearized.world_mean_m[selected])
+        conditional_covariances.append(
+            linearized.conditional_world_covariance_m2[selected]
+        )
+        marginal_covariances.append(linearized.marginal_world_covariance_m2[selected])
+        local_jacobians.append(linearized.gauge_jacobian[selected])
+        gauge_indices.append(
+            np.full(selected_count, gauge_index, dtype=np.int64)
+        )
+        association_probabilities.append(factor.association_probability[selected])
+        prior_reliabilities.append(factor.prior_reliability[selected])
+        prior_nominal_probabilities.append(
+            np.full(
+                selected_count,
+                factor.prior_nominal_probability,
+                dtype=np.float64,
+            )
+        )
+        composite_weights.append(
+            np.full(selected_count, factor.composite_weight, dtype=np.float64)
+        )
+        point_ids.append(factor.point_ids[selected])
+        frame_indices.append(
+            np.full(selected_count, factor.frame_index, dtype=np.int64)
+        )
+        view_ids.extend([factor.view_id] * selected_count)
+        factor_ids.extend([factor.factor_id] * selected_count)
+        correlation_group_ids.extend(
+            [factor.correlation_group_id] * selected_count
+        )
+
+    if not means:
+        raise ValueError("observation-factor stack has no selected rows")
+
+    return SparseStackedObservationFactors(
+        world_mean_m=np.concatenate(means, axis=0),
+        conditional_world_covariance_m2=np.concatenate(
+            conditional_covariances,
+            axis=0,
+        ),
+        marginal_world_covariance_m2=np.concatenate(
+            marginal_covariances,
+            axis=0,
+        ),
+        local_gauge_jacobian=np.concatenate(local_jacobians, axis=0),
+        gauge_indices=np.concatenate(gauge_indices),
+        gauge_prior_covariance=bundle.joint_gauge_covariance,
+        association_probability=np.concatenate(association_probabilities),
+        prior_reliability=np.concatenate(prior_reliabilities),
+        prior_nominal_probability=np.concatenate(prior_nominal_probabilities),
+        composite_weight=np.concatenate(composite_weights),
+        point_ids=np.concatenate(point_ids),
+        frame_indices=np.concatenate(frame_indices),
+        view_ids=tuple(view_ids),
+        factor_ids=tuple(factor_ids),
+        correlation_group_ids=tuple(correlation_group_ids),
+        gauge_ids=gauge_ids,
+        causal_frame_stop=bundle.causal_frame_stop,
+    )
+
+
+__all__ = [
+    "SparseStackedObservationFactors",
+    "stack_sparse_observation_factors",
+]

--- a/tests/test_sparse_observation_factors.py
+++ b/tests/test_sparse_observation_factors.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from prob4d.gauge import GaugeEstimate
+from prob4d.observation_factors import ObservationFactor, ObservationFactorBundle
+from prob4d.sim3 import Sim3
+from prob4d.sparse_observation_factors import (
+    SparseStackedObservationFactors,
+    stack_sparse_observation_factors,
+)
+
+
+def _bundle(*, with_invalid_row: bool = False) -> ObservationFactorBundle:
+    covariance_0 = np.eye(7, dtype=np.float64) * 2.0e-4
+    covariance_1 = np.eye(7, dtype=np.float64) * 3.0e-4
+    cross = np.eye(7, dtype=np.float64) * 5.0e-5
+    joint = np.block(
+        [
+            [covariance_0, cross],
+            [cross, covariance_1],
+        ]
+    )
+    gauges = (
+        GaugeEstimate("window-0", Sim3.identity(), covariance_0),
+        GaugeEstimate("window-1", Sim3.identity(), covariance_1),
+    )
+    common = {
+        "valid_mask": np.asarray([True, not with_invalid_row]),
+        "local_covariance_m2": np.repeat(
+            np.eye(3, dtype=np.float64)[None] * 1.0e-3,
+            2,
+            axis=0,
+        ),
+        "association_probability": np.asarray([0.9, 0.8]),
+        "prior_reliability": np.asarray([0.85, 0.75]),
+        "prior_nominal_probability": 0.95,
+        "composite_weight": 0.5,
+        "causal_frame_stop": 6,
+    }
+    factors = (
+        ObservationFactor(
+            factor_id="factor-0",
+            frame_index=2,
+            view_id="camera-0",
+            window_id="window-0",
+            gauge_id="window-0",
+            point_ids=np.asarray([10, 11], dtype=np.int64),
+            points_local_m=np.asarray(
+                [[0.0, 0.0, 1.0], [0.2, 0.0, 1.1]],
+                dtype=np.float64,
+            ),
+            correlation_group_id="camera-0:frame-2",
+            **common,
+        ),
+        ObservationFactor(
+            factor_id="factor-1",
+            frame_index=4,
+            view_id="camera-0",
+            window_id="window-1",
+            gauge_id="window-1",
+            point_ids=np.asarray([20, 21], dtype=np.int64),
+            points_local_m=np.asarray(
+                [[0.1, 0.2, 1.2], [0.3, 0.1, 1.3]],
+                dtype=np.float64,
+            ),
+            correlation_group_id="camera-0:frame-4",
+            **common,
+        ),
+    )
+    return ObservationFactorBundle(
+        sequence_id="sequence-a",
+        case_id="case-a",
+        stream_id="prob4d:explicit-gauge:camera-0",
+        factors=factors,
+        gauges=gauges,
+        source_repository="FlorianPfaff/Prob4D",
+        source_revision="a" * 40,
+        causal_frame_stop=6,
+        joint_gauge_covariance=joint,
+        gauge_covariance_semantics="joint-cross-window",
+    )
+
+
+def test_sparse_stack_is_exactly_equivalent_to_dense_stack() -> None:
+    bundle = _bundle()
+    dense = bundle.stack()
+    sparse = stack_sparse_observation_factors(bundle)
+
+    np.testing.assert_allclose(sparse.world_mean_m, dense.world_mean_m)
+    np.testing.assert_allclose(
+        sparse.conditional_world_covariance_m2,
+        dense.conditional_world_covariance_m2,
+    )
+    np.testing.assert_allclose(
+        sparse.marginal_world_covariance_m2,
+        dense.marginal_world_covariance_m2,
+    )
+    np.testing.assert_allclose(
+        sparse.dense_gauge_jacobian(),
+        dense.gauge_jacobian,
+    )
+    np.testing.assert_allclose(
+        sparse.gauge_prior_covariance,
+        dense.gauge_prior_covariance,
+    )
+    np.testing.assert_array_equal(
+        sparse.association_probability,
+        dense.association_probability,
+    )
+    np.testing.assert_array_equal(
+        sparse.prior_reliability,
+        dense.prior_reliability,
+    )
+    np.testing.assert_array_equal(
+        sparse.prior_nominal_probability,
+        dense.prior_nominal_probability,
+    )
+    np.testing.assert_array_equal(
+        sparse.composite_weight,
+        dense.composite_weight,
+    )
+    np.testing.assert_array_equal(sparse.point_ids, dense.point_ids)
+    np.testing.assert_array_equal(sparse.frame_indices, dense.frame_indices)
+    assert sparse.view_ids == dense.view_ids
+    assert sparse.factor_ids == dense.factor_ids
+    assert sparse.correlation_group_ids == dense.correlation_group_ids
+    assert sparse.gauge_ids == dense.gauge_ids
+
+
+def test_sparse_gauge_operations_match_dense_linear_algebra() -> None:
+    bundle = _bundle()
+    dense = bundle.stack()
+    sparse = stack_sparse_observation_factors(bundle)
+    delta = np.linspace(-0.02, 0.03, 14, dtype=np.float64)
+
+    dense_response = np.einsum(
+        "nij,j->ni",
+        dense.gauge_jacobian,
+        delta,
+        optimize=True,
+    )
+    np.testing.assert_allclose(sparse.apply_gauge_delta(delta), dense_response)
+    np.testing.assert_allclose(
+        sparse.apply_gauge_delta(delta.reshape(2, 7)),
+        dense_response,
+    )
+    np.testing.assert_allclose(
+        sparse.gauge_marginal_covariance_m2(),
+        sparse.marginal_world_covariance_m2
+        - sparse.conditional_world_covariance_m2,
+        atol=1e-15,
+        rtol=1e-12,
+    )
+    assert np.any(sparse.gauge_prior_covariance[:7, 7:] != 0.0)
+
+
+def test_sparse_stack_preserves_include_invalid_semantics() -> None:
+    bundle = _bundle(with_invalid_row=True)
+    dense_default = bundle.stack()
+    sparse_default = stack_sparse_observation_factors(bundle)
+    dense_all = bundle.stack(include_invalid=True)
+    sparse_all = stack_sparse_observation_factors(bundle, include_invalid=True)
+
+    assert sparse_default.observation_count == len(dense_default.world_mean_m) == 2
+    assert sparse_all.observation_count == len(dense_all.world_mean_m) == 4
+    np.testing.assert_allclose(
+        sparse_all.dense_gauge_jacobian(),
+        dense_all.gauge_jacobian,
+    )
+
+
+def test_sparse_stack_owns_readonly_arrays_and_rejects_lossy_indices() -> None:
+    sparse = stack_sparse_observation_factors(_bundle())
+
+    with pytest.raises(ValueError):
+        sparse.local_gauge_jacobian[0, 0, 0] = 1.0
+    with pytest.raises(ValueError):
+        sparse.gauge_indices[0] = 1
+    with pytest.raises(TypeError, match="genuine integers"):
+        replace(
+            sparse,
+            gauge_indices=sparse.gauge_indices.astype(np.float64),
+        )
+
+
+def test_sparse_stack_reduces_expanded_gauge_design_storage() -> None:
+    sparse = stack_sparse_observation_factors(_bundle())
+
+    assert sparse.gauge_count == 2
+    assert sparse.dense_gauge_dimension == 14
+    assert sparse.sparse_gauge_design_nbytes == (
+        sparse.local_gauge_jacobian.nbytes + sparse.gauge_indices.nbytes
+    )
+    assert sparse.sparse_gauge_design_nbytes < sparse.dense_gauge_design_nbytes
+
+
+def test_sparse_contract_rejects_wrong_gauge_delta_shape() -> None:
+    sparse = stack_sparse_observation_factors(_bundle())
+
+    with pytest.raises(ValueError, match="gauge_delta must have shape"):
+        sparse.apply_gauge_delta(np.zeros(7, dtype=np.float64))
+    with pytest.raises(ValueError, match="must be finite"):
+        delta = np.zeros(14, dtype=np.float64)
+        delta[0] = np.nan
+        sparse.apply_gauge_delta(delta)
+
+
+def test_sparse_contract_requires_observation_factor_bundle() -> None:
+    with pytest.raises(TypeError, match="ObservationFactorBundle"):
+        stack_sparse_observation_factors(object())  # type: ignore[arg-type]
+
+
+def test_sparse_result_type_is_public_and_slotted() -> None:
+    sparse = stack_sparse_observation_factors(_bundle())
+
+    assert isinstance(sparse, SparseStackedObservationFactors)
+    with pytest.raises((AttributeError, TypeError)):
+        sparse.new_attribute = 1  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Add an exact in-memory sparse adapter for schema-v4 `ObservationFactorBundle` artifacts.

- retain one local `3 x 7` `Sim(3)` gauge Jacobian and one gauge index per selected row instead of expanding every row to `3 x 7K`;
- preserve the full ordered joint cross-window gauge prior, conditional and marginal point covariance, reliability, association, nominal probability, composite weight, and all row identities;
- provide dense-Jacobian materialization only at compatibility boundaries;
- provide direct gauge-delta application and per-row `J Sigma_gg J^T` reconstruction;
- defensively copy and freeze arrays and reject lossy gauge-index coercion;
- test exact parity against the historical dense stack, invalid-row semantics, covariance parity, immutability, and storage reduction;
- document the explicit-gauge no-double-counting rule and the remaining dense-prior boundary.

## Complexity improvement

The row gauge design changes from `O(MK)` storage to `O(M)`, where `M` is the selected observation count and `K` is the number of window gauges. The existing `7K x 7K` joint prior remains unchanged, so serialized factor semantics and artifact identities do not change.

## Compatibility and scientific boundary

This is an additive execution representation. Provider v1/v2 artifacts, factor-bundle schema v4, dense `StackedObservationFactors`, and content addresses remain unchanged. Lower memory use and exact dense parity are engineering properties; they do not establish uncertainty calibration, physical-state identifiability, safe Bayesian-PhysTwin acceptance, or Causal4D benefit.
