### PR TITLE
Default CPU memory profiling to GitHub-hosted runners

### DIFF
--- a/.github/workflows/production-memory-profile.yml
+++ b/.github/workflows/production-memory-profile.yml
@@ -12,6 +12,14 @@ on:
       - "tests/test_fusion_memory_benchmark.py"
   workflow_dispatch:
     inputs:
+      runner:
+        description: "Runner type"
+        required: true
+        default: github-hosted
+        type: choice
+        options:
+          - github-hosted
+          - self-hosted
       frames:
         description: "Number of full-resolution frames"
         required: true
@@ -82,7 +90,12 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    runs-on: >-
+      ${{
+        inputs.runner == 'self-hosted' &&
+        fromJSON('["self-hosted","Linux","X64","nvidia-smi"]') ||
+        'ubuntu-latest'
+      }}
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -129,7 +142,11 @@ jobs:
             echo
             free -b
             echo
-            nvidia-smi
+            if command -v nvidia-smi >/dev/null 2>&1; then
+              nvidia-smi
+            else
+              echo "nvidia-smi is unavailable on this CPU runner"
+            fi
             echo
             python -VV
             python -c 'import numpy; print("numpy=" + numpy.__version__)'

--- a/docs/production-memory-profile.md
+++ b/docs/production-memory-profile.md
@@ -1,9 +1,8 @@
 # Production memory profiling
 
-Prob4D provides an opt-in self-hosted workflow for reproducible, fresh-process
-memory measurements at the production `25 x 320 x 640` window shape. It is an
-engineering evidence surface for issue #50, not a reconstruction or downstream
-physics experiment.
+Prob4D provides a workflow for reproducible, fresh-process memory measurements
+at the production `25 x 320 x 640` window shape. It is an engineering evidence
+surface for issue #50, not a reconstruction or downstream physics experiment.
 
 ## Covered phases
 
@@ -23,7 +22,8 @@ process RSS, retained-array accounting, and a deterministic output digest.
 
 ## Runner and invocation
 
-The checked-in workflow targets the IPS self-hosted labels:
+The checked-in workflow uses `ubuntu-latest` by default. Manual dispatches can
+select `self-hosted` to target the IPS runner labels:
 
 ```text
 self-hosted, Linux, X64, nvidia-smi
@@ -44,16 +44,18 @@ include flow: true
 ```
 
 The optional `prediction_manifest` and `prediction_store` inputs are absolute
-paths on the self-hosted runner. When supplied, the workflow additionally runs
-the verified eager and mmap loading benchmarks in fresh processes. These paths
-are never uploaded; only their content-addressed identities and measurements are
-included in the JSON evidence.
+paths already present on the selected runner. They are primarily useful with
+the self-hosted option because GitHub-hosted runners are ephemeral. When
+supplied, the workflow additionally runs the verified eager and mmap loading
+benchmarks in fresh processes. These paths are never uploaded; only their
+content-addressed identities and measurements are included in the JSON evidence.
 
 ## Evidence artifact
 
 Each run uploads one `production-memory-profile-<run-id>` artifact containing:
 
-- `host.txt`, including CPU, RAM, GPU, driver, Python, and NumPy identity;
+- `host.txt`, including CPU, RAM, Python, NumPy, and any available GPU/driver
+  identity;
 - one JSON and captured stdout file per executed phase;
 - `summary.json`, binding the phase reports to the workflow revision and runner;
 - `SHA256SUMS` for every evidence file.


### PR DESCRIPTION
## Summary

- default the production memory profile to `ubuntu-latest`
- add a manual `runner` choice that restores the original self-hosted labels
- make NVIDIA environment reporting optional on CPU runners
- document the hosted default and the self-hosted-only usefulness of mounted prediction paths

## Why

The default synthetic profile is CPU-only. The latest full-resolution run peaked at about 2.59 GB RSS and completed in under five minutes, so it fits a standard private-repository GitHub-hosted Linux runner. The existing self-hosted path remains available for mounted prediction bundles and independent hardware measurements.

## Validation

- `actionlint` 1.7.12
- `git diff --check`
