### PR TITLE
Reuse validated prediction windows as zero-copy evaluation references

### DIFF
--- a/.github/workflows/prediction-window-truth-view.yml
+++ b/.github/workflows/prediction-window-truth-view.yml
@@ -1,0 +1,68 @@
+name: Prediction-window truth view
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/prediction-window-truth-view.yml"
+      - "docs/prediction-window-truth-view.md"
+      - "src/prob4d/truth_view.py"
+      - "tests/test_truth_view.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: prediction-window-truth-view-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out exact reviewed head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+          clean: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install compatible development environment
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install -e ".[dev]"
+          python -m pip install "numpy>=1.24,<2.3"
+          python -m pip check
+
+      - name: Check source quality and typing
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m ruff check src/prob4d/truth_view.py tests/test_truth_view.py
+          python -m ruff format --check src/prob4d/truth_view.py tests/test_truth_view.py
+          python -m mypy src/prob4d/truth_view.py
+
+      - name: Run focused and adjacent metric tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pytest -q \
+            tests/test_truth_view.py \
+            tests/test_metrics.py \
+            tests/test_evaluation_modes.py \
+            tests/test_data_immutability.py \
+            tests/test_prediction_store.py
+          python -m compileall -q src/prob4d

--- a/docs/prediction-window-truth-view.md
+++ b/docs/prediction-window-truth-view.md
@@ -1,0 +1,53 @@
+# Zero-copy prediction-window truth views
+
+`TruthSequence` is the ordinary external truth contract. Its constructor
+canonicalizes floating fields to `float64`, defensively copies every array, and
+makes the retained values read-only. That is the correct default for independent
+truth supplied by a caller.
+
+Some engineering checks intentionally compare a fused result against another
+already validated Prob4D prediction artifact. Examples include backend parity,
+storage-path profiling, and ablations that use the same MotionCrafter disjoint
+baseline as a common internal reference. Copying a full-resolution
+`PredictionWindow` through `TruthSequence` can duplicate hundreds of megabytes of
+point maps and scene flow even though the source artifact is already immutable.
+
+`PredictionWindowTruthView` makes this special case explicit:
+
+```python
+from prob4d.metrics import evaluate_sequence
+from prob4d.truth_view import prediction_window_truth_view
+
+reference = prediction_window_truth_view(disjoint_prediction_window)
+metrics = evaluate_sequence(fused_prediction, reference)
+```
+
+The view:
+
+- accepts only a validated `PredictionWindow`, including a verified read-only
+  memory-mapped execution-store window;
+- requires every retained source array to be non-writeable;
+- preserves array identity and storage dtype without conversion or copying;
+- remains a `TruthSequence` subtype, so existing metric and evaluation-mode
+  functions require no alternate estimator path; and
+- records the exact source window ID for audit output.
+
+The adapter changes ownership and retains the source storage dtype. Mixed
+prediction/reference arithmetic is still evaluated in floating-point NumPy
+operations, but a float32 reference is not first materialized as a complete
+float64 array. Consequently, derived operations performed solely on the
+reference—such as a reference-vector norm—may differ from the ordinary copied
+path by storage-rounding at the last few floating-point bits. The focused
+contract requires exact structural/count equality and bounds every scalar metric
+difference by `1e-20` on the adversarial float32 regression. Reports that require
+byte-identical metrics across storage dtypes should continue to use the ordinary
+`TruthSequence` copy.
+
+## Claim boundary
+
+A prediction-window truth view is suitable only where the prediction artifact is
+predeclared as a common internal reference. It does **not** convert a model output
+into external ground truth, establish reconstruction accuracy, calibrate
+uncertainty, or justify a downstream BayesianPhysTwin or Causal4D claim. Reports
+using this adapter should name the reference artifact and state that the result
+is an engineering or ablation comparison.

