### PR TITLE
Publish issue-49 inventory run beacon before execution

### DIFF
--- a/.github/workflows/issue-49-protected-cohort-inventory-launch.yml
+++ b/.github/workflows/issue-49-protected-cohort-inventory-launch.yml
@@ -21,6 +21,53 @@ jobs:
     runs-on: [self-hosted, Linux, X64, nvidia-smi]
     timeout-minutes: 45
     steps:
+      - name: Publish non-sensitive run beacon
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          receipt="$RUNNER_TEMP/issue-49-inventory-run-beacon.json"
+          response="$RUNNER_TEMP/issue-49-inventory-run-beacon-response.json"
+          python3 - "$receipt" <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          import sys
+
+          body = "\n".join(
+              [
+                  "## Protected-cohort metadata inventory started",
+                  "",
+                  f"- workflow run: `{os.environ['GITHUB_RUN_ID']}`",
+                  f"- exact source revision: `{os.environ['GITHUB_SHA']}`",
+                  "- status: **running**",
+                  "",
+                  "This is a non-sensitive run beacon. No protected path, filename, byte count, candidate identity, frame, prediction, truth, label, or outcome is included.",
+              ]
+          )
+          Path(sys.argv[1]).write_text(
+              json.dumps({"body": body}, sort_keys=True),
+              encoding="utf-8",
+          )
+          PY
+          curl --fail-with-body --silent --show-error \
+            --request POST \
+            --header "Authorization: Bearer $GITHUB_TOKEN" \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/issues/49/comments" \
+            --data-binary @"$receipt" \
+            > "$response"
+          python3 - "$response" "$RUNNER_TEMP/issue-49-inventory-comment-id" <<'PY'
+          import json
+          from pathlib import Path
+          import sys
+
+          response = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+          Path(sys.argv[2]).write_text(str(response["id"]), encoding="utf-8")
+          PY
+
       - name: Check out exact merged revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -111,16 +158,20 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
-      - name: Publish non-sensitive issue receipt
+      - name: Finalize non-sensitive issue receipt
         if: always()
         shell: bash
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
+          id_file="$RUNNER_TEMP/issue-49-inventory-comment-id"
+          [[ -f "$id_file" ]] || exit 0
+          comment_id=$(cat "$id_file")
           output="$RUNNER_TEMP/issue-49-protected-cohort-inventory"
-          [[ -f "$output/inventory.json" ]] || exit 0
-          python3 - "$output/inventory.json" "$output/receipt.json" <<'PY'
+          receipt="$RUNNER_TEMP/issue-49-inventory-final-receipt.json"
+          if [[ -f "$output/inventory.json" ]]; then
+            python3 - "$output/inventory.json" "$receipt" <<'PY'
           import json
           import os
           from pathlib import Path
@@ -138,6 +189,7 @@ jobs:
                   "",
                   f"- workflow run: `{run_id}`",
                   f"- exact source revision: `{os.environ['GITHUB_SHA']}`",
+                  "- status: **inventory and boundary validation completed**",
                   f"- candidate acquisition sessions: **{report['candidate_session_count']}**",
                   f"- candidates without known-open/public path flags: **{clean}**",
                   f"- metadata-only artifact ID: `{report['artifact_id']}`",
@@ -153,10 +205,34 @@ jobs:
               encoding="utf-8",
           )
           PY
+          else
+            python3 - "$receipt" <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          import sys
+
+          body = "\n".join(
+              [
+                  "## Protected-cohort metadata inventory receipt",
+                  "",
+                  f"- workflow run: `{os.environ['GITHUB_RUN_ID']}`",
+                  f"- exact source revision: `{os.environ['GITHUB_SHA']}`",
+                  "- status: **failed before a validated inventory was retained**",
+                  "",
+                  "No protected path, filename, byte count, candidate identity, frame, prediction, truth, label, or outcome was posted.",
+              ]
+          )
+          Path(sys.argv[1]).write_text(
+              json.dumps({"body": body}, sort_keys=True),
+              encoding="utf-8",
+          )
+          PY
+          fi
           curl --fail-with-body --silent --show-error \
-            --request POST \
+            --request PATCH \
             --header "Authorization: Bearer $GITHUB_TOKEN" \
             --header "Accept: application/vnd.github+json" \
             --header "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/$GITHUB_REPOSITORY/issues/49/comments" \
-            --data-binary @"$output/receipt.json"
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/issues/comments/$comment_id" \
+            --data-binary @"$receipt"


### PR DESCRIPTION
## Purpose

Make the temporary protected-cohort metadata inventory self-diagnosing even if it fails before producing a report.

Before checkout or inventory execution, the launcher posts a non-sensitive issue-49 beacon containing only the workflow run ID and exact source revision. On completion it replaces the same comment with aggregate candidate counts and the metadata report identity; on early failure it records that no validated inventory was retained.

No protected path, filename, size, candidate identity, frame, prediction, truth, label, or outcome is posted. The temporary workflows will be removed after the run is retrieved and inspected.