### PR TITLE
Add source-only cross-window tracklet association

### DIFF
--- a/.github/workflows/cross-window-tracklets.yml
+++ b/.github/workflows/cross-window-tracklets.yml
@@ -1,0 +1,71 @@
+name: Cross-window tracklet association
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/cross-window-tracklets.yml"
+      - "docs/cross-window-tracklet-association.md"
+      - "src/prob4d/cross_window_tracklets.py"
+      - "src/prob4d/causal_tracklets.py"
+      - "src/prob4d/sim3.py"
+      - "tests/test_cross_window_tracklets.py"
+      - "tests/test_causal_tracklets.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cross-window-tracklets-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONUNBUFFERED: "1"
+
+jobs:
+  focused-contract:
+    name: Source-only association contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install development environment
+        run: python -m pip install -e ".[dev]"
+      - name: Check focused source quality
+        run: |
+          python -m ruff check \
+            src/prob4d/cross_window_tracklets.py \
+            tests/test_cross_window_tracklets.py
+          python -m mypy src/prob4d/cross_window_tracklets.py
+      - name: Run association and producer regressions
+        run: >-
+          python -m pytest -q
+          tests/test_cross_window_tracklets.py
+          tests/test_causal_tracklets.py
+      - name: Verify portable result identity from installed package
+        run: |
+          python - <<'PY'
+          import json
+
+          from prob4d.cross_window_tracklets import CrossWindowAssociationConfig
+
+          configuration = CrossWindowAssociationConfig()
+          encoded = json.dumps(
+              configuration.to_dict(),
+              sort_keys=True,
+              separators=(",", ":"),
+              allow_nan=False,
+          )
+          assert "maximum_spatial_candidate_pairs" in encoded
+          PY

--- a/docs/cross-window-tracklet-association.md
+++ b/docs/cross-window-tracklet-association.md
@@ -28,8 +28,15 @@ suffix in either window therefore cannot change the score.
 
 ## Candidate score
 
-For each pair of window-local tracks with enough shared frames, the diagnostic
-transforms both point sequences into the common global frame. It reports:
+Before scoring complete track pairs, the diagnostic applies a bounded spatial
+gate on every shared absolute frame. The default gate admits a pair only when its
+global points come within `maximum_shared_frame_distance_m` on at least one
+shared frame. Distance matrices are evaluated in bounded chunks;
+`candidate_chunk_size` changes temporary memory only, not the selected pairs. Set
+the distance gate to `None` only for an explicitly exhaustive small diagnostic.
+
+For each spatial candidate with enough shared frames, the diagnostic transforms
+both point sequences into the common global frame. It reports:
 
 - shared absolute frame IDs;
 - association-probability-weighted RMS and maximum displacement;
@@ -43,7 +50,8 @@ Without covariance input, the normalized residual uses the frozen isotropic
 residual uses the sum of the two global point covariances plus an explicit
 positive floor. The covariance may already include local point uncertainty,
 gauge uncertainty, or both; the diagnostic never silently adds or removes a
-gauge term.
+gauge term. Cross-window covariance is not inferred: callers with shared source
+errors must supply an appropriately conservative marginal scale.
 
 The compatibility score is a source-side ranking statistic, not a calibrated
 posterior probability. It combines the Gaussian-shaped normalized residual score
@@ -61,10 +69,10 @@ A candidate becomes a link only when all of the following hold:
 5. weighted RMS passes its maximum; and
 6. the compatibility score passes its minimum.
 
-The output remains one-to-one on both sides and records non-mutual, ambiguous,
-threshold-rejected, low-support, zero-support, and insufficient-overlap counts.
-Rejected tracks remain explicitly unmatched rather than being forced into an
-identity.
+The output remains one-to-one on both sides and records spatially rejected,
+non-mutual, ambiguous, threshold-rejected, low-support, zero-support, and
+insufficient-overlap counts. Rejected tracks remain explicitly unmatched rather
+than being forced into an identity.
 
 ## Example
 
@@ -83,11 +91,13 @@ result = associate_cross_window_tracklets(
         minimum_shared_frames=3,
         minimum_effective_support=1.5,
         maximum_weighted_rms_m=0.025,
+        maximum_shared_frame_distance_m=0.075,
         minimum_compatibility_score=0.20,
         minimum_score_margin=0.10,
     ),
     left_global_covariance_m2=left_covariance,
     right_global_covariance_m2=right_covariance,
+    candidate_chunk_size=256,
 )
 
 for link in result.links:

--- a/docs/cross-window-tracklet-association.md
+++ b/docs/cross-window-tracklet-association.md
@@ -9,7 +9,7 @@ that tracks from different windows represent the same material point.
 The diagnostic does **not** rewrite observation-factor point IDs and is not part
 of the claim-bearing provider-v2 export path. It produces auditable candidate
 scores and admits only unambiguous mutual-best links. Downstream experiments can
-therefore measure whether cross-window identity has useful oracle headroom before
+therefore measure whether cross-window identity has useful headroom before
 introducing it into a Bayesian update.
 
 ## Information boundary
@@ -26,14 +26,27 @@ residuals, intervention outcomes, or post-cutoff observations. Only absolute
 frames present in both tracklets contribute to a candidate. A nonshared causal
 suffix in either window therefore cannot change the score.
 
-## Candidate score
+## Bounded spatial candidate generation
 
-Before scoring complete track pairs, the diagnostic applies a bounded spatial
-gate on every shared absolute frame. The default gate admits a pair only when its
-global points come within `maximum_shared_frame_distance_m` on at least one
-shared frame. Distance matrices are evaluated in bounded chunks;
-`candidate_chunk_size` changes temporary memory only, not the selected pairs. Set
-the distance gate to `None` only for an explicitly exhaustive small diagnostic.
+Before scoring complete track pairs, the diagnostic applies a spatial gate on
+every shared absolute frame. The default gate admits a pair only when its global
+points come within `maximum_shared_frame_distance_m` on at least one shared
+frame.
+
+Distance matrices are tiled on **both** track axes. The largest temporary distance
+block is therefore proportional to `candidate_chunk_size ** 2`, rather than to
+one chunk times every track in the other window. Changing the chunk size changes
+only temporary memory and not the sorted candidate set, result descriptor, or
+`result_id`.
+
+The retained pair set is separately bounded by
+`maximum_spatial_candidate_pairs`. Exceeding that limit fails closed rather than
+silently allocating or scoring an effectively exhaustive Cartesian product. Set
+`maximum_shared_frame_distance_m=None` only for an explicitly exhaustive small
+diagnostic; the same candidate-count ceiling still applies. The ceiling can be
+set to `None` only in a separately justified controlled experiment.
+
+## Candidate score
 
 For each spatial candidate with enough shared frames, the diagnostic transforms
 both point sequences into the common global frame. It reports:
@@ -46,12 +59,18 @@ both point sequences into the common global frame. It reports:
 - a bounded compatibility score.
 
 Without covariance input, the normalized residual uses the frozen isotropic
-`isotropic_distance_scale_m`. When covariance is supplied for both windows, each
-residual uses the sum of the two global point covariances plus an explicit
-positive floor. The covariance may already include local point uncertainty,
-gauge uncertainty, or both; the diagnostic never silently adds or removes a
-gauge term. Cross-window covariance is not inferred: callers with shared source
-errors must supply an appropriately conservative marginal scale.
+three-dimensional RMS scale `isotropic_distance_scale_m`. When covariance is
+supplied for both windows, each residual uses the sum of the two global point
+covariances plus an explicit positive floor. The reported normalized square is
+the Mahalanobis square divided by the three residual dimensions. Consequently,
+a correctly calibrated three-dimensional Gaussian residual has an expected
+normalized square of one rather than three.
+
+The covariance may already include local point uncertainty, gauge uncertainty,
+or both; the diagnostic never silently adds or removes a gauge term.
+Cross-window covariance is not inferred: callers with shared source errors must
+supply an appropriately conservative marginal scale or keep the covariance-free
+control.
 
 The compatibility score is a source-side ranking statistic, not a calibrated
 posterior probability. It combines the Gaussian-shaped normalized residual score
@@ -74,6 +93,19 @@ non-mutual, ambiguous, threshold-rejected, low-support, zero-support, and
 insufficient-overlap counts. Rejected tracks remain explicitly unmatched rather
 than being forced into an identity.
 
+## Portable result identity
+
+`CrossWindowAssociationResult.descriptor()` emits the complete semantic result:
+configuration, candidates, accepted links, unmatched tracks, and rejection
+accounting. `result_id` is the SHA-256 digest of the canonical finite-JSON
+encoding of that descriptor. `to_dict()` adds the ID to the descriptor for compact
+result retention.
+
+Execution-only tiling is deliberately excluded from the descriptor. Runs using
+different `candidate_chunk_size` values must therefore produce byte-equivalent
+semantic dictionaries and the same result identity; a focused regression checks
+this invariant.
+
 ## Example
 
 ```python
@@ -92,6 +124,7 @@ result = associate_cross_window_tracklets(
         minimum_effective_support=1.5,
         maximum_weighted_rms_m=0.025,
         maximum_shared_frame_distance_m=0.075,
+        maximum_spatial_candidate_pairs=250_000,
         minimum_compatibility_score=0.20,
         minimum_score_margin=0.10,
     ),
@@ -100,6 +133,7 @@ result = associate_cross_window_tracklets(
     candidate_chunk_size=256,
 )
 
+print(result.result_id)
 for link in result.links:
     print(link.left_track_id, link.right_track_id, link.compatibility_score)
 ```

