### PR TITLE
Publish non-sensitive issue-49 inventory run receipt

### DIFF
--- a/.github/workflows/issue-49-protected-cohort-inventory-launch.yml
+++ b/.github/workflows/issue-49-protected-cohort-inventory-launch.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 concurrency:
   group: issue-49-protected-cohort-inventory-main
@@ -109,3 +110,53 @@ jobs:
           path: ${{ runner.temp }}/issue-49-protected-cohort-inventory
           if-no-files-found: error
           retention-days: 14
+
+      - name: Publish non-sensitive issue receipt
+        if: always()
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          output="$RUNNER_TEMP/issue-49-protected-cohort-inventory"
+          [[ -f "$output/inventory.json" ]] || exit 0
+          python3 - "$output/inventory.json" "$output/receipt.json" <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          import sys
+
+          report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+          clean = sum(
+              not item["known_open_or_public_risk_flags"]
+              for item in report["candidate_sessions"]
+          )
+          run_id = os.environ["GITHUB_RUN_ID"]
+          body = "\n".join(
+              [
+                  "## Protected-cohort metadata inventory receipt",
+                  "",
+                  f"- workflow run: `{run_id}`",
+                  f"- exact source revision: `{os.environ['GITHUB_SHA']}`",
+                  f"- candidate acquisition sessions: **{report['candidate_session_count']}**",
+                  f"- candidates without known-open/public path flags: **{clean}**",
+                  f"- metadata-only artifact ID: `{report['artifact_id']}`",
+                  f"- expected Actions artifact: `issue-49-protected-cohort-inventory-{run_id}`",
+                  "",
+                  "No protected path, filename, byte count, or candidate identity is included in this public receipt.",
+                  "",
+                  report["claim_boundary"],
+              ]
+          )
+          Path(sys.argv[2]).write_text(
+              json.dumps({"body": body}, sort_keys=True),
+              encoding="utf-8",
+          )
+          PY
+          curl --fail-with-body --silent --show-error \
+            --request POST \
+            --header "Authorization: Bearer $GITHUB_TOKEN" \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/issues/49/comments" \
+            --data-binary @"$output/receipt.json"


### PR DESCRIPTION
## Purpose

Make the temporary push-triggered protected-cohort inventory discoverable through the available GitHub interface without exposing protected filesystem metadata.

The only product change is to grant `issues: write` to the temporary launcher and post a compact receipt on issue #49 containing only:

- workflow run ID;
- exact source revision;
- candidate-session count;
- count without known-open/public path flags;
- content identity of the metadata-only report; and
- expected Actions artifact name.

No protected path, filename, file size, candidate identity, video byte, frame, prediction, truth, label, or outcome is posted. The underlying inventory remains target-blind and read-only. This launcher will be removed together with the inventory workflow after artifact inspection.