### PR TITLE
Separate pre-target selection locks from deployment ledgers

### DIFF
--- a/.github/workflows/selection-lock.yml
+++ b/.github/workflows/selection-lock.yml
@@ -1,0 +1,86 @@
+name: Pre-target selection lock
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/selection-lock.yml"
+      - "docs/selection-lock.md"
+      - "src/prob4d/selection_lock.py"
+      - "src/prob4d/deployment_ledger.py"
+      - "src/prob4d/_selection_evidence_common.py"
+      - "src/prob4d/_selection_evidence_records.py"
+      - "src/prob4d/_selection_evidence_replay.py"
+      - "tests/test_selection_lock.py"
+      - "tests/test_selection_evidence.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: selection-lock-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONUNBUFFERED: "1"
+
+jobs:
+  focused-contract:
+    name: Target-free lock and append-only ledger
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install compatible development environment
+        run: |
+          python -m pip install -e ".[dev]"
+          python -m pip install "numpy>=1.24,<2.3"
+      - name: Check source quality
+        run: |
+          python -m ruff check \
+            src/prob4d/selection_lock.py \
+            src/prob4d/deployment_ledger.py \
+            tests/test_selection_lock.py
+          python -m ruff format --check \
+            src/prob4d/selection_lock.py \
+            src/prob4d/deployment_ledger.py \
+            tests/test_selection_lock.py
+          python -m mypy \
+            src/prob4d/selection_lock.py \
+            src/prob4d/deployment_ledger.py
+      - name: Run split and combined evidence regressions
+        run: >-
+          python -m pytest -q
+          tests/test_selection_lock.py
+          tests/test_selection_evidence.py
+      - name: Verify installed public modules
+        run: |
+          python - <<'PY'
+          from prob4d.deployment_ledger import (
+              DEPLOYMENT_LEDGER_SCHEMA,
+              DeploymentLedgerV1,
+              append_deployment_decision,
+          )
+          from prob4d.selection_lock import (
+              SELECTION_LOCK_SCHEMA,
+              SelectionLockV1,
+              build_selection_lock,
+          )
+
+          assert SELECTION_LOCK_SCHEMA == "prob4d.selection-lock"
+          assert DEPLOYMENT_LEDGER_SCHEMA == "prob4d.deployment-ledger"
+          assert callable(build_selection_lock)
+          assert callable(append_deployment_decision)
+          assert SelectionLockV1.__module__ == "prob4d.selection_lock"
+          assert DeploymentLedgerV1.__module__ == "prob4d.deployment_ledger"
+          PY

--- a/docs/selection-lock.md
+++ b/docs/selection-lock.md
@@ -1,0 +1,87 @@
+# Pre-target selection locks and deployment ledgers
+
+`prob4d.selection_lock` and `prob4d.deployment_ledger` separate two evidence
+stages that must not share one content identity:
+
+1. source-calibration candidate selection, sealed before target access; and
+2. target deployment decisions, appended only after the selection lock exists.
+
+The earlier `prob4d.selection_evidence` bundle remains a complete combined audit
+artifact. The split contracts provide a stronger temporal proof for prospective
+experiments without rewriting that version-2 artifact.
+
+## SelectionLockV1
+
+A selection lock contains:
+
+- the exact experiment, repository, and source revision;
+- every fully specified candidate;
+- the complete calibration object/session by candidate matrix;
+- the frozen objective, feasibility constraints, and tie-break rule;
+- the independently replayed complete candidate order;
+- the selected candidate; and
+- finite immutable metadata such as split-registry and calibration identities.
+
+It deliberately contains no deployment row and no target outcome. The lock ID and
+replay digest can therefore be committed to the code and paper repositories before
+opening target payloads.
+
+```python
+from prob4d.selection_lock import build_selection_lock, write_selection_lock
+
+lock = build_selection_lock(
+    experiment_id="prob4d-bpt-real-provider-v1",
+    source_repository="IPS-Stuttgart/Prob4D",
+    source_revision="<40-character lowercase Git SHA>",
+    candidates=candidates,
+    calibration_rows=calibration_rows,
+    selection_rule=selection_rule,
+    metadata={"split_registry_id": split_registry_id},
+)
+write_selection_lock(lock, "evidence/selection-lock.json")
+```
+
+Loading the JSON independently replays the complete candidate order and rejects
+missing matrix rows, duplicate keys, changed candidate order, changed selection,
+noncanonical provenance, altered claim boundaries, or content-ID mismatch.
+
+## DeploymentLedgerV1
+
+A deployment ledger is rooted at one exact `selection_lock_id`. The empty root can
+be serialized before deployment begins. Each append returns a new immutable ledger
+prefix while preserving the previous artifact and its ID:
+
+```python
+from prob4d.deployment_ledger import (
+    append_deployment_decision,
+    build_deployment_ledger,
+    write_deployment_ledger,
+)
+
+ledger = build_deployment_ledger(lock, metadata={"target_split": "sealed-v1"})
+write_deployment_ledger(ledger, "evidence/deployment-ledger-000.json")
+
+ledger = append_deployment_decision(ledger, decision)
+write_deployment_ledger(ledger, "evidence/deployment-ledger-001.json")
+```
+
+Every non-root ledger records the exact previous-prefix ID. Group IDs cannot be
+appended twice, every decision must use the locked candidate, and the existing
+`DeploymentDecisionV1` contract requires accepted decisions to deploy the exact
+candidate artifact and rejected decisions to deploy the exact fallback artifact.
+
+## Required prospective order
+
+```text
+retain complete source-calibration rows
+-> create and independently replay SelectionLockV1
+-> commit selection_lock_id before target access
+-> create empty DeploymentLedgerV1
+-> open each registered target unit under the frozen protocol
+-> append its guard decision and exact deployed artifact
+-> freeze target outcomes and run the separately registered analysis
+```
+
+Changing a target decision changes the deployment-ledger ID but cannot change the
+selection-lock ID. Neither artifact alone establishes provider competence or
+physical benefit; those remain object/session-level held-out analysis claims.

