### PR TITLE
Harden calibration and factor artifact scalar types

### DIFF
--- a/docs/strict-artifact-loading.md
+++ b/docs/strict-artifact-loading.md
@@ -1,0 +1,25 @@
+# Strict artifact loading
+
+Prob4D's current content-addressed calibration artifacts and schema-v4
+observation-factor manifests use portable JSON types as part of their contract.
+Loaders reject Python-style coercion aliases rather than normalizing them after
+parsing.
+
+The strict boundary requires:
+
+- schema versions, counts, frame indices, dimensions, and window settings to be
+  JSON integers, excluding Booleans and integral floating-point values;
+- probabilities, scales, and calibration coefficients to be finite JSON numbers,
+  excluding strings and Booleans;
+- revisions, identifiers, repository names, array keys, and SHA-256 digests to
+  already be strings;
+- metadata object keys to be strings at every nesting level;
+- exact schema-v1 calibration and schema-v4 manifest field sets;
+- literal JSON Booleans for security- and covariance-semantics flags; and
+- unique JSON object keys. Duplicate keys and non-finite `NaN`/`Infinity` tokens
+  fail before any artifact is constructed.
+
+Valid existing calibration descriptors, canonical bytes, and artifact IDs are
+unchanged. Observation-factor schema v2 and v3 remain explicit compatibility
+inputs; their historical value upgrading is not promoted into the schema-v4
+contract.

