### PR TITLE
Harden self-hosted validation and add security scanning

### DIFF
--- a/.github/workflows/cross-provider-guard.yml
+++ b/.github/workflows/cross-provider-guard.yml
@@ -81,16 +81,14 @@ jobs:
           python -m compileall -q src/prob4d
 
       - name: Verify installed grouped command
-        run: |
-          set -euo pipefail
-          prob4d diagnostic cross-provider-guard --help
+        run: prob4d diagnostic cross-provider-guard --help
 
   stress:
     name: Fresh-seed provider-specific and shared-bias controls
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
       - name: Check out exact source
@@ -104,16 +102,8 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
-
-      - name: Isolate the self-hosted Python environment
-        shell: bash
-        run: |
-          set -euo pipefail
-          environment="$RUNNER_TEMP/prob4d-cross-provider-stress-venv"
-          python -m venv --clear "$environment"
-          "$environment/bin/python" -m ensurepip --upgrade
-          "$environment/bin/python" -m pip install --upgrade pip
-          echo "$environment/bin" >> "$GITHUB_PATH"
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install lightweight package
         run: |

--- a/.github/workflows/fail-closed-quality.yml
+++ b/.github/workflows/fail-closed-quality.yml
@@ -19,20 +19,11 @@ env:
   PYTHONUNBUFFERED: "1"
   QUALITY_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before || '' }}
   QUALITY_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-  SELF_HOSTED_RECOVERY: >-
-    ${{ github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        startsWith(github.head_ref, 'ci/self-hosted-') }}
 
 jobs:
   authoritative-quality:
     name: Authoritative Ruff and mypy
