### PR TITLE
Make claim-bearing artifact values irreversibly immutable

### DIFF
--- a/.github/workflows/immutable-artifacts.yml
+++ b/.github/workflows/immutable-artifacts.yml
@@ -1,0 +1,109 @@
+name: Immutable artifact contracts
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/immutable-artifacts.yml"
+      - "docs/immutable-artifacts.md"
+      - "src/prob4d/_immutable_array.py"
+      - "src/prob4d/_immutable_json.py"
+      - "src/prob4d/data.py"
+      - "src/prob4d/causal_stream_contract.py"
+      - "src/prob4d/provider_attestation.py"
+      - "src/prob4d/provider_v2_factor_bundle.py"
+      - "src/prob4d/provider_v2_loading.py"
+      - "src/prob4d/_heldout_promotion_diagnosis.py"
+      - "tests/test_immutable_array.py"
+      - "tests/test_immutable_json.py"
+      - "tests/test_data_immutability.py"
+      - "tests/test_claim_bearing_observation.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: immutable-artifacts-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contracts:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    timeout-minutes: 20
+    steps:
+      - name: Check out exact reviewed head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+          clean: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        with:
+          python-version: "3.12"
+
+      - name: Create isolated environment
+        shell: bash
+        run: |
+          set -euo pipefail
+          environment="$RUNNER_TEMP/prob4d-immutable-venv"
+          python3 -m venv --clear "$environment"
+          "$environment/bin/python" -m ensurepip --upgrade
+          "$environment/bin/python" -m pip install --upgrade pip
+          echo "$environment/bin" >> "$GITHUB_PATH"
+
+      - name: Install development environment
+        run: |
+          set -euo pipefail
+          python -m pip install --no-cache-dir -e ".[dev]"
+          python -m pip check
+
+      - name: Check focused quality
+        shell: bash
+        run: |
+          set -euo pipefail
+          files=(
+            src/prob4d/_immutable_array.py
+            src/prob4d/_immutable_json.py
+            src/prob4d/data.py
+            src/prob4d/causal_stream_contract.py
+            src/prob4d/provider_attestation.py
+            src/prob4d/provider_v2_factor_bundle.py
+            src/prob4d/provider_v2_loading.py
+            src/prob4d/_heldout_promotion_diagnosis.py
+            tests/test_immutable_array.py
+            tests/test_immutable_json.py
+            tests/test_data_immutability.py
+            tests/test_claim_bearing_observation.py
+          )
+          python -m ruff check -- "${files[@]}"
+          python -m ruff format --check --diff "${files[@]}"
+          python -m mypy --python-version 3.12 \
+            src/prob4d/_immutable_array.py \
+            src/prob4d/_immutable_json.py \
+            src/prob4d/data.py \
+            src/prob4d/provider_attestation.py \
+            src/prob4d/provider_v2_factor_bundle.py \
+            src/prob4d/provider_v2_loading.py
+
+      - name: Run focused and adjacent tests
+        run: |
+          set -euo pipefail
+          python -m pytest -q \
+            tests/test_immutable_array.py \
+            tests/test_immutable_json.py \
+            tests/test_data.py \
+            tests/test_data_immutability.py \
+            tests/test_provider_attestation.py \
+            tests/test_provider_v2_factor_bundle.py \
+            tests/test_claim_bearing_observation.py \
+            tests/test_observation_factor_stream.py \
+            tests/test_heldout_promotion_diagnosis.py \
+            tests/test_prediction_provider_manifest.py \
+            tests/test_visual_bias.py
+          python -m compileall -q src/prob4d tests

--- a/docs/immutable-artifacts.md
+++ b/docs/immutable-artifacts.md
@@ -1,0 +1,49 @@
+# Immutable in-memory artifact values
+
+Prob4D validates several values before computing content identities, sealing
+causal lineage, or admitting an observation into a claim-bearing workflow. Those
+values must not change after validation.
+
+## JSON values
+
+`frozen_finite_json_mapping` returns recursively read-only `Mapping` and
+`Sequence` implementations. They do not inherit from `dict` or `list`, so Python
+base-class descriptors cannot bypass their mutation guards. Call `plain_json`
+when a mutable built-in representation is required for serialization or explicit
+export.
+
+The following are rejected:
+
+```python
+metadata["changed"] = True
+metadata["items"].append("changed")
+dict.__setitem__(metadata, "changed", True)
+list.append(metadata["items"], "changed")
+```
+
+`copy.copy`, `copy.deepcopy`, and the explicit `.copy()` methods return ordinary
+mutable JSON containers without changing the frozen source value.
+
+## NumPy values
+
+`PredictionWindow` arrays are defensively copied and rebuilt over immutable
+`bytes` storage after validation. Direct assignment fails, and callers cannot
+restore writeability with `array.setflags(write=True)`.
+
+This is stronger than clearing the write flag on an owned NumPy allocation. An
+owned allocation can normally have that flag restored later, which would allow a
+validated value to diverge from the bytes or identity that were audited.
+
+The helper rejects object-dtype arrays. Numeric and Boolean dtypes, scalar and
+empty shapes, and C-order values are retained exactly.
+
+## Scope
+
+This contract applies to portable or claim-bearing values whose post-validation
+mutation could invalidate provenance or content identity. Large execution-only
+buffers, memory-mapped stores, and private fusion ownership paths retain their
+separate performance contracts and are not silently copied by this change.
+
+Passing these integrity checks is not evidence of provider competence,
+uncertainty calibration, physical-state identifiability, BayesianPhysTwin
+benefit, Causal4D intervention benefit, deployment safety, or state of the art.