--- a/src/prob4d/deployment_ledger.py
+++ b/src/prob4d/deployment_ledger.py
@@ -1,0 +1,332 @@
+"""Append-only target deployment ledgers bound to a pre-target selection lock."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any
+
+from ._immutable_json import frozen_finite_json_mapping, plain_json
+from ._selection_evidence_common import (
+    _GIT_SHA,
+    _SHA256,
+    _exact_keys,
+    _sha256_json,
+    _strict_digest,
+    _strict_integer,
+    _strict_list,
+    _strict_mapping,
+    _strict_string,
+)
+from ._selection_evidence_records import DeploymentDecisionV1
+from .selection_lock import SelectionLockV1
+
+DEPLOYMENT_LEDGER_SCHEMA = "prob4d.deployment-ledger"
+DEPLOYMENT_LEDGER_VERSION = 1
+DEPLOYMENT_LEDGER_CLAIM_BOUNDARY = (
+    "This append-only ledger records target deployment decisions under one immutable "
+    "pre-target selection lock. It cannot change candidate selection. Accuracy or physical "
+    "benefit must be established by a separately frozen target analysis."
+)
+
+
+@dataclass(frozen=True, slots=True)
+class DeploymentLedgerV1:
+    """One immutable prefix of target deployment decisions."""
+
+    experiment_id: str
+    selection_lock_id: str
+    selected_candidate_id: str
+    source_repository: str
+    source_revision: str
+    decisions: tuple[DeploymentDecisionV1, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "experiment_id",
+            _strict_string(self.experiment_id, name="experiment_id"),
+        )
+        object.__setattr__(
+            self,
+            "selection_lock_id",
+            _strict_digest(
+                self.selection_lock_id,
+                name="selection_lock_id",
+                pattern=_SHA256,
+            ),
+        )
+        selected = _strict_string(
+            self.selected_candidate_id,
+            name="selected_candidate_id",
+        )
+        object.__setattr__(self, "selected_candidate_id", selected)
+        repository = _strict_string(self.source_repository, name="source_repository")
+        if repository.count("/") != 1 or repository.startswith("/") or repository.endswith("/"):
+            raise ValueError("source_repository must have owner/name form")
+        object.__setattr__(self, "source_repository", repository)
+        object.__setattr__(
+            self,
+            "source_revision",
+            _strict_digest(
+                self.source_revision,
+                name="source_revision",
+                pattern=_GIT_SHA,
+            ),
+        )
+        if type(self.decisions) is not tuple or not all(
+            isinstance(decision, DeploymentDecisionV1) for decision in self.decisions
+        ):
+            raise ValueError("decisions must be a tuple of DeploymentDecisionV1")
+        group_ids = tuple(decision.group_id for decision in self.decisions)
+        if len(set(group_ids)) != len(group_ids):
+            raise ValueError("deployment decision group IDs must be unique")
+        if any(decision.candidate_id != selected for decision in self.decisions):
+            raise ValueError("every deployment decision must use the locked candidate")
+        object.__setattr__(
+            self,
+            "metadata",
+            frozen_finite_json_mapping(self.metadata, name="metadata"),
+        )
+
+    def _base_descriptor(self) -> dict[str, object]:
+        return {
+            "schema_name": DEPLOYMENT_LEDGER_SCHEMA,
+            "schema_version": DEPLOYMENT_LEDGER_VERSION,
+            "experiment_id": self.experiment_id,
+            "selection_lock_id": self.selection_lock_id,
+            "selected_candidate_id": self.selected_candidate_id,
+            "source_repository": self.source_repository,
+            "source_revision": self.source_revision,
+            "metadata": plain_json(self.metadata),
+            "claim_boundary": DEPLOYMENT_LEDGER_CLAIM_BOUNDARY,
+        }
+
+    def _descriptor_for(
+        self,
+        decisions: tuple[DeploymentDecisionV1, ...],
+    ) -> dict[str, object]:
+        base = self._base_descriptor()
+        previous_id: str | None = None
+        for stop in range(len(decisions)):
+            prefix = {
+                **base,
+                "decisions": [decision.to_dict() for decision in decisions[:stop]],
+                "previous_ledger_id": previous_id,
+            }
+            previous_id = _sha256_json(prefix)
+        return {
+            **base,
+            "decisions": [decision.to_dict() for decision in decisions],
+            "previous_ledger_id": previous_id,
+        }
+
+    def descriptor(self) -> dict[str, object]:
+        return self._descriptor_for(self.decisions)
+
+    @property
+    def previous_ledger_id(self) -> str | None:
+        value = self.descriptor()["previous_ledger_id"]
+        return None if value is None else str(value)
+
+    @property
+    def deployment_ledger_id(self) -> str:
+        return _sha256_json(self.descriptor())
+
+    @property
+    def accepted_update_count(self) -> int:
+        return sum(decision.accepted for decision in self.decisions)
+
+    @property
+    def fallback_update_count(self) -> int:
+        return len(self.decisions) - self.accepted_update_count
+
+    @property
+    def exact_fallback_count(self) -> int:
+        return sum(
+            not decision.accepted and decision.exact_fallback_reproduced
+            for decision in self.decisions
+        )
+
+    def summary(self) -> dict[str, object]:
+        return {
+            "deployment_ledger_id": self.deployment_ledger_id,
+            "previous_ledger_id": self.previous_ledger_id,
+            "selection_lock_id": self.selection_lock_id,
+            "selected_candidate_id": self.selected_candidate_id,
+            "deployment_group_count": len(self.decisions),
+            "accepted_update_count": self.accepted_update_count,
+            "fallback_update_count": self.fallback_update_count,
+            "exact_fallback_count": self.exact_fallback_count,
+        }
+
+    def to_dict(self) -> dict[str, object]:
+        result = self.descriptor()
+        result["deployment_ledger_id"] = self.deployment_ledger_id
+        return result
+
+
+def build_deployment_ledger(
+    selection_lock: SelectionLockV1,
+    *,
+    metadata: Mapping[str, Any] | None = None,
+) -> DeploymentLedgerV1:
+    """Create an empty target ledger bound to one pre-target lock."""
+
+    if not isinstance(selection_lock, SelectionLockV1):
+        raise ValueError("selection_lock must be a SelectionLockV1")
+    return DeploymentLedgerV1(
+        experiment_id=selection_lock.experiment_id,
+        selection_lock_id=selection_lock.selection_lock_id,
+        selected_candidate_id=selection_lock.selected_candidate_id,
+        source_repository=selection_lock.source_repository,
+        source_revision=selection_lock.source_revision,
+        metadata={} if metadata is None else metadata,
+    )
+
+
+def append_deployment_decision(
+    ledger: DeploymentLedgerV1,
+    decision: DeploymentDecisionV1,
+) -> DeploymentLedgerV1:
+    """Return a new ledger prefix without mutating any prior artifact."""
+
+    if not isinstance(ledger, DeploymentLedgerV1):
+        raise ValueError("ledger must be a DeploymentLedgerV1")
+    if not isinstance(decision, DeploymentDecisionV1):
+        raise ValueError("decision must be a DeploymentDecisionV1")
+    if any(existing.group_id == decision.group_id for existing in ledger.decisions):
+        raise ValueError("deployment group was already appended")
+    return replace(ledger, decisions=(*ledger.decisions, decision))
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON key {key!r}")
+        result[key] = value
+    return result
+
+
+def deployment_ledger_from_dict(value: Any) -> DeploymentLedgerV1:
+    """Parse and fully validate one portable deployment-ledger prefix."""
+
+    mapping = _strict_mapping(value, name="deployment ledger")
+    _exact_keys(
+        mapping,
+        {
+            "schema_name",
+            "schema_version",
+            "experiment_id",
+            "selection_lock_id",
+            "selected_candidate_id",
+            "source_repository",
+            "source_revision",
+            "decisions",
+            "previous_ledger_id",
+            "metadata",
+            "claim_boundary",
+            "deployment_ledger_id",
+        },
+        name="deployment ledger",
+    )
+    if mapping["schema_name"] != DEPLOYMENT_LEDGER_SCHEMA:
+        raise ValueError("unsupported deployment ledger schema")
+    version = _strict_integer(mapping["schema_version"], name="schema_version", minimum=1)
+    if version != DEPLOYMENT_LEDGER_VERSION:
+        raise ValueError("unsupported deployment ledger version")
+    if mapping["claim_boundary"] != DEPLOYMENT_LEDGER_CLAIM_BOUNDARY:
+        raise ValueError("deployment ledger claim_boundary mismatch")
+    decision_values = _strict_list(mapping["decisions"], name="decisions")
+    ledger = DeploymentLedgerV1(
+        experiment_id=mapping["experiment_id"],
+        selection_lock_id=mapping["selection_lock_id"],
+        selected_candidate_id=mapping["selected_candidate_id"],
+        source_repository=mapping["source_repository"],
+        source_revision=mapping["source_revision"],
+        decisions=tuple(DeploymentDecisionV1.from_dict(item) for item in decision_values),
+        metadata=_strict_mapping(mapping["metadata"], name="metadata"),
+    )
+    serialized_previous = mapping["previous_ledger_id"]
+    if serialized_previous is not None:
+        serialized_previous = _strict_digest(
+            serialized_previous,
+            name="previous_ledger_id",
+            pattern=_SHA256,
+        )
+    ledger_id = _strict_digest(
+        mapping["deployment_ledger_id"],
+        name="deployment_ledger_id",
+        pattern=_SHA256,
+    )
+    if serialized_previous != ledger.previous_ledger_id:
+        raise ValueError("previous_ledger_id mismatch")
+    if ledger_id != ledger.deployment_ledger_id:
+        raise ValueError("deployment_ledger_id mismatch")
+    return ledger
+
+
+def write_deployment_ledger(
+    ledger: DeploymentLedgerV1,
+    path: str | os.PathLike[str],
+) -> None:
+    """Write one immutable deployment prefix atomically."""
+
+    if not isinstance(ledger, DeploymentLedgerV1):
+        raise ValueError("ledger must be a DeploymentLedgerV1")
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_name(f".{destination.name}.tmp")
+    temporary.write_text(
+        json.dumps(ledger.to_dict(), sort_keys=True, indent=2, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(temporary, destination)
+
+
+def load_deployment_ledger(path: str | os.PathLike[str]) -> DeploymentLedgerV1:
+    """Load and verify one portable ledger prefix and its previous-prefix identity."""
+
+    try:
+        value = json.loads(
+            Path(path).read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ValueError("deployment ledger is unreadable or invalid JSON") from error
+    return deployment_ledger_from_dict(value)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Verify a deployment ledger and print its compact summary."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("ledger", type=Path)
+    arguments = parser.parse_args(argv)
+    ledger = load_deployment_ledger(arguments.ledger)
+    print(json.dumps(ledger.summary(), sort_keys=True, indent=2, allow_nan=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "DEPLOYMENT_LEDGER_CLAIM_BOUNDARY",
+    "DEPLOYMENT_LEDGER_SCHEMA",
+    "DEPLOYMENT_LEDGER_VERSION",
+    "DeploymentDecisionV1",
+    "DeploymentLedgerV1",
+    "append_deployment_decision",
+    "build_deployment_ledger",
+    "deployment_ledger_from_dict",
+    "load_deployment_ledger",
+    "write_deployment_ledger",
+]

--- a/src/prob4d/selection_lock.py
+++ b/src/prob4d/selection_lock.py
@@ -1,0 +1,333 @@
+"""Pre-target selection locks for replayable source-calibration decisions.
+
+A selection lock contains only candidate definitions, the complete calibration
+matrix, and the frozen deterministic selection rule. Its content identity can be
+committed before any target deployment decision or target outcome is opened.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from ._immutable_json import frozen_finite_json_mapping, plain_json
+from ._selection_evidence_common import (
+    _GIT_SHA,
+    _SHA256,
+    MetricConstraintV1,
+    MetricOrderV1,
+    SelectionRuleV1,
+    _exact_keys,
+    _sha256_json,
+    _strict_digest,
+    _strict_integer,
+    _strict_list,
+    _strict_mapping,
+    _strict_string,
+)
+from ._selection_evidence_records import CalibrationMetricRowV1, CandidateSpecV1
+from ._selection_evidence_replay import (
+    SelectionReplayReportV1,
+    replay_candidate_order,
+)
+
+SELECTION_LOCK_SCHEMA = "prob4d.selection-lock"
+SELECTION_LOCK_VERSION = 1
+SELECTION_LOCK_CLAIM_BOUNDARY = (
+    "This artifact authenticates candidate selection from retained source-calibration "
+    "groups only. It contains no target deployment decision or target outcome. Physical "
+    "benefit requires a separately content-addressed deployment ledger and frozen target "
+    "analysis."
+)
+
+
+@dataclass(frozen=True, slots=True)
+class SelectionLockV1:
+    """Complete source-calibration decision sealed before target access."""
+
+    experiment_id: str
+    source_repository: str
+    source_revision: str
+    candidates: tuple[CandidateSpecV1, ...]
+    calibration_rows: tuple[CalibrationMetricRowV1, ...]
+    selection_rule: SelectionRuleV1
+    selection_order: tuple[str, ...]
+    selected_candidate_id: str
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "experiment_id",
+            _strict_string(self.experiment_id, name="experiment_id"),
+        )
+        repository = _strict_string(self.source_repository, name="source_repository")
+        if repository.count("/") != 1 or repository.startswith("/") or repository.endswith("/"):
+            raise ValueError("source_repository must have owner/name form")
+        object.__setattr__(self, "source_repository", repository)
+        object.__setattr__(
+            self,
+            "source_revision",
+            _strict_digest(
+                self.source_revision,
+                name="source_revision",
+                pattern=_GIT_SHA,
+            ),
+        )
+        if (
+            type(self.candidates) is not tuple
+            or not self.candidates
+            or not all(isinstance(candidate, CandidateSpecV1) for candidate in self.candidates)
+        ):
+            raise ValueError("candidates must be a nonempty tuple of CandidateSpecV1")
+        candidate_ids = tuple(candidate.candidate_id for candidate in self.candidates)
+        if candidate_ids != tuple(sorted(candidate_ids)) or len(set(candidate_ids)) != len(
+            candidate_ids
+        ):
+            raise ValueError("candidates must be sorted by unique candidate_id")
+        if (
+            type(self.calibration_rows) is not tuple
+            or not self.calibration_rows
+            or not all(isinstance(row, CalibrationMetricRowV1) for row in self.calibration_rows)
+        ):
+            raise ValueError("calibration_rows must be a nonempty tuple of CalibrationMetricRowV1")
+        row_keys = tuple((row.group_id, row.candidate_id) for row in self.calibration_rows)
+        if row_keys != tuple(sorted(row_keys)) or len(set(row_keys)) != len(row_keys):
+            raise ValueError("calibration_rows must be sorted by unique group/candidate key")
+        if not isinstance(self.selection_rule, SelectionRuleV1):
+            raise ValueError("selection_rule must be a SelectionRuleV1")
+        replayed_order, _ = replay_candidate_order(
+            self.candidates,
+            self.calibration_rows,
+            self.selection_rule,
+        )
+        if type(self.selection_order) is not tuple or self.selection_order != replayed_order:
+            raise ValueError("selection_order does not match deterministic replay")
+        selected = _strict_string(
+            self.selected_candidate_id,
+            name="selected_candidate_id",
+        )
+        if selected != replayed_order[0]:
+            raise ValueError("selected_candidate_id does not match deterministic replay")
+        object.__setattr__(self, "selected_candidate_id", selected)
+        object.__setattr__(
+            self,
+            "metadata",
+            frozen_finite_json_mapping(self.metadata, name="metadata"),
+        )
+
+    def descriptor(self) -> dict[str, object]:
+        return {
+            "schema_name": SELECTION_LOCK_SCHEMA,
+            "schema_version": SELECTION_LOCK_VERSION,
+            "experiment_id": self.experiment_id,
+            "source_repository": self.source_repository,
+            "source_revision": self.source_revision,
+            "candidates": [candidate.to_dict() for candidate in self.candidates],
+            "calibration_rows": [row.to_dict() for row in self.calibration_rows],
+            "selection_rule": self.selection_rule.to_dict(),
+            "selection_order": list(self.selection_order),
+            "selected_candidate_id": self.selected_candidate_id,
+            "metadata": plain_json(self.metadata),
+            "claim_boundary": SELECTION_LOCK_CLAIM_BOUNDARY,
+        }
+
+    @property
+    def selection_lock_id(self) -> str:
+        return _sha256_json(self.descriptor())
+
+    def replay_report(self) -> SelectionReplayReportV1:
+        order, summaries = replay_candidate_order(
+            self.candidates,
+            self.calibration_rows,
+            self.selection_rule,
+        )
+        return SelectionReplayReportV1(
+            evidence_artifact_id=self.selection_lock_id,
+            candidate_order=order,
+            selected_candidate_id=order[0],
+            candidate_summaries=summaries,
+            deployment_group_count=0,
+            accepted_update_count=0,
+            fallback_update_count=0,
+            exact_fallback_count=0,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        result = self.descriptor()
+        result["selection_lock_id"] = self.selection_lock_id
+        result["replay_digest"] = self.replay_report().replay_digest
+        return result
+
+
+def build_selection_lock(
+    *,
+    experiment_id: str,
+    source_repository: str,
+    source_revision: str,
+    candidates: Sequence[CandidateSpecV1],
+    calibration_rows: Sequence[CalibrationMetricRowV1],
+    selection_rule: SelectionRuleV1,
+    metadata: Mapping[str, Any] | None = None,
+) -> SelectionLockV1:
+    """Build one canonical lock without requiring any target-side records."""
+
+    candidate_tuple = tuple(sorted(candidates, key=lambda item: item.candidate_id))
+    row_tuple = tuple(sorted(calibration_rows, key=lambda item: (item.group_id, item.candidate_id)))
+    order, _ = replay_candidate_order(candidate_tuple, row_tuple, selection_rule)
+    return SelectionLockV1(
+        experiment_id=experiment_id,
+        source_repository=source_repository,
+        source_revision=source_revision,
+        candidates=candidate_tuple,
+        calibration_rows=row_tuple,
+        selection_rule=selection_rule,
+        selection_order=order,
+        selected_candidate_id=order[0],
+        metadata={} if metadata is None else metadata,
+    )
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON key {key!r}")
+        result[key] = value
+    return result
+
+
+def selection_lock_from_dict(value: Any) -> SelectionLockV1:
+    """Parse, validate, and independently replay one portable lock."""
+
+    mapping = _strict_mapping(value, name="selection lock")
+    _exact_keys(
+        mapping,
+        {
+            "schema_name",
+            "schema_version",
+            "experiment_id",
+            "source_repository",
+            "source_revision",
+            "candidates",
+            "calibration_rows",
+            "selection_rule",
+            "selection_order",
+            "selected_candidate_id",
+            "metadata",
+            "claim_boundary",
+            "selection_lock_id",
+            "replay_digest",
+        },
+        name="selection lock",
+    )
+    if mapping["schema_name"] != SELECTION_LOCK_SCHEMA:
+        raise ValueError("unsupported selection lock schema")
+    version = _strict_integer(mapping["schema_version"], name="schema_version", minimum=1)
+    if version != SELECTION_LOCK_VERSION:
+        raise ValueError("unsupported selection lock version")
+    if mapping["claim_boundary"] != SELECTION_LOCK_CLAIM_BOUNDARY:
+        raise ValueError("selection lock claim_boundary mismatch")
+    candidate_values = _strict_list(mapping["candidates"], name="candidates")
+    row_values = _strict_list(mapping["calibration_rows"], name="calibration_rows")
+    order_values = _strict_list(mapping["selection_order"], name="selection_order")
+    lock = SelectionLockV1(
+        experiment_id=mapping["experiment_id"],
+        source_repository=mapping["source_repository"],
+        source_revision=mapping["source_revision"],
+        candidates=tuple(CandidateSpecV1.from_dict(item) for item in candidate_values),
+        calibration_rows=tuple(CalibrationMetricRowV1.from_dict(item) for item in row_values),
+        selection_rule=SelectionRuleV1.from_dict(mapping["selection_rule"]),
+        selection_order=tuple(
+            _strict_string(item, name="selection_order item") for item in order_values
+        ),
+        selected_candidate_id=mapping["selected_candidate_id"],
+        metadata=_strict_mapping(mapping["metadata"], name="metadata"),
+    )
+    lock_id = _strict_digest(
+        mapping["selection_lock_id"],
+        name="selection_lock_id",
+        pattern=_SHA256,
+    )
+    replay_digest = _strict_digest(
+        mapping["replay_digest"],
+        name="replay_digest",
+        pattern=_SHA256,
+    )
+    if lock_id != lock.selection_lock_id:
+        raise ValueError("selection_lock_id mismatch")
+    if replay_digest != lock.replay_report().replay_digest:
+        raise ValueError("selection lock replay_digest mismatch")
+    return lock
+
+
+def write_selection_lock(lock: SelectionLockV1, path: str | os.PathLike[str]) -> None:
+    """Write one canonical lock atomically."""
+
+    if not isinstance(lock, SelectionLockV1):
+        raise ValueError("lock must be a SelectionLockV1")
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_name(f".{destination.name}.tmp")
+    temporary.write_text(
+        json.dumps(lock.to_dict(), sort_keys=True, indent=2, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(temporary, destination)
+
+
+def load_selection_lock(path: str | os.PathLike[str]) -> SelectionLockV1:
+    """Load and fully replay one portable lock."""
+
+    try:
+        value = json.loads(
+            Path(path).read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_keys,
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ValueError("selection lock is unreadable or invalid JSON") from error
+    return selection_lock_from_dict(value)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Verify a selection lock and print its target-free replay report."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("lock", type=Path)
+    arguments = parser.parse_args(argv)
+    lock = load_selection_lock(arguments.lock)
+    print(
+        json.dumps(
+            lock.replay_report().to_dict(),
+            sort_keys=True,
+            indent=2,
+            allow_nan=False,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "CalibrationMetricRowV1",
+    "CandidateSpecV1",
+    "MetricConstraintV1",
+    "MetricOrderV1",
+    "SELECTION_LOCK_CLAIM_BOUNDARY",
+    "SELECTION_LOCK_SCHEMA",
+    "SELECTION_LOCK_VERSION",
+    "SelectionLockV1",
+    "SelectionRuleV1",
+    "build_selection_lock",
+    "load_selection_lock",
+    "selection_lock_from_dict",
+    "write_selection_lock",
+]

--- a/tests/test_selection_lock.py
+++ b/tests/test_selection_lock.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+
+from prob4d.deployment_ledger import (
+    append_deployment_decision,
+    build_deployment_ledger,
+    deployment_ledger_from_dict,
+    load_deployment_ledger,
+    write_deployment_ledger,
+)
+from prob4d.selection_evidence import DeploymentDecisionV1
+from prob4d.selection_lock import (
+    CalibrationMetricRowV1,
+    CandidateSpecV1,
+    MetricConstraintV1,
+    MetricOrderV1,
+    SelectionRuleV1,
+    build_selection_lock,
+    load_selection_lock,
+    selection_lock_from_dict,
+    write_selection_lock,
+)
+
+SOURCE_REVISION = "a" * 40
+
+
+def candidates() -> tuple[CandidateSpecV1, ...]:
+    return (
+        CandidateSpecV1(
+            candidate_id="fallback",
+            method_id="physical-fallback",
+            complexity_rank=0,
+            parameters={"visual_update": False},
+        ),
+        CandidateSpecV1(
+            candidate_id="persistent-gauge",
+            method_id="persistent-explicit-joint-gauge",
+            complexity_rank=2,
+            parameters={"minimum_track_length": 3, "guard": 0.25},
+        ),
+        CandidateSpecV1(
+            candidate_id="overfit",
+            method_id="persistent-high-capacity",
+            complexity_rank=5,
+            parameters={"rank": 16},
+        ),
+    )
+
+
+def rows() -> tuple[CalibrationMetricRowV1, ...]:
+    values = {
+        ("object-a", "fallback"): (5.0, 0.0, 1.0),
+        ("object-b", "fallback"): (5.4, 0.0, 1.0),
+        ("object-a", "persistent-gauge"): (2.1, 0.0, 0.95),
+        ("object-b", "persistent-gauge"): (2.3, 0.0, 0.96),
+        ("object-a", "overfit"): (1.0, 0.0, 0.80),
+        ("object-b", "overfit"): (1.1, 0.0, 0.82),
+    }
+    return tuple(
+        CalibrationMetricRowV1(
+            group_id=group_id,
+            candidate_id=candidate_id,
+            metrics={
+                "rmse_mm": rmse,
+                "harmful_updates": harmful,
+                "coverage": coverage,
+            },
+        )
+        for (group_id, candidate_id), (rmse, harmful, coverage) in values.items()
+    )
+
+
+def rule() -> SelectionRuleV1:
+    return SelectionRuleV1(
+        primary=MetricOrderV1("rmse_mm", "minimize"),
+        tie_break_metrics=(MetricOrderV1("coverage", "maximize"),),
+        constraints=(
+            MetricConstraintV1("harmful_updates", "at_most", 0.0, "sum"),
+            MetricConstraintV1("coverage", "at_least", 0.9),
+        ),
+    )
+
+
+def selection_lock():
+    return build_selection_lock(
+        experiment_id="prob4d-bpt-real-provider-v1",
+        source_repository="IPS-Stuttgart/Prob4D",
+        source_revision=SOURCE_REVISION,
+        candidates=candidates(),
+        calibration_rows=rows(),
+        selection_rule=rule(),
+        metadata={"split_registry_id": "f" * 64},
+    )
+
+
+def decision(
+    group_id: str,
+    *,
+    accepted: bool,
+    guard_value: float,
+    candidate_id: str = "persistent-gauge",
+) -> DeploymentDecisionV1:
+    candidate_artifact_id = ("b" if group_id == "target-a" else "c") * 64
+    fallback_artifact_id = ("d" if group_id == "target-a" else "e") * 64
+    return DeploymentDecisionV1(
+        group_id=group_id,
+        candidate_id=candidate_id,
+        accepted=accepted,
+        guard_name="target-blind-residual-guard-v1",
+        guard_value=guard_value,
+        candidate_artifact_id=candidate_artifact_id,
+        fallback_artifact_id=fallback_artifact_id,
+        deployed_artifact_id=(candidate_artifact_id if accepted else fallback_artifact_id),
+        reason="accepted" if accepted else "guard rejection; exact fallback",
+    )
+
+
+def test_selection_lock_exists_before_any_target_deployment() -> None:
+    lock = selection_lock()
+
+    assert lock.selection_order == (
+        "persistent-gauge",
+        "fallback",
+        "overfit",
+    )
+    assert lock.selected_candidate_id == "persistent-gauge"
+    assert "decisions" not in lock.to_dict()
+    report = lock.replay_report()
+    assert report.deployment_group_count == 0
+    assert report.accepted_update_count == 0
+    assert report.fallback_update_count == 0
+    assert report.exact_fallback_count == 0
+
+
+def test_selection_lock_builder_is_input_order_invariant() -> None:
+    expected = selection_lock()
+    rebuilt = build_selection_lock(
+        experiment_id=expected.experiment_id,
+        source_repository=expected.source_repository,
+        source_revision=expected.source_revision,
+        candidates=tuple(reversed(candidates())),
+        calibration_rows=tuple(reversed(rows())),
+        selection_rule=rule(),
+        metadata={"split_registry_id": "f" * 64},
+    )
+
+    assert rebuilt.selection_lock_id == expected.selection_lock_id
+    assert rebuilt.replay_report().replay_digest == expected.replay_report().replay_digest
+
+
+def test_selection_lock_round_trip_and_tamper_rejection(tmp_path: Path) -> None:
+    lock = selection_lock()
+    path = tmp_path / "selection-lock.json"
+
+    write_selection_lock(lock, path)
+    loaded = load_selection_lock(path)
+    assert loaded.to_dict() == lock.to_dict()
+
+    selected_tamper = copy.deepcopy(lock.to_dict())
+    selected_tamper["selected_candidate_id"] = "fallback"
+    with pytest.raises(ValueError, match="selected_candidate_id"):
+        selection_lock_from_dict(selected_tamper)
+
+    boundary_tamper = copy.deepcopy(lock.to_dict())
+    boundary_tamper["claim_boundary"] = "selection may use target outcomes"
+    with pytest.raises(ValueError, match="claim_boundary"):
+        selection_lock_from_dict(boundary_tamper)
+
+    version_tamper = copy.deepcopy(lock.to_dict())
+    version_tamper["schema_version"] = True
+    with pytest.raises(ValueError, match="schema_version"):
+        selection_lock_from_dict(version_tamper)
+
+
+def test_selection_lock_rejects_incomplete_calibration_matrix() -> None:
+    with pytest.raises(ValueError, match="complete group-by-candidate matrix"):
+        build_selection_lock(
+            experiment_id="experiment",
+            source_repository="IPS-Stuttgart/Prob4D",
+            source_revision=SOURCE_REVISION,
+            candidates=candidates(),
+            calibration_rows=rows()[:-1],
+            selection_rule=rule(),
+        )
+
+
+def test_deployment_ledger_forms_an_immutable_hash_chain() -> None:
+    lock = selection_lock()
+    root = build_deployment_ledger(lock, metadata={"target_split": "sealed-v1"})
+    first = append_deployment_decision(
+        root,
+        decision("target-a", accepted=True, guard_value=0.1),
+    )
+    second = append_deployment_decision(
+        first,
+        decision("target-b", accepted=False, guard_value=0.8),
+    )
+
+    assert root.decisions == ()
+    assert root.previous_ledger_id is None
+    assert first.previous_ledger_id == root.deployment_ledger_id
+    assert second.previous_ledger_id == first.deployment_ledger_id
+    assert len(first.decisions) == 1
+    assert len(second.decisions) == 2
+    assert second.accepted_update_count == 1
+    assert second.fallback_update_count == 1
+    assert second.exact_fallback_count == 1
+    assert second.selection_lock_id == lock.selection_lock_id
+
+
+def test_ledger_append_rejects_duplicate_group_and_candidate_drift() -> None:
+    root = build_deployment_ledger(selection_lock())
+    first = append_deployment_decision(
+        root,
+        decision("target-a", accepted=True, guard_value=0.1),
+    )
+
+    with pytest.raises(ValueError, match="already appended"):
+        append_deployment_decision(
+            first,
+            decision("target-a", accepted=False, guard_value=2.0),
+        )
+    with pytest.raises(ValueError, match="locked candidate"):
+        append_deployment_decision(
+            first,
+            decision(
+                "target-b",
+                accepted=True,
+                guard_value=0.1,
+                candidate_id="fallback",
+            ),
+        )
+
+
+def test_deployment_ledger_round_trip_and_chain_tamper_rejection(
+    tmp_path: Path,
+) -> None:
+    ledger = append_deployment_decision(
+        append_deployment_decision(
+            build_deployment_ledger(selection_lock()),
+            decision("target-a", accepted=True, guard_value=0.1),
+        ),
+        decision("target-b", accepted=False, guard_value=0.8),
+    )
+    path = tmp_path / "deployment-ledger.json"
+
+    write_deployment_ledger(ledger, path)
+    loaded = load_deployment_ledger(path)
+    assert loaded.to_dict() == ledger.to_dict()
+
+    payload = copy.deepcopy(ledger.to_dict())
+    payload["previous_ledger_id"] = "0" * 64
+    with pytest.raises(ValueError, match="previous_ledger_id"):
+        deployment_ledger_from_dict(payload)
+
+
+def test_target_decisions_never_change_the_selection_lock_identity() -> None:
+    lock = selection_lock()
+    ledger = build_deployment_ledger(lock)
+    original_lock_id = lock.selection_lock_id
+
+    ledger = append_deployment_decision(
+        ledger,
+        decision("target-a", accepted=False, guard_value=99.0),
+    )
+    ledger = append_deployment_decision(
+        ledger,
+        decision("target-b", accepted=True, guard_value=-5.0),
+    )
+
+    assert lock.selection_lock_id == original_lock_id
+    assert ledger.selection_lock_id == original_lock_id
+    assert ledger.deployment_ledger_id != original_lock_id
+
+
+def test_duplicate_json_keys_fail_closed(tmp_path: Path) -> None:
+    path = tmp_path / "duplicate.json"
+    path.write_text(
+        '{"schema_name": "one", "schema_name": "two"}',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="duplicate JSON key"):
+        load_selection_lock(path)
+
+
+def test_written_lock_contains_complete_calibration_matrix(tmp_path: Path) -> None:
+    lock = selection_lock()
+    path = tmp_path / "selection-lock.json"
+    write_selection_lock(lock, path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+
+    assert len(payload["calibration_rows"]) == 6
+    assert payload["selection_lock_id"] == lock.selection_lock_id
+    assert payload["selection_order"] == [
+        "persistent-gauge",
+        "fallback",
+        "overfit",
+    ]


### PR DESCRIPTION
## What changed

- add `SelectionLockV1`, a content-addressed artifact containing only candidate definitions, the complete source-calibration group × candidate matrix, the frozen selection rule, the independently replayed candidate order, and the selected candidate;
- allow the lock and replay digest to exist before any target deployment row or target outcome is opened;
- add `DeploymentLedgerV1`, rooted at one exact selection-lock identity, with immutable append operations and a previous-prefix hash chain;
- preserve `DeploymentDecisionV1` exact-candidate/exact-fallback semantics for every appended target unit;
- reject candidate drift, duplicate target groups, broken prefix identities, duplicate JSON keys, altered claim boundaries, incomplete calibration matrices, and content-ID tampering;
- add atomic persistence, verifier entry points, documentation, and focused tests covering target-free locking, input-order invariance, exact fallback, append-only lineage, and separation of selection from deployment.

## Why

Merged PR #96 provides a complete combined audit artifact, but that artifact identity also contains later deployment decisions. This additive split gives a stronger temporal proof: the selection identity can be committed before target access, while target decisions are retained in a separate append-only ledger that cannot alter the locked choice.

## Validation

Clean head `892b1ead6db57a0d38b106a164d266d2dfeae4cf`, rebuilt directly on merged #96, passed:

- focused pre-target selection-lock and append-only-ledger workflow;
- Ruff and Ruff-format checks;
- mypy for both public modules;
- split-contract tests plus the existing combined-evidence regressions;
- fail-closed quality workflow;
- complete Python 3.10–3.14, dependency-floor, build, wheel/sdist, and installed-artifact workflow.

The final PR contains only the two public modules, documentation, tests, and one read-only hosted validation workflow. Temporary rebuild machinery is absent.

## Compatibility

This is additive to merged #96. `prob4d.selection_evidence` remains the complete combined audit artifact. No provider-v2 observation semantics, estimator, calibration method, BayesianPhysTwin guard, or Causal4D behavior changes.

## Scientific boundary

A valid lock proves only that the declared source-calibration selection can be reconstructed without target decisions. A valid ledger proves exact candidate/fallback deployment lineage. Physical benefit still requires the separately frozen object/session-level target analysis.