-    runs-on: >-
-      ${{ github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository &&
-          startsWith(github.head_ref, 'ci/self-hosted-') &&
-          fromJSON('["self-hosted","Linux","X64","nvidia-smi"]') ||
-          'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Check out repository
@@ -40,28 +31,12 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Set up hosted Python 3.12
-        if: env.SELF_HOSTED_RECOVERY != 'true'
+      - name: Set up Python 3.12
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
           cache: pip
           cache-dependency-path: pyproject.toml
-      - name: Set up self-hosted Python 3.12
-        if: env.SELF_HOSTED_RECOVERY == 'true'
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.12"
-      - name: Isolate the self-hosted Python environment
-        if: env.SELF_HOSTED_RECOVERY == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          environment="$RUNNER_TEMP/prob4d-fail-closed-quality"
-          python -m venv --clear "$environment"
-          "$environment/bin/python" -m ensurepip --upgrade
-          "$environment/bin/python" -m pip install --upgrade pip
-          echo "$environment/bin" >> "$GITHUB_PATH"
       - name: Install development and compatible typing environment
         run: |
           python -m pip install -e ".[dev]"

--- a/.github/workflows/immutable-artifacts.yml
+++ b/.github/workflows/immutable-artifacts.yml
@@ -32,30 +32,22 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Check out exact reviewed head
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
           clean: true
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
-
-      - name: Create isolated environment
-        shell: bash
-        run: |
-          set -euo pipefail
-          environment="$RUNNER_TEMP/prob4d-immutable-venv"
-          python3 -m venv --clear "$environment"
-          "$environment/bin/python" -m ensurepip --upgrade
-          "$environment/bin/python" -m pip install --upgrade pip
-          echo "$environment/bin" >> "$GITHUB_PATH"
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install development environment
         run: |

--- a/.github/workflows/material-identity-marginalization.yml
+++ b/.github/workflows/material-identity-marginalization.yml
@@ -9,15 +9,6 @@ on:
       - "src/prob4d/material_identity_mixture.py"
       - "tests/test_material_identity_mixture.py"
   workflow_dispatch:
-    inputs:
-      runner:
-        description: "Runner type"
-        required: true
-        default: github-hosted
-        type: choice
-        options:
-          - github-hosted
-          - self-hosted
 
 permissions:
   contents: read
@@ -33,30 +24,20 @@ env:
 jobs:
   contract:
     name: Local-ID mixture and marginalization contract
-    runs-on: >-
-      ${{
-        inputs.runner == 'self-hosted' &&
-        fromJSON('["self-hosted","Linux","X64","nvidia-smi"]') ||
-        'ubuntu-latest'
-      }}
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
-      - name: Set up hosted Python 3.12
-        if: inputs.runner != 'self-hosted'
+      - name: Set up Python 3.12
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
           cache: pip
           cache-dependency-path: pyproject.toml
-      - name: Set up self-hosted Python 3.12
-        if: inputs.runner == 'self-hosted'
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.12"
       - name: Install development and compatible typing environment
         run: |
           python -m pip install -e ".[dev]"

--- a/.github/workflows/observation-bias-binding.yml
+++ b/.github/workflows/observation-bias-binding.yml
@@ -34,7 +34,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
       - name: Check out the reviewed revision
@@ -47,16 +47,8 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
-
-      - name: Isolate the self-hosted Python environment
-        shell: bash
-        run: |
-          set -euo pipefail
-          environment="$RUNNER_TEMP/prob4d-observation-bias-binding"
-          python -m venv --clear "$environment"
-          "$environment/bin/python" -m ensurepip --upgrade
-          "$environment/bin/python" -m pip install --upgrade pip
-          echo "$environment/bin" >> "$GITHUB_PATH"
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install the lightweight development environment
         run: |
@@ -88,8 +80,7 @@ jobs:
           python -m compileall -q src/prob4d
 
       - name: Exercise the installed command surface
-        run: |
-          prob4d observation bias-binding --help
+        run: prob4d observation bias-binding --help
 
       - name: Build and audit release artifacts
         run: |

--- a/.github/workflows/production-memory-profile.yml
+++ b/.github/workflows/production-memory-profile.yml
@@ -12,14 +12,6 @@ on:
       - "tests/test_fusion_memory_benchmark.py"
   workflow_dispatch:
     inputs:
-      runner:
-        description: "Runner type"
-        required: true
-        default: github-hosted
-        type: choice
-        options:
-          - github-hosted
-          - self-hosted
       frames:
         description: "Number of full-resolution frames"
         required: true
@@ -90,16 +82,12 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: >-
-      ${{
-        inputs.runner == 'self-hosted' &&
-        fromJSON('["self-hosted","Linux","X64","nvidia-smi"]') ||
-        'ubuntu-latest'
-      }}
+    runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
           persist-credentials: false
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
@@ -145,7 +133,7 @@ jobs:
             if command -v nvidia-smi >/dev/null 2>&1; then
               nvidia-smi
             else
-              echo "nvidia-smi is unavailable on this CPU runner"
+              echo "nvidia-smi is unavailable on this hosted runner"
             fi
             echo
             python -VV
@@ -254,11 +242,12 @@ jobs:
           encoded = json.dumps(summary, indent=2, sort_keys=True, allow_nan=False) + "\n"
           (root / "summary.json").write_text(encoded, encoding="utf-8")
 
+          sums = []
           for path in sorted(root.iterdir()):
-              if path.is_file():
+              if path.is_file() and path.name != "SHA256SUMS":
                   digest = hashlib.sha256(path.read_bytes()).hexdigest()
-                  with (root / "SHA256SUMS").open("a", encoding="utf-8") as stream:
-                      stream.write(f"{digest}  {path.name}\n")
+                  sums.append(f"{digest}  {path.name}")
+          (root / "SHA256SUMS").write_text("\n".join(sums) + "\n", encoding="utf-8")
 
           mib = 1024 * 1024
           fusion = reports["fusion"]

--- a/.github/workflows/recursive-visual-bias.yml
+++ b/.github/workflows/recursive-visual-bias.yml
@@ -32,7 +32,7 @@ jobs:
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Check out the reviewed revision
@@ -45,16 +45,8 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
-
-      - name: Isolate the self-hosted Python environment
-        shell: bash
-        run: |
-          set -euo pipefail
-          environment="$RUNNER_TEMP/prob4d-recursive-visual-bias"
-          python -m venv --clear "$environment"
-          "$environment/bin/python" -m ensurepip --upgrade
-          "$environment/bin/python" -m pip install --upgrade pip
-          echo "$environment/bin" >> "$GITHUB_PATH"
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install the lightweight development environment
         run: |
@@ -86,5 +78,4 @@ jobs:
           python -m compileall -q src/prob4d
 
       - name: Smoke-test the installed command surface
-        run: |
-          prob4d observation visual-bias-stream --help
+        run: prob4d observation visual-bias-stream --help

--- a/.github/workflows/security-scanning.yml
+++ b/.github/workflows/security-scanning.yml
@@ -1,0 +1,101 @@
+name: Security scanning
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "37 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: security-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONUNBUFFERED: "1"
+
+jobs:
+  codeql:
+    name: CodeQL / ${{ matrix.language }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: read
+      packages: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [python, actions]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+          queries: security-extended
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
+        with:
+          category: "/language:${{ matrix.language }}"
+
+  dependency-audit:
+    name: Audit resolved runtime dependencies
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install the pinned audit tool
+        run: python -m pip install "pip-audit==2.10.1"
+
+      - name: Audit the project runtime dependency resolution
+        shell: bash
+        run: |
+          set -u
+          status=0
+          python -m pip_audit \
+            --strict \
+            --progress-spinner off \
+            --format json \
+            --output pip-audit.json \
+            . || status=$?
+          if [[ -f pip-audit.json ]]; then
+            cat pip-audit.json
+          else
+            echo "pip-audit did not produce its JSON report" >&2
+          fi
+          exit "$status"
+
+      - name: Upload the audit report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: pip-audit-${{ github.sha }}
+          path: pip-audit.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/self-hosted-compute-evidence.yml
+++ b/.github/workflows/self-hosted-compute-evidence.yml
@@ -9,9 +9,9 @@ on:
       - "src/prob4d/causal_gauge_graph_monte_carlo.py"
       - "src/prob4d/cycle_guard_conformal_monte_carlo.py"
       - "src/prob4d/cycle_guard_conformal_reporting.py"
-      - "src/prob4d/fusion_memory_benchmark.py"
-      - "src/prob4d/evaluation_memory_benchmark.py"
       - "tests/test_joint_covariance_metrics.py"
+      - "tests/test_causal_gauge_graph_monte_carlo.py"
+      - "tests/test_cycle_guard_conformal_monte_carlo.py"
   workflow_dispatch:
 
 permissions:
@@ -19,42 +19,45 @@ permissions:
 
 concurrency:
   group: compute-evidence-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONHASHSEED: "0"
   PYTHONUNBUFFERED: "1"
+  OMP_NUM_THREADS: "1"
+  OPENBLAS_NUM_THREADS: "1"
+  MKL_NUM_THREADS: "1"
+  NUMEXPR_NUM_THREADS: "1"
   SOURCE_REVISION: ${{ github.event.pull_request.head.sha || github.sha }}
 
 jobs:
   monte-carlo:
-    name: Large covariance and Monte Carlo studies
+    name: Hosted covariance and Monte Carlo studies
     if: >-
       github.event_name == 'workflow_dispatch' ||
       github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:
-      - name: Check out repository
+      - name: Check out exact reviewed source
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 1
           persist-credentials: false
+          clean: true
       - name: Set up Python 3.12
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
-      - name: Bootstrap isolated environment
-        shell: bash
-        run: |
-          set -euo pipefail
-          python -m venv --clear .compute-venv
-          echo "${PWD}/.compute-venv/bin" >> "${GITHUB_PATH}"
+          cache: pip
+          cache-dependency-path: pyproject.toml
       - name: Install development environment
         run: |
-          python -m pip install --upgrade pip
           python -m pip install -e ".[dev]"
           python -m pip install "numpy>=1.24,<2.3"
+          python -m pip check
       - name: Run focused scientific regressions
         shell: bash
         run: |
@@ -224,7 +227,7 @@ jobs:
             exit "$status"
           fi
           echo "decision_exit_code=$status" >> "$GITHUB_OUTPUT"
-      - name: Build checksummed Monte Carlo summary
+      - name: Build checksummed evidence summary
         if: always()
         shell: bash
         env:
@@ -242,11 +245,12 @@ jobs:
           root = Path("outputs/compute-evidence")
           summary: dict[str, object] = {
               "schema": "prob4d.compute-evidence",
-              "version": 1,
+              "version": 2,
               "repository": os.environ["GITHUB_REPOSITORY"],
               "source_revision": os.environ["SOURCE_REVISION"],
               "run_id": os.environ["GITHUB_RUN_ID"],
               "runner_name": os.environ["RUNNER_NAME"],
+              "runner_environment": "github-hosted",
               "cycle_guard_decision_exit_code": os.environ.get(
                   "CYCLE_GUARD_EXIT_CODE", "unavailable"
               ),
@@ -277,6 +281,7 @@ jobs:
           ) as stream:
               stream.write("## Compute evidence\n\n")
               stream.write(f"Source revision: `{os.environ['SOURCE_REVISION']}`\n")
+              stream.write("Runner boundary: GitHub-hosted.\n")
           PY
       - name: Upload Monte Carlo evidence
         if: always()
@@ -284,137 +289,5 @@ jobs:
         with:
           name: monte-carlo-evidence-${{ github.run_id }}
           path: outputs/compute-evidence
-          if-no-files-found: error
-          retention-days: 30
-
-  memory-profile:
-    name: Full-resolution self-hosted memory profile
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.pull_request.head.repo.full_name == github.repository &&
-       startsWith(github.head_ref, 'ci/self-hosted-'))
-    runs-on: [self-hosted, Linux, X64, nvidia-smi]
-    timeout-minutes: 120
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Set up Python 3.12
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.12"
-      - name: Bootstrap isolated environment
-        shell: bash
-        run: |
-          set -euo pipefail
-          python -m venv --clear .memory-venv
-          echo "${PWD}/.memory-venv/bin" >> "${GITHUB_PATH}"
-      - name: Install lightweight package
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e .
-      - name: Record host identity
-        shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p outputs/memory-profile
-          {
-            echo "repository=${GITHUB_REPOSITORY}"
-            echo "source_revision=${SOURCE_REVISION}"
-            echo "checked_out_revision=$(git rev-parse HEAD)"
-            echo "run_id=${GITHUB_RUN_ID}"
-            echo "runner_name=${RUNNER_NAME}"
-            echo "runner_os=${RUNNER_OS}"
-            echo "runner_arch=${RUNNER_ARCH}"
-            echo
-            uname -a
-            echo
-            lscpu
-            echo
-            free -b
-            echo
-            nvidia-smi
-            echo
-            python -VV
-          } > outputs/memory-profile/host.txt 2>&1
-      - name: Run full-resolution memory benchmarks
-        shell: bash
-        run: |
-          set -euo pipefail
-          python -m prob4d.fusion_memory_benchmark \
-            --frames 32 \
-            --height 360 \
-            --width 640 \
-            --contributors 4 \
-            --method covariance_intersection \
-            --fusion-tile-size 16384 \
-            --output-json outputs/memory-profile/fusion.json \
-            > outputs/memory-profile/fusion.stdout.json
-          python -m prob4d.evaluation_memory_benchmark \
-            --frames 32 \
-            --height 360 \
-            --width 640 \
-            --include-flow \
-            --evaluation-chunk-size 65536 \
-            --output-json outputs/memory-profile/evaluation.json \
-            > outputs/memory-profile/evaluation.stdout.json
-      - name: Validate, hash, and summarize memory evidence
-        if: always()
-        shell: bash
-        run: |
-          set -euo pipefail
-          python - <<'PY'
-          from __future__ import annotations
-
-          import hashlib
-          import json
-          import os
-          from pathlib import Path
-
-          root = Path("outputs/memory-profile")
-          summary: dict[str, object] = {
-              "schema": "prob4d.self-hosted-memory-evidence",
-              "version": 1,
-              "repository": os.environ["GITHUB_REPOSITORY"],
-              "source_revision": os.environ["SOURCE_REVISION"],
-              "run_id": os.environ["GITHUB_RUN_ID"],
-              "runner_name": os.environ["RUNNER_NAME"],
-              "claim_boundary": (
-                  "Hardware-specific engineering evidence only. No reconstruction "
-                  "accuracy or downstream physical-benefit claim."
-              ),
-          }
-          for name in ("fusion", "evaluation"):
-              path = root / f"{name}.json"
-              if path.is_file():
-                  report = json.loads(path.read_text())
-                  summary[name] = {
-                      "configuration": report.get("configuration"),
-                      "timing_seconds": report.get("timing_seconds"),
-                      "memory_bytes": report.get("memory_bytes"),
-                  }
-          (root / "summary.json").write_text(
-              json.dumps(summary, indent=2, sort_keys=True, allow_nan=False) + "\n",
-              encoding="utf-8",
-          )
-          entries = []
-          for path in sorted(root.rglob("*")):
-              if path.is_file() and path.name != "SHA256SUMS":
-                  entries.append(
-                      f"{hashlib.sha256(path.read_bytes()).hexdigest()}  "
-                      f"{path.relative_to(root).as_posix()}"
-                  )
-          (root / "SHA256SUMS").write_text(
-              "\n".join(entries) + "\n", encoding="utf-8"
-          )
-          PY
-      - name: Upload self-hosted memory evidence
-        if: always()
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
-        with:
-          name: self-hosted-memory-evidence-${{ github.run_id }}
-          path: outputs/memory-profile
           if-no-files-found: error
           retention-days: 30

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,49 +17,22 @@ concurrency:
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
   PYTHONUNBUFFERED: "1"
-  SELF_HOSTED_RECOVERY: >-
-    ${{ github.event_name == 'pull_request' &&
-        github.event.pull_request.head.repo.full_name == github.repository &&
-        startsWith(github.head_ref, 'ci/self-hosted-') }}
 
 jobs:
-  # Trusted same-repository recovery branches use workstation2; forks and
-  # ordinary CI retain the GitHub-hosted default.
   quality:
     name: Quality and provider contract
-    runs-on: >-
-      ${{ github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository &&
-          startsWith(github.head_ref, 'ci/self-hosted-') &&
-          fromJSON('["self-hosted","Linux","X64","nvidia-smi"]') ||
-          'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Set up hosted Python 3.12
-        if: env.SELF_HOSTED_RECOVERY != 'true'
+      - name: Set up Python 3.12
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
           cache: pip
           cache-dependency-path: pyproject.toml
-      - name: Set up self-hosted Python 3.12
-        if: env.SELF_HOSTED_RECOVERY == 'true'
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.12"
-      - name: Isolate the self-hosted quality environment
-        if: env.SELF_HOSTED_RECOVERY == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          environment="$RUNNER_TEMP/prob4d-tests-quality"
-          python -m venv --clear "$environment"
-          "$environment/bin/python" -m ensurepip --upgrade
-          "$environment/bin/python" -m pip install --upgrade pip
-          echo "$environment/bin" >> "$GITHUB_PATH"
       - name: Install development tools
         run: python -m pip install -e ".[dev]"
       - name: Run Ruff
@@ -151,12 +124,7 @@ jobs:
 
   test:
     name: NumPy core / Python ${{ matrix.python-version }}
-    runs-on: >-
-      ${{ github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository &&
-          startsWith(github.head_ref, 'ci/self-hosted-') &&
-          fromJSON('["self-hosted","Linux","X64","nvidia-smi"]') ||
-          'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -166,28 +134,12 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Set up hosted Python ${{ matrix.python-version }}
-        if: env.SELF_HOSTED_RECOVERY != 'true'
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
           cache-dependency-path: pyproject.toml
-      - name: Set up self-hosted Python ${{ matrix.python-version }}
-        if: env.SELF_HOSTED_RECOVERY == 'true'
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Isolate the self-hosted test environment
-        if: env.SELF_HOSTED_RECOVERY == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          environment="$RUNNER_TEMP/prob4d-tests-${{ matrix.python-version }}"
-          python -m venv --clear "$environment"
-          "$environment/bin/python" -m ensurepip --upgrade
-          "$environment/bin/python" -m pip install --upgrade pip
-          echo "$environment/bin" >> "$GITHUB_PATH"
       - name: Install lightweight package
         run: python -m pip install -e ".[dev]"
       - name: Verify stable imports do not load GPU stacks
@@ -234,39 +186,18 @@ jobs:
 
   minimum-dependencies:
     name: Declared runtime floors / Python 3.10
-    runs-on: >-
-      ${{ github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository &&
-          startsWith(github.head_ref, 'ci/self-hosted-') &&
-          fromJSON('["self-hosted","Linux","X64","nvidia-smi"]') ||
-          'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Set up hosted Python 3.10
-        if: env.SELF_HOSTED_RECOVERY != 'true'
+      - name: Set up Python 3.10
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.10"
           cache: pip
           cache-dependency-path: requirements/ci/minimum.txt
-      - name: Set up self-hosted Python 3.10
-        if: env.SELF_HOSTED_RECOVERY == 'true'
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.10"
-      - name: Isolate the self-hosted minimum-dependency environment
-        if: env.SELF_HOSTED_RECOVERY == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          environment="$RUNNER_TEMP/prob4d-minimum-dependencies"
-          python -m venv --clear "$environment"
-          "$environment/bin/python" -m ensurepip --upgrade
-          "$environment/bin/python" -m pip install --upgrade pip
-          echo "$environment/bin" >> "$GITHUB_PATH"
       - name: Install exact runtime floor and test tooling
         run: |
           python -m pip install --upgrade pip
@@ -298,37 +229,16 @@ jobs:
   build:
     name: Build distributions
     needs: [quality, test, minimum-dependencies]
-    runs-on: >-
-      ${{ github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository &&
-          startsWith(github.head_ref, 'ci/self-hosted-') &&
-          fromJSON('["self-hosted","Linux","X64","nvidia-smi"]') ||
-          'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Set up hosted Python 3.12
-        if: env.SELF_HOSTED_RECOVERY != 'true'
+      - name: Set up Python 3.12
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
-      - name: Set up self-hosted Python 3.12
-        if: env.SELF_HOSTED_RECOVERY == 'true'
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.12"
-      - name: Isolate the self-hosted build environment
-        if: env.SELF_HOSTED_RECOVERY == 'true'
-        shell: bash
-        run: |
-          set -euo pipefail
-          environment="$RUNNER_TEMP/prob4d-build"
-          python -m venv --clear "$environment"
-          "$environment/bin/python" -m ensurepip --upgrade
-          "$environment/bin/python" -m pip install --upgrade pip
-          echo "$environment/bin" >> "$GITHUB_PATH"
       - name: Build and validate wheel and source distribution
         run: |
           python -m pip install build numpy pytest twine
@@ -347,12 +257,7 @@ jobs:
   installed-artifact:
     name: Installed ${{ matrix.kind }} and CLI smoke
     needs: build
-    runs-on: >-
-      ${{ github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository &&
-          startsWith(github.head_ref, 'ci/self-hosted-') &&
-          fromJSON('["self-hosted","Linux","X64","nvidia-smi"]') ||
-          'ubuntu-latest' }}
+    runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
       fail-fast: false

--- a/.github/workflows/trusted-self-hosted-validation.yml
+++ b/.github/workflows/trusted-self-hosted-validation.yml
@@ -4,123 +4,117 @@ on:
   workflow_dispatch:
     inputs:
       pr_number:
-        description: "Open same-repository pull request number"
+        description: Open same-repository pull request number
         required: true
         type: string
       head_sha:
-        description: "Exact reviewed 40-character pull-request head SHA"
+        description: Exact reviewed 40-character pull-request head SHA
         required: true
         type: string
-      run_full_suite:
-        description: "Run the complete pytest suite"
+      profile:
+        description: Reviewed self-hosted workload
         required: true
-        default: true
-        type: boolean
-      run_memory_profile:
-        description: "Run the full-resolution engineering memory profile"
-        required: true
-        default: false
-        type: boolean
+        default: full-validation
+        type: choice
+        options:
+          - full-validation
+          - production-memory
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
-  group: trusted-self-hosted-${{ inputs.pr_number }}-${{ inputs.head_sha }}
+  group: trusted-exact-head-${{ inputs.pr_number }}-${{ inputs.head_sha }}
   cancel-in-progress: false
 
 env:
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
   PYTHONHASHSEED: "0"
   PYTHONUNBUFFERED: "1"
+  PYTHONDONTWRITEBYTECODE: "1"
+  OMP_NUM_THREADS: "1"
+  OPENBLAS_NUM_THREADS: "1"
+  MKL_NUM_THREADS: "1"
+  NUMEXPR_NUM_THREADS: "1"
 
 jobs:
   authorize:
     name: Authorize exact pull-request head
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    permissions:
-      contents: read
-      pull-requests: read
     outputs:
-      pr_number: ${{ steps.authorize.outputs.pr_number }}
-      head_sha: ${{ steps.authorize.outputs.head_sha }}
-      base_sha: ${{ steps.authorize.outputs.base_sha }}
-      head_ref: ${{ steps.authorize.outputs.head_ref }}
+      pr_number: ${{ steps.pr.outputs.pr_number }}
+      head_sha: ${{ steps.pr.outputs.head_sha }}
+      base_sha: ${{ steps.pr.outputs.base_sha }}
+      head_ref: ${{ steps.pr.outputs.head_ref }}
     steps:
-      - name: Require the trusted workflow definition from main
+      - name: Require the default-branch workflow definition
         shell: bash
         env:
           DISPATCH_REF: ${{ github.ref }}
         run: |
           set -euo pipefail
-          if [[ "$DISPATCH_REF" != "refs/heads/main" ]]; then
-            echo "Trusted self-hosted validation must be dispatched from main." >&2
+          test "$DISPATCH_REF" = "refs/heads/main" || {
+            echo "trusted validation must be dispatched from main" >&2
             exit 1
-          fi
+          }
 
-      - name: Verify the open same-repository pull request and exact SHA
-        id: authorize
+      - name: Verify open same-repository pull request and exact SHA
+        id: pr
         shell: bash
         env:
+          API_URL: ${{ github.api_url }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          EXPECTED_HEAD_SHA: ${{ inputs.head_sha }}
           GITHUB_TOKEN: ${{ github.token }}
-          REQUESTED_PR: ${{ inputs.pr_number }}
-          REQUESTED_SHA: ${{ inputs.head_sha }}
         run: |
           set -euo pipefail
-          if [[ ! "$REQUESTED_PR" =~ ^[1-9][0-9]*$ ]]; then
-            echo "pr_number must be a positive integer" >&2
-            exit 1
-          fi
-          if [[ ! "$REQUESTED_SHA" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "head_sha must be an exact lowercase 40-character commit SHA" >&2
-            exit 1
-          fi
-
-          response="$RUNNER_TEMP/prob4d-trusted-pr.json"
-          curl --fail-with-body --silent --show-error \
-            --header "Authorization: Bearer $GITHUB_TOKEN" \
-            --header "Accept: application/vnd.github+json" \
-            --header "X-GitHub-Api-Version: 2022-11-28" \
-            "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/pulls/$REQUESTED_PR" \
-            > "$response"
-
-          python - "$response" "$GITHUB_OUTPUT" <<'PY'
+          python - <<'PY'
           from __future__ import annotations
 
           import json
           import os
-          from pathlib import Path
-          import sys
+          import re
+          import urllib.request
 
-          pull = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
-          repository = os.environ["GITHUB_REPOSITORY"]
-          requested_sha = os.environ["REQUESTED_SHA"]
+          repository = os.environ["REPOSITORY"]
+          pr_number = os.environ["PR_NUMBER"]
+          expected_head_sha = os.environ["EXPECTED_HEAD_SHA"]
+          if re.fullmatch(r"[1-9][0-9]*", pr_number) is None:
+              raise SystemExit("pr_number must be a positive integer")
+          if re.fullmatch(r"[0-9a-f]{40}", expected_head_sha) is None:
+              raise SystemExit("head_sha must be a full lowercase SHA-1")
 
-          if pull.get("state") != "open":
+          request = urllib.request.Request(
+              f"{os.environ['API_URL']}/repos/{repository}/pulls/{pr_number}",
+              headers={
+                  "Accept": "application/vnd.github+json",
+                  "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+                  "X-GitHub-Api-Version": "2022-11-28",
+              },
+          )
+          with urllib.request.urlopen(request, timeout=30) as response:
+              pull = json.load(response)
+
+          actual_head_sha = str(pull["head"]["sha"])
+          if pull["state"] != "open":
               raise SystemExit("the requested pull request is not open")
-          if pull.get("base", {}).get("ref") != "main":
-              raise SystemExit("the requested pull request is not based on main")
-          head_repository = pull.get("head", {}).get("repo")
-          if not isinstance(head_repository, dict):
-              raise SystemExit("the requested pull request has no accessible head repository")
-          if head_repository.get("full_name") != repository:
-              raise SystemExit("fork pull requests are not eligible for self-hosted execution")
-          actual_sha = pull.get("head", {}).get("sha")
-          if actual_sha != requested_sha:
-              raise SystemExit(
-                  "the requested SHA is stale or does not match the pull-request head"
-              )
+          if pull["base"]["ref"] != "main":
+              raise SystemExit("pull request base must be main")
+          if pull["head"]["repo"]["full_name"] != repository:
+              raise SystemExit("only same-repository pull requests are admitted")
+          if pull["base"]["repo"]["full_name"] != repository:
+              raise SystemExit("pull request base repository changed")
+          if actual_head_sha != expected_head_sha:
+              raise SystemExit("pull-request head moved or expected SHA is stale")
 
-          outputs = {
-              "pr_number": str(pull["number"]),
-              "head_sha": actual_sha,
-              "base_sha": pull["base"]["sha"],
-              "head_ref": pull["head"]["ref"],
-          }
-          with Path(sys.argv[2]).open("a", encoding="utf-8") as stream:
-              for name, value in outputs.items():
-                  stream.write(f"{name}={value}\n")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"pr_number={pull['number']}\n")
+              output.write(f"head_sha={actual_head_sha}\n")
+              output.write(f"base_sha={pull['base']['sha']}\n")
+              output.write(f"head_ref={pull['head']['ref']}\n")
           PY
 
   validate:
@@ -129,87 +123,93 @@ jobs:
     environment: trusted-self-hosted-validation
     runs-on: [self-hosted, Linux, X64, nvidia-smi]
     timeout-minutes: 180
-    permissions:
-      contents: read
-    env:
-      EXPECTED_PR_NUMBER: ${{ needs.authorize.outputs.pr_number }}
-      EXPECTED_HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
-      EXPECTED_BASE_SHA: ${{ needs.authorize.outputs.base_sha }}
     steps:
-      - name: Check out only the authorized exact head
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ needs.authorize.outputs.head_sha }}
-          fetch-depth: 1
-          persist-credentials: false
-          clean: true
-
-      - name: Verify exact source and clean checkout before execution
+      - name: Initialize isolated validation workspace
+        id: workspace
         shell: bash
         run: |
           set -euo pipefail
-          actual="$(git rev-parse HEAD)"
-          if [[ "$actual" != "$EXPECTED_HEAD_SHA" ]]; then
-            echo "checked-out revision $actual does not match $EXPECTED_HEAD_SHA" >&2
-            exit 1
-          fi
-          if [[ -n "$(git status --porcelain=v1 --untracked-files=all)" ]]; then
-            echo "checkout is not clean before validation" >&2
-            git status --short >&2
-            exit 1
-          fi
-
-      - name: Set up Python 3.12
-        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-        with:
-          python-version: "3.12"
-
-      - name: Create isolated runtime directories
-        shell: bash
-        run: |
-          set -euo pipefail
-          root="$RUNNER_TEMP/prob4d-trusted-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          rm -rf -- "$root"
-          mkdir -p "$root/home" "$root/cache" "$root/tmp" "$root/evidence"
-          python -m venv --clear "$root/venv"
-          "$root/venv/bin/python" -m ensurepip --upgrade
-          "$root/venv/bin/python" -m pip install --upgrade pip
+          root="${RUNNER_TEMP}/prob4d-exact-head-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          expected="${RUNNER_TEMP}/prob4d-exact-head-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          test "$root" = "$expected"
+          /usr/bin/rm -rf -- "$root"
+          /usr/bin/mkdir -p \
+            "$root/home" \
+            "$root/cache" \
+            "$root/tmp" \
+            "$root/evidence"
+          echo "root=$root" >> "$GITHUB_OUTPUT"
           {
-            echo "TRUSTED_ROOT=$root"
             echo "HOME=$root/home"
             echo "XDG_CACHE_HOME=$root/cache"
             echo "PIP_CACHE_DIR=$root/cache/pip"
             echo "HF_HOME=$root/cache/huggingface"
             echo "TMPDIR=$root/tmp"
           } >> "$GITHUB_ENV"
-          echo "$root/venv/bin" >> "$GITHUB_PATH"
 
-      - name: Install the lightweight development environment
+      - name: Check out only the authorized exact head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.authorize.outputs.head_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+          clean: true
+
+      - name: Verify exact clean checkout
+        shell: bash
+        env:
+          EXPECTED_HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          test "$(/usr/bin/git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
+          test -z "$(/usr/bin/git status --porcelain=v1 --untracked-files=all)"
+
+      - name: Provision Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Create isolated Python environment
         shell: bash
         run: |
           set -euo pipefail
-          python -m pip install --no-cache-dir -e ".[dev]"
-          python -m pip install --no-cache-dir "numpy>=1.24,<2.3"
-          python -m pip check
+          root="${{ steps.workspace.outputs.root }}"
+          python -m venv "$root/venv"
+          "$root/venv/bin/python" -m pip install \
+            "pip==25.2" \
+            "setuptools==80.9.0" \
+            "wheel==0.45.1"
+
+      - name: Install reviewed source
+        shell: bash
+        run: |
+          set -euo pipefail
+          python_bin="${{ steps.workspace.outputs.root }}/venv/bin/python"
+          "$python_bin" -m pip install --no-cache-dir ".[dev]" "numpy>=1.24,<2.3"
+          "$python_bin" -m pip check
 
       - name: Verify workflow security policies first
         shell: bash
         run: |
           set -euo pipefail
-          python -m pytest -q \
+          python_bin="${{ steps.workspace.outputs.root }}/venv/bin/python"
+          "$python_bin" -m pytest -q -p no:cacheprovider \
             tests/test_github_action_pins.py \
             tests/test_trusted_self_hosted_validation_policy.py \
             tests/test_security_scanning_workflow_policy.py
 
-      - name: Run source quality and stable-interface typing
+      - name: Run full source validation
+        if: inputs.profile == 'full-validation'
         shell: bash
         run: |
           set -euo pipefail
-          python -m ruff check src tests scripts/ci
-          python -m ruff format --check \
+          root="${{ steps.workspace.outputs.root }}"
+          python_bin="$root/venv/bin/python"
+          "$python_bin" -m ruff check src tests scripts/ci
+          "$python_bin" -m ruff format --check \
             tests/test_trusted_self_hosted_validation_policy.py \
             tests/test_security_scanning_workflow_policy.py
-          python -m mypy \
+          "$python_bin" -m mypy \
             src/prob4d/cli.py \
             src/prob4d/calibration_compatibility.py \
             src/prob4d/composition_jacobian.py \
@@ -228,143 +228,131 @@ jobs:
             src/prob4d/provider_v2_loading.py \
             src/prob4d/runtime_revision.py \
             src/prob4d/source_diagnostics.py
-
-      - name: Run complete test suite
-        if: inputs.run_full_suite
-        shell: bash
-        run: |
-          set -euo pipefail
-          python -m pytest \
-            --tb=short \
-            --junitxml="$TRUSTED_ROOT/evidence/pytest.xml"
-
-      - name: Compile, build, and audit distributions
-        shell: bash
-        run: |
-          set -euo pipefail
-          python -m compileall -q src/prob4d tests
-          rm -rf build dist *.egg-info src/*.egg-info
-          python -m build
-          python -m twine check dist/*
+          "$python_bin" -m pytest --tb=short \
+            --junitxml="$root/evidence/pytest.xml"
+          "$python_bin" -m compileall -q src/prob4d tests
+          /usr/bin/rm -rf build dist ./*.egg-info
+          /usr/bin/git restore --worktree -- src/prob4d.egg-info
+          "$python_bin" -m build
+          "$python_bin" -m twine check dist/*
           archive="$(find dist -maxdepth 1 -name '*.tar.gz' -print -quit)"
           test -n "$archive"
-          python scripts/ci/check_sdist.py "$archive"
-          python -m pip check
+          "$python_bin" scripts/ci/check_sdist.py "$archive"
+          "$python_bin" -m pip check
+          /usr/bin/git restore --worktree -- src/prob4d.egg-info
+          /usr/bin/git diff --exit-code
+          test -z "$(/usr/bin/git status --porcelain=v1)"
 
-      - name: Run optional full-resolution memory profile
-        if: inputs.run_memory_profile
-        shell: bash
-        run: |
-          set -euo pipefail
-          mkdir -p "$TRUSTED_ROOT/evidence/memory"
-          python -m prob4d.fusion_memory_benchmark \
-            --frames 32 \
-            --height 360 \
-            --width 640 \
-            --contributors 4 \
-            --method covariance_intersection \
-            --fusion-tile-size 16384 \
-            --output-json "$TRUSTED_ROOT/evidence/memory/fusion.json"
-          python -m prob4d.evaluation_memory_benchmark \
-            --frames 32 \
-            --height 360 \
-            --width 640 \
-            --include-flow \
-            --evaluation-chunk-size 65536 \
-            --output-json "$TRUSTED_ROOT/evidence/memory/evaluation.json"
-
-      - name: Record exact-head validation evidence
-        if: always()
+      - name: Run reviewed production memory profile
+        if: inputs.profile == 'production-memory'
         shell: bash
         env:
-          VALIDATION_STATUS: ${{ job.status }}
-          RUN_FULL_SUITE: ${{ inputs.run_full_suite }}
-          RUN_MEMORY_PROFILE: ${{ inputs.run_memory_profile }}
+          EXPECTED_HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
         run: |
           set -euo pipefail
-          mkdir -p "$TRUSTED_ROOT/evidence"
-          python - <<'PY'
+          root="${{ steps.workspace.outputs.root }}"
+          python_bin="$root/venv/bin/python"
+          output="$root/evidence/memory"
+          /usr/bin/mkdir -p "$output"
+          "$python_bin" -m prob4d.fusion_memory_benchmark \
+            --frames 25 --height 320 --width 640 --contributors 3 \
+            --method covariance_intersection \
+            --fusion-tile-size 16384 \
+            --output-json "$output/fusion.json"
+          "$python_bin" -m prob4d.evaluation_memory_benchmark \
+            --frames 25 --height 320 --width 640 --include-flow \
+            --evaluation-chunk-size 65536 \
+            --output-json "$output/evaluation.json"
+          EXPECTED_HEAD_SHA="$EXPECTED_HEAD_SHA" EVIDENCE_ROOT="$root" \
+            "$python_bin" - <<'PY'
           from __future__ import annotations
 
-          import hashlib
           import json
           import os
           from pathlib import Path
-          import platform
-          import subprocess
 
-          root = Path(os.environ["TRUSTED_ROOT"])
-          distributions = []
-          for path in sorted(Path("dist").glob("*")):
-              if not path.is_file():
-                  continue
-              distributions.append(
-                  {
-                      "name": path.name,
-                      "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
-                      "size_bytes": path.stat().st_size,
-                  }
-              )
+          root = Path(os.environ["EVIDENCE_ROOT"]) / "evidence" / "memory"
+          for name in ("fusion", "evaluation"):
+              report = json.loads((root / f"{name}.json").read_text(encoding="utf-8"))
+              if report["repository_revision"] != os.environ["EXPECTED_HEAD_SHA"]:
+                  raise SystemExit(f"{name} report is not bound to the reviewed head")
+              peak = report["memory_bytes"]["peak_process_rss"]
+              if peak is None or int(peak) <= 0:
+                  raise SystemExit(f"{name} report has no positive peak RSS")
+          PY
+          /usr/bin/git diff --exit-code
+          test -z "$(/usr/bin/git status --porcelain=v1)"
 
-          report = {
-              "schema": "prob4d.trusted-exact-head-validation",
-              "version": 1,
-              "repository": os.environ["GITHUB_REPOSITORY"],
-              "pull_request_number": int(os.environ["EXPECTED_PR_NUMBER"]),
-              "head_sha": os.environ["EXPECTED_HEAD_SHA"],
-              "base_sha": os.environ["EXPECTED_BASE_SHA"],
-              "checked_out_sha": subprocess.check_output(
-                  ["git", "rev-parse", "HEAD"], text=True
-              ).strip(),
-              "workflow_run_id": os.environ["GITHUB_RUN_ID"],
-              "workflow_run_attempt": os.environ["GITHUB_RUN_ATTEMPT"],
-              "runner_name": os.environ["RUNNER_NAME"],
-              "runner_os": os.environ["RUNNER_OS"],
-              "runner_arch": os.environ["RUNNER_ARCH"],
-              "python": platform.python_version(),
-              "validation_status": os.environ["VALIDATION_STATUS"],
-              "run_full_suite": os.environ["RUN_FULL_SUITE"] == "true",
-              "run_memory_profile": os.environ["RUN_MEMORY_PROFILE"] == "true",
-              "distributions": distributions,
-              "claim_boundary": (
-                  "Privileged exact-source implementation validation only. This record "
-                  "does not establish empirical accuracy, calibration, physical benefit, "
-                  "deployment safety, or authorization to open target data."
-              ),
-          }
-          if report["checked_out_sha"] != report["head_sha"]:
-              raise SystemExit("evidence source revision does not match the authorized head")
-          encoded = json.dumps(report, indent=2, sort_keys=True, allow_nan=False) + "\n"
-          (root / "evidence" / "validation.json").write_text(
-              encoded, encoding="utf-8"
-          )
+      - name: Record exact validation evidence
+        if: ${{ always() && steps.workspace.outcome == 'success' }}
+        shell: bash
+        env:
+          EXPECTED_HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+          EXPECTED_BASE_SHA: ${{ needs.authorize.outputs.base_sha }}
+          HEAD_REF: ${{ needs.authorize.outputs.head_ref }}
+          VALIDATION_STATUS: ${{ job.status }}
+        run: |
+          set -euo pipefail
+          export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+          root="${{ steps.workspace.outputs.root }}"
+          python_bin="$root/venv/bin/python"
+          checked_out_sha="$(/usr/bin/git rev-parse HEAD)"
+          test "$checked_out_sha" = "$EXPECTED_HEAD_SHA"
+          {
+            echo "repository=${GITHUB_REPOSITORY}"
+            echo "pull_request=${{ needs.authorize.outputs.pr_number }}"
+            echo "head_sha=$EXPECTED_HEAD_SHA"
+            echo "checked_out_sha=$checked_out_sha"
+            echo "base_sha=$EXPECTED_BASE_SHA"
+            echo "head_ref=$HEAD_REF"
+            echo "profile=${{ inputs.profile }}"
+            echo "validation_status=$VALIDATION_STATUS"
+            echo "runner_name=$RUNNER_NAME"
+            echo "runner_os=$RUNNER_OS"
+            echo "runner_arch=$RUNNER_ARCH"
+            "$python_bin" --version
+            "$python_bin" -m pip --version
+            "$python_bin" -m pip freeze --all
+          } > "$root/evidence/environment.txt"
+          {
+            /usr/bin/uname -a
+            command -v lscpu >/dev/null 2>&1 && lscpu || true
+            command -v free >/dev/null 2>&1 && free -b || true
+            command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi || true
+          } > "$root/evidence/host.txt" 2>&1
+          "$python_bin" - "$root/evidence" <<'PY'
+          from __future__ import annotations
 
-          sums = []
-          for path in sorted((root / "evidence").rglob("*")):
+          import hashlib
+          from pathlib import Path
+          import sys
+
+          root = Path(sys.argv[1])
+          lines = []
+          for path in sorted(root.rglob("*")):
               if path.is_file() and path.name != "SHA256SUMS":
                   digest = hashlib.sha256(path.read_bytes()).hexdigest()
-                  sums.append(f"{digest}  {path.relative_to(root / 'evidence').as_posix()}")
-          (root / "evidence" / "SHA256SUMS").write_text(
-              "\n".join(sums) + "\n", encoding="utf-8"
-          )
+                  lines.append(f"{digest}  {path.relative_to(root).as_posix()}")
+          (root / "SHA256SUMS").write_text("\n".join(lines) + "\n", encoding="utf-8")
           PY
 
       - name: Upload compact validation evidence
-        if: always()
+        if: ${{ always() && steps.workspace.outcome == 'success' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: trusted-exact-head-${{ needs.authorize.outputs.pr_number }}-${{ needs.authorize.outputs.head_sha }}
-          path: ${{ runner.temp }}/prob4d-trusted-${{ github.run_id }}-${{ github.run_attempt }}/evidence
+          name: trusted-exact-head-${{ needs.authorize.outputs.pr_number }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.workspace.outputs.root }}/evidence/
           if-no-files-found: warn
           retention-days: 30
 
-      - name: Remove the isolated runtime and checkout
-        if: always()
+      - name: Remove isolated validation workspace and checkout residue
+        if: ${{ always() && steps.workspace.outcome == 'success' }}
         shell: bash
         run: |
-          set +e
-          if [[ -n "${TRUSTED_ROOT:-}" && "$TRUSTED_ROOT" == "$RUNNER_TEMP"/prob4d-trusted-* ]]; then
-            rm -rf -- "$TRUSTED_ROOT"
-          fi
-          git reset --hard HEAD
-          git clean -ffdx
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          expected="${RUNNER_TEMP}/prob4d-exact-head-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          test "$root" = "$expected"
+          /usr/bin/rm -rf -- "$root"
+          /usr/bin/git reset --hard HEAD
+          /usr/bin/git clean -ffdx

--- a/.github/workflows/trusted-self-hosted-validation.yml
+++ b/.github/workflows/trusted-self-hosted-validation.yml
@@ -1,0 +1,370 @@
+name: Trusted exact-head validation
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Open same-repository pull request number"
+        required: true
+        type: string
+      head_sha:
+        description: "Exact reviewed 40-character pull-request head SHA"
+        required: true
+        type: string
+      run_full_suite:
+        description: "Run the complete pytest suite"
+        required: true
+        default: true
+        type: boolean
+      run_memory_profile:
+        description: "Run the full-resolution engineering memory profile"
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: trusted-self-hosted-${{ inputs.pr_number }}-${{ inputs.head_sha }}
+  cancel-in-progress: false
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONHASHSEED: "0"
+  PYTHONUNBUFFERED: "1"
+
+jobs:
+  authorize:
+    name: Authorize exact pull-request head
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      pr_number: ${{ steps.authorize.outputs.pr_number }}
+      head_sha: ${{ steps.authorize.outputs.head_sha }}
+      base_sha: ${{ steps.authorize.outputs.base_sha }}
+      head_ref: ${{ steps.authorize.outputs.head_ref }}
+    steps:
+      - name: Require the trusted workflow definition from main
+        shell: bash
+        env:
+          DISPATCH_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          if [[ "$DISPATCH_REF" != "refs/heads/main" ]]; then
+            echo "Trusted self-hosted validation must be dispatched from main." >&2
+            exit 1
+          fi
+
+      - name: Verify the open same-repository pull request and exact SHA
+        id: authorize
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          REQUESTED_PR: ${{ inputs.pr_number }}
+          REQUESTED_SHA: ${{ inputs.head_sha }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$REQUESTED_PR" =~ ^[1-9][0-9]*$ ]]; then
+            echo "pr_number must be a positive integer" >&2
+            exit 1
+          fi
+          if [[ ! "$REQUESTED_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "head_sha must be an exact lowercase 40-character commit SHA" >&2
+            exit 1
+          fi
+
+          response="$RUNNER_TEMP/prob4d-trusted-pr.json"
+          curl --fail-with-body --silent --show-error \
+            --header "Authorization: Bearer $GITHUB_TOKEN" \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/pulls/$REQUESTED_PR" \
+            > "$response"
+
+          python - "$response" "$GITHUB_OUTPUT" <<'PY'
+          from __future__ import annotations
+
+          import json
+          import os
+          from pathlib import Path
+          import sys
+
+          pull = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+          repository = os.environ["GITHUB_REPOSITORY"]
+          requested_sha = os.environ["REQUESTED_SHA"]
+
+          if pull.get("state") != "open":
+              raise SystemExit("the requested pull request is not open")
+          if pull.get("base", {}).get("ref") != "main":
+              raise SystemExit("the requested pull request is not based on main")
+          head_repository = pull.get("head", {}).get("repo")
+          if not isinstance(head_repository, dict):
+              raise SystemExit("the requested pull request has no accessible head repository")
+          if head_repository.get("full_name") != repository:
+              raise SystemExit("fork pull requests are not eligible for self-hosted execution")
+          actual_sha = pull.get("head", {}).get("sha")
+          if actual_sha != requested_sha:
+              raise SystemExit(
+                  "the requested SHA is stale or does not match the pull-request head"
+              )
+
+          outputs = {
+              "pr_number": str(pull["number"]),
+              "head_sha": actual_sha,
+              "base_sha": pull["base"]["sha"],
+              "head_ref": pull["head"]["ref"],
+          }
+          with Path(sys.argv[2]).open("a", encoding="utf-8") as stream:
+              for name, value in outputs.items():
+                  stream.write(f"{name}={value}\n")
+          PY
+
+  validate:
+    name: Validate approved exact head on workstation2
+    needs: authorize
+    environment: trusted-self-hosted-validation
+    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    timeout-minutes: 180
+    permissions:
+      contents: read
+    env:
+      EXPECTED_PR_NUMBER: ${{ needs.authorize.outputs.pr_number }}
+      EXPECTED_HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+      EXPECTED_BASE_SHA: ${{ needs.authorize.outputs.base_sha }}
+    steps:
+      - name: Check out only the authorized exact head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.authorize.outputs.head_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          clean: true
+
+      - name: Verify exact source and clean checkout before execution
+        shell: bash
+        run: |
+          set -euo pipefail
+          actual="$(git rev-parse HEAD)"
+          if [[ "$actual" != "$EXPECTED_HEAD_SHA" ]]; then
+            echo "checked-out revision $actual does not match $EXPECTED_HEAD_SHA" >&2
+            exit 1
+          fi
+          if [[ -n "$(git status --porcelain=v1 --untracked-files=all)" ]]; then
+            echo "checkout is not clean before validation" >&2
+            git status --short >&2
+            exit 1
+          fi
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Create isolated runtime directories
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="$RUNNER_TEMP/prob4d-trusted-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          rm -rf -- "$root"
+          mkdir -p "$root/home" "$root/cache" "$root/tmp" "$root/evidence"
+          python -m venv --clear "$root/venv"
+          "$root/venv/bin/python" -m ensurepip --upgrade
+          "$root/venv/bin/python" -m pip install --upgrade pip
+          {
+            echo "TRUSTED_ROOT=$root"
+            echo "HOME=$root/home"
+            echo "XDG_CACHE_HOME=$root/cache"
+            echo "PIP_CACHE_DIR=$root/cache/pip"
+            echo "HF_HOME=$root/cache/huggingface"
+            echo "TMPDIR=$root/tmp"
+          } >> "$GITHUB_ENV"
+          echo "$root/venv/bin" >> "$GITHUB_PATH"
+
+      - name: Install the lightweight development environment
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --no-cache-dir -e ".[dev]"
+          python -m pip install --no-cache-dir "numpy>=1.24,<2.3"
+          python -m pip check
+
+      - name: Verify workflow security policies first
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pytest -q \
+            tests/test_github_action_pins.py \
+            tests/test_trusted_self_hosted_validation_policy.py \
+            tests/test_security_scanning_workflow_policy.py
+
+      - name: Run source quality and stable-interface typing
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m ruff check src tests scripts/ci
+          python -m ruff format --check \
+            tests/test_trusted_self_hosted_validation_policy.py \
+            tests/test_security_scanning_workflow_policy.py
+          python -m mypy \
+            src/prob4d/cli.py \
+            src/prob4d/calibration_compatibility.py \
+            src/prob4d/composition_jacobian.py \
+            src/prob4d/covariance_root.py \
+            src/prob4d/observation_factor_stream.py \
+            src/prob4d/prediction_store.py \
+            src/prob4d/prediction_store_benchmark.py \
+            src/prob4d/prediction_store_cli.py \
+            src/prob4d/project_identity.py \
+            src/prob4d/provider_attestation.py \
+            src/prob4d/provider_manifest.py \
+            src/prob4d/provider_manifest_cli.py \
+            src/prob4d/provider_v1.py \
+            src/prob4d/provider_v2.py \
+            src/prob4d/provider_v2_cli.py \
+            src/prob4d/provider_v2_loading.py \
+            src/prob4d/runtime_revision.py \
+            src/prob4d/source_diagnostics.py
+
+      - name: Run complete test suite
+        if: inputs.run_full_suite
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pytest \
+            --tb=short \
+            --junitxml="$TRUSTED_ROOT/evidence/pytest.xml"
+
+      - name: Compile, build, and audit distributions
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m compileall -q src/prob4d tests
+          rm -rf build dist *.egg-info src/*.egg-info
+          python -m build
+          python -m twine check dist/*
+          archive="$(find dist -maxdepth 1 -name '*.tar.gz' -print -quit)"
+          test -n "$archive"
+          python scripts/ci/check_sdist.py "$archive"
+          python -m pip check
+
+      - name: Run optional full-resolution memory profile
+        if: inputs.run_memory_profile
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$TRUSTED_ROOT/evidence/memory"
+          python -m prob4d.fusion_memory_benchmark \
+            --frames 32 \
+            --height 360 \
+            --width 640 \
+            --contributors 4 \
+            --method covariance_intersection \
+            --fusion-tile-size 16384 \
+            --output-json "$TRUSTED_ROOT/evidence/memory/fusion.json"
+          python -m prob4d.evaluation_memory_benchmark \
+            --frames 32 \
+            --height 360 \
+            --width 640 \
+            --include-flow \
+            --evaluation-chunk-size 65536 \
+            --output-json "$TRUSTED_ROOT/evidence/memory/evaluation.json"
+
+      - name: Record exact-head validation evidence
+        if: always()
+        shell: bash
+        env:
+          VALIDATION_STATUS: ${{ job.status }}
+          RUN_FULL_SUITE: ${{ inputs.run_full_suite }}
+          RUN_MEMORY_PROFILE: ${{ inputs.run_memory_profile }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$TRUSTED_ROOT/evidence"
+          python - <<'PY'
+          from __future__ import annotations
+
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+          import platform
+          import subprocess
+
+          root = Path(os.environ["TRUSTED_ROOT"])
+          distributions = []
+          for path in sorted(Path("dist").glob("*")):
+              if not path.is_file():
+                  continue
+              distributions.append(
+                  {
+                      "name": path.name,
+                      "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+                      "size_bytes": path.stat().st_size,
+                  }
+              )
+
+          report = {
+              "schema": "prob4d.trusted-exact-head-validation",
+              "version": 1,
+              "repository": os.environ["GITHUB_REPOSITORY"],
+              "pull_request_number": int(os.environ["EXPECTED_PR_NUMBER"]),
+              "head_sha": os.environ["EXPECTED_HEAD_SHA"],
+              "base_sha": os.environ["EXPECTED_BASE_SHA"],
+              "checked_out_sha": subprocess.check_output(
+                  ["git", "rev-parse", "HEAD"], text=True
+              ).strip(),
+              "workflow_run_id": os.environ["GITHUB_RUN_ID"],
+              "workflow_run_attempt": os.environ["GITHUB_RUN_ATTEMPT"],
+              "runner_name": os.environ["RUNNER_NAME"],
+              "runner_os": os.environ["RUNNER_OS"],
+              "runner_arch": os.environ["RUNNER_ARCH"],
+              "python": platform.python_version(),
+              "validation_status": os.environ["VALIDATION_STATUS"],
+              "run_full_suite": os.environ["RUN_FULL_SUITE"] == "true",
+              "run_memory_profile": os.environ["RUN_MEMORY_PROFILE"] == "true",
+              "distributions": distributions,
+              "claim_boundary": (
+                  "Privileged exact-source implementation validation only. This record "
+                  "does not establish empirical accuracy, calibration, physical benefit, "
+                  "deployment safety, or authorization to open target data."
+              ),
+          }
+          if report["checked_out_sha"] != report["head_sha"]:
+              raise SystemExit("evidence source revision does not match the authorized head")
+          encoded = json.dumps(report, indent=2, sort_keys=True, allow_nan=False) + "\n"
+          (root / "evidence" / "validation.json").write_text(
+              encoded, encoding="utf-8"
+          )
+
+          sums = []
+          for path in sorted((root / "evidence").rglob("*")):
+              if path.is_file() and path.name != "SHA256SUMS":
+                  digest = hashlib.sha256(path.read_bytes()).hexdigest()
+                  sums.append(f"{digest}  {path.relative_to(root / 'evidence').as_posix()}")
+          (root / "evidence" / "SHA256SUMS").write_text(
+              "\n".join(sums) + "\n", encoding="utf-8"
+          )
+          PY
+
+      - name: Upload compact validation evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: trusted-exact-head-${{ needs.authorize.outputs.pr_number }}-${{ needs.authorize.outputs.head_sha }}
+          path: ${{ runner.temp }}/prob4d-trusted-${{ github.run_id }}-${{ github.run_attempt }}/evidence
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Remove the isolated runtime and checkout
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          if [[ -n "${TRUSTED_ROOT:-}" && "$TRUSTED_ROOT" == "$RUNNER_TEMP"/prob4d-trusted-* ]]; then
+            rm -rf -- "$TRUSTED_ROOT"
+          fi
+          git reset --hard HEAD
+          git clean -ffdx

--- a/.github/workflows/vggt-provider-neutral.yml
+++ b/.github/workflows/vggt-provider-neutral.yml
@@ -26,7 +26,7 @@ jobs:
   contract:
     name: Integrity, causal lineage, and installed CLI
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - name: Check out exact pull-request head
@@ -40,16 +40,8 @@ jobs:
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
-
-      - name: Isolate the self-hosted Python environment
-        shell: bash
-        run: |
-          set -euo pipefail
-          environment="$RUNNER_TEMP/prob4d-vggt-provider-venv"
-          python -m venv --clear "$environment"
-          "$environment/bin/python" -m ensurepip --upgrade
-          "$environment/bin/python" -m pip install --upgrade pip
-          echo "$environment/bin" >> "$GITHUB_PATH"
+          cache: pip
+          cache-dependency-path: pyproject.toml
 
       - name: Install development environment
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,20 @@ identity, or evidence admission require focused adversarial tests and correspond
 changelog documentation. Exact fallback and causal-prefix invariants must remain
 fail-closed.
 
+## Privileged validation
+
+Ordinary pull-request workflows must remain on ephemeral GitHub-hosted runners. Do not
+route pull-request source to a persistent self-hosted runner through a branch prefix,
+changed workflow, or mutable runner-selection input.
+
+When one explicitly reviewed revision genuinely requires the local GPU, large memory,
+or approved data, use the protected `Trusted exact-head validation` workflow described
+in `docs/trusted-self-hosted-validation.md`. The workflow must be dispatched from
+`main`, bind the current open same-repository pull-request head by its full SHA, and
+pause at the independently reviewed `trusted-self-hosted-validation` environment before
+self-hosted checkout. A successful privileged run is implementation evidence only; it
+does not authorize target access or promote a scientific claim.
+
 ## Pull requests
 
 A pull request should describe:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,11 +5,38 @@
 Security and integrity fixes are applied to the current `0.3.x` development line.
 Frozen historical revisions remain reproducible but may not receive backports.
 
+## Self-hosted workflow boundary
+
+Ordinary pull-request workflows run on GitHub-hosted infrastructure. Pull-request
+source, branch names, and workflow inputs must not select or trigger a persistent
+self-hosted runner.
+
+The only approved path for executing reviewed pull-request source on a self-hosted
+runner is the manual `Trusted exact-head validation` workflow. It must be dispatched
+from `main`, verify an open same-repository pull request and its exact current
+40-character head SHA on a hosted runner, and use the protected
+`trusted-self-hosted-validation` environment before checkout on the self-hosted host.
+The environment must have an independent required reviewer and no attached secrets or
+write credentials. See `docs/trusted-self-hosted-validation.md` for the complete
+operational and host-hardening requirements. Repository setup and acceptance testing are
+tracked in issue #157.
+
+Environment approval is not a sandbox. Suspected access to unrelated runner files,
+credentials, datasets, services, or network resources is a security incident even when
+repository and workflow permissions were read-only.
+
+## Automated scanning
+
+The repository runs pinned CodeQL analysis for Python and GitHub Actions plus a strict,
+pinned `pip-audit` dependency scan on pull requests, default-branch pushes, a weekly
+schedule, and explicit dispatch. Workflow-policy tests require immutable action pins,
+disabled checkout credential persistence, and the protected self-hosted boundary.
+
 ## Reporting a vulnerability
 
 Do not open a public issue for a suspected vulnerability involving credential exposure,
 artifact path traversal, unsafe deserialization, workflow privilege, model-source
-integrity, or evidence tampering.
+integrity, evidence tampering, or self-hosted runner access.
 
 Use GitHub's private vulnerability-reporting or Security Advisory interface for this
 repository. Include the affected revision, a minimal reproduction, the expected

--- a/docs/production-memory-profile.md
+++ b/docs/production-memory-profile.md
@@ -1,19 +1,24 @@
 # Production memory profiling
 
-Prob4D provides a workflow for reproducible, fresh-process memory measurements
-at the production `25 x 320 x 640` window shape. It is an engineering evidence
-surface for issue #50, not a reconstruction or downstream physics experiment.
+Prob4D provides fresh-process memory measurements at the production
+`25 x 320 x 640` window shape. This is an engineering evidence surface, not a
+reconstruction-accuracy or downstream-physics experiment.
+
+Issue #50 is complete. The repository retains the bounded fusion, evaluation,
+loading, and artifact-parity implementations plus their recorded evidence. New
+profiling work should be opened only when a concrete regression or bottleneck is
+identified.
 
 ## Covered phases
 
-The workflow runs each measured phase in a separate Python process:
+The standard workflow runs each measured phase in a separate Python process:
 
 1. dense covariance-intersection fusion with configurable contributor and tile
    counts;
-2. metric, prefix-aligned, and oracle-aligned provider evaluation with optional
-   dense scene flow and configurable evaluation chunks;
-3. optional eager-NPZ and read-only mmap-NPY loading for an actual prediction
-   bundle already present on the runner.
+2. bounded provider evaluation with optional dense scene flow and configurable
+   evaluation chunks; and
+3. optional eager-NPZ and read-only mmap-NPY loading when a prediction bundle is
+   explicitly staged in the ephemeral job.
 
 Separate processes prevent an earlier phase's high-water RSS mark from being
 attributed to a later phase. Every JSON report records the exact repository
@@ -22,15 +27,12 @@ process RSS, retained-array accounting, and a deterministic output digest.
 
 ## Runner and invocation
 
-The checked-in workflow uses `ubuntu-latest` by default. Manual dispatches can
-select `self-hosted` to target the IPS runner labels:
-
-```text
-self-hosted, Linux, X64, nvidia-smi
-```
+`.github/workflows/production-memory-profile.yml` always uses a GitHub-hosted
+runner. Pull-request source and workflow inputs cannot redirect it to a persistent
+self-hosted machine.
 
 A pull request that changes the workflow or one of its benchmark surfaces runs
-the full synthetic profile automatically. For a manual run, open **Actions →
+the synthetic profile automatically. For a manual hosted run, open **Actions →
 Production memory profile → Run workflow**. The defaults are:
 
 ```text
@@ -43,18 +45,23 @@ evaluation chunk size: 65536
 include flow: true
 ```
 
-The optional `prediction_manifest` and `prediction_store` inputs are absolute
-paths already present on the selected runner. They are primarily useful with
-the self-hosted option because GitHub-hosted runners are ephemeral. When
-supplied, the workflow additionally runs the verified eager and mmap loading
-benchmarks in fresh processes. These paths are never uploaded; only their
-content-addressed identities and measurements are included in the JSON evidence.
+The optional `prediction_manifest` and `prediction_store` values refer only to
+paths already staged inside that ephemeral hosted job. They do not provide access
+to files on `workstation2` or another persistent host.
+
+Hardware-specific validation on `workstation2` uses the separate
+`Trusted exact-head validation` workflow. That workflow must be dispatched from
+`main`, verifies an open same-repository pull request and its exact current
+40-character head SHA on a hosted runner, and enters the protected
+`trusted-self-hosted-validation` environment before checking out reviewed source.
+See [trusted self-hosted exact-head validation](trusted-self-hosted-validation.md).
 
 ## Evidence artifact
 
-Each run uploads one `production-memory-profile-<run-id>` artifact containing:
+Each standard run uploads one `production-memory-profile-<run-id>` artifact
+containing:
 
-- `host.txt`, including CPU, RAM, Python, NumPy, and any available GPU/driver
+- `host.txt`, including CPU, RAM, Python, NumPy, and any available driver
   identity;
 - one JSON and captured stdout file per executed phase;
 - `summary.json`, binding the phase reports to the workflow revision and runner;
@@ -63,14 +70,17 @@ Each run uploads one `production-memory-profile-<run-id>` artifact containing:
 The workflow fails closed when a required phase does not report positive peak
 RSS or when a report revision differs from `GITHUB_SHA`.
 
-## Claim boundary and remaining work
+The protected exact-head workflow emits a separate compact validation artifact
+that binds the approved pull request, exact head and base revisions, runner,
+distribution hashes, selected validation lanes, and final job status.
+
+## Claim boundary
 
 Synthetic full-resolution runs establish only resource behavior for the selected
-host and configuration. Optional actual-bundle loading adds storage evidence but
-does not establish visual accuracy, calibration, Bayesian-PhysTwin acceptance,
-or Causal4D benefit.
+host and configuration. Actual-bundle loading adds storage evidence but does not
+establish visual accuracy, uncertainty calibration, BayesianPhysTwin acceptance,
+Causal4D benefit, deployment safety, or permission to open target data.
 
-Issue #50 remains open until one frozen real multi-overlap bundle is profiled
-phase by phase through loading, disagreement, gauge estimation, fusion,
-provider export, and evaluation. The workflow is the repeatable hardware and
-artifact substrate for that final evidence gate.
+A successful protected self-hosted run is privileged implementation validation
+for one exact revision. It does not replace a frozen scientific protocol or its
+information-order and evidence-publication requirements.

--- a/docs/trusted-self-hosted-validation.md
+++ b/docs/trusted-self-hosted-validation.md
@@ -1,0 +1,100 @@
+# Trusted self-hosted exact-head validation
+
+Prob4D uses GitHub-hosted runners for ordinary pull-request checks. Pull-request
+source must not select, trigger, or redirect a job onto a persistent self-hosted
+runner merely through a branch name, changed workflow, or dispatch input.
+
+The only repository workflow allowed to execute reviewed pull-request source on
+`workstation2` is `.github/workflows/trusted-self-hosted-validation.yml`. It is a
+manual, exact-revision validation path for work that genuinely needs local GPU,
+large-memory, or approved data access.
+
+## Required repository environment
+
+Create an environment named exactly:
+
+```text
+trusted-self-hosted-validation
+```
+
+Protect it before the workflow is used:
+
+- require at least one independent reviewer;
+- do not attach environment secrets;
+- do not attach repository, deployment, cloud, or package-write credentials;
+- restrict deployment branches so the workflow definition must come from
+  `main`;
+- do not permit the pull-request author to approve their own execution where the
+  repository settings support that restriction; and
+- require the approver to compare the displayed pull-request number and full
+  40-character head SHA with the reviewed source.
+
+The workflow itself also verifies, on a GitHub-hosted runner and before any
+self-hosted checkout, that:
+
+- it was dispatched from `refs/heads/main`;
+- the pull request is open and based on `main`;
+- the pull request belongs to this repository rather than a fork; and
+- the requested SHA is exactly the current pull-request head.
+
+A stale SHA, changed head, fork, closed pull request, non-main base, or dispatch
+from another ref fails before self-hosted execution.
+
+## Operation
+
+From the default branch, open **Actions → Trusted exact-head validation → Run
+workflow** and provide:
+
+1. the open pull-request number;
+2. the exact reviewed 40-character head SHA;
+3. whether to run the complete pytest suite; and
+4. whether to run the optional full-resolution memory profile.
+
+The self-hosted job pauses at the protected environment. After approval, it
+checks out only the authorized SHA with persisted Git credentials disabled,
+verifies a clean exact checkout, creates isolated home/cache/temp/virtualenv
+directories below `RUNNER_TEMP`, and runs policy checks before general project
+code. It records the source, base, pull request, runner, Python version,
+distribution digests, selected validation lanes, and final job status in a
+compact evidence artifact.
+
+The ordinary pull-request test, quality, contract, provider-neutral, visual-bias,
+identity, memory, and controlled-stress workflows remain GitHub-hosted. A
+self-hosted validation request is therefore explicit and exceptional rather than
+a fallback selected by pull-request-controlled source.
+
+## Runner hardening outside GitHub Actions
+
+Environment approval is an authorization barrier, not a sandbox. Once approved,
+the reviewed revision can execute arbitrary code as the runner operating-system
+account. The host must therefore be configured defensively:
+
+- use a dedicated non-administrator runner account;
+- remove cloud, SSH, package-registry, and personal credentials from that account;
+- mount only explicitly approved datasets, preferably read-only;
+- keep unopened target cohorts outside the runner's ordinary namespace until a
+  separately authorized protocol requires them;
+- restrict access to unrelated repositories, user homes, caches, services, and
+  network destinations;
+- use disposable workspaces and inspect cleanup failures; and
+- rotate or rebuild the runner after a suspected boundary violation.
+
+The workflow redirects common Python, XDG, Hugging Face, pip, and temporary paths
+to a run-specific directory and removes that directory after artifact upload.
+This reduces accidental state reuse but does not prevent deliberately malicious
+code from reading any resource available to the runner account.
+
+## Evidence and claim boundary
+
+A successful run proves that one exact source revision passed the selected
+implementation checks in the recorded environment. It does not establish:
+
+- observation accuracy or uncertainty calibration;
+- BayesianPhysTwin or Causal4D benefit;
+- permission to open a held-out or confirmatory cohort;
+- deployment or safety readiness; or
+- reproducibility on a different host or dependency resolution.
+
+Claim-bearing experiments must continue to use their separately frozen protocol,
+information-order, dataset, calibration, artifact, and evidence-publication
+contracts.

--- a/scripts/ci/check_sdist.py
+++ b/scripts/ci/check_sdist.py
@@ -16,6 +16,7 @@ REQUIRED_PATHS = frozenset(
         ".github/CODEOWNERS",
         ".github/dependabot.yml",
         ".github/workflows/ecosystem-release-capsule.yml",
+        ".github/workflows/heldout-cohort-binding.yml",
         ".github/workflows/heldout-provider-promotion.yml",
         ".github/workflows/observation-bias-binding.yml",
         ".github/workflows/provider-runtime.yml",
@@ -30,6 +31,7 @@ REQUIRED_PATHS = frozenset(
         "README.md",
         "SECURITY.md",
         "docs/ecosystem-release-capsule.md",
+        "docs/examples/deform360-heldout-provider-promotion-config.json",
         "docs/examples/heldout-provider-promotion-config.json",
         "docs/examples/material-identity-mixture-config.json",
         "docs/heldout-provider-promotion.md",
@@ -47,12 +49,16 @@ REQUIRED_PATHS = frozenset(
         "requirements/ci/minimum.txt",
         "scripts/ci/build_ecosystem_release_capsule.py",
         "scripts/ci/check_sdist.py",
+        "src/prob4d/_deform360_cohort_binding.py",
+        "src/prob4d/_deform360_cohort_io.py",
+        "src/prob4d/_deform360_cohort_schema.py",
         "src/prob4d/_heldout_promotion_common.py",
         "src/prob4d/_heldout_promotion_diagnosis.py",
         "src/prob4d/_heldout_promotion_evaluation.py",
         "src/prob4d/_heldout_promotion_lock.py",
         "src/prob4d/_heldout_promotion_query.py",
         "src/prob4d/_heldout_promotion_report.py",
+        "src/prob4d/deform360_cohort_binding.py",
         "src/prob4d/heldout_promotion.py",
         "src/prob4d/joint_covariance_metrics.py",
         "src/prob4d/material_identity_cli.py",
@@ -62,6 +68,7 @@ REQUIRED_PATHS = frozenset(
         "src/prob4d/visual_bias_stream.py",
         "tests/fixtures/prob4d_joint_observation_v1.json",
         "tests/test_data_storage.py",
+        "tests/test_deform360_cohort_binding.py",
         "tests/test_ecosystem_release_capsule.py",
         "tests/test_github_action_pins.py",
         "tests/test_heldout_promotion.py",
@@ -82,6 +89,7 @@ REQUIRED_PATHS = frozenset(
 REPRESENTATIVE_TESTS = (
     "tests/test_sim3.py",
     "tests/test_data_storage.py",
+    "tests/test_deform360_cohort_binding.py",
     "tests/test_ecosystem_release_capsule.py",
     "tests/test_heldout_promotion.py",
     "tests/test_heldout_promotion_diagnosis.py",
@@ -113,8 +121,13 @@ def _validated_members(archive: Path) -> tuple[str, tuple[tarfile.TarInfo, ...]]
         if path.is_absolute() or not path.parts or ".." in path.parts:
             raise RuntimeError(f"unsafe source-distribution path: {member.name}")
         roots.add(path.parts[0])
-        if member.issym() or member.islnk() or not (member.isdir() or member.isfile()):
-            raise RuntimeError(f"source distribution contains a non-regular member: {member.name}")
+        if member.issym() or member.islnk() or not (
+            member.isdir() or member.isfile()
+        ):
+            raise RuntimeError(
+                "source distribution contains a non-regular member: "
+                f"{member.name}"
+            )
         if len(path.parts) > 1:
             relative_paths.add(PurePosixPath(*path.parts[1:]).as_posix())
 

--- a/scripts/ci/check_sdist.py
+++ b/scripts/ci/check_sdist.py
@@ -20,7 +20,9 @@ REQUIRED_PATHS = frozenset(
         ".github/workflows/observation-bias-binding.yml",
         ".github/workflows/provider-runtime.yml",
         ".github/workflows/recursive-visual-bias.yml",
+        ".github/workflows/security-scanning.yml",
         ".github/workflows/tests.yml",
+        ".github/workflows/trusted-self-hosted-validation.yml",
         "CHANGELOG.md",
         "CITATION.cff",
         "CONTRIBUTING.md",
@@ -39,6 +41,7 @@ REQUIRED_PATHS = frozenset(
         "docs/provider-v2.md",
         "docs/recursive-visual-bias.md",
         "docs/repository-identity.md",
+        "docs/trusted-self-hosted-validation.md",
         "protocols/cycle-guard-conformal-v1.json",
         "protocols/cycle-guard-normalization-v1.json",
         "requirements/ci/minimum.txt",
@@ -71,6 +74,8 @@ REQUIRED_PATHS = frozenset(
         "tests/test_promotion_evidence.py",
         "tests/test_provider_runtime.py",
         "tests/test_release_metadata.py",
+        "tests/test_security_scanning_workflow_policy.py",
+        "tests/test_trusted_self_hosted_validation_policy.py",
         "tests/test_visual_bias_stream.py",
     }
 )
@@ -88,6 +93,8 @@ REPRESENTATIVE_TESTS = (
     "tests/test_joint_observation_contract_fixture.py",
     "tests/test_project_identity.py",
     "tests/test_release_metadata.py",
+    "tests/test_security_scanning_workflow_policy.py",
+    "tests/test_trusted_self_hosted_validation_policy.py",
     "tests/test_visual_bias_stream.py",
     "tests/test_github_action_pins.py",
 )

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -82,6 +82,8 @@ def test_release_governance_files_exist() -> None:
     for name in (
         ".github/dependabot.yml",
         ".github/workflows/ecosystem-release-capsule.yml",
+        ".github/workflows/security-scanning.yml",
+        ".github/workflows/trusted-self-hosted-validation.yml",
         "CHANGELOG.md",
         "CITATION.cff",
         "CONTRIBUTING.md",
@@ -89,6 +91,7 @@ def test_release_governance_files_exist() -> None:
         "MANIFEST.in",
         "SECURITY.md",
         "docs/ecosystem-release-capsule.md",
+        "docs/trusted-self-hosted-validation.md",
         "scripts/ci/build_ecosystem_release_capsule.py",
     ):
         assert (ROOT / name).is_file(), name

--- a/tests/test_security_scanning_workflow_policy.py
+++ b/tests/test_security_scanning_workflow_policy.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "security-scanning.yml"
+
+
+def test_security_scanning_has_read_only_triggers_and_permissions() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "push:" in text
+    assert "pull_request:" in text
+    assert "schedule:" in text
+    assert "workflow_dispatch:" in text
+    assert "permissions:\n  contents: read" in text
+    assert "contents: write" not in text
+    assert "persist-credentials: false" in text
+    assert "continue-on-error: true" not in text
+
+
+def test_codeql_scans_python_and_workflow_sources() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "language: [python, actions]" in text
+    assert "build-mode: none" in text
+    assert "queries: security-extended" in text
+    assert "security-events: write" in text
+    assert "github/codeql-action/init@" in text
+    assert "github/codeql-action/analyze@" in text
+    assert 'category: "/language:${{ matrix.language }}"' in text
+
+
+def test_dependency_audit_is_strict_pinned_and_archived() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'python -m pip install "pip-audit==2.10.1"' in text
+    assert "python -m pip_audit" in text
+    assert "--strict" in text
+    assert "--progress-spinner off" in text
+    assert "--output pip-audit.json" in text
+    assert "if: always()" in text
+    assert "actions/upload-artifact@" in text
+    assert "if-no-files-found: warn" in text

--- a/tests/test_trusted_self_hosted_validation_policy.py
+++ b/tests/test_trusted_self_hosted_validation_policy.py
@@ -28,6 +28,8 @@ def test_only_the_protected_manual_workflow_can_use_self_hosted_runners() -> Non
         text = path.read_text(encoding="utf-8")
         if "self-hosted" in text:
             offenders.append(path.relative_to(ROOT).as_posix())
+        assert "ci/self-hosted-" not in text, path
+        assert "SELF_HOSTED_RECOVERY" not in text, path
     assert offenders == []
 
 
@@ -41,30 +43,43 @@ def test_trusted_workflow_is_manual_main_bound_and_exact_sha_authorized() -> Non
     assert "refs/heads/main" in text
     assert "environment: trusted-self-hosted-validation" in text
     assert "runs-on: [self-hosted, Linux, X64, nvidia-smi]" in text
-    assert "^[0-9a-f]{40}$" in text
-    assert "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/pulls/$REQUESTED_PR" in text
-    assert 'pull.get("state") != "open"' in text
-    assert 'pull.get("base", {}).get("ref") != "main"' in text
-    assert 'head_repository.get("full_name") != repository' in text
-    assert "actual_sha != requested_sha" in text
+    assert "[0-9a-f]{40}" in text
+    assert "only same-repository pull requests are admitted" in text
+    assert "pull request base must be main" in text
+    assert "actual_head_sha != expected_head_sha" in text
     assert 'ref: ${{ needs.authorize.outputs.head_sha }}' in text
     assert "persist-credentials: false" in text
 
 
-def test_trusted_workflow_is_read_only_isolated_and_cleans_up() -> None:
+def test_trusted_workflow_uses_immutable_workspace_output_and_absolute_tools() -> None:
     text = TRUSTED_WORKFLOW.read_text(encoding="utf-8")
 
-    assert "permissions:\n  contents: read" in text
+    assert "permissions:\n  contents: read\n  pull-requests: read" in text
     assert "contents: write" not in text
     assert "pull-requests: write" not in text
     assert "secrets." not in text
-    assert "HOME=$root/home" in text
-    assert "XDG_CACHE_HOME=$root/cache" in text
-    assert "PIP_CACHE_DIR=$root/cache/pip" in text
-    assert "TMPDIR=$root/tmp" in text
-    assert "git reset --hard HEAD" in text
-    assert "git clean -ffdx" in text
-    assert "prob4d.trusted-exact-head-validation" in text
+    assert 'echo "root=$root" >> "$GITHUB_OUTPUT"' in text
+    assert "steps.workspace.outputs.root" in text
+    assert "TRUSTED_ROOT" not in text
+    assert "GITHUB_PATH" not in text
+    assert '"$root/venv/bin/python"' in text
+    assert '$(/usr/bin/git rev-parse HEAD)' in text
+    assert '/usr/bin/rm -rf -- "$root"' in text
+    assert "/usr/bin/git reset --hard HEAD" in text
+    assert "/usr/bin/git clean -ffdx" in text
+    assert "/usr/bin/git restore --worktree -- src/prob4d.egg-info" in text
+    assert "/usr/bin/rm -rf build dist ./*.egg-info src/*.egg-info" not in text
+
+
+def test_privileged_profiles_are_fixed_and_reports_bind_exact_source() -> None:
+    text = TRUSTED_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "full-validation" in text
+    assert "production-memory" in text
+    assert "--frames 25 --height 320 --width 640 --contributors 3" in text
+    assert "--include-flow" in text
+    assert 'report["repository_revision"] != os.environ["EXPECTED_HEAD_SHA"]' in text
+    assert "git push" not in text
 
 
 def test_completed_temporary_inventory_workflows_are_removed() -> None:

--- a/tests/test_trusted_self_hosted_validation_policy.py
+++ b/tests/test_trusted_self_hosted_validation_policy.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_ROOT = ROOT / ".github" / "workflows"
+TRUSTED_WORKFLOW = WORKFLOW_ROOT / "trusted-self-hosted-validation.yml"
+REMOVED_TEMPORARY_WORKFLOWS = (
+    WORKFLOW_ROOT / "issue-49-protected-cohort-inventory.yml",
+    WORKFLOW_ROOT / "issue-49-protected-cohort-inventory-launch.yml",
+    WORKFLOW_ROOT / "issue-49-protected-cohort-inventory-priority.yml",
+)
+
+
+def _workflow_files() -> tuple[Path, ...]:
+    return tuple(
+        sorted(WORKFLOW_ROOT.glob("*.yml"))
+        + sorted(WORKFLOW_ROOT.glob("*.yaml"))
+    )
+
+
+def test_only_the_protected_manual_workflow_can_use_self_hosted_runners() -> None:
+    assert TRUSTED_WORKFLOW.is_file()
+    offenders = []
+    for path in _workflow_files():
+        if path == TRUSTED_WORKFLOW:
+            continue
+        text = path.read_text(encoding="utf-8")
+        if "self-hosted" in text:
+            offenders.append(path.relative_to(ROOT).as_posix())
+    assert offenders == []
+
+
+def test_trusted_workflow_is_manual_main_bound_and_exact_sha_authorized() -> None:
+    text = TRUSTED_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "workflow_dispatch:" in text
+    assert "\n  pull_request:" not in text
+    assert "pull_request_target:" not in text
+    assert 'DISPATCH_REF: ${{ github.ref }}' in text
+    assert "refs/heads/main" in text
+    assert "environment: trusted-self-hosted-validation" in text
+    assert "runs-on: [self-hosted, Linux, X64, nvidia-smi]" in text
+    assert "^[0-9a-f]{40}$" in text
+    assert "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/pulls/$REQUESTED_PR" in text
+    assert 'pull.get("state") != "open"' in text
+    assert 'pull.get("base", {}).get("ref") != "main"' in text
+    assert 'head_repository.get("full_name") != repository' in text
+    assert "actual_sha != requested_sha" in text
+    assert 'ref: ${{ needs.authorize.outputs.head_sha }}' in text
+    assert "persist-credentials: false" in text
+
+
+def test_trusted_workflow_is_read_only_isolated_and_cleans_up() -> None:
+    text = TRUSTED_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "permissions:\n  contents: read" in text
+    assert "contents: write" not in text
+    assert "pull-requests: write" not in text
+    assert "secrets." not in text
+    assert "HOME=$root/home" in text
+    assert "XDG_CACHE_HOME=$root/cache" in text
+    assert "PIP_CACHE_DIR=$root/cache/pip" in text
+    assert "TMPDIR=$root/tmp" in text
+    assert "git reset --hard HEAD" in text
+    assert "git clean -ffdx" in text
+    assert "prob4d.trusted-exact-head-validation" in text
+
+
+def test_completed_temporary_inventory_workflows_are_removed() -> None:
+    for path in REMOVED_TEMPORARY_WORKFLOWS:
+        assert not path.exists(), path.relative_to(ROOT).as_posix()


### PR DESCRIPTION
## Summary

- keep ordinary pull-request quality, test, provider, identity, visual-bias, controlled-stress, compute-evidence, and memory-profile jobs on GitHub-hosted runners;
- remove branch-name and workflow-input routes that could execute pull-request-controlled source directly on `workstation2`;
- add one manual `Trusted exact-head validation` workflow that authorizes an open same-repository PR and its exact current 40-character head SHA on a hosted runner before entering a protected environment;
- isolate common home/cache/temp/virtualenv paths, disable persisted checkout credentials, retain read-only GitHub permissions, record exact-source evidence, and clean the self-hosted workspace after validation;
- add pinned CodeQL scans for Python and GitHub Actions plus strict pinned `pip-audit` dependency scanning;
- add fail-closed policy tests requiring immutable action pins, hosted ordinary CI, the single protected self-hosted boundary, and removal of completed temporary inventory launchers;
- include the workflows, policy tests, and operating guidance in release and source-distribution audits; and
- correct the production-memory documentation now that issue #50 is complete.

## Why

A same-repository branch-name prefix, a changed workflow, or a dispatch input is not a trust boundary for a persistent self-hosted runner. Even with a read-only GitHub token and disabled checkout credential persistence, reviewed source can access any host file, mounted dataset, cached credential, service, or network resource available to the runner account.

The replacement control plane separates authorization from execution:

1. the workflow definition must be dispatched from `main`;
2. a GitHub-hosted job verifies the PR is open, based on `main`, same-repository, and still at the supplied exact SHA;
3. the self-hosted job is gated by the hard-coded `trusted-self-hosted-validation` environment; and
4. only the authorized SHA is checked out and executed.

## Operational prerequisite

Before first use, create and protect the GitHub environment named exactly:

```text
trusted-self-hosted-validation
```

Require an independent reviewer, attach no secrets or write credentials, restrict deployment branches to the default branch, and verify the displayed PR number and full head SHA at approval. The host should use a dedicated runner account with only explicitly approved data mounts, preferably read-only. Environment approval is authorization, not a sandbox.

## Validation

The branch adds static workflow-policy tests, source-distribution checks, full-suite coverage through the ordinary Python matrix, CodeQL, and dependency auditing. The new protected workflow also runs the policy checks before general reviewed source when manually approved.

## Scientific boundary

This changes workflow privilege, repository security, release auditing, and documentation only. It does not change the estimator, provider-v1/v2 behavior, artifact schemas, calibration semantics, frozen evidence, issue #49 scientific decision, BayesianPhysTwin acceptance, or Causal4D behavior. A green exact-head run is implementation evidence, not accuracy, calibration, target-access, deployment, or scientific-claim evidence.