### PR TITLE
Add calibrated material-identity marginalization

### DIFF
--- a/.github/workflows/material-identity-marginalization.yml
+++ b/.github/workflows/material-identity-marginalization.yml
@@ -1,0 +1,64 @@
+name: Material identity marginalization
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/material-identity-marginalization.yml"
+      - "docs/material-identity-marginalization.md"
+      - "src/prob4d/material_identity_mixture.py"
+      - "tests/test_material_identity_mixture.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: material-identity-marginalization-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONUNBUFFERED: "1"
+
+jobs:
+  contract:
+    name: Local-ID mixture and marginalization contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install development environment
+        run: python -m pip install -e ".[dev]"
+      - name: Check focused source quality
+        run: |
+          python -m ruff check \
+            src/prob4d/material_identity_mixture.py \
+            tests/test_material_identity_mixture.py
+          python -m mypy src/prob4d/material_identity_mixture.py
+      - name: Run focused regressions
+        run: python -m pytest -q tests/test_material_identity_mixture.py
+      - name: Verify installed public module
+        run: |
+          python - <<'PY'
+          from prob4d.material_identity_mixture import (
+              LIKELIHOOD_MARGINALIZATION_SEMANTICS,
+              MATERIAL_IDENTITY_MIXTURE_SCHEMA,
+              MOMENT_MATCH_SEMANTICS,
+              NULL_HYPOTHESIS_SEMANTICS,
+          )
+
+          assert MATERIAL_IDENTITY_MIXTURE_SCHEMA.startswith("prob4d.")
+          assert LIKELIHOOD_MARGINALIZATION_SEMANTICS.startswith("logsumexp-")
+          assert MOMENT_MATCH_SEMANTICS == "law-of-total-covariance-v1"
+          assert NULL_HYPOTHESIS_SEMANTICS == "newest-window-local-reference-v1"
+          PY

--- a/.github/workflows/material-identity-marginalization.yml
+++ b/.github/workflows/material-identity-marginalization.yml
@@ -57,8 +57,10 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
-      - name: Install development environment
-        run: python -m pip install -e ".[dev]"
+      - name: Install development and compatible typing environment
+        run: |
+          python -m pip install -e ".[dev]"
+          python -m pip install "numpy>=1.24,<2.3"
       - name: Check focused source quality
         run: |
           python -m ruff check \

--- a/.github/workflows/material-identity-marginalization.yml
+++ b/.github/workflows/material-identity-marginalization.yml
@@ -9,6 +9,15 @@ on:
       - "src/prob4d/material_identity_mixture.py"
       - "tests/test_material_identity_mixture.py"
   workflow_dispatch:
+    inputs:
+      runner:
+        description: "Runner type"
+        required: true
+        default: github-hosted
+        type: choice
+        options:
+          - github-hosted
+          - self-hosted
 
 permissions:
   contents: read
@@ -24,19 +33,30 @@ env:
 jobs:
   contract:
     name: Local-ID mixture and marginalization contract
-    runs-on: ubuntu-latest
+    runs-on: >-
+      ${{
+        inputs.runner == 'self-hosted' &&
+        fromJSON('["self-hosted","Linux","X64","nvidia-smi"]') ||
+        'ubuntu-latest'
+      }}
     timeout-minutes: 20
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Set up Python 3.12
+      - name: Set up hosted Python 3.12
+        if: inputs.runner != 'self-hosted'
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
           cache: pip
           cache-dependency-path: pyproject.toml
+      - name: Set up self-hosted Python 3.12
+        if: inputs.runner == 'self-hosted'
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
       - name: Install development environment
         run: python -m pip install -e ".[dev]"
       - name: Check focused source quality

--- a/docs/material-identity-marginalization.md
+++ b/docs/material-identity-marginalization.md
@@ -18,12 +18,14 @@ target track:
   reference;
 - zero or more linked source endpoints, each stored as its original
   `(window_id, track_id)` pair;
+- an ordered admitted-window sequence with the target window last;
 - the source association result identity and source score;
 - a source-calibrated log weight;
 - the association-rule, calibration, producer, and implementation identities.
 
-No global point ID, connected component, or provider-v2 observation rewrite is
-created.
+Every linked source endpoint must occur before the target in the bound window
+order. No global point ID, connected component, or provider-v2 observation
+rewrite is created.
 
 ## Exact downstream marginalization
 

--- a/docs/material-identity-marginalization.md
+++ b/docs/material-identity-marginalization.md
@@ -1,0 +1,71 @@
+# Material-identity marginalization
+
+`prob4d.material_identity_mixture` is an experimental boundary for carrying
+uncertainty about cross-window material identity without rewriting any Prob4D
+observation ID.
+
+## Motivation
+
+Within-window causal tracklets provide persistent local identities. Cross-window
+association can propose links between overlapping windows, but one hard link
+hides ambiguity. A wider covariance must also not make an association rank better
+merely because it is less informative.
+
+The mixture contract therefore keeps a small set of local hypotheses for one
+target track:
+
+- exactly one **null** hypothesis, representing the unchanged newest-window
+  reference;
+- zero or more linked source endpoints, each stored as its original
+  `(window_id, track_id)` pair;
+- the source association result identity and source score;
+- a source-calibrated log weight;
+- the association-rule, calibration, producer, and implementation identities.
+
+No global point ID, connected component, or provider-v2 observation rewrite is
+created.
+
+## Exact downstream marginalization
+
+A downstream consumer can evaluate its own log likelihood `ell_a` for every
+identity hypothesis `a` and compute
+
+```text
+log p(y | x, g) = logsumexp_a(log q_a + ell_a),
+```
+
+where `q_a` is the normalized source-calibrated identity weight and `g` can be
+the existing complete joint `Sim(3)` gauge nuisance. Candidate IDs must match the
+mixture order exactly, preventing likelihood rows from being silently assigned
+to the wrong endpoint.
+
+`marginalize_identity_log_likelihoods` returns the marginal log likelihood and
+the posterior identity probabilities. A likelihood power of zero returns the
+source prior without evaluating impossible `-inf` likelihood rows.
+
+For consumers that need one Gaussian approximation,
+`moment_match_gaussian_identity_hypotheses` applies the law of total covariance:
+
+```text
+mean = sum_a q_a mean_a
+cov  = sum_a q_a cov_a
+     + sum_a q_a (mean_a - mean)(mean_a - mean)^T.
+```
+
+The second term is retained explicitly as between-hypothesis uncertainty.
+
+## Fallback behavior
+
+A mixture containing only the null hypothesis returns the null likelihood, mean,
+and covariance exactly. The contract always requires exactly one null
+hypothesis, so rejected or absent cross-window links preserve the newest-window
+reference rather than dropping the case.
+
+## Information and claim boundary
+
+The log weights must be calibrated only on declared source/calibration objects or
+sessions. The artifact does not decide whether BayesianPhysTwin accepts an
+update, does not establish provider competence, and does not establish a
+Causal4D intervention benefit. Promotion requires a separately frozen
+object/session-held-out comparison of newest-window, hard-link,
+identity-marginalized, oracle, and exact-fallback arms.

