### PR TITLE
Reject non-string keys in immutable JSON metadata

### DIFF
--- a/src/prob4d/_immutable_json.py
+++ b/src/prob4d/_immutable_json.py
@@ -130,9 +130,7 @@ def frozen_finite_json_mapping(
             )
         )
     except (TypeError, ValueError) as error:
-        raise ValueError(
-            f"{name} must be finite JSON data with string object keys"
-        ) from error
+        raise ValueError(f"{name} must be finite JSON data") from error
     if not isinstance(normalized, dict):
         raise ValueError(f"{name} must be a JSON object")
     return _freeze_json(normalized)

--- a/src/prob4d/_immutable_json.py
+++ b/src/prob4d/_immutable_json.py
@@ -7,14 +7,29 @@ from collections.abc import Mapping
 from typing import Any
 
 
-def plain_json(value: Any) -> Any:
-    """Return ordinary JSON-compatible containers for a frozen JSON value."""
-
+def _plain_json(value: Any, *, path: str) -> Any:
     if isinstance(value, Mapping):
-        return {str(key): plain_json(item) for key, item in value.items()}
+        result: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError(
+                    f"JSON object keys must be strings at {path}; "
+                    f"got {type(key).__name__}"
+                )
+            result[key] = _plain_json(item, path=f"{path}[{key!r}]")
+        return result
     if isinstance(value, (list, tuple)):
-        return [plain_json(item) for item in value]
+        return [
+            _plain_json(item, path=f"{path}[{index}]")
+            for index, item in enumerate(value)
+        ]
     return value
+
+
+def plain_json(value: Any) -> Any:
+    """Return ordinary JSON-compatible containers without coercing object keys."""
+
+    return _plain_json(value, path="$")
 
 
 class FrozenJsonDict(dict[str, Any]):
@@ -93,9 +108,7 @@ class FrozenJsonList(list[Any]):
 
 def _freeze_json(value: Any) -> Any:
     if isinstance(value, dict):
-        return FrozenJsonDict(
-            {str(key): _freeze_json(item) for key, item in value.items()}
-        )
+        return FrozenJsonDict({key: _freeze_json(item) for key, item in value.items()})
     if isinstance(value, list):
         return FrozenJsonList(_freeze_json(item) for item in value)
     return value
@@ -117,7 +130,9 @@ def frozen_finite_json_mapping(
             )
         )
     except (TypeError, ValueError) as error:
-        raise ValueError(f"{name} must be finite JSON data") from error
+        raise ValueError(
+            f"{name} must be finite JSON data with string object keys"
+        ) from error
     if not isinstance(normalized, dict):
         raise ValueError(f"{name} must be a JSON object")
     return _freeze_json(normalized)

--- a/tests/test_immutable_json.py
+++ b/tests/test_immutable_json.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import copy
+from collections.abc import Mapping
+from typing import Any, cast
+
+import pytest
+
+from prob4d._immutable_json import (
+    FrozenJsonDict,
+    FrozenJsonList,
+    frozen_finite_json_mapping,
+    plain_json,
+)
+
+
+def test_plain_json_copies_nested_containers_and_converts_tuples() -> None:
+    original = {
+        "nested": {
+            "values": (1, 2),
+        },
+        "flag": True,
+    }
+
+    normalized = plain_json(original)
+
+    assert normalized == {
+        "nested": {
+            "values": [1, 2],
+        },
+        "flag": True,
+    }
+    assert normalized is not original
+    assert normalized["nested"] is not original["nested"]
+    assert normalized["nested"]["values"] is not original["nested"]["values"]
+
+
+def test_plain_json_rejects_a_top_level_non_string_key() -> None:
+    payload: dict[object, object] = {1: "value"}
+
+    with pytest.raises(
+        TypeError,
+        match=r"JSON object keys must be strings at \$; got int",
+    ):
+        plain_json(payload)
+
+
+def test_plain_json_reports_the_nested_mapping_path() -> None:
+    payload: dict[str, object] = {
+        "outer": [
+            {
+                "inner": {
+                    2: "value",
+                },
+            }
+        ]
+    }
+
+    with pytest.raises(TypeError) as caught:
+        plain_json(payload)
+
+    assert str(caught.value) == (
+        "JSON object keys must be strings at $['outer'][0]['inner']; got int"
+    )
+
+
+def test_plain_json_rejects_integer_string_key_collisions() -> None:
+    payload: dict[object, object] = {
+        1: "integer-key",
+        "1": "string-key",
+    }
+
+    with pytest.raises(TypeError, match="JSON object keys must be strings"):
+        plain_json(payload)
+
+
+def test_frozen_mapping_wraps_non_string_keys_without_losing_the_cause() -> None:
+    payload: dict[object, object] = {
+        "nested": {
+            1: "value",
+        }
+    }
+
+    with pytest.raises(
+        ValueError,
+        match="metadata must be finite JSON data with string object keys",
+    ) as caught:
+        frozen_finite_json_mapping(cast(Mapping[str, Any], payload))
+
+    assert isinstance(caught.value.__cause__, TypeError)
+
+
+def test_frozen_mapping_remains_recursively_immutable_and_copyable() -> None:
+    frozen = cast(
+        FrozenJsonDict,
+        frozen_finite_json_mapping(
+            {
+                "nested": {
+                    "values": [1, 2],
+                }
+            }
+        ),
+    )
+    nested = cast(FrozenJsonDict, frozen["nested"])
+    values = cast(FrozenJsonList, nested["values"])
+
+    with pytest.raises(TypeError, match="metadata is immutable"):
+        frozen["new"] = "value"
+    with pytest.raises(TypeError, match="metadata is immutable"):
+        values.append(3)
+
+    thawed = copy.deepcopy(frozen)
+    thawed["nested"]["values"].append(3)
+
+    assert thawed == {"nested": {"values": [1, 2, 3]}}
+    assert plain_json(frozen) == {"nested": {"values": [1, 2]}}