--- a/docs/cross-window-tracklet-association.md
+++ b/docs/cross-window-tracklet-association.md
@@ -1,0 +1,110 @@
+# Cross-window tracklet association diagnostic
+
+`prob4d.cross_window_tracklets` evaluates whether two causally sealed
+`CausalTrackletSet` objects contain geometrically compatible material tracks in
+their shared absolute frames. It addresses a deliberately narrow gap: existing
+track IDs are persistent inside one prediction window, but they are not evidence
+that tracks from different windows represent the same material point.
+
+The diagnostic does **not** rewrite observation-factor point IDs and is not part
+of the claim-bearing provider-v2 export path. It produces auditable candidate
+scores and admits only unambiguous mutual-best links. Downstream experiments can
+therefore measure whether cross-window identity has useful oracle headroom before
+introducing it into a Bayesian update.
+
+## Information boundary
+
+The association consumes only:
+
+- two prefix-only `CausalTrackletSet` objects;
+- one global-from-local `Sim3` transform for each window;
+- optional per-observation global point covariance; and
+- a frozen source-only association configuration.
+
+It does not consume target truth, BayesianPhysTwin innovations, physical-model
+residuals, intervention outcomes, or post-cutoff observations. Only absolute
+frames present in both tracklets contribute to a candidate. A nonshared causal
+suffix in either window therefore cannot change the score.
+
+## Candidate score
+
+For each pair of window-local tracks with enough shared frames, the diagnostic
+transforms both point sequences into the common global frame. It reports:
+
+- shared absolute frame IDs;
+- association-probability-weighted RMS and maximum displacement;
+- effective support, using the product of the two source-side tracklet
+  association probabilities;
+- an uncertainty-normalized RMS; and
+- a bounded compatibility score.
+
+Without covariance input, the normalized residual uses the frozen isotropic
+`isotropic_distance_scale_m`. When covariance is supplied for both windows, each
+residual uses the sum of the two global point covariances plus an explicit
+positive floor. The covariance may already include local point uncertainty,
+gauge uncertainty, or both; the diagnostic never silently adds or removes a
+gauge term.
+
+The compatibility score is a source-side ranking statistic, not a calibrated
+posterior probability. It combines the Gaussian-shaped normalized residual score
+with an effective-support factor. Promotion would require independent calibration
+and a downstream guarded physical-prediction gate.
+
+## Conservative link admission
+
+A candidate becomes a link only when all of the following hold:
+
+1. it is the deterministic best candidate for the left track;
+2. it is also the deterministic best candidate for the right track;
+3. both best-versus-second-best score margins pass the frozen ambiguity gate;
+4. effective support passes its minimum;
+5. weighted RMS passes its maximum; and
+6. the compatibility score passes its minimum.
+
+The output remains one-to-one on both sides and records non-mutual, ambiguous,
+threshold-rejected, low-support, zero-support, and insufficient-overlap counts.
+Rejected tracks remain explicitly unmatched rather than being forced into an
+identity.
+
+## Example
+
+```python
+from prob4d.cross_window_tracklets import (
+    CrossWindowAssociationConfig,
+    associate_cross_window_tracklets,
+)
+
+result = associate_cross_window_tracklets(
+    left_tracklets,
+    right_tracklets,
+    left_global_from_local=left_gauge,
+    right_global_from_local=right_gauge,
+    configuration=CrossWindowAssociationConfig(
+        minimum_shared_frames=3,
+        minimum_effective_support=1.5,
+        maximum_weighted_rms_m=0.025,
+        minimum_compatibility_score=0.20,
+        minimum_score_margin=0.10,
+    ),
+    left_global_covariance_m2=left_covariance,
+    right_global_covariance_m2=right_covariance,
+)
+
+for link in result.links:
+    print(link.left_track_id, link.right_track_id, link.compatibility_score)
+```
+
+## Required experiment before integration
+
+Compare, by independent physical object or acquisition session:
+
+1. existing within-window persistent identities;
+2. cross-window links from this diagnostic;
+3. a framewise identity control; and
+4. exact physical fallback.
+
+Freeze all association gates on development/calibration objects. Report source
+association precision and retention where labels exist, but keep the decisive
+endpoints downstream: accepted-update RMSE, harmful accepted updates, interval
+coverage and width, rejection rate, and exact fallback. A negative result should
+leave provider-v2 identity semantics unchanged.

