### PR TITLE
Bound fused-prediction export memory

### DIFF
--- a/.github/workflows/bounded-fused-export.yml
+++ b/.github/workflows/bounded-fused-export.yml
@@ -1,0 +1,67 @@
+name: Bounded fused-prediction export
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/bounded-fused-export.yml"
+      - "docs/bounded-fused-export.md"
+      - "src/prob4d/bounded_export.py"
+      - "tests/test_bounded_export.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bounded-fused-export-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out exact reviewed head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+          clean: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install compatible development environment
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install -e ".[dev]"
+          python -m pip install "numpy>=1.24,<2.3"
+          python -m pip check
+
+      - name: Check source quality and typing
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m ruff check src/prob4d/bounded_export.py tests/test_bounded_export.py
+          python -m ruff format --check src/prob4d/bounded_export.py tests/test_bounded_export.py
+          python -m mypy src/prob4d/bounded_export.py
+
+      - name: Run focused and adjacent archive tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pytest -q \
+            tests/test_bounded_export.py \
+            tests/test_io.py \
+            tests/test_fusion.py \
+            tests/test_covariance_validation.py
+          python -m compileall -q src/prob4d

--- a/docs/bounded-fused-export.md
+++ b/docs/bounded-fused-export.md
@@ -1,0 +1,70 @@
+# Bounded-memory fused-prediction export
+
+`prob4d.io.save_fused_prediction` writes the canonical fused-prediction NPZ
+schema directly through NumPy. That path is simple and remains the default. For
+a large `FusedSequence`, however, it can transiently materialize complete
+float32 point/flow copies and complete six-component packed covariance arrays
+before the archive is written.
+
+`prob4d.bounded_export.save_fused_prediction_bounded` is an additive writer for
+large engineering and provider-export workloads:
+
+```python
+from prob4d.bounded_export import save_fused_prediction_bounded
+
+save_fused_prediction_bounded(
+    "fused.npz",
+    fused,
+    method_id="prob4d_ci_smoothed_uncalibrated",
+    fusion_method="covariance_intersection",
+    include_covariance=True,
+    metadata={"calibration": "uncalibrated-fixed-model"},
+    chunk_rows=262_144,
+)
+```
+
+The writer preserves the existing archive contract:
+
+- identical field names;
+- identical array dtypes and shapes;
+- identical numeric values after the established float32 export conversion;
+- the same `FusedPredictionMetadata` validation and covariance semantics; and
+- compatibility with `load_fused_prediction`,
+  `load_fused_prediction_metadata`, and
+  `load_fused_prediction_artifact`.
+
+Large fields are first written as NPY members in the destination directory.
+Point and flow conversion is chunked. Symmetric 3×3 covariance matrices are
+packed directly into six float32 values per sample without creating a complete
+float64 packed array. The NPY members are then streamed into a temporary ZIP
+archive, fsynced, and atomically installed at the destination.
+
+The NPZ container bytes are not required to equal those produced by
+`numpy.savez` because ZIP timestamps and compression implementation details are
+container metadata. Tests require exact equality of every decoded field and
+complete metadata equality.
+
+## Resource trade-off
+
+The peak array temporary is bounded by `chunk_rows`, but temporary disk usage can
+approach:
+
+```text
+staged NPY members + final NPZ archive
+```
+
+For uncompressed export this can be roughly twice the final artifact size until
+the atomic replacement completes. The staging directory is removed on success
+or failure, and an existing destination remains unchanged if archive assembly
+fails.
+
+This is useful when RAM, rather than disk capacity, is the limiting resource.
+The ordinary writer remains appropriate for small artifacts or environments
+where temporary disk usage is more constrained.
+
+## Claim boundary
+
+The bounded writer changes the export implementation, not estimator or
+covariance semantics. It does not establish reconstruction accuracy,
+uncertainty calibration, provider competence, BayesianPhysTwin benefit,
+Causal4D benefit, deployment safety, or state of the art.

