### PR TITLE
Prevent local scripts package shadowing in CI

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,5 @@
+"""Repository-local command-line and evidence-generation scripts.
+
+Declaring this directory as a regular package prevents unrelated installed
+``scripts`` packages from shadowing these modules during test collection.
+"""


### PR DESCRIPTION
## Root cause

The workstation2 recovery run reached pytest but failed during collection because `scripts.export_sparse_gauge_anchors` and `scripts.export_vggt_prob4d_blends` resolved through a conflicting installed `scripts` package instead of this repository's namespace directory. GitHub-hosted runners did not contain that conflicting package, so the same tests passed there.

## Fix

Add `scripts/__init__.py` so Prob4D's repository-local scripts form an explicit regular package and take precedence from the configured repository-root Python path.

## Verification

The existing complete suite contains direct imports of both affected modules. This branch uses the trusted `ci/self-hosted-*` convention, so those imports are exercised on workstation2, where the collision was reproduced.