### PR TITLE
Route trusted CI recovery branches to workstation2

### DIFF
--- a/.github/workflows/fail-closed-quality.yml
+++ b/.github/workflows/fail-closed-quality.yml
@@ -23,7 +23,12 @@ env:
 jobs:
   authoritative-quality:
     name: Authoritative Ruff and mypy
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{ github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          startsWith(github.head_ref, 'ci/self-hosted-') &&
+          fromJSON('["self-hosted","Linux","X64","nvidia-smi"]') ||
+          'ubuntu-latest' }}
     timeout-minutes: 20
     steps:
       - name: Check out repository

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,8 @@ jobs:
       ${{ github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository &&
           startsWith(github.head_ref, 'ci/self-hosted-') &&
-          'nvidia-smi' || 'ubuntu-latest' }}
+          fromJSON('["self-hosted","Linux","X64","nvidia-smi"]') ||
+          'ubuntu-latest' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -133,7 +134,8 @@ jobs:
       ${{ github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository &&
           startsWith(github.head_ref, 'ci/self-hosted-') &&
-          'nvidia-smi' || 'ubuntu-latest' }}
+          fromJSON('["self-hosted","Linux","X64","nvidia-smi"]') ||
+          'ubuntu-latest' }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -198,7 +200,8 @@ jobs:
       ${{ github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository &&
           startsWith(github.head_ref, 'ci/self-hosted-') &&
-          'nvidia-smi' || 'ubuntu-latest' }}
+          fromJSON('["self-hosted","Linux","X64","nvidia-smi"]') ||
+          'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -244,7 +247,8 @@ jobs:
       ${{ github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository &&
           startsWith(github.head_ref, 'ci/self-hosted-') &&
-          'nvidia-smi' || 'ubuntu-latest' }}
+          fromJSON('["self-hosted","Linux","X64","nvidia-smi"]') ||
+          'ubuntu-latest' }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -275,7 +279,8 @@ jobs:
       ${{ github.event_name == 'pull_request' &&
           github.event.pull_request.head.repo.full_name == github.repository &&
           startsWith(github.head_ref, 'ci/self-hosted-') &&
-          'nvidia-smi' || 'ubuntu-latest' }}
+          fromJSON('["self-hosted","Linux","X64","nvidia-smi"]') ||
+          'ubuntu-latest' }}
     timeout-minutes: 15
     strategy:
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,9 +19,15 @@ env:
   PYTHONUNBUFFERED: "1"
 
 jobs:
+  # Trusted same-repository recovery branches use workstation2; forks and
+  # ordinary CI retain the GitHub-hosted default.
   quality:
     name: Quality and provider contract
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{ github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          startsWith(github.head_ref, 'ci/self-hosted-') &&
+          'nvidia-smi' || 'ubuntu-latest' }}
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -123,7 +129,11 @@ jobs:
 
   test:
     name: NumPy core / Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{ github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          startsWith(github.head_ref, 'ci/self-hosted-') &&
+          'nvidia-smi' || 'ubuntu-latest' }}
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -184,7 +194,11 @@ jobs:
 
   minimum-dependencies:
     name: Declared runtime floors / Python 3.10
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{ github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          startsWith(github.head_ref, 'ci/self-hosted-') &&
+          'nvidia-smi' || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -226,7 +240,11 @@ jobs:
   build:
     name: Build distributions
     needs: [quality, test, minimum-dependencies]
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{ github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          startsWith(github.head_ref, 'ci/self-hosted-') &&
+          'nvidia-smi' || 'ubuntu-latest' }}
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -253,7 +271,11 @@ jobs:
   installed-artifact:
     name: Installed ${{ matrix.kind }} and CLI smoke
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{ github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository &&
+          startsWith(github.head_ref, 'ci/self-hosted-') &&
+          'nvidia-smi' || 'ubuntu-latest' }}
     timeout-minutes: 15
     strategy:
       fail-fast: false


### PR DESCRIPTION
## What changed

- keep ordinary pushes, manual runs, and forked pull requests on `ubuntu-latest`;
- route only same-repository pull-request branches named `ci/self-hosted-*` to the existing `nvidia-smi` self-hosted runner label;
- apply the recovery route consistently to quality, Python 3.10–3.14, minimum-dependency, distribution-build, and installed-artifact jobs.

## Why

Run 30908119198 and its sibling workflows concluded without recording a single job step, and a retry remained queued without runner assignment. This is runner-capacity failure rather than a Python/test failure. The recovery branch convention provides a narrow, auditable escape hatch without exposing the self-hosted runner to forks or changing the normal GitHub-hosted default.

## Validation intent

This pull request itself uses the `ci/self-hosted-*` branch convention, so the complete existing test matrix should execute on workstation2 and provide fresh diagnostics for any real source failure hidden by the original runner outage.