--- a/tests/test_immutable_json.py
+++ b/tests/test_immutable_json.py
@@ -83,11 +83,12 @@ def test_frozen_mapping_wraps_non_string_keys_without_losing_the_cause() -> None
 
     with pytest.raises(
         ValueError,
-        match="metadata must be finite JSON data with string object keys",
+        match="metadata must be finite JSON data",
     ) as caught:
         frozen_finite_json_mapping(cast(Mapping[str, Any], payload))
 
     assert isinstance(caught.value.__cause__, TypeError)
+    assert "JSON object keys must be strings" in str(caught.value.__cause__)
 
 
 def test_frozen_mapping_remains_recursively_immutable_and_copyable() -> None:


### PR DESCRIPTION
## Summary

- reject non-string mapping keys recursively before JSON normalization;
- stop converting object keys through `str(...)` in `plain_json` and `_freeze_json`;
- report the exact nested mapping path that contains an invalid key;
- prevent integer/string key collisions from silently dropping metadata;
- preserve the existing outer `ValueError` contract of `frozen_finite_json_mapping` while retaining the precise `TypeError` as its cause;
- add six focused regressions for valid copying, nested paths, key collisions, wrapped failures, recursive immutability, and deepcopy behavior.

## Root cause

The shared immutable-JSON helper converted every mapping key with `str(key)`. A payload such as `{1: "integer", "1": "string"}` therefore collapsed both distinct Python keys into one JSON key before hashing or freezing, silently discarding one value. The helper is used by content-addressed observation, factor-stream, source-diagnostic, reliability, prediction-store, and provider-factor metadata surfaces.

## Compatibility

Valid JSON mappings already use string object keys, so their canonical JSON, hashes, frozen values, and copied values are unchanged. The existing `"<name> must be finite JSON data"` error remains unchanged for callers of `frozen_finite_json_mapping`; only previously coerced noncanonical inputs are newly rejected.

## Validation

Local focused validation:

- `tests/test_immutable_json.py`: **6 passed**;
- Python compilation succeeded;
- valid tuple-to-list conversion, recursive freezing, mutation rejection, and deepcopy behavior remain covered.

GitHub Actions on head `65b7a8a4771ec7c933a2d356137b6d0c3bb58013`:

- authoritative fail-closed Ruff and stable-interface mypy: passed;
- repository Ruff, mypy, provider-contract, runtime-attestation, and policy checks: passed;
- complete Python 3.12 and Python 3.14 suites: passed;
- exact Python 3.10 / NumPy 1.24.0 floor suite: passed.

The first Python 3.10, 3.11, and 3.13 matrix jobs failed before executing any step and produced no log blob, indicating GitHub-hosted runner startup failures rather than test failures. Failed-job-only retries have been requested and remain queued. The PR stays draft until those retries and the dependent distribution smokes complete.