### PR TITLE
[maintenance] Validate generic provider import on workstation2

### DIFF
--- a/.github/workflows/generic-provider-import.yml
+++ b/.github/workflows/generic-provider-import.yml
@@ -1,0 +1,92 @@
+name: Generic provider import
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/generic-provider-import.yml"
+      - "docs/examples/provider-neutral-import-spec.json"
+      - "docs/generic-provider-import.md"
+      - "scripts/ci/check_sdist.py"
+      - "src/prob4d/prediction_cli.py"
+      - "src/prob4d/prediction_provider_import.py"
+      - "src/prob4d/prediction_provider_manifest.py"
+      - "src/prob4d/prediction_provider_scaffold.py"
+      - "tests/test_cli.py"
+      - "tests/test_prediction_provider_import.py"
+      - "tests/test_prediction_provider_manifest.py"
+      - "tests/test_prediction_provider_scaffold.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: generic-provider-import-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONUNBUFFERED: "1"
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out exact reviewed source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install lightweight development environment
+        run: |
+          python -m pip install -e ".[dev]" "numpy>=1.24,<2.3"
+          python -m pip check
+
+      - name: Validate source and focused contracts
+        run: |
+          python -m ruff check \
+            scripts/ci/check_sdist.py \
+            src/prob4d/prediction_cli.py \
+            src/prob4d/prediction_provider_import.py \
+            src/prob4d/prediction_provider_scaffold.py \
+            tests/test_cli.py \
+            tests/test_prediction_provider_import.py \
+            tests/test_prediction_provider_scaffold.py
+          python -m ruff format --check \
+            scripts/ci/check_sdist.py \
+            src/prob4d/prediction_cli.py \
+            src/prob4d/prediction_provider_import.py \
+            src/prob4d/prediction_provider_scaffold.py \
+            tests/test_cli.py \
+            tests/test_prediction_provider_import.py \
+            tests/test_prediction_provider_scaffold.py
+          python -m mypy \
+            src/prob4d/prediction_provider_import.py \
+            src/prob4d/prediction_provider_scaffold.py
+          python -m pytest -q \
+            tests/test_cli.py \
+            tests/test_prediction_provider_import.py \
+            tests/test_prediction_provider_manifest.py \
+            tests/test_prediction_provider_scaffold.py \
+            tests/test_data.py \
+            tests/test_data_storage.py
+          python -m compileall -q src/prob4d
+          python -m py_compile scripts/ci/check_sdist.py
+
+      - name: Smoke-test installed commands
+        run: |
+          prob4d prediction import-generic --help
+          prob4d prediction scaffold-generic --help
+          prob4d prediction scaffold-generic \
+            "$RUNNER_TEMP/provider-import-scaffold"
+          test -s "$RUNNER_TEMP/provider-import-scaffold/provider-import.json"
+          test -s "$RUNNER_TEMP/provider-import-scaffold/README.md"
+          test -d "$RUNNER_TEMP/provider-import-scaffold/windows"

--- a/docs/examples/provider-neutral-import-spec.json
+++ b/docs/examples/provider-neutral-import-spec.json
@@ -1,0 +1,61 @@
+{
+  "schema": "prob4d.prediction-provider-import-spec",
+  "schema_version": 1,
+  "sequence_id": "sequence-a",
+  "provider_family": "Example4D",
+  "provider_repository": "example/Example4D",
+  "provider_revision": "0123456789abcdef0123456789abcdef01234567",
+  "provider_run_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "model_set_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "loader_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "coordinate_semantics": "window-local-sim3",
+  "point_semantics": "dense-point-map",
+  "flow_semantics": "forward-point-displacement",
+  "ray_semantics": "absent",
+  "source_dependency_semantics": "per-output-exclusive-source-frame-interval-v1",
+  "payloads": [
+    {
+      "product_role": "independent-window",
+      "window_id": "window_0000",
+      "path": "windows/window_0000.npz",
+      "view_id": "camera-0",
+      "stochastic_member_id": "example4d-seed-17-window-0000",
+      "dependence_group_ids": [
+        "model-set:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        "input-video:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+        "stochastic-member:17"
+      ],
+      "frame_lineage": [
+        {
+          "output_frame_id": 0,
+          "source_frame_start": 0,
+          "source_frame_stop_exclusive": 3,
+          "contributor_ids": [
+            "window_0000"
+          ]
+        },
+        {
+          "output_frame_id": 1,
+          "source_frame_start": 0,
+          "source_frame_stop_exclusive": 3,
+          "contributor_ids": [
+            "window_0000"
+          ]
+        },
+        {
+          "output_frame_id": 2,
+          "source_frame_start": 0,
+          "source_frame_stop_exclusive": 3,
+          "contributor_ids": [
+            "window_0000"
+          ]
+        }
+      ]
+    }
+  ],
+  "metadata": {
+    "uses_truth": false,
+    "uses_downstream_physical_innovation": false,
+    "adapter_version": "example4d-prob4d-v1"
+  }
+}

