### PR TITLE
Add integrity-bound VGGT provider-neutral imports

### DIFF
--- a/.github/workflows/vggt-provider-neutral.yml
+++ b/.github/workflows/vggt-provider-neutral.yml
@@ -16,7 +16,7 @@ on:
       - "tests/test_vggt_provider_adapter.py"
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: vggt-provider-neutral-${{ github.ref }}
@@ -25,6 +25,7 @@ concurrency:
 jobs:
   contract:
     name: Integrity, causal lineage, and installed CLI
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-slim
     timeout-minutes: 20
     steps:
@@ -32,7 +33,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          persist-credentials: false
+          persist-credentials: true
           clean: true
 
       - name: Set up Python 3.12
@@ -48,7 +49,36 @@ jobs:
           python -m pip install -e ".[dev]"
           python -m pip check
 
+      - name: Apply deterministic Ruff formatting once
+        id: formatting
+        shell: bash
+        run: |
+          set -euo pipefail
+          files=(
+            src/prob4d/cli.py
+            src/prob4d/prediction_cli.py
+            src/prob4d/vggt_baseline.py
+            src/prob4d/vggt_integrity.py
+            src/prob4d/vggt_provider_adapter.py
+            tests/test_cli.py
+            tests/test_vggt_baseline.py
+            tests/test_vggt_provider_adapter.py
+          )
+          python -m ruff format -- "${files[@]}"
+          if git diff --quiet -- "${files[@]}"; then
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -- "${files[@]}"
+          git diff --cached --check
+          git commit -m "Apply Ruff formatting to the VGGT provider boundary"
+          git push origin HEAD:agent/vggt-provider-neutral-v1
+          echo "pushed=true" >> "$GITHUB_OUTPUT"
+
       - name: Check focused source quality