--- a/src/prob4d/cross_window_tracklets.py
+++ b/src/prob4d/cross_window_tracklets.py
@@ -1,0 +1,459 @@
+"""Source-only association diagnostics for tracklets from overlapping windows.
+
+The routines in this module do not rewrite Prob4D observation identities. They
+score geometrically compatible tracklets from two causally sealed windows and
+admit only unambiguous mutual-best links. Cross-window material identity remains
+experimental until its gates are calibrated on independent data.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .causal_tracklets import CausalTrackletSet
+from .sim3 import Sim3
+
+FloatArray = NDArray[np.floating]
+IntArray = NDArray[np.integer]
+
+
+def _integer(value: Any, *, name: str, minimum: int = 0) -> int:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)):
+        raise ValueError(f"{name} must be an integer")
+    result = int(value)
+    if result < minimum:
+        raise ValueError(f"{name} must be at least {minimum}")
+    return result
+
+
+def _real(
+    value: Any,
+    *,
+    name: str,
+    minimum: float = 0.0,
+    maximum: float | None = None,
+    strictly_positive: bool = False,
+) -> float:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(
+        value, (int, float, np.integer, np.floating)
+    ):
+        raise ValueError(f"{name} must be a real number")
+    result = float(value)
+    if not np.isfinite(result):
+        raise ValueError(f"{name} must be finite")
+    if (strictly_positive and result <= minimum) or (
+        not strictly_positive and result < minimum
+    ):
+        relation = "greater than" if strictly_positive else "at least"
+        raise ValueError(f"{name} must be {relation} {minimum}")
+    if maximum is not None and result > maximum:
+        raise ValueError(f"{name} must be at most {maximum}")
+    return result
+
+
+@dataclass(frozen=True)
+class CrossWindowAssociationConfig:
+    """Frozen source-only gates for pairwise cross-window association."""
+
+    minimum_shared_frames: int = 2
+    minimum_effective_support: float = 1.0
+    isotropic_distance_scale_m: float = 0.02
+    covariance_floor_m2: float = 1e-10
+    maximum_weighted_rms_m: float = 0.05
+    minimum_compatibility_score: float = 0.05
+    minimum_score_margin: float = 0.05
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "minimum_shared_frames",
+            _integer(self.minimum_shared_frames, name="minimum_shared_frames", minimum=1),
+        )
+        for name in (
+            "minimum_effective_support",
+            "isotropic_distance_scale_m",
+            "covariance_floor_m2",
+            "maximum_weighted_rms_m",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _real(
+                    getattr(self, name),
+                    name=name,
+                    minimum=0.0,
+                    strictly_positive=True,
+                ),
+            )
+        for name in ("minimum_compatibility_score", "minimum_score_margin"):
+            object.__setattr__(
+                self,
+                name,
+                _real(getattr(self, name), name=name, minimum=0.0, maximum=1.0),
+            )
+
+
+@dataclass(frozen=True)
+class CrossWindowAssociationCandidate:
+    """One source-only compatibility score between two window-local tracks."""
+
+    left_track_id: int
+    right_track_id: int
+    shared_frame_indices: tuple[int, ...]
+    effective_support: float
+    weighted_rms_m: float
+    maximum_distance_m: float
+    normalized_rms: float
+    compatibility_score: float
+    used_covariance: bool
+
+
+@dataclass(frozen=True)
+class CrossWindowAssociationLink:
+    """An admitted unambiguous mutual-best cross-window association."""
+
+    left_track_id: int
+    right_track_id: int
+    shared_frame_indices: tuple[int, ...]
+    compatibility_score: float
+    left_score_margin: float
+    right_score_margin: float
+
+
+@dataclass(frozen=True)
+class CrossWindowAssociationResult:
+    """Candidates, admitted links, unmatched tracks, and rejection accounting."""
+
+    left_window_id: str
+    right_window_id: str
+    causal_frame_stop: int
+    configuration: CrossWindowAssociationConfig
+    candidates: tuple[CrossWindowAssociationCandidate, ...]
+    links: tuple[CrossWindowAssociationLink, ...]
+    unmatched_left_track_ids: tuple[int, ...]
+    unmatched_right_track_ids: tuple[int, ...]
+    evaluated_track_pair_count: int
+    insufficient_shared_frame_pair_count: int
+    zero_support_pair_count: int
+    low_support_pair_count: int
+    non_mutual_best_count: int
+    ambiguous_mutual_best_count: int
+    threshold_rejected_mutual_best_count: int
+
+    @property
+    def accepted_pairs(self) -> tuple[tuple[int, int], ...]:
+        return tuple((link.left_track_id, link.right_track_id) for link in self.links)
+
+
+def _global_covariances(
+    value: FloatArray,
+    *,
+    observation_count: int,
+    name: str,
+) -> FloatArray:
+    raw = np.asarray(value)
+    if raw.dtype.kind not in {"i", "u", "f"}:
+        raise ValueError(f"{name} must contain real numeric values")
+    covariance = np.asarray(raw, dtype=np.float64).copy()
+    expected = (observation_count, 3, 3)
+    if covariance.shape != expected:
+        raise ValueError(f"{name} must have shape {expected}")
+    if not np.all(np.isfinite(covariance)):
+        raise ValueError(f"{name} must be finite")
+    symmetric = 0.5 * (covariance + np.swapaxes(covariance, -1, -2))
+    if not np.allclose(covariance, symmetric, atol=1e-12, rtol=1e-10):
+        raise ValueError(f"{name} must be symmetric")
+    eigenvalues = np.linalg.eigvalsh(symmetric)
+    scale = np.maximum(1.0, np.max(np.abs(eigenvalues), axis=1))
+    if np.any(np.min(eigenvalues, axis=1) < -1e-10 * scale):
+        raise ValueError(f"{name} must be positive semidefinite")
+    symmetric.setflags(write=False)
+    return symmetric
+
+
+def _track_rows(tracklets: CausalTrackletSet) -> dict[int, IntArray]:
+    return {
+        track_id: np.flatnonzero(tracklets.track_ids == track_id)
+        for track_id in range(tracklets.track_count)
+    }
+
+
+def _frame_rows(tracklets: CausalTrackletSet, rows: IntArray) -> dict[int, int]:
+    return {int(tracklets.frame_indices[row]): int(row) for row in rows}
+
+
+def _normalized_square(
+    residual: FloatArray,
+    *,
+    left_covariance: FloatArray | None,
+    right_covariance: FloatArray | None,
+    config: CrossWindowAssociationConfig,
+) -> float:
+    if left_covariance is None or right_covariance is None:
+        return float(residual @ residual / config.isotropic_distance_scale_m**2)
+    covariance = (
+        left_covariance
+        + right_covariance
+        + config.covariance_floor_m2 * np.eye(3)
+    )
+    eigenvalues, eigenvectors = np.linalg.eigh(covariance)
+    eigenvalues = np.maximum(eigenvalues, config.covariance_floor_m2)
+    coordinates = eigenvectors.T @ residual
+    return float(np.sum(coordinates**2 / eigenvalues) / 3.0)
+
+
+def _candidate_rank(
+    candidate: CrossWindowAssociationCandidate,
+    *,
+    side: Literal["left", "right"],
+) -> tuple[float, float, float, int]:
+    other_id = (
+        candidate.right_track_id if side == "left" else candidate.left_track_id
+    )
+    return (
+        -candidate.compatibility_score,
+        candidate.weighted_rms_m,
+        -candidate.effective_support,
+        other_id,
+    )
+
+
+def _best_by_side(
+    candidates: tuple[CrossWindowAssociationCandidate, ...],
+    *,
+    side: Literal["left", "right"],
+) -> tuple[
+    dict[int, CrossWindowAssociationCandidate],
+    dict[tuple[int, int], float],
+]:
+    grouped: dict[int, list[CrossWindowAssociationCandidate]] = {}
+    for candidate in candidates:
+        track_id = (
+            candidate.left_track_id if side == "left" else candidate.right_track_id
+        )
+        grouped.setdefault(track_id, []).append(candidate)
+    best: dict[int, CrossWindowAssociationCandidate] = {}
+    margins: dict[tuple[int, int], float] = {}
+    for track_id, group in grouped.items():
+        ordered = sorted(group, key=lambda item: _candidate_rank(item, side=side))
+        selected = ordered[0]
+        second = ordered[1].compatibility_score if len(ordered) > 1 else 0.0
+        best[track_id] = selected
+        margins[(selected.left_track_id, selected.right_track_id)] = max(
+            0.0, selected.compatibility_score - second
+        )
+    return best, margins
+
+
+def associate_cross_window_tracklets(
+    left: CausalTrackletSet,
+    right: CausalTrackletSet,
+    *,
+    left_global_from_local: Sim3,
+    right_global_from_local: Sim3,
+    configuration: CrossWindowAssociationConfig | None = None,
+    left_global_covariance_m2: FloatArray | None = None,
+    right_global_covariance_m2: FloatArray | None = None,
+) -> CrossWindowAssociationResult:
+    """Score and conservatively admit source-only links between two windows.
+
+    Optional covariance arrays must already be in the global frame and align with
+    the flattened observations in each tracklet set. They may contain local point
+    uncertainty, gauge uncertainty, or both. Supplying one side only is rejected.
+    """
+
+    if not isinstance(left, CausalTrackletSet) or not isinstance(
+        right, CausalTrackletSet
+    ):
+        raise TypeError("left and right must be CausalTrackletSet instances")
+    if left.window_id == right.window_id:
+        raise ValueError("cross-window association requires distinct window IDs")
+    if not isinstance(left_global_from_local, Sim3) or not isinstance(
+        right_global_from_local, Sim3
+    ):
+        raise TypeError("window gauges must be Sim3 instances")
+    config = configuration or CrossWindowAssociationConfig()
+    if not isinstance(config, CrossWindowAssociationConfig):
+        raise TypeError("configuration must be CrossWindowAssociationConfig")
+    if (left_global_covariance_m2 is None) != (right_global_covariance_m2 is None):
+        raise ValueError("global covariance must be supplied for both windows or neither")
+    left_covariance = (
+        None
+        if left_global_covariance_m2 is None
+        else _global_covariances(
+            left_global_covariance_m2,
+            observation_count=left.observation_count,
+            name="left_global_covariance_m2",
+        )
+    )
+    right_covariance = (
+        None
+        if right_global_covariance_m2 is None
+        else _global_covariances(
+            right_global_covariance_m2,
+            observation_count=right.observation_count,
+            name="right_global_covariance_m2",
+        )
+    )
+    used_covariance = left_covariance is not None
+
+    candidates: list[CrossWindowAssociationCandidate] = []
+    insufficient_shared_frames = 0
+    zero_support_pairs = 0
+    low_support_pairs = 0
+    left_tracks = _track_rows(left)
+    right_tracks = _track_rows(right)
+
+    for left_track_id, left_rows in left_tracks.items():
+        left_by_frame = _frame_rows(left, left_rows)
+        for right_track_id, right_rows in right_tracks.items():
+            right_by_frame = _frame_rows(right, right_rows)
+            shared_frames = tuple(sorted(left_by_frame.keys() & right_by_frame.keys()))
+            if len(shared_frames) < config.minimum_shared_frames:
+                insufficient_shared_frames += 1
+                continue
+            left_indices = np.asarray(
+                [left_by_frame[frame] for frame in shared_frames], dtype=np.int64
+            )
+            right_indices = np.asarray(
+                [right_by_frame[frame] for frame in shared_frames], dtype=np.int64
+            )
+            left_points = left_global_from_local.transform_points(
+                left.points_local[left_indices]
+            )
+            right_points = right_global_from_local.transform_points(
+                right.points_local[right_indices]
+            )
+            residuals = left_points - right_points
+            distances = np.linalg.norm(residuals, axis=1)
+            weights = (
+                left.association_probability[left_indices]
+                * right.association_probability[right_indices]
+            )
+            support = float(np.sum(weights))
+            if support <= 0.0:
+                zero_support_pairs += 1
+                continue
+            normalized_squares = np.asarray(
+                [
+                    _normalized_square(
+                        residual,
+                        left_covariance=(
+                            None
+                            if left_covariance is None
+                            else left_covariance[left_index]
+                        ),
+                        right_covariance=(
+                            None
+                            if right_covariance is None
+                            else right_covariance[right_index]
+                        ),
+                        config=config,
+                    )
+                    for residual, left_index, right_index in zip(
+                        residuals, left_indices, right_indices, strict=True
+                    )
+                ],
+                dtype=np.float64,
+            )
+            weighted_rms = float(np.sqrt(np.sum(weights * distances**2) / support))
+            normalized_rms = float(
+                np.sqrt(np.sum(weights * normalized_squares) / support)
+            )
+            support_fraction = min(1.0, support / config.minimum_effective_support)
+            score = float(support_fraction * np.exp(-0.5 * normalized_rms**2))
+            if support < config.minimum_effective_support:
+                low_support_pairs += 1
+            candidates.append(
+                CrossWindowAssociationCandidate(
+                    left_track_id=left_track_id,
+                    right_track_id=right_track_id,
+                    shared_frame_indices=shared_frames,
+                    effective_support=support,
+                    weighted_rms_m=weighted_rms,
+                    maximum_distance_m=float(np.max(distances)),
+                    normalized_rms=normalized_rms,
+                    compatibility_score=score,
+                    used_covariance=used_covariance,
+                )
+            )
+
+    candidate_tuple = tuple(
+        sorted(candidates, key=lambda item: (item.left_track_id, item.right_track_id))
+    )
+    left_best, left_margins = _best_by_side(candidate_tuple, side="left")
+    right_best, right_margins = _best_by_side(candidate_tuple, side="right")
+    links: list[CrossWindowAssociationLink] = []
+    non_mutual = 0
+    ambiguous = 0
+    threshold_rejected = 0
+
+    for left_track_id, candidate in sorted(left_best.items()):
+        right_candidate = right_best.get(candidate.right_track_id)
+        if right_candidate is None or right_candidate.left_track_id != left_track_id:
+            non_mutual += 1
+            continue
+        pair = (candidate.left_track_id, candidate.right_track_id)
+        left_margin = left_margins[pair]
+        right_margin = right_margins[pair]
+        if (
+            left_margin < config.minimum_score_margin
+            or right_margin < config.minimum_score_margin
+        ):
+            ambiguous += 1
+            continue
+        if (
+            candidate.effective_support < config.minimum_effective_support
+            or candidate.weighted_rms_m > config.maximum_weighted_rms_m
+            or candidate.compatibility_score < config.minimum_compatibility_score
+        ):
+            threshold_rejected += 1
+            continue
+        links.append(
+            CrossWindowAssociationLink(
+                left_track_id=candidate.left_track_id,
+                right_track_id=candidate.right_track_id,
+                shared_frame_indices=candidate.shared_frame_indices,
+                compatibility_score=candidate.compatibility_score,
+                left_score_margin=left_margin,
+                right_score_margin=right_margin,
+            )
+        )
+
+    link_tuple = tuple(links)
+    linked_left = {link.left_track_id for link in link_tuple}
+    linked_right = {link.right_track_id for link in link_tuple}
+    return CrossWindowAssociationResult(
+        left_window_id=left.window_id,
+        right_window_id=right.window_id,
+        causal_frame_stop=min(left.causal_frame_stop, right.causal_frame_stop),
+        configuration=config,
+        candidates=candidate_tuple,
+        links=link_tuple,
+        unmatched_left_track_ids=tuple(
+            track_id for track_id in left_tracks if track_id not in linked_left
+        ),
+        unmatched_right_track_ids=tuple(
+            track_id for track_id in right_tracks if track_id not in linked_right
+        ),
+        evaluated_track_pair_count=left.track_count * right.track_count,
+        insufficient_shared_frame_pair_count=insufficient_shared_frames,
+        zero_support_pair_count=zero_support_pairs,
+        low_support_pair_count=low_support_pairs,
+        non_mutual_best_count=non_mutual,
+        ambiguous_mutual_best_count=ambiguous,
+        threshold_rejected_mutual_best_count=threshold_rejected,
+    )
+
+
+__all__ = [
+    "CrossWindowAssociationCandidate",
+    "CrossWindowAssociationConfig",
+    "CrossWindowAssociationLink",
+    "CrossWindowAssociationResult",
+    "associate_cross_window_tracklets",
+]

--- a/src/prob4d/cross_window_tracklets.py
+++ b/src/prob4d/cross_window_tracklets.py
@@ -64,6 +64,7 @@ class CrossWindowAssociationConfig:
     isotropic_distance_scale_m: float = 0.02
     covariance_floor_m2: float = 1e-10
     maximum_weighted_rms_m: float = 0.05
+    maximum_shared_frame_distance_m: float | None = 0.10
     minimum_compatibility_score: float = 0.05
     minimum_score_margin: float = 0.05
 
@@ -88,6 +89,23 @@ class CrossWindowAssociationConfig:
                     minimum=0.0,
                     strictly_positive=True,
                 ),
+            )
+        if self.maximum_shared_frame_distance_m is not None:
+            maximum_shared_distance = _real(
+                self.maximum_shared_frame_distance_m,
+                name="maximum_shared_frame_distance_m",
+                minimum=0.0,
+                strictly_positive=True,
+            )
+            if maximum_shared_distance < self.maximum_weighted_rms_m:
+                raise ValueError(
+                    "maximum_shared_frame_distance_m must not be smaller than "
+                    "maximum_weighted_rms_m"
+                )
+            object.__setattr__(
+                self,
+                "maximum_shared_frame_distance_m",
+                maximum_shared_distance,
             )
         for name in ("minimum_compatibility_score", "minimum_score_margin"):
             object.__setattr__(
@@ -136,7 +154,11 @@ class CrossWindowAssociationResult:
     links: tuple[CrossWindowAssociationLink, ...]
     unmatched_left_track_ids: tuple[int, ...]
     unmatched_right_track_ids: tuple[int, ...]
+    possible_track_pair_count: int
+    spatial_candidate_pair_count: int
+    spatially_rejected_pair_count: int
     evaluated_track_pair_count: int
+    shared_gate_frame_count: int
     insufficient_shared_frame_pair_count: int
     zero_support_pair_count: int
     low_support_pair_count: int
@@ -186,6 +208,61 @@ def _frame_rows(tracklets: CausalTrackletSet, rows: IntArray) -> dict[int, int]:
     return {int(tracklets.frame_indices[row]): int(row) for row in rows}
 
 
+def _spatial_candidate_pairs(
+    left: CausalTrackletSet,
+    right: CausalTrackletSet,
+    *,
+    left_global_from_local: Sim3,
+    right_global_from_local: Sim3,
+    maximum_distance_m: float | None,
+    chunk_size: int,
+) -> tuple[tuple[int, ...], tuple[tuple[int, int], ...]]:
+    shared_frames = tuple(
+        sorted(
+            set(int(value) for value in np.unique(left.frame_indices))
+            & set(int(value) for value in np.unique(right.frame_indices))
+        )
+    )
+    if not shared_frames:
+        return (), ()
+    if maximum_distance_m is None:
+        return shared_frames, tuple(
+            (left_track_id, right_track_id)
+            for left_track_id in range(left.track_count)
+            for right_track_id in range(right.track_count)
+        )
+
+    maximum_square = maximum_distance_m**2
+    pairs: set[tuple[int, int]] = set()
+    for frame in shared_frames:
+        left_rows = np.flatnonzero(left.frame_indices == frame)
+        right_rows = np.flatnonzero(right.frame_indices == frame)
+        if not len(left_rows) or not len(right_rows):
+            continue
+        left_points = left_global_from_local.transform_points(left.points_local[left_rows])
+        right_points = right_global_from_local.transform_points(
+            right.points_local[right_rows]
+        )
+        right_track_ids = right.track_ids[right_rows]
+        for start in range(0, len(left_rows), chunk_size):
+            stop = min(start + chunk_size, len(left_rows))
+            differences = (
+                left_points[start:stop, None, :] - right_points[None, :, :]
+            )
+            squared = np.einsum("...i,...i->...", differences, differences)
+            local_left, local_right = np.nonzero(squared <= maximum_square)
+            for left_offset, right_offset in zip(
+                local_left, local_right, strict=True
+            ):
+                pairs.add(
+                    (
+                        int(left.track_ids[left_rows[start + int(left_offset)]]),
+                        int(right_track_ids[int(right_offset)]),
+                    )
+                )
+    return shared_frames, tuple(sorted(pairs))
+
+
 def _normalized_square(
     residual: FloatArray,
     *,
@@ -203,7 +280,7 @@ def _normalized_square(
     eigenvalues, eigenvectors = np.linalg.eigh(covariance)
     eigenvalues = np.maximum(eigenvalues, config.covariance_floor_m2)
     coordinates = eigenvectors.T @ residual
-    return float(np.sum(coordinates**2 / eigenvalues) / 3.0)
+    return float(np.sum(coordinates**2 / eigenvalues))
 
 
 def _candidate_rank(
@@ -258,6 +335,7 @@ def associate_cross_window_tracklets(
     configuration: CrossWindowAssociationConfig | None = None,
     left_global_covariance_m2: FloatArray | None = None,
     right_global_covariance_m2: FloatArray | None = None,
+    candidate_chunk_size: int = 256,
 ) -> CrossWindowAssociationResult:
     """Score and conservatively admit source-only links between two windows.
 