--- a/docs/generic-provider-import.md
+++ b/docs/generic-provider-import.md
@@ -1,0 +1,103 @@
+# Generic external-provider import
+
+Prob4D can ingest canonical prediction windows from an external 4-D provider
+without adding that provider's runtime, model weights, or dependency stack to the
+Prob4D package.
+
+The boundary has two steps:
+
+```text
+external provider
+    -> versioned PredictionWindow NPZ files + strict import specification
+    -> PredictionProviderManifestV1
+```
+
+The resulting neutral manifest standardizes provenance and causal admission. It
+does not establish provider accuracy, calibration, independence, or downstream
+BayesianPhysTwin benefit.
+
+## Create a scaffold
+
+```bash
+prob4d prediction scaffold-generic \
+  outputs/sequence-a/external-provider
+```
+
+The command creates a new directory containing:
+
+```text
+README.md
+provider-import.json
+windows/
+```
+
+It refuses to replace an existing directory. The generated JSON is intentionally
+not admissible: every `REPLACE_WITH_...` value must be replaced with exact
+provenance before import.
+
+## Export canonical payloads
+
+Each payload must be a versioned `PredictionWindow` archive. The provider owns
+inference and writes these files; Prob4D owns validation and conversion into the
+portable manifest.
+
+The specification declares:
+
+- exact provider repository and revision;
+- provider-run, model-set, and loader content identities;
+- coordinate, point, flow, and ray semantics;
+- product role, view, stochastic-member identity, and dependence groups;
+- one confined relative payload path; and
+- one exclusive causal source-frame interval for every output frame.
+
+A complete static example is retained at
+[`examples/provider-neutral-import-spec.json`](examples/provider-neutral-import-spec.json).
+
+## Import and verify
+
+```bash
+prob4d prediction import-generic \
+  outputs/sequence-a/external-provider/provider-import.json \
+  outputs/sequence-a/external-provider/provider-neutral.json
+
+prob4d prediction validate \
+  outputs/sequence-a/external-provider/provider-neutral.json \
+  --causal-frame-stop 134
+```
+
+Prob4D derives the payload SHA-256, byte count, dense storage precision, and
+optional-field declarations from the exact NPZ bytes. It parses private byte
+snapshots and rechecks the source files before publication.
+
+The importer rejects:
+
+- absolute paths, parent traversal, and symbolic-link traversal;
+- duplicate JSON keys, non-finite values, and unknown fields;
+- malformed provider, revision, run, model-set, or loader identities;
+- caller-controlled importer metadata;
+- payload mutation during import;
+- window-ID or output-frame lineage mismatch; and
+- an output manifest outside the confined payload bundle.
+
+After writing the neutral manifest, the importer immediately performs full
+payload verification. A repeated identical publication is idempotent; a different
+manifest at the same path is rejected by the canonical manifest writer.
+
+## Python API
+
+```python
+from prob4d.prediction_provider_import import (
+    import_prediction_provider_specification,
+)
+from prob4d.prediction_provider_scaffold import (
+    scaffold_prediction_provider_import,
+)
+```
+
+## Downstream boundary
+
+A valid manifest proves byte-level interoperability, declared source lineage,
+and causal admission only. Source/calibration-only covariance, reliability,
+identity, and bias modelling remain separate steps. BayesianPhysTwin still owns
+the guarded physical update and exact fallback, and Causal4D should consume only
+the selected BayesianPhysTwin belief rather than raw provider output.