--- a/src/prob4d/_observation_factor_manifest_validation.py
+++ b/src/prob4d/_observation_factor_manifest_validation.py
@@ -1,0 +1,251 @@
+"""Strict schema-v4 observation-factor manifest type validation."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from ._observation_factor_bundle import (
+    OBSERVATION_FACTOR_SCHEMA,
+    OBSERVATION_FACTOR_SCHEMA_VERSION,
+)
+from ._strict_json import (
+    require_exact_fields,
+    require_exact_integer,
+    require_finite_json_mapping,
+    require_json_number,
+    require_mapping,
+    require_nonempty_string,
+    require_sha256,
+)
+
+_ROOT_FIELDS_V4 = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "gauge_parameterization",
+        "sequence_id",
+        "case_id",
+        "stream_id",
+        "source_repository",
+        "source_revision",
+        "causal_frame_stop",
+        "causal_frame_stop_convention",
+        "metadata",
+        "payload",
+        "gauges",
+        "factors",
+        "gauge_covariance",
+    }
+)
+_PAYLOAD_FIELDS = frozenset({"path", "sha256", "allow_pickle"})
+_GAUGE_FIELDS = frozenset({"gauge_id", "mean_key", "covariance_key"})
+_FACTOR_FIELDS = frozenset(
+    {
+        "factor_id",
+        "frame_index",
+        "view_id",
+        "window_id",
+        "gauge_id",
+        "correlation_group_id",
+        "causal_frame_stop",
+        "prior_nominal_probability",
+        "composite_weight",
+        "arrays",
+        "ray_directions_local_key",
+    }
+)
+_FACTOR_ARRAY_FIELDS = frozenset(
+    {
+        "point_ids",
+        "points_local_m",
+        "valid_mask",
+        "local_covariance_m2",
+        "association_probability",
+        "prior_reliability",
+    }
+)
+_GAUGE_COVARIANCE_FIELDS = frozenset(
+    {
+        "semantics",
+        "joint_covariance_key",
+        "ordered_gauge_ids",
+        "cross_window_covariance_preserved",
+        "diagonal_blocks_match_gauge_marginals",
+    }
+)
+
+
+def _require_json_list(value: Any, *, name: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise ValueError(f"{name} must be a JSON array")
+    return value
+
+
+def _validate_gauges(value: Any) -> None:
+    gauges = _require_json_list(value, name="gauges")
+    if not gauges:
+        raise ValueError("gauges must not be empty")
+    gauge_ids: list[str] = []
+    for index, item in enumerate(gauges):
+        gauge = require_mapping(item, name=f"gauges[{index}]")
+        require_exact_fields(gauge, _GAUGE_FIELDS, name=f"gauges[{index}]")
+        gauge_ids.append(
+            require_nonempty_string(
+                gauge["gauge_id"],
+                name=f"gauges[{index}].gauge_id",
+            )
+        )
+        require_nonempty_string(
+            gauge["mean_key"],
+            name=f"gauges[{index}].mean_key",
+        )
+        require_nonempty_string(
+            gauge["covariance_key"],
+            name=f"gauges[{index}].covariance_key",
+        )
+    if len(set(gauge_ids)) != len(gauge_ids):
+        raise ValueError("gauge IDs must be unique")
+
+
+def _validate_factors(value: Any) -> None:
+    factors = _require_json_list(value, name="factors")
+    if not factors:
+        raise ValueError("factors must not be empty")
+    factor_ids: list[str] = []
+    for index, item in enumerate(factors):
+        factor = require_mapping(item, name=f"factors[{index}]")
+        require_exact_fields(factor, _FACTOR_FIELDS, name=f"factors[{index}]")
+        for field in (
+            "factor_id",
+            "view_id",
+            "window_id",
+            "gauge_id",
+            "correlation_group_id",
+        ):
+            value_string = require_nonempty_string(
+                factor[field],
+                name=f"factors[{index}].{field}",
+            )
+            if field == "factor_id":
+                factor_ids.append(value_string)
+        require_exact_integer(
+            factor["frame_index"],
+            name=f"factors[{index}].frame_index",
+            minimum=0,
+        )
+        require_exact_integer(
+            factor["causal_frame_stop"],
+            name=f"factors[{index}].causal_frame_stop",
+            minimum=1,
+        )
+        require_json_number(
+            factor["prior_nominal_probability"],
+            name=f"factors[{index}].prior_nominal_probability",
+        )
+        require_json_number(
+            factor["composite_weight"],
+            name=f"factors[{index}].composite_weight",
+        )
+        arrays = require_mapping(
+            factor["arrays"],
+            name=f"factors[{index}].arrays",
+        )
+        require_exact_fields(
+            arrays,
+            _FACTOR_ARRAY_FIELDS,
+            name=f"factors[{index}].arrays",
+        )
+        for field in sorted(_FACTOR_ARRAY_FIELDS):
+            require_nonempty_string(
+                arrays[field],
+                name=f"factors[{index}].arrays.{field}",
+            )
+        ray_key = factor["ray_directions_local_key"]
+        if ray_key is not None:
+            require_nonempty_string(
+                ray_key,
+                name=f"factors[{index}].ray_directions_local_key",
+            )
+    if len(set(factor_ids)) != len(factor_ids):
+        raise ValueError("factor IDs must be unique")
+
+
+def _validate_gauge_covariance(value: Any) -> None:
+    covariance = require_mapping(value, name="gauge_covariance")
+    require_exact_fields(
+        covariance,
+        _GAUGE_COVARIANCE_FIELDS,
+        name="gauge_covariance",
+    )
+    require_nonempty_string(
+        covariance["semantics"],
+        name="gauge_covariance.semantics",
+    )
+    require_nonempty_string(
+        covariance["joint_covariance_key"],
+        name="gauge_covariance.joint_covariance_key",
+    )
+    ordered_ids = _require_json_list(
+        covariance["ordered_gauge_ids"],
+        name="gauge_covariance.ordered_gauge_ids",
+    )
+    if not ordered_ids or any(
+        not isinstance(item, str) or not item for item in ordered_ids
+    ):
+        raise ValueError(
+            "gauge_covariance.ordered_gauge_ids must contain nonempty strings"
+        )
+    for field in (
+        "cross_window_covariance_preserved",
+        "diagonal_blocks_match_gauge_marginals",
+    ):
+        if not isinstance(covariance[field], bool):
+            raise ValueError(f"gauge_covariance.{field} must be Boolean")
+
+
+def validate_observation_factor_manifest_types(record: Mapping[str, Any]) -> None:
+    """Reject scalar coercions in current manifests before legacy upgrading."""
+
+    require_finite_json_mapping(record, name="observation-factor manifest")
+    if record.get("schema") != OBSERVATION_FACTOR_SCHEMA:
+        raise ValueError("manifest is not a Prob4D observation-factor bundle")
+    schema_version = require_exact_integer(
+        record.get("schema_version"),
+        name="schema_version",
+    )
+    if schema_version != OBSERVATION_FACTOR_SCHEMA_VERSION:
+        return
+
+    require_exact_fields(record, _ROOT_FIELDS_V4, name="schema-v4 manifest")
+    for field in (
+        "gauge_parameterization",
+        "sequence_id",
+        "case_id",
+        "stream_id",
+        "source_repository",
+        "source_revision",
+    ):
+        require_nonempty_string(record[field], name=field)
+    require_exact_integer(
+        record["causal_frame_stop"],
+        name="causal_frame_stop",
+        minimum=1,
+    )
+    if record["causal_frame_stop_convention"] != "exclusive":
+        raise ValueError("schema-v4 causal frame stop must be exclusive")
+    require_finite_json_mapping(record["metadata"], name="metadata")
+
+    payload = require_mapping(record["payload"], name="payload")
+    require_exact_fields(payload, _PAYLOAD_FIELDS, name="payload")
+    require_nonempty_string(payload["path"], name="payload.path")
+    require_sha256(payload["sha256"], name="payload.sha256")
+    if payload["allow_pickle"] is not False:
+        raise ValueError("payload.allow_pickle must be the literal Boolean false")
+
+    _validate_gauges(record["gauges"])
+    _validate_factors(record["factors"])
+    _validate_gauge_covariance(record["gauge_covariance"])
+
+
+__all__ = ["validate_observation_factor_manifest_types"]

--- a/src/prob4d/_strict_calibration.py
+++ b/src/prob4d/_strict_calibration.py
@@ -1,0 +1,73 @@
+"""Strict public calibration classes and content-addressed JSON loaders."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, cast
+
+from ._gauge_calibration import (
+    GaugeCovarianceCalibrationV1 as _GaugeCovarianceCalibrationV1,
+    save_gauge_covariance_calibration,
+)
+from ._point_calibration import (
+    PointUncertaintyCalibrationV1 as _PointUncertaintyCalibrationV1,
+    save_point_uncertainty_calibration,
+)
+from ._strict_calibration_artifact import (
+    validate_gauge_calibration_payload,
+    validate_gauge_calibration_values,
+    validate_point_calibration_payload,
+    validate_point_calibration_values,
+)
+from ._strict_json import load_json_object
+
+
+class GaugeCovarianceCalibrationV1(_GaugeCovarianceCalibrationV1):
+    """Gauge calibration that rejects noncanonical constructor values."""
+
+    def __post_init__(self) -> None:
+        validate_gauge_calibration_values(self)
+        super().__post_init__()
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> GaugeCovarianceCalibrationV1:
+        validate_gauge_calibration_payload(payload)
+        return cast(GaugeCovarianceCalibrationV1, super().from_dict(payload))
+
+
+class PointUncertaintyCalibrationV1(_PointUncertaintyCalibrationV1):
+    """Point calibration that rejects noncanonical constructor values."""
+
+    def __post_init__(self) -> None:
+        validate_point_calibration_values(self)
+        super().__post_init__()
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> PointUncertaintyCalibrationV1:
+        validate_point_calibration_payload(payload)
+        return cast(PointUncertaintyCalibrationV1, super().from_dict(payload))
+
+
+def load_gauge_covariance_calibration(
+    path: str | Path,
+) -> GaugeCovarianceCalibrationV1:
+    payload = load_json_object(path, name="gauge covariance calibration")
+    return GaugeCovarianceCalibrationV1.from_dict(payload)
+
+
+def load_point_uncertainty_calibration(
+    path: str | Path,
+) -> PointUncertaintyCalibrationV1:
+    payload = load_json_object(path, name="point uncertainty calibration")
+    return PointUncertaintyCalibrationV1.from_dict(payload)
+
+
+__all__ = [
+    "GaugeCovarianceCalibrationV1",
+    "PointUncertaintyCalibrationV1",
+    "load_gauge_covariance_calibration",
+    "load_point_uncertainty_calibration",
+    "save_gauge_covariance_calibration",
+    "save_point_uncertainty_calibration",
+]

