### PR TITLE
Prioritize one issue-49 protected-cohort inventory run

### DIFF
--- a/.github/workflows/issue-49-protected-cohort-inventory-priority.yml
+++ b/.github/workflows/issue-49-protected-cohort-inventory-priority.yml
@@ -1,0 +1,191 @@
+name: Prioritize unopened held-out cohort inventory
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/issue-49-protected-cohort-inventory-priority.yml"
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: issue-49-protected-cohort-inventory-main
+  cancel-in-progress: true
+
+jobs:
+  inventory:
+    name: Priority target-blind protected cohort inventory
+    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    timeout-minutes: 45
+    steps:
+      - name: Publish non-sensitive run beacon
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          receipt="$RUNNER_TEMP/issue-49-inventory-beacon.json"
+          response="$RUNNER_TEMP/issue-49-inventory-beacon-response.json"
+          python3 - "$receipt" <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          import sys
+
+          body = "\n".join(
+              [
+                  "## Priority protected-cohort metadata inventory started",
+                  "",
+                  f"- workflow run: `{os.environ['GITHUB_RUN_ID']}`",
+                  f"- exact source revision: `{os.environ['GITHUB_SHA']}`",
+                  "- status: **running**",
+                  "",
+                  "Superseded inventory scans were cancelled before this run. No protected path, filename, byte count, candidate identity, frame, prediction, truth, label, or outcome is included in this beacon.",
+              ]
+          )
+          Path(sys.argv[1]).write_text(
+              json.dumps({"body": body}, sort_keys=True),
+              encoding="utf-8",
+          )
+          PY
+          curl --fail-with-body --silent --show-error \
+            --request POST \
+            --header "Authorization: Bearer $GITHUB_TOKEN" \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/issues/49/comments" \
+            --data-binary @"$receipt" \
+            > "$response"
+          python3 - "$response" "$RUNNER_TEMP/issue-49-inventory-comment-id" <<'PY'
+          import json
+          from pathlib import Path
+          import sys
+
+          response = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+          Path(sys.argv[2]).write_text(str(response["id"]), encoding="utf-8")
+          PY
+
+      - name: Check out exact merged revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          clean: true
+
+      - name: Execute reviewed filesystem-metadata inventory
+        shell: bash
+        run: |
+          set -euo pipefail
+          workflow=.github/workflows/issue-49-protected-cohort-inventory.yml
+          script="$RUNNER_TEMP/issue-49-protected-cohort-inventory.py"
+          output="$RUNNER_TEMP/issue-49-protected-cohort-inventory"
+          mkdir -p "$output"
+          awk '
+            /python3 - \"\$output\/inventory.json\" <<'"'"'PY'"'"'/ {capture=1; next}
+            capture && /^          PY$/ {exit}
+            capture {sub(/^          /, ""); print}
+          ' "$workflow" > "$script"
+          test -s "$script"
+          python3 "$script" "$output/inventory.json"
+          (
+            cd "$output"
+            sha256sum inventory.json > SHA256SUMS
+          )
+
+      - name: Validate information boundary
+        shell: bash
+        run: |
+          set -euo pipefail
+          output="$RUNNER_TEMP/issue-49-protected-cohort-inventory"
+          python3 - "$output/inventory.json" <<'PY'
+          import json
+          from pathlib import Path
+          import sys
+
+          report = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+          assert report["schema"] == "prob4d.issue-49-protected-cohort-inventory"
+          assert report["schema_version"] == 1
+          assert all(value is False for value in report["information_boundary"].values())
+          selection = report["selection_boundary"]
+          assert selection["recommendation_is_binding_target_selection"] is False
+          assert selection["selection_uses_video_or_payload_bytes"] is False
+          assert selection["selection_uses_container_probe"] is False
+          assert selection["selection_uses_decoded_frames"] is False
+          assert selection["selection_uses_truth_labels_or_target_outcomes"] is False
+          assert isinstance(report["artifact_id"], str) and len(report["artifact_id"]) == 64
+          PY
+
+      - name: Upload metadata-only evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.0
+        with:
+          name: issue-49-protected-cohort-inventory-${{ github.run_id }}
+          path: ${{ runner.temp }}/issue-49-protected-cohort-inventory
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Finalize non-sensitive issue receipt
+        if: always()
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          id_file="$RUNNER_TEMP/issue-49-inventory-comment-id"
+          [[ -f "$id_file" ]] || exit 0
+          comment_id=$(cat "$id_file")
+          output="$RUNNER_TEMP/issue-49-protected-cohort-inventory"
+          receipt="$RUNNER_TEMP/issue-49-inventory-final.json"
+          python3 - "$output/inventory.json" "$receipt" <<'PY'
+          import json
+          import os
+          from pathlib import Path
+          import sys
+
+          source = Path(sys.argv[1])
+          run_id = os.environ["GITHUB_RUN_ID"]
+          if source.is_file():
+              report = json.loads(source.read_text(encoding="utf-8"))
+              clean = sum(
+                  not item["known_open_or_public_risk_flags"]
+                  for item in report["candidate_sessions"]
+              )
+              lines = [
+                  "## Priority protected-cohort metadata inventory receipt",
+                  "",
+                  f"- workflow run: `{run_id}`",
+                  f"- exact source revision: `{os.environ['GITHUB_SHA']}`",
+                  "- status: **inventory and boundary validation completed**",
+                  f"- candidate acquisition sessions: **{report['candidate_session_count']}**",
+                  f"- candidates without known-open/public path flags: **{clean}**",
+                  f"- metadata-only artifact ID: `{report['artifact_id']}`",
+                  f"- expected Actions artifact: `issue-49-protected-cohort-inventory-{run_id}`",
+                  "",
+                  "No protected path, filename, byte count, or candidate identity is included in this public receipt.",
+                  "",
+                  report["claim_boundary"],
+              ]
+          else:
+              lines = [
+                  "## Priority protected-cohort metadata inventory receipt",
+                  "",
+                  f"- workflow run: `{run_id}`",
+                  f"- exact source revision: `{os.environ['GITHUB_SHA']}`",
+                  "- status: **failed before a validated inventory was retained**",
+                  "",
+                  "No protected path, filename, byte count, candidate identity, frame, prediction, truth, label, or outcome was posted.",
+              ]
+          Path(sys.argv[2]).write_text(
+              json.dumps({"body": "\n".join(lines)}, sort_keys=True),
+              encoding="utf-8",
+          )
+          PY
+          curl --fail-with-body --silent --show-error \
+            --request PATCH \
+            --header "Authorization: Bearer $GITHUB_TOKEN" \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$GITHUB_REPOSITORY/issues/comments/$comment_id" \
+            --data-binary @"$receipt"


### PR DESCRIPTION
## Purpose

Cancel superseded serialized inventory scans and execute one self-diagnosing, target-blind metadata inventory for issue #49.

This temporary workflow shares the existing concurrency group but sets `cancel-in-progress: true`. It posts a run-ID beacon before execution, performs the reviewed filesystem-metadata-only scan, validates the information boundary, uploads the private artifact, and replaces the beacon with aggregate counts or an explicit early-failure state.

No candidate bytes, video containers, frames, predictions, truth, labels, or outcomes are opened. No protected path or candidate identity is posted publicly. All temporary launcher workflows will be removed after artifact inspection.