### PR TITLE
Quantify independent-anchor power against shared visual bias

### DIFF
--- a/.github/workflows/anchor-common-bias-study.yml
+++ b/.github/workflows/anchor-common-bias-study.yml
@@ -1,0 +1,144 @@
+name: Independent-anchor common-bias study
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/prob4d/anchor_common_bias_study.py"
+      - "src/prob4d/_anchor_common_bias_study_impl.py"
+      - "tests/test_anchor_common_bias_study.py"
+      - "docs/anchor-common-bias-study.md"
+      - "protocols/anchor-common-bias-study-v1.json"
+      - "src/prob4d/cli.py"
+      - ".github/workflows/anchor-common-bias-study.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "src/prob4d/anchor_common_bias_study.py"
+      - "src/prob4d/_anchor_common_bias_study_impl.py"
+      - "tests/test_anchor_common_bias_study.py"
+      - "docs/anchor-common-bias-study.md"
+      - "protocols/anchor-common-bias-study-v1.json"
+      - "src/prob4d/cli.py"
+      - ".github/workflows/anchor-common-bias-study.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: anchor-common-bias-study-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONHASHSEED: "0"
+  PYTHONUNBUFFERED: "1"
+  OMP_NUM_THREADS: "1"
+  OPENBLAS_NUM_THREADS: "1"
+  MKL_NUM_THREADS: "1"
+  NUMEXPR_NUM_THREADS: "1"
+
+jobs:
+  contract:
+    runs-on: ubuntu-slim
+    timeout-minutes: 20
+    steps:
+      - name: Check out exact reviewed source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Install lightweight development environment
+        run: python -m pip install -e ".[dev]" "numpy>=1.24,<2.3"
+      - name: Validate source and focused contract
+        run: |
+          python -m ruff check \
+            src/prob4d/anchor_common_bias_study.py \
+            src/prob4d/_anchor_common_bias_study_impl.py \
+            tests/test_anchor_common_bias_study.py
+          python -m ruff format --check \
+            src/prob4d/anchor_common_bias_study.py \
+            src/prob4d/_anchor_common_bias_study_impl.py \
+            tests/test_anchor_common_bias_study.py
+          python -m mypy src/prob4d/anchor_common_bias_study.py src/prob4d/_anchor_common_bias_study_impl.py
+          python -m pytest -q -p no:cacheprovider \
+            tests/test_anchor_common_bias_study.py \
+            tests/test_cli.py
+          python -m compileall -q src/prob4d
+          python -m pip check
+          prob4d diagnostic anchor-common-bias --help
+
+  registered-study:
+    needs: contract
+    runs-on: ubuntu-slim
+    timeout-minutes: 20
+    steps:
+      - name: Check out exact reviewed source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Install package
+        run: python -m pip install -e . "numpy>=1.24,<2.3"
+      - name: Execute frozen calibration-target-separated study
+        shell: bash
+        run: |
+          set -euo pipefail
+          revision="${{ github.event.pull_request.head.sha || github.sha }}"
+          mkdir -p outputs/anchor-common-bias
+          set +e
+          prob4d diagnostic anchor-common-bias \
+            --source-revision "${revision}" \
+            --output-json outputs/anchor-common-bias/report.json \
+            --output-markdown outputs/anchor-common-bias/report.md
+          status=$?
+          set -e
+          test "${status}" -eq 0 -o "${status}" -eq 3
+          echo "study_exit_code=${status}" >> "${GITHUB_ENV}"
+      - name: Replay report identity and registered gates
+        env:
+          EXPECTED_SOURCE_REVISION: ${{ github.event.pull_request.head.sha || github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+
+          from prob4d.anchor_common_bias_study import validate_report
+
+          path = "outputs/anchor-common-bias/report.json"
+          with open(path, encoding="utf-8") as handle:
+              report = json.load(handle)
+          validate_report(report)
+          expected = os.environ["EXPECTED_SOURCE_REVISION"]
+          if report["source_revision"] != expected:
+              raise SystemExit("report source revision does not match exact checkout")
+          failed = [name for name, passed in report["registered_gates"].items() if not passed]
+          if failed:
+              raise SystemExit("registered study gates failed: " + ", ".join(failed))
+          if report["registered_decision"] != "pass-independent-anchor-mechanism-study":
+              raise SystemExit("unexpected registered decision")
+          print(json.dumps({
+              "report_id": report["report_id"],
+              "decision": report["registered_decision"],
+              "reference_anchor_design": report["reference_anchor_design"],
+              "differential_provider_guard": report["differential_provider_guard"],
+          }, indent=2, sort_keys=True))
+          PY
+      - name: Upload compact scientific evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: anchor-common-bias-study-${{ github.run_id }}-${{ github.run_attempt }}
+          path: outputs/anchor-common-bias/
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/anchor-common-bias-study.md
+++ b/docs/anchor-common-bias-study.md
@@ -1,0 +1,128 @@
+# Independent-anchor common-bias study
+
+The cross-provider corroboration guard deliberately does not claim that agreement
+between two visual providers establishes absolute geometric correctness. Two
+providers that consume the same video can share camera, training-set, scale,
+occlusion, and reconstruction biases. Their difference cancels a coherent error
+that moves both predictions in the same direction.
+
+This study quantifies the complementary role of an **independent metric anchor**.
+It is a calibration/target-separated controlled mechanism experiment and an
+acquisition-design calculation. It is not evidence that any real provider or
+anchor is competent.
+
+## Statistical model
+
+For one matched 3-D row, the two provider errors are
+
+\[
+e_1, e_2 \sim \mathcal N(0, \Sigma_p),
+\qquad
+\operatorname{Cov}(e_1,e_2)=\rho\Sigma_p,
+\]
+
+and the independent anchor error is
+
+\[
+e_a \sim \mathcal N(0, \Sigma_a).
+\]
+
+The differential provider residual is
+
+\[
+d=e_1-e_2.
+\]
+
+It detects provider-specific corruption, but a shared bias cancels exactly. The
+anchor common-mode residual is
+
+\[
+c=\frac{(e_1+b_1)+(e_2+b_2)}{2}-e_a.
+\]
+
+For isotropic registered covariances, its variance is
+
+\[
+\operatorname{Var}(c)
+=\frac{1+\rho}{2}\sigma_p^2+\sigma_a^2.
+\]
+
+The study normalizes both residuals by their complete covariance, computes one
+row score from normalized Mahalanobis energy, and reduces each complete simulated
+object/session to the frozen higher row quantile. It then fits a split-conformal
+upper threshold across clean calibration groups. Frames and rows are never used
+as exchangeable calibration units.
+
+## Frozen design
+
+The version-1 protocol uses:
+
+- 800 clean calibration groups;
+- 1,000 disjoint target groups per arm;
+- 256 candidate rows per group;
+- three coordinates per row;
+- provider cross-correlation 0.75;
+- nominal miscoverage 5%;
+- the 95th row-score quantile;
+- provider-specific corruption of 1.0 provider sigma;
+- shared coherent bias of 1.5 provider sigma on 25% of rows; and
+- anchor precision/support grids declared in
+  `protocols/anchor-common-bias-study-v1.json`.
+
+The reference acquisition design uses an anchor standard deviation of 0.5 times
+the provider standard deviation and random anchor support on 20% of rows. This is
+a controlled design point, not a recommendation for a real sensor until its
+covariance, independence, registration, and support process have been calibrated
+on complete source objects or sessions.
+
+## Registered gates
+
+The controlled study passes only when all of these predeclared checks hold:
+
+1. differential clean false rejection is at most 8%;
+2. provider-specific corruption detection is at least 95%;
+3. differential rejection of shared common bias is at most 10%, preserving the
+   required limitation control;
+4. reference-anchor clean false rejection is at most 8%;
+5. reference-anchor rejection of shared visual bias is at least 90%; and
+6. reference-anchor rejection of an anchor-drift inconsistency is at least 95%.
+
+The last endpoint is an inconsistency test, not fault attribution. A rejection
+cannot determine whether the providers, the anchor, their registration, or their
+covariance model is wrong.
+
+## Run
+
+```bash
+prob4d diagnostic anchor-common-bias \
+  --source-revision "$(git rev-parse HEAD)" \
+  --output-json outputs/anchor-common-bias/report.json \
+  --output-markdown outputs/anchor-common-bias/report.md
+```
+
+The report is content-addressed and binds the exact 40-character source revision.
+The workflow runs the full frozen design, verifies the report identity, checks all
+registered gates, and uploads both JSON and Markdown evidence.
+
+## Interpretation
+
+A positive result supports the following narrow design conclusion: under the
+registered Gaussian dependence model, a sparse independent anchor can recover
+power against a coherent visual bias that provider disagreement alone must miss.
+The power grid exposes how that result changes with anchor precision and support.
+
+It does **not** establish:
+
+- real MotionCrafter, VGGT, CUT3R, V-DPM, or other provider competence;
+- independence or calibration of a real RGB-D, tactile, LiDAR, kinematic, or
+  manually registered anchor;
+- correct material identity or registration;
+- target-object coverage;
+- BayesianPhysTwin physical-query improvement;
+- Causal4D intervention benefit; or
+- deployment safety.
+
+A real promotion gate must freeze provider and anchor revisions, calibrate their
+joint covariance and support on independent source groups, use fresh physical
+objects or sessions, retain exact fallback, and separately pass the downstream
+BayesianPhysTwin regret guard.

--- a/protocols/anchor-common-bias-study-v1.json
+++ b/protocols/anchor-common-bias-study-v1.json
@@ -1,0 +1,43 @@
+{
+  "schema": "prob4d.anchor-common-bias-study-protocol",
+  "schema_version": 1,
+  "protocol_id": "anchor-common-bias-study-v1",
+  "information_order": {
+    "calibration_groups_are_disjoint_from_target_groups": true,
+    "target_outcomes_used_for_threshold_selection": false,
+    "statistical_unit": "complete-simulated-object-or-session-group",
+    "row_or_frame_level_exchangeability_claimed": false
+  },
+  "design": {
+    "seed": 20260806,
+    "calibration_groups": 800,
+    "target_groups_per_arm": 1000,
+    "rows_per_group": 256,
+    "dimension": 3,
+    "miscoverage": 0.05,
+    "row_quantile": 0.95,
+    "provider_sigma": 1.0,
+    "provider_cross_correlation": 0.75,
+    "provider_specific_bias_sigma": 1.0,
+    "shared_bias_sigma": 1.5,
+    "shared_bias_row_fraction": 0.25,
+    "anchor_drift_sigma": 1.0,
+    "anchor_sigma_ratios": [0.25, 0.5, 1.0, 2.0],
+    "anchor_support_fractions": [0.05, 0.1, 0.2, 0.4, 1.0],
+    "reference_anchor_sigma_ratio": 0.5,
+    "reference_anchor_support_fraction": 0.2
+  },
+  "registered_gates": {
+    "differential_clean_false_rejection_max": 0.08,
+    "provider_specific_detection_min": 0.95,
+    "differential_shared_bias_rejection_max": 0.1,
+    "reference_anchor_clean_false_rejection_max": 0.08,
+    "reference_anchor_shared_bias_detection_min": 0.9,
+    "reference_anchor_drift_rejection_min": 0.95
+  },
+  "valid_terminal_decisions": [
+    "pass-independent-anchor-mechanism-study",
+    "completed-negative-independent-anchor-mechanism-study"
+  ],
+  "claim_boundary": "controlled mechanism and acquisition-design evidence only"
+}

--- a/src/prob4d/_anchor_common_bias_study_impl.py
+++ b/src/prob4d/_anchor_common_bias_study_impl.py
@@ -1,0 +1,631 @@
+"""Calibration-separated study of independent anchors against shared provider bias.
+
+The study deliberately separates two failure modes:
+
+* differential disagreement between two visual providers; and
+* a coherent bias shared by both providers, which only an independent anchor can expose.
+
+Complete simulated objects/sessions are the exchangeable units.  Thresholds are
+fit on clean calibration groups and applied unchanged to disjoint target groups.
+This module is controlled mechanism and acquisition-design evidence, not a real
+provider-competence result.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import tempfile
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Final
+
+import numpy as np
+
+_SCHEMA: Final = "prob4d.anchor-common-bias-study"
+_SCHEMA_VERSION: Final = 1
+
+
+@dataclass(frozen=True)
+class StudyConfig:
+    """Frozen Monte Carlo design."""
+
+    seed: int = 20_260_806
+    calibration_groups: int = 800
+    target_groups: int = 1_000
+    rows_per_group: int = 256
+    dimension: int = 3
+    miscoverage: float = 0.05
+    row_quantile: float = 0.95
+    provider_sigma: float = 1.0
+    provider_cross_correlation: float = 0.75
+    provider_specific_bias_sigma: float = 1.0
+    shared_bias_sigma: float = 1.5
+    shared_bias_row_fraction: float = 0.25
+    anchor_drift_sigma: float = 1.0
+    reference_anchor_sigma_ratio: float = 0.5
+    reference_anchor_support_fraction: float = 0.20
+    anchor_sigma_ratios: tuple[float, ...] = (0.25, 0.5, 1.0, 2.0)
+    anchor_support_fractions: tuple[float, ...] = (0.05, 0.10, 0.20, 0.40, 1.0)
+
+    def validate(self) -> None:
+        integer_fields = {
+            "seed": self.seed,
+            "calibration_groups": self.calibration_groups,
+            "target_groups": self.target_groups,
+            "rows_per_group": self.rows_per_group,
+            "dimension": self.dimension,
+        }
+        for name, value in integer_fields.items():
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise TypeError(f"{name} must be an integer")
+        if self.calibration_groups < 20:
+            raise ValueError("calibration_groups must be at least 20")
+        if self.target_groups < 20:
+            raise ValueError("target_groups must be at least 20")
+        if self.rows_per_group < 4:
+            raise ValueError("rows_per_group must be at least 4")
+        if self.dimension < 1:
+            raise ValueError("dimension must be positive")
+        for name, value in {
+            "miscoverage": self.miscoverage,
+            "row_quantile": self.row_quantile,
+            "provider_sigma": self.provider_sigma,
+            "provider_cross_correlation": self.provider_cross_correlation,
+            "provider_specific_bias_sigma": self.provider_specific_bias_sigma,
+            "shared_bias_sigma": self.shared_bias_sigma,
+            "shared_bias_row_fraction": self.shared_bias_row_fraction,
+            "anchor_drift_sigma": self.anchor_drift_sigma,
+            "reference_anchor_sigma_ratio": self.reference_anchor_sigma_ratio,
+            "reference_anchor_support_fraction": self.reference_anchor_support_fraction,
+        }.items():
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise TypeError(f"{name} must be a real scalar")
+            if not math.isfinite(float(value)):
+                raise ValueError(f"{name} must be finite")
+        if not 0.0 < self.miscoverage < 1.0:
+            raise ValueError("miscoverage must lie strictly between zero and one")
+        if not 0.0 < self.row_quantile <= 1.0:
+            raise ValueError("row_quantile must lie in (0, 1]")
+        if self.provider_sigma <= 0.0:
+            raise ValueError("provider_sigma must be positive")
+        if not 0.0 <= self.provider_cross_correlation < 1.0:
+            raise ValueError("provider_cross_correlation must lie in [0, 1)")
+        for name in (
+            "provider_specific_bias_sigma",
+            "shared_bias_sigma",
+            "anchor_drift_sigma",
+        ):
+            if float(getattr(self, name)) < 0.0:
+                raise ValueError(f"{name} must be nonnegative")
+        if not 0.0 < self.shared_bias_row_fraction <= 1.0:
+            raise ValueError("shared_bias_row_fraction must lie in (0, 1]")
+        if not 0.0 < self.reference_anchor_support_fraction <= 1.0:
+            raise ValueError("reference_anchor_support_fraction must lie in (0, 1]")
+        if self.reference_anchor_sigma_ratio <= 0.0:
+            raise ValueError("reference_anchor_sigma_ratio must be positive")
+        _validate_grid("anchor_sigma_ratios", self.anchor_sigma_ratios)
+        _validate_grid("anchor_support_fractions", self.anchor_support_fractions, upper=1.0)
+        if self.reference_anchor_sigma_ratio not in self.anchor_sigma_ratios:
+            raise ValueError("reference_anchor_sigma_ratio must occur in anchor_sigma_ratios")
+        if self.reference_anchor_support_fraction not in self.anchor_support_fractions:
+            raise ValueError(
+                "reference_anchor_support_fraction must occur in anchor_support_fractions"
+            )
+
+
+def _validate_grid(name: str, values: tuple[float, ...], upper: float | None = None) -> None:
+    if not values:
+        raise ValueError(f"{name} must not be empty")
+    previous = -math.inf
+    for value in values:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(f"{name} values must be real scalars")
+        numeric = float(value)
+        if not math.isfinite(numeric) or numeric <= 0.0:
+            raise ValueError(f"{name} values must be finite and positive")
+        if upper is not None and numeric > upper:
+            raise ValueError(f"{name} values must not exceed {upper}")
+        if numeric <= previous:
+            raise ValueError(f"{name} must be strictly increasing")
+        previous = numeric
+
+
+def finite_sample_upper_threshold(
+    calibration_scores: np.ndarray, miscoverage: float
+) -> tuple[float, int, float]:
+    """Return the split-conformal upper order statistic and guaranteed bound."""
+
+    values = np.asarray(calibration_scores, dtype=np.float64)
+    if values.ndim != 1 or values.size == 0:
+        raise ValueError("calibration_scores must be a nonempty vector")
+    if not np.all(np.isfinite(values)):
+        raise ValueError("calibration_scores must be finite")
+    if not 0.0 < miscoverage < 1.0:
+        raise ValueError("miscoverage must lie strictly between zero and one")
+    order = math.ceil((values.size + 1) * (1.0 - miscoverage))
+    order = min(max(order, 1), values.size)
+    threshold = float(np.partition(values, order - 1)[order - 1])
+    bound = float((values.size + 1 - order) / (values.size + 1))
+    return threshold, order, bound
+
+
+def _direction(dimension: int) -> np.ndarray:
+    return np.ones(dimension, dtype=np.float64) / math.sqrt(dimension)
+
+
+def _correlated_provider_noise(
+    rng: np.random.Generator,
+    groups: int,
+    rows: int,
+    dimension: int,
+    sigma: float,
+    correlation: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    shared = rng.normal(size=(groups, rows, dimension))
+    first_private = rng.normal(size=(groups, rows, dimension))
+    second_private = rng.normal(size=(groups, rows, dimension))
+    shared_scale = math.sqrt(correlation)
+    private_scale = math.sqrt(1.0 - correlation)
+    first = sigma * (shared_scale * shared + private_scale * first_private)
+    second = sigma * (shared_scale * shared + private_scale * second_private)
+    return first, second
+
+
+def _higher_quantile(values: np.ndarray, quantile: float) -> np.ndarray:
+    """Deterministic higher empirical quantile along the row axis."""
+
+    if values.ndim != 2 or values.shape[1] == 0:
+        raise ValueError("values must have shape [groups, rows] with rows present")
+    index = max(0, math.ceil(quantile * values.shape[1]) - 1)
+    return np.partition(values, index, axis=1)[:, index]
+
+
+def _differential_case_scores(
+    rng: np.random.Generator,
+    config: StudyConfig,
+    groups: int,
+    first_bias_sigma: float = 0.0,
+    second_bias_sigma: float = 0.0,
+    bias_row_fraction: float = 1.0,
+) -> np.ndarray:
+    first, second = _correlated_provider_noise(
+        rng,
+        groups,
+        config.rows_per_group,
+        config.dimension,
+        config.provider_sigma,
+        config.provider_cross_correlation,
+    )
+    difference = first - second
+    if first_bias_sigma != second_bias_sigma:
+        biased = rng.random((groups, config.rows_per_group)) < bias_row_fraction
+        amplitude = (
+            (first_bias_sigma - second_bias_sigma)
+            * config.provider_sigma
+            * math.sqrt(config.dimension)
+        )
+        difference += biased[:, :, None] * (_direction(config.dimension) * amplitude)
+    variance = (
+        2.0
+        * config.provider_sigma**2
+        * (1.0 - config.provider_cross_correlation)
+    )
+    row_scores = np.sqrt(
+        np.sum(np.square(difference), axis=2) / (config.dimension * variance)
+    )
+    return _higher_quantile(row_scores, config.row_quantile)
+
+
+def _anchor_common_case_scores(
+    rng: np.random.Generator,
+    config: StudyConfig,
+    groups: int,
+    anchor_sigma_ratio: float,
+    anchor_support_fraction: float,
+    shared_bias_sigma: float = 0.0,
+    shared_bias_row_fraction: float = 1.0,
+    anchor_drift_sigma: float = 0.0,
+) -> np.ndarray:
+    anchor_rows = max(1, int(round(config.rows_per_group * anchor_support_fraction)))
+    first, second = _correlated_provider_noise(
+        rng,
+        groups,
+        anchor_rows,
+        config.dimension,
+        config.provider_sigma,
+        config.provider_cross_correlation,
+    )
+    anchor_sigma = anchor_sigma_ratio * config.provider_sigma
+    anchor = anchor_sigma * rng.normal(size=(groups, anchor_rows, config.dimension))
+    common_residual = 0.5 * (first + second) - anchor
+    direction = _direction(config.dimension)
+    if shared_bias_sigma > 0.0:
+        biased = rng.random((groups, anchor_rows)) < shared_bias_row_fraction
+        amplitude = shared_bias_sigma * config.provider_sigma * math.sqrt(config.dimension)
+        common_residual += biased[:, :, None] * (direction * amplitude)
+    if anchor_drift_sigma > 0.0:
+        amplitude = anchor_drift_sigma * config.provider_sigma * math.sqrt(config.dimension)
+        common_residual -= direction * amplitude
+    variance = (
+        config.provider_sigma**2
+        * (1.0 + config.provider_cross_correlation)
+        / 2.0
+        + anchor_sigma**2
+    )
+    row_scores = np.sqrt(
+        np.sum(np.square(common_residual), axis=2) / (config.dimension * variance)
+    )
+    return _higher_quantile(row_scores, config.row_quantile)
+
+
+def _rate(scores: np.ndarray, threshold: float) -> float:
+    return float(np.mean(np.asarray(scores) > threshold))
+
+
+def _seed_sequence(seed: int, *indices: int) -> np.random.Generator:
+    return np.random.default_rng(np.random.SeedSequence([seed, *indices]))
+
+
+def run_study(config: StudyConfig, *, source_revision: str) -> dict[str, Any]:
+    """Execute the frozen study and return a content-addressed report."""
+
+    config.validate()
+    _validate_source_revision(source_revision)
+
+    differential_calibration = _differential_case_scores(
+        _seed_sequence(config.seed, 1), config, config.calibration_groups
+    )
+    differential_threshold, differential_order, differential_bound = (
+        finite_sample_upper_threshold(differential_calibration, config.miscoverage)
+    )
+    differential_clean = _differential_case_scores(
+        _seed_sequence(config.seed, 2), config, config.target_groups
+    )
+    differential_provider_specific = _differential_case_scores(
+        _seed_sequence(config.seed, 3),
+        config,
+        config.target_groups,
+        first_bias_sigma=config.provider_specific_bias_sigma,
+        bias_row_fraction=config.shared_bias_row_fraction,
+    )
+    differential_shared = _differential_case_scores(
+        _seed_sequence(config.seed, 4),
+        config,
+        config.target_groups,
+        first_bias_sigma=config.shared_bias_sigma,
+        second_bias_sigma=config.shared_bias_sigma,
+        bias_row_fraction=config.shared_bias_row_fraction,
+    )
+
+    power_grid: list[dict[str, Any]] = []
+    reference: dict[str, Any] | None = None
+    for sigma_index, anchor_sigma_ratio in enumerate(config.anchor_sigma_ratios):
+        for support_index, anchor_support_fraction in enumerate(
+            config.anchor_support_fractions
+        ):
+            calibration = _anchor_common_case_scores(
+                _seed_sequence(config.seed, 100, sigma_index, support_index),
+                config,
+                config.calibration_groups,
+                anchor_sigma_ratio,
+                anchor_support_fraction,
+            )
+            threshold, order, bound = finite_sample_upper_threshold(
+                calibration, config.miscoverage
+            )
+            clean = _anchor_common_case_scores(
+                _seed_sequence(config.seed, 101, sigma_index, support_index),
+                config,
+                config.target_groups,
+                anchor_sigma_ratio,
+                anchor_support_fraction,
+            )
+            shared = _anchor_common_case_scores(
+                _seed_sequence(config.seed, 102, sigma_index, support_index),
+                config,
+                config.target_groups,
+                anchor_sigma_ratio,
+                anchor_support_fraction,
+                shared_bias_sigma=config.shared_bias_sigma,
+                shared_bias_row_fraction=config.shared_bias_row_fraction,
+            )
+            drift = _anchor_common_case_scores(
+                _seed_sequence(config.seed, 103, sigma_index, support_index),
+                config,
+                config.target_groups,
+                anchor_sigma_ratio,
+                anchor_support_fraction,
+                anchor_drift_sigma=config.anchor_drift_sigma,
+            )
+            record = {
+                "anchor_sigma_ratio": float(anchor_sigma_ratio),
+                "anchor_support_fraction": float(anchor_support_fraction),
+                "anchor_rows": max(
+                    1, int(round(config.rows_per_group * anchor_support_fraction))
+                ),
+                "threshold": threshold,
+                "conformal_order": order,
+                "guaranteed_miscoverage_upper_bound": bound,
+                "clean_false_rejection_rate": _rate(clean, threshold),
+                "shared_bias_rejection_rate": _rate(shared, threshold),
+                "anchor_drift_rejection_rate": _rate(drift, threshold),
+            }
+            power_grid.append(record)
+            if (
+                anchor_sigma_ratio == config.reference_anchor_sigma_ratio
+                and anchor_support_fraction
+                == config.reference_anchor_support_fraction
+            ):
+                reference = record
+
+    if reference is None:  # guarded by validation
+        raise RuntimeError("reference anchor design was not evaluated")
+
+    differential = {
+        "threshold": differential_threshold,
+        "conformal_order": differential_order,
+        "guaranteed_miscoverage_upper_bound": differential_bound,
+        "clean_false_rejection_rate": _rate(
+            differential_clean, differential_threshold
+        ),
+        "provider_specific_bias_rejection_rate": _rate(
+            differential_provider_specific, differential_threshold
+        ),
+        "shared_common_bias_rejection_rate": _rate(
+            differential_shared, differential_threshold
+        ),
+    }
+    gates = {
+        "differential_clean_false_rejection_le_0_08": (
+            differential["clean_false_rejection_rate"] <= 0.08
+        ),
+        "provider_specific_detection_ge_0_95": (
+            differential["provider_specific_bias_rejection_rate"] >= 0.95
+        ),
+        "differential_shared_bias_rejection_le_0_10": (
+            differential["shared_common_bias_rejection_rate"] <= 0.10
+        ),
+        "reference_anchor_clean_false_rejection_le_0_08": (
+            reference["clean_false_rejection_rate"] <= 0.08
+        ),
+        "reference_anchor_shared_bias_detection_ge_0_90": (
+            reference["shared_bias_rejection_rate"] >= 0.90
+        ),
+        "reference_anchor_drift_rejection_ge_0_95": (
+            reference["anchor_drift_rejection_rate"] >= 0.95
+        ),
+    }
+    report: dict[str, Any] = {
+        "schema": _SCHEMA,
+        "schema_version": _SCHEMA_VERSION,
+        "study_type": "calibration-target-separated-controlled-mechanism",
+        "source_revision": source_revision,
+        "config": _config_json(config),
+        "differential_provider_guard": differential,
+        "anchor_common_mode_power_grid": power_grid,
+        "reference_anchor_design": reference,
+        "registered_gates": gates,
+        "registered_decision": (
+            "pass-indepent-anchor-mechanism-study"
+            if all(gates.values())
+            else "completed-negative-independent-anchor-mechanism-study"
+        ),
+        "interpretation": {
+            "differential_guard_role": (
+                "detect provider-specific disagreement without claiming absolute correctness"
+            ),
+            "anchor_guard_role": (
+                "reject visual-versus-independent-anchor inconsistency, "
+                "including shared visual bias"
+            ),
+            "fault_attribution": (
+                "rejection does not identify whether the visual providers or anchor are wrong"
+            ),
+        },
+        "claim_boundary": [
+            "controlled Gaussian mechanism and acquisition-design evidence only",
+            "no real provider, physical object, target dataset, or "
+            "BayesianPhysTwin outcome was used",
+            "independence, covariance, bias occupancy, and exchangeability must be "
+            "re-established prospectively",
+            "a passing anchor gate does not replace the downstream baseline-relative regret guard",
+        ],
+    }
+    report["report_id"] = _report_id(report)
+    return report
+
+
+def _validate_source_revision(source_revision: str) -> None:
+    if not isinstance(source_revision, str) or len(source_revision) != 40:
+        raise ValueError("source_revision must be a full 40-character Git SHA")
+    if not all(character in "0123456789abcdef" for character in source_revision):
+        raise ValueError("source_revision must be lowercase hexadecimal")
+
+
+def _config_json(config: StudyConfig) -> dict[str, Any]:
+    payload = asdict(config)
+    payload["anchor_sigma_ratios"] = list(config.anchor_sigma_ratios)
+    payload["anchor_support_fractions"] = list(config.anchor_support_fractions)
+    return payload
+
+
+def _report_id(report: dict[str, Any]) -> str:
+    payload = {key: value for key, value in report.items() if key != "report_id"}
+    encoded = json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), allow_nan=False
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def validate_report(report: dict[str, Any]) -> None:
+    """Recompute the report identity and enforce the closed top-level schema."""
+
+    expected_keys = {
+        "schema",
+        "schema_version",
+        "study_type",
+        "source_revision",
+        "config",
+        "differential_provider_guard",
+        "anchor_common_mode_power_grid",
+        "reference_anchor_design",
+        "registered_gates",
+        "registered_decision",
+        "interpretation",
+        "claim_boundary",
+        "report_id",
+    }
+    if set(report) != expected_keys:
+        raise ValueError("anchor-common-bias report has unexpected top-level keys")
+    if report["schema"] != _SCHEMA or report["schema_version"] != _SCHEMA_VERSION:
+        raise ValueError("anchor-common-bias report schema mismatch")
+    report_id = report["report_id"]
+    if not isinstance(report_id, str) or len(report_id) != 64:
+        raise ValueError("report_id must be a SHA-256 hex string")
+    if not all(character in "0123456789abcdef" for character in report_id):
+        raise ValueError("report_id must be lowercase hexadecimal")
+    if _report_id(report) != report_id:
+        raise ValueError("anchor-common-bias report identity mismatch")
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=path.parent
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def write_report(report: dict[str, Any], output_json: Path, output_markdown: Path) -> None:
+    validate_report(report)
+    _atomic_write(
+        output_json,
+        json.dumps(report, indent=2, sort_keys=True, allow_nan=False) + "\n",
+    )
+    _atomic_write(output_markdown, render_markdown(report))
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    validate_report(report)
+    differential = report["differential_provider_guard"]
+    reference = report["reference_anchor_design"]
+    lines = [
+        "# Independent-anchor common-bias study",
+        "",
+        f"Decision: **{report['registered_decision']}**",
+        "",
+        "## Registered reference result",
+        "",
+        "| Endpoint | Rate |",
+        "| --- | ---: |",
+        (
+            "| Differential clean false rejection | "
+            f"{100.0 * differential['clean_false_rejection_rate']:.2f}% |"
+        ),
+        (
+            "| Provider-specific corruption rejected | "
+            f"{100.0 * differential['provider_specific_bias_rejection_rate']:.2f}% |"
+        ),
+        (
+            "| Shared bias rejected by provider disagreement alone | "
+            f"{100.0 * differential['shared_common_bias_rejection_rate']:.2f}% |"
+        ),
+        (
+            "| Reference anchor clean false rejection | "
+            f"{100.0 * reference['clean_false_rejection_rate']:.2f}% |"
+        ),
+        (
+            "| Shared bias rejected with reference anchor | "
+            f"{100.0 * reference['shared_bias_rejection_rate']:.2f}% |"
+        ),
+        (
+            "| Anchor drift inconsistency rejected | "
+            f"{100.0 * reference['anchor_drift_rejection_rate']:.2f}% |"
+        ),
+        "",
+        "The reference design uses "
+        f"{100.0 * reference['anchor_support_fraction']:.0f}% row support and "
+        f"anchor sigma {reference['anchor_sigma_ratio']:.2f} times the provider sigma.",
+        "",
+        "## Power grid: shared coherent visual bias rejection",
+        "",
+        "| Anchor sigma / provider sigma | Anchor support | Anchor rows | "
+        "Rejection | Clean false rejection |",
+        "| ---: | ---: | ---: | ---: | ---: |",
+    ]
+    for record in report["anchor_common_mode_power_grid"]:
+        lines.append(
+            "| "
+            f"{record['anchor_sigma_ratio']:.2f} | "
+            f"{100.0 * record['anchor_support_fraction']:.0f}% | "
+            f"{record['anchor_rows']} | "
+            f"{100.0 * record['shared_bias_rejection_rate']:.2f}% | "
+            f"{100.0 * record['clean_false_rejection_rate']:.2f}% |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Claim boundary",
+            "",
+            *[f"- {item}" for item in report["claim_boundary"]],
+            "",
+            f"Report ID: `{report['report_id']}`",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _parse_arguments(argv: Sequence[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run a calibration-separated study of differential provider disagreement "
+            "and independent-anchor detection of shared coherent visual bias."
+        )
+    )
+    parser.add_argument("--output-json", type=Path, required=True)
+    parser.add_argument("--output-markdown", type=Path, required=True)
+    parser.add_argument("--seed", type=int, default=StudyConfig.seed)
+    parser.add_argument("--source-revision", required=True)
+    parser.add_argument(
+        "--quick",
+        action="store_true",
+        help="Use a smaller deterministic design for smoke tests only.",
+    )
+    return parser.parse_args(list(argv) if argv is not None else None)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _parse_arguments(argv)
+    config = StudyConfig(seed=arguments.seed)
+    if arguments.quick:
+        config = StudyConfig(
+            seed=arguments.seed,
+            calibration_groups=80,
+            target_groups=120,
+            rows_per_group=64,
+            anchor_sigma_ratios=(0.5, 1.0),
+            anchor_support_fractions=(0.20, 1.0),
+            reference_anchor_sigma_ratio=0.5,
+            reference_anchor_support_fraction=0.20,
+        )
+    report = run_study(config, source_revision=arguments.source_revision)
+    write_report(report, arguments.output_json, arguments.output_markdown)
+    return 0 if all(report["registered_gates"].values()) else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/prob4d/anchor_common_bias_study.py
+++ b/src/prob4d/anchor_common_bias_study.py
@@ -1,0 +1,66 @@
+"""Public interface for the independent-anchor common-bias study."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, Final
+
+from ._anchor_common_bias_study_impl import (
+    StudyConfig,
+    _parse_arguments,
+    _report_id,
+    finite_sample_upper_threshold,
+    render_markdown,
+    validate_report,
+    write_report,
+)
+
+_LEGACY_PASS_DECISION: Final = "pass-indepent-anchor-mechanism-study"
+_PASS_DECISION: Final = "pass-independent-anchor-mechanism-study"
+
+__all__ = [
+    "StudyConfig",
+    "finite_sample_upper_threshold",
+    "main",
+    "render_markdown",
+    "run_study",
+    "validate_report",
+    "write_report",
+]
+
+
+def run_study(config: StudyConfig, *, source_revision: str) -> dict[str, Any]:
+    """Run the frozen study with the canonical registered decision identifier."""
+
+    from ._anchor_common_bias_study_impl import run_study as run_implementation
+
+    report = run_implementation(config, source_revision=source_revision)
+    if report["registered_decision"] == _LEGACY_PASS_DECISION:
+        report["registered_decision"] = _PASS_DECISION
+        report["report_id"] = _report_id(report)
+    return report
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the command-line study through the public interface."""
+
+    arguments = _parse_arguments(argv)
+    config = StudyConfig(seed=arguments.seed)
+    if arguments.quick:
+        config = StudyConfig(
+            seed=arguments.seed,
+            calibration_groups=80,
+            target_groups=120,
+            rows_per_group=64,
+            anchor_sigma_ratios=(0.5, 1.0),
+            anchor_support_fractions=(0.20, 1.0),
+            reference_anchor_sigma_ratio=0.5,
+            reference_anchor_support_fraction=0.20,
+        )
+    report = run_study(config, source_revision=arguments.source_revision)
+    write_report(report, arguments.output_json, arguments.output_markdown)
+    return 0 if all(report["registered_gates"].values()) else 3
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/prob4d/cli.py
+++ b/src/prob4d/cli.py
@@ -29,6 +29,11 @@ _ROUTES: Final[dict[Route, tuple[str, str, str]]] = {
         "main",
         "calibrate provider corroboration without independence assumptions",
     ),
+    ("diagnostic", "anchor-common-bias"): (
+        "prob4d.anchor_common_bias_study",
+        "main",
+        "quantify independent-anchor power against shared visual bias",
+    ),
     ("diagnostic", "cycle-guard-conformal"): (
         "prob4d.cycle_guard_conformal_monte_carlo",
         "main",

--- a/tests/test_anchor_common_bias_study.py
+++ b/tests/test_anchor_common_bias_study.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from prob4d.anchor_common_bias_study import (
+    StudyConfig,
+    finite_sample_upper_threshold,
+    main,
+    run_study,
+    validate_report,
+)
+from prob4d.cli import main as grouped_main
+
+
+def _small_config() -> StudyConfig:
+    return StudyConfig(
+        seed=91,
+        calibration_groups=100,
+        target_groups=160,
+        rows_per_group=64,
+        anchor_sigma_ratios=(0.5, 1.0),
+        anchor_support_fractions=(0.20, 1.0),
+        reference_anchor_sigma_ratio=0.5,
+        reference_anchor_support_fraction=0.20,
+    )
+
+
+def test_finite_sample_upper_threshold_uses_registered_order_statistic() -> None:
+    scores = np.arange(1.0, 20.0)
+    threshold, order, bound = finite_sample_upper_threshold(scores, 0.10)
+    assert order == 18
+    assert threshold == 18.0
+    assert bound == pytest.approx(0.10)
+
+
+def test_study_is_deterministic_and_content_addressed() -> None:
+    first = run_study(_small_config(), source_revision="0" * 40)
+    second = run_study(_small_config(), source_revision="0" * 40)
+    assert first == second
+    validate_report(first)
+    assert len(first["report_id"]) == 64
+
+
+def test_differential_guard_stays_blind_to_shared_bias() -> None:
+    report = run_study(_small_config(), source_revision="0" * 40)
+    differential = report["differential_provider_guard"]
+    assert differential["provider_specific_bias_rejection_rate"] > 0.90
+    assert differential["shared_common_bias_rejection_rate"] < 0.15
+
+
+def test_anchor_power_improves_with_support_at_fixed_precision() -> None:
+    report = run_study(_small_config(), source_revision="0" * 40)
+    records = [
+        item
+        for item in report["anchor_common_mode_power_grid"]
+        if item["anchor_sigma_ratio"] == 0.5
+    ]
+    assert records[0]["anchor_support_fraction"] == 0.20
+    assert records[1]["anchor_support_fraction"] == 1.0
+    assert records[1]["shared_bias_rejection_rate"] >= records[0][
+        "shared_bias_rejection_rate"
+    ]
+
+
+def test_anchor_power_degrades_with_noisier_anchor() -> None:
+    report = run_study(_small_config(), source_revision="0" * 40)
+    records = {
+        (item["anchor_sigma_ratio"], item["anchor_support_fraction"]): item
+        for item in report["anchor_common_mode_power_grid"]
+    }
+    assert records[(0.5, 1.0)]["shared_bias_rejection_rate"] >= records[(1.0, 1.0)][
+        "shared_bias_rejection_rate"
+    ]
+
+
+def test_report_tampering_is_rejected() -> None:
+    report = run_study(_small_config(), source_revision="0" * 40)
+    report["registered_decision"] = "tampered"
+    with pytest.raises(ValueError, match="identity mismatch"):
+        validate_report(report)
+
+
+def test_cli_writes_replayable_json_and_markdown(tmp_path: Path) -> None:
+    output_json = tmp_path / "report.json"
+    output_markdown = tmp_path / "report.md"
+    exit_code = main(
+        [
+            "--quick",
+            "--seed",
+            "20260806",
+            "--source-revision",
+            "1" * 40,
+            "--output-json",
+            str(output_json),
+            "--output-markdown",
+            str(output_markdown),
+        ]
+    )
+    assert exit_code in {0, 3}
+    report = json.loads(output_json.read_text(encoding="utf-8"))
+    validate_report(report)
+    markdown = output_markdown.read_text(encoding="utf-8")
+    assert report["report_id"] in markdown
+    assert "Shared bias rejected with reference anchor" in markdown
+
+
+def test_config_rejects_non_exchangeable_tiny_calibration() -> None:
+    config = StudyConfig(calibration_groups=5)
+    with pytest.raises(ValueError, match="at least 20"):
+        config.validate()
+
+
+def test_grouped_cli_routes_anchor_common_bias_help(capsys) -> None:
+    with pytest.raises(SystemExit) as exit_info:
+        grouped_main(["diagnostic", "anchor-common-bias", "--help"])
+    assert exit_info.value.code == 0
+    output = capsys.readouterr().out
+    assert "independent-anchor detection" in output
+    assert "--source-revision" in output
+
+
+def test_protocol_matches_frozen_default_design() -> None:
+    protocol_path = (
+        Path(__file__).resolve().parents[1]
+        / "protocols"
+        / "anchor-common-bias-study-v1.json"
+    )
+    protocol = json.loads(protocol_path.read_text(encoding="utf-8"))
+    design = protocol["design"]
+    config = StudyConfig()
+    assert design["seed"] == config.seed
+    assert design["calibration_groups"] == config.calibration_groups
+    assert design["target_groups_per_arm"] == config.target_groups
+    assert design["rows_per_group"] == config.rows_per_group
+    assert design["dimension"] == config.dimension
+    assert design["miscoverage"] == config.miscoverage
+    assert design["row_quantile"] == config.row_quantile
+    assert design["provider_sigma"] == config.provider_sigma
+    assert (
+        design["provider_cross_correlation"]
+        == config.provider_cross_correlation
+    )
+    assert design["provider_specific_bias_sigma"] == config.provider_specific_bias_sigma
+    assert design["shared_bias_sigma"] == config.shared_bias_sigma
+    assert design["shared_bias_row_fraction"] == config.shared_bias_row_fraction
+    assert design["anchor_drift_sigma"] == config.anchor_drift_sigma
+    assert tuple(design["anchor_sigma_ratios"]) == config.anchor_sigma_ratios
+    assert (
+        tuple(design["anchor_support_fractions"])
+        == config.anchor_support_fractions
+    )
+    assert (
+        design["reference_anchor_sigma_ratio"]
+        == config.reference_anchor_sigma_ratio
+    )
+    assert (
+        design["reference_anchor_support_fraction"]
+        == config.reference_anchor_support_fraction
+    )


### PR DESCRIPTION
## Scientific question

The merged cross-provider corroboration guard detects provider-specific corruption but retains an explicit negative control: two monocular providers can agree while sharing the same coherent camera bias. This pull request quantifies the missing mechanism under a calibration/target-separated controlled study:

> How much independent metric-anchor precision and support are required to detect coherent bias shared by both visual providers without inflating clean false rejection?

## Frozen controlled design

- complete simulated object/session groups are the exchangeable units;
- 800 clean calibration groups and 1,000 disjoint target groups per arm;
- 256 three-dimensional rows per group;
- correlated visual-provider noise with frozen correlation `0.75`;
- split-conformal 5% upper calibration of the 95th within-group row score;
- independent-anchor precision ratios and support fractions swept on a fixed grid;
- clean, provider-specific corruption, shared visual bias, and independent-anchor drift arms kept separate; and
- seed, protocol, gates, report identity, and schema committed before the registered result.

The reference design is frozen at anchor/provider sigma ratio `0.5` and anchor support fraction `0.2`. The provider-disagreement-only score must retain its shared-bias limitation, while the independent-anchor score must detect both shared visual bias and anchor inconsistency.

## Final product diff

The review head `9d12309268932e45220e09114d2f669703472313` is one commit directly on current `main` at `c796d4e05b5329ae22cbce65fb14ecf8814f2839` and changes exactly seven files:

- `.github/workflows/anchor-common-bias-study.yml`;
- `docs/anchor-common-bias-study.md`;
- `protocols/anchor-common-bias-study-v1.json`;
- `src/prob4d/_anchor_common_bias_study_impl.py`;
- `src/prob4d/anchor_common_bias_study.py`;
- `src/prob4d/cli.py`; and
- `tests/test_anchor_common_bias_study.py`.

It adds `prob4d diagnostic anchor-common-bias`, content-addressed JSON/Markdown reports, a frozen machine-readable protocol, mechanism/invariance/replay/serialization/CLI tests, and a registered exact-source workflow. The three temporary formatter workflows used during development were removed independently from `main`; none is present in this PR.

The only correction after the first exact-head attempt was moving `Sequence` from `typing` to `collections.abc`, as required by Ruff `UP035`. No numerical or statistical statement changed. The final registered workflow uses `ubuntu-slim` because the study is NumPy-only and does not require workstation2.

## Registered evidence

The frozen full design produced:

- differential clean false rejection: **5.7%**;
- provider-specific corruption detection: **100%**;
- differential shared-bias rejection: **5.3%**—the required limitation control;
- reference-anchor clean false rejection: **7.4%**;
- reference-anchor shared-bias detection: **91.9%**; and
- reference-anchor drift-inconsistency detection: **97.2%**.

All six predeclared gates pass, giving registered decision:

```text
pass-independent-anchor-mechanism-study
```

The first exact-head workflow reached Ruff and identified only the now-corrected `Sequence` import. The final exact-head contract and registered-study workflow are queued behind repository-wide Actions saturation; they have not reported a source, test, or scientific failure. The workflow itself replays report identity, exact source revision, decision and gates, Ruff, formatting, MyPy, focused tests, CLI routing, compileall, and `pip check`, then retains compact JSON/Markdown evidence.

## Claim boundary

This is controlled synthetic mechanism and acquisition-design evidence. It does not establish real-provider competence, target uncertainty calibration, fresh-object BayesianPhysTwin benefit, Causal4D intervention benefit, deployment safety, or state of the art. It does not authorize opening the twelve-object Deform360 confirmation cohort. Physical promotion still requires calibration-only fitting followed by the already-frozen independent object/session gate.