@@ -279,6 +357,11 @@ def associate_cross_window_tracklets(
     config = configuration or CrossWindowAssociationConfig()
     if not isinstance(config, CrossWindowAssociationConfig):
         raise TypeError("configuration must be CrossWindowAssociationConfig")
+    chunk_size = _integer(
+        candidate_chunk_size,
+        name="candidate_chunk_size",
+        minimum=1,
+    )
     if (left_global_covariance_m2 is None) != (right_global_covariance_m2 is None):
         raise ValueError("global covariance must be supplied for both windows or neither")
     left_covariance = (
@@ -307,80 +390,93 @@ def associate_cross_window_tracklets(
     low_support_pairs = 0
     left_tracks = _track_rows(left)
     right_tracks = _track_rows(right)
+    shared_gate_frames, pair_candidates = _spatial_candidate_pairs(
+        left,
+        right,
+        left_global_from_local=left_global_from_local,
+        right_global_from_local=right_global_from_local,
+        maximum_distance_m=config.maximum_shared_frame_distance_m,
+        chunk_size=chunk_size,
+    )
 
-    for left_track_id, left_rows in left_tracks.items():
-        left_by_frame = _frame_rows(left, left_rows)
-        for right_track_id, right_rows in right_tracks.items():
-            right_by_frame = _frame_rows(right, right_rows)
-            shared_frames = tuple(sorted(left_by_frame.keys() & right_by_frame.keys()))
-            if len(shared_frames) < config.minimum_shared_frames:
-                insufficient_shared_frames += 1
-                continue
-            left_indices = np.asarray(
-                [left_by_frame[frame] for frame in shared_frames], dtype=np.int64
-            )
-            right_indices = np.asarray(
-                [right_by_frame[frame] for frame in shared_frames], dtype=np.int64
-            )
-            left_points = left_global_from_local.transform_points(
-                left.points_local[left_indices]
-            )
-            right_points = right_global_from_local.transform_points(
-                right.points_local[right_indices]
-            )
-            residuals = left_points - right_points
-            distances = np.linalg.norm(residuals, axis=1)
-            weights = (
-                left.association_probability[left_indices]
-                * right.association_probability[right_indices]
-            )
-            support = float(np.sum(weights))
-            if support <= 0.0:
-                zero_support_pairs += 1
-                continue
-            normalized_squares = np.asarray(
-                [
-                    _normalized_square(
-                        residual,
-                        left_covariance=(
-                            None
-                            if left_covariance is None
-                            else left_covariance[left_index]
-                        ),
-                        right_covariance=(
-                            None
-                            if right_covariance is None
-                            else right_covariance[right_index]
-                        ),
-                        config=config,
-                    )
-                    for residual, left_index, right_index in zip(
-                        residuals, left_indices, right_indices, strict=True
-                    )
-                ],
-                dtype=np.float64,
-            )
-            weighted_rms = float(np.sqrt(np.sum(weights * distances**2) / support))
-            normalized_rms = float(
-                np.sqrt(np.sum(weights * normalized_squares) / support)
-            )
-            support_fraction = min(1.0, support / config.minimum_effective_support)
-            score = float(support_fraction * np.exp(-0.5 * normalized_rms**2))
-            if support < config.minimum_effective_support:
-                low_support_pairs += 1
-            candidates.append(
-                CrossWindowAssociationCandidate(
-                    left_track_id=left_track_id,
-                    right_track_id=right_track_id,
-                    shared_frame_indices=shared_frames,
-                    effective_support=support,
-                    weighted_rms_m=weighted_rms,
-                    maximum_distance_m=float(np.max(distances)),
-                    normalized_rms=normalized_rms,
-                    compatibility_score=score,
-                    used_covariance=used_covariance,
+    left_frame_rows = {
+        track_id: _frame_rows(left, rows) for track_id, rows in left_tracks.items()
+    }
+    right_frame_rows = {
+        track_id: _frame_rows(right, rows) for track_id, rows in right_tracks.items()
+    }
+    for left_track_id, right_track_id in pair_candidates:
+        left_by_frame = left_frame_rows[left_track_id]
+        right_by_frame = right_frame_rows[right_track_id]
+        shared_frames = tuple(sorted(left_by_frame.keys() & right_by_frame.keys()))
+        if len(shared_frames) < config.minimum_shared_frames:
+            insufficient_shared_frames += 1
+            continue
+        left_indices = np.asarray(
+            [left_by_frame[frame] for frame in shared_frames], dtype=np.int64
+        )
+        right_indices = np.asarray(
+            [right_by_frame[frame] for frame in shared_frames], dtype=np.int64
+        )
+        left_points = left_global_from_local.transform_points(
+            left.points_local[left_indices]
+        )
+        right_points = right_global_from_local.transform_points(
+            right.points_local[right_indices]
+        )
+        residuals = left_points - right_points
+        distances = np.linalg.norm(residuals, axis=1)
+        weights = (
+            left.association_probability[left_indices]
+            * right.association_probability[right_indices]
+        )
+        support = float(np.sum(weights))
+        if support <= 0.0:
+            zero_support_pairs += 1
+            continue
+        normalized_squares = np.asarray(
+            [
+                _normalized_square(
+                    residual,
+                    left_covariance=(
+                        None
+                        if left_covariance is None
+                        else left_covariance[left_index]
+                    ),
+                    right_covariance=(
+                        None
+                        if right_covariance is None
+                        else right_covariance[right_index]
+                    ),
+                    config=config,
                 )
+                for residual, left_index, right_index in zip(
+                    residuals, left_indices, right_indices, strict=True
+                )
+            ],
+            dtype=np.float64,
+        )
+        weighted_rms = float(np.sqrt(np.sum(weights * distances**2) / support))
+        normalized_rms = float(
+            np.sqrt(np.sum(weights * normalized_squares) / support)
+        )
+        support_fraction = min(1.0, support / config.minimum_effective_support)
+        score = float(support_fraction * np.exp(-0.5 * normalized_rms**2))
+        if support < config.minimum_effective_support:
+            low_support_pairs += 1
+        candidates.append(
+            CrossWindowAssociationCandidate(
+                left_track_id=left_track_id,
+                right_track_id=right_track_id,
+                shared_frame_indices=shared_frames,
+                effective_support=support,
+                weighted_rms_m=weighted_rms,
+                maximum_distance_m=float(np.max(distances)),
+                normalized_rms=normalized_rms,
+                compatibility_score=score,
+                used_covariance=used_covariance,
             )
+        )
 
     candidate_tuple = tuple(
         sorted(candidates, key=lambda item: (item.left_track_id, item.right_track_id))
@@ -440,7 +536,13 @@ def associate_cross_window_tracklets(
         unmatched_right_track_ids=tuple(
             track_id for track_id in right_tracks if track_id not in linked_right
         ),
-        evaluated_track_pair_count=left.track_count * right.track_count,
+        possible_track_pair_count=left.track_count * right.track_count,
+        spatial_candidate_pair_count=len(pair_candidates),
+        spatially_rejected_pair_count=(
+            left.track_count * right.track_count - len(pair_candidates)
+        ),
+        evaluated_track_pair_count=len(pair_candidates),
+        shared_gate_frame_count=len(shared_gate_frames),
         insufficient_shared_frame_pair_count=insufficient_shared_frames,
         zero_support_pair_count=zero_support_pairs,
         low_support_pair_count=low_support_pairs,

--- a/src/prob4d/cross_window_tracklets.py
+++ b/src/prob4d/cross_window_tracklets.py
@@ -8,6 +8,8 @@ experimental until its gates are calibrated on independent data.
 
 from __future__ import annotations
 
+import hashlib
+import json
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -19,6 +21,8 @@ from .sim3 import Sim3
 
 FloatArray = NDArray[np.floating]
 IntArray = NDArray[np.integer]
+
+_RESIDUAL_DIMENSION = 3
 
 
 def _integer(value: Any, *, name: str, minimum: int = 0) -> int:
@@ -65,6 +69,7 @@ class CrossWindowAssociationConfig:
     covariance_floor_m2: float = 1e-10
     maximum_weighted_rms_m: float = 0.05
     maximum_shared_frame_distance_m: float | None = 0.10
+    maximum_spatial_candidate_pairs: int | None = 1_000_000
     minimum_compatibility_score: float = 0.05
     minimum_score_margin: float = 0.05
 
@@ -107,12 +112,35 @@ class CrossWindowAssociationConfig:
                 "maximum_shared_frame_distance_m",
                 maximum_shared_distance,
             )
+        if self.maximum_spatial_candidate_pairs is not None:
+            object.__setattr__(
+                self,
+                "maximum_spatial_candidate_pairs",
+                _integer(
+                    self.maximum_spatial_candidate_pairs,
+                    name="maximum_spatial_candidate_pairs",
+                    minimum=1,
+                ),
+            )
         for name in ("minimum_compatibility_score", "minimum_score_margin"):
             object.__setattr__(
                 self,
                 name,
                 _real(getattr(self, name), name=name, minimum=0.0, maximum=1.0),
             )
+
+    def to_dict(self) -> dict[str, int | float | None]:
+        return {
+            "minimum_shared_frames": self.minimum_shared_frames,
+            "minimum_effective_support": self.minimum_effective_support,
+            "isotropic_distance_scale_m": self.isotropic_distance_scale_m,
+            "covariance_floor_m2": self.covariance_floor_m2,
+            "maximum_weighted_rms_m": self.maximum_weighted_rms_m,
+            "maximum_shared_frame_distance_m": self.maximum_shared_frame_distance_m,
+            "maximum_spatial_candidate_pairs": self.maximum_spatial_candidate_pairs,
+            "minimum_compatibility_score": self.minimum_compatibility_score,
+            "minimum_score_margin": self.minimum_score_margin,
+        }
 
 
 @dataclass(frozen=True)
@@ -129,6 +157,19 @@ class CrossWindowAssociationCandidate:
     compatibility_score: float
     used_covariance: bool
 
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "left_track_id": self.left_track_id,
+            "right_track_id": self.right_track_id,
+            "shared_frame_indices": list(self.shared_frame_indices),
+            "effective_support": self.effective_support,
+            "weighted_rms_m": self.weighted_rms_m,
+            "maximum_distance_m": self.maximum_distance_m,
+            "normalized_rms": self.normalized_rms,
+            "compatibility_score": self.compatibility_score,
+            "used_covariance": self.used_covariance,
+        }
+
 
 @dataclass(frozen=True)
 class CrossWindowAssociationLink:
@@ -140,6 +181,16 @@ class CrossWindowAssociationLink:
     compatibility_score: float
     left_score_margin: float
     right_score_margin: float
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "left_track_id": self.left_track_id,
+            "right_track_id": self.right_track_id,
+            "shared_frame_indices": list(self.shared_frame_indices),
+            "compatibility_score": self.compatibility_score,
+            "left_score_margin": self.left_score_margin,
+            "right_score_margin": self.right_score_margin,
+        }
 
 
 @dataclass(frozen=True)
@@ -170,6 +221,54 @@ class CrossWindowAssociationResult:
     def accepted_pairs(self) -> tuple[tuple[int, int], ...]:
         return tuple((link.left_track_id, link.right_track_id) for link in self.links)
 
+    def descriptor(self) -> dict[str, object]:
+        """Return the complete portable result descriptor without its self-ID."""
+
+        return {
+            "schema_name": "prob4d.cross-window-tracklet-association",
+            "schema_version": 1,
+            "left_window_id": self.left_window_id,
+            "right_window_id": self.right_window_id,
+            "causal_frame_stop": self.causal_frame_stop,
+            "configuration": self.configuration.to_dict(),
+            "candidates": [candidate.to_dict() for candidate in self.candidates],
+            "links": [link.to_dict() for link in self.links],
+            "unmatched_left_track_ids": list(self.unmatched_left_track_ids),
+            "unmatched_right_track_ids": list(self.unmatched_right_track_ids),
+            "possible_track_pair_count": self.possible_track_pair_count,
+            "spatial_candidate_pair_count": self.spatial_candidate_pair_count,
+            "spatially_rejected_pair_count": self.spatially_rejected_pair_count,
+            "evaluated_track_pair_count": self.evaluated_track_pair_count,
+            "shared_gate_frame_count": self.shared_gate_frame_count,
+            "insufficient_shared_frame_pair_count": (
+                self.insufficient_shared_frame_pair_count
+            ),
+            "zero_support_pair_count": self.zero_support_pair_count,
+            "low_support_pair_count": self.low_support_pair_count,
+            "non_mutual_best_count": self.non_mutual_best_count,
+            "ambiguous_mutual_best_count": self.ambiguous_mutual_best_count,
+            "threshold_rejected_mutual_best_count": (
+                self.threshold_rejected_mutual_best_count
+            ),
+        }
+
+    @property
+    def result_id(self) -> str:
+        """Return a deterministic SHA-256 identity for the semantic result."""
+
+        encoded = json.dumps(
+            self.descriptor(),
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode("utf-8")
+        return hashlib.sha256(encoded).hexdigest()
+
+    def to_dict(self) -> dict[str, object]:
+        result = self.descriptor()
+        result["result_id"] = self.result_id
+        return result
+
 
 def _global_covariances(
     value: FloatArray,
@@ -181,7 +280,7 @@ def _global_covariances(
     if raw.dtype.kind not in {"i", "u", "f"}:
         raise ValueError(f"{name} must contain real numeric values")
     covariance = np.asarray(raw, dtype=np.float64).copy()
-    expected = (observation_count, 3, 3)
+    expected = (observation_count, _RESIDUAL_DIMENSION, _RESIDUAL_DIMENSION)
     if covariance.shape != expected:
         raise ValueError(f"{name} must have shape {expected}")
     if not np.all(np.isfinite(covariance)):
@@ -215,6 +314,7 @@ def _spatial_candidate_pairs(
     left_global_from_local: Sim3,
     right_global_from_local: Sim3,
     maximum_distance_m: float | None,
+    maximum_candidate_pairs: int | None,
     chunk_size: int,
 ) -> tuple[tuple[int, ...], tuple[tuple[int, int], ...]]:
     shared_frames = tuple(
@@ -225,7 +325,17 @@ def _spatial_candidate_pairs(
     )
     if not shared_frames:
         return (), ()
+
+    possible_pairs = left.track_count * right.track_count
     if maximum_distance_m is None:
+        if (
+            maximum_candidate_pairs is not None
+            and possible_pairs > maximum_candidate_pairs
+        ):
+            raise ValueError(
+                "exhaustive spatial candidate count exceeds "
+                "maximum_spatial_candidate_pairs"
+            )
         return shared_frames, tuple(
             (left_track_id, right_track_id)
             for left_track_id in range(left.track_count)
@@ -243,23 +353,35 @@ def _spatial_candidate_pairs(
         right_points = right_global_from_local.transform_points(
             right.points_local[right_rows]
         )
+        left_track_ids = left.track_ids[left_rows]
         right_track_ids = right.track_ids[right_rows]
-        for start in range(0, len(left_rows), chunk_size):
-            stop = min(start + chunk_size, len(left_rows))
-            differences = (
-                left_points[start:stop, None, :] - right_points[None, :, :]
-            )
-            squared = np.einsum("...i,...i->...", differences, differences)
-            local_left, local_right = np.nonzero(squared <= maximum_square)
-            for left_offset, right_offset in zip(
-                local_left, local_right, strict=True
-            ):
-                pairs.add(
-                    (
-                        int(left.track_ids[left_rows[start + int(left_offset)]]),
-                        int(right_track_ids[int(right_offset)]),
-                    )
+        for left_start in range(0, len(left_rows), chunk_size):
+            left_stop = min(left_start + chunk_size, len(left_rows))
+            for right_start in range(0, len(right_rows), chunk_size):
+                right_stop = min(right_start + chunk_size, len(right_rows))
+                differences = (
+                    left_points[left_start:left_stop, None, :]
+                    - right_points[None, right_start:right_stop, :]
                 )
+                squared = np.einsum("...i,...i->...", differences, differences)
+                local_left, local_right = np.nonzero(squared <= maximum_square)
+                for left_offset, right_offset in zip(
+                    local_left, local_right, strict=True
+                ):
+                    pairs.add(
+                        (
+                            int(left_track_ids[left_start + int(left_offset)]),
+                            int(right_track_ids[right_start + int(right_offset)]),
+                        )
+                    )
+                if (
+                    maximum_candidate_pairs is not None
+                    and len(pairs) > maximum_candidate_pairs
+                ):
+                    raise ValueError(
+                        "spatial candidate count exceeds "
+                        "maximum_spatial_candidate_pairs"
+                    )
     return shared_frames, tuple(sorted(pairs))
 
 
@@ -275,12 +397,13 @@ def _normalized_square(
     covariance = (
         left_covariance
         + right_covariance
-        + config.covariance_floor_m2 * np.eye(3)
+        + config.covariance_floor_m2 * np.eye(_RESIDUAL_DIMENSION)
     )
     eigenvalues, eigenvectors = np.linalg.eigh(covariance)
     eigenvalues = np.maximum(eigenvalues, config.covariance_floor_m2)
     coordinates = eigenvectors.T @ residual
-    return float(np.sum(coordinates**2 / eigenvalues))
+    mahalanobis_square = float(np.sum(coordinates**2 / eigenvalues))
+    return mahalanobis_square / _RESIDUAL_DIMENSION
 
 
 def _candidate_rank(
@@ -396,6 +519,7 @@ def associate_cross_window_tracklets(
         left_global_from_local=left_global_from_local,
         right_global_from_local=right_global_from_local,
         maximum_distance_m=config.maximum_shared_frame_distance_m,
+        maximum_candidate_pairs=config.maximum_spatial_candidate_pairs,
         chunk_size=chunk_size,
     )
 
@@ -523,6 +647,7 @@ def associate_cross_window_tracklets(
     link_tuple = tuple(links)
     linked_left = {link.left_track_id for link in link_tuple}
     linked_right = {link.right_track_id for link in link_tuple}
+    possible_pairs = left.track_count * right.track_count
     return CrossWindowAssociationResult(
         left_window_id=left.window_id,
         right_window_id=right.window_id,
@@ -536,11 +661,9 @@ def associate_cross_window_tracklets(
         unmatched_right_track_ids=tuple(
             track_id for track_id in right_tracks if track_id not in linked_right
         ),
-        possible_track_pair_count=left.track_count * right.track_count,
+        possible_track_pair_count=possible_pairs,
         spatial_candidate_pair_count=len(pair_candidates),
-        spatially_rejected_pair_count=(
-            left.track_count * right.track_count - len(pair_candidates)
-        ),
+        spatially_rejected_pair_count=possible_pairs - len(pair_candidates),
         evaluated_track_pair_count=len(pair_candidates),
         shared_gate_frame_count=len(shared_gate_frames),
         insufficient_shared_frame_pair_count=insufficient_shared_frames,

--- a/tests/test_cross_window_tracklets.py
+++ b/tests/test_cross_window_tracklets.py
@@ -1,3 +1,5 @@
+import json
+
 import numpy as np
 import pytest
 
@@ -157,6 +159,35 @@ def test_cross_window_association_uses_global_covariance_when_supplied() -> None
     assert loose_candidate.normalized_rms < tight_candidate.normalized_rms
 
 
+def test_covariance_score_uses_reduced_mahalanobis_rms() -> None:
+    left = make_tracklets(
+        "left",
+        [np.array([[0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])],
+    )
+    right = make_tracklets(
+        "right",
+        [np.array([[1.0, 1.0, 1.0], [1.0, 1.0, 1.0]])],
+    )
+    half_identity = np.repeat((0.5 * np.eye(3))[None], 2, axis=0)
+    result = associate_cross_window_tracklets(
+        left,
+        right,
+        left_global_from_local=Sim3.identity(),
+        right_global_from_local=Sim3.identity(),
+        configuration=CrossWindowAssociationConfig(
+            covariance_floor_m2=1e-15,
+            maximum_weighted_rms_m=2.0,
+            maximum_shared_frame_distance_m=2.0,
+            minimum_compatibility_score=0.0,
+            minimum_score_margin=0.0,
+        ),
+        left_global_covariance_m2=half_identity,
+        right_global_covariance_m2=half_identity,
+    )
+
+    assert result.candidates[0].normalized_rms == pytest.approx(1.0)
+
+
 def test_nonshared_causal_suffix_does_not_change_association() -> None:
     left_short = make_tracklets(
         "left-short",
@@ -235,6 +266,8 @@ def test_cross_window_configuration_rejects_boolean_numeric_aliases() -> None:
         CrossWindowAssociationConfig(minimum_shared_frames=True)
     with pytest.raises(ValueError, match="minimum_score_margin"):
         CrossWindowAssociationConfig(minimum_score_margin=False)
+    with pytest.raises(ValueError, match="maximum_spatial_candidate_pairs"):
+        CrossWindowAssociationConfig(maximum_spatial_candidate_pairs=True)
 
 
 def test_spatial_gate_avoids_exhaustive_distractor_pairs() -> None:
@@ -271,3 +304,108 @@ def test_spatial_gate_avoids_exhaustive_distractor_pairs() -> None:
     assert result.spatially_rejected_pair_count == 4
     assert result.evaluated_track_pair_count == 2
     assert result.accepted_pairs == ((0, 0), (1, 1))
+
+
+def test_two_axis_chunking_is_result_and_identity_invariant() -> None:
+    left = make_tracklets(
+        "left",
+        [
+            np.array([[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]]),
+            np.array([[1.0, 0.0, 1.0], [1.0, 0.0, 1.0]]),
+            np.array([[2.0, 0.0, 1.0], [2.0, 0.0, 1.0]]),
+        ],
+    )
+    right = make_tracklets(
+        "right",
+        [
+            np.array([[2.01, 0.0, 1.0], [2.01, 0.0, 1.0]]),
+            np.array([[0.01, 0.0, 1.0], [0.01, 0.0, 1.0]]),
+            np.array([[1.01, 0.0, 1.0], [1.01, 0.0, 1.0]]),
+        ],
+    )
+    settings = {
+        "left_global_from_local": Sim3.identity(),
+        "right_global_from_local": Sim3.identity(),
+        "configuration": CrossWindowAssociationConfig(
+            maximum_shared_frame_distance_m=0.1,
+            maximum_weighted_rms_m=0.05,
+        ),
+    }
+
+    small = associate_cross_window_tracklets(
+        left,
+        right,
+        candidate_chunk_size=1,
+        **settings,
+    )
+    large = associate_cross_window_tracklets(
+        left,
+        right,
+        candidate_chunk_size=128,
+        **settings,
+    )
+
+    assert small.accepted_pairs == ((0, 1), (1, 2), (2, 0))
+    assert small.to_dict() == large.to_dict()
+    assert small.result_id == large.result_id
+    assert json.loads(json.dumps(small.to_dict()))["result_id"] == small.result_id
+
+
+def test_spatial_candidate_cap_fails_closed() -> None:
+    left = make_tracklets(
+        "left",
+        [
+            np.array([[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]]),
+            np.array([[0.01, 0.0, 1.0], [0.01, 0.0, 1.0]]),
+        ],
+    )
+    right = make_tracklets(
+        "right",
+        [
+            np.array([[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]]),
+            np.array([[0.01, 0.0, 1.0], [0.01, 0.0, 1.0]]),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="maximum_spatial_candidate_pairs"):
+        associate_cross_window_tracklets(
+            left,
+            right,
+            left_global_from_local=Sim3.identity(),
+            right_global_from_local=Sim3.identity(),
+            configuration=CrossWindowAssociationConfig(
+                maximum_shared_frame_distance_m=0.1,
+                maximum_weighted_rms_m=0.05,
+                maximum_spatial_candidate_pairs=3,
+            ),
+            candidate_chunk_size=1,
+        )
+
+
+def test_exhaustive_candidate_mode_is_also_capped() -> None:
+    left = make_tracklets(
+        "left",
+        [
+            np.array([[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]]),
+            np.array([[1.0, 0.0, 1.0], [1.0, 0.0, 1.0]]),
+        ],
+    )
+    right = make_tracklets(
+        "right",
+        [
+            np.array([[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]]),
+            np.array([[1.0, 0.0, 1.0], [1.0, 0.0, 1.0]]),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="maximum_spatial_candidate_pairs"):
+        associate_cross_window_tracklets(
+            left,
+            right,
+            left_global_from_local=Sim3.identity(),
+            right_global_from_local=Sim3.identity(),
+            configuration=CrossWindowAssociationConfig(
+                maximum_shared_frame_distance_m=None,
+                maximum_spatial_candidate_pairs=3,
+            ),
+        )

--- a/tests/test_cross_window_tracklets.py
+++ b/tests/test_cross_window_tracklets.py
@@ -1,0 +1,236 @@
+import numpy as np
+import pytest
+
+from prob4d.causal_tracklets import CausalTrackletSet
+from prob4d.cross_window_tracklets import (
+    CrossWindowAssociationConfig,
+    associate_cross_window_tracklets,
+)
+from prob4d.sim3 import Sim3
+
+
+def make_tracklets(
+    window_id: str,
+    tracks: list[np.ndarray],
+    *,
+    frame_start: int = 1,
+) -> CausalTrackletSet:
+    frame_count = tracks[0].shape[0]
+    assert all(track.shape == (frame_count, 3) for track in tracks)
+    frames = np.arange(frame_start, frame_start + frame_count, dtype=np.int64)
+    track_ids: list[int] = []
+    frame_indices: list[int] = []
+    local_indices: list[int] = []
+    points: list[np.ndarray] = []
+    for track_id, track in enumerate(tracks):
+        for local_index, (frame, point) in enumerate(zip(frames, track, strict=True)):
+            track_ids.append(track_id)
+            frame_indices.append(int(frame))
+            local_indices.append(local_index)
+            points.append(point)
+    count = len(track_ids)
+    return CausalTrackletSet(
+        window_id=window_id,
+        causal_frame_stop=int(frames[-1]) + 1,
+        source_shape=(frame_count, 1, 1),
+        seed_frame_index=int(frames[0]),
+        track_ids=np.asarray(track_ids, dtype=np.int64),
+        frame_indices=np.asarray(frame_indices, dtype=np.int64),
+        local_frame_indices=np.asarray(local_indices, dtype=np.int64),
+        rows=np.zeros(count, dtype=np.int64),
+        columns=np.zeros(count, dtype=np.int64),
+        points_local=np.asarray(points, dtype=np.float64),
+        link_probability=np.ones(count, dtype=np.float64),
+        association_probability=np.ones(count, dtype=np.float64),
+        metadata={"test": True},
+    )
+
+
+def test_cross_window_association_recovers_swapped_window_local_ids() -> None:
+    left = make_tracklets(
+        "left",
+        [
+            np.array([[0.0, 0.0, 1.0], [0.1, 0.0, 1.0], [0.2, 0.0, 1.0]]),
+            np.array([[1.0, 0.0, 1.0], [1.1, 0.0, 1.0], [1.2, 0.0, 1.0]]),
+        ],
+    )
+    right = make_tracklets(
+        "right",
+        [
+            np.array([[-1.0, 0.0, 1.0], [-0.9, 0.0, 1.0], [-0.8, 0.0, 1.0]]),
+            np.array([[-2.0, 0.0, 1.0], [-1.9, 0.0, 1.0], [-1.8, 0.0, 1.0]]),
+        ],
+    )
+
+    result = associate_cross_window_tracklets(
+        left,
+        right,
+        left_global_from_local=Sim3.identity(),
+        right_global_from_local=Sim3(translation=np.array([2.0, 0.0, 0.0])),
+        configuration=CrossWindowAssociationConfig(
+            isotropic_distance_scale_m=0.05,
+            maximum_weighted_rms_m=0.05,
+            minimum_compatibility_score=0.5,
+            minimum_score_margin=0.2,
+        ),
+    )
+
+    assert result.accepted_pairs == ((0, 1), (1, 0))
+    assert result.unmatched_left_track_ids == ()
+    assert result.unmatched_right_track_ids == ()
+    assert all(link.compatibility_score == pytest.approx(1.0) for link in result.links)
+
+
+def test_cross_window_association_rejects_an_ambiguous_mutual_best() -> None:
+    left = make_tracklets(
+        "left",
+        [np.array([[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]])],
+    )
+    right = make_tracklets(
+        "right",
+        [
+            np.array([[0.01, 0.0, 1.0], [0.01, 0.0, 1.0]]),
+            np.array([[-0.01, 0.0, 1.0], [-0.01, 0.0, 1.0]]),
+        ],
+    )
+
+    result = associate_cross_window_tracklets(
+        left,
+        right,
+        left_global_from_local=Sim3.identity(),
+        right_global_from_local=Sim3.identity(),
+        configuration=CrossWindowAssociationConfig(
+            isotropic_distance_scale_m=0.1,
+            maximum_weighted_rms_m=0.1,
+            minimum_score_margin=0.05,
+        ),
+    )
+
+    assert result.links == ()
+    assert result.ambiguous_mutual_best_count == 1
+    assert result.unmatched_left_track_ids == (0,)
+    assert result.unmatched_right_track_ids == (0, 1)
+
+
+def test_cross_window_association_uses_global_covariance_when_supplied() -> None:
+    left = make_tracklets(
+        "left",
+        [np.array([[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]])],
+    )
+    right = make_tracklets(
+        "right",
+        [np.array([[0.1, 0.0, 1.0], [0.1, 0.0, 1.0]])],
+    )
+    tight = np.repeat((1e-4 * np.eye(3))[None], 2, axis=0)
+    loose = np.repeat((0.1 * np.eye(3))[None], 2, axis=0)
+    config = CrossWindowAssociationConfig(
+        maximum_weighted_rms_m=0.2,
+        minimum_compatibility_score=0.0,
+        minimum_score_margin=0.0,
+    )
+
+    tight_result = associate_cross_window_tracklets(
+        left,
+        right,
+        left_global_from_local=Sim3.identity(),
+        right_global_from_local=Sim3.identity(),
+        configuration=config,
+        left_global_covariance_m2=tight,
+        right_global_covariance_m2=tight,
+    )
+    loose_result = associate_cross_window_tracklets(
+        left,
+        right,
+        left_global_from_local=Sim3.identity(),
+        right_global_from_local=Sim3.identity(),
+        configuration=config,
+        left_global_covariance_m2=loose,
+        right_global_covariance_m2=loose,
+    )
+
+    tight_candidate = tight_result.candidates[0]
+    loose_candidate = loose_result.candidates[0]
+    assert tight_candidate.used_covariance
+    assert loose_candidate.used_covariance
+    assert loose_candidate.compatibility_score > tight_candidate.compatibility_score
+    assert loose_candidate.normalized_rms < tight_candidate.normalized_rms
+
+
+def test_nonshared_causal_suffix_does_not_change_association() -> None:
+    left_short = make_tracklets(
+        "left-short",
+        [np.array([[0.0, 0.0, 1.0], [0.1, 0.0, 1.0]])],
+    )
+    left_long = make_tracklets(
+        "left-long",
+        [
+            np.array(
+                [
+                    [0.0, 0.0, 1.0],
+                    [0.1, 0.0, 1.0],
+                    [10_000.0, 0.0, 1.0],
+                ]
+            )
+        ],
+    )
+    right = make_tracklets(
+        "right",
+        [np.array([[0.0, 0.0, 1.0], [0.1, 0.0, 1.0]])],
+    )
+    settings = {
+        "right": right,
+        "left_global_from_local": Sim3.identity(),
+        "right_global_from_local": Sim3.identity(),
+    }
+
+    short_result = associate_cross_window_tracklets(left_short, **settings)
+    long_result = associate_cross_window_tracklets(left_long, **settings)
+
+    assert short_result.candidates[0].shared_frame_indices == (1, 2)
+    assert long_result.candidates[0].shared_frame_indices == (1, 2)
+    assert short_result.candidates[0].compatibility_score == pytest.approx(
+        long_result.candidates[0].compatibility_score
+    )
+    assert short_result.candidates[0].weighted_rms_m == pytest.approx(
+        long_result.candidates[0].weighted_rms_m
+    )
+
+
+def test_cross_window_association_rejects_one_sided_or_invalid_covariance() -> None:
+    left = make_tracklets(
+        "left",
+        [np.array([[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]])],
+    )
+    right = make_tracklets(
+        "right",
+        [np.array([[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]])],
+    )
+    covariance = np.repeat(np.eye(3)[None], 2, axis=0)
+
+    with pytest.raises(ValueError, match="both windows or neither"):
+        associate_cross_window_tracklets(
+            left,
+            right,
+            left_global_from_local=Sim3.identity(),
+            right_global_from_local=Sim3.identity(),
+            left_global_covariance_m2=covariance,
+        )
+
+    invalid = covariance.copy()
+    invalid[0, 0, 0] = -1.0
+    with pytest.raises(ValueError, match="positive semidefinite"):
+        associate_cross_window_tracklets(
+            left,
+            right,
+            left_global_from_local=Sim3.identity(),
+            right_global_from_local=Sim3.identity(),
+            left_global_covariance_m2=invalid,
+            right_global_covariance_m2=covariance,
+        )
+
+
+def test_cross_window_configuration_rejects_boolean_numeric_aliases() -> None:
+    with pytest.raises(ValueError, match="minimum_shared_frames"):
+        CrossWindowAssociationConfig(minimum_shared_frames=True)
+    with pytest.raises(ValueError, match="minimum_score_margin"):
+        CrossWindowAssociationConfig(minimum_score_margin=False)

--- a/tests/test_cross_window_tracklets.py
+++ b/tests/test_cross_window_tracklets.py
@@ -125,6 +125,7 @@ def test_cross_window_association_uses_global_covariance_when_supplied() -> None
     loose = np.repeat((0.1 * np.eye(3))[None], 2, axis=0)
     config = CrossWindowAssociationConfig(
         maximum_weighted_rms_m=0.2,
+        maximum_shared_frame_distance_m=0.2,
         minimum_compatibility_score=0.0,
         minimum_score_margin=0.0,
     )
@@ -234,3 +235,39 @@ def test_cross_window_configuration_rejects_boolean_numeric_aliases() -> None:
         CrossWindowAssociationConfig(minimum_shared_frames=True)
     with pytest.raises(ValueError, match="minimum_score_margin"):
         CrossWindowAssociationConfig(minimum_score_margin=False)
+
+
+def test_spatial_gate_avoids_exhaustive_distractor_pairs() -> None:
+    left = make_tracklets(
+        "left",
+        [
+            np.array([[0.0, 0.0, 1.0], [0.0, 0.0, 1.0]]),
+            np.array([[10.0, 0.0, 1.0], [10.0, 0.0, 1.0]]),
+        ],
+    )
+    right = make_tracklets(
+        "right",
+        [
+            np.array([[0.01, 0.0, 1.0], [0.01, 0.0, 1.0]]),
+            np.array([[10.01, 0.0, 1.0], [10.01, 0.0, 1.0]]),
+            np.array([[100.0, 0.0, 1.0], [100.0, 0.0, 1.0]]),
+        ],
+    )
+
+    result = associate_cross_window_tracklets(
+        left,
+        right,
+        left_global_from_local=Sim3.identity(),
+        right_global_from_local=Sim3.identity(),
+        configuration=CrossWindowAssociationConfig(
+            maximum_shared_frame_distance_m=0.1,
+            maximum_weighted_rms_m=0.05,
+        ),
+        candidate_chunk_size=1,
+    )
+
+    assert result.possible_track_pair_count == 6
+    assert result.spatial_candidate_pair_count == 2
+    assert result.spatially_rejected_pair_count == 4
+    assert result.evaluated_track_pair_count == 2
+    assert result.accepted_pairs == ((0, 0), (1, 1))


### PR DESCRIPTION
## What changed

- add `prob4d.cross_window_tracklets`, an experimental source-only diagnostic for associating persistent tracklets across overlapping prediction windows;
- score only shared absolute prefix frames after applying each window's `Sim3` gauge;
- tile spatial distance checks on both track axes so temporary memory is bounded by `candidate_chunk_size ** 2` rather than one chunk times the complete opposite window;
- fail closed when the retained spatial candidate set exceeds a frozen `maximum_spatial_candidate_pairs` ceiling, including exhaustive mode;
- optionally consume caller-supplied global point covariance without silently changing gauge or cross-window correlation semantics;
- use a reduced three-dimensional Mahalanobis square for covariance-normalized RMS, so calibrated Gaussian residuals have expected normalized square one rather than three;
- admit only deterministic mutual-best, one-to-one links that pass support, weighted-RMS, compatibility, and best-versus-second-best ambiguity gates;
- retain complete candidate scores, unmatched tracks, spatial rejection, and downstream rejection accounting without rewriting provider-v2 point identities;
- emit a canonical finite-JSON semantic descriptor and chunk-invariant SHA-256 `result_id`;
- add a dedicated hosted Ruff, mypy, and regression workflow for the experimental contract.

## Why

Prob4D's current causal scene-flow track IDs are persistent within one prediction window. The stream contract deliberately does not assert that IDs from different windows denote the same material point. This leaves a specific downstream failure mode: explicit gauge uncertainty can be correct while Bayesian physical-state inference remains weak because material identity resets at every window boundary.

This PR adds a conservative diagnostic to measure that headroom without changing the production spanning-tree provider, claim-bearing observation schemas, or the frozen Prob4D-to-BayesianPhysTwin decisive study in PR #89.

## Scientific boundary

The compatibility score is a source-side ranking statistic, not a calibrated posterior probability. It consumes no target truth, BayesianPhysTwin innovation, physical-model residual, intervention outcome, or post-cutoff observation. The diagnostic does not promote, merge, or rewrite observation identities. Promotion requires gates frozen on development/calibration objects and an independent downstream guarded physical-prediction experiment.

The optional covariance score consumes caller-supplied global marginal covariance. It does not infer unknown cross-window source correlation; shared-source errors require a separately justified conservative scale or the covariance-free control.

## Validation

- Python compilation passed for the revised module and tests.
- Focused independent algorithm harness: **11 passed**.
- Covered gauge-correct identity recovery, ambiguity rejection, covariance-sensitive scoring, reduced-Mahalanobis normalization, nonshared-suffix invariance, invalid covariance, Boolean aliases, bounded distractor filtering, two-axis chunk invariance, portable result identity, and candidate-cap failure.
- Maximum revised source/test line length is below 100 characters.
- Authoritative GitHub workflows are queued: the focused association contract, fail-closed quality, and the full Python 3.10-3.14/minimum-NumPy/build/artifact matrix.