--- a/scripts/ci/check_sdist.py
+++ b/scripts/ci/check_sdist.py
@@ -17,7 +17,9 @@ REQUIRED_PATHS = frozenset(
         ".github/dependabot.yml",
         ".github/workflows/ecosystem-release-capsule.yml",
         ".github/workflows/heldout-provider-promotion.yml",
+        ".github/workflows/generic-provider-import.yml",
         ".github/workflows/observation-bias-binding.yml",
+        ".github/workflows/provider-neutral-common-mode.yml",
         ".github/workflows/provider-runtime.yml",
         ".github/workflows/recursive-visual-bias.yml",
         ".github/workflows/tests.yml",
@@ -30,12 +32,15 @@ REQUIRED_PATHS = frozenset(
         "docs/ecosystem-release-capsule.md",
         "docs/examples/heldout-provider-promotion-config.json",
         "docs/examples/material-identity-mixture-config.json",
+        "docs/examples/provider-neutral-import-spec.json",
+        "docs/generic-provider-import.md",
         "docs/heldout-provider-promotion.md",
         "docs/joint-covariance-diagnostics.md",
         "docs/material-identity-cli.md",
         "docs/observation-bias-binding.md",
-        "docs/provider-neutral-runtime.md",
         "docs/prediction-window-storage.md",
+        "docs/provider-neutral-predictions.md",
+        "docs/provider-neutral-runtime.md",
         "docs/provider-v2.md",
         "docs/recursive-visual-bias.md",
         "docs/repository-identity.md",
@@ -54,10 +59,15 @@ REQUIRED_PATHS = frozenset(
         "src/prob4d/joint_covariance_metrics.py",
         "src/prob4d/material_identity_cli.py",
         "src/prob4d/observation_bias_binding.py",
+        "src/prob4d/prediction_cli.py",
+        "src/prob4d/prediction_provider_import.py",
+        "src/prob4d/prediction_provider_manifest.py",
+        "src/prob4d/prediction_provider_scaffold.py",
         "src/prob4d/promotion_evidence.py",
         "src/prob4d/provider_runtime.py",
         "src/prob4d/visual_bias_stream.py",
         "tests/fixtures/prob4d_joint_observation_v1.json",
+        "tests/test_cli.py",
         "tests/test_data_storage.py",
         "tests/test_ecosystem_release_capsule.py",
         "tests/test_github_action_pins.py",
@@ -67,6 +77,9 @@ REQUIRED_PATHS = frozenset(
         "tests/test_joint_observation_contract_fixture.py",
         "tests/test_material_identity_cli.py",
         "tests/test_observation_bias_binding.py",
+        "tests/test_prediction_provider_import.py",
+        "tests/test_prediction_provider_manifest.py",
+        "tests/test_prediction_provider_scaffold.py",
         "tests/test_project_identity.py",
         "tests/test_promotion_evidence.py",
         "tests/test_provider_runtime.py",
@@ -83,6 +96,8 @@ REPRESENTATIVE_TESTS = (
     "tests/test_joint_covariance_metrics.py",
     "tests/test_material_identity_cli.py",
     "tests/test_observation_bias_binding.py",
+    "tests/test_prediction_provider_import.py",
+    "tests/test_prediction_provider_scaffold.py",
     "tests/test_promotion_evidence.py",
     "tests/test_provider_manifest.py",
     "tests/test_joint_observation_contract_fixture.py",
@@ -107,7 +122,10 @@ def _validated_members(archive: Path) -> tuple[str, tuple[tarfile.TarInfo, ...]]
             raise RuntimeError(f"unsafe source-distribution path: {member.name}")
         roots.add(path.parts[0])
         if member.issym() or member.islnk() or not (member.isdir() or member.isfile()):
-            raise RuntimeError(f"source distribution contains a non-regular member: {member.name}")
+            raise RuntimeError(
+                "source distribution contains a non-regular member: "
+                f"{member.name}"
+            )
         if len(path.parts) > 1:
             relative_paths.add(PurePosixPath(*path.parts[1:]).as_posix())
 

--- a/src/prob4d/prediction_cli.py
+++ b/src/prob4d/prediction_cli.py
@@ -24,6 +24,14 @@ def _help_parser() -> argparse.ArgumentParser:
         help="convert an integrity-bound official VGGT sample",
     )
     subparsers.add_parser(
+        "import-generic",
+        help="import external canonical PredictionWindow payloads",
+    )
+    subparsers.add_parser(
+        "scaffold-generic",
+        help="create a no-clobber external-provider import scaffold",
+    )
+    subparsers.add_parser(
         "validate",
         help="strictly validate a neutral manifest and its payloads",
     )
@@ -46,6 +54,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         from .vggt_provider_adapter import main as vggt_main
 
         return int(vggt_main(arguments[1:]))
+    if arguments[0] == "import-generic":
+        from .prediction_provider_import import main as generic_main
+
+        return int(generic_main(arguments[1:]))
+    if arguments[0] == "scaffold-generic":
+        from .prediction_provider_scaffold import main as scaffold_main
+
+        return int(scaffold_main(arguments[1:]))
     if arguments[0] == "runtime":
         from .provider_runtime import main as runtime_main
 

--- a/src/prob4d/prediction_provider_import.py
+++ b/src/prob4d/prediction_provider_import.py
@@ -1,0 +1,380 @@
+"""Strict generic import into the canonical prediction-provider manifest.
+
+External providers write canonical :class:`~prob4d.data.PredictionWindow` NPZ
+payloads and a small source specification. This module validates the exact
+payload bytes, per-output causal lineage, provider/model identities, dependence
+semantics, and optional fields before materializing the single canonical
+``PredictionProviderManifestV1`` contract.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import tempfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from ._strict_json import (
+    require_exact_fields,
+    require_exact_integer,
+    require_exact_string,
+    require_finite_json_mapping,
+    require_mapping,
+    require_revision,
+    require_sha256,
+    require_string_sequence,
+)
+from .data import PredictionWindow
+from .prediction_provider_manifest import (
+    PREDICTION_PROVIDER_MANIFEST_VERSION,
+    SOURCE_DEPENDENCY_SEMANTICS,
+    PredictionFrameLineageV1,
+    PredictionPayloadDescriptorV1,
+    PredictionProviderManifestV1,
+    _relative_member,
+    _resolved_member,
+    save_prediction_provider_manifest,
+    verify_prediction_provider_manifest,
+)
+
+PREDICTION_PROVIDER_IMPORT_SPEC_SCHEMA: Final = (
+    "prob4d.prediction-provider-import-spec"
+)
+PREDICTION_PROVIDER_IMPORT_SPEC_VERSION: Final = 1
+
+_SPEC_FIELDS: Final = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "sequence_id",
+        "provider_family",
+        "provider_repository",
+        "provider_revision",
+        "provider_run_id",
+        "model_set_id",
+        "loader_id",
+        "coordinate_semantics",
+        "point_semantics",
+        "flow_semantics",
+        "ray_semantics",
+        "source_dependency_semantics",
+        "payloads",
+        "metadata",
+    }
+)
+_SPEC_PAYLOAD_FIELDS: Final = frozenset(
+    {
+        "product_role",
+        "window_id",
+        "path",
+        "view_id",
+        "stochastic_member_id",
+        "dependence_group_ids",
+        "frame_lineage",
+    }
+)
+_RESERVED_METADATA_FIELDS: Final = frozenset(
+    {
+        "source_adapter",
+        "source_import_spec_sha256",
+        "source_import_spec_schema_version",
+        "target_manifest_schema_version",
+    }
+)
+
+
+def _sha256_bytes(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _read_bytes(path: Path, *, name: str) -> bytes:
+    try:
+        return path.read_bytes()
+    except OSError as error:
+        raise ValueError(f"cannot read {name} {path.name!r}") from error
+
+
+def _load_json_bytes(payload: bytes, *, name: str) -> dict[str, Any]:
+    def object_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, item in pairs:
+            if key in result:
+                raise ValueError(f"{name} contains duplicate JSON object key {key!r}")
+            result[key] = item
+        return result
+
+    def reject_constant(token: str) -> Any:
+        raise ValueError(f"{name} contains non-finite JSON number {token!r}")
+
+    try:
+        value = json.loads(
+            payload.decode("utf-8"),
+            object_pairs_hook=object_pairs,
+            parse_constant=reject_constant,
+        )
+    except UnicodeDecodeError as error:
+        raise ValueError(f"{name} must contain UTF-8 JSON") from error
+    except json.JSONDecodeError as error:
+        raise ValueError(f"{name} must contain valid JSON") from error
+    if not isinstance(value, dict):
+        raise ValueError(f"{name} must contain one JSON object")
+    return value
+
+
+def _snapshot_window(
+    path: Path,
+    *,
+    expected_window_id: str,
+) -> tuple[PredictionWindow, str, int]:
+    """Parse one canonical payload from the exact bytes bound to its identity."""
+
+    if not path.is_file():
+        raise ValueError(f"prediction payload {path.name!r} is missing")
+    payload = _read_bytes(path, name="prediction payload")
+    sha256 = _sha256_bytes(payload)
+    with tempfile.TemporaryDirectory(prefix="prob4d-provider-import-") as temporary:
+        snapshot = Path(temporary) / "prediction-window.npz"
+        snapshot.write_bytes(payload)
+        try:
+            window = PredictionWindow.from_npz(snapshot)
+        except (OSError, KeyError, ValueError) as error:
+            raise ValueError(
+                f"prediction payload {path.name!r} is not a canonical PredictionWindow"
+            ) from error
+    if _read_bytes(path, name="prediction payload") != payload:
+        raise ValueError("prediction payload changed during generic import")
+    if window.window_id != expected_window_id:
+        raise ValueError("import specification and payload window IDs differ")
+    return window, sha256, len(payload)
+
+
+def _load_specification(path: Path) -> tuple[Mapping[str, Any], str, bytes]:
+    """Parse one strict specification from its exact identity-bearing bytes."""
+
+    payload = _read_bytes(path, name="prediction-provider import specification")
+    record = _load_json_bytes(
+        payload,
+        name="prediction-provider import specification",
+    )
+    if _read_bytes(path, name="prediction-provider import specification") != payload:
+        raise ValueError(
+            "prediction-provider import specification changed during import"
+        )
+    require_exact_fields(record, _SPEC_FIELDS, name="provider import specification")
+    if record["schema"] != PREDICTION_PROVIDER_IMPORT_SPEC_SCHEMA:
+        raise ValueError("unsupported prediction-provider import specification schema")
+    version = require_exact_integer(
+        record["schema_version"],
+        name="prediction-provider import specification version",
+        minimum=1,
+    )
+    if version != PREDICTION_PROVIDER_IMPORT_SPEC_VERSION:
+        raise ValueError("unsupported prediction-provider import specification version")
+    return record, _sha256_bytes(payload), payload
+
+
+def _lineage_from_specification(
+    value: object,
+    *,
+    name: str,
+) -> tuple[PredictionFrameLineageV1, ...]:
+    if not isinstance(value, list) or not value:
+        raise ValueError(f"{name} must be a nonempty JSON array")
+    return tuple(PredictionFrameLineageV1.from_record(item) for item in value)
+
+
+def import_prediction_provider_specification(
+    specification_path: str | Path,
+    output_path: str | Path,
+) -> PredictionProviderManifestV1:
+    """Validate external canonical payloads and write one neutral manifest.
+
+    Payload paths in the source specification are resolved relative to the
+    specification file. Persisted paths are rewritten relative to the output
+    manifest, while exact payload bytes and all scientific/provenance semantics
+    remain identity-bearing through ``PredictionPayloadDescriptorV1``.
+    """
+
+    specification_input = Path(specification_path)
+    if specification_input.is_symlink():
+        raise ValueError("prediction-provider import specification is a symbolic link")
+    output_input = Path(output_path)
+    if output_input.is_symlink():
+        raise ValueError("prediction-provider output manifest is a symbolic link")
+    specification = specification_input.resolve()
+    output = output_input.resolve()
+    record, specification_sha256, specification_bytes = _load_specification(
+        specification
+    )
+
+    raw_payloads = record["payloads"]
+    if not isinstance(raw_payloads, list) or not raw_payloads:
+        raise ValueError("prediction-provider import specification requires payloads")
+
+    payloads: list[PredictionPayloadDescriptorV1] = []
+    for index, raw_payload in enumerate(raw_payloads):
+        payload_record = require_mapping(
+            raw_payload,
+            name=f"provider import payload {index}",
+        )
+        require_exact_fields(
+            payload_record,
+            _SPEC_PAYLOAD_FIELDS,
+            name=f"provider import payload {index}",
+        )
+        window_id = require_exact_string(
+            payload_record["window_id"],
+            name=f"provider import payload {index} window_id",
+        )
+        source_member = _resolved_member(
+            specification.parent,
+            require_exact_string(
+                payload_record["path"],
+                name=f"provider import payload {index} path",
+            ),
+            name=f"provider import payload {index} path",
+        )
+        window, sha256, byte_count = _snapshot_window(
+            source_member,
+            expected_window_id=window_id,
+        )
+        lineage = _lineage_from_specification(
+            payload_record["frame_lineage"],
+            name=f"provider import payload {index} frame_lineage",
+        )
+        output_frame_ids = tuple(int(value) for value in window.frame_indices)
+        if tuple(item.output_frame_id for item in lineage) != output_frame_ids:
+            raise ValueError(
+                "provider import frame lineage differs from payload frame identities"
+            )
+        dependence_groups = require_string_sequence(
+            payload_record["dependence_group_ids"],
+            name=f"provider import payload {index} dependence_group_ids",
+        )
+        payloads.append(
+            PredictionPayloadDescriptorV1(
+                product_role=payload_record["product_role"],
+                window_id=window_id,
+                path=_relative_member(
+                    source_member,
+                    root=output.parent,
+                    name=f"provider import payload {index} output path",
+                ),
+                sha256=sha256,
+                byte_count=byte_count,
+                view_id=payload_record["view_id"],
+                stochastic_member_id=payload_record["stochastic_member_id"],
+                dependence_group_ids=dependence_groups,
+                dense_storage_dtype=window.dense_storage_dtype,
+                has_scene_flow=window.scene_flow is not None,
+                has_ray_directions=window.ray_directions is not None,
+                frame_lineage=lineage,
+            )
+        )
+
+    payloads.sort(
+        key=lambda item: (
+            item.view_id,
+            item.output_frame_ids[0],
+            item.window_id,
+            item.stochastic_member_id,
+        )
+    )
+    metadata = dict(
+        require_finite_json_mapping(
+            record["metadata"],
+            name="provider import metadata",
+        )
+    )
+    conflicting = sorted(_RESERVED_METADATA_FIELDS.intersection(metadata))
+    if conflicting:
+        raise ValueError(
+            "provider import metadata uses reserved fields: " + ", ".join(conflicting)
+        )
+    metadata.update(
+        {
+            "source_adapter": "prob4d-external-provider-import-spec-v1",
+            "source_import_spec_sha256": specification_sha256,
+            "source_import_spec_schema_version": (
+                PREDICTION_PROVIDER_IMPORT_SPEC_VERSION
+            ),
+            "target_manifest_schema_version": PREDICTION_PROVIDER_MANIFEST_VERSION,
+        }
+    )
+
+    source_semantics = require_exact_string(
+        record["source_dependency_semantics"],
+        name="source_dependency_semantics",
+    )
+    if source_semantics != SOURCE_DEPENDENCY_SEMANTICS:
+        raise ValueError("unsupported source-dependency semantics")
+    manifest = PredictionProviderManifestV1(
+        sequence_id=record["sequence_id"],
+        provider_family=record["provider_family"],
+        provider_repository=record["provider_repository"],
+        provider_revision=require_revision(
+            record["provider_revision"],
+            name="provider_revision",
+        ),
+        provider_run_id=require_sha256(
+            record["provider_run_id"],
+            name="provider_run_id",
+        ),
+        model_set_id=require_sha256(record["model_set_id"], name="model_set_id"),
+        loader_id=require_sha256(record["loader_id"], name="loader_id"),
+        coordinate_semantics=record["coordinate_semantics"],
+        point_semantics=record["point_semantics"],
+        flow_semantics=record["flow_semantics"],
+        ray_semantics=record["ray_semantics"],
+        source_dependency_semantics=source_semantics,
+        payloads=tuple(payloads),
+        metadata=metadata,
+    )
+
+    if (
+        _read_bytes(
+            specification,
+            name="prediction-provider import specification",
+        )
+        != specification_bytes
+    ):
+        raise ValueError(
+            "prediction-provider import specification changed during import"
+        )
+    save_prediction_provider_manifest(output, manifest)
+    verified, _ = verify_prediction_provider_manifest(output)
+    return verified
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Import external canonical predictions into the neutral manifest."
+    )
+    parser.add_argument("specification")
+    parser.add_argument("output")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _build_parser().parse_args(list(argv) if argv is not None else None)
+    manifest = import_prediction_provider_specification(
+        arguments.specification,
+        arguments.output,
+    )
+    print(json.dumps(manifest.summary(), indent=2, sort_keys=True))
+    return 0
+
+
+__all__ = [
+    "PREDICTION_PROVIDER_IMPORT_SPEC_SCHEMA",
+    "PREDICTION_PROVIDER_IMPORT_SPEC_VERSION",
+    "import_prediction_provider_specification",
+    "main",
+]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/prob4d/prediction_provider_scaffold.py
+++ b/src/prob4d/prediction_provider_scaffold.py
@@ -1,0 +1,208 @@
+"""No-clobber scaffold for external provider-neutral prediction imports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Final
+
+from .prediction_provider_import import (
+    PREDICTION_PROVIDER_IMPORT_SPEC_SCHEMA,
+    PREDICTION_PROVIDER_IMPORT_SPEC_VERSION,
+)
+from .prediction_provider_manifest import SOURCE_DEPENDENCY_SEMANTICS
+
+PREDICTION_PROVIDER_SCAFFOLD_SPECIFICATION: Final = "provider-import.json"
+PREDICTION_PROVIDER_SCAFFOLD_README: Final = "README.md"
+
+
+def _scaffold_specification() -> dict[str, object]:
+    return {
+        "schema": PREDICTION_PROVIDER_IMPORT_SPEC_SCHEMA,
+        "schema_version": PREDICTION_PROVIDER_IMPORT_SPEC_VERSION,
+        "sequence_id": "REPLACE_WITH_SEQUENCE_ID",
+        "provider_family": "REPLACE_WITH_PROVIDER_FAMILY",
+        "provider_repository": "REPLACE_WITH_OWNER_SLASH_REPOSITORY",
+        "provider_revision": "REPLACE_WITH_LOWERCASE_40_OR_64_HEX_REVISION",
+        "provider_run_id": "REPLACE_WITH_LOWERCASE_SHA256",
+        "model_set_id": "REPLACE_WITH_LOWERCASE_SHA256",
+        "loader_id": "REPLACE_WITH_LOWERCASE_SHA256",
+        "coordinate_semantics": "window-local-sim3",
+        "point_semantics": "dense-point-map",
+        "flow_semantics": "forward-point-displacement",
+        "ray_semantics": "absent",
+        "source_dependency_semantics": SOURCE_DEPENDENCY_SEMANTICS,
+        "payloads": [
+            {
+                "product_role": "independent-window",
+                "window_id": "window_0000",
+                "path": "windows/window_0000.npz",
+                "view_id": "camera-0",
+                "stochastic_member_id": "REPLACE_WITH_STOCHASTIC_MEMBER_ID",
+                "dependence_group_ids": [
+                    "model-set:REPLACE_WITH_MODEL_SET_ID",
+                    "input-video:REPLACE_WITH_INPUT_VIDEO_SHA256",
+                    "stochastic-member:REPLACE_WITH_MEMBER_ID",
+                ],
+                "frame_lineage": [
+                    {
+                        "output_frame_id": 0,
+                        "source_frame_start": 0,
+                        "source_frame_stop_exclusive": 1,
+                        "contributor_ids": ["window_0000"],
+                    }
+                ],
+            }
+        ],
+        "metadata": {
+            "uses_truth": False,
+            "uses_downstream_physical_innovation": False,
+            "adapter_version": "REPLACE_WITH_ADAPTER_VERSION",
+        },
+    }
+
+
+def _scaffold_readme() -> str:
+    return """# Prob4D generic provider import scaffold
+
+This directory is intentionally **not importable yet**. Replace every
+`REPLACE_WITH_...` value in `provider-import.json`, copy canonical versioned
+`PredictionWindow` archives below `windows/`, and declare one exact causal source
+interval for every output frame.
+
+The specification must describe the bytes that were actually executed:
+
+- exact provider source revision;
+- content identities for the provider run, model set, and loader;
+- coordinate, point, flow, and ray semantics;
+- stochastic-member and shared-dependency groups; and
+- complete per-output source-frame lineage.
+
+Then run:
+
+```bash
+prob4d prediction import-generic \\
+  provider-import.json \\
+  provider-neutral.json
+
+prob4d prediction validate provider-neutral.json
+```
+
+Prob4D derives payload hashes, byte counts, dense precision, and optional-field
+presence from the exact NPZ bytes. The importer rejects traversal, symbolic links,
+duplicate JSON keys, non-finite values, schema drift, malformed identities,
+changed source bytes, and lineage that disagrees with payload frame identities.
+
+A valid neutral manifest proves provenance and causal admission only. It does not
+establish provider accuracy, calibration, independence, downstream physical-query
+benefit, or Causal4D intervention benefit.
+"""
+
+
+def _fsync_directory(path: Path) -> None:
+    try:
+        descriptor = os.open(path, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(descriptor)
+    except OSError:
+        pass
+    finally:
+        os.close(descriptor)
+
+
+def _write_new_text(path: Path, content: str) -> None:
+    with path.open("x", encoding="utf-8") as stream:
+        stream.write(content)
+        stream.flush()
+        os.fsync(stream.fileno())
+
+
+def scaffold_prediction_provider_import(
+    output_directory: str | Path,
+) -> tuple[Path, Path]:
+    """Create an intentionally incomplete, no-clobber provider import scaffold."""
+
+    destination_input = Path(output_directory)
+    if destination_input.is_symlink():
+        raise ValueError("prediction-provider scaffold destination is a symbolic link")
+    destination = destination_input.resolve()
+    if destination.exists():
+        raise FileExistsError(
+            "prediction-provider scaffold destination already exists; refusing to replace it"
+        )
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.mkdir()
+    windows = destination / "windows"
+    specification = destination / PREDICTION_PROVIDER_SCAFFOLD_SPECIFICATION
+    readme = destination / PREDICTION_PROVIDER_SCAFFOLD_README
+    try:
+        windows.mkdir()
+        _write_new_text(
+            specification,
+            json.dumps(_scaffold_specification(), indent=2, allow_nan=False) + "\n",
+        )
+        _write_new_text(readme, _scaffold_readme())
+        _fsync_directory(windows)
+        _fsync_directory(destination)
+        _fsync_directory(destination.parent)
+    except BaseException:
+        specification.unlink(missing_ok=True)
+        readme.unlink(missing_ok=True)
+        try:
+            windows.rmdir()
+        except OSError:
+            pass
+        try:
+            destination.rmdir()
+        except OSError:
+            pass
+        raise
+    return specification, readme
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Create a no-clobber generic-provider import scaffold with explicit "
+            "provenance and causal-lineage placeholders."
+        )
+    )
+    parser.add_argument("output_directory")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _build_parser().parse_args(list(argv) if argv is not None else None)
+    specification, readme = scaffold_prediction_provider_import(
+        arguments.output_directory
+    )
+    print(
+        json.dumps(
+            {
+                "output_directory": str(specification.parent),
+                "specification": str(specification),
+                "readme": str(readme),
+                "ready_for_import": False,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+__all__ = [
+    "PREDICTION_PROVIDER_SCAFFOLD_README",
+    "PREDICTION_PROVIDER_SCAFFOLD_SPECIFICATION",
+    "main",
+    "scaffold_prediction_provider_import",
+]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -72,8 +72,27 @@ def test_grouped_cli_routes_provider_neutral_prediction_help(capsys) -> None:
     assert exit_info.value.code == 0
     output = capsys.readouterr().out
     assert "import-motioncrafter" in output
+    assert "import-vggt" in output
+    assert "import-generic" in output
+    assert "scaffold-generic" in output
     assert "validate" in output
     assert "runtime" in output
+
+
+def test_grouped_cli_routes_generic_provider_import_help(capsys) -> None:
+    with pytest.raises(SystemExit) as import_exit:
+        main(["prediction", "import-generic", "--help"])
+    assert import_exit.value.code == 0
+    import_help = capsys.readouterr().out
+    assert "external canonical predictions" in import_help
+    assert "specification" in import_help
+
+    with pytest.raises(SystemExit) as scaffold_exit:
+        main(["prediction", "scaffold-generic", "--help"])
+    assert scaffold_exit.value.code == 0
+    scaffold_help = capsys.readouterr().out
+    assert "no-clobber generic-provider import scaffold" in scaffold_help
+    assert "output_directory" in scaffold_help
 
 
 def test_grouped_cli_routes_provider_runtime_help(capsys) -> None:

--- a/tests/test_prediction_provider_import.py
+++ b/tests/test_prediction_provider_import.py
@@ -1,0 +1,353 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import prob4d.prediction_provider_import as provider_import
+from prob4d.data import PredictionWindow
+from prob4d.prediction_provider_import import (
+    PREDICTION_PROVIDER_IMPORT_SPEC_SCHEMA,
+    PREDICTION_PROVIDER_IMPORT_SPEC_VERSION,
+    import_prediction_provider_specification,
+)
+from prob4d.prediction_provider_manifest import (
+    PREDICTION_PROVIDER_MANIFEST_VERSION,
+    SOURCE_DEPENDENCY_SEMANTICS,
+    load_prediction_provider_manifest,
+    verify_prediction_provider_manifest,
+)
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _write_window(
+    path: Path,
+    *,
+    window_id: str,
+    frames: tuple[int, ...],
+) -> None:
+    point_map = np.zeros((len(frames), 2, 3, 3), dtype=np.float32)
+    point_map[..., 0] = np.arange(len(frames), dtype=np.float32)[:, None, None]
+    point_map[..., 2] = 1.0
+    valid = np.ones(point_map.shape[:-1], dtype=bool)
+    flow = np.full_like(point_map, 0.025)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    PredictionWindow(
+        window_id=window_id,
+        frame_indices=np.asarray(frames, dtype=np.int64),
+        point_map=point_map,
+        valid_mask=valid,
+        scene_flow=flow,
+        deform_mask=valid,
+        dense_storage_dtype="float32",
+    ).to_npz(path)
+
+
+def _lineage(
+    frames: tuple[int, ...],
+    *,
+    source_start: int,
+    source_stop: int,
+    contributor: str,
+) -> list[dict[str, object]]:
+    return [
+        {
+            "output_frame_id": frame,
+            "source_frame_start": source_start,
+            "source_frame_stop_exclusive": source_stop,
+            "contributor_ids": [contributor],
+        }
+        for frame in frames
+    ]
+
+
+def _payload(
+    *,
+    window_id: str,
+    path: str,
+    frames: tuple[int, ...],
+    source_start: int,
+    source_stop: int,
+    seed: int,
+) -> dict[str, object]:
+    return {
+        "product_role": "independent-window",
+        "window_id": window_id,
+        "path": path,
+        "view_id": "camera-0",
+        "stochastic_member_id": f"seed-{seed}",
+        "dependence_group_ids": [
+            "model-set:shared",
+            "input-video:shared",
+            f"stochastic-member:{seed}",
+        ],
+        "frame_lineage": _lineage(
+            frames,
+            source_start=source_start,
+            source_stop=source_stop,
+            contributor=window_id,
+        ),
+    }
+
+
+def _specification(payloads: list[dict[str, object]]) -> dict[str, object]:
+    return {
+        "schema": PREDICTION_PROVIDER_IMPORT_SPEC_SCHEMA,
+        "schema_version": PREDICTION_PROVIDER_IMPORT_SPEC_VERSION,
+        "sequence_id": "case-a",
+        "provider_family": "Example4D",
+        "provider_repository": "example/Example4D",
+        "provider_revision": "a" * 40,
+        "provider_run_id": "b" * 64,
+        "model_set_id": "c" * 64,
+        "loader_id": "d" * 64,
+        "coordinate_semantics": "window-local-sim3",
+        "point_semantics": "dense-point-map",
+        "flow_semantics": "forward-point-displacement",
+        "ray_semantics": "absent",
+        "source_dependency_semantics": SOURCE_DEPENDENCY_SEMANTICS,
+        "payloads": payloads,
+        "metadata": {
+            "uses_truth": False,
+            "uses_downstream_physical_innovation": False,
+        },
+    }
+
+
+def _write_specification(root: Path, value: dict[str, object]) -> Path:
+    path = root / "provider-import.json"
+    path.write_text(json.dumps(value, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def _two_window_bundle(tmp_path: Path) -> tuple[Path, Path]:
+    root = tmp_path / "bundle"
+    first_frames = (0, 1, 2)
+    second_frames = (2, 3, 4)
+    _write_window(
+        root / "windows/window_0000.npz",
+        window_id="window_0000",
+        frames=first_frames,
+    )
+    _write_window(
+        root / "windows/window_0001.npz",
+        window_id="window_0001",
+        frames=second_frames,
+    )
+    specification = _specification(
+        [
+            _payload(
+                window_id="window_0001",
+                path="windows/window_0001.npz",
+                frames=second_frames,
+                source_start=2,
+                source_stop=5,
+                seed=18,
+            ),
+            _payload(
+                window_id="window_0000",
+                path="windows/window_0000.npz",
+                frames=first_frames,
+                source_start=0,
+                source_stop=3,
+                seed=17,
+            ),
+        ]
+    )
+    return _write_specification(root, specification), root / "provider-neutral.json"
+
+
+def test_generic_import_roundtrip_and_canonical_order(tmp_path: Path) -> None:
+    specification, output = _two_window_bundle(tmp_path)
+    manifest = import_prediction_provider_specification(specification, output)
+
+    assert [item.window_id for item in manifest.payloads] == [
+        "window_0000",
+        "window_0001",
+    ]
+    assert manifest.metadata["source_adapter"] == (
+        "prob4d-external-provider-import-spec-v1"
+    )
+    assert manifest.metadata["source_import_spec_sha256"] == _sha256(specification)
+    assert manifest.metadata["source_import_spec_schema_version"] == (
+        PREDICTION_PROVIDER_IMPORT_SPEC_VERSION
+    )
+    assert manifest.metadata["target_manifest_schema_version"] == (
+        PREDICTION_PROVIDER_MANIFEST_VERSION
+    )
+
+    loaded = load_prediction_provider_manifest(output)
+    assert loaded.artifact_id == manifest.artifact_id
+    _, report = verify_prediction_provider_manifest(output, causal_frame_stop=5)
+    assert report["verified_payload_count"] == 2
+    assert report["admitted_payload_count"] == 2
+
+
+def test_frame_lineage_must_match_payload_frames(tmp_path: Path) -> None:
+    specification, output = _two_window_bundle(tmp_path)
+    value = json.loads(specification.read_text(encoding="utf-8"))
+    value["payloads"][0]["frame_lineage"][0]["output_frame_id"] = 1
+    specification.write_text(json.dumps(value), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="lineage differs"):
+        import_prediction_provider_specification(specification, output)
+
+
+def test_parent_traversal_and_reserved_metadata_are_rejected(tmp_path: Path) -> None:
+    specification, output = _two_window_bundle(tmp_path)
+    value = json.loads(specification.read_text(encoding="utf-8"))
+    value["payloads"][0]["path"] = "../outside.npz"
+    specification.write_text(json.dumps(value), encoding="utf-8")
+    with pytest.raises(ValueError, match="safe POSIX relative path"):
+        import_prediction_provider_specification(specification, output)
+
+    specification, output = _two_window_bundle(tmp_path / "reserved")
+    value = json.loads(specification.read_text(encoding="utf-8"))
+    value["metadata"]["source_adapter"] = "caller-controlled"
+    specification.write_text(json.dumps(value), encoding="utf-8")
+    with pytest.raises(ValueError, match="reserved fields"):
+        import_prediction_provider_specification(specification, output)
+
+
+def test_output_manifest_must_share_a_confined_payload_root(tmp_path: Path) -> None:
+    specification, _ = _two_window_bundle(tmp_path)
+    output = tmp_path / "elsewhere/provider-neutral.json"
+    with pytest.raises(ValueError, match="must lie inside the manifest directory"):
+        import_prediction_provider_specification(specification, output)
+
+
+def test_payload_mutation_during_import_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    specification, output = _two_window_bundle(tmp_path)
+    source_member = specification.parent / "windows/window_0001.npz"
+    original = provider_import.PredictionWindow.from_npz
+    mutated = False
+
+    def mutating_loader(
+        path: str | Path,
+        *args: object,
+        **kwargs: object,
+    ) -> PredictionWindow:
+        nonlocal mutated
+        window = original(path, *args, **kwargs)
+        if not mutated:
+            source_member.write_bytes(source_member.read_bytes() + b"tamper")
+            mutated = True
+        return window
+
+    monkeypatch.setattr(
+        provider_import.PredictionWindow,
+        "from_npz",
+        staticmethod(mutating_loader),
+    )
+    with pytest.raises(ValueError, match="changed during generic import"):
+        import_prediction_provider_specification(specification, output)
+
+
+def test_payload_is_parsed_from_a_private_exact_byte_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    specification, output = _two_window_bundle(tmp_path)
+    source_members = {
+        (specification.parent / "windows/window_0000.npz").resolve(),
+        (specification.parent / "windows/window_0001.npz").resolve(),
+    }
+    original = provider_import.PredictionWindow.from_npz
+    parsed_paths: list[Path] = []
+
+    def observing_loader(
+        path: str | Path,
+        *args: object,
+        **kwargs: object,
+    ) -> PredictionWindow:
+        parsed_paths.append(Path(path).resolve())
+        return original(path, *args, **kwargs)
+
+    monkeypatch.setattr(
+        provider_import.PredictionWindow,
+        "from_npz",
+        staticmethod(observing_loader),
+    )
+    import_prediction_provider_specification(specification, output)
+
+    assert len(parsed_paths) == 4  # import snapshots plus final manifest verification
+    assert all(path not in source_members for path in parsed_paths[:2])
+    assert all(path.name == "prediction-window.npz" for path in parsed_paths[:2])
+
+
+def test_specification_mutation_during_import_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    specification, output = _two_window_bundle(tmp_path)
+    original = provider_import._load_json_bytes
+
+    def mutating_loader(payload: bytes, *, name: str) -> dict[str, object]:
+        record = original(payload, name=name)
+        value = json.loads(specification.read_text(encoding="utf-8"))
+        value["sequence_id"] = "changed"
+        specification.write_text(json.dumps(value), encoding="utf-8")
+        return record
+
+    monkeypatch.setattr(provider_import, "_load_json_bytes", mutating_loader)
+    with pytest.raises(ValueError, match="changed during import"):
+        import_prediction_provider_specification(specification, output)
+
+
+def test_symlink_payload_is_rejected(tmp_path: Path) -> None:
+    root = tmp_path / "bundle"
+    outside = tmp_path / "outside.npz"
+    _write_window(outside, window_id="window_0000", frames=(0, 1, 2))
+    (root / "windows").mkdir(parents=True)
+    try:
+        (root / "windows/window_0000.npz").symlink_to(outside)
+    except OSError:
+        pytest.skip("symlinks are unavailable")
+    specification = _write_specification(
+        root,
+        _specification(
+            [
+                _payload(
+                    window_id="window_0000",
+                    path="windows/window_0000.npz",
+                    frames=(0, 1, 2),
+                    source_start=0,
+                    source_stop=3,
+                    seed=17,
+                )
+            ]
+        ),
+    )
+    with pytest.raises(ValueError, match="symbolic link"):
+        import_prediction_provider_specification(
+            specification,
+            root / "provider-neutral.json",
+        )
+
+
+def test_symlink_specification_and_output_are_rejected(tmp_path: Path) -> None:
+    specification, output = _two_window_bundle(tmp_path)
+    specification_link = tmp_path / "provider-import-link.json"
+    output_target = tmp_path / "existing-output.json"
+    output_target.write_text("do not replace\n", encoding="utf-8")
+    output_link = tmp_path / "provider-output-link.json"
+    try:
+        specification_link.symlink_to(specification)
+        output_link.symlink_to(output_target)
+    except OSError:
+        pytest.skip("symlinks are unavailable")
+
+    with pytest.raises(ValueError, match="specification is a symbolic link"):
+        import_prediction_provider_specification(specification_link, output)
+    with pytest.raises(ValueError, match="output manifest is a symbolic link"):
+        import_prediction_provider_specification(specification, output_link)
+    assert output_target.read_text(encoding="utf-8") == "do not replace\n"

--- a/tests/test_prediction_provider_scaffold.py
+++ b/tests/test_prediction_provider_scaffold.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from prob4d.prediction_provider_import import (
+    PREDICTION_PROVIDER_IMPORT_SPEC_SCHEMA,
+    PREDICTION_PROVIDER_IMPORT_SPEC_VERSION,
+)
+from prob4d.prediction_provider_scaffold import (
+    scaffold_prediction_provider_import,
+)
+
+
+def test_scaffold_is_explicitly_incomplete_and_no_clobber(tmp_path: Path) -> None:
+    destination = tmp_path / "external-provider"
+    specification, readme = scaffold_prediction_provider_import(destination)
+
+    assert specification == destination / "provider-import.json"
+    assert readme == destination / "README.md"
+    assert (destination / "windows").is_dir()
+    record = json.loads(specification.read_text(encoding="utf-8"))
+    assert record["schema"] == PREDICTION_PROVIDER_IMPORT_SPEC_SCHEMA
+    assert record["schema_version"] == PREDICTION_PROVIDER_IMPORT_SPEC_VERSION
+    assert record["provider_revision"].startswith("REPLACE_WITH_")
+    assert record["payloads"][0]["path"] == "windows/window_0000.npz"
+    assert not (destination / "windows/window_0000.npz").exists()
+    assert "intentionally **not importable yet**" in readme.read_text(encoding="utf-8")
+
+    with pytest.raises(FileExistsError, match="refusing to replace"):
+        scaffold_prediction_provider_import(destination)
+    assert record == json.loads(specification.read_text(encoding="utf-8"))
+
+
+def test_scaffold_rejects_symlink_destination(tmp_path: Path) -> None:
+    real_directory = tmp_path / "real"
+    real_directory.mkdir()
+    destination = tmp_path / "link"
+    try:
+        destination.symlink_to(real_directory, target_is_directory=True)
+    except OSError:
+        pytest.skip("symlinks are unavailable")
+    with pytest.raises(ValueError, match="destination is a symbolic link"):
+        scaffold_prediction_provider_import(destination)


### PR DESCRIPTION
Temporary read-only validation PR for product PR #155.

The head is `059e99d1ba2b77daf0676661b7e6be239a732c14`, an empty retrigger commit whose tree is exactly `c810762c3cef839a6ce767d43abce9f771ab98a6`, identical to product commit `8f97c11ad44e0309bb6734e8417bd52d7ddf7333`. Its `ci/self-hosted-*` branch name was intended to route the repository's existing Tests workflow to the trusted `workstation2` runner. It contains no validation-only source changes and must not be merged.

## Disposition

Closed without merge. GitHub did not register a workflow run or status after open, reopen, and exact-tree synchronization events. This trigger therefore supplied no additional validation evidence. Product PR #155 remains draft and records both the completed local/static checks and the unexecuted Ruff/MyPy/pytest boundary.