+        if: steps.formatting.outputs.pushed != 'true'
         run: |
           set -euo pipefail
           files=(
@@ -70,6 +100,7 @@ jobs:
             src/prob4d/vggt_provider_adapter.py
 
       - name: Run focused and adjacent tests
+        if: steps.formatting.outputs.pushed != 'true'
         run: |
           set -euo pipefail
           python -m pytest -q \
@@ -80,6 +111,7 @@ jobs:
           python -m compileall -q src/prob4d
 
       - name: Build and smoke-test the installed wheel
+        if: steps.formatting.outputs.pushed != 'true'
         run: |
           set -euo pipefail
           wheelhouse="$RUNNER_TEMP/vggt-provider-wheelhouse"

--- a/.github/workflows/vggt-provider-neutral.yml
+++ b/.github/workflows/vggt-provider-neutral.yml
@@ -40,8 +40,16 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
-          cache: pip
-          cache-dependency-path: pyproject.toml
+
+      - name: Isolate the self-hosted Python environment
+        shell: bash
+        run: |
+          set -euo pipefail
+          environment="$RUNNER_TEMP/prob4d-vggt-provider-venv"
+          python -m venv --clear "$environment"
+          "$environment/bin/python" -m ensurepip --upgrade
+          "$environment/bin/python" -m pip install --upgrade pip
+          echo "$environment/bin" >> "$GITHUB_PATH"
 
       - name: Install development environment
         run: |

--- a/.github/workflows/vggt-provider-neutral.yml
+++ b/.github/workflows/vggt-provider-neutral.yml
@@ -16,7 +16,7 @@ on:
       - "tests/test_vggt_provider_adapter.py"
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: vggt-provider-neutral-${{ github.ref }}
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-          persist-credentials: true
+          persist-credentials: false
           clean: true
 
       - name: Set up Python 3.12
@@ -57,36 +57,7 @@ jobs:
           python -m pip install -e ".[dev]"
           python -m pip check
 
-      - name: Apply deterministic Ruff formatting once
-        id: formatting
-        shell: bash
-        run: |
-          set -euo pipefail
-          files=(
-            src/prob4d/cli.py
-            src/prob4d/prediction_cli.py
-            src/prob4d/vggt_baseline.py
-            src/prob4d/vggt_integrity.py
-            src/prob4d/vggt_provider_adapter.py
-            tests/test_cli.py
-            tests/test_vggt_baseline.py
-            tests/test_vggt_provider_adapter.py
-          )
-          python -m ruff format -- "${files[@]}"
-          if git diff --quiet -- "${files[@]}"; then
-            echo "pushed=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add -- "${files[@]}"
-          git diff --cached --check
-          git commit -m "Apply Ruff formatting to the VGGT provider boundary"
-          git push origin HEAD:agent/vggt-provider-neutral-v1
-          echo "pushed=true" >> "$GITHUB_OUTPUT"
-
       - name: Check focused source quality
-        if: steps.formatting.outputs.pushed != 'true'
         run: |
           set -euo pipefail
           files=(
@@ -108,7 +79,6 @@ jobs:
             src/prob4d/vggt_provider_adapter.py
 
       - name: Run focused and adjacent tests
-        if: steps.formatting.outputs.pushed != 'true'
         run: |
           set -euo pipefail
           python -m pytest -q \
@@ -119,7 +89,6 @@ jobs:
           python -m compileall -q src/prob4d
 
       - name: Build and smoke-test the installed wheel
-        if: steps.formatting.outputs.pushed != 'true'
         run: |
           set -euo pipefail
           wheelhouse="$RUNNER_TEMP/vggt-provider-wheelhouse"

--- a/.github/workflows/vggt-provider-neutral.yml
+++ b/.github/workflows/vggt-provider-neutral.yml
@@ -55,6 +55,7 @@ jobs:
         run: |
           set -euo pipefail
           python -m pip install -e ".[dev]"
+          python -m pip install "numpy>=1.24,<2.3"
           python -m pip check
 
       - name: Check focused source quality

--- a/.github/workflows/vggt-provider-neutral.yml
+++ b/.github/workflows/vggt-provider-neutral.yml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   contract:
     name: Integrity, causal lineage, and installed CLI
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     timeout-minutes: 20
     steps:
       - name: Check out exact pull-request head

--- a/.github/workflows/vggt-provider-neutral.yml
+++ b/.github/workflows/vggt-provider-neutral.yml
@@ -26,7 +26,7 @@ jobs:
   contract:
     name: Integrity, causal lineage, and installed CLI
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-slim
+    runs-on: [self-hosted, Linux, X64, nvidia-smi]
     timeout-minutes: 20
     steps:
       - name: Check out exact pull-request head

--- a/.github/workflows/vggt-provider-neutral.yml
+++ b/.github/workflows/vggt-provider-neutral.yml
@@ -73,7 +73,7 @@ jobs:
           )
           python -m ruff check -- "${files[@]}"
           python -m ruff format --check --diff "${files[@]}"
-          python -m mypy \
+          python -m mypy --python-version 3.12 \
             src/prob4d/prediction_cli.py \
             src/prob4d/vggt_baseline.py \
             src/prob4d/vggt_integrity.py \

--- a/.github/workflows/vggt-provider-neutral.yml
+++ b/.github/workflows/vggt-provider-neutral.yml
@@ -1,0 +1,95 @@
+name: VGGT provider-neutral boundary
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/vggt-provider-neutral.yml"
+      - "docs/provider-neutral-predictions.md"
+      - "src/prob4d/cli.py"
+      - "src/prob4d/prediction_cli.py"
+      - "src/prob4d/vggt_baseline.py"
+      - "src/prob4d/vggt_integrity.py"
+      - "src/prob4d/vggt_provider_adapter.py"
+      - "tests/test_cli.py"
+      - "tests/test_vggt_baseline.py"
+      - "tests/test_vggt_provider_adapter.py"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: vggt-provider-neutral-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract:
+    name: Integrity, causal lineage, and installed CLI
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out exact pull-request head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+          clean: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install development environment
+        run: |
+          set -euo pipefail
+          python -m pip install -e ".[dev]"
+          python -m pip check
+
+      - name: Check focused source quality
+        run: |
+          set -euo pipefail
+          files=(
+            src/prob4d/cli.py
+            src/prob4d/prediction_cli.py
+            src/prob4d/vggt_baseline.py
+            src/prob4d/vggt_integrity.py
+            src/prob4d/vggt_provider_adapter.py
+            tests/test_cli.py
+            tests/test_vggt_baseline.py
+            tests/test_vggt_provider_adapter.py
+          )
+          python -m ruff check -- "${files[@]}"
+          python -m ruff format --check --diff "${files[@]}"
+          python -m mypy \
+            src/prob4d/prediction_cli.py \
+            src/prob4d/vggt_baseline.py \
+            src/prob4d/vggt_integrity.py \
+            src/prob4d/vggt_provider_adapter.py
+
+      - name: Run focused and adjacent tests
+        run: |
+          set -euo pipefail
+          python -m pytest -q \
+            tests/test_cli.py \
+            tests/test_prediction_provider_manifest.py \
+            tests/test_vggt_baseline.py \
+            tests/test_vggt_provider_adapter.py
+          python -m compileall -q src/prob4d
+
+      - name: Build and smoke-test the installed wheel
+        run: |
+          set -euo pipefail
+          wheelhouse="$RUNNER_TEMP/vggt-provider-wheelhouse"
+          python -m build --wheel --outdir "$wheelhouse"
+          wheel="$(find "$wheelhouse" -maxdepth 1 -name '*.whl' -print -quit)"
+          test -n "$wheel"
+          python -m venv "$RUNNER_TEMP/vggt-provider-wheel-venv"
+          installed="$RUNNER_TEMP/vggt-provider-wheel-venv/bin/python"
+          "$installed" -m pip install "$wheel"
+          "$RUNNER_TEMP/vggt-provider-wheel-venv/bin/prob4d" prediction --help
+          "$RUNNER_TEMP/vggt-provider-wheel-venv/bin/prob4d" \
+            prediction import-vggt --help
+          "$installed" -m pip check

--- a/docs/provider-neutral-predictions.md
+++ b/docs/provider-neutral-predictions.md
@@ -65,11 +65,65 @@ The imported dependence groups distinguish shared model/input-video dependence
 from stochastic-member identity. Different seeds from the same model are not
 silently described as independent providers.
 
+## Integrity-bound VGGT export and import
+
+The official VGGT baseline now writes a closed version-2 run record. Remote
+checkpoints require an exact immutable revision, which is passed through to
+`VGGT.from_pretrained`; local checkpoints are bound by their file SHA-256. The
+run record additionally binds the exact VGGT checkout, executed Prob4D loader
+module bytes, preprocessing mode, input-video bytes, and every cached prediction
+archive.
+
+```bash
+prob4d vggt baseline \
+  --dataset-root /data/Sintel_video \
+  --output-root outputs/vggt \
+  --vggt-root /opt/vggt \
+  --checkpoint facebook/VGGT-1B \
+  --checkpoint-revision <exact-40-character-revision> \
+  --resume
+```
+
+Convert one registered sample into canonical provider-neutral payloads without
+rerunning the model:
+
+```bash
+prob4d prediction import-vggt \
+  outputs/vggt/run-part-00.json \
+  outputs/vggt/provider/scene-a.json \
+  --sequence-id scene-a \
+  --sample-id scene-a/video.mp4 \
+  --dataset-root /data/Sintel_video \
+  --prediction-root outputs/vggt
+
+prob4d prediction validate \
+  outputs/vggt/provider/scene-a.json
+```
+
+By default the adapter exports both official VGGT point constructions,
+`world_points` and `depth_unprojected`. They receive the same model-set,
+input-video, provider-run, and deterministic-member dependence groups. They are
+alternative constructions from one model execution, not independent sensor
+likelihoods and not two votes for a downstream update.
+
+VGGT processes the complete supplied sequence jointly. Every exported output
+frame therefore records the full sequence as its source interval. For a clip
+starting at absolute frame 109, pass `--frame-start 109`; a causal cutoff admits
+the payload only after the complete supplied clip ends. A predictive experiment
+that needs an earlier cutoff must run VGGT on that prefix rather than relabel a
+full-sequence result as causal.
+
+The adapter declares `sequence-local-sim3`, no scene flow, and no stored camera
+rays. It verifies that the two official constructions share the same frame grid,
+camera extrinsics, and intrinsics before placing them in one manifest. Non-finite
+points are retained as an explicit invalid mask and replaced by zero only in the
+inactive canonical payload entries.
+
 ## Alternative providers
 
-An adapter for VGGT or another 4-D model should emit the same neutral contract
-from independently validated source bytes. It must declare one of the supported
-coordinate semantics:
+Another 4-D model should emit the same neutral contract from independently
+validated source bytes. It must declare one of the supported coordinate
+semantics:
 
 - `window-local-sim3`;
 - `sequence-local-sim3`;
@@ -97,6 +151,7 @@ from prob4d.prediction_provider_manifest import (
     save_prediction_provider_manifest,
     verify_prediction_provider_manifest,
 )
+from prob4d.vggt_provider_adapter import import_vggt_prediction_manifest
 ```
 
 `verify_prediction_provider_manifest` checks the content identity and, by

--- a/src/prob4d/cli.py
+++ b/src/prob4d/cli.py
@@ -158,11 +158,9 @@ def _ambiguous_observation_export(argv: Sequence[str] | None = None) -> int:
     arguments = list(() if argv is None else argv)
     help_requested = any(value in {"-h", "--help"} for value in arguments)
     lines = [
-        "usage: prob4d observation <export-calibrated|export-exploratory|export-v1> "
-        "[arguments]",
+        "usage: prob4d observation <export-calibrated|export-exploratory|export-v1> [arguments]",
         "",
-        "'prob4d observation export' is intentionally ambiguous and does not run "
-        "an exporter.",
+        "'prob4d observation export' is intentionally ambiguous and does not run an exporter.",
         "",
         "Choose one explicit contract:",
         "  export-calibrated   claim-bearing provider-v2 export",

--- a/src/prob4d/cli.py
+++ b/src/prob4d/cli.py
@@ -95,7 +95,7 @@ _ROUTES: Final[dict[Route, tuple[str, str, str]]] = {
         "validate explicit shared visual-bias nuisance sidecars",
     ),
     ("prediction",): (
-        "prob4d.prediction_provider_manifest",
+        "prob4d.prediction_cli",
         "main",
         "import and validate provider-neutral prediction manifests",
     ),

--- a/src/prob4d/prediction_cli.py
+++ b/src/prob4d/prediction_cli.py
@@ -1,0 +1,49 @@
+"""Grouped provider-neutral prediction command dispatcher."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from collections.abc import Sequence
+
+from .prediction_provider_manifest import main as legacy_prediction_main
+
+
+def _help_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="prob4d prediction",
+        description="import and validate provider-neutral prediction manifests",
+    )
+    subparsers = parser.add_subparsers(dest="command")
+    subparsers.add_parser(
+        "import-motioncrafter",
+        help="convert an integrity-bound MotionCrafter prediction bundle",
+    )
+    subparsers.add_parser(
+        "import-vggt",
+        help="convert an integrity-bound official VGGT sample",
+    )
+    subparsers.add_parser(
+        "validate",
+        help="strictly validate a neutral manifest and its payloads",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    if not arguments:
+        _help_parser().print_help()
+        return 0
+    if arguments[0] in {"-h", "--help"}:
+        _help_parser().parse_args(arguments)
+        return 0
+    if arguments[0] == "import-vggt":
+        from .vggt_provider_adapter import main as vggt_main
+
+        return int(vggt_main(arguments[1:]))
+    return int(legacy_prediction_main(arguments))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/prob4d/vggt_baseline.py
+++ b/src/prob4d/vggt_baseline.py
@@ -142,9 +142,7 @@ def load_vggt(
     checkpoint_path = Path(checkpoint)
     if checkpoint_path.is_file():
         if checkpoint_revision is not None:
-            raise ValueError(
-                "--checkpoint-revision is not permitted for a local checkpoint file"
-            )
+            raise ValueError("--checkpoint-revision is not permitted for a local checkpoint file")
         model = VGGT()
         state = torch.load(checkpoint_path, map_location="cpu", weights_only=True)
         model.load_state_dict(state)
@@ -199,23 +197,15 @@ def infer_sample(
         predictions = model(images)
 
     image_shape = tuple(images.shape[-2:])
-    extrinsics, intrinsics = pose_encoding_to_extri_intri(
-        predictions["pose_enc"], image_shape
-    )
+    extrinsics, intrinsics = pose_encoding_to_extri_intri(predictions["pose_enc"], image_shape)
     extrinsics_array = extrinsics[0].float().cpu().numpy()
     intrinsics_array = intrinsics[0].float().cpu().numpy()
     direct_points = predictions["world_points"][0].float().cpu().numpy()
     depth = predictions["depth"][0].float().cpu().numpy()
-    unprojected_points = unproject_depth_map_to_point_map(
-        depth, extrinsics_array, intrinsics_array
-    )
+    unprojected_points = unproject_depth_map_to_point_map(depth, extrinsics_array, intrinsics_array)
     return {
-        "world_points": canonicalize_to_first_camera(
-            direct_points, extrinsics_array
-        ),
-        "depth_unprojected": canonicalize_to_first_camera(
-            unprojected_points, extrinsics_array
-        ),
+        "world_points": canonicalize_to_first_camera(direct_points, extrinsics_array),
+        "depth_unprojected": canonicalize_to_first_camera(unprojected_points, extrinsics_array),
         "camera_extrinsics": extrinsics_array,
         "camera_intrinsics": intrinsics_array,
     }
@@ -270,9 +260,7 @@ def write_prediction_archive(
         )
         if path.exists():
             if not _archives_equal(path, temporary):
-                raise ValueError(
-                    f"refusing to replace different VGGT prediction {path}"
-                )
+                raise ValueError(f"refusing to replace different VGGT prediction {path}")
             return
         os.replace(temporary, path)
     finally:
@@ -306,16 +294,10 @@ def main(argv: Sequence[str] | None = None) -> int:
     if not samples:
         raise ValueError("selected VGGT partition contains no samples")
     checkpoint_path = Path(args.checkpoint)
-    checkpoint_sha256 = (
-        file_sha256(checkpoint_path) if checkpoint_path.is_file() else None
-    )
+    checkpoint_sha256 = file_sha256(checkpoint_path) if checkpoint_path.is_file() else None
     if checkpoint_sha256 is not None and args.checkpoint_revision is not None:
-        raise ValueError(
-            "--checkpoint-revision is not permitted for a local checkpoint file"
-        )
-    integrity_bound = (
-        checkpoint_sha256 is not None or args.checkpoint_revision is not None
-    )
+        raise ValueError("--checkpoint-revision is not permitted for a local checkpoint file")
+    integrity_bound = checkpoint_sha256 is not None or args.checkpoint_revision is not None
     if integrity_bound:
         checkpoint_identity(
             checkpoint=args.checkpoint,
@@ -341,8 +323,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     sample_records: list[dict[str, Any]] = []
     for sample_index, sample in enumerate(samples, start=1):
         output_paths = {
-            name: prediction_path(args.output_root, sample, name)
-            for name in VGGT_REPRESENTATIONS
+            name: prediction_path(args.output_root, sample, name) for name in VGGT_REPRESENTATIONS
         }
         if args.resume and all(path.exists() for path in output_paths.values()):
             print(f"[{sample_index}/{len(samples)}] verify {sample.video_path}", flush=True)

--- a/src/prob4d/vggt_baseline.py
+++ b/src/prob4d/vggt_baseline.py
@@ -3,17 +3,29 @@
 from __future__ import annotations
 
 import argparse
-import hashlib
 import json
+import os
 import subprocess
 import sys
 import tempfile
 import time
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 import numpy as np
+
+from .vggt_integrity import (
+    VGGT_REPRESENTATIONS,
+    build_run_record,
+    build_sample_record,
+    checkpoint_identity,
+    describe_prediction_archive,
+    file_sha256,
+    relative_member,
+    save_vggt_run_metadata,
+)
 
 
 @dataclass(frozen=True)
@@ -111,17 +123,12 @@ def git_commit(repository: Path) -> str:
     ).stdout.strip()
 
 
-def file_sha256(path: Path) -> str:
-    """Return a reproducibility checksum for a local checkpoint file."""
-
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
-
-
-def load_vggt(vggt_root: Path, checkpoint: str, device: str) -> tuple[Any, Any, Any, Any]:
+def load_vggt(
+    vggt_root: Path,
+    checkpoint: str,
+    checkpoint_revision: str | None,
+    device: str,
+) -> tuple[Any, Any, Any, Any]:
     """Load official VGGT model and conversion utilities lazily."""
 
     import torch
@@ -132,12 +139,23 @@ def load_vggt(vggt_root: Path, checkpoint: str, device: str) -> tuple[Any, Any, 
     from vggt.utils.load_fn import load_and_preprocess_images
     from vggt.utils.pose_enc import pose_encoding_to_extri_intri
 
-    if Path(checkpoint).is_file():
+    checkpoint_path = Path(checkpoint)
+    if checkpoint_path.is_file():
+        if checkpoint_revision is not None:
+            raise ValueError(
+                "--checkpoint-revision is not permitted for a local checkpoint file"
+            )
         model = VGGT()
-        state = torch.load(checkpoint, map_location="cpu", weights_only=True)
+        state = torch.load(checkpoint_path, map_location="cpu", weights_only=True)
         model.load_state_dict(state)
     else:
-        model = VGGT.from_pretrained(checkpoint)
+        if checkpoint_revision is None:
+            model = VGGT.from_pretrained(checkpoint)
+        else:
+            model = VGGT.from_pretrained(
+                checkpoint,
+                revision=checkpoint_revision,
+            )
     model.track_head = None
     model.eval().to(device)
     return (
@@ -172,20 +190,32 @@ def infer_sample(
     )
     with (
         torch.inference_mode(),
-        torch.amp.autocast(device_type="cuda", dtype=dtype, enabled=device.startswith("cuda")),
+        torch.amp.autocast(
+            device_type="cuda",
+            dtype=dtype,
+            enabled=device.startswith("cuda"),
+        ),
     ):
         predictions = model(images)
 
     image_shape = tuple(images.shape[-2:])
-    extrinsics, intrinsics = pose_encoding_to_extri_intri(predictions["pose_enc"], image_shape)
+    extrinsics, intrinsics = pose_encoding_to_extri_intri(
+        predictions["pose_enc"], image_shape
+    )
     extrinsics_array = extrinsics[0].float().cpu().numpy()
     intrinsics_array = intrinsics[0].float().cpu().numpy()
     direct_points = predictions["world_points"][0].float().cpu().numpy()
     depth = predictions["depth"][0].float().cpu().numpy()
-    unprojected_points = unproject_depth_map_to_point_map(depth, extrinsics_array, intrinsics_array)
+    unprojected_points = unproject_depth_map_to_point_map(
+        depth, extrinsics_array, intrinsics_array
+    )
     return {
-        "world_points": canonicalize_to_first_camera(direct_points, extrinsics_array),
-        "depth_unprojected": canonicalize_to_first_camera(unprojected_points, extrinsics_array),
+        "world_points": canonicalize_to_first_camera(
+            direct_points, extrinsics_array
+        ),
+        "depth_unprojected": canonicalize_to_first_camera(
+            unprojected_points, extrinsics_array
+        ),
         "camera_extrinsics": extrinsics_array,
         "camera_intrinsics": intrinsics_array,
     }
@@ -197,79 +227,205 @@ def prediction_path(output_root: Path, sample: Sample, representation: str) -> P
     return output_root / representation / sample.video_path.with_suffix(".npz")
 
 
-def parse_args() -> argparse.Namespace:
+def _archives_equal(first: Path, second: Path) -> bool:
+    expected_fields = {"point_map", "camera_extrinsics", "camera_intrinsics"}
+    try:
+        with np.load(first, allow_pickle=False) as first_archive:
+            with np.load(second, allow_pickle=False) as second_archive:
+                if set(first_archive.files) != expected_fields:
+                    return False
+                if set(second_archive.files) != expected_fields:
+                    return False
+                return all(
+                    np.array_equal(first_archive[name], second_archive[name])
+                    for name in sorted(expected_fields)
+                )
+    except (OSError, ValueError):
+        return False
+
+
+def write_prediction_archive(
+    path: Path,
+    *,
+    point_map: np.ndarray,
+    camera_extrinsics: np.ndarray,
+    camera_intrinsics: np.ndarray,
+) -> None:
+    """Write one prediction archive atomically without replacing different data."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.stem}.",
+        suffix=".npz",
+        dir=path.parent,
+    )
+    os.close(descriptor)
+    temporary = Path(temporary_name)
+    try:
+        np.savez_compressed(
+            temporary,
+            point_map=np.asarray(point_map, dtype=np.float16),
+            camera_extrinsics=np.asarray(camera_extrinsics, dtype=np.float32),
+            camera_intrinsics=np.asarray(camera_intrinsics, dtype=np.float32),
+        )
+        if path.exists():
+            if not _archives_equal(path, temporary):
+                raise ValueError(
+                    f"refusing to replace different VGGT prediction {path}"
+                )
+            return
+        os.replace(temporary, path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--dataset-root", type=Path, required=True)
     parser.add_argument("--output-root", type=Path, required=True)
     parser.add_argument("--vggt-root", type=Path, required=True)
     parser.add_argument("--checkpoint", default="facebook/VGGT-1B")
+    parser.add_argument(
+        "--checkpoint-revision",
+        help="exact remote checkpoint revision; required unless --checkpoint is a file",
+    )
     parser.add_argument("--device", default="cuda")
     parser.add_argument("--preprocess-mode", choices=("crop", "pad"), default="crop")
     parser.add_argument("--partition-index", type=int, default=0)
     parser.add_argument("--partition-count", type=int, default=1)
     parser.add_argument("--resume", action="store_true")
-    return parser.parse_args()
+    return parser.parse_args(list(argv) if argv is not None else None)
 
 
-def main() -> int:
-    args = parse_args()
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
     samples = select_partition(
         read_samples(args.dataset_root), args.partition_index, args.partition_count
     )
-    representations = ("world_points", "depth_unprojected")
-    model, image_loader, pose_converter, unprojector = load_vggt(
-        args.vggt_root, args.checkpoint, args.device
+    if not samples:
+        raise ValueError("selected VGGT partition contains no samples")
+    checkpoint_path = Path(args.checkpoint)
+    checkpoint_sha256 = (
+        file_sha256(checkpoint_path) if checkpoint_path.is_file() else None
     )
+    if checkpoint_sha256 is not None and args.checkpoint_revision is not None:
+        raise ValueError(
+            "--checkpoint-revision is not permitted for a local checkpoint file"
+        )
+    integrity_bound = (
+        checkpoint_sha256 is not None or args.checkpoint_revision is not None
+    )
+    if integrity_bound:
+        checkpoint_identity(
+            checkpoint=args.checkpoint,
+            checkpoint_sha256=checkpoint_sha256,
+            checkpoint_revision=args.checkpoint_revision,
+        )
+    else:
+        print(
+            "warning: remote checkpoint is unpinned; outputs remain a legacy "
+            "exploratory baseline and cannot be imported provider-neutrally",
+            file=sys.stderr,
+            flush=True,
+        )
+    model, image_loader, pose_converter, unprojector = load_vggt(
+        args.vggt_root,
+        args.checkpoint,
+        args.checkpoint_revision,
+        args.device,
+    )
+    vggt_revision = git_commit(args.vggt_root)
+    loader_sha256 = file_sha256(Path(__file__).resolve())
     started = time.time()
-    completed: list[str] = []
+    sample_records: list[dict[str, Any]] = []
     for sample_index, sample in enumerate(samples, start=1):
         output_paths = {
-            name: prediction_path(args.output_root, sample, name) for name in representations
+            name: prediction_path(args.output_root, sample, name)
+            for name in VGGT_REPRESENTATIONS
         }
         if args.resume and all(path.exists() for path in output_paths.values()):
-            print(f"[{sample_index}/{len(samples)}] skip {sample.video_path}", flush=True)
-            continue
-        print(f"[{sample_index}/{len(samples)}] infer {sample.video_path}", flush=True)
-        with tempfile.TemporaryDirectory(prefix="prob4d-vggt-") as temporary:
-            frame_paths = extract_video_frames(
-                args.dataset_root / sample.video_path, Path(temporary)
+            print(f"[{sample_index}/{len(samples)}] verify {sample.video_path}", flush=True)
+        else:
+            print(f"[{sample_index}/{len(samples)}] infer {sample.video_path}", flush=True)
+            with tempfile.TemporaryDirectory(prefix="prob4d-vggt-") as temporary:
+                frame_paths = extract_video_frames(
+                    args.dataset_root / sample.video_path, Path(temporary)
+                )
+                arrays = infer_sample(
+                    model=model,
+                    load_and_preprocess_images=image_loader,
+                    pose_encoding_to_extri_intri=pose_converter,
+                    unproject_depth_map_to_point_map=unprojector,
+                    frame_paths=frame_paths,
+                    device=args.device,
+                    preprocess_mode=args.preprocess_mode,
+                )
+            for representation, output_path in output_paths.items():
+                write_prediction_archive(
+                    output_path,
+                    point_map=arrays[representation],
+                    camera_extrinsics=arrays["camera_extrinsics"],
+                    camera_intrinsics=arrays["camera_intrinsics"],
+                )
+        members = [
+            describe_prediction_archive(
+                output_paths[representation],
+                representation=representation,
+                relative_path=relative_member(
+                    output_paths[representation],
+                    root=args.output_root,
+                    name=f"VGGT {representation} prediction path",
+                ),
             )
-            arrays = infer_sample(
-                model=model,
-                load_and_preprocess_images=image_loader,
-                pose_encoding_to_extri_intri=pose_converter,
-                unproject_depth_map_to_point_map=unprojector,
-                frame_paths=frame_paths,
-                device=args.device,
-                preprocess_mode=args.preprocess_mode,
+            for representation in VGGT_REPRESENTATIONS
+        ]
+        sample_records.append(
+            build_sample_record(
+                sample_id=sample.video_path.as_posix(),
+                input_video_path=args.dataset_root / sample.video_path,
+                representations=members,
             )
-        for representation, output_path in output_paths.items():
-            output_path.parent.mkdir(parents=True, exist_ok=True)
-            np.savez_compressed(
-                output_path,
-                point_map=arrays[representation].astype(np.float16),
-                camera_extrinsics=arrays["camera_extrinsics"].astype(np.float32),
-                camera_intrinsics=arrays["camera_intrinsics"].astype(np.float32),
-            )
-        completed.append(str(sample.video_path))
+        )
 
-    checkpoint_path = Path(args.checkpoint)
-    metadata = {
-        "method": "VGGT-1B",
-        "official_repository": "https://github.com/facebookresearch/vggt",
-        "vggt_commit": git_commit(args.vggt_root),
-        "checkpoint": args.checkpoint,
-        "checkpoint_sha256": (file_sha256(checkpoint_path) if checkpoint_path.is_file() else None),
-        "dataset_root": str(args.dataset_root.resolve()),
-        "preprocess_mode": args.preprocess_mode,
-        "partition_index": args.partition_index,
-        "partition_count": args.partition_count,
-        "completed": completed,
-        "elapsed_seconds": time.time() - started,
-    }
+    elapsed = time.time() - started
     args.output_root.mkdir(parents=True, exist_ok=True)
     metadata_path = args.output_root / f"run-part-{args.partition_index:02d}.json"
-    metadata_path.write_text(json.dumps(metadata, indent=2) + "\n", encoding="utf-8")
+    if integrity_bound:
+        metadata = build_run_record(
+            vggt_commit=vggt_revision,
+            loader_module_sha256=loader_sha256,
+            checkpoint=args.checkpoint,
+            checkpoint_sha256=checkpoint_sha256,
+            checkpoint_revision=args.checkpoint_revision,
+            preprocess_mode=args.preprocess_mode,
+            partition_index=args.partition_index,
+            partition_count=args.partition_count,
+            samples=sample_records,
+            dataset_root=args.dataset_root,
+            output_root=args.output_root,
+            elapsed_seconds=elapsed,
+        )
+        save_vggt_run_metadata(metadata_path, metadata)
+    else:
+        legacy_metadata = {
+            "method": "VGGT-1B",
+            "official_repository": "https://github.com/facebookresearch/vggt",
+            "vggt_commit": vggt_revision,
+            "checkpoint": args.checkpoint,
+            "checkpoint_sha256": None,
+            "dataset_root": str(args.dataset_root.resolve()),
+            "preprocess_mode": args.preprocess_mode,
+            "partition_index": args.partition_index,
+            "partition_count": args.partition_count,
+            "completed": [sample.video_path.as_posix() for sample in samples],
+            "elapsed_seconds": elapsed,
+            "integrity_bound": False,
+        }
+        metadata_path.write_text(
+            json.dumps(legacy_metadata, indent=2) + "\n",
+            encoding="utf-8",
+        )
     print(metadata_path)
     return 0
 

--- a/src/prob4d/vggt_integrity.py
+++ b/src/prob4d/vggt_integrity.py
@@ -151,9 +151,7 @@ def checkpoint_identity(
         name="VGGT checkpoint revision",
     )
     if (checksum is None) == (revision is None):
-        raise ValueError(
-            "exactly one of checkpoint_sha256 or checkpoint_revision is required"
-        )
+        raise ValueError("exactly one of checkpoint_sha256 or checkpoint_revision is required")
     if checksum is not None:
         return {"kind": "local-file-sha256", "value": checksum}
     assert revision is not None
@@ -315,10 +313,7 @@ def describe_prediction_archive(
 def member_identity_record(member: Mapping[str, Any]) -> dict[str, Any]:
     """Return path-independent prediction-member identity fields."""
 
-    return {
-        key: member[key]
-        for key in sorted(_MEMBER_FIELDS - {"path"})
-    }
+    return {key: member[key] for key in sorted(_MEMBER_FIELDS - {"path"})}
 
 
 def _validated_member(value: object) -> dict[str, Any]:
@@ -339,9 +334,7 @@ def _validated_member(value: object) -> dict[str, Any]:
             name="VGGT prediction byte_count",
             minimum=1,
         ),
-        "point_shape": list(
-            _require_shape(mapping["point_shape"], name="point_shape", rank=4)
-        ),
+        "point_shape": list(_require_shape(mapping["point_shape"], name="point_shape", rank=4)),
         "point_dtype": require_exact_string(mapping["point_dtype"], name="point_dtype"),
         "camera_extrinsics_shape": list(
             _require_shape(
@@ -398,9 +391,7 @@ def sample_identity_record(sample: Mapping[str, Any]) -> dict[str, Any]:
         "input_video_sha256": sample["input_video_sha256"],
         "input_video_byte_count": sample["input_video_byte_count"],
         "frame_count": sample["frame_count"],
-        "representations": [
-            member_identity_record(member) for member in representations
-        ],
+        "representations": [member_identity_record(member) for member in representations],
     }
 
 
@@ -786,9 +777,7 @@ def verify_sample_files(
     resolved: dict[str, Path] = {}
     for representation in selected:
         if representation not in by_name:
-            raise ValueError(
-                f"VGGT sample lacks representation {representation!r}"
-            )
+            raise ValueError(f"VGGT sample lacks representation {representation!r}")
         member = by_name[representation]
         path = resolve_member(
             Path(output_root),

--- a/src/prob4d/vggt_integrity.py
+++ b/src/prob4d/vggt_integrity.py
@@ -1,0 +1,838 @@
+"""Integrity-bound metadata for official VGGT prediction exports.
+
+The VGGT baseline is optional and GPU-heavy, but its provenance and cached
+prediction products can be validated with NumPy only.  This module defines a
+closed versioned run record, content identities for model/sample/run state, and
+confined file verification shared by the producer and provider-neutral adapter.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import tempfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path, PurePosixPath
+from typing import Any, Final
+
+import numpy as np
+
+from ._strict_json import (
+    load_json_object,
+    require_exact_fields,
+    require_exact_integer,
+    require_exact_string,
+    require_mapping,
+    require_revision,
+    require_sha256,
+)
+
+VGGT_RUN_SCHEMA: Final = "prob4d.vggt-baseline-run"
+VGGT_RUN_VERSION: Final = 2
+VGGT_REPRESENTATIONS: Final = ("world_points", "depth_unprojected")
+VGGT_OFFICIAL_REPOSITORY: Final = "facebookresearch/vggt"
+VGGT_METHOD: Final = "VGGT-1B"
+
+_MODEL_ID_DOMAIN: Final = "prob4d.vggt-model-set.v1"
+_SAMPLE_ID_DOMAIN: Final = "prob4d.vggt-sample-run.v1"
+_RUN_ID_DOMAIN: Final = "prob4d.vggt-run.v1"
+
+_MEMBER_FIELDS: Final = frozenset(
+    {
+        "representation",
+        "path",
+        "sha256",
+        "byte_count",
+        "point_shape",
+        "point_dtype",
+        "camera_extrinsics_shape",
+        "camera_extrinsics_dtype",
+        "camera_intrinsics_shape",
+        "camera_intrinsics_dtype",
+        "valid_point_count",
+        "invalid_point_count",
+    }
+)
+_SAMPLE_FIELDS: Final = frozenset(
+    {
+        "sample_id",
+        "sample_run_id",
+        "input_video_sha256",
+        "input_video_byte_count",
+        "frame_count",
+        "representations",
+    }
+)
+_RUN_FIELDS: Final = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "run_id",
+        "method",
+        "official_repository",
+        "vggt_commit",
+        "model_set_id",
+        "loader_module_sha256",
+        "checkpoint",
+        "checkpoint_sha256",
+        "checkpoint_revision",
+        "preprocess_mode",
+        "partition_index",
+        "partition_count",
+        "samples",
+        "dataset_root",
+        "output_root",
+        "elapsed_seconds",
+    }
+)
+
+
+def canonical_json_bytes(value: Mapping[str, Any]) -> bytes:
+    """Return deterministic finite JSON bytes for an identity record."""
+
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def record_id(domain: str, value: Mapping[str, Any]) -> str:
+    """Content-address one canonical record under an explicit domain."""
+
+    digest = hashlib.sha256()
+    digest.update(domain.encode("utf-8"))
+    digest.update(b"\0")
+    digest.update(canonical_json_bytes(value))
+    return digest.hexdigest()
+
+
+def file_sha256(path: str | Path) -> str:
+    """Return the SHA-256 of one ordinary readable file."""
+
+    digest = hashlib.sha256()
+    source = Path(path)
+    try:
+        with source.open("rb") as stream:
+            for block in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(block)
+    except OSError as error:
+        raise ValueError(f"cannot read {source.name!r}") from error
+    return digest.hexdigest()
+
+
+def _optional_sha256(value: object, *, name: str) -> str | None:
+    if value is None:
+        return None
+    return require_sha256(value, name=name)
+
+
+def _optional_revision(value: object, *, name: str) -> str | None:
+    if value is None:
+        return None
+    return require_revision(value, name=name)
+
+
+def checkpoint_identity(
+    *,
+    checkpoint: object,
+    checkpoint_sha256: object,
+    checkpoint_revision: object,
+) -> dict[str, str]:
+    """Validate and normalize one immutable local or remote checkpoint identity."""
+
+    locator = require_exact_string(checkpoint, name="VGGT checkpoint")
+    checksum = _optional_sha256(checkpoint_sha256, name="VGGT checkpoint SHA-256")
+    revision = _optional_revision(
+        checkpoint_revision,
+        name="VGGT checkpoint revision",
+    )
+    if (checksum is None) == (revision is None):
+        raise ValueError(
+            "exactly one of checkpoint_sha256 or checkpoint_revision is required"
+        )
+    if checksum is not None:
+        return {"kind": "local-file-sha256", "value": checksum}
+    assert revision is not None
+    return {
+        "kind": "remote-revision",
+        "locator": locator,
+        "value": revision,
+    }
+
+
+def build_model_set_id(
+    *,
+    vggt_commit: object,
+    checkpoint: object,
+    checkpoint_sha256: object,
+    checkpoint_revision: object,
+    preprocess_mode: object,
+) -> str:
+    """Bind VGGT code, exact checkpoint, and image preprocessing semantics."""
+
+    commit = require_revision(vggt_commit, name="VGGT commit")
+    preprocess = require_exact_string(preprocess_mode, name="VGGT preprocess mode")
+    if preprocess not in {"crop", "pad"}:
+        raise ValueError("VGGT preprocess mode must be 'crop' or 'pad'")
+    identity = {
+        "vggt_commit": commit,
+        "checkpoint": checkpoint_identity(
+            checkpoint=checkpoint,
+            checkpoint_sha256=checkpoint_sha256,
+            checkpoint_revision=checkpoint_revision,
+        ),
+        "preprocess_mode": preprocess,
+    }
+    return record_id(_MODEL_ID_DOMAIN, identity)
+
+
+def safe_relative_path(value: object, *, name: str) -> str:
+    """Require a confined portable POSIX-relative path."""
+
+    text = require_exact_string(value, name=name)
+    if "\\" in text:
+        raise ValueError(f"{name} must be a safe POSIX relative path")
+    path = PurePosixPath(text)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError(f"{name} must be a safe POSIX relative path")
+    return path.as_posix()
+
+
+def relative_member(path: Path, *, root: Path, name: str) -> str:
+    """Return one safe path relative to a declared root."""
+
+    root_resolved = root.resolve()
+    path_resolved = path.resolve()
+    try:
+        relative = path_resolved.relative_to(root_resolved)
+    except ValueError as error:
+        raise ValueError(f"{name} must lie inside its declared root") from error
+    return safe_relative_path(relative.as_posix(), name=name)
+
+
+def resolve_member(root: Path, relative_path: object, *, name: str) -> Path:
+    """Resolve a safe ordinary member without traversing symbolic links."""
+
+    relative = safe_relative_path(relative_path, name=name)
+    root_resolved = root.resolve()
+    current = root_resolved
+    for part in PurePosixPath(relative).parts:
+        current = current / part
+        if current.is_symlink():
+            raise ValueError(f"{name} must not traverse a symbolic link")
+    resolved = current.resolve()
+    try:
+        resolved.relative_to(root_resolved)
+    except ValueError as error:
+        raise ValueError(f"{name} escapes its declared root") from error
+    if not resolved.is_file():
+        raise ValueError(f"{name} is missing or is not an ordinary file")
+    return resolved
+
+
+def _shape_record(shape: Sequence[int]) -> list[int]:
+    return [int(value) for value in shape]
+
+
+def _require_shape(value: object, *, name: str, rank: int) -> tuple[int, ...]:
+    if not isinstance(value, list) or len(value) != rank:
+        raise ValueError(f"{name} must be a JSON array of length {rank}")
+    result = tuple(
+        require_exact_integer(item, name=f"{name}[{index}]", minimum=1)
+        for index, item in enumerate(value)
+    )
+    return result
+
+
+def describe_prediction_archive(
+    path: str | Path,
+    *,
+    representation: str,
+    relative_path: str,
+) -> dict[str, Any]:
+    """Validate and describe one official VGGT prediction archive."""
+
+    if representation not in VGGT_REPRESENTATIONS:
+        raise ValueError(f"unsupported VGGT representation {representation!r}")
+    source = Path(path)
+    safe_path = safe_relative_path(relative_path, name="VGGT prediction path")
+    expected_fields = {"point_map", "camera_extrinsics", "camera_intrinsics"}
+    try:
+        with np.load(source, allow_pickle=False) as archive:
+            fields = set(archive.files)
+            if fields != expected_fields:
+                raise ValueError(
+                    "VGGT prediction archive fields changed; "
+                    f"missing={sorted(expected_fields - fields)}, "
+                    f"extra={sorted(fields - expected_fields)}"
+                )
+            point_map = np.asarray(archive["point_map"])
+            extrinsics = np.asarray(archive["camera_extrinsics"])
+            intrinsics = np.asarray(archive["camera_intrinsics"])
+    except (OSError, ValueError) as error:
+        if isinstance(error, ValueError) and str(error).startswith("VGGT prediction"):
+            raise
+        raise ValueError(f"cannot load VGGT prediction archive {source.name!r}") from error
+
+    if point_map.ndim != 4 or point_map.shape[-1] != 3:
+        raise ValueError("VGGT point_map must have shape (T, H, W, 3)")
+    frame_count = int(point_map.shape[0])
+    if extrinsics.shape != (frame_count, 3, 4):
+        raise ValueError("VGGT camera_extrinsics must have shape (T, 3, 4)")
+    if intrinsics.shape != (frame_count, 3, 3):
+        raise ValueError("VGGT camera_intrinsics must have shape (T, 3, 3)")
+    if point_map.dtype.kind != "f":
+        raise ValueError("VGGT point_map must use a floating dtype")
+    if extrinsics.dtype.kind != "f" or intrinsics.dtype.kind != "f":
+        raise ValueError("VGGT camera matrices must use floating dtypes")
+    if not np.all(np.isfinite(extrinsics)) or not np.all(np.isfinite(intrinsics)):
+        raise ValueError("VGGT camera matrices must be finite")
+    valid = np.all(np.isfinite(point_map), axis=-1)
+    valid_count = int(np.count_nonzero(valid))
+    if valid_count == 0:
+        raise ValueError("VGGT prediction contains no finite 3-D point")
+    total = int(valid.size)
+    return {
+        "representation": representation,
+        "path": safe_path,
+        "sha256": file_sha256(source),
+        "byte_count": int(source.stat().st_size),
+        "point_shape": _shape_record(point_map.shape),
+        "point_dtype": str(point_map.dtype),
+        "camera_extrinsics_shape": _shape_record(extrinsics.shape),
+        "camera_extrinsics_dtype": str(extrinsics.dtype),
+        "camera_intrinsics_shape": _shape_record(intrinsics.shape),
+        "camera_intrinsics_dtype": str(intrinsics.dtype),
+        "valid_point_count": valid_count,
+        "invalid_point_count": total - valid_count,
+    }
+
+
+def member_identity_record(member: Mapping[str, Any]) -> dict[str, Any]:
+    """Return path-independent prediction-member identity fields."""
+
+    return {
+        key: member[key]
+        for key in sorted(_MEMBER_FIELDS - {"path"})
+    }
+
+
+def _validated_member(value: object) -> dict[str, Any]:
+    mapping = require_mapping(value, name="VGGT representation descriptor")
+    require_exact_fields(mapping, _MEMBER_FIELDS, name="VGGT representation descriptor")
+    representation = require_exact_string(
+        mapping["representation"],
+        name="VGGT representation",
+    )
+    if representation not in VGGT_REPRESENTATIONS:
+        raise ValueError(f"unsupported VGGT representation {representation!r}")
+    result: dict[str, Any] = {
+        "representation": representation,
+        "path": safe_relative_path(mapping["path"], name="VGGT prediction path"),
+        "sha256": require_sha256(mapping["sha256"], name="VGGT prediction SHA-256"),
+        "byte_count": require_exact_integer(
+            mapping["byte_count"],
+            name="VGGT prediction byte_count",
+            minimum=1,
+        ),
+        "point_shape": list(
+            _require_shape(mapping["point_shape"], name="point_shape", rank=4)
+        ),
+        "point_dtype": require_exact_string(mapping["point_dtype"], name="point_dtype"),
+        "camera_extrinsics_shape": list(
+            _require_shape(
+                mapping["camera_extrinsics_shape"],
+                name="camera_extrinsics_shape",
+                rank=3,
+            )
+        ),
+        "camera_extrinsics_dtype": require_exact_string(
+            mapping["camera_extrinsics_dtype"],
+            name="camera_extrinsics_dtype",
+        ),
+        "camera_intrinsics_shape": list(
+            _require_shape(
+                mapping["camera_intrinsics_shape"],
+                name="camera_intrinsics_shape",
+                rank=3,
+            )
+        ),
+        "camera_intrinsics_dtype": require_exact_string(
+            mapping["camera_intrinsics_dtype"],
+            name="camera_intrinsics_dtype",
+        ),
+        "valid_point_count": require_exact_integer(
+            mapping["valid_point_count"],
+            name="valid_point_count",
+            minimum=1,
+        ),
+        "invalid_point_count": require_exact_integer(
+            mapping["invalid_point_count"],
+            name="invalid_point_count",
+            minimum=0,
+        ),
+    }
+    point_shape = tuple(result["point_shape"])
+    frame_count = point_shape[0]
+    if tuple(result["camera_extrinsics_shape"]) != (frame_count, 3, 4):
+        raise ValueError("camera_extrinsics_shape disagrees with point_shape")
+    if tuple(result["camera_intrinsics_shape"]) != (frame_count, 3, 3):
+        raise ValueError("camera_intrinsics_shape disagrees with point_shape")
+    point_count = int(np.prod(point_shape[:-1]))
+    if result["valid_point_count"] + result["invalid_point_count"] != point_count:
+        raise ValueError("VGGT valid/invalid point counts disagree with point_shape")
+    return result
+
+
+def sample_identity_record(sample: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the portable identity record for one dataset sample."""
+
+    representations = sample["representations"]
+    assert isinstance(representations, list)
+    return {
+        "sample_id": sample["sample_id"],
+        "input_video_sha256": sample["input_video_sha256"],
+        "input_video_byte_count": sample["input_video_byte_count"],
+        "frame_count": sample["frame_count"],
+        "representations": [
+            member_identity_record(member) for member in representations
+        ],
+    }
+
+
+def build_sample_record(
+    *,
+    sample_id: str,
+    input_video_path: str | Path,
+    representations: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Create one path-confined, content-addressed sample record."""
+
+    normalized_sample_id = safe_relative_path(sample_id, name="VGGT sample_id")
+    video = Path(input_video_path)
+    if not video.is_file() or video.is_symlink():
+        raise ValueError("VGGT input video must be one ordinary file")
+    members = [_validated_member(member) for member in representations]
+    members.sort(key=lambda item: str(item["representation"]))
+    names = [str(item["representation"]) for item in members]
+    if not members or len(set(names)) != len(names):
+        raise ValueError("VGGT sample representations must be nonempty and unique")
+    frame_counts = {int(item["point_shape"][0]) for item in members}
+    if len(frame_counts) != 1:
+        raise ValueError("VGGT sample representations disagree on frame count")
+    record: dict[str, Any] = {
+        "sample_id": normalized_sample_id,
+        "sample_run_id": "",
+        "input_video_sha256": file_sha256(video),
+        "input_video_byte_count": int(video.stat().st_size),
+        "frame_count": frame_counts.pop(),
+        "representations": members,
+    }
+    record["sample_run_id"] = record_id(
+        _SAMPLE_ID_DOMAIN,
+        sample_identity_record(record),
+    )
+    return record
+
+
+def _validated_sample(value: object) -> dict[str, Any]:
+    mapping = require_mapping(value, name="VGGT sample record")
+    require_exact_fields(mapping, _SAMPLE_FIELDS, name="VGGT sample record")
+    raw_members = mapping["representations"]
+    if not isinstance(raw_members, list) or not raw_members:
+        raise ValueError("VGGT sample representations must be a nonempty JSON array")
+    members = [_validated_member(member) for member in raw_members]
+    names = [str(member["representation"]) for member in members]
+    if names != sorted(names) or len(set(names)) != len(names):
+        raise ValueError("VGGT sample representations must be sorted and unique")
+    frame_count = require_exact_integer(
+        mapping["frame_count"],
+        name="VGGT frame_count",
+        minimum=1,
+    )
+    if any(int(member["point_shape"][0]) != frame_count for member in members):
+        raise ValueError("VGGT member frame count disagrees with sample record")
+    result: dict[str, Any] = {
+        "sample_id": safe_relative_path(mapping["sample_id"], name="VGGT sample_id"),
+        "sample_run_id": require_sha256(
+            mapping["sample_run_id"],
+            name="VGGT sample_run_id",
+        ),
+        "input_video_sha256": require_sha256(
+            mapping["input_video_sha256"],
+            name="VGGT input-video SHA-256",
+        ),
+        "input_video_byte_count": require_exact_integer(
+            mapping["input_video_byte_count"],
+            name="VGGT input-video byte_count",
+            minimum=1,
+        ),
+        "frame_count": frame_count,
+        "representations": members,
+    }
+    expected = record_id(_SAMPLE_ID_DOMAIN, sample_identity_record(result))
+    if result["sample_run_id"] != expected:
+        raise ValueError("VGGT sample_run_id mismatch")
+    return result
+
+
+def run_identity_record(record: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the portable, path- and timing-independent run identity record."""
+
+    samples = record["samples"]
+    assert isinstance(samples, list)
+    return {
+        "method": record["method"],
+        "official_repository": record["official_repository"],
+        "vggt_commit": record["vggt_commit"],
+        "model_set_id": record["model_set_id"],
+        "loader_module_sha256": record["loader_module_sha256"],
+        "preprocess_mode": record["preprocess_mode"],
+        "partition_index": record["partition_index"],
+        "partition_count": record["partition_count"],
+        "samples": [sample_identity_record(sample) for sample in samples],
+    }
+
+
+def build_run_record(
+    *,
+    vggt_commit: str,
+    loader_module_sha256: str,
+    checkpoint: str,
+    checkpoint_sha256: str | None,
+    checkpoint_revision: str | None,
+    preprocess_mode: str,
+    partition_index: int,
+    partition_count: int,
+    samples: Sequence[Mapping[str, Any]],
+    dataset_root: str | Path,
+    output_root: str | Path,
+    elapsed_seconds: float,
+) -> dict[str, Any]:
+    """Create a closed version-2 VGGT run record."""
+
+    commit = require_revision(vggt_commit, name="VGGT commit")
+    loader_id = require_sha256(
+        loader_module_sha256,
+        name="VGGT loader-module SHA-256",
+    )
+    preprocess = require_exact_string(preprocess_mode, name="VGGT preprocess mode")
+    if preprocess not in {"crop", "pad"}:
+        raise ValueError("VGGT preprocess mode must be 'crop' or 'pad'")
+    index = require_exact_integer(partition_index, name="partition_index", minimum=0)
+    count = require_exact_integer(partition_count, name="partition_count", minimum=1)
+    if index >= count:
+        raise ValueError("partition_index must be smaller than partition_count")
+    normalized_samples = [_validated_sample(sample) for sample in samples]
+    normalized_samples.sort(key=lambda item: str(item["sample_id"]))
+    sample_ids = [str(item["sample_id"]) for item in normalized_samples]
+    if not normalized_samples or len(set(sample_ids)) != len(sample_ids):
+        raise ValueError("VGGT run samples must be nonempty and unique")
+    if type(elapsed_seconds) not in {int, float}:
+        raise ValueError("elapsed_seconds must be one finite JSON number")
+    elapsed = float(elapsed_seconds)
+    if not math.isfinite(elapsed) or elapsed < 0.0:
+        raise ValueError("elapsed_seconds must be finite and nonnegative")
+    checkpoint_name = require_exact_string(checkpoint, name="VGGT checkpoint")
+    checksum = _optional_sha256(
+        checkpoint_sha256,
+        name="VGGT checkpoint SHA-256",
+    )
+    revision = _optional_revision(
+        checkpoint_revision,
+        name="VGGT checkpoint revision",
+    )
+    model_set_id = build_model_set_id(
+        vggt_commit=commit,
+        checkpoint=checkpoint_name,
+        checkpoint_sha256=checksum,
+        checkpoint_revision=revision,
+        preprocess_mode=preprocess,
+    )
+    record: dict[str, Any] = {
+        "schema": VGGT_RUN_SCHEMA,
+        "schema_version": VGGT_RUN_VERSION,
+        "run_id": "",
+        "method": VGGT_METHOD,
+        "official_repository": VGGT_OFFICIAL_REPOSITORY,
+        "vggt_commit": commit,
+        "model_set_id": model_set_id,
+        "loader_module_sha256": loader_id,
+        "checkpoint": checkpoint_name,
+        "checkpoint_sha256": checksum,
+        "checkpoint_revision": revision,
+        "preprocess_mode": preprocess,
+        "partition_index": index,
+        "partition_count": count,
+        "samples": normalized_samples,
+        "dataset_root": str(Path(dataset_root).resolve()),
+        "output_root": str(Path(output_root).resolve()),
+        "elapsed_seconds": elapsed,
+    }
+    record["run_id"] = record_id(_RUN_ID_DOMAIN, run_identity_record(record))
+    return record
+
+
+def validate_run_record(value: object) -> dict[str, Any]:
+    """Strictly validate and normalize one VGGT run record."""
+
+    mapping = require_mapping(value, name="VGGT run metadata")
+    require_exact_fields(mapping, _RUN_FIELDS, name="VGGT run metadata")
+    schema = require_exact_string(mapping["schema"], name="VGGT run schema")
+    version = require_exact_integer(
+        mapping["schema_version"],
+        name="VGGT run schema_version",
+        minimum=1,
+    )
+    if schema != VGGT_RUN_SCHEMA:
+        raise ValueError("unsupported VGGT run metadata schema")
+    if version != VGGT_RUN_VERSION:
+        raise ValueError("unsupported VGGT run metadata version")
+    method = require_exact_string(mapping["method"], name="VGGT method")
+    repository = require_exact_string(
+        mapping["official_repository"],
+        name="VGGT official repository",
+    )
+    if method != VGGT_METHOD or repository != VGGT_OFFICIAL_REPOSITORY:
+        raise ValueError("VGGT method or official repository identity changed")
+    raw_samples = mapping["samples"]
+    if not isinstance(raw_samples, list) or not raw_samples:
+        raise ValueError("VGGT run samples must be a nonempty JSON array")
+    samples = [_validated_sample(sample) for sample in raw_samples]
+    sample_ids = [str(sample["sample_id"]) for sample in samples]
+    if sample_ids != sorted(sample_ids) or len(set(sample_ids)) != len(sample_ids):
+        raise ValueError("VGGT run samples must be sorted and unique")
+    index = require_exact_integer(
+        mapping["partition_index"],
+        name="partition_index",
+        minimum=0,
+    )
+    count = require_exact_integer(
+        mapping["partition_count"],
+        name="partition_count",
+        minimum=1,
+    )
+    if index >= count:
+        raise ValueError("partition_index must be smaller than partition_count")
+    if type(mapping["elapsed_seconds"]) not in {int, float}:
+        raise ValueError("elapsed_seconds must be one finite JSON number")
+    elapsed = float(mapping["elapsed_seconds"])
+    if not math.isfinite(elapsed) or elapsed < 0.0:
+        raise ValueError("elapsed_seconds must be finite and nonnegative")
+    commit = require_revision(mapping["vggt_commit"], name="VGGT commit")
+    checkpoint_name = require_exact_string(mapping["checkpoint"], name="VGGT checkpoint")
+    checksum = _optional_sha256(
+        mapping["checkpoint_sha256"],
+        name="VGGT checkpoint SHA-256",
+    )
+    revision = _optional_revision(
+        mapping["checkpoint_revision"],
+        name="VGGT checkpoint revision",
+    )
+    preprocess = require_exact_string(
+        mapping["preprocess_mode"],
+        name="VGGT preprocess mode",
+    )
+    expected_model_set = build_model_set_id(
+        vggt_commit=commit,
+        checkpoint=checkpoint_name,
+        checkpoint_sha256=checksum,
+        checkpoint_revision=revision,
+        preprocess_mode=preprocess,
+    )
+    result: dict[str, Any] = {
+        "schema": VGGT_RUN_SCHEMA,
+        "schema_version": VGGT_RUN_VERSION,
+        "run_id": require_sha256(mapping["run_id"], name="VGGT run_id"),
+        "method": method,
+        "official_repository": repository,
+        "vggt_commit": commit,
+        "model_set_id": require_sha256(
+            mapping["model_set_id"],
+            name="VGGT model_set_id",
+        ),
+        "loader_module_sha256": require_sha256(
+            mapping["loader_module_sha256"],
+            name="VGGT loader-module SHA-256",
+        ),
+        "checkpoint": checkpoint_name,
+        "checkpoint_sha256": checksum,
+        "checkpoint_revision": revision,
+        "preprocess_mode": preprocess,
+        "partition_index": index,
+        "partition_count": count,
+        "samples": samples,
+        "dataset_root": require_exact_string(
+            mapping["dataset_root"],
+            name="VGGT dataset_root",
+        ),
+        "output_root": require_exact_string(
+            mapping["output_root"],
+            name="VGGT output_root",
+        ),
+        "elapsed_seconds": elapsed,
+    }
+    if result["model_set_id"] != expected_model_set:
+        raise ValueError("VGGT model_set_id mismatch")
+    expected_run = record_id(_RUN_ID_DOMAIN, run_identity_record(result))
+    if result["run_id"] != expected_run:
+        raise ValueError("VGGT run_id mismatch")
+    return result
+
+
+def load_vggt_run_metadata(path: str | Path) -> dict[str, Any]:
+    """Load strict, duplicate-free version-2 VGGT run metadata."""
+
+    record = load_json_object(path, name="VGGT run metadata")
+    if record.get("schema") != VGGT_RUN_SCHEMA:
+        raise ValueError(
+            "legacy or unpinned VGGT metadata cannot enter the provider-neutral "
+            "boundary; rerun with an exact checkpoint revision"
+        )
+    return validate_run_record(record)
+
+
+def _fsync_directory(path: Path) -> None:
+    try:
+        descriptor = os.open(path, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(descriptor)
+    except OSError:
+        pass
+    finally:
+        os.close(descriptor)
+
+
+def save_vggt_run_metadata(
+    path: str | Path,
+    record: Mapping[str, Any],
+) -> Path:
+    """Persist one run record atomically and refuse identity-changing overwrite."""
+
+    destination = Path(path)
+    normalized = validate_run_record(record)
+    content = json.dumps(normalized, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    if destination.exists():
+        existing = load_vggt_run_metadata(destination)
+        if existing["run_id"] != normalized["run_id"]:
+            raise ValueError("refusing to replace different VGGT run metadata")
+        return destination
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{destination.name}.",
+        suffix=".tmp",
+        dir=destination.parent,
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            stream.write(content)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary_name, destination)
+        _fsync_directory(destination.parent)
+    finally:
+        if os.path.exists(temporary_name):
+            os.unlink(temporary_name)
+    return destination
+
+
+def find_sample_record(
+    run_record: Mapping[str, Any],
+    sample_id: str,
+) -> dict[str, Any]:
+    """Return one exact sample record from validated run metadata."""
+
+    normalized_id = safe_relative_path(sample_id, name="VGGT sample_id")
+    samples = run_record["samples"]
+    assert isinstance(samples, list)
+    matches = [sample for sample in samples if sample["sample_id"] == normalized_id]
+    if len(matches) != 1:
+        raise ValueError(f"VGGT run metadata does not contain sample {normalized_id!r}")
+    return dict(matches[0])
+
+
+def verify_sample_files(
+    *,
+    sample: Mapping[str, Any],
+    dataset_root: str | Path,
+    output_root: str | Path,
+    representations: Sequence[str],
+) -> tuple[Path, dict[str, Path]]:
+    """Verify exact input-video and cached-prediction bytes for one sample."""
+
+    selected = tuple(representations)
+    if not selected or len(set(selected)) != len(selected):
+        raise ValueError("selected VGGT representations must be nonempty and unique")
+    if any(name not in VGGT_REPRESENTATIONS for name in selected):
+        raise ValueError("selected VGGT representation is unsupported")
+    video = resolve_member(
+        Path(dataset_root),
+        sample["sample_id"],
+        name="VGGT input-video path",
+    )
+    if int(video.stat().st_size) != sample["input_video_byte_count"]:
+        raise ValueError("VGGT input-video byte count mismatch")
+    if file_sha256(video) != sample["input_video_sha256"]:
+        raise ValueError("VGGT input-video SHA-256 mismatch")
+    members = sample["representations"]
+    assert isinstance(members, list)
+    by_name = {str(member["representation"]): member for member in members}
+    resolved: dict[str, Path] = {}
+    for representation in selected:
+        if representation not in by_name:
+            raise ValueError(
+                f"VGGT sample lacks representation {representation!r}"
+            )
+        member = by_name[representation]
+        path = resolve_member(
+            Path(output_root),
+            member["path"],
+            name=f"VGGT {representation} prediction path",
+        )
+        if int(path.stat().st_size) != member["byte_count"]:
+            raise ValueError(f"VGGT {representation} byte count mismatch")
+        if file_sha256(path) != member["sha256"]:
+            raise ValueError(f"VGGT {representation} SHA-256 mismatch")
+        described = describe_prediction_archive(
+            path,
+            representation=representation,
+            relative_path=str(member["path"]),
+        )
+        if member_identity_record(described) != member_identity_record(member):
+            raise ValueError(f"VGGT {representation} archive semantics changed")
+        resolved[representation] = path
+    return video, resolved
+
+
+__all__ = [
+    "VGGT_METHOD",
+    "VGGT_OFFICIAL_REPOSITORY",
+    "VGGT_REPRESENTATIONS",
+    "VGGT_RUN_SCHEMA",
+    "VGGT_RUN_VERSION",
+    "build_model_set_id",
+    "build_run_record",
+    "build_sample_record",
+    "canonical_json_bytes",
+    "checkpoint_identity",
+    "describe_prediction_archive",
+    "file_sha256",
+    "find_sample_record",
+    "load_vggt_run_metadata",
+    "member_identity_record",
+    "record_id",
+    "relative_member",
+    "resolve_member",
+    "run_identity_record",
+    "safe_relative_path",
+    "sample_identity_record",
+    "save_vggt_run_metadata",
+    "validate_run_record",
+    "verify_sample_files",
+]

--- a/src/prob4d/vggt_provider_adapter.py
+++ b/src/prob4d/vggt_provider_adapter.py
@@ -99,9 +99,7 @@ def _write_window_atomically(path: Path, window: PredictionWindow) -> None:
             dense_storage_dtype=window.dense_storage_dtype,
         )
         if not _windows_equal(existing, window):
-            raise ValueError(
-                f"refusing to replace different canonical VGGT payload {path.name!r}"
-            )
+            raise ValueError(f"refusing to replace different canonical VGGT payload {path.name!r}")
         return
     descriptor, temporary_name = tempfile.mkstemp(
         prefix=f".{path.stem}.",
@@ -146,9 +144,7 @@ def import_vggt_prediction_manifest(
     """Import one exact VGGT sample without treating constructions as independent."""
 
     if storage_dtype not in DENSE_STORAGE_DTYPES:
-        raise ValueError(
-            "storage_dtype must be one of " + ", ".join(DENSE_STORAGE_DTYPES)
-        )
+        raise ValueError("storage_dtype must be one of " + ", ".join(DENSE_STORAGE_DTYPES))
     if type(frame_start) is not int or frame_start < 0:
         raise ValueError("frame_start must be a nonnegative integer")
     if not sequence_id:
@@ -170,9 +166,7 @@ def import_vggt_prediction_manifest(
         name: _load_source_arrays(source_paths[name]) for name in selected
     }
     reference_name = selected[0]
-    reference_points, reference_extrinsics, reference_intrinsics = source_arrays[
-        reference_name
-    ]
+    reference_points, reference_extrinsics, reference_intrinsics = source_arrays[reference_name]
     for name in selected[1:]:
         points, extrinsics, intrinsics = source_arrays[name]
         if points.shape != reference_points.shape:
@@ -195,23 +189,17 @@ def import_vggt_prediction_manifest(
         f"input-video:{video_sha256}",
         f"provider-run:{sample_run_id}",
     )
-    deterministic_member = (
-        f"{_STOCHASTIC_DOMAIN}:"
-        + record_id(
-            _STOCHASTIC_DOMAIN,
-            {
-                "sample_run_id": sample_run_id,
-                "model_set_id": model_set_id,
-                "preprocess_mode": run["preprocess_mode"],
-            },
-        )
+    deterministic_member = f"{_STOCHASTIC_DOMAIN}:" + record_id(
+        _STOCHASTIC_DOMAIN,
+        {
+            "sample_run_id": sample_run_id,
+            "model_set_id": model_set_id,
+            "preprocess_mode": run["preprocess_mode"],
+        },
     )
 
     payloads: list[PredictionPayloadDescriptorV1] = []
-    source_members = {
-        str(member["representation"]): member
-        for member in sample["representations"]
-    }
+    source_members = {str(member["representation"]): member for member in sample["representations"]}
     for representation in selected:
         points, _, _ = source_arrays[representation]
         window = _canonical_window(
@@ -220,11 +208,7 @@ def import_vggt_prediction_manifest(
             frame_start=frame_start,
             storage_dtype=storage_dtype,
         )
-        payload_path = (
-            manifest_root
-            / "payloads"
-            / f"{sequence_token}-vggt-{representation}.npz"
-        )
+        payload_path = manifest_root / "payloads" / f"{sequence_token}-vggt-{representation}.npz"
         _write_window_atomically(payload_path, window)
         relative_path = relative_member(
             payload_path,

--- a/src/prob4d/vggt_provider_adapter.py
+++ b/src/prob4d/vggt_provider_adapter.py
@@ -1,0 +1,372 @@
+"""Convert integrity-bound VGGT caches into provider-neutral predictions."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import tempfile
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from .data import DENSE_STORAGE_DTYPES, PredictionWindow
+from .prediction_provider_manifest import (
+    PredictionFrameLineageV1,
+    PredictionPayloadDescriptorV1,
+    PredictionProviderManifestV1,
+    save_prediction_provider_manifest,
+    verify_prediction_provider_manifest,
+)
+from .vggt_integrity import (
+    VGGT_OFFICIAL_REPOSITORY,
+    VGGT_REPRESENTATIONS,
+    checkpoint_identity,
+    file_sha256,
+    find_sample_record,
+    load_vggt_run_metadata,
+    record_id,
+    relative_member,
+    verify_sample_files,
+)
+
+_ADAPTER_DOMAIN = "prob4d.vggt-provider-adapter.v1"
+_STOCHASTIC_DOMAIN = "prob4d.vggt-deterministic-member.v1"
+
+
+def _load_source_arrays(path: Path) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    try:
+        with np.load(path, allow_pickle=False) as archive:
+            points = np.asarray(archive["point_map"])
+            extrinsics = np.asarray(archive["camera_extrinsics"])
+            intrinsics = np.asarray(archive["camera_intrinsics"])
+    except (KeyError, OSError, ValueError) as error:
+        raise ValueError(f"cannot reopen verified VGGT archive {path.name!r}") from error
+    return points, extrinsics, intrinsics
+
+
+def _canonical_window(
+    *,
+    representation: str,
+    points: np.ndarray,
+    frame_start: int,
+    storage_dtype: str,
+) -> PredictionWindow:
+    if type(frame_start) is not int or frame_start < 0:
+        raise ValueError("frame_start must be a nonnegative integer")
+    valid = np.all(np.isfinite(points), axis=-1)
+    if not np.any(valid):
+        raise ValueError(f"VGGT {representation} contains no finite point")
+    dense = np.asarray(points, dtype=np.float32 if storage_dtype == "float32" else np.float64)
+    dense = dense.copy()
+    dense[~valid] = 0.0
+    frame_count = int(dense.shape[0])
+    return PredictionWindow(
+        window_id=f"vggt-{representation}",
+        frame_indices=np.arange(
+            frame_start,
+            frame_start + frame_count,
+            dtype=np.int64,
+        ),
+        point_map=dense,
+        valid_mask=valid,
+        dense_storage_dtype=storage_dtype,
+    )
+
+
+def _windows_equal(first: PredictionWindow, second: PredictionWindow) -> bool:
+    return (
+        first.window_id == second.window_id
+        and first.dense_storage_dtype == second.dense_storage_dtype
+        and np.array_equal(first.frame_indices, second.frame_indices)
+        and np.array_equal(first.point_map, second.point_map)
+        and np.array_equal(first.valid_mask, second.valid_mask)
+        and first.scene_flow is None
+        and second.scene_flow is None
+        and first.ray_directions is None
+        and second.ray_directions is None
+    )
+
+
+def _write_window_atomically(path: Path, window: PredictionWindow) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        existing = PredictionWindow.from_npz(
+            path,
+            dense_storage_dtype=window.dense_storage_dtype,
+        )
+        if not _windows_equal(existing, window):
+            raise ValueError(
+                f"refusing to replace different canonical VGGT payload {path.name!r}"
+            )
+        return
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.stem}.",
+        suffix=".npz",
+        dir=path.parent,
+    )
+    os.close(descriptor)
+    try:
+        window.to_npz(temporary_name)
+        os.replace(temporary_name, path)
+    finally:
+        if os.path.exists(temporary_name):
+            os.unlink(temporary_name)
+
+
+def _adapter_id() -> str:
+    return file_sha256(Path(__file__).resolve())
+
+
+def _selected_representations(values: Sequence[str] | None) -> tuple[str, ...]:
+    selected = tuple(VGGT_REPRESENTATIONS if not values else values)
+    if len(set(selected)) != len(selected):
+        raise ValueError("VGGT representations must be unique")
+    if any(value not in VGGT_REPRESENTATIONS for value in selected):
+        raise ValueError("unsupported VGGT representation")
+    return selected
+
+
+def import_vggt_prediction_manifest(
+    run_metadata_path: str | Path,
+    output_manifest_path: str | Path,
+    *,
+    sequence_id: str,
+    sample_id: str,
+    dataset_root: str | Path,
+    prediction_root: str | Path,
+    representations: Sequence[str] | None = None,
+    frame_start: int = 0,
+    view_id: str = "camera-0",
+    storage_dtype: str = "float32",
+) -> PredictionProviderManifestV1:
+    """Import one exact VGGT sample without treating constructions as independent."""
+
+    if storage_dtype not in DENSE_STORAGE_DTYPES:
+        raise ValueError(
+            "storage_dtype must be one of " + ", ".join(DENSE_STORAGE_DTYPES)
+        )
+    if type(frame_start) is not int or frame_start < 0:
+        raise ValueError("frame_start must be a nonnegative integer")
+    if not sequence_id:
+        raise ValueError("sequence_id must not be empty")
+    if not view_id:
+        raise ValueError("view_id must not be empty")
+
+    run = load_vggt_run_metadata(run_metadata_path)
+    sample = find_sample_record(run, sample_id)
+    selected = _selected_representations(representations)
+    _, source_paths = verify_sample_files(
+        sample=sample,
+        dataset_root=dataset_root,
+        output_root=prediction_root,
+        representations=selected,
+    )
+
+    source_arrays: dict[str, tuple[np.ndarray, np.ndarray, np.ndarray]] = {
+        name: _load_source_arrays(source_paths[name]) for name in selected
+    }
+    reference_name = selected[0]
+    reference_points, reference_extrinsics, reference_intrinsics = source_arrays[
+        reference_name
+    ]
+    for name in selected[1:]:
+        points, extrinsics, intrinsics = source_arrays[name]
+        if points.shape != reference_points.shape:
+            raise ValueError("VGGT representations disagree on the prediction grid")
+        if not np.array_equal(extrinsics, reference_extrinsics):
+            raise ValueError("VGGT representations mix different camera extrinsics")
+        if not np.array_equal(intrinsics, reference_intrinsics):
+            raise ValueError("VGGT representations mix different camera intrinsics")
+
+    output_path = Path(output_manifest_path)
+    manifest_root = output_path.parent.resolve()
+    sequence_token = hashlib.sha256(sequence_id.encode("utf-8")).hexdigest()[:16]
+    frame_count = int(reference_points.shape[0])
+    source_stop = frame_start + frame_count
+    sample_run_id = str(sample["sample_run_id"])
+    model_set_id = str(run["model_set_id"])
+    video_sha256 = str(sample["input_video_sha256"])
+    dependence_groups = (
+        f"model-set:{model_set_id}",
+        f"input-video:{video_sha256}",
+        f"provider-run:{sample_run_id}",
+    )
+    deterministic_member = (
+        f"{_STOCHASTIC_DOMAIN}:"
+        + record_id(
+            _STOCHASTIC_DOMAIN,
+            {
+                "sample_run_id": sample_run_id,
+                "model_set_id": model_set_id,
+                "preprocess_mode": run["preprocess_mode"],
+            },
+        )
+    )
+
+    payloads: list[PredictionPayloadDescriptorV1] = []
+    source_members = {
+        str(member["representation"]): member
+        for member in sample["representations"]
+    }
+    for representation in selected:
+        points, _, _ = source_arrays[representation]
+        window = _canonical_window(
+            representation=representation,
+            points=points,
+            frame_start=frame_start,
+            storage_dtype=storage_dtype,
+        )
+        payload_path = (
+            manifest_root
+            / "payloads"
+            / f"{sequence_token}-vggt-{representation}.npz"
+        )
+        _write_window_atomically(payload_path, window)
+        relative_path = relative_member(
+            payload_path,
+            root=manifest_root,
+            name="canonical VGGT payload path",
+        )
+        lineage = tuple(
+            PredictionFrameLineageV1(
+                output_frame_id=int(frame_id),
+                source_frame_start=frame_start,
+                source_frame_stop_exclusive=source_stop,
+                contributor_ids=(sample_run_id,),
+            )
+            for frame_id in window.frame_indices
+        )
+        payloads.append(
+            PredictionPayloadDescriptorV1(
+                product_role="external-sequence",
+                window_id=window.window_id,
+                path=relative_path,
+                sha256=file_sha256(payload_path),
+                byte_count=int(payload_path.stat().st_size),
+                view_id=view_id,
+                stochastic_member_id=deterministic_member,
+                dependence_group_ids=dependence_groups,
+                dense_storage_dtype=storage_dtype,
+                has_scene_flow=False,
+                has_ray_directions=False,
+                frame_lineage=lineage,
+            )
+        )
+
+    checkpoint = checkpoint_identity(
+        checkpoint=run["checkpoint"],
+        checkpoint_sha256=run["checkpoint_sha256"],
+        checkpoint_revision=run["checkpoint_revision"],
+    )
+    adapter_id = _adapter_id()
+    manifest = PredictionProviderManifestV1(
+        sequence_id=sequence_id,
+        provider_family="VGGT",
+        provider_repository=VGGT_OFFICIAL_REPOSITORY,
+        provider_revision=str(run["vggt_commit"]),
+        provider_run_id=sample_run_id,
+        model_set_id=model_set_id,
+        loader_id=str(run["loader_module_sha256"]),
+        coordinate_semantics="sequence-local-sim3",
+        point_semantics="dense-point-map",
+        flow_semantics="absent",
+        ray_semantics="absent",
+        payloads=tuple(payloads),
+        metadata={
+            "source_adapter": _ADAPTER_DOMAIN,
+            "source_adapter_sha256": adapter_id,
+            "source_run_id": run["run_id"],
+            "source_sample_run_id": sample_run_id,
+            "source_video_sha256": video_sha256,
+            "source_video_byte_count": sample["input_video_byte_count"],
+            "source_prediction_members": [
+                {
+                    key: source_members[name][key]
+                    for key in (
+                        "representation",
+                        "sha256",
+                        "byte_count",
+                        "point_shape",
+                        "point_dtype",
+                        "valid_point_count",
+                        "invalid_point_count",
+                    )
+                }
+                for name in selected
+            ],
+            "checkpoint_identity": checkpoint,
+            "preprocess_mode": run["preprocess_mode"],
+            "full_sequence_dependency": True,
+            "alternative_constructions_share_evidence": True,
+            "uses_truth": False,
+            "uses_downstream_physical_innovation": False,
+        },
+    )
+    save_prediction_provider_manifest(output_path, manifest)
+    verify_prediction_provider_manifest(output_path)
+    return manifest
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="prob4d prediction import-vggt",
+        description=(
+            "convert one integrity-bound VGGT sample into provider-neutral "
+            "PredictionWindow payloads"
+        ),
+    )
+    parser.add_argument("run_metadata")
+    parser.add_argument("output")
+    parser.add_argument("--sequence-id", required=True)
+    parser.add_argument("--sample-id", required=True)
+    parser.add_argument("--dataset-root", type=Path, required=True)
+    parser.add_argument("--prediction-root", type=Path, required=True)
+    parser.add_argument(
+        "--representation",
+        action="append",
+        choices=VGGT_REPRESENTATIONS,
+        help="repeat to select constructions; defaults to both official products",
+    )
+    parser.add_argument("--frame-start", type=int, default=0)
+    parser.add_argument("--view-id", default="camera-0")
+    parser.add_argument(
+        "--storage-dtype",
+        choices=DENSE_STORAGE_DTYPES,
+        default="float32",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _build_parser().parse_args(list(argv) if argv is not None else None)
+    manifest = import_vggt_prediction_manifest(
+        arguments.run_metadata,
+        arguments.output,
+        sequence_id=arguments.sequence_id,
+        sample_id=arguments.sample_id,
+        dataset_root=arguments.dataset_root,
+        prediction_root=arguments.prediction_root,
+        representations=arguments.representation,
+        frame_start=arguments.frame_start,
+        view_id=arguments.view_id,
+        storage_dtype=arguments.storage_dtype,
+    )
+    _, report = verify_prediction_provider_manifest(arguments.output)
+    output: dict[str, Any] = {
+        **manifest.summary(),
+        "verified_payload_count": report["verified_payload_count"],
+        "full_sequence_dependency": True,
+    }
+    print(json.dumps(output, indent=2, sort_keys=True))
+    return 0
+
+
+__all__ = ["import_vggt_prediction_manifest", "main"]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -70,7 +70,18 @@ def test_grouped_cli_routes_provider_neutral_prediction_help(capsys) -> None:
     assert exit_info.value.code == 0
     output = capsys.readouterr().out
     assert "import-motioncrafter" in output
+    assert "import-vggt" in output
     assert "validate" in output
+
+
+def test_grouped_cli_routes_vggt_import_help(capsys) -> None:
+    with pytest.raises(SystemExit) as exit_info:
+        main(["prediction", "import-vggt", "--help"])
+    assert exit_info.value.code == 0
+    output = capsys.readouterr().out
+    assert "integrity-bound VGGT sample" in output
+    assert "--sample-id" in output
+    assert "--prediction-root" in output
 
 
 def test_grouped_cli_routes_common_mode_and_visual_bias_help(capsys) -> None:

--- a/tests/test_vggt_provider_adapter.py
+++ b/tests/test_vggt_provider_adapter.py
@@ -113,7 +113,6 @@ def test_vggt_run_metadata_is_path_and_timing_independent(tmp_path: Path) -> Non
     assert second["run_id"] == first["run_id"]
 
 
-
 def test_legacy_unpinned_metadata_is_not_provider_neutral(tmp_path: Path) -> None:
     path = tmp_path / "legacy.json"
     path.write_text(
@@ -129,6 +128,7 @@ def test_legacy_unpinned_metadata_is_not_provider_neutral(tmp_path: Path) -> Non
     )
     with pytest.raises(ValueError, match="legacy or unpinned"):
         load_vggt_run_metadata(path)
+
 
 def test_import_vggt_writes_shared_dependent_causal_payloads(tmp_path: Path) -> None:
     metadata_path, dataset_root, prediction_root, sample_id = _fixture(tmp_path)
@@ -147,12 +147,8 @@ def test_import_vggt_writes_shared_dependent_causal_payloads(tmp_path: Path) -> 
     assert manifest.provider_family == "VGGT"
     assert manifest.coordinate_semantics == "sequence-local-sim3"
     assert len(manifest.payloads) == 2
-    assert manifest.payloads[0].dependence_group_ids == (
-        manifest.payloads[1].dependence_group_ids
-    )
-    assert manifest.payloads[0].stochastic_member_id == (
-        manifest.payloads[1].stochastic_member_id
-    )
+    assert manifest.payloads[0].dependence_group_ids == (manifest.payloads[1].dependence_group_ids)
+    assert manifest.payloads[0].stochastic_member_id == (manifest.payloads[1].stochastic_member_id)
     assert all(not payload.is_causally_admitted(11) for payload in manifest.payloads)
     assert all(payload.is_causally_admitted(12) for payload in manifest.payloads)
 
@@ -205,9 +201,7 @@ def test_import_rejects_mixed_camera_runs(tmp_path: Path) -> None:
         sample_id=sample_id,
         input_video_path=dataset_root / sample_id,
         representations=[
-            item
-            if item["representation"] == "world_points"
-            else replacement
+            item if item["representation"] == "world_points" else replacement
             for item in run["samples"][0]["representations"]
         ],
     )

--- a/tests/test_vggt_provider_adapter.py
+++ b/tests/test_vggt_provider_adapter.py
@@ -1,0 +1,271 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from prob4d.data import PredictionWindow
+from prob4d.prediction_provider_manifest import (
+    load_prediction_provider_manifest,
+    verify_prediction_provider_manifest,
+)
+from prob4d.vggt_baseline import write_prediction_archive
+from prob4d.vggt_integrity import (
+    build_run_record,
+    build_sample_record,
+    describe_prediction_archive,
+    load_vggt_run_metadata,
+    relative_member,
+    save_vggt_run_metadata,
+)
+from prob4d.vggt_provider_adapter import import_vggt_prediction_manifest
+
+
+def _write_vggt_archive(
+    path: Path,
+    *,
+    offset: float,
+    extrinsic_shift: float = 0.0,
+) -> None:
+    points = np.zeros((2, 2, 3, 3), dtype=np.float16)
+    points[..., 0] = offset
+    points[..., 2] = 1.0
+    points[0, 0, 0] = np.nan
+    extrinsics = np.zeros((2, 3, 4), dtype=np.float32)
+    extrinsics[:, :3, :3] = np.eye(3, dtype=np.float32)
+    extrinsics[0, 0, 3] = extrinsic_shift
+    intrinsics = np.repeat(np.eye(3, dtype=np.float32)[None], 2, axis=0)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    np.savez_compressed(
+        path,
+        point_map=points,
+        camera_extrinsics=extrinsics,
+        camera_intrinsics=intrinsics,
+    )
+
+
+def _fixture(tmp_path: Path) -> tuple[Path, Path, Path, str]:
+    dataset_root = tmp_path / "dataset"
+    prediction_root = tmp_path / "predictions"
+    sample_id = "scene/video.mp4"
+    video = dataset_root / sample_id
+    video.parent.mkdir(parents=True)
+    video.write_bytes(b"exact-video-bytes")
+
+    members = []
+    for index, representation in enumerate(("world_points", "depth_unprojected")):
+        path = prediction_root / representation / "scene/video.npz"
+        _write_vggt_archive(path, offset=float(index))
+        members.append(
+            describe_prediction_archive(
+                path,
+                representation=representation,
+                relative_path=relative_member(
+                    path,
+                    root=prediction_root,
+                    name="prediction path",
+                ),
+            )
+        )
+    sample = build_sample_record(
+        sample_id=sample_id,
+        input_video_path=video,
+        representations=members,
+    )
+    run = build_run_record(
+        vggt_commit="a" * 40,
+        loader_module_sha256="b" * 64,
+        checkpoint="/models/vggt.pt",
+        checkpoint_sha256="c" * 64,
+        checkpoint_revision=None,
+        preprocess_mode="crop",
+        partition_index=0,
+        partition_count=1,
+        samples=[sample],
+        dataset_root=dataset_root,
+        output_root=prediction_root,
+        elapsed_seconds=1.25,
+    )
+    metadata_path = prediction_root / "run-part-00.json"
+    save_vggt_run_metadata(metadata_path, run)
+    return metadata_path, dataset_root, prediction_root, sample_id
+
+
+def test_vggt_run_metadata_is_path_and_timing_independent(tmp_path: Path) -> None:
+    metadata_path, _, _, _ = _fixture(tmp_path)
+    first = load_vggt_run_metadata(metadata_path)
+    second = build_run_record(
+        vggt_commit=str(first["vggt_commit"]),
+        loader_module_sha256=str(first["loader_module_sha256"]),
+        checkpoint=str(first["checkpoint"]),
+        checkpoint_sha256=str(first["checkpoint_sha256"]),
+        checkpoint_revision=None,
+        preprocess_mode=str(first["preprocess_mode"]),
+        partition_index=0,
+        partition_count=1,
+        samples=first["samples"],
+        dataset_root=tmp_path / "moved-dataset",
+        output_root=tmp_path / "moved-predictions",
+        elapsed_seconds=99.0,
+    )
+    assert second["run_id"] == first["run_id"]
+
+
+
+def test_legacy_unpinned_metadata_is_not_provider_neutral(tmp_path: Path) -> None:
+    path = tmp_path / "legacy.json"
+    path.write_text(
+        json.dumps(
+            {
+                "method": "VGGT-1B",
+                "checkpoint": "facebook/VGGT-1B",
+                "checkpoint_sha256": None,
+                "integrity_bound": False,
+            }
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="legacy or unpinned"):
+        load_vggt_run_metadata(path)
+
+def test_import_vggt_writes_shared_dependent_causal_payloads(tmp_path: Path) -> None:
+    metadata_path, dataset_root, prediction_root, sample_id = _fixture(tmp_path)
+    output = tmp_path / "bundle/provider.json"
+
+    manifest = import_vggt_prediction_manifest(
+        metadata_path,
+        output,
+        sequence_id="sequence-a",
+        sample_id=sample_id,
+        dataset_root=dataset_root,
+        prediction_root=prediction_root,
+        frame_start=10,
+    )
+
+    assert manifest.provider_family == "VGGT"
+    assert manifest.coordinate_semantics == "sequence-local-sim3"
+    assert len(manifest.payloads) == 2
+    assert manifest.payloads[0].dependence_group_ids == (
+        manifest.payloads[1].dependence_group_ids
+    )
+    assert manifest.payloads[0].stochastic_member_id == (
+        manifest.payloads[1].stochastic_member_id
+    )
+    assert all(not payload.is_causally_admitted(11) for payload in manifest.payloads)
+    assert all(payload.is_causally_admitted(12) for payload in manifest.payloads)
+
+    loaded = load_prediction_provider_manifest(output)
+    assert loaded.artifact_id == manifest.artifact_id
+    _, report = verify_prediction_provider_manifest(output, causal_frame_stop=12)
+    assert report["verified_payload_count"] == 2
+    assert report["admitted_payload_count"] == 2
+
+    first_payload = output.parent / loaded.payloads[0].path
+    window = PredictionWindow.from_npz(first_payload, dense_storage_dtype="float32")
+    assert window.frame_indices.tolist() == [10, 11]
+    assert not window.valid_mask[0, 0, 0]
+    assert np.all(window.point_map[~window.valid_mask] == 0.0)
+
+
+def test_import_rejects_tampered_cached_prediction(tmp_path: Path) -> None:
+    metadata_path, dataset_root, prediction_root, sample_id = _fixture(tmp_path)
+    source = prediction_root / "world_points/scene/video.npz"
+    source.write_bytes(source.read_bytes() + b"tamper")
+
+    with pytest.raises(ValueError, match="byte count mismatch"):
+        import_vggt_prediction_manifest(
+            metadata_path,
+            tmp_path / "bundle/provider.json",
+            sequence_id="sequence-a",
+            sample_id=sample_id,
+            dataset_root=dataset_root,
+            prediction_root=prediction_root,
+        )
+
+
+def test_import_rejects_mixed_camera_runs(tmp_path: Path) -> None:
+    metadata_path, dataset_root, prediction_root, sample_id = _fixture(tmp_path)
+    path = prediction_root / "depth_unprojected/scene/video.npz"
+    _write_vggt_archive(path, offset=1.0, extrinsic_shift=2.0)
+
+    run = json.loads(metadata_path.read_text(encoding="utf-8"))
+    member = next(
+        item
+        for item in run["samples"][0]["representations"]
+        if item["representation"] == "depth_unprojected"
+    )
+    replacement = describe_prediction_archive(
+        path,
+        representation="depth_unprojected",
+        relative_path=member["path"],
+    )
+    sample = build_sample_record(
+        sample_id=sample_id,
+        input_video_path=dataset_root / sample_id,
+        representations=[
+            item
+            if item["representation"] == "world_points"
+            else replacement
+            for item in run["samples"][0]["representations"]
+        ],
+    )
+    revised = build_run_record(
+        vggt_commit=run["vggt_commit"],
+        loader_module_sha256=run["loader_module_sha256"],
+        checkpoint=run["checkpoint"],
+        checkpoint_sha256=run["checkpoint_sha256"],
+        checkpoint_revision=None,
+        preprocess_mode=run["preprocess_mode"],
+        partition_index=0,
+        partition_count=1,
+        samples=[sample],
+        dataset_root=dataset_root,
+        output_root=prediction_root,
+        elapsed_seconds=2.0,
+    )
+    revised_path = prediction_root / "run-part-01.json"
+    save_vggt_run_metadata(revised_path, revised)
+
+    with pytest.raises(ValueError, match="camera extrinsics"):
+        import_vggt_prediction_manifest(
+            revised_path,
+            tmp_path / "bundle/provider.json",
+            sequence_id="sequence-a",
+            sample_id=sample_id,
+            dataset_root=dataset_root,
+            prediction_root=prediction_root,
+        )
+
+
+def test_atomic_vggt_archive_writer_is_idempotent_and_refuses_drift(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "prediction.npz"
+    points = np.ones((1, 1, 1, 3), dtype=np.float32)
+    extrinsics = np.zeros((1, 3, 4), dtype=np.float32)
+    intrinsics = np.eye(3, dtype=np.float32)[None]
+
+    write_prediction_archive(
+        path,
+        point_map=points,
+        camera_extrinsics=extrinsics,
+        camera_intrinsics=intrinsics,
+    )
+    original = path.read_bytes()
+    write_prediction_archive(
+        path,
+        point_map=points,
+        camera_extrinsics=extrinsics,
+        camera_intrinsics=intrinsics,
+    )
+    assert path.read_bytes() == original
+
+    with pytest.raises(ValueError, match="refusing to replace"):
+        write_prediction_archive(
+            path,
+            point_map=points + 1.0,
+            camera_extrinsics=extrinsics,
+            camera_intrinsics=intrinsics,
+        )


### PR DESCRIPTION
## Summary

Implement the next provider-neutral Prob4D improvement without changing frozen provider-v1/provider-v2 observation semantics or schema-v4 factor identities.

- add strict version-2 VGGT run metadata with immutable VGGT source, loader, preprocessing, checkpoint, input-video, prediction-member, sample, model-set, and run identities;
- require either a local checkpoint SHA-256 or an exact 40/64-character remote checkpoint revision for provider-neutral admission;
- preserve the existing unpinned VGGT baseline as an explicitly legacy/exploratory output that the claim-bearing importer rejects;
- make cached VGGT prediction production atomic, idempotent, and fail closed on semantic drift;
- convert either official VGGT point construction into canonical versioned `PredictionWindow` payloads and a `PredictionProviderManifestV1`;
- retain full-sequence source-frame lineage for every VGGT output frame and shared model/input/run dependence across the two official constructions; and
- add grouped CLI routes, documentation, adversarial tests, and a read-only exact-head workflow.

## Why

Prob4D's provider-neutral boundary was initially demonstrated only with a MotionCrafter adapter. A genuinely different provider is needed to prove that the contract does not merely rename MotionCrafter internals. VGGT also exposes a useful failure mode: both official point constructions share model, input, camera, and run dependence, so they must not be counted as independent visual evidence.

## Compatibility

- frozen provider-v1/provider-v2 modules, observation artifacts, factor bundles, streams, material identities, and held-out decisions remain unchanged;
- the existing `prob4d vggt baseline` path remains available;
- only exact integrity-bound version-2 VGGT runs can cross the new provider-neutral import boundary;
- VGGT output is declared `sequence-local-sim3`, not metric world coordinates; and
- every frame conservatively records dependence on the complete supplied sequence.

## Validation

Before publication, the exact patch passed:

- Python byte compilation for all modified and new modules;
- six focused adapter/integrity tests in an isolated source-layout harness;
- line-length and whitespace checks; and
- YAML parsing for the new workflow.

The pull request contains one reviewable implementation commit. Its exact-head workflow runs Ruff lint/format, mypy, focused and adjacent pytest regressions, wheel construction, and installed-command smoke tests.

## Claim boundary

This is provider abstraction, immutable provenance, causal-lineage, dependence, and interoperability infrastructure. It does not establish VGGT or MotionCrafter competence, calibrated uncertainty, BayesianPhysTwin benefit on fresh physical objects, Causal4D intervention benefit, deployment safety, or state of the art. It does not authorize tuning on the opened 19-interaction PhysTwin diagnostic cohort.