--- a/src/prob4d/_strict_calibration_artifact.py
+++ b/src/prob4d/_strict_calibration_artifact.py
@@ -1,0 +1,193 @@
+"""Strict scalar and field validation for calibration artifact schema v1."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from ._strict_json import (
+    require_exact_fields,
+    require_exact_integer,
+    require_finite_json_mapping,
+    require_json_number,
+    require_mapping,
+    require_nonempty_string,
+    require_revision,
+    require_sha256,
+    require_string_sequence,
+)
+
+_COMMON_PROVENANCE_FIELDS = frozenset(
+    {
+        "calibration_case_ids",
+        "source_repository",
+        "source_revision",
+        "motioncrafter_revision",
+        "model_identifier",
+        "covariance_method",
+        "image_resolution",
+        "window_size",
+        "window_overlap",
+        "covariance_cluster_size",
+        "input_artifact_sha256",
+        "metadata",
+    }
+)
+_GAUGE_CALIBRATION_FIELDS = frozenset(
+    {"scale", "rotation", "translation", "count", "trim_quantile"}
+)
+_POINT_CALIBRATION_FIELDS = frozenset(
+    {
+        "parallel_floor",
+        "parallel_depth_coefficient",
+        "lateral_floor",
+        "lateral_depth_coefficient",
+        "disagreement_gain",
+        "parallel_scale",
+        "lateral_scale",
+        "count",
+        "trim_quantile",
+        "parallel_scale_update",
+        "lateral_scale_update",
+        "parallel_normalized_mse",
+        "lateral_normalized_mse",
+    }
+)
+_ARTIFACT_FIELDS = frozenset(
+    {"artifact_id", "schema", "version", "calibration", "provenance"}
+)
+
+
+def _require_optional_integer(
+    value: Any,
+    *,
+    name: str,
+    minimum: int,
+) -> None:
+    if value is not None:
+        require_exact_integer(value, name=name, minimum=minimum)
+
+
+def _validate_resolution(value: Any) -> None:
+    if value is None:
+        return
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise ValueError("image_resolution must contain two positive integers")
+    resolution = tuple(value)
+    if len(resolution) != 2:
+        raise ValueError("image_resolution must contain two positive integers")
+    for item in resolution:
+        require_exact_integer(item, name="image_resolution item", minimum=1)
+
+
+def _validate_common_provenance_values(value: Mapping[str, Any]) -> None:
+    require_exact_fields(
+        value,
+        _COMMON_PROVENANCE_FIELDS,
+        name="calibration provenance",
+    )
+    case_ids = require_string_sequence(
+        value["calibration_case_ids"],
+        name="calibration_case_ids",
+    )
+    if len(set(case_ids)) != len(case_ids):
+        raise ValueError("calibration_case_ids must be unique")
+    require_nonempty_string(value["source_repository"], name="source_repository")
+    require_revision(value["source_revision"], name="source_revision")
+    require_revision(value["motioncrafter_revision"], name="motioncrafter_revision")
+    require_nonempty_string(value["model_identifier"], name="model_identifier")
+    require_nonempty_string(value["covariance_method"], name="covariance_method")
+    _validate_resolution(value["image_resolution"])
+    _require_optional_integer(value["window_size"], name="window_size", minimum=1)
+    _require_optional_integer(
+        value["window_overlap"],
+        name="window_overlap",
+        minimum=0,
+    )
+    _require_optional_integer(
+        value["covariance_cluster_size"],
+        name="covariance_cluster_size",
+        minimum=1,
+    )
+    digests = require_string_sequence(
+        value["input_artifact_sha256"],
+        name="input_artifact_sha256",
+    )
+    for digest in digests:
+        require_sha256(digest, name="input_artifact_sha256")
+    if len(set(digests)) != len(digests):
+        raise ValueError("input_artifact_sha256 values must be unique")
+    require_finite_json_mapping(value["metadata"], name="metadata")
+
+
+def _common_values_from_artifact(artifact: Any) -> dict[str, Any]:
+    return {
+        field: getattr(artifact, field)
+        for field in _COMMON_PROVENANCE_FIELDS
+    }
+
+
+def _validate_number_fields(
+    value: Mapping[str, Any],
+    *,
+    fields: frozenset[str],
+) -> None:
+    for field in fields - {"count"}:
+        require_json_number(value[field], name=field)
+    require_exact_integer(value["count"], name="count", minimum=1)
+
+
+def validate_gauge_calibration_values(artifact: Any) -> None:
+    calibration = {
+        field: getattr(artifact, field)
+        for field in _GAUGE_CALIBRATION_FIELDS
+    }
+    _validate_number_fields(calibration, fields=_GAUGE_CALIBRATION_FIELDS)
+    _validate_common_provenance_values(_common_values_from_artifact(artifact))
+
+
+def validate_point_calibration_values(artifact: Any) -> None:
+    calibration = {
+        field: getattr(artifact, field)
+        for field in _POINT_CALIBRATION_FIELDS
+    }
+    _validate_number_fields(calibration, fields=_POINT_CALIBRATION_FIELDS)
+    _validate_common_provenance_values(_common_values_from_artifact(artifact))
+
+
+def _validate_payload(
+    payload: Mapping[str, Any],
+    *,
+    calibration_fields: frozenset[str],
+) -> None:
+    require_exact_fields(payload, _ARTIFACT_FIELDS, name="calibration artifact")
+    require_sha256(payload["artifact_id"], name="artifact_id")
+    require_nonempty_string(payload["schema"], name="schema")
+    require_exact_integer(payload["version"], name="version")
+    calibration = require_mapping(payload["calibration"], name="calibration")
+    require_exact_fields(calibration, calibration_fields, name="calibration")
+    _validate_number_fields(calibration, fields=calibration_fields)
+    provenance = require_mapping(payload["provenance"], name="provenance")
+    _validate_common_provenance_values(provenance)
+
+
+def validate_gauge_calibration_payload(payload: Mapping[str, Any]) -> None:
+    _validate_payload(
+        payload,
+        calibration_fields=_GAUGE_CALIBRATION_FIELDS,
+    )
+
+
+def validate_point_calibration_payload(payload: Mapping[str, Any]) -> None:
+    _validate_payload(
+        payload,
+        calibration_fields=_POINT_CALIBRATION_FIELDS,
+    )
+
+
+__all__ = [
+    "validate_gauge_calibration_payload",
+    "validate_gauge_calibration_values",
+    "validate_point_calibration_payload",
+    "validate_point_calibration_values",
+]

--- a/src/prob4d/_strict_json.py
+++ b/src/prob4d/_strict_json.py
@@ -57,7 +57,10 @@ def require_exact_integer(
 def require_json_number(value: Any, *, name: str) -> float:
     if not isinstance(value, (int, float)) or isinstance(value, bool):
         raise ValueError(f"{name} must be a JSON number")
-    normalized = float(value)
+    try:
+        normalized = float(value)
+    except (OverflowError, ValueError) as error:
+        raise ValueError(f"{name} must be finite") from error
     if not math.isfinite(normalized):
         raise ValueError(f"{name} must be finite")
     return normalized

--- a/src/prob4d/_strict_json.py
+++ b/src/prob4d/_strict_json.py
@@ -1,0 +1,166 @@
+"""Strict portable-JSON validation for content-addressed artifacts."""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, cast
+
+from ._immutable_json import plain_json
+
+
+class _StrictJsonValueError(ValueError):
+    """Internal marker for already contextualized strict-JSON failures."""
+
+
+def require_mapping(value: Any, *, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{name} must be a mapping")
+    return cast(Mapping[str, Any], value)
+
+
+def require_exact_fields(
+    value: Mapping[str, Any],
+    expected: frozenset[str],
+    *,
+    name: str,
+) -> None:
+    missing = expected - value.keys()
+    extra = value.keys() - expected
+    if missing or extra:
+        raise ValueError(
+            f"{name} fields changed; missing={sorted(missing)}, extra={sorted(extra)}"
+        )
+
+
+def require_nonempty_string(value: Any, *, name: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{name} must be a nonempty string")
+    return value
+
+
+def require_exact_integer(
+    value: Any,
+    *,
+    name: str,
+    minimum: int | None = None,
+) -> int:
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"{name} must be an integer")
+    if minimum is not None and value < minimum:
+        raise ValueError(f"{name} must be at least {minimum}")
+    return value
+
+
+def require_json_number(value: Any, *, name: str) -> float:
+    if not isinstance(value, (int, float)) or isinstance(value, bool):
+        raise ValueError(f"{name} must be a JSON number")
+    normalized = float(value)
+    if not math.isfinite(normalized):
+        raise ValueError(f"{name} must be finite")
+    return normalized
+
+
+def require_sha256(value: Any, *, name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{name} must be a string")
+    if len(value) != 64 or any(
+        character not in "0123456789abcdef" for character in value
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return value
+
+
+def require_revision(value: Any, *, name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{name} must be a string")
+    if len(value) not in {40, 64} or any(
+        character not in "0123456789abcdef" for character in value
+    ):
+        raise ValueError(
+            f"{name} must be an exact lowercase 40- or 64-character revision"
+        )
+    return value
+
+
+def require_string_sequence(
+    value: Any,
+    *,
+    name: str,
+    allow_empty: bool = False,
+) -> tuple[str, ...]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise ValueError(f"{name} must be a sequence of strings")
+    values = tuple(value)
+    if not allow_empty and not values:
+        raise ValueError(f"{name} must not be empty")
+    if any(not isinstance(item, str) or not item for item in values):
+        raise ValueError(f"{name} must contain nonempty strings")
+    return cast(tuple[str, ...], values)
+
+
+def require_finite_json_mapping(value: Any, *, name: str) -> Mapping[str, Any]:
+    mapping = require_mapping(value, name=name)
+    try:
+        normalized = json.loads(
+            json.dumps(
+                plain_json(mapping),
+                sort_keys=True,
+                separators=(",", ":"),
+                allow_nan=False,
+            )
+        )
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"{name} must be finite JSON data") from error
+    if not isinstance(normalized, dict):
+        raise ValueError(f"{name} must be a JSON object")
+    return mapping
+
+
+def load_json_object(path: str | Path, *, name: str) -> dict[str, Any]:
+    """Load one finite JSON object while rejecting duplicate object keys."""
+
+    def object_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, item in pairs:
+            if key in result:
+                raise _StrictJsonValueError(
+                    f"{name} contains duplicate JSON object key {key!r}"
+                )
+            result[key] = item
+        return result
+
+    def reject_constant(token: str) -> Any:
+        raise _StrictJsonValueError(
+            f"{name} contains non-finite JSON number {token!r}"
+        )
+
+    try:
+        value = json.loads(
+            Path(path).read_text(encoding="utf-8"),
+            object_pairs_hook=object_pairs,
+            parse_constant=reject_constant,
+        )
+    except _StrictJsonValueError:
+        raise
+    except json.JSONDecodeError as error:
+        raise ValueError(f"{name} must contain valid JSON") from error
+    if not isinstance(value, dict):
+        raise ValueError(f"{name} must contain one JSON object")
+    return value
+
+
+__all__ = [
+    "load_json_object",
+    "require_exact_fields",
+    "require_exact_integer",
+    "require_finite_json_mapping",
+    "require_json_number",
+    "require_mapping",
+    "require_nonempty_string",
+    "require_revision",
+    "require_sha256",
+    "require_string_sequence",
+]

--- a/src/prob4d/_strict_observation_factor_io.py
+++ b/src/prob4d/_strict_observation_factor_io.py
@@ -1,0 +1,34 @@
+"""Strict current-schema loading for observation-factor bundles."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ._observation_factor_bundle import ObservationFactorBundle
+from ._observation_factor_io import (
+    load_observation_factor_bundle as _load_observation_factor_bundle,
+    write_observation_factor_bundle,
+)
+from ._observation_factor_manifest_validation import (
+    validate_observation_factor_manifest_types,
+)
+from ._strict_json import load_json_object
+
+
+def load_observation_factor_bundle(
+    manifest_path: str | Path,
+) -> ObservationFactorBundle:
+    """Load a bundle after fail-closed portable-JSON type validation."""
+
+    record = load_json_object(
+        manifest_path,
+        name="observation-factor manifest",
+    )
+    validate_observation_factor_manifest_types(record)
+    return _load_observation_factor_bundle(manifest_path)
+
+
+__all__ = [
+    "load_observation_factor_bundle",
+    "write_observation_factor_bundle",
+]