--- a/src/prob4d/material_identity_mixture.py
+++ b/src/prob4d/material_identity_mixture.py
@@ -58,6 +58,7 @@ _MIXTURE_FIELDS = frozenset(
         "schema_version",
         "mixture_id",
         "target_endpoint",
+        "window_order",
         "causal_frame_stop",
         "association_rule_id",
         "calibration_id",
@@ -333,6 +334,7 @@ class MaterialIdentityMixtureV1:
     """A calibrated discrete identity mixture for one target-local track."""
 
     target_endpoint: LocalTrackEndpoint
+    window_order: tuple[str, ...]
     causal_frame_stop: int
     association_rule_id: str
     calibration_id: str
@@ -351,6 +353,17 @@ class MaterialIdentityMixtureV1:
     def __post_init__(self) -> None:
         if not isinstance(self.target_endpoint, LocalTrackEndpoint):
             raise ValueError("target_endpoint must be LocalTrackEndpoint")
+        if type(self.window_order) is not tuple or not self.window_order:
+            raise ValueError("window_order must be a non-empty tuple")
+        window_order = tuple(
+            _string(window_id, name=f"window_order[{index}]")
+            for index, window_id in enumerate(self.window_order)
+        )
+        if len(set(window_order)) != len(window_order):
+            raise ValueError("window_order must contain unique window IDs")
+        if window_order[-1] != self.target_endpoint.window_id:
+            raise ValueError("target_endpoint window must be last in window_order")
+        source_windows = frozenset(window_order[:-1])
         causal_frame_stop = _integer(
             self.causal_frame_stop,
             name="causal_frame_stop",
@@ -374,16 +387,16 @@ class MaterialIdentityMixtureV1:
         ]
         if len(set(linked_endpoints)) != len(linked_endpoints):
             raise ValueError("linked source endpoints must be unique")
-        if any(
-            endpoint.window_id == self.target_endpoint.window_id
-            for endpoint in linked_endpoints
-        ):
-            raise ValueError("linked source endpoints must come from prior windows")
+        if any(endpoint.window_id not in source_windows for endpoint in linked_endpoints):
+            raise ValueError(
+                "linked source endpoint windows must precede the target in window_order"
+            )
         if self.weight_semantics != WEIGHT_SEMANTICS:
             raise ValueError("unsupported weight_semantics")
         if self.null_hypothesis_semantics != NULL_HYPOTHESIS_SEMANTICS:
             raise ValueError("unsupported null_hypothesis_semantics")
 
+        object.__setattr__(self, "window_order", window_order)
         object.__setattr__(self, "causal_frame_stop", causal_frame_stop)
         object.__setattr__(
             self,
@@ -463,6 +476,7 @@ class MaterialIdentityMixtureV1:
             "schema": MATERIAL_IDENTITY_MIXTURE_SCHEMA,
             "schema_version": MATERIAL_IDENTITY_MIXTURE_VERSION,
             "target_endpoint": self.target_endpoint.to_dict(),
+            "window_order": list(self.window_order),
             "causal_frame_stop": self.causal_frame_stop,
             "association_rule_id": self.association_rule_id,
             "calibration_id": self.calibration_id,
@@ -835,8 +849,16 @@ def load_material_identity_mixture(path: str | Path) -> MaterialIdentityMixtureV
             )
         )
         supplied_ids.append(_sha256(raw_candidate["candidate_id"], name=f"{name}.candidate_id"))