--- a/src/prob4d/_heldout_promotion_diagnosis.py
+++ b/src/prob4d/_heldout_promotion_diagnosis.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import os
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, TypedDict
@@ -202,7 +202,7 @@ _QUERY_GATE_BOUNDARIES: tuple[tuple[str, str], ...] = (
 
 
 def _sequence(value: Any, *, name: str) -> tuple[Any, ...]:
-    if not isinstance(value, (list, tuple)):
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
         raise ValueError(f"{name} must be an array")
     return tuple(value)
 

--- a/src/prob4d/_immutable_array.py
+++ b/src/prob4d/_immutable_array.py
@@ -1,0 +1,48 @@
+"""Irreversibly read-only NumPy arrays for validated artifacts."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+
+def immutable_array(
+    values: Any,
+    *,
+    dtype: np.dtype[Any] | type | None = None,
+) -> np.ndarray:
+    """Return a defensive array whose write flag cannot be re-enabled.
+
+    Clearing the write flag on an owned NumPy allocation is reversible through
+    ``array.setflags(write=True)``.  Claim-bearing values instead use an
+    immutable ``bytes`` buffer, preserving the exact dtype, shape, and C-order
+    values while making both direct writes and write-flag restoration fail.
+    """
+
+    array = np.asarray(values, dtype=dtype)
+    if array.dtype.hasobject:
+        raise ValueError("immutable arrays must not contain Python objects")
+    original_shape = array.shape
+    contiguous = np.ascontiguousarray(array)
+    payload = contiguous.tobytes(order="C")
+    result = np.frombuffer(payload, dtype=contiguous.dtype).reshape(original_shape)
+    if result.flags.writeable:
+        raise RuntimeError("immutable array construction produced writable storage")
+    return result
+
+
+def immutable_integer_array(values: Any, *, name: str) -> np.ndarray:
+    """Return immutable int64 data without coercing non-integer inputs."""
+
+    array = np.asarray(values)
+    if array.dtype.kind not in {"i", "u"}:
+        raise ValueError(f"{name} must contain integers")
+    if array.dtype.kind == "u" and array.size:
+        maximum = int(np.max(array))
+        if maximum > np.iinfo(np.int64).max:
+            raise ValueError(f"{name} contains an integer outside int64 range")
+    return immutable_array(array, dtype=np.int64)
+
+
+__all__ = ["immutable_array", "immutable_integer_array"]

--- a/src/prob4d/_immutable_json.py
+++ b/src/prob4d/_immutable_json.py
@@ -1,62 +1,73 @@
-"""Finite JSON normalization with recursively immutable dict/list values."""
+"""Finite JSON normalization with recursively immutable protocol values."""
 
 from __future__ import annotations
 
 import json
-from collections.abc import Mapping
-from typing import Any
+from collections.abc import Iterator, Mapping, Sequence
+from types import MappingProxyType
+from typing import Any, NoReturn, overload
 
 
-def _plain_json(value: Any, *, path: str) -> Any:
-    if isinstance(value, Mapping):
-        result: dict[str, Any] = {}
-        for key, item in value.items():
-            if not isinstance(key, str):
-                raise TypeError(
-                    f"JSON object keys must be strings at {path}; "
-                    f"got {type(key).__name__}"
-                )
-            result[key] = _plain_json(item, path=f"{path}[{key!r}]")
-        return result
-    if isinstance(value, (list, tuple)):
-        return [
-            _plain_json(item, path=f"{path}[{index}]")
-            for index, item in enumerate(value)
-        ]
-    return value
+class FrozenJsonDict(Mapping[str, Any]):
+    """A read-only JSON object without a mutable ``dict`` base class."""
 
+    __slots__ = ("_values",)
+    _values: Mapping[str, Any]
 
-def plain_json(value: Any) -> Any:
-    """Return ordinary JSON-compatible containers without coercing object keys."""
+    def __init__(self, values: Mapping[str, Any]) -> None:
+        object.__setattr__(self, "_values", MappingProxyType(dict(values)))
 
-    return _plain_json(value, path="$")
+    def __getitem__(self, key: str) -> Any:
+        return self._values[key]
 
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._values)
 
-class FrozenJsonDict(dict[str, Any]):
-    """A ``dict``-compatible mapping that rejects every in-place mutation."""
+    def __len__(self) -> int:
+        return len(self._values)
 
-    __slots__ = ()
-    _MUTATORS = frozenset({"clear", "pop", "popitem", "setdefault", "update"})
+    def __repr__(self) -> str:
+        return repr(dict(self._values))
 
-    def __getattribute__(self, name: str) -> Any:
-        if name in type(self)._MUTATORS:
-            return self._immutable
-        return super().__getattribute__(name)
+    def __setattr__(self, name: str, value: object) -> NoReturn:
+        del name, value
+        raise TypeError("metadata is immutable")
+
+    def __delattr__(self, name: str) -> NoReturn:
+        del name
+        raise TypeError("metadata is immutable")
 
     @staticmethod
-    def _immutable(*args: object, **kwargs: object) -> None:
+    def _immutable(*args: object, **kwargs: object) -> NoReturn:
         del args, kwargs
         raise TypeError("metadata is immutable")
 
-    def __setitem__(self, key: str, value: Any) -> None:
+    def __setitem__(self, key: object, value: object) -> NoReturn:
         self._immutable(key, value)
 
-    def __delitem__(self, key: str) -> None:
+    def __delitem__(self, key: object) -> NoReturn:
         self._immutable(key)
 
-    def __ior__(self, other: object) -> FrozenJsonDict:
+    def clear(self) -> NoReturn:
+        self._immutable()
+
+    def pop(self, *args: object) -> NoReturn:
+        self._immutable(*args)
+
+    def popitem(self) -> NoReturn:
+        self._immutable()
+
+    def setdefault(self, *args: object) -> NoReturn:
+        self._immutable(*args)
+
+    def update(self, *args: object, **kwargs: object) -> NoReturn:
+        self._immutable(*args, **kwargs)
+
+    def __ior__(self, other: object) -> NoReturn:
         self._immutable(other)
-        return self
+
+    def copy(self) -> dict[str, Any]:
+        return plain_json(self)
 
     def __copy__(self) -> dict[str, Any]:
         return plain_json(self)
@@ -66,37 +77,91 @@ class FrozenJsonDict(dict[str, Any]):
         return plain_json(self)
 
 
-class FrozenJsonList(list[Any]):
-    """A ``list``-compatible sequence that rejects every in-place mutation."""
+class FrozenJsonList(Sequence[Any]):
+    """A read-only JSON array without a mutable ``list`` base class."""
 
-    __slots__ = ()
-    _MUTATORS = frozenset(
-        {"append", "clear", "extend", "insert", "pop", "remove", "reverse", "sort"}
-    )
+    __slots__ = ("_values",)
+    _values: tuple[Any, ...]
 
-    def __getattribute__(self, name: str) -> Any:
-        if name in type(self)._MUTATORS:
-            return self._immutable
-        return super().__getattribute__(name)
+    def __init__(self, values: Sequence[Any]) -> None:
+        object.__setattr__(self, "_values", tuple(values))
+
+    @overload
+    def __getitem__(self, index: int) -> Any: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> tuple[Any, ...]: ...
+
+    def __getitem__(self, index: int | slice) -> Any | tuple[Any, ...]:
+        return self._values[index]
+
+    def __iter__(self) -> Iterator[Any]:
+        return iter(self._values)
+
+    def __len__(self) -> int:
+        return len(self._values)
+
+    def __repr__(self) -> str:
+        return repr(list(self._values))
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, FrozenJsonList):
+            return self._values == other._values
+        if isinstance(other, (list, tuple)):
+            return self._values == tuple(other)
+        return False
+
+    def __setattr__(self, name: str, value: object) -> NoReturn:
+        del name, value
+        raise TypeError("metadata is immutable")
+
+    def __delattr__(self, name: str) -> NoReturn:
+        del name
+        raise TypeError("metadata is immutable")
 
     @staticmethod
-    def _immutable(*args: object, **kwargs: object) -> None:
+    def _immutable(*args: object, **kwargs: object) -> NoReturn:
         del args, kwargs
         raise TypeError("metadata is immutable")
 
-    def __setitem__(self, key: int | slice, value: Any) -> None:
+    def __setitem__(self, key: object, value: object) -> NoReturn:
         self._immutable(key, value)
 
-    def __delitem__(self, key: int | slice) -> None:
+    def __delitem__(self, key: object) -> NoReturn:
         self._immutable(key)
 
-    def __iadd__(self, other: object) -> FrozenJsonList:
-        self._immutable(other)
-        return self
+    def append(self, value: object) -> NoReturn:
+        self._immutable(value)
 
-    def __imul__(self, other: object) -> FrozenJsonList:
+    def clear(self) -> NoReturn:
+        self._immutable()
+
+    def extend(self, values: object) -> NoReturn:
+        self._immutable(values)
+
+    def insert(self, index: object, value: object) -> NoReturn:
+        self._immutable(index, value)
+
+    def pop(self, *args: object) -> NoReturn:
+        self._immutable(*args)
+
+    def remove(self, value: object) -> NoReturn:
+        self._immutable(value)
+
+    def reverse(self) -> NoReturn:
+        self._immutable()
+
+    def sort(self, *args: object, **kwargs: object) -> NoReturn:
+        self._immutable(*args, **kwargs)
+
+    def __iadd__(self, other: object) -> NoReturn:
         self._immutable(other)
-        return self
+
+    def __imul__(self, other: object) -> NoReturn:
+        self._immutable(other)
+
+    def copy(self) -> list[Any]:
+        return plain_json(self)
 
     def __copy__(self) -> list[Any]:
         return plain_json(self)
@@ -106,11 +171,35 @@ class FrozenJsonList(list[Any]):
         return plain_json(self)
 
 
+_JSON_ARRAY_TYPES = (list, tuple, FrozenJsonList)
+
+
+def _plain_json(value: Any, *, path: str) -> Any:
+    if isinstance(value, Mapping):
+        result: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError(
+                    f"JSON object keys must be strings at {path}; got {type(key).__name__}"
+                )
+            result[key] = _plain_json(item, path=f"{path}[{key!r}]")
+        return result
+    if isinstance(value, _JSON_ARRAY_TYPES):
+        return [_plain_json(item, path=f"{path}[{index}]") for index, item in enumerate(value)]
+    return value
+
+
+def plain_json(value: Any) -> Any:
+    """Return ordinary JSON-compatible containers without coercing object keys."""
+
+    return _plain_json(value, path="$")
+
+
 def _freeze_json(value: Any) -> Any:
     if isinstance(value, dict):
         return FrozenJsonDict({key: _freeze_json(item) for key, item in value.items()})
     if isinstance(value, list):
-        return FrozenJsonList(_freeze_json(item) for item in value)
+        return FrozenJsonList(tuple(_freeze_json(item) for item in value))
     return value
 
 

--- a/src/prob4d/causal_stream_contract.py
+++ b/src/prob4d/causal_stream_contract.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import replace
 
 import numpy as np
@@ -40,8 +40,7 @@ def bind_causal_stream_contract_v2(
         "stream contract v2 can only bind the strict Prob4D causal stream",
     )
     _require(
-        artifact.window_names
-        and artifact.window_names[0] == metric_anchor.window_id,
+        artifact.window_names and artifact.window_names[0] == metric_anchor.window_id,
         "metric gauge anchor must identify the first exported window",
     )
     metadata = dict(artifact.metadata)
@@ -81,8 +80,7 @@ def bind_causal_stream_contract_v2(
     )
     factor_rank = len(artifact.factor_names)
     expected_factor_names = tuple(
-        f"{PROB4D_JOINT_GAUGE_FACTOR_PREFIX}{index:04d}"
-        for index in range(factor_rank)
+        f"{PROB4D_JOINT_GAUGE_FACTOR_PREFIX}{index:04d}" for index in range(factor_rank)
     )
     _require(
         factor_rank > 0 and artifact.factor_names == expected_factor_names,
@@ -110,8 +108,7 @@ def bind_causal_stream_contract_v2(
         "exported metric gauge-anchor identity changed",
     )
     _require(
-        existing_anchor.get("source_artifact_sha256")
-        == metric_anchor.source_artifact_sha256,
+        existing_anchor.get("source_artifact_sha256") == metric_anchor.source_artifact_sha256,
         "exported metric gauge-anchor source digest changed",
     )
     lineage = metadata.get("causal_source_lineage")
@@ -121,22 +118,21 @@ def bind_causal_stream_contract_v2(
     )
     selected_windows = lineage.get("selected_windows")
     _require(
-        isinstance(selected_windows, list) and bool(selected_windows),
+        isinstance(selected_windows, Sequence)
+        and not isinstance(selected_windows, (str, bytes))
+        and bool(selected_windows),
         "stream contract v2 requires selected source-window lineage",
     )
     first_window = selected_windows[0]
     _require(
         isinstance(first_window, Mapping)
         and first_window.get("window_id") == metric_anchor.window_id
-        and first_window.get("payload_sha256")
-        == metric_anchor.source_artifact_sha256,
+        and first_window.get("payload_sha256") == metric_anchor.source_artifact_sha256,
         "metric gauge anchor is not bound to the first selected payload",
     )
 
     anchor_metadata = metric_anchor.contract_metadata(case_id=artifact.case_id)
-    metadata["prob4d_causal_stream_contract_version"] = (
-        PROB4D_CAUSAL_STREAM_CONTRACT_VERSION
-    )
+    metadata["prob4d_causal_stream_contract_version"] = PROB4D_CAUSAL_STREAM_CONTRACT_VERSION
     metadata["metric_gauge_anchor"] = anchor_metadata
     metadata["metric_anchor_covariance_in_joint_factor"] = True
     metadata["prob4d_causal_stream_contract"] = {
@@ -147,9 +143,7 @@ def bind_causal_stream_contract_v2(
             "gauge tree"
         ),
         "factor_group_semantics": "one shared latent vector across all windows",
-        "metric_anchor_covariance_treatment": anchor_metadata[
-            "covariance_treatment"
-        ],
+        "metric_anchor_covariance_treatment": anchor_metadata["covariance_treatment"],
         "causal_frame_stop_convention": "exclusive",
     }
     return replace(artifact, metadata=metadata)

--- a/src/prob4d/data.py
+++ b/src/prob4d/data.py
@@ -9,6 +9,8 @@ from typing import Any, Final, Literal, TypeAlias, cast
 import numpy as np
 from numpy.typing import NDArray
 
+from ._immutable_array import immutable_array
+
 FloatArray: TypeAlias = NDArray[np.floating[Any]]
 BoolArray: TypeAlias = NDArray[np.bool_]
 IntArray: TypeAlias = NDArray[np.integer[Any]]
@@ -39,18 +41,15 @@ _PREDICTION_WINDOW_OPTIONAL_MEMBERS: Final[frozenset[str]] = frozenset(
 
 
 def _readonly_owned(value: np.ndarray) -> np.ndarray:
-    """Freeze an array that is already an owned defensive copy."""
+    """Move an already validated array onto irreversible read-only storage."""
 
-    value.setflags(write=False)
-    return value
+    return immutable_array(value)
 
 
 def _validated_dense_storage_dtype(value: object) -> DenseStorageDType:
     normalized = str(value)
     if normalized not in DENSE_STORAGE_DTYPES:
-        raise ValueError(
-            "dense_storage_dtype must be one of " + ", ".join(DENSE_STORAGE_DTYPES)
-        )
+        raise ValueError("dense_storage_dtype must be one of " + ", ".join(DENSE_STORAGE_DTYPES))
     return cast(DenseStorageDType, normalized)
 
 
@@ -77,8 +76,7 @@ def _validated_versioned_archive(data: Any) -> DenseStorageDType:
     extra = sorted(files - allowed)
     if missing or extra:
         raise ValueError(
-            "prediction-window archive fields changed; "
-            f"missing={missing}, extra={extra}"
+            f"prediction-window archive fields changed; missing={missing}, extra={extra}"
         )
     if ("scene_flow" in files) != ("deform_mask" in files):
         raise ValueError(
@@ -379,9 +377,7 @@ class PredictionWindow:
                     raise ValueError(
                         "prediction files without frame_indices require start_frame explicitly"
                     )
-                stored_id = (
-                    str(data["window_id"].item()) if "window_id" in data else path.stem
-                )
+                stored_id = str(data["window_id"].item()) if "window_id" in data else path.stem
 
             return cls(
                 window_id=window_id or stored_id,

--- a/src/prob4d/provider_attestation.py
+++ b/src/prob4d/provider_attestation.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Any, cast
+
+from ._immutable_json import plain_json
 
 PROVIDER_ATTESTATION_SCHEMA = "prob4d.provider-attestation"
 PROVIDER_ATTESTATION_VERSION = 1
@@ -87,7 +89,7 @@ def _require_string_mapping_keys(
                 name=name,
                 path=f"{path}.{key}",
             )
-    elif isinstance(value, (list, tuple)):
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
         for index, item in enumerate(value):
             _require_string_mapping_keys(
                 item,
@@ -102,7 +104,7 @@ def _finite_json_mapping(value: Any, *, name: str) -> dict[str, Any]:
     try:
         normalized = json.loads(
             json.dumps(
-                dict(value),
+                plain_json(value),
                 sort_keys=True,
                 separators=(",", ":"),
                 allow_nan=False,
@@ -144,8 +146,7 @@ def _require_integer(value: Any, *, name: str) -> int:
 def _require_sha256(value: Any, *, name: str) -> str:
     _require(isinstance(value, str), f"{name} must be a string")
     _require(
-        len(value) == 64
-        and all(character in "0123456789abcdef" for character in value),
+        len(value) == 64 and all(character in "0123456789abcdef" for character in value),
         f"{name} must be a lowercase SHA-256 digest",
     )
     return value
@@ -154,8 +155,7 @@ def _require_sha256(value: Any, *, name: str) -> str:
 def _require_revision(value: Any, *, name: str) -> str:
     _require(isinstance(value, str), f"{name} must be a string")
     _require(
-        len(value) in {40, 64}
-        and all(character in "0123456789abcdef" for character in value),
+        len(value) in {40, 64} and all(character in "0123456789abcdef" for character in value),
         f"{name} must be an exact lowercase Git commit",
     )
     return value
@@ -163,7 +163,7 @@ def _require_revision(value: Any, *, name: str) -> str:
 
 def _canonical_json(value: Mapping[str, Any]) -> bytes:
     return json.dumps(
-        dict(value),
+        plain_json(value),
         sort_keys=True,
         separators=(",", ":"),
         allow_nan=False,
@@ -217,12 +217,13 @@ def validate_provider_manifest(
 
     capabilities = normalized.get("capabilities")
     _require(
-        isinstance(capabilities, list)
+        isinstance(capabilities, Sequence)
+        and not isinstance(capabilities, (str, bytes))
         and all(isinstance(item, str) and item for item in capabilities)
         and len(capabilities) == len(set(capabilities)),
         "provider manifest capabilities must be unique nonempty strings",
     )
-    capability_list = cast(list[Any], capabilities)
+    capability_list = cast(Sequence[Any], capabilities)
     _require(
         _REQUIRED_CAPABILITIES.issubset(capability_list),
         "provider manifest lacks required claim-bearing capabilities",
@@ -252,9 +253,7 @@ def validate_provider_manifest(
         "provider-v2 manifest must not default to uncalibrated export",
     )
     _require(
-        limitation_mapping.get(
-            "deployment_environment_revision_is_independent_vcs_evidence"
-        )
+        limitation_mapping.get("deployment_environment_revision_is_independent_vcs_evidence")
         is False,
         "provider manifest misstates deployment revision evidence",
     )

--- a/src/prob4d/provider_v2_factor_bundle.py
+++ b/src/prob4d/provider_v2_factor_bundle.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -41,9 +41,7 @@ from .provider_v1 import (
 )
 from .runtime_revision import assert_runtime_revision
 
-CLAIM_BEARING_FACTOR_BUNDLE_SCHEMA = (
-    "prob4d.claim-bearing-observation-factor-bundle"
-)
+CLAIM_BEARING_FACTOR_BUNDLE_SCHEMA = "prob4d.claim-bearing-observation-factor-bundle"
 CLAIM_BEARING_FACTOR_BUNDLE_VERSION = 1
 _REQUIRED_PROVIDER_CAPABILITIES = frozenset(
     {
@@ -81,9 +79,7 @@ _ENVELOPE_FIELDS = frozenset(
         "metadata",
     }
 )
-_CALIBRATION_FIELDS = frozenset(
-    {"gauge_artifact_id", "point_artifact_id"}
-)
+_CALIBRATION_FIELDS = frozenset({"gauge_artifact_id", "point_artifact_id"})
 
 
 def _canonical_json(value: Mapping[str, Any]) -> bytes:
@@ -120,9 +116,7 @@ def _require_nonempty_string(value: object, *, name: str) -> str:
 
 def _require_sha256(value: object, *, name: str) -> str:
     digest = _require_nonempty_string(value, name=name)
-    if len(digest) != 64 or any(
-        character not in "0123456789abcdef" for character in digest
-    ):
+    if len(digest) != 64 or any(character not in "0123456789abcdef" for character in digest):
         raise ValueError(f"{name} must be a lowercase SHA-256 digest")
     return digest
 
@@ -185,8 +179,7 @@ def _validated_calibration_ids(value: object) -> Mapping[str, str]:
         raise ValueError("calibration_artifact_ids must be a mapping")
     if set(value) != _CALIBRATION_FIELDS:
         raise ValueError(
-            "calibration_artifact_ids must contain exactly gauge_artifact_id "
-            "and point_artifact_id"
+            "calibration_artifact_ids must contain exactly gauge_artifact_id and point_artifact_id"
         )
     result: dict[str, str] = {}
     for name in sorted(_CALIBRATION_FIELDS):
@@ -201,11 +194,9 @@ def _validated_calibration_ids(value: object) -> Mapping[str, str]:
 
 
 def _validated_gauge_ids(value: object) -> tuple[str, ...]:
-    if not isinstance(value, (list, tuple)) or not value:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence) or not value:
         raise ValueError("gauge_ids must be a nonempty sequence")
-    result = tuple(
-        _require_nonempty_string(item, name="gauge_id") for item in value
-    )
+    result = tuple(_require_nonempty_string(item, name="gauge_id") for item in value)
     if len(set(result)) != len(result):
         raise ValueError("gauge_ids must be unique")
     return result
@@ -239,7 +230,7 @@ def _validated_lineage(
     )
 
     selected = lineage.get("selected_windows")
-    if not isinstance(selected, list) or not selected:
+    if isinstance(selected, (str, bytes)) or not isinstance(selected, Sequence) or not selected:
         raise ValueError("claim-bearing factors require selected source-window lineage")
     selected_ids: set[str] = set()
     for raw_window in selected:
@@ -293,19 +284,17 @@ def _provider_fields(
     )
     manifest = validated["provider_manifest"]
     capabilities = manifest.get("capabilities")
-    if not isinstance(capabilities, list) or not _REQUIRED_PROVIDER_CAPABILITIES.issubset(
-        capabilities
+    if (
+        isinstance(capabilities, (str, bytes))
+        or not isinstance(capabilities, Sequence)
+        or not _REQUIRED_PROVIDER_CAPABILITIES.issubset(capabilities)
     ):
-        raise ValueError(
-            "provider manifest lacks claim-bearing observation-factor capabilities"
-        )
+        raise ValueError("provider manifest lacks claim-bearing observation-factor capabilities")
     provider_manifest_id = _require_sha256(
         validated.get("provider_manifest_id"),
         name="provider_manifest_id",
     )
-    calibration_ids = _validated_calibration_ids(
-        validated.get("calibration_artifact_ids")
-    )
+    calibration_ids = _validated_calibration_ids(validated.get("calibration_artifact_ids"))
     runtime = validated.get("runtime_revision")
     if not isinstance(runtime, Mapping):
         raise ValueError("validated provider runtime revision must be a mapping")
@@ -422,17 +411,13 @@ class ClaimBearingObservationFactorBundleEnvelopeV1:
             self.provider_manifest_id,
             name="provider_manifest_id",
         )
-        calibration_ids = _validated_calibration_ids(
-            self.calibration_artifact_ids
-        )
+        calibration_ids = _validated_calibration_ids(self.calibration_artifact_ids)
         runtime_source = _require_nonempty_string(
             self.runtime_revision_source,
             name="runtime_revision_source",
         )
         if self.runtime_revision_independently_verified is not True:
-            raise ValueError(
-                "runtime_revision_independently_verified must be literally True"
-            )
+            raise ValueError("runtime_revision_independently_verified must be literally True")
         if manifest_id != attested_manifest_id:
             raise ValueError("provider_manifest_id differs from provider attestation")
         if dict(calibration_ids) != dict(attested_calibration_ids):
@@ -473,10 +458,14 @@ class ClaimBearingObservationFactorBundleEnvelopeV1:
 
         expected = _sha256_json(self.identity_record())
         supplied = self.artifact_id
-        if supplied is not None and _require_sha256(
-            supplied,
-            name="artifact_id",
-        ) != expected:
+        if (
+            supplied is not None
+            and _require_sha256(
+                supplied,
+                name="artifact_id",
+            )
+            != expected
+        ):
             raise ValueError("claim-bearing factor envelope artifact ID mismatch")
         object.__setattr__(self, "artifact_id", expected)
 
@@ -504,9 +493,7 @@ class ClaimBearingObservationFactorBundleEnvelopeV1:
             ),
             "causal_source_lineage": plain_json(self.causal_source_lineage),
             "provider_manifest_id": self.provider_manifest_id,
-            "calibration_artifact_ids": plain_json(
-                self.calibration_artifact_ids
-            ),
+            "calibration_artifact_ids": plain_json(self.calibration_artifact_ids),
             "runtime_revision_source": self.runtime_revision_source,
             "runtime_revision_independently_verified": (
                 self.runtime_revision_independently_verified
@@ -531,8 +518,7 @@ class ClaimBearingObservationFactorBundleEnvelopeV1:
             missing = sorted(_ENVELOPE_FIELDS - value.keys())
             extra = sorted(value.keys() - _ENVELOPE_FIELDS)
             raise ValueError(
-                "claim-bearing factor envelope fields changed; "
-                f"missing={missing}, extra={extra}"
+                f"claim-bearing factor envelope fields changed; missing={missing}, extra={extra}"
             )
         if value.get("schema") != CLAIM_BEARING_FACTOR_BUNDLE_SCHEMA:
             raise ValueError("unexpected claim-bearing factor envelope schema")
@@ -607,7 +593,7 @@ def _lineage_window_bounds(
     lineage: Mapping[str, Any],
 ) -> dict[str, tuple[int, int]]:
     selected = lineage.get("selected_windows")
-    if not isinstance(selected, list):
+    if isinstance(selected, (str, bytes)) or not isinstance(selected, Sequence):
         raise ValueError("causal source lineage selected_windows changed type")
     result: dict[str, tuple[int, int]] = {}
     for raw_window in selected:
@@ -745,11 +731,7 @@ def seal_claim_bearing_observation_factor_bundle(
     envelope_file = Path(envelope_path)
     envelope_file.parent.mkdir(parents=True, exist_ok=True)
     default_manifest, default_payload = _default_bundle_paths(envelope_file)
-    manifest_file = (
-        default_manifest
-        if bundle_manifest_path is None
-        else Path(bundle_manifest_path)
-    )
+    manifest_file = default_manifest if bundle_manifest_path is None else Path(bundle_manifest_path)
     payload_file = default_payload if payload_path is None else Path(payload_path)
     if manifest_file.resolve() == envelope_file.resolve():
         raise ValueError("bundle manifest and claim-bearing envelope must differ")
@@ -838,9 +820,7 @@ def write_claim_bearing_observation_factor_bundle(
     from .provider_v2 import prob4d_provider_manifest
 
     attestation = build_provider_attestation(
-        provider_manifest=prob4d_provider_manifest(
-            provider_revision=bundle.source_revision
-        ),
+        provider_manifest=prob4d_provider_manifest(provider_revision=bundle.source_revision),
         provider_revision=bundle.source_revision,
         export_mode="calibrated",
         calibration_compatibility_validated=True,
@@ -852,9 +832,7 @@ def write_claim_bearing_observation_factor_bundle(
         composition_jacobian_mode="analytic",
         runtime_revision=runtime.as_metadata(),
     )
-    lineage = causal_selection.artifact_lineage_metadata(
-        causal_frame_stop=bundle.causal_frame_stop
-    )
+    lineage = causal_selection.artifact_lineage_metadata(causal_frame_stop=bundle.causal_frame_stop)
     return seal_claim_bearing_observation_factor_bundle(
         bundle,
         envelope_path,

--- a/src/prob4d/provider_v2_loading.py
+++ b/src/prob4d/provider_v2_loading.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
@@ -25,9 +25,7 @@ def _required_mapping(value: object, *, name: str) -> Mapping[str, object]:
 
 def _require_sha256(value: object, *, name: str) -> str:
     digest = str(value)
-    if len(digest) != 64 or any(
-        character not in "0123456789abcdef" for character in digest
-    ):
+    if len(digest) != 64 or any(character not in "0123456789abcdef" for character in digest):
         raise ValueError(f"{name} must be a lowercase SHA-256 digest")
     return digest
 
@@ -124,9 +122,7 @@ def validate_claim_bearing_observation_belief(
     if metadata.get("gauge_mode") != "sequential":
         raise ValueError("claim-bearing observation requires sequential gauge mode")
     if metadata.get("joint_cross_window_gauge_covariance_represented") is not True:
-        raise ValueError(
-            "claim-bearing observation requires joint cross-window gauge covariance"
-        )
+        raise ValueError("claim-bearing observation requires joint cross-window gauge covariance")
     if metadata.get("metric_anchor_covariance_in_joint_factor") is not True:
         raise ValueError(
             "claim-bearing observation requires metric-anchor covariance in the joint factor"
@@ -148,7 +144,11 @@ def validate_claim_bearing_observation_belief(
     if lineage.get("future_prediction_payloads_opened") != 0:
         raise ValueError("claim-bearing observation opened future prediction payloads")
     selected_windows = lineage.get("selected_windows")
-    if not isinstance(selected_windows, list) or not selected_windows:
+    if (
+        isinstance(selected_windows, (str, bytes))
+        or not isinstance(selected_windows, Sequence)
+        or not selected_windows
+    ):
         raise ValueError("claim-bearing observation requires selected source-window lineage")
     for selected_window in selected_windows:
         window = _required_mapping(selected_window, name="selected source window")
@@ -178,13 +178,9 @@ def validate_claim_bearing_observation_belief(
     if calibration.get("status") != "calibrated":
         raise ValueError("claim-bearing observation requires both covariance calibrations")
     if calibration.get("uncalibrated_exploratory_covariance_allowed") is not False:
-        raise ValueError(
-            "claim-bearing observation cannot allow uncalibrated covariance"
-        )
+        raise ValueError("claim-bearing observation cannot allow uncalibrated covariance")
     if calibration.get("pointwise_covariance_fallback_allowed") is not False:
-        raise ValueError(
-            "claim-bearing observation cannot allow pointwise covariance fallback"
-        )
+        raise ValueError("claim-bearing observation cannot allow pointwise covariance fallback")
     alignment_count = _require_nonnegative_integer(
         calibration.get("alignment_count"),
         name="claim-bearing alignment_count",
@@ -254,9 +250,7 @@ def load_claim_bearing_observation_belief(
 ) -> ValidatedClaimBearingObservation:
     """Load one artifact and require all claim-bearing provider-v2 invariants."""
 
-    return validate_claim_bearing_observation_belief(
-        load_observation_belief_export(path)
-    )
+    return validate_claim_bearing_observation_belief(load_observation_belief_export(path))
 
 
 __all__ = [

--- a/tests/test_claim_bearing_observation.py
+++ b/tests/test_claim_bearing_observation.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from copy import copy, deepcopy
 from dataclasses import replace
 from pathlib import Path
@@ -128,8 +129,8 @@ def test_observation_metadata_is_recursively_immutable_and_hash_stable() -> None
 
     caller_metadata["caller_owned"]["items"][0]["value"] = 99  # type: ignore[index]
     assert artifact.metadata["caller_owned"]["items"][0]["value"] == 1  # type: ignore[index]
-    assert isinstance(artifact.metadata, dict)
-    assert isinstance(artifact.metadata["nested"]["values"], list)  # type: ignore[index]
+    assert isinstance(artifact.metadata, Mapping)
+    assert isinstance(artifact.metadata["nested"]["values"], Sequence)  # type: ignore[index]
 
     with pytest.raises(TypeError, match="metadata is immutable"):
         artifact.metadata["new"] = "value"  # type: ignore[index]

--- a/tests/test_data_immutability.py
+++ b/tests/test_data_immutability.py
@@ -43,6 +43,10 @@ def test_prediction_window_defensively_copies_and_freezes_arrays() -> None:
     with pytest.raises(ValueError, match="read-only"):
         window.point_map[0, 0, 0, 0] = 2.0
 
+    for array in (window.frame_indices, window.point_map, window.valid_mask):
+        with pytest.raises(ValueError, match="cannot set WRITEABLE flag"):
+            array.setflags(write=True)
+
 
 def test_prediction_window_normalizes_and_freezes_optional_arrays() -> None:
     frames, points, valid = _inputs()
@@ -73,6 +77,11 @@ def test_prediction_window_normalizes_and_freezes_optional_arrays() -> None:
     np.testing.assert_allclose(window.scene_flow, 1.0)
     assert np.all(window.deform_mask)
     assert np.all(np.linalg.norm(window.ray_directions[window.valid_mask], axis=-1) > 0.0)
+
+    for array in (window.scene_flow, window.deform_mask, window.ray_directions):
+        assert array is not None
+        with pytest.raises(ValueError, match="cannot set WRITEABLE flag"):
+            array.setflags(write=True)
 
 
 def test_prediction_window_rejects_nonfinite_active_optional_values() -> None:

--- a/tests/test_immutable_array.py
+++ b/tests/test_immutable_array.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from prob4d._immutable_array import immutable_array, immutable_integer_array
+
+
+def test_immutable_array_copies_values_and_cannot_be_reenabled() -> None:
+    source = np.arange(12, dtype=np.float32).reshape(2, 2, 3)
+    frozen = immutable_array(source)
+
+    source[...] = -1.0
+    np.testing.assert_array_equal(
+        frozen,
+        np.arange(12, dtype=np.float32).reshape(2, 2, 3),
+    )
+    assert not frozen.flags.writeable
+    with pytest.raises(ValueError, match="cannot set WRITEABLE flag"):
+        frozen.setflags(write=True)
+    with pytest.raises(ValueError, match="read-only"):
+        frozen[0, 0, 0] = 99.0
+
+
+def test_immutable_array_preserves_empty_and_scalar_shapes() -> None:
+    scalar = immutable_array(np.asarray(3.5, dtype=np.float64))
+    empty = immutable_array(np.empty((0, 3), dtype=np.float32))
+
+    assert scalar.shape == ()
+    assert scalar.dtype == np.dtype(np.float64)
+    assert float(scalar) == 3.5
+    assert empty.shape == (0, 3)
+    assert empty.dtype == np.dtype(np.float32)
+    assert not scalar.flags.writeable
+    assert not empty.flags.writeable
+
+
+def test_immutable_array_rejects_object_storage() -> None:
+    with pytest.raises(ValueError, match="must not contain Python objects"):
+        immutable_array(np.asarray([object()], dtype=object))
+
+
+def test_immutable_integer_array_rejects_coercion_and_preserves_values() -> None:
+    frozen = immutable_integer_array(np.asarray([1, 2], dtype=np.uint8), name="ids")
+
+    np.testing.assert_array_equal(frozen, [1, 2])
+    assert frozen.dtype == np.dtype(np.int64)
+    with pytest.raises(ValueError, match="must contain integers"):
+        immutable_integer_array(np.asarray([1.0]), name="ids")
+    with pytest.raises(ValueError, match="must contain integers"):
+        immutable_integer_array(np.asarray([True]), name="ids")

--- a/tests/test_immutable_json.py
+++ b/tests/test_immutable_json.py
@@ -115,3 +115,28 @@ def test_frozen_mapping_remains_recursively_immutable_and_copyable() -> None:
 
     assert thawed == {"nested": {"values": [1, 2, 3]}}
     assert plain_json(frozen) == {"nested": {"values": [1, 2]}}
+
+
+def test_frozen_json_has_no_mutable_builtin_base_class_escape() -> None:
+    frozen = frozen_finite_json_mapping({"items": [1, 2]})
+    values = cast(FrozenJsonList, frozen["items"])
+
+    assert not isinstance(frozen, dict)
+    assert not isinstance(values, list)
+    with pytest.raises(TypeError):
+        dict.__setitem__(frozen, "changed", True)  # type: ignore[arg-type]
+    with pytest.raises(TypeError):
+        list.append(values, 3)  # type: ignore[arg-type]
+
+
+def test_frozen_json_explicit_copy_returns_mutable_plain_values() -> None:
+    frozen = cast(
+        FrozenJsonDict,
+        frozen_finite_json_mapping({"nested": {"items": [1]}}),
+    )
+
+    copied = frozen.copy()
+    copied["nested"]["items"].append(2)
+
+    assert copied == {"nested": {"items": [1, 2]}}
+    assert plain_json(frozen) == {"nested": {"items": [1]}}


### PR DESCRIPTION
## Purpose

Close two in-memory integrity gaps at Prob4D's claim-bearing boundaries:

- frozen JSON values inherited from mutable built-ins, so base-class descriptors could bypass their normal mutation guards; and
- `PredictionWindow` arrays only cleared NumPy's write flag, which callers could restore on owned storage after validation.

## Changes

- replace frozen `dict`/`list` subclasses with genuine read-only `Mapping` and `Sequence` values;
- add immutable byte-backed NumPy array helpers whose write flag cannot be restored;
- migrate all validated `PredictionWindow` arrays to that representation;
- update provider-v2, causal-stream, attestation, and held-out-diagnosis consumers to use protocol-oriented sequence validation;
- retain explicit mutable exports through `plain_json`, `.copy()`, and APIs such as `PredictionWindow.rays()`;
- add adversarial tests for `dict.__setitem__`, `list.append`, direct array writes, caller aliasing, and `setflags(write=True)`; and
- add a focused read-only workflow and compatibility documentation.

## Compatibility

- no provider-v1/v2, observation, factor-bundle, stream, prediction-window, or calibration schema changes;
- valid JSON serialization and portable content identities remain unchanged;
- large execution-only `FusedSequence` and mmap ownership paths remain unchanged to preserve bounded-memory execution.

## Validation

The exact product source was built on current `main` at `e37c3d50d4a07a2c3760389e79d59b0ac9402dc4` and validated on `workstation2` in Actions run `31077365209`:

- deterministic source patch and gzip identities verified;
- exact declared-file inventory passed;
- Ruff formatting and lint passed;
- MyPy passed for the changed stable modules;
- complete repository suite: **755 passed**;
- Python byte compilation and `pip check` passed;
- wheel and source-distribution builds passed; and
- Twine validation passed.

The workflow uploaded artifact `validated-immutable-product` (`sha256:e3451be06769d247003168dd4f3210936b8634bdd835945b4a239c8b6019668d`). Its internal checksums were independently reverified and its Git blobs form this one-commit branch at `7d0fb278b51d6828f9185defc19f248f92e6843a`.

After correcting the workflow's self-hosted Python bootstrap, the dedicated read-only `Immutable artifact contracts` check passed on the exact reviewable head in run `31077828475`.

## Claim boundary

This is artifact-integrity and provenance infrastructure. It does not establish provider competence, uncertainty calibration, physical-state identifiability, BayesianPhysTwin or Causal4D benefit, deployment safety, or state of the art.