### PR TITLE
Superseded: harden project identity and source diagnostic contracts

### DIFF
--- a/docs/repository-identity.md
+++ b/docs/repository-identity.md
@@ -19,6 +19,13 @@ The descriptor currently contains:
 - historical alias `FlorianPfaff/Prob4D`; and
 - the repository string retained by frozen observation artifacts.
 
+Repository aliases are matched case-insensitively but are otherwise exact.
+Leading or trailing whitespace, string subclasses, and objects that merely
+provide a string representation fail closed rather than being normalized.
+Descriptor validation also requires exact JSON primitive types, so Boolean
+schema versions and tuple-for-array substitutions cannot compare equal to the
+canonical descriptor through Python coercion rules.
+
 ## Frozen artifact boundary
 
 Provider-v1 artifacts, causal-stream-v1/v2 artifacts, conformance vectors, and

--- a/docs/source-only-diagnostics.md
+++ b/docs/source-only-diagnostics.md
@@ -32,6 +32,11 @@ The metadata binds the common-gauge identity, immutable model-set identity,
 window IDs, frame IDs, and the fact that no alignment was performed inside the
 diagnostic.
 
+Feature names, common-gauge IDs, and model-set IDs are exact built-in strings.
+Leading or trailing whitespace, string subclasses, and objects that merely
+provide a string representation are rejected rather than normalized into a
+portable identity.
+
 ## Reliability augmentation
 
 Use `augment_source_reliability_features` to append one or more diagnostic grids
@@ -60,9 +65,14 @@ reliability calibration. Existing calibration artifacts remain unchanged.
 | high | high | detected failure |
 
 The disagreement and error thresholds are explicit inputs and should be frozen
-from development or calibration units. The low-disagreement/high-error rate and
-severity are evaluation outputs only; they must not be used to refit reliability
-on the same target outcomes.
+from development or calibration units. Thresholds must be genuine finite real
+scalars, and retained quadrant counts must be genuine non-negative integers.
+Numeric strings, booleans, and integral floats are not accepted as aliases.
+Empty low-disagreement/high-error cells require zero retained severity, while a
+non-empty cell must have a mean no greater than its maximum.
+
+The low-disagreement/high-error rate and severity are evaluation outputs only;
+they must not be used to refit reliability on the same target outcomes.
 
 These diagnostics do not establish that Prob4D observations improve a physical
 twin. Provider competence, BayesianPhysTwin acceptance, harmful accepted updates,

--- a/src/prob4d/_strict_json.py
+++ b/src/prob4d/_strict_json.py
@@ -41,6 +41,18 @@ def require_nonempty_string(value: Any, *, name: str) -> str:
     return value
 
 