--- a/src/prob4d/bounded_export.py
+++ b/src/prob4d/bounded_export.py
@@ -1,0 +1,281 @@
+"""Bounded-memory export for existing fused-prediction NPZ artifacts.
+
+The ordinary :func:`prob4d.io.save_fused_prediction` path is convenient for
+small and medium sequences, but NumPy materializes full float32 point/flow
+copies and full packed covariance arrays before writing. This module preserves
+the same field schema while staging large NPY members in bounded chunks and
+atomically assembling the final NPZ archive.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+import zipfile
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Final
+
+import numpy as np
+from numpy.lib.format import open_memmap
+from numpy.typing import DTypeLike
+
+from ._immutable_json import plain_json
+from .fusion import FusedSequence
+from .io import FusedPredictionMetadata, fusion_covariance_semantics
+
+DEFAULT_EXPORT_CHUNK_ROWS: Final = 262_144
+_PACKED_COVARIANCE_WIDTH: Final = 6
+
+
+def _fsync_directory(path: Path) -> None:
+    try:
+        descriptor = os.open(path, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(descriptor)
+    except OSError:
+        pass
+    finally:
+        os.close(descriptor)
+
+
+def _normalized_destination(path: str | Path) -> Path:
+    destination = Path(path)
+    if not str(destination).endswith(".npz"):
+        destination = Path(str(destination) + ".npz")
+    return destination
+
+
+def _write_small_array(path: Path, value: np.ndarray) -> None:
+    with path.open("wb") as stream:
+        np.save(stream, value, allow_pickle=False)
+        stream.flush()
+        os.fsync(stream.fileno())
+
+
+def _stage_cast_array(
+    path: Path,
+    value: np.ndarray,
+    *,
+    dtype: DTypeLike,
+    chunk_rows: int,
+) -> None:
+    source = np.asarray(value)
+    target = open_memmap(
+        path,
+        mode="w+",
+        dtype=dtype,
+        shape=source.shape,
+        fortran_order=False,
+    )
+    source_rows = source.reshape(-1)
+    target_rows = target.reshape(-1)
+    for start in range(0, source_rows.size, chunk_rows):
+        stop = min(start + chunk_rows, source_rows.size)
+        target_rows[start:stop] = source_rows[start:stop]
+    target.flush()
+    del target
+    with path.open("rb+") as stream:
+        os.fsync(stream.fileno())
+
+
+def _stage_packed_covariance(
+    path: Path,
+    covariance: np.ndarray,
+    *,
+    chunk_rows: int,
+) -> None:
+    source = np.asarray(covariance)
+    if source.shape[-2:] != (3, 3):
+        raise ValueError("covariance must end in shape (3, 3)")
+    packed_shape = source.shape[:-2] + (_PACKED_COVARIANCE_WIDTH,)
+    target = open_memmap(
+        path,
+        mode="w+",
+        dtype=np.float32,
+        shape=packed_shape,
+        fortran_order=False,
+    )
+    source_rows = source.reshape(-1, 3, 3)
+    target_rows = target.reshape(-1, _PACKED_COVARIANCE_WIDTH)
+    for start in range(0, source_rows.shape[0], chunk_rows):
+        stop = min(start + chunk_rows, source_rows.shape[0])
+        values = source_rows[start:stop]
+        output = target_rows[start:stop]
+        output[:, 0] = values[:, 0, 0]
+        output[:, 1] = values[:, 0, 1]
+        output[:, 2] = values[:, 0, 2]
+        output[:, 3] = values[:, 1, 1]
+        output[:, 4] = values[:, 1, 2]
+        output[:, 5] = values[:, 2, 2]
+    target.flush()
+    del target
+    with path.open("rb+") as stream:
+        os.fsync(stream.fileno())
+
+
+def _archive_members(
+    destination: Path,
+    members: Mapping[str, Path],
+    *,
+    compressed: bool,
+) -> None:
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{destination.name}.",
+        suffix=".tmp",
+        dir=destination.parent,
+    )
+    os.close(descriptor)
+    temporary = Path(temporary_name)
+    compression = zipfile.ZIP_DEFLATED if compressed else zipfile.ZIP_STORED
+    try:
+        with zipfile.ZipFile(
+            temporary,
+            mode="w",
+            compression=compression,
+            allowZip64=True,
+        ) as archive:
+            for field, member in members.items():
+                archive.write(member, arcname=f"{field}.npy")
+        with temporary.open("rb+") as stream:
+            os.fsync(stream.fileno())
+        os.replace(temporary, destination)
+        _fsync_directory(destination.parent)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def save_fused_prediction_bounded(
+    path: str | Path,
+    sequence: FusedSequence,
+    *,
+    method_id: str,
+    fusion_method: str,
+    include_covariance: bool = True,
+    metadata: Mapping[str, Any] | None = None,
+    compressed: bool = False,
+    chunk_rows: int = DEFAULT_EXPORT_CHUNK_ROWS,
+) -> FusedPredictionMetadata:
+    """Atomically write the existing fused-prediction schema with bounded RAM.
+
+    Large point, flow, and covariance fields are staged as NPY files in the
+    destination directory. Casting and symmetric-covariance packing operate on
+    at most ``chunk_rows`` scalar values or covariance matrices at a time. The
+    final archive remains readable by :func:`prob4d.io.load_fused_prediction` and
+    contains the same field names, dtypes, shapes, and values as the ordinary
+    writer. ZIP container bytes are not promised to match another writer.
+
+    Temporary disk usage can approach the sum of the staged NPY members and the
+    final NPZ archive. Existing destinations are replaced only after every
+    member and the complete archive have been written successfully.
+    """
+
+    if isinstance(chunk_rows, bool) or not isinstance(chunk_rows, int) or chunk_rows < 1:
+        raise ValueError("chunk_rows must be a positive integer")
+    if not isinstance(sequence, FusedSequence):
+        raise TypeError("sequence must be a validated FusedSequence")
+
+    covariance_semantics, correlation_assumption = fusion_covariance_semantics(fusion_method)
+    artifact_metadata = FusedPredictionMetadata(
+        method_id=method_id,
+        fusion_method=fusion_method,
+        covariance_semantics=covariance_semantics,
+        correlation_assumption=correlation_assumption,
+        metadata={} if metadata is None else metadata,
+    )
+    destination = _normalized_destination(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    workspace = Path(
+        tempfile.mkdtemp(
+            prefix=f".{destination.name}.members.",
+            dir=destination.parent,
+        )
+    )
+
+    members: dict[str, Path] = {}
+
+    def stage_small(field: str, value: np.ndarray) -> None:
+        member = workspace / f"{field}.npy"
+        _write_small_array(member, value)
+        members[field] = member
+
+    def stage_cast(field: str, value: np.ndarray, dtype: DTypeLike) -> None:
+        member = workspace / f"{field}.npy"
+        _stage_cast_array(
+            member,
+            value,
+            dtype=dtype,
+            chunk_rows=chunk_rows,
+        )
+        members[field] = member
+
+    def stage_covariance(field: str, value: np.ndarray) -> None:
+        member = workspace / f"{field}.npy"
+        _stage_packed_covariance(member, value, chunk_rows=chunk_rows)
+        members[field] = member
+
+    try:
+        stage_small("artifact_schema", np.asarray(artifact_metadata.schema_name))
+        stage_small(
+            "artifact_version",
+            np.asarray(artifact_metadata.schema_version, dtype=np.int64),
+        )
+        stage_small("method_id", np.asarray(artifact_metadata.method_id))
+        stage_small("fusion_method", np.asarray(artifact_metadata.fusion_method))
+        stage_small(
+            "covariance_semantics",
+            np.asarray(artifact_metadata.covariance_semantics),
+        )
+        stage_small(
+            "correlation_assumption",
+            np.asarray(artifact_metadata.correlation_assumption),
+        )
+        stage_small(
+            "artifact_metadata_json",
+            np.asarray(
+                json.dumps(
+                    plain_json(artifact_metadata.metadata),
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    allow_nan=False,
+                )
+            ),
+        )
+        stage_cast("point_map", sequence.point_map, np.dtype(np.float32))
+        stage_cast("valid_mask", sequence.valid_mask, np.dtype(bool))
+        stage_cast("frame_indices", sequence.frame_indices, np.dtype(np.int64))
+
+        if include_covariance:
+            stage_covariance("point_covariance_packed", sequence.point_covariance)
+            stage_cast(
+                "contributors",
+                sequence.contributors,
+                sequence.contributors.dtype,
+            )
+
+        if sequence.scene_flow is not None:
+            if sequence.deform_mask is None:
+                raise ValueError("scene-flow deformation mask is missing")
+            stage_cast("scene_flow", sequence.scene_flow, np.dtype(np.float32))
+            stage_cast("deform_mask", sequence.deform_mask, np.dtype(bool))
+            if include_covariance:
+                if sequence.flow_covariance is None:
+                    raise ValueError("scene-flow covariance is missing from fused sequence")
+                stage_covariance(
+                    "flow_covariance_packed",
+                    sequence.flow_covariance,
+                )
+
+        _archive_members(destination, members, compressed=compressed)
+    finally:
+        shutil.rmtree(workspace, ignore_errors=True)
+
+    return artifact_metadata
+
+
+__all__ = ["DEFAULT_EXPORT_CHUNK_ROWS", "save_fused_prediction_bounded"]

--- a/tests/test_bounded_export.py
+++ b/tests/test_bounded_export.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import prob4d.bounded_export as bounded_export
+from prob4d.bounded_export import save_fused_prediction_bounded
+from prob4d.fusion import FusedSequence
+from prob4d.io import (
+    load_fused_prediction_artifact,
+    load_fused_prediction_metadata,
+    save_fused_prediction,
+)
+
+
+def _sequence() -> FusedSequence:
+    generator = np.random.default_rng(20260806)
+    shape = (4, 3, 5)
+    point_map = generator.normal(size=shape + (3,))
+    valid_mask = generator.random(shape) > 0.2
+    point_covariance = np.empty(shape + (3, 3), dtype=np.float64)
+    for index in np.ndindex(shape):
+        factor = generator.normal(size=(3, 3))
+        point_covariance[index] = factor @ factor.T + 0.01 * np.eye(3)
+    scene_flow = generator.normal(scale=0.05, size=shape + (3,))
+    deform_mask = valid_mask & (generator.random(shape) > 0.25)
+    flow_covariance = np.empty_like(point_covariance)
+    for index in np.ndindex(shape):
+        factor = generator.normal(scale=0.1, size=(3, 3))
+        flow_covariance[index] = factor @ factor.T + 0.001 * np.eye(3)
+    return FusedSequence(
+        frame_indices=np.arange(10, 14, dtype=np.int64),
+        point_map=point_map,
+        valid_mask=valid_mask,
+        point_covariance=point_covariance,
+        contributors=generator.integers(1, 4, size=shape, dtype=np.uint16),
+        scene_flow=scene_flow,
+        deform_mask=deform_mask,
+        flow_covariance=flow_covariance,
+    )
+
+
+@pytest.mark.parametrize("compressed", [False, True])
+def test_bounded_export_matches_ordinary_field_contract(
+    tmp_path: Path,
+    compressed: bool,
+) -> None:
+    sequence = _sequence()
+    ordinary = tmp_path / "ordinary.npz"
+    bounded = tmp_path / "bounded.npz"
+    kwargs = {
+        "method_id": "bounded-ci",
+        "fusion_method": "covariance_intersection",
+        "metadata": {"calibration": "source-only", "rank": 2},
+        "compressed": compressed,
+    }
+
+    ordinary_metadata = save_fused_prediction(ordinary, sequence, **kwargs)
+    bounded_metadata = save_fused_prediction_bounded(
+        bounded,
+        sequence,
+        chunk_rows=7,
+        **kwargs,
+    )
+
+    assert bounded_metadata.to_dict() == ordinary_metadata.to_dict()
+    with (
+        np.load(ordinary, allow_pickle=False) as ordinary_data,
+        np.load(
+            bounded,
+            allow_pickle=False,
+        ) as bounded_data,
+    ):
+        assert bounded_data.files == ordinary_data.files
+        for field in ordinary_data.files:
+            ordinary_value = ordinary_data[field]
+            bounded_value = bounded_data[field]
+            assert bounded_value.dtype == ordinary_value.dtype
+            assert bounded_value.shape == ordinary_value.shape
+            np.testing.assert_array_equal(bounded_value, ordinary_value)
+
+    ordinary_artifact = load_fused_prediction_artifact(ordinary)
+    bounded_artifact = load_fused_prediction_artifact(bounded)
+    assert bounded_artifact.metadata.to_dict() == ordinary_artifact.metadata.to_dict()
+    np.testing.assert_array_equal(
+        bounded_artifact.sequence.point_map,
+        ordinary_artifact.sequence.point_map,
+    )
+    np.testing.assert_array_equal(
+        bounded_artifact.sequence.point_covariance,
+        ordinary_artifact.sequence.point_covariance,
+    )
+    np.testing.assert_array_equal(
+        bounded_artifact.sequence.scene_flow,
+        ordinary_artifact.sequence.scene_flow,
+    )
+    np.testing.assert_array_equal(
+        bounded_artifact.sequence.flow_covariance,
+        ordinary_artifact.sequence.flow_covariance,
+    )
+
+
+def test_bounded_export_without_covariance_preserves_optional_fields(
+    tmp_path: Path,
+) -> None:
+    sequence = _sequence()
+    destination = tmp_path / "without-covariance"
+
+    save_fused_prediction_bounded(
+        destination,
+        sequence,
+        method_id="uniform",
+        fusion_method="uniform",
+        include_covariance=False,
+        chunk_rows=5,
+    )
+
+    archive = destination.with_suffix(".npz")
+    assert archive.is_file()
+    with np.load(archive, allow_pickle=False) as data:
+        assert "point_covariance_packed" not in data.files
+        assert "flow_covariance_packed" not in data.files
+        assert "contributors" not in data.files
+        assert "scene_flow" in data.files
+        assert "deform_mask" in data.files
+        np.testing.assert_array_equal(
+            data["point_map"],
+            sequence.point_map.astype(np.float32),
+        )
+        np.testing.assert_array_equal(
+            data["scene_flow"],
+            sequence.scene_flow.astype(np.float32),
+        )
+    metadata = load_fused_prediction_metadata(archive)
+    assert metadata.fusion_method == "uniform"
+
+
+@pytest.mark.parametrize("chunk_rows", [0, -1, True, 1.5])
+def test_bounded_export_rejects_invalid_chunk_rows(
+    tmp_path: Path,
+    chunk_rows: object,
+) -> None:
+    with pytest.raises(ValueError, match="positive integer"):
+        save_fused_prediction_bounded(
+            tmp_path / "invalid.npz",
+            _sequence(),
+            method_id="uniform",
+            fusion_method="uniform",
+            chunk_rows=chunk_rows,  # type: ignore[arg-type]
+        )
+
+
+def test_bounded_export_keeps_existing_destination_on_archive_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "existing.npz"
+    original = b"pre-existing-artifact"
+    destination.write_bytes(original)
+
+    def fail_archive(*args: object, **kwargs: object) -> None:
+        raise RuntimeError("injected archive failure")
+
+    monkeypatch.setattr(bounded_export, "_archive_members", fail_archive)
+    with pytest.raises(RuntimeError, match="injected archive failure"):
+        save_fused_prediction_bounded(
+            destination,
+            _sequence(),
+            method_id="uniform",
+            fusion_method="uniform",
+            chunk_rows=3,
+        )
+
+    assert destination.read_bytes() == original
+    assert not list(tmp_path.glob(".existing.npz.members.*"))
+    assert not list(tmp_path.glob(".existing.npz.*.tmp"))


### PR DESCRIPTION
## Purpose

Address the largest avoidable allocation identified by the frozen issue-#50 real-bundle profile. The ordinary NumPy writer transiently materializes complete float32 point/flow copies and complete packed covariance arrays before producing the NPZ archive. At full resolution those temporaries contribute directly to the observed provider-export peak.

## Changes

- add `save_fused_prediction_bounded`, an additive writer for the existing fused-prediction NPZ schema;
- cast point and flow fields into NPY staging members in bounded chunks;
- pack symmetric 3×3 covariance matrices directly into six float32 values per sample without a complete intermediate packed array;
- stream staged NPY members into uncompressed or compressed ZIP64 archives;
- fsync and atomically replace the final destination;
- preserve an existing destination if staging or archive assembly fails; and
- document the RAM-versus-temporary-disk trade-off and narrow claim boundary.

The ordinary writer and all existing call sites remain unchanged. Decoded field names, dtypes, shapes, values, metadata, and covariance semantics match exactly. ZIP container bytes are not treated as semantic identity because timestamps and compression metadata are not estimator output.

## Validation

The exact four product blobs passed on review head `41b59634323c66536704fa17b517070b63d50850`:

- Ruff lint and formatting;
- MyPy;
- **36 focused and adjacent tests**;
- exact field-by-field equality against the ordinary writer for compressed and uncompressed archives;
- complete metadata and loader compatibility;
- point, flow, packed covariance, contributor, and optional-field parity;
- atomic failure cleanup and preservation of an existing destination;
- fusion, IO, and covariance-validation coverage; and
- Python byte compilation.

The branch was then rebuilt as one clean commit on current `main` at `55b7e56080b196da6555afcea6fe4a1f0569042f`. Only the parent changed; all four product blobs are identical to the validated tree.

## Claim boundary

This changes archive construction only. It does not change an estimator, covariance interpretation, calibration, provider decision, BayesianPhysTwin result, Causal4D result, deployment claim, or state-of-the-art claim.