### PR TITLE
Make repository-local script imports deterministic

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,5 @@
+"""Repository-local scientific and maintenance scripts.
+
+The package marker prevents unrelated site-packages named ``scripts`` from
+shadowing these modules during test collection on persistent runners.
+"""


### PR DESCRIPTION
## What changed

Add `scripts/__init__.py` so the repository's scientific scripts form an explicit local package during test collection.

## Why

The newly restored self-hosted CI route exposed two collection failures on `workstation2`:

- `scripts.export_sparse_gauge_anchors` not found;
- `scripts.export_vggt_prob4d_blends` not found.

Both modules are present in the exact tested commit. The persistent runner has another installed top-level package named `scripts`, which can override this repository's implicit namespace package. An explicit package marker makes `pythonpath = ["."]` deterministic without changing distribution contents because setuptools discovers packages only under `src/`.

## Validation

The existing tests `tests/test_sparse_gauge_anchor_script.py` and `tests/test_vggt_prob4d_blends.py` exercise the affected imports. This branch uses the trusted `ci/self-hosted-*` convention so the complete existing matrix runs in the environment that reproduced the defect.