+def require_exact_string(value: Any, *, name: str) -> str:
+    """Return one non-empty built-in string without silently normalizing it."""
+
+    if type(value) is not str:
+        raise ValueError(f"{name} must be a genuine string")
+    if not value:
+        raise ValueError(f"{name} must be a nonempty string")
+    if value != value.strip():
+        raise ValueError(f"{name} must not contain leading or trailing whitespace")
+    return value
+
+
 def require_exact_integer(
     value: Any,
     *,
@@ -159,6 +171,7 @@ __all__ = [
     "load_json_object",
     "require_exact_fields",
     "require_exact_integer",
+    "require_exact_string",
     "require_finite_json_mapping",
     "require_json_number",
     "require_mapping",

--- a/src/prob4d/project_identity.py
+++ b/src/prob4d/project_identity.py
@@ -1,8 +1,8 @@
 """Transfer-resistant identity for the Prob4D project.
 
 Historical observation artifacts deliberately retain the repository name that was
-current when their schemas were frozen.  Repository display names are therefore
-not suitable as the long-lived identity of the project.  This module publishes a
+current when their schemas were frozen. Repository display names are therefore
+not suitable as the long-lived identity of the project. This module publishes a
 stable GitHub repository ID, the current canonical name, and the accepted
 historical aliases without changing any frozen provider-v1 or causal-stream
 payload.
@@ -14,6 +14,8 @@ import argparse
 import json
 from collections.abc import Mapping, Sequence
 from typing import Any, Final
+
+from ._strict_json import require_exact_string
 
 PROB4D_PROJECT_IDENTITY_SCHEMA: Final = "prob4d.project-identity"
 PROB4D_PROJECT_IDENTITY_VERSION: Final = 1
@@ -37,16 +39,26 @@ _IDENTITY_FIELDS: Final = frozenset(
         "accepted_repository_aliases",
     }
 )
+_STRING_IDENTITY_FIELDS: Final = (
+    "schema_name",
+    "project_id",
+    "canonical_repository",
+    "frozen_artifact_repository",
+)
+_INTEGER_IDENTITY_FIELDS: Final = (
+    "schema_version",
+    "github_repository_id",
+)
 
 
 def canonical_prob4d_repository(value: object) -> str:
     """Return the canonical repository name for a recognized Prob4D alias.
 
-    GitHub repository names are case-insensitive.  Whitespace and unrelated
-    repositories fail closed instead of being silently normalized.
+    GitHub repository names are case-insensitive. Whitespace, coercible objects,
+    and unrelated repositories fail closed instead of being silently normalized.
     """
 
-    repository = str(value).strip()
+    repository = require_exact_string(value, name="Prob4D repository identity")
     for alias in PROB4D_REPOSITORY_ALIASES:
         if repository.casefold() == alias.casefold():
             return PROB4D_CANONICAL_REPOSITORY
@@ -78,9 +90,12 @@ def prob4d_project_identity() -> dict[str, object]:
 
 
 def validate_prob4d_project_identity(value: Mapping[str, Any]) -> dict[str, object]:
-    """Validate and normalize a project-identity descriptor."""
+    """Validate one descriptor without accepting coercible primitive aliases."""
 
-    fields = set(value)
+    field_names = tuple(value)
+    if any(type(field) is not str for field in field_names):
+        raise ValueError("Prob4D project-identity field names must be genuine strings")
+    fields = set(field_names)
     if fields != _IDENTITY_FIELDS:
         missing = sorted(_IDENTITY_FIELDS - fields)
         extra = sorted(fields - _IDENTITY_FIELDS)
@@ -88,7 +103,30 @@ def validate_prob4d_project_identity(value: Mapping[str, Any]) -> dict[str, obje
             "Prob4D project-identity fields changed; "
             f"missing={missing}, extra={extra}"
         )
+
     normalized = dict(value)
+    for field in _STRING_IDENTITY_FIELDS:
+        require_exact_string(
+            normalized[field],
+            name=f"Prob4D project-identity {field}",
+        )
+    for field in _INTEGER_IDENTITY_FIELDS:
+        if type(normalized[field]) is not int:
+            raise ValueError(
+                f"Prob4D project-identity {field} must be a genuine integer"
+            )
+
+    aliases = normalized["accepted_repository_aliases"]
+    if type(aliases) is not list:
+        raise ValueError(
+            "Prob4D project-identity accepted_repository_aliases must be a JSON array"
+        )
+    for index, alias in enumerate(aliases):
+        require_exact_string(
+            alias,
+            name=f"Prob4D project-identity accepted_repository_aliases[{index}]",
+        )
+
     expected = prob4d_project_identity()
     if normalized != expected:
         raise ValueError("Prob4D project-identity descriptor does not match this project")

--- a/src/prob4d/source_diagnostics.py
+++ b/src/prob4d/source_diagnostics.py
@@ -1,7 +1,7 @@
 """Source-side diagnostics for common-mode observation failures.
 
 Overlap disagreement detects mutually inconsistent windows, but a shared visual
-backbone can be confidently wrong in every window.  This module adds diagnostics
+backbone can be confidently wrong in every window. This module adds diagnostics
 that remain independent of Bayesian-PhysTwin innovations and target labels:
 
 - one-step consistency between decoded point motion and predicted scene flow;
@@ -21,6 +21,8 @@ import numpy as np
 from numpy.typing import NDArray
 
 from ._immutable_json import frozen_finite_json_mapping, plain_json
+from ._scientific_scalars import require_finite_real, require_genuine_integer
+from ._strict_json import require_exact_string
 from .data import PredictionWindow
 from .source_reliability import SourceReliabilityFeatures
 
@@ -44,8 +46,18 @@ class SourceOnlyDiagnosticGrid:
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        names = tuple(str(value).strip() for value in self.feature_names)
-        if not names or any(not value for value in names):
+        if type(self.feature_names) is not tuple:
+            raise TypeError(
+                "diagnostic feature_names must be a canonical tuple of strings"
+            )
+        names = tuple(
+            require_exact_string(
+                value,
+                name=f"diagnostic feature_names[{index}]",
+            )
+            for index, value in enumerate(self.feature_names)
+        )
+        if not names:
             raise ValueError("diagnostic feature_names must be non-empty")
         if len(set(names)) != len(names):
             raise ValueError("diagnostic feature_names must be unique")
@@ -141,7 +153,7 @@ def build_flow_point_consistency_diagnostic(
     """Compare one-step decoded point displacement with predicted scene flow.
 
     The diagnostic assumes that ``scene_flow[t]`` predicts motion from local frame
-    ``t`` to local frame ``t + 1``.  It is opt-in and records this assumption in
+    ``t`` to local frame ``t + 1``. It is opt-in and records this assumption in
     metadata so a producer with different flow semantics cannot silently reuse it.
     """
 
@@ -228,7 +240,7 @@ def build_common_gauge_seed_dispersion_diagnostic(
 ) -> SourceOnlyDiagnosticGrid:
     """Measure empirical point dispersion across independently seeded predictions.
 
-    Every input must already be represented in the same declared gauge.  The
+    Every input must already be represented in the same declared gauge. The
     function deliberately does not align samples itself because target-informed or
     differently fitted gauges would change the meaning of empirical dispersion.
     """
@@ -236,10 +248,8 @@ def build_common_gauge_seed_dispersion_diagnostic(
     samples = list(windows)
     if len(samples) < 2:
         raise ValueError("seed dispersion requires at least two prediction windows")
-    gauge_id = str(common_gauge_id).strip()
-    model_identity = str(model_set_id).strip()
-    if not gauge_id or not model_identity:
-        raise ValueError("common_gauge_id and model_set_id must be non-empty")
+    gauge_id = require_exact_string(common_gauge_id, name="common_gauge_id")
+    model_identity = require_exact_string(model_set_id, name="model_set_id")
     window_ids = [window.window_id for window in samples]
     if len(set(window_ids)) != len(window_ids):
         raise ValueError("seed-dispersion window IDs must be unique")
@@ -332,12 +342,19 @@ class CommonModeFailureAudit:
     low_disagreement_high_error_max: float
 
     def __post_init__(self) -> None:
-        thresholds = np.asarray(
-            [self.disagreement_threshold, self.error_threshold],
-            dtype=np.float64,
+        disagreement_threshold = require_finite_real(
+            self.disagreement_threshold,
+            name="disagreement_threshold",
+            minimum=0.0,
         )
-        if not np.all(np.isfinite(thresholds)) or np.any(thresholds < 0.0):
-            raise ValueError("common-mode audit thresholds must be finite and non-negative")
+        error_threshold = require_finite_real(
+            self.error_threshold,
+            name="error_threshold",
+            minimum=0.0,
+        )
+        object.__setattr__(self, "disagreement_threshold", disagreement_threshold)
+        object.__setattr__(self, "error_threshold", error_threshold)
+
         count_names = (
             "valid_count",
             "low_disagreement_low_error_count",
@@ -346,24 +363,47 @@ class CommonModeFailureAudit:
             "high_disagreement_high_error_count",
         )
         for name in count_names:
-            value = getattr(self, name)
-            if isinstance(value, bool) or int(value) != value or value < 0:
-                raise ValueError(f"{name} must be a non-negative integer")
-            object.__setattr__(self, name, int(value))
+            normalized = require_genuine_integer(
+                getattr(self, name),
+                name=name,
+                minimum=0,
+            )
+            object.__setattr__(self, name, normalized)
         if self.valid_count < 1:
             raise ValueError("common-mode audit requires at least one valid row")
         total = sum(getattr(self, name) for name in count_names[1:])
         if total != self.valid_count:
             raise ValueError("common-mode quadrant counts do not sum to valid_count")
-        severity = np.asarray(
-            [
-                self.low_disagreement_high_error_mean,
-                self.low_disagreement_high_error_max,
-            ],
-            dtype=np.float64,
+
+        severity_mean = require_finite_real(
+            self.low_disagreement_high_error_mean,
+            name="low_disagreement_high_error_mean",
+            minimum=0.0,
         )
-        if not np.all(np.isfinite(severity)) or np.any(severity < 0.0):
-            raise ValueError("common-mode failure severity must be finite and non-negative")
+        severity_max = require_finite_real(
+            self.low_disagreement_high_error_max,
+            name="low_disagreement_high_error_max",
+            minimum=0.0,
+        )
+        if self.low_disagreement_high_error_count == 0:
+            if severity_mean != 0.0 or severity_max != 0.0:
+                raise ValueError(
+                    "empty low-disagreement/high-error cells require zero severity"
+                )
+        elif severity_mean > severity_max:
+            raise ValueError(
+                "low-disagreement/high-error mean cannot exceed its maximum"
+            )
+        object.__setattr__(
+            self,
+            "low_disagreement_high_error_mean",
+            severity_mean,
+        )
+        object.__setattr__(
+            self,
+            "low_disagreement_high_error_max",
+            severity_max,
+        )
 
     @property
     def low_disagreement_high_error_rate(self) -> float:
@@ -389,7 +429,7 @@ def audit_common_mode_failures(
     """Report the low-disagreement/high-error quadrant on opened evaluation data.
 
     Thresholds are explicit inputs and should be frozen from development or
-    calibration units.  This function is evaluation-only: its result must not be
+    calibration units. This function is evaluation-only: its result must not be
     used to refit a source-reliability model on the same target outcomes.
     """
 
@@ -410,15 +450,16 @@ def audit_common_mode_failures(
     if not np.any(valid):
         raise ValueError("common-mode audit has no valid rows")
 
-    disagreement_limit = float(disagreement_threshold)
-    error_limit = float(error_threshold)
-    if (
-        not np.isfinite(disagreement_limit)
-        or disagreement_limit < 0.0
-        or not np.isfinite(error_limit)
-        or error_limit < 0.0
-    ):
-        raise ValueError("common-mode thresholds must be finite and non-negative")
+    disagreement_limit = require_finite_real(
+        disagreement_threshold,
+        name="disagreement_threshold",
+        minimum=0.0,
+    )
+    error_limit = require_finite_real(
+        error_threshold,
+        name="error_threshold",
+        minimum=0.0,
+    )
 
     high_disagreement = disagreement > disagreement_limit
     high_error = errors > error_limit

--- a/tests/test_project_identity.py
+++ b/tests/test_project_identity.py
@@ -18,6 +18,15 @@ from prob4d.project_identity import (
 )
 
 
+class _RepositoryStringLike:
+    def __str__(self) -> str:
+        return PROB4D_CANONICAL_REPOSITORY
+
+
+class _RepositoryStringSubclass(str):
+    pass
+
+
 def test_project_identity_is_transfer_resistant_and_preserves_frozen_alias() -> None:
     descriptor = prob4d_project_identity()
 
@@ -51,11 +60,54 @@ def test_current_and_historical_repository_names_resolve_to_canonical() -> None:
         canonical_prob4d_repository("other/Prob4D")
 
 
+def test_repository_aliases_reject_normalization_and_string_coercion() -> None:
+    invalid_values = (
+        f" {PROB4D_CANONICAL_REPOSITORY}",
+        f"{PROB4D_CANONICAL_REPOSITORY} ",
+        "",
+        _RepositoryStringLike(),
+        _RepositoryStringSubclass(PROB4D_CANONICAL_REPOSITORY),
+        None,
+    )
+    for value in invalid_values:
+        with pytest.raises(ValueError):
+            canonical_prob4d_repository(value)
+        assert not is_prob4d_repository(value)
+
+
 def test_project_identity_rejects_modified_descriptors() -> None:
     descriptor = prob4d_project_identity()
     descriptor["canonical_repository"] = "other/Prob4D"
     with pytest.raises(ValueError, match="does not match"):
         validate_prob4d_project_identity(descriptor)
+
+
+def test_project_identity_rejects_coercible_primitive_aliases() -> None:
+    descriptor = prob4d_project_identity()
+    descriptor["schema_version"] = True
+    with pytest.raises(ValueError, match="schema_version must be a genuine integer"):
+        validate_prob4d_project_identity(descriptor)
+
+    descriptor = prob4d_project_identity()
+    descriptor["schema_name"] = _RepositoryStringSubclass(
+        str(descriptor["schema_name"])
+    )
+    with pytest.raises(ValueError, match="schema_name must be a genuine string"):
+        validate_prob4d_project_identity(descriptor)
+
+    descriptor = prob4d_project_identity()
+    descriptor["accepted_repository_aliases"] = tuple(
+        descriptor["accepted_repository_aliases"]
+    )
+    with pytest.raises(ValueError, match="must be a JSON array"):
+        validate_prob4d_project_identity(descriptor)
+
+
+def test_project_identity_rejects_non_string_field_names() -> None:
+    descriptor = prob4d_project_identity()
+    descriptor[1] = descriptor.pop("schema_name")  # type: ignore[index]
+    with pytest.raises(ValueError, match="field names must be genuine strings"):
+        validate_prob4d_project_identity(descriptor)  # type: ignore[arg-type]
 
 
 def test_project_identity_cli_emits_valid_json(capsys) -> None:

--- a/tests/test_source_diagnostics.py
+++ b/tests/test_source_diagnostics.py
@@ -5,12 +5,23 @@ import pytest
 
 from prob4d.data import PredictionWindow
 from prob4d.source_diagnostics import (
+    CommonModeFailureAudit,
+    SourceOnlyDiagnosticGrid,
     audit_common_mode_failures,
     augment_source_reliability_features,
     build_common_gauge_seed_dispersion_diagnostic,
     build_flow_point_consistency_diagnostic,
 )
 from prob4d.source_reliability import SourceReliabilityFeatures
+
+
+class _StringLike:
+    def __str__(self) -> str:
+        return "coerced-identifier"
+
+
+class _StringSubclass(str):
+    pass
 
 
 def _window(
@@ -42,6 +53,23 @@ def _window(
     )
 
 
+def _diagnostic_metadata() -> dict[str, bool]:
+    return {
+        "uses_truth": False,
+        "uses_downstream_physical_innovation": False,
+        "uses_association_probability": False,
+    }
+
+
+def _diagnostic_with_names(feature_names: object) -> SourceOnlyDiagnosticGrid:
+    return SourceOnlyDiagnosticGrid(
+        feature_names=feature_names,  # type: ignore[arg-type]
+        values=np.zeros((1, 1, 1), dtype=np.float64),
+        available_mask=np.ones((1, 1), dtype=bool),
+        metadata=_diagnostic_metadata(),
+    )
+
+
 def test_flow_point_consistency_is_zero_for_matching_one_step_flow() -> None:
     diagnostic = build_flow_point_consistency_diagnostic(_window("seed-1"))
 
@@ -65,6 +93,25 @@ def test_flow_point_consistency_detects_magnitude_and_direction_mismatch() -> No
     assert np.allclose(diagnostic.values[:-1, ..., 2], 1.0)
 
 
+def test_diagnostic_feature_names_reject_coercion_and_normalization() -> None:
+    with pytest.raises(TypeError, match="canonical tuple"):
+        _diagnostic_with_names(["feature"])
+    with pytest.raises(TypeError, match="canonical tuple"):
+        _diagnostic_with_names("feature")
+
+    invalid_tuples = (
+        (1,),
+        (" feature",),
+        ("feature ",),
+        ("",),
+        (_StringLike(),),
+        (_StringSubclass("feature"),),
+    )
+    for feature_names in invalid_tuples:
+        with pytest.raises(ValueError):
+            _diagnostic_with_names(feature_names)
+
+
 def test_seed_dispersion_requires_common_grid_and_reports_sample_spread() -> None:
     first = _window("seed-1")
     identical = _window("seed-2")
@@ -86,6 +133,31 @@ def test_seed_dispersion_requires_common_grid_and_reports_sample_spread() -> Non
     assert np.all(spread.values[..., 2] > 0.0)
     assert np.allclose(spread.values[..., 1], 1.0)
     assert spread.metadata["alignment_performed_by_diagnostic"] is False
+
+
+def test_seed_dispersion_rejects_noncanonical_identifiers() -> None:
+    windows = [_window("seed-1"), _window("seed-2")]
+    invalid_values = (
+        " identifier",
+        "identifier ",
+        "",
+        _StringLike(),
+        _StringSubclass("identifier"),
+        1,
+    )
+    for value in invalid_values:
+        with pytest.raises(ValueError):
+            build_common_gauge_seed_dispersion_diagnostic(
+                windows,
+                common_gauge_id=value,  # type: ignore[arg-type]
+                model_set_id="model-set-a",
+            )
+        with pytest.raises(ValueError):
+            build_common_gauge_seed_dispersion_diagnostic(
+                windows,
+                common_gauge_id="metric-anchor-a",
+                model_set_id=value,  # type: ignore[arg-type]
+            )
 
 
 def test_seed_dispersion_rejects_different_frame_identity() -> None:
@@ -141,3 +213,59 @@ def test_common_mode_audit_reports_all_four_quadrants() -> None:
     assert audit.low_disagreement_high_error_rate == pytest.approx(0.25)
     assert audit.low_disagreement_high_error_mean == pytest.approx(0.9)
     assert audit.to_dict()["low_disagreement_high_error_rate"] == pytest.approx(0.25)
+
+
+def test_common_mode_audit_rejects_coercible_scalars() -> None:
+    with pytest.raises(TypeError, match="genuine real scalar"):
+        audit_common_mode_failures(
+            np.asarray([0.1]),
+            np.asarray([0.1]),
+            disagreement_threshold="0.5",  # type: ignore[arg-type]
+            error_threshold=0.5,
+        )
+    with pytest.raises(TypeError, match="genuine real scalar"):
+        audit_common_mode_failures(
+            np.asarray([0.1]),
+            np.asarray([0.1]),
+            disagreement_threshold=False,
+            error_threshold=0.5,
+        )
+    with pytest.raises(TypeError, match="genuine integer"):
+        CommonModeFailureAudit(
+            disagreement_threshold=0.5,
+            error_threshold=0.5,
+            valid_count=1.0,  # type: ignore[arg-type]
+            low_disagreement_low_error_count=1,
+            high_disagreement_low_error_count=0,
+            low_disagreement_high_error_count=0,
+            high_disagreement_high_error_count=0,
+            low_disagreement_high_error_mean=0.0,
+            low_disagreement_high_error_max=0.0,
+        )
+
+
+def test_common_mode_audit_rejects_inconsistent_severity() -> None:
+    with pytest.raises(ValueError, match="require zero severity"):
+        CommonModeFailureAudit(
+            disagreement_threshold=0.5,
+            error_threshold=0.5,
+            valid_count=1,
+            low_disagreement_low_error_count=1,
+            high_disagreement_low_error_count=0,
+            low_disagreement_high_error_count=0,
+            high_disagreement_high_error_count=0,
+            low_disagreement_high_error_mean=0.1,
+            low_disagreement_high_error_max=0.1,
+        )
+    with pytest.raises(ValueError, match="mean cannot exceed"):
+        CommonModeFailureAudit(
+            disagreement_threshold=0.5,
+            error_threshold=0.5,
+            valid_count=1,
+            low_disagreement_low_error_count=0,
+            high_disagreement_low_error_count=0,
+            low_disagreement_high_error_count=1,
+            high_disagreement_high_error_count=0,
+            low_disagreement_high_error_mean=2.0,
+            low_disagreement_high_error_max=1.0,
+        )


### PR DESCRIPTION
Superseded by PR #112, which contains the byte-identical head and uses the repository’s trusted self-hosted recovery route because the GitHub-hosted jobs remained queued without runner assignment.