+    raw_window_order = payload["window_order"]
+    if type(raw_window_order) is not list or not raw_window_order:
+        raise ValueError("window_order must be a non-empty JSON array")
+    window_order = tuple(
+        _string(window_id, name=f"window_order[{index}]")
+        for index, window_id in enumerate(raw_window_order)
+    )
     mixture = MaterialIdentityMixtureV1(
         target_endpoint=target,
+        window_order=window_order,
         causal_frame_stop=payload["causal_frame_stop"],
         association_rule_id=payload["association_rule_id"],
         calibration_id=payload["calibration_id"],

--- a/src/prob4d/material_identity_mixture.py
+++ b/src/prob4d/material_identity_mixture.py
@@ -1,0 +1,887 @@
+"""Experimental probabilistic mixtures over cross-window material identities.
+
+The contracts in this module preserve every endpoint as a window-local
+``(window_id, track_id)`` identity.  They do not construct global point IDs or
+connected components.  A mandatory null hypothesis represents the unchanged
+newest-window reference, so an empty linked candidate set reproduces the exact
+fallback behavior.
+
+Prob4D owns the portable source-side identity mixture.  A downstream consumer,
+such as BayesianPhysTwin, may marginalize its own likelihood over the retained
+hypotheses.  This module does not decide whether a physical-state update is
+accepted.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ._immutable_json import frozen_finite_json_mapping, plain_json
+
+FloatArray = NDArray[np.floating]
+
+MATERIAL_IDENTITY_MIXTURE_SCHEMA = "prob4d.material-identity-mixture"
+MATERIAL_IDENTITY_MIXTURE_VERSION = 1
+MATERIAL_IDENTITY_HYPOTHESIS_SCHEMA = "prob4d.material-identity-hypothesis"
+MATERIAL_IDENTITY_HYPOTHESIS_VERSION = 1
+WEIGHT_SEMANTICS: Literal["source-calibrated-log-weight-v1"] = (
+    "source-calibrated-log-weight-v1"
+)
+NULL_HYPOTHESIS_SEMANTICS: Literal[
+    "newest-window-local-reference-v1"
+] = "newest-window-local-reference-v1"
+LIKELIHOOD_MARGINALIZATION_SEMANTICS: Literal[
+    "logsumexp-discrete-identity-v1"
+] = "logsumexp-discrete-identity-v1"
+MOMENT_MATCH_SEMANTICS: Literal[
+    "law-of-total-covariance-v1"
+] = "law-of-total-covariance-v1"
+CLAIM_BOUNDARY = (
+    "Source-calibrated cross-window material-identity hypotheses only. Endpoints "
+    "remain window-local, the null hypothesis preserves the newest-window "
+    "reference exactly, and no physical-state update or Causal4D benefit is "
+    "established by this artifact."
+)
+
+_MIXTURE_FIELDS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "mixture_id",
+        "target_endpoint",
+        "causal_frame_stop",
+        "association_rule_id",
+        "calibration_id",
+        "tracklet_producer_revision",
+        "association_revision",
+        "weight_semantics",
+        "null_hypothesis_semantics",
+        "candidates",
+        "metadata",
+        "claim_boundary",
+    }
+)
+_CANDIDATE_FIELDS = frozenset(
+    {
+        "candidate_id",
+        "kind",
+        "source_endpoint",
+        "association_result_id",
+        "source_score",
+        "calibrated_log_weight",
+        "metadata",
+    }
+)
+_ENDPOINT_FIELDS = frozenset({"window_id", "track_id"})
+
+
+def _canonical_json(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        plain_json(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _sha256_json(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json(value)).hexdigest()
+
+
+def _strict_json_object_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        result[key] = value
+    return result
+
+
+def _reject_nonfinite_json_constant(value: str) -> None:
+    raise ValueError(f"non-finite JSON constant is not permitted: {value}")
+
+
+def _load_strict_json(path: Path) -> Mapping[str, Any]:
+    try:
+        payload = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_strict_json_object_pairs,
+            parse_constant=_reject_nonfinite_json_constant,
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot read material-identity mixture {path}") from error
+    if not isinstance(payload, Mapping):
+        raise ValueError("material-identity mixture root must be a JSON object")
+    return payload
+
+
+def _require_exact_fields(
+    value: Mapping[str, Any],
+    *,
+    expected: frozenset[str],
+    name: str,
+) -> None:
+    missing = sorted(expected - set(value))
+    extra = sorted(set(value) - expected)
+    if missing or extra:
+        raise ValueError(f"{name} fields changed: missing={missing}, extra={extra}")
+
+
+def _string(value: object, *, name: str) -> str:
+    if type(value) is not str or not value:
+        raise ValueError(f"{name} must be a non-empty string")
+    return str(value)
+
+
+def _integer(value: object, *, name: str, minimum: int = 0) -> int:
+    if type(value) is not int and not isinstance(value, np.integer):
+        raise ValueError(f"{name} must be an integer")
+    result = int(value)
+    if result < minimum:
+        raise ValueError(f"{name} must be at least {minimum}")
+    return result
+
+
+def _finite_real(
+    value: object,
+    *,
+    name: str,
+    minimum: float | None = None,
+    maximum: float | None = None,
+) -> float:
+    if type(value) not in {int, float} and not isinstance(
+        value, (np.integer, np.floating)
+    ):
+        raise ValueError(f"{name} must be a real number")
+    result = float(value)
+    if not np.isfinite(result):
+        raise ValueError(f"{name} must be finite")
+    if minimum is not None and result < minimum:
+        raise ValueError(f"{name} must be at least {minimum}")
+    if maximum is not None and result > maximum:
+        raise ValueError(f"{name} must be at most {maximum}")
+    return result
+
+
+def _sha256(value: object, *, name: str) -> str:
+    digest = _string(value, name=name)
+    if len(digest) != 64 or any(
+        character not in "0123456789abcdef" for character in digest
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return digest
+
+
+def _revision(value: object, *, name: str) -> str:
+    revision = _string(value, name=name)
+    if len(revision) not in {40, 64} or any(
+        character not in "0123456789abcdef" for character in revision
+    ):
+        raise ValueError(f"{name} must be an exact lowercase Git revision")
+    return revision
+
+
+def _readonly(value: np.ndarray, *, dtype: Any) -> np.ndarray:
+    result = np.asarray(value, dtype=dtype).copy()
+    result.setflags(write=False)
+    return result
+
+
+def _logsumexp(values: FloatArray) -> float:
+    array = np.asarray(values, dtype=np.float64)
+    if array.ndim != 1 or array.size == 0:
+        raise ValueError("logsumexp values must be a non-empty vector")
+    if np.any(np.isnan(array)) or np.any(np.isposinf(array)):
+        raise ValueError("logsumexp values may not contain NaN or positive infinity")
+    maximum = float(np.max(array))
+    if np.isneginf(maximum):
+        return float("-inf")
+    return float(maximum + np.log(np.sum(np.exp(array - maximum))))
+
+
+@dataclass(frozen=True, order=True)
+class LocalTrackEndpoint:
+    """A window-local track identity that is never rewritten globally."""
+
+    window_id: str
+    track_id: int
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "window_id", _string(self.window_id, name="window_id"))
+        object.__setattr__(
+            self,
+            "track_id",
+            _integer(self.track_id, name="track_id", minimum=0),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {"window_id": self.window_id, "track_id": self.track_id}
+
+    @classmethod
+    def from_mapping(cls, value: object, *, name: str) -> LocalTrackEndpoint:
+        if not isinstance(value, Mapping):
+            raise ValueError(f"{name} must be a JSON object")
+        _require_exact_fields(value, expected=_ENDPOINT_FIELDS, name=name)
+        return cls(window_id=value["window_id"], track_id=value["track_id"])
+
+
+@dataclass(frozen=True)
+class MaterialIdentityCandidateV1:
+    """One null or linked source hypothesis for a target-local track."""
+
+    source_endpoint: LocalTrackEndpoint | None
+    association_result_id: str | None
+    source_score: float | None
+    calibrated_log_weight: float
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        log_weight = _finite_real(
+            self.calibrated_log_weight,
+            name="calibrated_log_weight",
+        )
+        if self.source_endpoint is None:
+            if self.association_result_id is not None or self.source_score is not None:
+                raise ValueError(
+                    "the null hypothesis must not carry source association evidence"
+                )
+        else:
+            if not isinstance(self.source_endpoint, LocalTrackEndpoint):
+                raise ValueError("source_endpoint must be LocalTrackEndpoint or None")
+            object.__setattr__(
+                self,
+                "association_result_id",
+                _sha256(
+                    self.association_result_id,
+                    name="association_result_id",
+                ),
+            )
+            object.__setattr__(
+                self,
+                "source_score",
+                _finite_real(
+                    self.source_score,
+                    name="source_score",
+                    minimum=0.0,
+                    maximum=1.0,
+                ),
+            )
+        object.__setattr__(self, "calibrated_log_weight", log_weight)
+        object.__setattr__(
+            self,
+            "metadata",
+            frozen_finite_json_mapping(
+                self.metadata,
+                name="material-identity candidate metadata",
+            ),
+        )
+
+    @property
+    def kind(self) -> Literal["null", "linked"]:
+        return "null" if self.source_endpoint is None else "linked"
+
+    def ordering_key(self) -> tuple[object, ...]:
+        if self.source_endpoint is None:
+            return (0, "", -1, "")
+        return (
+            1,
+            self.source_endpoint.window_id,
+            self.source_endpoint.track_id,
+            self.association_result_id,
+        )
+
+    def identity_record(self, *, target_endpoint: LocalTrackEndpoint) -> dict[str, object]:
+        return {
+            "schema": MATERIAL_IDENTITY_HYPOTHESIS_SCHEMA,
+            "schema_version": MATERIAL_IDENTITY_HYPOTHESIS_VERSION,
+            "target_endpoint": target_endpoint.to_dict(),
+            "kind": self.kind,
+            "source_endpoint": (
+                None if self.source_endpoint is None else self.source_endpoint.to_dict()
+            ),
+            "association_result_id": self.association_result_id,
+        }
+
+    def candidate_id(self, *, target_endpoint: LocalTrackEndpoint) -> str:
+        return _sha256_json(self.identity_record(target_endpoint=target_endpoint))
+
+    def to_record(self, *, target_endpoint: LocalTrackEndpoint) -> dict[str, object]:
+        return {
+            "candidate_id": self.candidate_id(target_endpoint=target_endpoint),
+            "kind": self.kind,
+            "source_endpoint": (
+                None if self.source_endpoint is None else self.source_endpoint.to_dict()
+            ),
+            "association_result_id": self.association_result_id,
+            "source_score": self.source_score,
+            "calibrated_log_weight": self.calibrated_log_weight,
+            "metadata": plain_json(self.metadata),
+        }
+
+
+@dataclass(frozen=True)
+class MaterialIdentityMixtureV1:
+    """A calibrated discrete identity mixture for one target-local track."""
+
+    target_endpoint: LocalTrackEndpoint
+    causal_frame_stop: int
+    association_rule_id: str
+    calibration_id: str
+    tracklet_producer_revision: str
+    association_revision: str
+    candidates: tuple[MaterialIdentityCandidateV1, ...]
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    weight_semantics: Literal[
+        "source-calibrated-log-weight-v1"
+    ] = WEIGHT_SEMANTICS
+    null_hypothesis_semantics: Literal[
+        "newest-window-local-reference-v1"
+    ] = NULL_HYPOTHESIS_SEMANTICS
+    mixture_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.target_endpoint, LocalTrackEndpoint):
+            raise ValueError("target_endpoint must be LocalTrackEndpoint")
+        causal_frame_stop = _integer(
+            self.causal_frame_stop,
+            name="causal_frame_stop",
+            minimum=1,
+        )
+        if type(self.candidates) is not tuple or not self.candidates:
+            raise ValueError("candidates must be a non-empty tuple")
+        if any(
+            not isinstance(candidate, MaterialIdentityCandidateV1)
+            for candidate in self.candidates
+        ):
+            raise ValueError("candidates must contain MaterialIdentityCandidateV1 values")
+        candidates = tuple(sorted(self.candidates, key=lambda candidate: candidate.ordering_key()))
+        null_count = sum(candidate.source_endpoint is None for candidate in candidates)
+        if null_count != 1:
+            raise ValueError("exactly one null identity hypothesis is required")
+        linked_endpoints = [
+            candidate.source_endpoint
+            for candidate in candidates
+            if candidate.source_endpoint is not None
+        ]
+        if len(set(linked_endpoints)) != len(linked_endpoints):
+            raise ValueError("linked source endpoints must be unique")
+        if any(
+            endpoint.window_id == self.target_endpoint.window_id
+            for endpoint in linked_endpoints
+        ):
+            raise ValueError("linked source endpoints must come from prior windows")
+        if self.weight_semantics != WEIGHT_SEMANTICS:
+            raise ValueError("unsupported weight_semantics")
+        if self.null_hypothesis_semantics != NULL_HYPOTHESIS_SEMANTICS:
+            raise ValueError("unsupported null_hypothesis_semantics")
+
+        object.__setattr__(self, "causal_frame_stop", causal_frame_stop)
+        object.__setattr__(
+            self,
+            "association_rule_id",
+            _sha256(self.association_rule_id, name="association_rule_id"),
+        )
+        object.__setattr__(
+            self,
+            "calibration_id",
+            _sha256(self.calibration_id, name="calibration_id"),
+        )
+        object.__setattr__(
+            self,
+            "tracklet_producer_revision",
+            _revision(
+                self.tracklet_producer_revision,
+                name="tracklet_producer_revision",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "association_revision",
+            _revision(self.association_revision, name="association_revision"),
+        )
+        object.__setattr__(self, "candidates", candidates)
+        object.__setattr__(
+            self,
+            "metadata",
+            frozen_finite_json_mapping(
+                self.metadata,
+                name="material-identity mixture metadata",
+            ),
+        )
+
+        expected = _sha256_json(self.identity_record())
+        supplied = self.mixture_id
+        if supplied is not None and _sha256(supplied, name="mixture_id") != expected:
+            raise ValueError("material-identity mixture ID mismatch")
+        object.__setattr__(self, "mixture_id", expected)
+
+    @property
+    def candidate_ids(self) -> tuple[str, ...]:
+        return tuple(
+            candidate.candidate_id(target_endpoint=self.target_endpoint)
+            for candidate in self.candidates
+        )
+
+    @property
+    def normalized_log_weights(self) -> FloatArray:
+        log_weights = np.asarray(
+            [candidate.calibrated_log_weight for candidate in self.candidates],
+            dtype=np.float64,
+        )
+        normalizer = _logsumexp(log_weights)
+        return _readonly(log_weights - normalizer, dtype=np.float64)
+
+    @property
+    def probabilities(self) -> FloatArray:
+        return _readonly(np.exp(self.normalized_log_weights), dtype=np.float64)
+
+    @property
+    def null_probability(self) -> float:
+        return float(self.probabilities[0])
+
+    @property
+    def identity_entropy_nats(self) -> float:
+        probabilities = self.probabilities
+        active = probabilities > 0.0
+        return float(-np.sum(probabilities[active] * np.log(probabilities[active])))
+
+    @property
+    def effective_hypothesis_count(self) -> float:
+        return float(np.exp(self.identity_entropy_nats))
+
+    def identity_record(self) -> dict[str, object]:
+        return {
+            "schema": MATERIAL_IDENTITY_MIXTURE_SCHEMA,
+            "schema_version": MATERIAL_IDENTITY_MIXTURE_VERSION,
+            "target_endpoint": self.target_endpoint.to_dict(),
+            "causal_frame_stop": self.causal_frame_stop,
+            "association_rule_id": self.association_rule_id,
+            "calibration_id": self.calibration_id,
+            "tracklet_producer_revision": self.tracklet_producer_revision,
+            "association_revision": self.association_revision,
+            "weight_semantics": self.weight_semantics,
+            "null_hypothesis_semantics": self.null_hypothesis_semantics,
+            "candidates": [
+                candidate.to_record(target_endpoint=self.target_endpoint)
+                for candidate in self.candidates
+            ],
+            "metadata": plain_json(self.metadata),
+            "claim_boundary": CLAIM_BOUNDARY,
+        }
+
+    def to_record(self) -> dict[str, object]:
+        return {**self.identity_record(), "mixture_id": self.mixture_id}
+
+
+@dataclass(frozen=True)
+class MarginalizedIdentityLikelihood:
+    """Result of exact discrete identity likelihood marginalization."""
+
+    candidate_ids: tuple[str, ...]
+    log_marginal_likelihood: float
+    posterior_probabilities: FloatArray
+    identity_entropy_nats: float
+    effective_hypothesis_count: float
+    likelihood_power: float
+    semantics: Literal[
+        "logsumexp-discrete-identity-v1"
+    ] = LIKELIHOOD_MARGINALIZATION_SEMANTICS
+
+    def __post_init__(self) -> None:
+        if type(self.candidate_ids) is not tuple or not self.candidate_ids:
+            raise ValueError("candidate_ids must be a non-empty tuple")
+        if len(set(self.candidate_ids)) != len(self.candidate_ids):
+            raise ValueError("candidate_ids must be unique")
+        if any(type(value) is not str or not value for value in self.candidate_ids):
+            raise ValueError("candidate_ids must contain non-empty strings")
+        probabilities = np.asarray(self.posterior_probabilities, dtype=np.float64)
+        if probabilities.shape != (len(self.candidate_ids),):
+            raise ValueError("posterior_probabilities do not match candidate_ids")
+        if not np.all(np.isfinite(probabilities)) or np.any(probabilities < 0.0):
+            raise ValueError("posterior_probabilities must be finite and non-negative")
+        if not np.isclose(float(np.sum(probabilities)), 1.0, atol=1e-12, rtol=1e-12):
+            raise ValueError("posterior_probabilities must sum to one")
+        log_marginal = _finite_real(
+            self.log_marginal_likelihood,
+            name="log_marginal_likelihood",
+        )
+        entropy = _finite_real(
+            self.identity_entropy_nats,
+            name="identity_entropy_nats",
+            minimum=0.0,
+        )
+        effective = _finite_real(
+            self.effective_hypothesis_count,
+            name="effective_hypothesis_count",
+            minimum=1.0,
+        )
+        power = _finite_real(
+            self.likelihood_power,
+            name="likelihood_power",
+            minimum=0.0,
+        )
+        if self.semantics != LIKELIHOOD_MARGINALIZATION_SEMANTICS:
+            raise ValueError("unsupported likelihood marginalization semantics")
+        object.__setattr__(
+            self,
+            "posterior_probabilities",
+            _readonly(probabilities, dtype=np.float64),
+        )
+        object.__setattr__(self, "log_marginal_likelihood", log_marginal)
+        object.__setattr__(self, "identity_entropy_nats", entropy)
+        object.__setattr__(self, "effective_hypothesis_count", effective)
+        object.__setattr__(self, "likelihood_power", power)
+
+
+@dataclass(frozen=True)
+class GaussianIdentityMomentMatch:
+    """Moment-matched Gaussian under a discrete material-identity mixture."""
+
+    candidate_ids: tuple[str, ...]
+    probabilities: FloatArray
+    mean: FloatArray
+    covariance: FloatArray
+    within_hypothesis_covariance: FloatArray
+    between_hypothesis_covariance: FloatArray
+    identity_entropy_nats: float
+    effective_hypothesis_count: float
+    semantics: Literal[
+        "law-of-total-covariance-v1"
+    ] = MOMENT_MATCH_SEMANTICS
+
+    def __post_init__(self) -> None:
+        probabilities = np.asarray(self.probabilities, dtype=np.float64)
+        mean = np.asarray(self.mean, dtype=np.float64)
+        covariance = np.asarray(self.covariance, dtype=np.float64)
+        within = np.asarray(self.within_hypothesis_covariance, dtype=np.float64)
+        between = np.asarray(self.between_hypothesis_covariance, dtype=np.float64)
+        if type(self.candidate_ids) is not tuple or not self.candidate_ids:
+            raise ValueError("candidate_ids must be a non-empty tuple")
+        if len(set(self.candidate_ids)) != len(self.candidate_ids):
+            raise ValueError("candidate_ids must be unique")
+        if any(type(value) is not str or not value for value in self.candidate_ids):
+            raise ValueError("candidate_ids must contain non-empty strings")
+        if probabilities.shape != (len(self.candidate_ids),):
+            raise ValueError("probabilities do not match candidate_ids")
+        if mean.ndim != 1 or mean.size == 0:
+            raise ValueError("mean must be a non-empty vector")
+        expected = (mean.size, mean.size)
+        if any(value.shape != expected for value in (covariance, within, between)):
+            raise ValueError("moment covariances must be square and match the mean")
+        for name, value in (
+            ("probabilities", probabilities),
+            ("mean", mean),
+            ("covariance", covariance),
+            ("within_hypothesis_covariance", within),
+            ("between_hypothesis_covariance", between),
+        ):
+            if not np.all(np.isfinite(value)):
+                raise ValueError(f"{name} must be finite")
+        if np.any(probabilities < 0.0) or not np.isclose(
+            float(np.sum(probabilities)), 1.0, atol=1e-12, rtol=1e-12
+        ):
+            raise ValueError("probabilities must be non-negative and sum to one")
+        if not np.allclose(covariance, within + between, atol=1e-12, rtol=1e-12):
+            raise ValueError("total covariance must equal within plus between covariance")
+        for name, value in (
+            ("covariance", covariance),
+            ("within_hypothesis_covariance", within),
+            ("between_hypothesis_covariance", between),
+        ):
+            if not np.allclose(value, value.T, atol=1e-12, rtol=1e-12):
+                raise ValueError(f"{name} must be symmetric")
+            scale = max(1.0, float(np.linalg.norm(value, ord=2)))
+            if float(np.min(np.linalg.eigvalsh(value))) < -1e-10 * scale:
+                raise ValueError(f"{name} must be positive semidefinite")
+        entropy = _finite_real(
+            self.identity_entropy_nats,
+            name="identity_entropy_nats",
+            minimum=0.0,
+        )
+        effective = _finite_real(
+            self.effective_hypothesis_count,
+            name="effective_hypothesis_count",
+            minimum=1.0,
+        )
+        if self.semantics != MOMENT_MATCH_SEMANTICS:
+            raise ValueError("unsupported moment-match semantics")
+        object.__setattr__(self, "identity_entropy_nats", entropy)
+        object.__setattr__(self, "effective_hypothesis_count", effective)
+        object.__setattr__(self, "probabilities", _readonly(probabilities, dtype=np.float64))
+        object.__setattr__(self, "mean", _readonly(mean, dtype=np.float64))
+        object.__setattr__(self, "covariance", _readonly(covariance, dtype=np.float64))
+        object.__setattr__(
+            self,
+            "within_hypothesis_covariance",
+            _readonly(within, dtype=np.float64),
+        )
+        object.__setattr__(
+            self,
+            "between_hypothesis_covariance",
+            _readonly(between, dtype=np.float64),
+        )
+
+
+def marginalize_identity_log_likelihoods(
+    mixture: MaterialIdentityMixtureV1,
+    candidate_ids: tuple[str, ...],
+    log_likelihoods: FloatArray,
+    *,
+    likelihood_power: float = 1.0,
+) -> MarginalizedIdentityLikelihood:
+    """Marginalize a downstream log likelihood over local identity hypotheses.
+
+    ``candidate_ids`` must exactly match the mixture order.  This prevents a
+    consumer from silently assigning a likelihood to the wrong local endpoint.
+    A power of zero returns the calibrated source prior without consulting the
+    supplied likelihood values.
+    """
+
+    if not isinstance(mixture, MaterialIdentityMixtureV1):
+        raise ValueError("mixture must be MaterialIdentityMixtureV1")
+    if type(candidate_ids) is not tuple or candidate_ids != mixture.candidate_ids:
+        raise ValueError("candidate_ids must exactly match mixture.candidate_ids")
+    values = np.asarray(log_likelihoods, dtype=np.float64)
+    if values.shape != (len(candidate_ids),):
+        raise ValueError("log_likelihoods must match the candidate count")
+    if np.any(np.isnan(values)) or np.any(np.isposinf(values)):
+        raise ValueError("log_likelihoods may not contain NaN or positive infinity")
+    power = _finite_real(
+        likelihood_power,
+        name="likelihood_power",
+        minimum=0.0,
+    )
+    prior_log_weights = np.asarray(mixture.normalized_log_weights, dtype=np.float64)
+    if power == 0.0:
+        log_terms = prior_log_weights
+    else:
+        log_terms = prior_log_weights + power * values
+    log_marginal = _logsumexp(log_terms)
+    if np.isneginf(log_marginal):
+        raise ValueError("every identity hypothesis has impossible likelihood")
+    probabilities = np.exp(log_terms - log_marginal)
+    active = probabilities > 0.0
+    entropy = float(-np.sum(probabilities[active] * np.log(probabilities[active])))
+    return MarginalizedIdentityLikelihood(
+        candidate_ids=candidate_ids,
+        log_marginal_likelihood=log_marginal,
+        posterior_probabilities=probabilities,
+        identity_entropy_nats=entropy,
+        effective_hypothesis_count=float(np.exp(entropy)),
+        likelihood_power=power,
+    )
+
+
+def moment_match_gaussian_identity_hypotheses(
+    mixture: MaterialIdentityMixtureV1,
+    candidate_ids: tuple[str, ...],
+    means: FloatArray,
+    covariances: FloatArray,
+    *,
+    probabilities: FloatArray | None = None,
+) -> GaussianIdentityMomentMatch:
+    """Apply the law of total covariance over local identity hypotheses."""
+
+    if not isinstance(mixture, MaterialIdentityMixtureV1):
+        raise ValueError("mixture must be MaterialIdentityMixtureV1")
+    if type(candidate_ids) is not tuple or candidate_ids != mixture.candidate_ids:
+        raise ValueError("candidate_ids must exactly match mixture.candidate_ids")
+    mean_array = np.asarray(means, dtype=np.float64)
+    covariance_array = np.asarray(covariances, dtype=np.float64)
+    count = len(candidate_ids)
+    if mean_array.ndim != 2 or mean_array.shape[0] != count or mean_array.shape[1] < 1:
+        raise ValueError("means must have shape (candidate_count, dimension)")
+    dimension = mean_array.shape[1]
+    if covariance_array.shape != (count, dimension, dimension):
+        raise ValueError("covariances must have shape (candidate_count, dimension, dimension)")
+    if not np.all(np.isfinite(mean_array)) or not np.all(np.isfinite(covariance_array)):
+        raise ValueError("means and covariances must be finite")
+    for index, covariance in enumerate(covariance_array):
+        if not np.allclose(covariance, covariance.T, atol=1e-12, rtol=1e-12):
+            raise ValueError(f"covariances[{index}] must be symmetric")
+        scale = max(1.0, float(np.linalg.norm(covariance, ord=2)))
+        if float(np.min(np.linalg.eigvalsh(covariance))) < -1e-10 * scale:
+            raise ValueError(f"covariances[{index}] must be positive semidefinite")
+
+    if probabilities is None:
+        weights = np.asarray(mixture.probabilities, dtype=np.float64)
+    else:
+        weights = np.asarray(probabilities, dtype=np.float64)
+        if weights.shape != (count,):
+            raise ValueError("probabilities must match the candidate count")
+        if not np.all(np.isfinite(weights)) or np.any(weights < 0.0):
+            raise ValueError("probabilities must be finite and non-negative")
+        total = float(np.sum(weights))
+        if not np.isclose(total, 1.0, atol=1e-12, rtol=1e-12):
+            raise ValueError("probabilities must sum to one")
+
+    marginal_mean = np.sum(weights[:, None] * mean_array, axis=0)
+    within = np.sum(weights[:, None, None] * covariance_array, axis=0)
+    centered = mean_array - marginal_mean
+    between = np.einsum("i,ij,ik->jk", weights, centered, centered)
+    within = 0.5 * (within + within.T)
+    between = 0.5 * (between + between.T)
+    covariance = within + between
+    active = weights > 0.0
+    entropy = float(-np.sum(weights[active] * np.log(weights[active])))
+    return GaussianIdentityMomentMatch(
+        candidate_ids=candidate_ids,
+        probabilities=weights,
+        mean=marginal_mean,
+        covariance=covariance,
+        within_hypothesis_covariance=within,
+        between_hypothesis_covariance=between,
+        identity_entropy_nats=entropy,
+        effective_hypothesis_count=float(np.exp(entropy)),
+    )
+
+
+def write_material_identity_mixture(
+    path: str | Path,
+    mixture: MaterialIdentityMixtureV1,
+    *,
+    overwrite: bool = False,
+) -> None:
+    """Atomically write one portable material-identity mixture."""
+
+    if type(overwrite) is not bool:
+        raise ValueError("overwrite must be a Boolean")
+    destination = Path(path)
+    if destination.exists() and not overwrite:
+        raise FileExistsError(destination)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    payload = _canonical_json(mixture.to_record()) + b"\n"
+    temporary = destination.with_name(
+        f".{destination.name}.tmp-{os.getpid()}-{hashlib.sha256(payload).hexdigest()[:16]}"
+    )
+    try:
+        with temporary.open("xb") as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        if destination.exists() and not overwrite:
+            raise FileExistsError(destination)
+        os.replace(temporary, destination)
+    finally:
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def load_material_identity_mixture(path: str | Path) -> MaterialIdentityMixtureV1:
+    """Load and independently validate one portable identity mixture."""
+
+    payload = _load_strict_json(Path(path))
+    _require_exact_fields(payload, expected=_MIXTURE_FIELDS, name="mixture")
+    if payload["schema"] != MATERIAL_IDENTITY_MIXTURE_SCHEMA:
+        raise ValueError("unsupported material-identity mixture schema")
+    if payload["schema_version"] != MATERIAL_IDENTITY_MIXTURE_VERSION:
+        raise ValueError("unsupported material-identity mixture schema version")
+    if payload["weight_semantics"] != WEIGHT_SEMANTICS:
+        raise ValueError("unsupported material-identity weight semantics")
+    if payload["null_hypothesis_semantics"] != NULL_HYPOTHESIS_SEMANTICS:
+        raise ValueError("unsupported null-hypothesis semantics")
+    if payload["claim_boundary"] != CLAIM_BOUNDARY:
+        raise ValueError("material-identity mixture claim boundary changed")
+    target = LocalTrackEndpoint.from_mapping(
+        payload["target_endpoint"],
+        name="target_endpoint",
+    )
+    raw_candidates = payload["candidates"]
+    if type(raw_candidates) is not list or not raw_candidates:
+        raise ValueError("candidates must be a non-empty JSON array")
+    candidates: list[MaterialIdentityCandidateV1] = []
+    supplied_ids: list[str] = []
+    for index, raw_candidate in enumerate(raw_candidates):
+        name = f"candidates[{index}]"
+        if not isinstance(raw_candidate, Mapping):
+            raise ValueError(f"{name} must be a JSON object")
+        _require_exact_fields(raw_candidate, expected=_CANDIDATE_FIELDS, name=name)
+        kind = raw_candidate["kind"]
+        if kind not in {"null", "linked"}:
+            raise ValueError(f"{name}.kind is unsupported")
+        source_raw = raw_candidate["source_endpoint"]
+        source = (
+            None
+            if source_raw is None
+            else LocalTrackEndpoint.from_mapping(
+                source_raw,
+                name=f"{name}.source_endpoint",
+            )
+        )
+        if (kind == "null") != (source is None):
+            raise ValueError(f"{name}.kind does not match source_endpoint")
+        candidates.append(
+            MaterialIdentityCandidateV1(
+                source_endpoint=source,
+                association_result_id=raw_candidate["association_result_id"],
+                source_score=raw_candidate["source_score"],
+                calibrated_log_weight=raw_candidate["calibrated_log_weight"],
+                metadata=(
+                    raw_candidate["metadata"]
+                    if isinstance(raw_candidate["metadata"], Mapping)
+                    else _raise_candidate_metadata(name)
+                ),
+            )
+        )
+        supplied_ids.append(_sha256(raw_candidate["candidate_id"], name=f"{name}.candidate_id"))
+    mixture = MaterialIdentityMixtureV1(
+        target_endpoint=target,
+        causal_frame_stop=payload["causal_frame_stop"],
+        association_rule_id=payload["association_rule_id"],
+        calibration_id=payload["calibration_id"],
+        tracklet_producer_revision=payload["tracklet_producer_revision"],
+        association_revision=payload["association_revision"],
+        candidates=tuple(candidates),
+        metadata=(
+            payload["metadata"]
+            if isinstance(payload["metadata"], Mapping)
+            else _raise_mixture_metadata()
+        ),
+        weight_semantics=payload["weight_semantics"],
+        null_hypothesis_semantics=payload["null_hypothesis_semantics"],
+        mixture_id=payload["mixture_id"],
+    )
+    if tuple(supplied_ids) != mixture.candidate_ids:
+        raise ValueError("material-identity candidate ID mismatch")
+    return mixture
+
+
+def _raise_candidate_metadata(name: str) -> Mapping[str, Any]:
+    raise ValueError(f"{name}.metadata must be a JSON object")
+
+
+def _raise_mixture_metadata() -> Mapping[str, Any]:
+    raise ValueError("metadata must be a JSON object")
+
+
+__all__ = [
+    "CLAIM_BOUNDARY",
+    "GaussianIdentityMomentMatch",
+    "LIKELIHOOD_MARGINALIZATION_SEMANTICS",
+    "LocalTrackEndpoint",
+    "MATERIAL_IDENTITY_HYPOTHESIS_SCHEMA",
+    "MATERIAL_IDENTITY_HYPOTHESIS_VERSION",
+    "MATERIAL_IDENTITY_MIXTURE_SCHEMA",
+    "MATERIAL_IDENTITY_MIXTURE_VERSION",
+    "MOMENT_MATCH_SEMANTICS",
+    "MarginalizedIdentityLikelihood",
+    "MaterialIdentityCandidateV1",
+    "MaterialIdentityMixtureV1",
+    "NULL_HYPOTHESIS_SEMANTICS",
+    "WEIGHT_SEMANTICS",
+    "load_material_identity_mixture",
+    "marginalize_identity_log_likelihoods",
+    "moment_match_gaussian_identity_hypotheses",
+    "write_material_identity_mixture",
+]

--- a/src/prob4d/material_identity_mixture.py
+++ b/src/prob4d/material_identity_mixture.py
@@ -20,14 +20,14 @@ import os
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, TypeAlias, cast
 
 import numpy as np
 from numpy.typing import NDArray
 
 from ._immutable_json import frozen_finite_json_mapping, plain_json
 
-FloatArray = NDArray[np.floating]
+FloatArray: TypeAlias = NDArray[np.floating[Any]]
 
 MATERIAL_IDENTITY_MIXTURE_SCHEMA = "prob4d.material-identity-mixture"
 MATERIAL_IDENTITY_MIXTURE_VERSION = 1
@@ -163,7 +163,7 @@ def _finite_real(
         value, (np.integer, np.floating)
     ):
         raise ValueError(f"{name} must be a real number")
-    result = float(value)
+    result = float(cast(Any, value))
     if not np.isfinite(result):
         raise ValueError(f"{name} must be finite")
     if minimum is not None and result < minimum:
@@ -376,7 +376,9 @@ class MaterialIdentityMixtureV1:
             for candidate in self.candidates
         ):
             raise ValueError("candidates must contain MaterialIdentityCandidateV1 values")
-        candidates = tuple(sorted(self.candidates, key=lambda candidate: candidate.ordering_key()))
+        candidates = tuple(
+            sorted(self.candidates, key=lambda candidate: candidate.ordering_key())
+        )
         null_count = sum(candidate.source_endpoint is None for candidate in candidates)
         if null_count != 1:
             raise ValueError("exactly one null identity hypothesis is required")
@@ -522,7 +524,9 @@ class MarginalizedIdentityLikelihood:
             raise ValueError("posterior_probabilities do not match candidate_ids")
         if not np.all(np.isfinite(probabilities)) or np.any(probabilities < 0.0):
             raise ValueError("posterior_probabilities must be finite and non-negative")
-        if not np.isclose(float(np.sum(probabilities)), 1.0, atol=1e-12, rtol=1e-12):
+        if not np.isclose(
+            float(np.sum(probabilities)), 1.0, atol=1e-12, rtol=1e-12
+        ):
             raise ValueError("posterior_probabilities must sum to one")
         log_marginal = _finite_real(
             self.log_marginal_likelihood,
@@ -604,7 +608,9 @@ class GaussianIdentityMomentMatch:
             float(np.sum(probabilities)), 1.0, atol=1e-12, rtol=1e-12
         ):
             raise ValueError("probabilities must be non-negative and sum to one")
-        if not np.allclose(covariance, within + between, atol=1e-12, rtol=1e-12):
+        if not np.allclose(
+            covariance, within + between, atol=1e-12, rtol=1e-12
+        ):
             raise ValueError("total covariance must equal within plus between covariance")
         for name, value in (
             ("covariance", covariance),
@@ -630,9 +636,17 @@ class GaussianIdentityMomentMatch:
             raise ValueError("unsupported moment-match semantics")
         object.__setattr__(self, "identity_entropy_nats", entropy)
         object.__setattr__(self, "effective_hypothesis_count", effective)
-        object.__setattr__(self, "probabilities", _readonly(probabilities, dtype=np.float64))
+        object.__setattr__(
+            self,
+            "probabilities",
+            _readonly(probabilities, dtype=np.float64),
+        )
         object.__setattr__(self, "mean", _readonly(mean, dtype=np.float64))
-        object.__setattr__(self, "covariance", _readonly(covariance, dtype=np.float64))
+        object.__setattr__(
+            self,
+            "covariance",
+            _readonly(covariance, dtype=np.float64),
+        )
         object.__setattr__(
             self,
             "within_hypothesis_covariance",
@@ -674,7 +688,10 @@ def marginalize_identity_log_likelihoods(
         name="likelihood_power",
         minimum=0.0,
     )
-    prior_log_weights = np.asarray(mixture.normalized_log_weights, dtype=np.float64)
+    prior_log_weights = np.asarray(
+        mixture.normalized_log_weights,
+        dtype=np.float64,
+    )
     if power == 0.0:
         log_terms = prior_log_weights
     else:
@@ -712,12 +729,20 @@ def moment_match_gaussian_identity_hypotheses(
     mean_array = np.asarray(means, dtype=np.float64)
     covariance_array = np.asarray(covariances, dtype=np.float64)
     count = len(candidate_ids)
-    if mean_array.ndim != 2 or mean_array.shape[0] != count or mean_array.shape[1] < 1:
+    if (
+        mean_array.ndim != 2
+        or mean_array.shape[0] != count
+        or mean_array.shape[1] < 1
+    ):
         raise ValueError("means must have shape (candidate_count, dimension)")
     dimension = mean_array.shape[1]
     if covariance_array.shape != (count, dimension, dimension):
-        raise ValueError("covariances must have shape (candidate_count, dimension, dimension)")
-    if not np.all(np.isfinite(mean_array)) or not np.all(np.isfinite(covariance_array)):
+        raise ValueError(
+            "covariances must have shape (candidate_count, dimension, dimension)"
+        )
+    if not np.all(np.isfinite(mean_array)) or not np.all(
+        np.isfinite(covariance_array)
+    ):
         raise ValueError("means and covariances must be finite")
     for index, covariance in enumerate(covariance_array):
         if not np.allclose(covariance, covariance.T, atol=1e-12, rtol=1e-12):
@@ -848,7 +873,9 @@ def load_material_identity_mixture(path: str | Path) -> MaterialIdentityMixtureV
                 ),
             )
         )
-        supplied_ids.append(_sha256(raw_candidate["candidate_id"], name=f"{name}.candidate_id"))
+        supplied_ids.append(
+            _sha256(raw_candidate["candidate_id"], name=f"{name}.candidate_id")
+        )
     raw_window_order = payload["window_order"]
     if type(raw_window_order) is not list or not raw_window_order:
         raise ValueError("window_order must be a non-empty JSON array")

--- a/tests/test_material_identity_mixture.py
+++ b/tests/test_material_identity_mixture.py
@@ -1,0 +1,301 @@
+import copy
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from prob4d.material_identity_mixture import (
+    LocalTrackEndpoint,
+    MaterialIdentityCandidateV1,
+    MaterialIdentityMixtureV1,
+    load_material_identity_mixture,
+    marginalize_identity_log_likelihoods,
+    moment_match_gaussian_identity_hypotheses,
+    write_material_identity_mixture,
+)
+
+SHA_A = "a" * 64
+SHA_B = "b" * 64
+REVISION_C = "c" * 40
+REVISION_D = "d" * 40
+RESULT_E = "e" * 64
+RESULT_F = "f" * 64
+
+
+def make_mixture(
+    *,
+    reverse: bool = False,
+    null_log_weight: float = 0.0,
+) -> MaterialIdentityMixtureV1:
+    candidates = [
+        MaterialIdentityCandidateV1(
+            source_endpoint=None,
+            association_result_id=None,
+            source_score=None,
+            calibrated_log_weight=null_log_weight,
+            metadata={"role": "exact-fallback"},
+        ),
+        MaterialIdentityCandidateV1(
+            source_endpoint=LocalTrackEndpoint("window-0", 3),
+            association_result_id=RESULT_E,
+            source_score=0.9,
+            calibrated_log_weight=np.log(3.0),
+            metadata={"support": 4},
+        ),
+        MaterialIdentityCandidateV1(
+            source_endpoint=LocalTrackEndpoint("window-1", 8),
+            association_result_id=RESULT_F,
+            source_score=0.7,
+            calibrated_log_weight=np.log(2.0),
+        ),
+    ]
+    if reverse:
+        candidates.reverse()
+    return MaterialIdentityMixtureV1(
+        target_endpoint=LocalTrackEndpoint("window-2", 5),
+        causal_frame_stop=42,
+        association_rule_id=SHA_A,
+        calibration_id=SHA_B,
+        tracklet_producer_revision=REVISION_C,
+        association_revision=REVISION_D,
+        candidates=tuple(candidates),
+        metadata={"experiment": "source-only"},
+    )
+
+
+def test_candidate_order_is_canonical_and_content_addressed() -> None:
+    first = make_mixture()
+    second = make_mixture(reverse=True)
+
+    assert first.mixture_id == second.mixture_id
+    assert first.candidate_ids == second.candidate_ids
+    assert first.candidates[0].source_endpoint is None
+    np.testing.assert_allclose(first.probabilities, [1.0 / 6.0, 3.0 / 6.0, 2.0 / 6.0])
+    assert first.null_probability == pytest.approx(1.0 / 6.0)
+    assert first.effective_hypothesis_count > 2.0
+
+
+def test_null_only_mixture_reproduces_exact_likelihood_and_moments() -> None:
+    mixture = MaterialIdentityMixtureV1(
+        target_endpoint=LocalTrackEndpoint("newest", 0),
+        causal_frame_stop=10,
+        association_rule_id=SHA_A,
+        calibration_id=SHA_B,
+        tracklet_producer_revision=REVISION_C,
+        association_revision=REVISION_D,
+        candidates=(
+            MaterialIdentityCandidateV1(
+                source_endpoint=None,
+                association_result_id=None,
+                source_score=None,
+                calibrated_log_weight=12.0,
+            ),
+        ),
+    )
+    candidate_ids = mixture.candidate_ids
+    likelihood = marginalize_identity_log_likelihoods(
+        mixture,
+        candidate_ids,
+        np.array([-4.25]),
+    )
+    assert likelihood.log_marginal_likelihood == pytest.approx(-4.25)
+    np.testing.assert_array_equal(likelihood.posterior_probabilities, [1.0])
+
+    mean = np.array([[1.0, -2.0]])
+    covariance = np.array([[[0.4, 0.1], [0.1, 0.8]]])
+    result = moment_match_gaussian_identity_hypotheses(
+        mixture,
+        candidate_ids,
+        mean,
+        covariance,
+    )
+    np.testing.assert_array_equal(result.mean, mean[0])
+    np.testing.assert_array_equal(result.covariance, covariance[0])
+    np.testing.assert_array_equal(result.between_hypothesis_covariance, np.zeros((2, 2)))
+
+
+def test_likelihood_marginalization_uses_stable_logsumexp() -> None:
+    mixture = make_mixture()
+    log_likelihoods = np.array([-1000.0, -999.0, -1004.0])
+    result = marginalize_identity_log_likelihoods(
+        mixture,
+        mixture.candidate_ids,
+        log_likelihoods,
+    )
+
+    prior = mixture.probabilities
+    expected_terms = prior * np.exp(log_likelihoods - np.max(log_likelihoods))
+    expected_probabilities = expected_terms / np.sum(expected_terms)
+    expected_log_marginal = np.max(log_likelihoods) + np.log(np.sum(expected_terms))
+    np.testing.assert_allclose(result.posterior_probabilities, expected_probabilities)
+    assert result.log_marginal_likelihood == pytest.approx(expected_log_marginal)
+    assert result.posterior_probabilities[1] > 0.85
+
+
+def test_zero_likelihood_power_returns_source_prior_without_nan() -> None:
+    mixture = make_mixture()
+    result = marginalize_identity_log_likelihoods(
+        mixture,
+        mixture.candidate_ids,
+        np.array([-np.inf, -5.0, -np.inf]),
+        likelihood_power=0.0,
+    )
+
+    assert result.log_marginal_likelihood == pytest.approx(0.0)
+    np.testing.assert_allclose(result.posterior_probabilities, mixture.probabilities)
+
+
+def test_moment_matching_retains_between_hypothesis_uncertainty() -> None:
+    mixture = make_mixture(null_log_weight=np.log(2.0))
+    probabilities = np.array([0.25, 0.5, 0.25])
+    means = np.array([[0.0, 0.0], [2.0, 0.0], [0.0, 2.0]])
+    covariances = np.repeat(np.eye(2)[None, :, :] * 0.1, 3, axis=0)
+
+    result = moment_match_gaussian_identity_hypotheses(
+        mixture,
+        mixture.candidate_ids,
+        means,
+        covariances,
+        probabilities=probabilities,
+    )
+
+    np.testing.assert_allclose(result.mean, [1.0, 0.5])
+    np.testing.assert_allclose(result.within_hypothesis_covariance, np.eye(2) * 0.1)
+    np.testing.assert_allclose(
+        result.between_hypothesis_covariance,
+        [[1.0, -0.5], [-0.5, 0.75]],
+    )
+    np.testing.assert_allclose(
+        result.covariance,
+        result.within_hypothesis_covariance + result.between_hypothesis_covariance,
+    )
+
+
+def test_candidate_alignment_and_invalid_covariance_fail_closed() -> None:
+    mixture = make_mixture()
+    reversed_ids = tuple(reversed(mixture.candidate_ids))
+    with pytest.raises(ValueError, match="exactly match"):
+        marginalize_identity_log_likelihoods(
+            mixture,
+            reversed_ids,
+            np.zeros(3),
+        )
+    with pytest.raises(ValueError, match="impossible"):
+        marginalize_identity_log_likelihoods(
+            mixture,
+            mixture.candidate_ids,
+            np.full(3, -np.inf),
+        )
+    bad_covariance = np.repeat(np.eye(2)[None, :, :], 3, axis=0)
+    bad_covariance[0, 0, 0] = -1.0
+    with pytest.raises(ValueError, match="positive semidefinite"):
+        moment_match_gaussian_identity_hypotheses(
+            mixture,
+            mixture.candidate_ids,
+            np.zeros((3, 2)),
+            bad_covariance,
+        )
+
+
+def test_duplicate_source_endpoint_and_missing_null_are_rejected() -> None:
+    linked = MaterialIdentityCandidateV1(
+        source_endpoint=LocalTrackEndpoint("source", 1),
+        association_result_id=RESULT_E,
+        source_score=0.5,
+        calibrated_log_weight=0.0,
+    )
+    settings = {
+        "target_endpoint": LocalTrackEndpoint("target", 2),
+        "causal_frame_stop": 5,
+        "association_rule_id": SHA_A,
+        "calibration_id": SHA_B,
+        "tracklet_producer_revision": REVISION_C,
+        "association_revision": REVISION_D,
+    }
+    with pytest.raises(ValueError, match="exactly one null"):
+        MaterialIdentityMixtureV1(candidates=(linked,), **settings)
+    null = MaterialIdentityCandidateV1(
+        source_endpoint=None,
+        association_result_id=None,
+        source_score=None,
+        calibrated_log_weight=0.0,
+    )
+    with pytest.raises(ValueError, match="unique"):
+        MaterialIdentityMixtureV1(candidates=(null, linked, linked), **settings)
+    same_window = MaterialIdentityCandidateV1(
+        source_endpoint=LocalTrackEndpoint("target", 7),
+        association_result_id=RESULT_F,
+        source_score=0.4,
+        calibrated_log_weight=0.0,
+    )
+    with pytest.raises(ValueError, match="prior windows"):
+        MaterialIdentityMixtureV1(candidates=(null, same_window), **settings)
+
+
+def test_metadata_is_recursively_immutable() -> None:
+    mixture = make_mixture()
+    with pytest.raises(TypeError, match="immutable"):
+        mixture.metadata["new"] = 1  # type: ignore[index]
+    with pytest.raises(TypeError, match="immutable"):
+        mixture.candidates[0].metadata["new"] = 1  # type: ignore[index]
+    copied = copy.deepcopy(mixture.metadata)
+    copied["new"] = 1
+
+
+def test_atomic_round_trip_and_tamper_rejection(tmp_path: Path) -> None:
+    mixture = make_mixture()
+    path = tmp_path / "mixture.json"
+    write_material_identity_mixture(path, mixture)
+    loaded = load_material_identity_mixture(path)
+    assert loaded == mixture
+    assert path.read_bytes().endswith(b"\n")
+    with pytest.raises(FileExistsError):
+        write_material_identity_mixture(path, mixture)
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["mixture_id"] = "0" * 64
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError, match="mixture ID mismatch"):
+        load_material_identity_mixture(path)
+
+
+def test_loader_rejects_duplicate_keys_and_candidate_id_tampering(tmp_path: Path) -> None:
+    mixture = make_mixture()
+    path = tmp_path / "mixture.json"
+    write_material_identity_mixture(path, mixture)
+
+    duplicate = path.read_text(encoding="utf-8").replace(
+        '"schema_version":1',
+        '"schema_version":1,"schema_version":1',
+        1,
+    )
+    path.write_text(duplicate, encoding="utf-8")
+    with pytest.raises(ValueError, match="duplicate JSON object key"):
+        load_material_identity_mixture(path)
+
+    write_material_identity_mixture(path, mixture, overwrite=True)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["candidates"][0]["candidate_id"] = "1" * 64
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError, match="candidate ID mismatch"):
+        load_material_identity_mixture(path)
+
+
+def test_noncanonical_scalar_aliases_are_rejected() -> None:
+    with pytest.raises(ValueError, match="integer"):
+        LocalTrackEndpoint("window", True)
+    with pytest.raises(ValueError, match="real number"):
+        MaterialIdentityCandidateV1(
+            source_endpoint=None,
+            association_result_id=None,
+            source_score=None,
+            calibrated_log_weight="0",  # type: ignore[arg-type]
+        )
+    with pytest.raises(ValueError, match="at most 1.0"):
+        MaterialIdentityCandidateV1(
+            source_endpoint=LocalTrackEndpoint("window", 1),
+            association_result_id=RESULT_E,
+            source_score=1.1,
+            calibrated_log_weight=0.0,
+        )

--- a/tests/test_material_identity_mixture.py
+++ b/tests/test_material_identity_mixture.py
@@ -54,6 +54,7 @@ def make_mixture(
         candidates.reverse()
     return MaterialIdentityMixtureV1(
         target_endpoint=LocalTrackEndpoint("window-2", 5),
+        window_order=("window-0", "window-1", "window-2"),
         causal_frame_stop=42,
         association_rule_id=SHA_A,
         calibration_id=SHA_B,
@@ -79,6 +80,7 @@ def test_candidate_order_is_canonical_and_content_addressed() -> None:
 def test_null_only_mixture_reproduces_exact_likelihood_and_moments() -> None:
     mixture = MaterialIdentityMixtureV1(
         target_endpoint=LocalTrackEndpoint("newest", 0),
+        window_order=("newest",),
         causal_frame_stop=10,
         association_rule_id=SHA_A,
         calibration_id=SHA_B,
@@ -207,6 +209,7 @@ def test_duplicate_source_endpoint_and_missing_null_are_rejected() -> None:
     )
     settings = {
         "target_endpoint": LocalTrackEndpoint("target", 2),
+        "window_order": ("source", "target"),
         "causal_frame_stop": 5,
         "association_rule_id": SHA_A,
         "calibration_id": SHA_B,
@@ -229,8 +232,21 @@ def test_duplicate_source_endpoint_and_missing_null_are_rejected() -> None:
         source_score=0.4,
         calibrated_log_weight=0.0,
     )
-    with pytest.raises(ValueError, match="prior windows"):
+    with pytest.raises(ValueError, match="precede the target"):
         MaterialIdentityMixtureV1(candidates=(null, same_window), **settings)
+    future = MaterialIdentityCandidateV1(
+        source_endpoint=LocalTrackEndpoint("future", 9),
+        association_result_id=RESULT_F,
+        source_score=0.4,
+        calibrated_log_weight=0.0,
+    )
+    with pytest.raises(ValueError, match="precede the target"):
+        MaterialIdentityMixtureV1(candidates=(null, future), **settings)
+    with pytest.raises(ValueError, match="last in window_order"):
+        MaterialIdentityMixtureV1(
+            candidates=(null, linked),
+            **{**settings, "window_order": ("target", "source")},
+        )
 
 
 def test_metadata_is_recursively_immutable() -> None:


### PR DESCRIPTION
## What changed

- add `prob4d.material_identity_mixture`, an experimental portable contract for retaining uncertainty over cross-window material identity without rewriting provider observation IDs;
- preserve every hypothesis as a window-local `(window_id, track_id)` endpoint;
- bind an ordered admitted-window sequence with the target window last and require every linked source endpoint to precede it;
- require exactly one null hypothesis representing the unchanged newest-window reference and permit zero or more source-linked hypotheses;
- bind the association rule, source calibration, tracklet producer, association implementation, association result, source score, candidate order, metadata, and complete mixture through deterministic SHA-256 identities;
- add strict duplicate-key and exact-field JSON loading, recursively immutable metadata, read-only numerical results, and atomic persistence;
- provide exact downstream likelihood marginalization through stable `logsumexp` with candidate-ID alignment;
- provide Gaussian moment matching with an explicit between-hypothesis covariance term using the law of total covariance;
- make the NumPy array alias explicit for mypy and validate real-number coercion only after the runtime type guard;
- add documentation, focused read-only CI, and adversarial regression coverage.

## Why

The development study in `IPS-Stuttgart/BayesianPhysTwin#124` found that source-linked cross-window identity substantially improved the guarded physical query, while naive local-ID reuse was harmful. Hard mutual-best links still hide ambiguity. This change supplies the missing probabilistic consumer boundary: downstream inference can marginalize over retained local alternatives rather than promote one association to a global identity.

## Core invariants

- local Prob4D observation identities are never rewritten globally;
- the target window is last in a unique ordered window sequence;
- every linked source endpoint belongs to a window before the target;
- exactly one null hypothesis is always retained;
- a null-only mixture reproduces the fallback likelihood, mean, and covariance exactly;
- linked endpoints must be unique;
- source weights are explicitly calibration-bound and may not be fitted from target outcomes;
- likelihood rows must carry candidate IDs in the exact mixture order;
- moment matching retains both within-hypothesis and between-hypothesis covariance;
- the artifact does not decide BayesianPhysTwin update acceptance.

## Validation

Authoritative GitHub Actions passed on head `8047e183676319a36a57f76b85078bd3e31b9777`:

- repository-wide `Tests`: success;
- `Fail-closed quality`: success;
- focused `Material identity marginalization`: success;
- Ruff: all focused checks passed;
- mypy: no issues in `src/prob4d/material_identity_mixture.py`;
- focused regression suite: `11 passed`;
- installed-package public-module smoke: passed.

The focused type lane constrains only its validation environment to `numpy>=1.24,<2.3`, avoiding unsupported syntax in newer NumPy stubs while the repository continues to test its declared runtime dependency matrix independently.

## Scientific boundary

This is source-calibrated identity-uncertainty infrastructure and a prospective experiment arm. It does not establish real provider competence, independent physical-object benefit, calibrated deployment uncertainty, BayesianPhysTwin acceptance safety, Causal4D intervention benefit, or state of the art. Promotion requires a separately frozen object/session-held-out comparison of newest-window, hard-link, identity-marginalized, oracle, and exact-fallback arms.