--- a/src/prob4d/calibration.py
+++ b/src/prob4d/calibration.py
@@ -6,14 +6,12 @@ from ._calibration_common import (
     POINT_UNCERTAINTY_CALIBRATION_SCHEMA,
     POINT_UNCERTAINTY_CALIBRATION_VERSION,
 )
-from ._gauge_calibration import (
+from ._strict_calibration import (
     GaugeCovarianceCalibrationV1,
-    load_gauge_covariance_calibration,
-    save_gauge_covariance_calibration,
-)
-from ._point_calibration import (
     PointUncertaintyCalibrationV1,
+    load_gauge_covariance_calibration,
     load_point_uncertainty_calibration,
+    save_gauge_covariance_calibration,
     save_point_uncertainty_calibration,
 )
 from .calibration_aggregation import (

--- a/src/prob4d/group_balanced_point_calibration.py
+++ b/src/prob4d/group_balanced_point_calibration.py
@@ -53,10 +53,15 @@ def fit_group_balanced_point_uncertainty_calibration(
     group-balanced.
     """
 
-    group_definition = str(group_definition).strip()
-    if not group_definition:
-        raise ValueError("group_definition must be non-empty")
-    supplied_metadata = dict(metadata or {})
+    if not isinstance(group_definition, str) or not group_definition.strip():
+        raise ValueError("group_definition must be a non-empty string")
+    normalized_group_definition = group_definition.strip()
+    if metadata is None:
+        supplied_metadata: dict[str, Any] = {}
+    elif not isinstance(metadata, Mapping):
+        raise ValueError("metadata must be a mapping")
+    else:
+        supplied_metadata = dict(metadata)
     if _GROUP_BALANCED_METADATA_KEY in supplied_metadata:
         raise ValueError(
             f"metadata key {_GROUP_BALANCED_METADATA_KEY!r} is reserved"
@@ -77,7 +82,7 @@ def fit_group_balanced_point_uncertainty_calibration(
         lateral_normalized_mse=group_report.lateral_normalized_mse,
     )
     supplied_metadata[_GROUP_BALANCED_METADATA_KEY] = {
-        "group_definition": group_definition,
+        "group_definition": normalized_group_definition,
         "report": group_report.to_dict(),
     }
     artifact = PointUncertaintyCalibrationV1.from_model(

--- a/src/prob4d/group_balanced_point_calibration.py
+++ b/src/prob4d/group_balanced_point_calibration.py
@@ -7,7 +7,7 @@ from typing import Any
 
 import numpy as np
 
-from ._point_calibration import PointUncertaintyCalibrationV1
+from ._strict_calibration import PointUncertaintyCalibrationV1
 from .calibration_aggregation import (
     GROUP_BALANCED_UPPER_WINSORIZED_RATIOS_V2,
     LEGACY_GROUP_BALANCED_TRIMMED_RATIOS_V1,

--- a/src/prob4d/observation_factors.py
+++ b/src/prob4d/observation_factors.py
@@ -19,14 +19,14 @@ from ._observation_factor_bundle import (
     sim3_point_jacobian,
     stack_observation_factors,
 )
-from ._observation_factor_io import (
-    load_observation_factor_bundle,
-    write_observation_factor_bundle,
-)
 from ._observation_factor_types import (
     LinearizedObservationFactor,
     ObservationFactor,
     StackedObservationFactors,
+)
+from ._strict_observation_factor_io import (
+    load_observation_factor_bundle,
+    write_observation_factor_bundle,
 )
 
 __all__ = [

--- a/tests/test_strict_artifact_loading.py
+++ b/tests/test_strict_artifact_loading.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Callable
 from dataclasses import replace
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 import numpy as np
 import pytest

--- a/tests/test_strict_artifact_loading.py
+++ b/tests/test_strict_artifact_loading.py
@@ -1,0 +1,302 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, Callable
+
+import numpy as np
+import pytest
+
+from prob4d.calibration import (
+    GaugeCovarianceCalibrationV1,
+    PointUncertaintyCalibrationV1,
+    load_gauge_covariance_calibration,
+    load_point_uncertainty_calibration,
+    save_gauge_covariance_calibration,
+    save_point_uncertainty_calibration,
+)
+from prob4d.gauge import GaugeEstimate
+from prob4d.observation_factors import (
+    ObservationFactor,
+    ObservationFactorBundle,
+    load_observation_factor_bundle,
+    write_observation_factor_bundle,
+)
+from prob4d.sim3 import Sim3
+
+_PROVENANCE = {
+    "calibration_case_ids": ("scene-a", "scene-b"),
+    "source_repository": "FlorianPfaff/Prob4D",
+    "source_revision": "a" * 40,
+    "motioncrafter_revision": "b" * 40,
+    "model_identifier": "motioncrafter-base@checkpoint-sha256:cafebabe",
+    "covariance_method": "held_out_scene_family_v1",
+    "image_resolution": (384, 640),
+    "window_size": 16,
+    "window_overlap": 8,
+    "covariance_cluster_size": 32,
+    "input_artifact_sha256": ("c" * 64,),
+    "metadata": {"split": {"kind": "scene-family", "fold": 1}},
+}
+
+
+def _gauge_calibration() -> GaugeCovarianceCalibrationV1:
+    return GaugeCovarianceCalibrationV1(
+        scale=4.0,
+        rotation=2.0,
+        translation=3.0,
+        count=12,
+        trim_quantile=0.99,
+        **_PROVENANCE,
+    )
+
+
+def _point_calibration() -> PointUncertaintyCalibrationV1:
+    return PointUncertaintyCalibrationV1(
+        parallel_floor=1e-4,
+        parallel_depth_coefficient=1e-3,
+        lateral_floor=2e-4,
+        lateral_depth_coefficient=2e-3,
+        disagreement_gain=0.5,
+        parallel_scale=1.5,
+        lateral_scale=1.25,
+        count=12,
+        trim_quantile=0.99,
+        parallel_scale_update=1.1,
+        lateral_scale_update=1.2,
+        parallel_normalized_mse=0.9,
+        lateral_normalized_mse=1.1,
+        **_PROVENANCE,
+    )
+
+
+@pytest.mark.parametrize(
+    ("artifact", "changes", "message"),
+    [
+        (_gauge_calibration, {"count": True}, "count must be an integer"),
+        (_gauge_calibration, {"count": 12.0}, "count must be an integer"),
+        (_gauge_calibration, {"scale": "4.0"}, "scale must be a JSON number"),
+        (
+            _gauge_calibration,
+            {"source_revision": 123},
+            "source_revision must be a string",
+        ),
+        (
+            _gauge_calibration,
+            {"calibration_case_ids": (1, "1")},
+            "calibration_case_ids must contain nonempty strings",
+        ),
+        (
+            _gauge_calibration,
+            {"image_resolution": (384.0, 640)},
+            "image_resolution item must be an integer",
+        ),
+        (
+            _gauge_calibration,
+            {"window_size": True},
+            "window_size must be an integer",
+        ),
+        (
+            _gauge_calibration,
+            {"input_artifact_sha256": (123,)},
+            "input_artifact_sha256 must contain nonempty strings",
+        ),
+        (
+            _gauge_calibration,
+            {"metadata": {1: "integer", "1": "string"}},
+            "metadata must be finite JSON data",
+        ),
+        (_point_calibration, {"count": "12"}, "count must be an integer"),
+        (
+            _point_calibration,
+            {"trim_quantile": False},
+            "trim_quantile must be a JSON number",
+        ),
+    ],
+)
+def test_calibration_constructors_reject_scalar_coercion(
+    artifact: Callable[[], Any],
+    changes: dict[str, Any],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        replace(artifact(), **changes)
+
+
+def test_valid_gauge_calibration_identity_is_unchanged(tmp_path: Path) -> None:
+    artifact = _gauge_calibration()
+
+    assert artifact.artifact_id == (
+        "ba5de02ee348fc413e4dc5a9c558aa2231db06c910cc165a94748215ae75f2fe"
+    )
+    path = tmp_path / "gauge.json"
+    save_gauge_covariance_calibration(artifact, path)
+    assert load_gauge_covariance_calibration(path) == artifact
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (lambda value: value.update(version=True), "version must be an integer"),
+        (
+            lambda value: value["calibration"].update(count=12.0),
+            "count must be an integer",
+        ),
+        (
+            lambda value: value.update(artifact_id=123),
+            "artifact_id must be a string",
+        ),
+        (
+            lambda value: value.update(unsigned_extra="not content addressed"),
+            "calibration artifact fields changed",
+        ),
+    ],
+)
+def test_gauge_loader_rejects_noncanonical_payloads(
+    tmp_path: Path,
+    mutate: Callable[[dict[str, Any]], None],
+    message: str,
+) -> None:
+    path = tmp_path / "gauge.json"
+    save_gauge_covariance_calibration(_gauge_calibration(), path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    mutate(payload)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match=message):
+        load_gauge_covariance_calibration(path)
+
+
+def test_point_loader_rejects_noncanonical_payload(tmp_path: Path) -> None:
+    path = tmp_path / "point.json"
+    save_point_uncertainty_calibration(_point_calibration(), path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["provenance"]["window_overlap"] = "8"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="window_overlap must be an integer"):
+        load_point_uncertainty_calibration(path)
+
+
+def test_calibration_loader_rejects_duplicate_json_keys(tmp_path: Path) -> None:
+    path = tmp_path / "gauge.json"
+    save_gauge_covariance_calibration(_gauge_calibration(), path)
+    text = path.read_text(encoding="utf-8")
+    text = text.replace(
+        '  "version": 1\n',
+        '  "version": 1,\n  "version": 1\n',
+        1,
+    )
+    path.write_text(text, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="duplicate JSON object key 'version'"):
+        load_gauge_covariance_calibration(path)
+
+
+def _factor() -> ObservationFactor:
+    return ObservationFactor(
+        factor_id="factor-0",
+        frame_index=4,
+        view_id="camera-0",
+        window_id="window-0",
+        gauge_id="window-0",
+        point_ids=np.asarray([11, 12]),
+        points_local_m=np.asarray([[1.0, 0.0, 0.0], [0.0, 2.0, 0.0]]),
+        valid_mask=np.asarray([True, True]),
+        local_covariance_m2=np.tile(np.eye(3) * 0.01, (2, 1, 1)),
+        association_probability=np.asarray([0.9, 0.6]),
+        prior_reliability=np.asarray([0.7, 0.4]),
+        prior_nominal_probability=0.8,
+        composite_weight=0.5,
+        correlation_group_id="backbone-window-0",
+        causal_frame_stop=9,
+        ray_directions_local=np.asarray([[1.0, 0.0, 0.0], [0.0, 2.0, 0.0]]),
+    )
+
+
+def _factor_bundle() -> ObservationFactorBundle:
+    gauge = GaugeEstimate("window-0", Sim3.identity(), np.eye(7) * 1e-4)
+    return ObservationFactorBundle(
+        sequence_id="sequence-a",
+        factors=(_factor(),),
+        gauges=(gauge,),
+        source_revision="0123456789abcdef",
+        causal_frame_stop=9,
+        case_id="double-stretch-sloth",
+        stream_id="prob4d:camera-points",
+        metadata={"producer": "unit-test", "metric": True},
+        joint_gauge_covariance=gauge.covariance,
+        gauge_covariance_semantics="joint-cross-window",
+    )
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            lambda value: value.update(schema_version=4.0),
+            "schema_version must be an integer",
+        ),
+        (
+            lambda value: value.update(causal_frame_stop="9"),
+            "causal_frame_stop must be an integer",
+        ),
+        (
+            lambda value: value["payload"].update(allow_pickle=0),
+            "payload.allow_pickle must be the literal Boolean false",
+        ),
+        (
+            lambda value: value["factors"][0].update(frame_index=True),
+            "frame_index must be an integer",
+        ),
+        (
+            lambda value: value["factors"][0].update(
+                prior_nominal_probability="0.8"
+            ),
+            "prior_nominal_probability must be a JSON number",
+        ),
+        (
+            lambda value: value["gauge_covariance"].update(
+                ordered_gauge_ids=[1]
+            ),
+            "ordered_gauge_ids must contain nonempty strings",
+        ),
+        (
+            lambda value: value.update(unsigned_extra="ignored before"),
+            "schema-v4 manifest fields changed",
+        ),
+    ],
+)
+def test_schema_v4_loader_rejects_scalar_coercion(
+    tmp_path: Path,
+    mutate: Callable[[dict[str, Any]], None],
+    message: str,
+) -> None:
+    manifest, _ = write_observation_factor_bundle(
+        _factor_bundle(),
+        tmp_path / "factors.json",
+    )
+    record = json.loads(manifest.read_text(encoding="utf-8"))
+    mutate(record)
+    manifest.write_text(json.dumps(record), encoding="utf-8")
+
+    with pytest.raises(ValueError, match=message):
+        load_observation_factor_bundle(manifest)
+
+
+def test_schema_v4_loader_rejects_duplicate_json_keys(tmp_path: Path) -> None:
+    manifest, _ = write_observation_factor_bundle(
+        _factor_bundle(),
+        tmp_path / "factors.json",
+    )
+    text = manifest.read_text(encoding="utf-8")
+    text = text.replace(
+        '  "schema_version": 4,\n',
+        '  "schema_version": 4,\n  "schema_version": 4,\n',
+        1,
+    )
+    manifest.write_text(text, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="duplicate JSON object key 'schema_version'"):
+        load_observation_factor_bundle(manifest)

--- a/tests/test_strict_group_calibration.py
+++ b/tests/test_strict_group_calibration.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from prob4d.calibration import (
+    GaugeCovarianceCalibrationV1,
+    PointUncertaintyCalibrationV1,
+    fit_group_balanced_point_uncertainty_calibration,
+)
+from prob4d.uncertainty import DepthDisagreementModel, StructuredCovariance
+
+_PROVENANCE = {
+    "calibration_case_ids": ("case-a", "case-b"),
+    "source_repository": "FlorianPfaff/Prob4D",
+    "source_revision": "a" * 40,
+    "motioncrafter_revision": "b" * 40,
+    "model_identifier": "motioncrafter@sha256:cafebabe",
+    "covariance_method": "depth_disagreement_anisotropic_v1",
+    "image_resolution": (2, 2),
+    "window_size": 3,
+    "window_overlap": 1,
+    "covariance_cluster_size": 2,
+    "input_artifact_sha256": ("c" * 64,),
+}
+
+
+def _group_inputs() -> tuple[np.ndarray, StructuredCovariance, np.ndarray]:
+    rays = np.zeros((6, 3), dtype=np.float64)
+    rays[:, 2] = 1.0
+    covariance = StructuredCovariance(
+        ray_directions=rays,
+        parallel_variance=np.ones(6),
+        lateral_variance=np.ones(6),
+    )
+    errors = np.zeros((6, 3), dtype=np.float64)
+    errors[:, 2] = np.asarray([1.0, 2.0, 10.0, 1.5, 2.5, 20.0])
+    groups = np.asarray(["case-a"] * 3 + ["case-b"] * 3)
+    return errors, covariance, groups
+
+
+def test_group_balanced_fit_returns_strict_public_artifact() -> None:
+    errors, covariance, groups = _group_inputs()
+
+    artifact, _ = fit_group_balanced_point_uncertainty_calibration(
+        DepthDisagreementModel(),
+        errors,
+        covariance,
+        groups,
+        group_definition=" object ",
+        **_PROVENANCE,
+    )
+
+    assert isinstance(artifact, PointUncertaintyCalibrationV1)
+    assert artifact.metadata[
+        "group_balanced_point_uncertainty_calibration"
+    ]["group_definition"] == "object"
+
+
+def test_group_balanced_fit_rejects_provenance_coercion() -> None:
+    errors, covariance, groups = _group_inputs()
+
+    with pytest.raises(ValueError, match="group_definition must be a non-empty string"):
+        fit_group_balanced_point_uncertainty_calibration(
+            DepthDisagreementModel(),
+            errors,
+            covariance,
+            groups,
+            group_definition=7,
+            **_PROVENANCE,
+        )
+    with pytest.raises(ValueError, match="metadata must be a mapping"):
+        fit_group_balanced_point_uncertainty_calibration(
+            DepthDisagreementModel(),
+            errors,
+            covariance,
+            groups,
+            group_definition="object",
+            metadata=0,
+            **_PROVENANCE,
+        )
+
+
+def test_oversized_calibration_number_fails_as_value_error() -> None:
+    with pytest.raises(ValueError, match="scale must be finite"):
+        GaugeCovarianceCalibrationV1(
+            scale=10**10000,
+            rotation=1.0,
+            translation=1.0,
+            count=2,
+            trim_quantile=0.99,
+            **_PROVENANCE,
+        )


### PR DESCRIPTION
## Summary

Harden the remaining content-addressed artifact boundaries that still accepted Python coercion aliases.

- validate public calibration-v1 constructors and payloads before `float()`, `int()`, or `str()` normalization;
- require portable-JSON scalar types for counts, dimensions, window settings, revisions, identifiers, digests, and calibration values;
- reject duplicate JSON object keys, non-finite or oversized numeric values, non-string metadata keys, and unsigned extra calibration fields;
- enforce exact schema-v4 observation-factor manifest fields and scalar types while retaining schema-v2/v3 as explicit legacy compatibility inputs;
- route group-balanced point calibration through the same strict artifact class and reject provenance-label/metadata coercion;
- preserve valid calibration descriptors, canonical bytes, artifact IDs, and the existing public calibration API surface;
- add adversarial regression tests and contract documentation.

## Validation

- Added constructor, loader, duplicate-key, scalar-alias, oversized-number, grouped-calibration, and schema-v4 manifest regression tests.
- Retained the existing gauge calibration golden artifact ID (`ba5de02e…f2fe`).
- Verified the published Git blobs against locally compiled source/test files and checked line lengths and patch whitespace.
- The repository's fail-closed quality workflow and full Python 3.10–3.14/minimum-dependency/build matrix run against the PR head.

## Scope

This PR intentionally does not change calibration mathematics, factor covariance semantics, or valid artifact identities. It closes the type-confusion and duplicate-key gap at the public serialization and constructor boundaries.