--- a/src/prob4d/truth_view.py
+++ b/src/prob4d/truth_view.py
@@ -1,0 +1,85 @@
+"""Zero-copy evaluation views over validated immutable prediction windows.
+
+A :class:`~prob4d.data.PredictionWindow` already enforces shapes, masks,
+finite active values, immutable ownership, and canonical dense-storage dtypes.
+When such a window is deliberately used as an internal engineering reference,
+copying it through :class:`~prob4d.metrics.TruthSequence` duplicates every dense
+point and flow field. This module provides an explicit subtype that reuses those
+validated read-only arrays without weakening the ordinary public truth contract.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .data import PredictionWindow
+from .metrics import TruthSequence
+
+
+class PredictionWindowTruthView(TruthSequence):
+    """A read-only ``TruthSequence`` view backed by one ``PredictionWindow``.
+
+    Construction accepts only a fully validated ``PredictionWindow`` (including
+    memory-mapped execution-store windows). The retained arrays must already be
+    read-only and are assigned by identity: no dtype conversion, defensive copy,
+    or dense materialization is performed.
+
+    This adapter is intended for internal parity, ablation, and engineering
+    diagnostics where a prediction artifact is intentionally the common
+    reference. It does not turn that artifact into external ground truth and
+    must not be used to support an accuracy claim.
+    """
+
+    _source_window_id: str
+
+    def __init__(self, window: PredictionWindow) -> None:
+        if not isinstance(window, PredictionWindow):
+            raise TypeError("window must be a validated PredictionWindow")
+
+        arrays = {
+            "frame_indices": window.frame_indices,
+            "point_map": window.point_map,
+            "valid_mask": window.valid_mask,
+            "scene_flow": window.scene_flow,
+            "deform_mask": window.deform_mask,
+        }
+        for name, value in arrays.items():
+            if value is not None and np.asarray(value).flags.writeable:
+                raise ValueError(
+                    f"validated prediction field {name!r} unexpectedly remains writeable"
+                )
+
+        object.__setattr__(self, "frame_indices", window.frame_indices)
+        object.__setattr__(self, "point_map", window.point_map)
+        object.__setattr__(self, "valid_mask", window.valid_mask)
+        object.__setattr__(self, "scene_flow", window.scene_flow)
+        object.__setattr__(self, "deform_mask", window.deform_mask)
+        object.__setattr__(self, "_source_window_id", window.window_id)
+
+    @property
+    def source_window_id(self) -> str:
+        """Return the exact prediction-window identity backing this view."""
+
+        return self._source_window_id
+
+    @property
+    def retained_array_bytes(self) -> int:
+        """Return dense bytes referenced by the view, without implying ownership."""
+
+        values = (
+            self.frame_indices,
+            self.point_map,
+            self.valid_mask,
+            self.scene_flow,
+            self.deform_mask,
+        )
+        return sum(np.asarray(value).nbytes for value in values if value is not None)
+
+
+def prediction_window_truth_view(window: PredictionWindow) -> PredictionWindowTruthView:
+    """Return a zero-copy truth-compatible view of a validated prediction window."""
+
+    return PredictionWindowTruthView(window)
+
+
+__all__ = ["PredictionWindowTruthView", "prediction_window_truth_view"]

--- a/tests/test_truth_view.py
+++ b/tests/test_truth_view.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from prob4d.data import PredictionWindow
+from prob4d.fusion import FusedSequence
+from prob4d.metrics import TruthSequence, evaluate_sequence
+from prob4d.truth_view import (
+    PredictionWindowTruthView,
+    prediction_window_truth_view,
+)
+
+
+def _window() -> PredictionWindow:
+    frame_indices = np.arange(3, dtype=np.int64)
+    rows, columns = np.indices((3, 4), dtype=np.float32)
+    points = np.empty((3, 3, 4, 3), dtype=np.float32)
+    for frame in range(3):
+        points[frame, ..., 0] = columns + 0.1 * frame
+        points[frame, ..., 1] = rows - 0.05 * frame
+        points[frame, ..., 2] = 2.0 + 0.2 * frame
+    valid = np.ones(points.shape[:-1], dtype=bool)
+    valid[1, 0, 0] = False
+    flow = np.full_like(points, 0.025)
+    deform = valid.copy()
+    deform[0, -1, -1] = False
+    return PredictionWindow(
+        window_id="reference-window",
+        frame_indices=frame_indices,
+        point_map=points,
+        valid_mask=valid,
+        scene_flow=flow,
+        deform_mask=deform,
+        dense_storage_dtype="float32",
+    )
+
+
+def _prediction(window: PredictionWindow) -> FusedSequence:
+    shape = window.shape
+    point_map = np.asarray(window.point_map, dtype=np.float64).copy()
+    point_map[..., 0] += 0.01
+    covariance = np.zeros(shape + (3, 3), dtype=np.float64)
+    diagonal = np.arange(3)
+    covariance[..., diagonal, diagonal] = 0.02
+    assert window.scene_flow is not None
+    assert window.deform_mask is not None
+    scene_flow = np.asarray(window.scene_flow, dtype=np.float64).copy()
+    scene_flow[..., 1] -= 0.002
+    flow_covariance = np.zeros_like(covariance)
+    flow_covariance[..., diagonal, diagonal] = 0.005
+    return FusedSequence(
+        frame_indices=window.frame_indices,
+        point_map=point_map,
+        valid_mask=window.valid_mask,
+        point_covariance=covariance,
+        contributors=np.ones(shape, dtype=np.uint16),
+        scene_flow=scene_flow,
+        deform_mask=window.deform_mask,
+        flow_covariance=flow_covariance,
+    )
+
+
+def test_prediction_window_truth_view_reuses_every_reference_array() -> None:
+    window = _window()
+    view = prediction_window_truth_view(window)
+
+    assert isinstance(view, TruthSequence)
+    assert isinstance(view, PredictionWindowTruthView)
+    assert view.source_window_id == window.window_id
+    assert view.frame_indices is window.frame_indices
+    assert view.point_map is window.point_map
+    assert view.valid_mask is window.valid_mask
+    assert view.scene_flow is window.scene_flow
+    assert view.deform_mask is window.deform_mask
+    assert view.point_map.dtype == np.dtype(np.float32)
+    assert view.retained_array_bytes == sum(
+        value.nbytes
+        for value in (
+            window.frame_indices,
+            window.point_map,
+            window.valid_mask,
+            window.scene_flow,
+            window.deform_mask,
+        )
+        if value is not None
+    )
+
+    with pytest.raises(ValueError):
+        view.point_map[0, 0, 0, 0] = 123.0
+    with pytest.raises(ValueError):
+        view.point_map.setflags(write=True)
+
+
+def test_prediction_window_truth_view_preserves_evaluation_results() -> None:
+    window = _window()
+    prediction = _prediction(window)
+    copied = TruthSequence(
+        frame_indices=window.frame_indices,
+        point_map=window.point_map,
+        valid_mask=window.valid_mask,
+        scene_flow=window.scene_flow,
+        deform_mask=window.deform_mask,
+    )
+    viewed = PredictionWindowTruthView(window)
+
+    copied_metrics = evaluate_sequence(
+        prediction,
+        copied,
+        boundary_frames=[2],
+        align_scale_translation=True,
+        evaluation_chunk_size=5,
+    )
+    viewed_metrics = evaluate_sequence(
+        prediction,
+        viewed,
+        boundary_frames=[2],
+        align_scale_translation=True,
+        evaluation_chunk_size=5,
+    )
+
+    copied_record = copied_metrics.to_dict()
+    viewed_record = viewed_metrics.to_dict()
+    assert viewed_record.keys() == copied_record.keys()
+    numeric_differences: dict[str, float] = {}
+    for name, copied_value in copied_record.items():
+        viewed_value = viewed_record[name]
+        if copied_value is None or isinstance(copied_value, int):
+            assert viewed_value == copied_value
+            continue
+        assert viewed_value is not None
+        numeric_differences[name] = abs(float(viewed_value) - float(copied_value))
+    assert max(numeric_differences.values(), default=0.0) <= 1e-20
+
+    assert viewed.point_map.dtype == np.dtype(np.float32)
+    assert copied.point_map.dtype == np.dtype(np.float64)
+    assert not np.shares_memory(copied.point_map, window.point_map)
+    assert np.shares_memory(viewed.point_map, window.point_map)
+
+
+def test_prediction_window_truth_view_rejects_unvalidated_values() -> None:
+    with pytest.raises(TypeError, match="validated PredictionWindow"):
+        PredictionWindowTruthView(object())  # type: ignore[arg-type]


### PR DESCRIPTION
## Purpose

Remove a measured evaluation-memory duplication without weakening Prob4D's ordinary external truth contract.

`TruthSequence` correctly copies and canonicalizes independent caller-supplied truth. Engineering parity and ablation checks sometimes deliberately use an already validated immutable `PredictionWindow` as a common internal reference. Reconstructing that artifact through `TruthSequence` duplicates every dense point and flow field, contributing directly to the 5.3–5.5 GiB evaluation peak observed in the frozen issue-#50 real-bundle profile.

## Changes

- add `PredictionWindowTruthView`, a `TruthSequence` subtype that accepts only a validated `PredictionWindow`;
- require all retained source arrays to be non-writeable;
- reuse frame, point, mask, flow, and deformation arrays by identity without dtype conversion or copying;
- retain the exact source window ID and referenced-byte accounting; and
- document the narrow engineering/ablation claim boundary.

Existing `TruthSequence`, metric, evaluation-mode, provider, and artifact APIs are unchanged. Callers must opt into the view explicitly.

## Floating-point contract

The view deliberately retains the source storage dtype. Compared with the ordinary float64 truth copy, reference-only operations such as float32 vector norms can differ at the final few floating-point bits. The regression therefore requires:

- exact field and count structure;
- exact `None` and integer-valued outputs;
- identical array ownership and immutability properties; and
- every scalar metric difference bounded by `1e-20`.

The observed maximum in the adversarial float32 regression is approximately `1e-23`. Callers requiring byte-identical metrics across reference storage dtypes should retain the ordinary `TruthSequence` copy.

## Validation

The unchanged four-file product tree passed on its preceding exact product head:

- Ruff lint and formatting;
- MyPy;
- **30 focused and adjacent tests**, including metric, evaluation-mode, immutability, and execution-store coverage; and
- Python byte compilation.

Fail-closed quality also passed. The branch was then rebuilt as one clean commit on runtime-enabled `main` at `d611322409e42ee72e98488503097594515f3a43`; only the parent changed, and the four product blobs are identical to the validated tree. Exact-head reruns are queued because of repository-wide Actions saturation.

## Claim boundary

This is an ownership and memory optimization for an explicitly declared internal reference. It does not convert a prediction into external ground truth, establish reconstruction accuracy, calibrate uncertainty, establish provider competence, or demonstrate BayesianPhysTwin or Causal4D benefit.