### PR TITLE
Add prospective joint cross-camera visual-bias calibration

### DIFF
--- a/.github/workflows/visual-bias-calibration.yml
+++ b/.github/workflows/visual-bias-calibration.yml
@@ -5,9 +5,13 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/visual-bias-calibration.yml"
+      - "docs/joint-visual-bias-calibration.md"
       - "docs/visual-bias-calibration.md"
       - "pyproject.toml"
+      - "src/prob4d/_joint_visual_bias_*.py"
+      - "src/prob4d/joint_visual_bias_calibration.py"
       - "src/prob4d/visual_bias_calibration.py"
+      - "tests/test_joint_visual_bias_calibration.py"
       - "tests/test_visual_bias_calibration.py"
   workflow_dispatch:
 
@@ -86,18 +90,28 @@ jobs:
       - name: Check source quality and typing
         run: |
           python -m ruff check \
+            src/prob4d/_joint_visual_bias_*.py \
+            src/prob4d/joint_visual_bias_calibration.py \
             src/prob4d/visual_bias_calibration.py \
+            tests/test_joint_visual_bias_calibration.py \
             tests/test_visual_bias_calibration.py
           python -m ruff format --check \
+            src/prob4d/_joint_visual_bias_*.py \
+            src/prob4d/joint_visual_bias_calibration.py \
             src/prob4d/visual_bias_calibration.py \
+            tests/test_joint_visual_bias_calibration.py \
             tests/test_visual_bias_calibration.py
-          python -m mypy src/prob4d/visual_bias_calibration.py
+          python -m mypy \
+            src/prob4d/_joint_visual_bias_*.py \
+            src/prob4d/joint_visual_bias_calibration.py \
+            src/prob4d/visual_bias_calibration.py
 
       - name: Run focused and adjacent regressions
         shell: bash
         run: |
           set -euo pipefail
           python -m pytest -q -p no:cacheprovider \
+            tests/test_joint_visual_bias_calibration.py \
             tests/test_visual_bias_calibration.py \
             tests/test_visual_bias.py \
             tests/test_visual_bias_stream.py \
@@ -121,11 +135,48 @@ jobs:
 
           wheel = next(Path("dist").glob("*.whl"))
           sdist = next(Path("dist").glob("*.tar.gz"))
-          required = "prob4d/visual_bias_calibration.py"
+          required_modules = (
+              "prob4d/_joint_visual_bias_calibration.py",
+              "prob4d/_joint_visual_bias_common.py",
+              "prob4d/_joint_visual_bias_group.py",
+              "prob4d/_joint_visual_bias_layout.py",
+              "prob4d/joint_visual_bias_calibration.py",
+              "prob4d/visual_bias_calibration.py",
+          )
           with zipfile.ZipFile(wheel) as archive:
-              assert required in archive.namelist()
+              names = set(archive.namelist())
+              assert all(required in names for required in required_modules)
           with tarfile.open(sdist, "r:gz") as archive:
-              assert any(name.endswith("/src/" + required) for name in archive.getnames())
+              names = archive.getnames()
+              assert all(
+                  any(name.endswith("/src/" + required) for name in names)
+                  for required in required_modules
+              )
+              assert any(
+                  name.endswith("/docs/joint-visual-bias-calibration.md")
+                  for name in names
+              )
+              assert any(
+                  name.endswith("/tests/test_joint_visual_bias_calibration.py")
+                  for name in names
+              )
+          PY
+
+      - name: Smoke-test joint layout from installed package
+        run: |
+          python - <<'PY'
+          from prob4d.joint_visual_bias_calibration import JointVisualBiasLayoutV1
+
+          layout = JointVisualBiasLayoutV1(
+              camera_ids=("camera-0", "camera-1"),
+              shared_basis_names=("shared-depth",),
+              camera_basis_names=("camera-depth",),
+          )
+          assert layout.basis_names == (
+              "shared::shared-depth",
+              "camera::camera-depth::camera-0",
+              "camera::camera-depth::camera-1",
+          )
           PY
 
       - name: Verify clean reviewed source

--- a/docs/joint-visual-bias-calibration.md
+++ b/docs/joint-visual-bias-calibration.md
@@ -1,0 +1,177 @@
+# Joint shared and camera-specific visual-bias calibration
+
+Several cameras can agree while sharing the same reconstruction bias. Treating
+one calibrated visual-bias sidecar per camera as independent would then count the
+shared error several times. `prob4d.joint_visual_bias_calibration` provides a
+prospective source/calibration-only wrapper that constructs one latent vector
+across all declared cameras and delegates fitting, rank selection, covariance
+estimation, persistence, and observation-sidecar construction to the existing
+`VisualBiasCalibrationV1` implementation.
+
+The frozen single-scope implementation is unchanged. New experiments select the
+joint wrapper explicitly.
+
+## Joint latent layout
+
+For camera set `v = 1, ..., V`, the ordered latent vector is
+
+```text
+b = [b_shared, b_camera_mode_1_camera_1, ..., b_camera_mode_1_camera_V, ...].
+```
+
+The corresponding residual model for one complete calibration object or session
+is
+
+```text
+r = G delta_xi + B_shared b_shared
+    + sum_v B_camera,v b_camera,v + epsilon.
+```
+
+Shared basis columns are active for every camera row. A camera-specific column is
+active only for rows from its named camera. The fitted selected covariance is the
+complete covariance of the retained coefficients, so it may contain:
+
+- covariance between shared and camera-specific modes;
+- covariance between different cameras; and
+- covariance between several retained camera-specific modes.
+
+The latent is represented once in the resulting `VisualBiasNuisanceV1`. It must
+not be instantiated independently for each camera or each recursive update.
+
+## Canonical basis ordering
+
+Candidate ranks in `VisualBiasCalibrationV1` are nested prefixes. The joint
+layout therefore uses a fixed order:
+
+1. shared modes in the supplied order;
+2. for each camera-specific mode, one column for every camera in sorted camera
+   order.
+
+For example:
+
+```python
+from prob4d.joint_visual_bias_calibration import JointVisualBiasLayoutV1
+
+layout = JointVisualBiasLayoutV1(
+    camera_ids=("camera-0", "camera-1", "camera-2"),
+    shared_basis_names=("shared-depth", "shared-scale-drift"),
+    camera_basis_names=("camera-depth-bowl",),
+)
+
+assert layout.basis_names == (
+    "shared::shared-depth",
+    "shared::shared-scale-drift",
+    "camera::camera-depth-bowl::camera-0",
+    "camera::camera-depth-bowl::camera-1",
+    "camera::camera-depth-bowl::camera-2",
+)
+```
+
+By default, a selected rank that cuts through one camera-specific mode fails
+closed. That prevents an apparently joint method from silently selecting the
+mode for only a subset of cameras. `allow_partial_camera_mode=True` is available
+only for explicitly labelled exploratory asymmetric studies.
+
+## Calibration groups
+
+Every `JointVisualBiasCalibrationGroupV1` represents one complete source or
+calibration object/session. It binds:
+
+- the exact joint layout identity;
+- one camera index for every residual row;
+- source residuals;
+- shared and camera-specific candidate Jacobians;
+- conditional point covariance;
+- optional complete gauge design;
+- row counts for every camera; and
+- immutable finite metadata and array digests.
+
+Every calibration group must contain rows from every declared camera. Frames,
+pixels, views, points, and tracks are not independent calibration groups.
+
+```python
+import numpy as np
+
+from prob4d.joint_visual_bias_calibration import (
+    JointVisualBiasCalibrationGroupV1,
+    fit_joint_visual_bias_calibration,
+)
+
+groups = tuple(
+    JointVisualBiasCalibrationGroupV1(
+        group_id=object_id,
+        layout=layout,
+        row_camera_indices=camera_index_per_row.astype(np.int64),
+        residual=residual_xyz.astype(np.float64),
+        shared_bias_jacobian=shared_basis.astype(np.float64),
+        camera_bias_jacobian=camera_basis.astype(np.float64),
+        conditional_covariance=conditional_covariance.astype(np.float64),
+        gauge_design=complete_gauge_design.astype(np.float64),
+        metadata={"episode_ids": episode_ids},
+    )
+    for object_id, camera_index_per_row, residual_xyz, shared_basis,
+        camera_basis, conditional_covariance, complete_gauge_design, episode_ids
+    in calibration_inputs
+)
+
+calibration = fit_joint_visual_bias_calibration(
+    groups,
+    provider_manifest_id=provider_manifest_id,
+    calibration_source_id=calibration_source_id,
+    group_definition="complete-physical-object-v1",
+    residual_definition="source-metric-minus-provider-point-v1",
+    uses_truth=True,
+    covariance_shrinkage=0.25,
+    minimum_nll_improvement=1e-4,
+)
+```
+
+The wrapper embeds the canonical layout, exact group artifact IDs, selection
+policy, covariance semantics, and information boundary into the ordinary
+content-addressed calibration metadata. Existing strict calibration persistence
+and loading therefore remain authoritative.
+
+## Observation sidecar
+
+A promoted calibration can instantiate one cross-camera latent for a new causal
+observation:
+
+```python
+from prob4d.joint_visual_bias_calibration import (
+    build_joint_visual_bias_nuisance_from_calibration,
+)
+
+sidecar = build_joint_visual_bias_nuisance_from_calibration(
+    calibration,
+    observation_artifact_id=observation_artifact_id,
+    observation_identity_sha256=ordered_row_identity_sha256,
+    row_camera_indices=camera_index_per_row,
+    shared_bias_jacobian=shared_basis_for_observation,
+    camera_bias_jacobian=camera_basis_for_observation,
+    conditional_covariance=conditional_covariance,
+    gauge_design=complete_gauge_design,
+    metadata={"case_id": case_id},
+)
+```
+
+The sidecar uses one bias ID, `joint-visual-cameras`, and the complete selected
+coefficient covariance. Recursive BayesianPhysTwin use must retain that latent
+once across time. Recreating an independent copy at each update would remove the
+cross-time covariance and overcount visual evidence.
+
+## Independent anchors
+
+Tactile, depth, LiDAR, force, robot-state, or other independent evidence must
+remain separate factors with no visual-bias Jacobian. Their scientific value is
+that they can break an ambiguity shared by all visual cameras. Absorbing them
+into the visual covariance would obscure that information boundary.
+
+## Claim boundary
+
+A valid joint calibration establishes only that the named shared and
+camera-specific candidate modes were fitted and source-selected on complete
+calibration groups under the retained rules. It does not prove that the basis is
+complete, that camera errors are stationary, that target coverage is calibrated,
+that a BayesianPhysTwin update is beneficial, that a Causal4D intervention is
+valid, or that the method is state of the art. Those remain separate fresh-object
+held-out gates.

--- a/src/prob4d/_joint_visual_bias_calibration.py
+++ b/src/prob4d/_joint_visual_bias_calibration.py
@@ -1,0 +1,248 @@
+"""Fitting and sidecar construction for joint cross-camera visual bias."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import numpy as np
+
+from ._immutable_array import immutable_integer_array
+from ._immutable_json import plain_json
+from ._joint_visual_bias_common import (
+    FloatArray,
+    JOINT_VISUAL_BIAS_CLAIM_BOUNDARY,
+    JOINT_VISUAL_BIAS_COVARIANCE_SEMANTICS,
+    JOINT_VISUAL_BIAS_METADATA_KEY,
+    _CALIBRATION_METADATA_FIELDS,
+    _metadata,
+    _nonempty_string,
+    _sha256,
+)
+from ._joint_visual_bias_group import JointVisualBiasCalibrationGroupV1
+from ._joint_visual_bias_layout import (
+    JointVisualBiasLayoutV1,
+    expand_joint_visual_bias_jacobian,
+)
+from .visual_bias import VisualBiasNuisanceV1
+from .visual_bias_calibration import (
+    VisualBiasCalibrationV1,
+    build_visual_bias_nuisance_from_calibration,
+    fit_visual_bias_calibration,
+)
+
+
+def joint_visual_bias_layout_from_calibration(
+    calibration: VisualBiasCalibrationV1,
+) -> JointVisualBiasLayoutV1:
+    """Recover and validate the joint layout bound into one calibration artifact."""
+
+    record = calibration.metadata.get(JOINT_VISUAL_BIAS_METADATA_KEY)
+    if not isinstance(record, Mapping):
+        raise ValueError("calibration has no joint visual-bias layout metadata")
+    missing = sorted(_CALIBRATION_METADATA_FIELDS - set(record))
+    extra = sorted(set(record) - _CALIBRATION_METADATA_FIELDS)
+    if missing or extra:
+        raise ValueError(
+            f"joint visual-bias metadata fields changed: missing={missing}, extra={extra}"
+        )
+    if record["schema"] != "prob4d.joint-visual-bias-calibration":
+        raise ValueError("unsupported joint visual-bias calibration schema")
+    if record["schema_version"] != 1:
+        raise ValueError("unsupported joint visual-bias calibration version")
+    if record["uses_target_outcomes"] is not False:
+        raise ValueError("joint visual-bias calibration may not use target outcomes")
+    if record["uses_downstream_physical_innovation"] is not False:
+        raise ValueError("joint visual-bias calibration may not use physical innovations")
+    if record["covariance_semantics"] != JOINT_VISUAL_BIAS_COVARIANCE_SEMANTICS:
+        raise ValueError("joint visual-bias covariance semantics changed")
+    if record["claim_boundary"] != JOINT_VISUAL_BIAS_CLAIM_BOUNDARY:
+        raise ValueError("joint visual-bias calibration claim boundary changed")
+    layout = JointVisualBiasLayoutV1.from_mapping(record["layout"])
+    if record["layout_id"] != layout.layout_id:
+        raise ValueError("joint visual-bias calibration layout ID mismatch")
+    if calibration.basis_names != layout.basis_names:
+        raise ValueError("calibration basis names differ from the joint layout")
+    group_ids = record["group_artifact_ids"]
+    if not isinstance(group_ids, Mapping) or not group_ids:
+        raise ValueError("joint visual-bias calibration has no group artifact identities")
+    normalized_group_ids: list[str] = []
+    for group_id, artifact_id in group_ids.items():
+        normalized_group_ids.append(
+            _nonempty_string(group_id, name="joint visual-bias group ID")
+        )
+        _sha256(
+            artifact_id,
+            name=f"joint visual-bias group artifact ID for {group_id!r}",
+        )
+    canonical_group_ids = tuple(sorted(calibration.group_ids))
+    if tuple(sorted(normalized_group_ids)) != canonical_group_ids:
+        raise ValueError("joint visual-bias group artifact identities differ from calibration")
+    if type(record["allow_partial_camera_mode"]) is not bool:
+        raise ValueError("allow_partial_camera_mode must be a JSON boolean")
+    return layout
+
+
+def joint_visual_bias_selection_summary(
+    calibration: VisualBiasCalibrationV1,
+) -> dict[str, object]:
+    """Describe how the nested selected rank intersects shared and camera blocks."""
+
+    layout = joint_visual_bias_layout_from_calibration(calibration)
+    shared_count = len(layout.shared_basis_names)
+    selected_shared = min(calibration.selected_rank, shared_count)
+    remaining = max(0, calibration.selected_rank - shared_count)
+    complete_modes, partial_count = divmod(remaining, len(layout.camera_ids))
+    partial_mode = None
+    partial_cameras: tuple[str, ...] = ()
+    if partial_count:
+        partial_mode = layout.camera_basis_names[complete_modes]
+        partial_cameras = layout.camera_ids[:partial_count]
+    return {
+        "layout_id": layout.layout_id,
+        "selected_rank": calibration.selected_rank,
+        "selected_basis_names": list(calibration.selected_basis_names),
+        "selected_shared_basis_names": list(
+            layout.shared_basis_names[:selected_shared]
+        ),
+        "complete_camera_basis_names": list(
+            layout.camera_basis_names[:complete_modes]
+        ),
+        "partial_camera_basis_name": partial_mode,
+        "partial_camera_ids": list(partial_cameras),
+        "complete_camera_mode_boundary": partial_mode is None,
+    }
+
+
+def fit_joint_visual_bias_calibration(
+    groups: Sequence[JointVisualBiasCalibrationGroupV1],
+    *,
+    provider_manifest_id: str,
+    calibration_source_id: str,
+    group_definition: str,
+    residual_definition: str,
+    uses_truth: bool,
+    covariance_shrinkage: float = 0.25,
+    minimum_nll_improvement: float = 0.0,
+    gauge_projection_tolerance: float = 1e-8,
+    allow_partial_camera_mode: bool = False,
+    metadata: Mapping[str, Any] | None = None,
+) -> VisualBiasCalibrationV1:
+    """Fit one joint latent across shared and camera-specific source modes."""
+
+    if type(allow_partial_camera_mode) is not bool:
+        raise ValueError("allow_partial_camera_mode must be a boolean")
+    values = tuple(groups)
+    if len(values) < 3 or not all(
+        isinstance(group, JointVisualBiasCalibrationGroupV1) for group in values
+    ):
+        raise ValueError("joint visual-bias calibration requires at least three groups")
+    ordered = tuple(sorted(values, key=lambda group: group.group_id))
+    if len({group.group_id for group in ordered}) != len(ordered):
+        raise ValueError("joint visual-bias group IDs must be unique")
+    layout = ordered[0].layout
+    if any(group.layout.layout_id != layout.layout_id for group in ordered[1:]):
+        raise ValueError("all joint visual-bias groups must use the same layout")
+    supplied_metadata = {} if metadata is None else dict(metadata)
+    frozen_metadata = _metadata(
+        supplied_metadata,
+        name="joint visual-bias calibration metadata",
+    )
+    joint_metadata = {
+        "schema": "prob4d.joint-visual-bias-calibration",
+        "schema_version": 1,
+        "layout": layout.to_dict(),
+        "layout_id": layout.layout_id,
+        "group_artifact_ids": {
+            group.group_id: group.group_artifact_id for group in ordered
+        },
+        "allow_partial_camera_mode": allow_partial_camera_mode,
+        "uses_target_outcomes": False,
+        "uses_downstream_physical_innovation": False,
+        "covariance_semantics": JOINT_VISUAL_BIAS_COVARIANCE_SEMANTICS,
+        "claim_boundary": JOINT_VISUAL_BIAS_CLAIM_BOUNDARY,
+    }
+    calibration = fit_visual_bias_calibration(
+        tuple(group.to_visual_bias_calibration_group() for group in ordered),
+        basis_names=layout.basis_names,
+        provider_manifest_id=provider_manifest_id,
+        calibration_source_id=calibration_source_id,
+        group_definition=group_definition,
+        residual_definition=residual_definition,
+        uses_truth=uses_truth,
+        covariance_shrinkage=covariance_shrinkage,
+        minimum_nll_improvement=minimum_nll_improvement,
+        gauge_projection_tolerance=gauge_projection_tolerance,
+        metadata={
+            **plain_json(frozen_metadata),
+            JOINT_VISUAL_BIAS_METADATA_KEY: joint_metadata,
+        },
+    )
+    summary = joint_visual_bias_selection_summary(calibration)
+    if not allow_partial_camera_mode and not summary["complete_camera_mode_boundary"]:
+        raise ValueError(
+            "selected nested rank cuts through a complete camera mode; "
+            "reorder or revise the source-frozen basis, or explicitly permit the "
+            "asymmetric exploratory selection"
+        )
+    return calibration
+
+
+def build_joint_visual_bias_nuisance_from_calibration(
+    calibration: VisualBiasCalibrationV1,
+    *,
+    observation_artifact_id: str,
+    observation_identity_sha256: str,
+    row_camera_indices: object,
+    shared_bias_jacobian: object,
+    camera_bias_jacobian: object,
+    bias_id: str = "joint-visual-cameras",
+    conditional_covariance: FloatArray | None = None,
+    gauge_design: FloatArray | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> VisualBiasNuisanceV1:
+    """Instantiate one joint cross-camera bias latent for a new observation."""
+
+    layout = joint_visual_bias_layout_from_calibration(calibration)
+    indices = immutable_integer_array(row_camera_indices, name="row_camera_indices")
+    expanded = expand_joint_visual_bias_jacobian(
+        layout,
+        indices,
+        shared_bias_jacobian,
+        camera_bias_jacobian,
+        require_all_cameras=False,
+    )
+    supplied_metadata = {} if metadata is None else dict(metadata)
+    frozen_metadata = _metadata(
+        supplied_metadata,
+        name="joint visual-bias nuisance metadata",
+    )
+    counts = {
+        camera_id: int(np.count_nonzero(indices == camera_index))
+        for camera_index, camera_id in enumerate(layout.camera_ids)
+    }
+    return build_visual_bias_nuisance_from_calibration(
+        calibration,
+        observation_artifact_id=observation_artifact_id,
+        observation_identity_sha256=observation_identity_sha256,
+        bias_id=bias_id,
+        bias_jacobian=expanded,
+        conditional_covariance=conditional_covariance,
+        gauge_design=gauge_design,
+        metadata={
+            **plain_json(frozen_metadata),
+            JOINT_VISUAL_BIAS_METADATA_KEY: {
+                "layout_id": layout.layout_id,
+                "camera_ids": list(layout.camera_ids),
+                "camera_row_counts": counts,
+                "selection": joint_visual_bias_selection_summary(calibration),
+            },
+        },
+    )
+
+__all__ = [
+    "build_joint_visual_bias_nuisance_from_calibration",
+    "fit_joint_visual_bias_calibration",
+    "joint_visual_bias_layout_from_calibration",
+    "joint_visual_bias_selection_summary",
+]

--- a/src/prob4d/_joint_visual_bias_calibration.py
+++ b/src/prob4d/_joint_visual_bias_calibration.py
@@ -68,9 +68,7 @@ def joint_visual_bias_layout_from_calibration(
         raise ValueError("joint visual-bias calibration has no group artifact identities")
     normalized_group_ids: list[str] = []
     for group_id, artifact_id in group_ids.items():
-        normalized_group_ids.append(
-            _nonempty_string(group_id, name="joint visual-bias group ID")
-        )
+        normalized_group_ids.append(_nonempty_string(group_id, name="joint visual-bias group ID"))
         _sha256(
             artifact_id,
             name=f"joint visual-bias group artifact ID for {group_id!r}",
@@ -102,12 +100,8 @@ def joint_visual_bias_selection_summary(
         "layout_id": layout.layout_id,
         "selected_rank": calibration.selected_rank,
         "selected_basis_names": list(calibration.selected_basis_names),
-        "selected_shared_basis_names": list(
-            layout.shared_basis_names[:selected_shared]
-        ),
-        "complete_camera_basis_names": list(
-            layout.camera_basis_names[:complete_modes]
-        ),
+        "selected_shared_basis_names": list(layout.shared_basis_names[:selected_shared]),
+        "complete_camera_basis_names": list(layout.camera_basis_names[:complete_modes]),
         "partial_camera_basis_name": partial_mode,
         "partial_camera_ids": list(partial_cameras),
         "complete_camera_mode_boundary": partial_mode is None,
@@ -153,9 +147,7 @@ def fit_joint_visual_bias_calibration(
         "schema_version": 1,
         "layout": layout.to_dict(),
         "layout_id": layout.layout_id,
-        "group_artifact_ids": {
-            group.group_id: group.group_artifact_id for group in ordered
-        },
+        "group_artifact_ids": {group.group_id: group.group_artifact_id for group in ordered},
         "allow_partial_camera_mode": allow_partial_camera_mode,
         "uses_target_outcomes": False,
         "uses_downstream_physical_innovation": False,

--- a/src/prob4d/_joint_visual_bias_calibration.py
+++ b/src/prob4d/_joint_visual_bias_calibration.py
@@ -10,11 +10,11 @@ import numpy as np
 from ._immutable_array import immutable_integer_array
 from ._immutable_json import plain_json
 from ._joint_visual_bias_common import (
-    FloatArray,
+    _CALIBRATION_METADATA_FIELDS,
     JOINT_VISUAL_BIAS_CLAIM_BOUNDARY,
     JOINT_VISUAL_BIAS_COVARIANCE_SEMANTICS,
     JOINT_VISUAL_BIAS_METADATA_KEY,
-    _CALIBRATION_METADATA_FIELDS,
+    FloatArray,
     _metadata,
     _nonempty_string,
     _sha256,
@@ -239,6 +239,7 @@ def build_joint_visual_bias_nuisance_from_calibration(
             },
         },
     )
+
 
 __all__ = [
     "build_joint_visual_bias_nuisance_from_calibration",

--- a/src/prob4d/_joint_visual_bias_common.py
+++ b/src/prob4d/_joint_visual_bias_common.py
@@ -187,18 +187,18 @@ def _metadata(
 ) -> Mapping[str, Any]:
     def reserved_keys(current: object) -> set[str]:
         if isinstance(current, Mapping):
-            result = _RESERVED_METADATA_KEYS & set(current)
+            mapping_result: set[str] = set(_RESERVED_METADATA_KEYS & set(current))
             for nested in current.values():
-                result |= reserved_keys(nested)
-            return result
+                mapping_result |= reserved_keys(nested)
+            return mapping_result
         if isinstance(current, Sequence) and not isinstance(
             current,
             (str, bytes, bytearray),
         ):
-            result: set[str] = set()
+            sequence_result: set[str] = set()
             for nested in current:
-                result |= reserved_keys(nested)
-            return result
+                sequence_result |= reserved_keys(nested)
+            return sequence_result
         return set()
 
     collisions = sorted(reserved_keys(value))

--- a/src/prob4d/_joint_visual_bias_common.py
+++ b/src/prob4d/_joint_visual_bias_common.py
@@ -19,9 +19,7 @@ IntArray: TypeAlias = NDArray[np.int64]
 JOINT_VISUAL_BIAS_LAYOUT_SCHEMA: Final = "prob4d.joint-visual-bias-layout"
 JOINT_VISUAL_BIAS_LAYOUT_VERSION: Final = 1
 JOINT_VISUAL_BIAS_BASIS_ORDER: Final = "shared-prefix-then-camera-mode-major-v1"
-JOINT_VISUAL_BIAS_COVARIANCE_SEMANTICS: Final = (
-    "complete-joint-selected-coefficient-covariance-v1"
-)
+JOINT_VISUAL_BIAS_COVARIANCE_SEMANTICS: Final = "complete-joint-selected-coefficient-covariance-v1"
 JOINT_VISUAL_BIAS_METADATA_KEY: Final = "joint_visual_bias_layout_v1"
 JOINT_VISUAL_BIAS_CLAIM_BOUNDARY: Final = (
     "Source/calibration-group joint visual-bias design and covariance only. "
@@ -112,9 +110,7 @@ def _layout_component(value: object, *, name: str) -> str:
 
 def _sha256(value: object, *, name: str) -> str:
     digest = _nonempty_string(value, name=name)
-    if len(digest) != 64 or any(
-        character not in "0123456789abcdef" for character in digest
-    ):
+    if len(digest) != 64 or any(character not in "0123456789abcdef" for character in digest):
         raise ValueError(f"{name} must be a lowercase SHA-256 digest")
     return digest
 
@@ -129,8 +125,7 @@ def _string_tuple(
     if type(value) is not tuple:
         raise TypeError(f"{name} must be a canonical tuple")
     result = tuple(
-        _layout_component(item, name=f"{name}[{index}]")
-        for index, item in enumerate(value)
+        _layout_component(item, name=f"{name}[{index}]") for index, item in enumerate(value)
     )
     if len(result) < minimum:
         raise ValueError(f"{name} must contain at least {minimum} values")
@@ -162,8 +157,7 @@ def _json_nonempty_string_tuple(value: object, *, name: str) -> tuple[str, ...]:
     if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
         raise ValueError(f"{name} must be a JSON array of strings")
     result = tuple(
-        _nonempty_string(item, name=f"{name}[{index}]")
-        for index, item in enumerate(value)
+        _nonempty_string(item, name=f"{name}[{index}]") for index, item in enumerate(value)
     )
     if len(set(result)) != len(result):
         raise ValueError(f"{name} must contain unique values")
@@ -211,6 +205,7 @@ def _metadata(
     if collisions:
         raise ValueError(f"{name} uses reserved keys: {collisions}")
     return frozen_finite_json_mapping(value, name=name)
+
 
 __all__ = [
     "FloatArray",

--- a/src/prob4d/_joint_visual_bias_common.py
+++ b/src/prob4d/_joint_visual_bias_common.py
@@ -1,0 +1,224 @@
+"""Shared contracts for joint shared/camera-specific visual-bias calibration."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any, Final, TypeAlias, cast
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ._immutable_array import immutable_array
+from ._immutable_json import frozen_finite_json_mapping, plain_json
+
+FloatArray: TypeAlias = NDArray[np.float64]
+IntArray: TypeAlias = NDArray[np.int64]
+
+JOINT_VISUAL_BIAS_LAYOUT_SCHEMA: Final = "prob4d.joint-visual-bias-layout"
+JOINT_VISUAL_BIAS_LAYOUT_VERSION: Final = 1
+JOINT_VISUAL_BIAS_BASIS_ORDER: Final = "shared-prefix-then-camera-mode-major-v1"
+JOINT_VISUAL_BIAS_COVARIANCE_SEMANTICS: Final = (
+    "complete-joint-selected-coefficient-covariance-v1"
+)
+JOINT_VISUAL_BIAS_METADATA_KEY: Final = "joint_visual_bias_layout_v1"
+JOINT_VISUAL_BIAS_CLAIM_BOUNDARY: Final = (
+    "Source/calibration-group joint visual-bias design and covariance only. "
+    "The selected nested basis need not be complete, target calibration is not "
+    "established, no physical-state update is accepted here, and tactile, depth, "
+    "LiDAR, or force evidence must remain separate factors."
+)
+
+_LAYOUT_FIELDS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "layout_id",
+        "camera_ids",
+        "shared_basis_names",
+        "camera_basis_names",
+        "expanded_basis_names",
+        "basis_order_semantics",
+        "claim_boundary",
+    }
+)
+_CALIBRATION_METADATA_FIELDS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "layout",
+        "layout_id",
+        "group_artifact_ids",
+        "allow_partial_camera_mode",
+        "uses_target_outcomes",
+        "uses_downstream_physical_innovation",
+        "covariance_semantics",
+        "claim_boundary",
+    }
+)
+_RESERVED_METADATA_KEYS = frozenset(
+    {
+        JOINT_VISUAL_BIAS_METADATA_KEY,
+        "uses_target_outcomes",
+        "uses_downstream_physical_innovation",
+    }
+)
+
+
+def _canonical_json(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        plain_json(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _sha256_json(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json(value)).hexdigest()
+
+
+def _array_sha256(value: np.ndarray) -> str:
+    array = np.ascontiguousarray(value)
+    digest = hashlib.sha256()
+    digest.update(array.dtype.str.encode("ascii"))
+    digest.update(json.dumps(list(array.shape), separators=(",", ":")).encode("ascii"))
+    digest.update(array.tobytes(order="C"))
+    return digest.hexdigest()
+
+
+def _array_descriptor(value: np.ndarray) -> dict[str, object]:
+    array = np.ascontiguousarray(value)
+    return {
+        "dtype": array.dtype.str,
+        "shape": list(array.shape),
+        "sha256": _array_sha256(array),
+    }
+
+
+def _nonempty_string(value: object, *, name: str) -> str:
+    if type(value) is not str or not value:
+        raise ValueError(f"{name} must be a non-empty string")
+    return value
+
+
+def _layout_component(value: object, *, name: str) -> str:
+    result = _nonempty_string(value, name=name)
+    if "::" in result:
+        raise ValueError(f"{name} must not contain the reserved delimiter '::'")
+    return result
+
+
+def _sha256(value: object, *, name: str) -> str:
+    digest = _nonempty_string(value, name=name)
+    if len(digest) != 64 or any(
+        character not in "0123456789abcdef" for character in digest
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return digest
+
+
+def _string_tuple(
+    value: object,
+    *,
+    name: str,
+    minimum: int = 0,
+    require_sorted: bool = False,
+) -> tuple[str, ...]:
+    if type(value) is not tuple:
+        raise TypeError(f"{name} must be a canonical tuple")
+    result = tuple(
+        _layout_component(item, name=f"{name}[{index}]")
+        for index, item in enumerate(value)
+    )
+    if len(result) < minimum:
+        raise ValueError(f"{name} must contain at least {minimum} values")
+    if len(set(result)) != len(result):
+        raise ValueError(f"{name} must contain unique values")
+    if require_sorted and result != tuple(sorted(result)):
+        raise ValueError(f"{name} must be sorted")
+    return result
+
+
+def _json_string_tuple(
+    value: object,
+    *,
+    name: str,
+    minimum: int = 0,
+    require_sorted: bool = False,
+) -> tuple[str, ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        raise ValueError(f"{name} must be a JSON array of strings")
+    return _string_tuple(
+        tuple(value),
+        name=name,
+        minimum=minimum,
+        require_sorted=require_sorted,
+    )
+
+
+def _json_nonempty_string_tuple(value: object, *, name: str) -> tuple[str, ...]:
+    if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+        raise ValueError(f"{name} must be a JSON array of strings")
+    result = tuple(
+        _nonempty_string(item, name=f"{name}[{index}]")
+        for index, item in enumerate(value)
+    )
+    if len(set(result)) != len(result):
+        raise ValueError(f"{name} must contain unique values")
+    return result
+
+
+def _float64_array(
+    value: object,
+    *,
+    name: str,
+    shape: tuple[int, ...] | None = None,
+) -> FloatArray:
+    array = np.asarray(value)
+    if array.dtype != np.dtype(np.float64):
+        raise ValueError(f"{name} must have dtype float64")
+    if shape is not None and array.shape != shape:
+        raise ValueError(f"{name} must have shape {shape}")
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} must be finite")
+    return cast(FloatArray, immutable_array(array, dtype=np.float64))
+
+
+def _metadata(
+    value: Mapping[str, Any],
+    *,
+    name: str,
+) -> Mapping[str, Any]:
+    def reserved_keys(current: object) -> set[str]:
+        if isinstance(current, Mapping):
+            result = _RESERVED_METADATA_KEYS & set(current)
+            for nested in current.values():
+                result |= reserved_keys(nested)
+            return result
+        if isinstance(current, Sequence) and not isinstance(
+            current,
+            (str, bytes, bytearray),
+        ):
+            result: set[str] = set()
+            for nested in current:
+                result |= reserved_keys(nested)
+            return result
+        return set()
+
+    collisions = sorted(reserved_keys(value))
+    if collisions:
+        raise ValueError(f"{name} uses reserved keys: {collisions}")
+    return frozen_finite_json_mapping(value, name=name)
+
+__all__ = [
+    "FloatArray",
+    "IntArray",
+    "JOINT_VISUAL_BIAS_BASIS_ORDER",
+    "JOINT_VISUAL_BIAS_CLAIM_BOUNDARY",
+    "JOINT_VISUAL_BIAS_COVARIANCE_SEMANTICS",
+    "JOINT_VISUAL_BIAS_LAYOUT_SCHEMA",
+    "JOINT_VISUAL_BIAS_LAYOUT_VERSION",
+    "JOINT_VISUAL_BIAS_METADATA_KEY",
+]

--- a/src/prob4d/_joint_visual_bias_group.py
+++ b/src/prob4d/_joint_visual_bias_group.py
@@ -1,0 +1,161 @@
+"""Immutable complete-group inputs for joint visual-bias calibration."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+from ._immutable_array import immutable_integer_array
+from ._immutable_json import plain_json
+from ._joint_visual_bias_common import (
+    FloatArray,
+    IntArray,
+    _array_descriptor,
+    _float64_array,
+    _metadata,
+    _nonempty_string,
+    _sha256_json,
+)
+from ._joint_visual_bias_layout import (
+    JointVisualBiasLayoutV1,
+    expand_joint_visual_bias_jacobian,
+)
+from .visual_bias_calibration import VisualBiasCalibrationGroup
+
+@dataclass(frozen=True, slots=True)
+class JointVisualBiasCalibrationGroupV1:
+    """One complete source/calibration object with a multiview joint-bias design."""
+
+    group_id: str
+    layout: JointVisualBiasLayoutV1
+    row_camera_indices: IntArray
+    residual: FloatArray
+    shared_bias_jacobian: FloatArray
+    camera_bias_jacobian: FloatArray
+    conditional_covariance: FloatArray
+    gauge_design: FloatArray | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    group_artifact_id: str | None = None
+
+    def __post_init__(self) -> None:
+        group_id = _nonempty_string(self.group_id, name="group_id")
+        if not isinstance(self.layout, JointVisualBiasLayoutV1):
+            raise TypeError("layout must be JointVisualBiasLayoutV1")
+        residual = _float64_array(self.residual, name="residual")
+        if residual.ndim != 2 or residual.shape[1] != 3 or residual.shape[0] < 1:
+            raise ValueError("residual must have shape (N, 3)")
+        row_count = residual.shape[0]
+        indices = immutable_integer_array(
+            self.row_camera_indices,
+            name="row_camera_indices",
+        )
+        if indices.shape != (row_count,):
+            raise ValueError("row_camera_indices must have one entry per residual row")
+        expanded = expand_joint_visual_bias_jacobian(
+            self.layout,
+            indices,
+            self.shared_bias_jacobian,
+            self.camera_bias_jacobian,
+            require_all_cameras=True,
+        )
+        shared = _float64_array(
+            self.shared_bias_jacobian,
+            name="shared_bias_jacobian",
+            shape=(row_count, 3, len(self.layout.shared_basis_names)),
+        )
+        camera = _float64_array(
+            self.camera_bias_jacobian,
+            name="camera_bias_jacobian",
+            shape=(row_count, 3, len(self.layout.camera_basis_names)),
+        )
+        covariance = _float64_array(
+            self.conditional_covariance,
+            name="conditional_covariance",
+            shape=(row_count, 3, 3),
+        )
+        gauge = None
+        if self.gauge_design is not None:
+            gauge = _float64_array(self.gauge_design, name="gauge_design")
+            if gauge.ndim != 3 or gauge.shape[:2] != (row_count, 3) or gauge.shape[2] < 1:
+                raise ValueError("gauge_design must have shape (N, 3, K) with K positive")
+        metadata = _metadata(self.metadata, name="joint visual-bias group metadata")
+        object.__setattr__(self, "group_id", group_id)
+        object.__setattr__(self, "row_camera_indices", indices)
+        object.__setattr__(self, "residual", residual)
+        object.__setattr__(self, "shared_bias_jacobian", shared)
+        object.__setattr__(self, "camera_bias_jacobian", camera)
+        object.__setattr__(self, "conditional_covariance", covariance)
+        object.__setattr__(self, "gauge_design", gauge)
+        object.__setattr__(self, "metadata", metadata)
+        # Reuse the established SPD, row, and gauge-design contract.
+        VisualBiasCalibrationGroup(
+            group_id=group_id,
+            residual=residual,
+            bias_jacobian=expanded,
+            conditional_covariance=covariance,
+            gauge_design=gauge,
+            metadata=self._v1_metadata(include_artifact_id=False),
+        )
+        expected = _sha256_json(self.identity_record())
+        if self.group_artifact_id is not None and self.group_artifact_id != expected:
+            raise ValueError("joint visual-bias group artifact ID mismatch")
+        object.__setattr__(self, "group_artifact_id", expected)
+
+    def camera_row_counts(self) -> dict[str, int]:
+        return {
+            camera_id: int(np.count_nonzero(self.row_camera_indices == camera_index))
+            for camera_index, camera_id in enumerate(self.layout.camera_ids)
+        }
+
+    def expanded_bias_jacobian(self) -> FloatArray:
+        return expand_joint_visual_bias_jacobian(
+            self.layout,
+            self.row_camera_indices,
+            self.shared_bias_jacobian,
+            self.camera_bias_jacobian,
+            require_all_cameras=True,
+        )
+
+    def _v1_metadata(self, *, include_artifact_id: bool) -> dict[str, Any]:
+        result = plain_json(self.metadata)
+        result["joint_visual_bias_layout_id"] = self.layout.layout_id
+        result["camera_row_counts"] = self.camera_row_counts()
+        if include_artifact_id:
+            result["joint_visual_bias_group_artifact_id"] = self.group_artifact_id
+        return result
+
+    def identity_record(self) -> dict[str, object]:
+        return {
+            "schema": "prob4d.joint-visual-bias-calibration-group",
+            "schema_version": 1,
+            "group_id": self.group_id,
+            "layout_id": self.layout.layout_id,
+            "arrays": {
+                "row_camera_indices": _array_descriptor(self.row_camera_indices),
+                "residual": _array_descriptor(self.residual),
+                "shared_bias_jacobian": _array_descriptor(self.shared_bias_jacobian),
+                "camera_bias_jacobian": _array_descriptor(self.camera_bias_jacobian),
+                "conditional_covariance": _array_descriptor(self.conditional_covariance),
+                "gauge_design": (
+                    None if self.gauge_design is None else _array_descriptor(self.gauge_design)
+                ),
+            },
+            "metadata": plain_json(self.metadata),
+        }
+
+    def to_visual_bias_calibration_group(self) -> VisualBiasCalibrationGroup:
+        return VisualBiasCalibrationGroup(
+            group_id=self.group_id,
+            residual=self.residual,
+            bias_jacobian=self.expanded_bias_jacobian(),
+            conditional_covariance=self.conditional_covariance,
+            gauge_design=self.gauge_design,
+            metadata=self._v1_metadata(include_artifact_id=True),
+        )
+
+
+
+__all__ = ["JointVisualBiasCalibrationGroupV1"]

--- a/src/prob4d/_joint_visual_bias_group.py
+++ b/src/prob4d/_joint_visual_bias_group.py
@@ -25,6 +25,7 @@ from ._joint_visual_bias_layout import (
 )
 from .visual_bias_calibration import VisualBiasCalibrationGroup
 
+
 @dataclass(frozen=True, slots=True)
 class JointVisualBiasCalibrationGroupV1:
     """One complete source/calibration object with a multiview joint-bias design."""
@@ -155,7 +156,6 @@ class JointVisualBiasCalibrationGroupV1:
             gauge_design=self.gauge_design,
             metadata=self._v1_metadata(include_artifact_id=True),
         )
-
 
 
 __all__ = ["JointVisualBiasCalibrationGroupV1"]

--- a/src/prob4d/_joint_visual_bias_layout.py
+++ b/src/prob4d/_joint_visual_bias_layout.py
@@ -125,11 +125,11 @@ class JointVisualBiasLayoutV1:
             ),
             layout_id=_sha256(value["layout_id"], name="layout_id"),
         )
-        expanded = _json_nonempty_string_tuple(
+        expanded_names = _json_nonempty_string_tuple(
             value["expanded_basis_names"],
             name="expanded_basis_names",
         )
-        if layout.basis_names != expanded:
+        if layout.basis_names != expanded_names:
             raise ValueError("joint visual-bias expanded basis names changed")
         return layout
 
@@ -165,7 +165,10 @@ def expand_joint_visual_bias_jacobian(
         name="camera_bias_jacobian",
         shape=(row_count, 3, len(layout.camera_basis_names)),
     )
-    expanded = np.zeros((row_count, 3, layout.basis_dimension), dtype=np.float64)
+    expanded = cast(
+        FloatArray,
+        np.zeros((row_count, 3, layout.basis_dimension), dtype=np.float64),
+    )
     shared_count = len(layout.shared_basis_names)
     if shared_count:
         expanded[:, :, :shared_count] = shared

--- a/src/prob4d/_joint_visual_bias_layout.py
+++ b/src/prob4d/_joint_visual_bias_layout.py
@@ -10,12 +10,12 @@ import numpy as np
 
 from ._immutable_array import immutable_array, immutable_integer_array
 from ._joint_visual_bias_common import (
-    FloatArray,
+    _LAYOUT_FIELDS,
     JOINT_VISUAL_BIAS_BASIS_ORDER,
     JOINT_VISUAL_BIAS_CLAIM_BOUNDARY,
     JOINT_VISUAL_BIAS_LAYOUT_SCHEMA,
     JOINT_VISUAL_BIAS_LAYOUT_VERSION,
-    _LAYOUT_FIELDS,
+    FloatArray,
     _float64_array,
     _json_nonempty_string_tuple,
     _json_string_tuple,
@@ -175,5 +175,6 @@ def expand_joint_visual_bias_jacobian(
             mask = indices == camera_index
             expanded[mask, :, column] = camera[mask, :, mode_index]
     return cast(FloatArray, immutable_array(expanded, dtype=np.float64))
+
 
 __all__ = ["JointVisualBiasLayoutV1", "expand_joint_visual_bias_jacobian"]

--- a/src/prob4d/_joint_visual_bias_layout.py
+++ b/src/prob4d/_joint_visual_bias_layout.py
@@ -1,0 +1,179 @@
+"""Canonical joint visual-bias latent layout and row-design expansion."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import cast
+
+import numpy as np
+
+from ._immutable_array import immutable_array, immutable_integer_array
+from ._joint_visual_bias_common import (
+    FloatArray,
+    JOINT_VISUAL_BIAS_BASIS_ORDER,
+    JOINT_VISUAL_BIAS_CLAIM_BOUNDARY,
+    JOINT_VISUAL_BIAS_LAYOUT_SCHEMA,
+    JOINT_VISUAL_BIAS_LAYOUT_VERSION,
+    _LAYOUT_FIELDS,
+    _float64_array,
+    _json_nonempty_string_tuple,
+    _json_string_tuple,
+    _sha256,
+    _sha256_json,
+    _string_tuple,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class JointVisualBiasLayoutV1:
+    """Canonical latent-column layout shared by calibration and observations."""
+
+    camera_ids: tuple[str, ...]
+    shared_basis_names: tuple[str, ...]
+    camera_basis_names: tuple[str, ...]
+    layout_id: str | None = None
+
+    def __post_init__(self) -> None:
+        camera_ids = _string_tuple(
+            self.camera_ids,
+            name="camera_ids",
+            minimum=2,
+            require_sorted=True,
+        )
+        shared = _string_tuple(
+            self.shared_basis_names,
+            name="shared_basis_names",
+        )
+        camera = _string_tuple(
+            self.camera_basis_names,
+            name="camera_basis_names",
+        )
+        if not shared and not camera:
+            raise ValueError("joint visual-bias layout requires at least one basis mode")
+        if set(shared) & set(camera):
+            raise ValueError("shared and camera-specific basis names must be disjoint")
+        object.__setattr__(self, "camera_ids", camera_ids)
+        object.__setattr__(self, "shared_basis_names", shared)
+        object.__setattr__(self, "camera_basis_names", camera)
+        expected = _sha256_json(self.descriptor())
+        if self.layout_id is not None and self.layout_id != expected:
+            raise ValueError("joint visual-bias layout ID mismatch")
+        object.__setattr__(self, "layout_id", expected)
+
+    @property
+    def basis_names(self) -> tuple[str, ...]:
+        shared = tuple(f"shared::{name}" for name in self.shared_basis_names)
+        camera = tuple(
+            f"camera::{basis_name}::{camera_id}"
+            for basis_name in self.camera_basis_names
+            for camera_id in self.camera_ids
+        )
+        return shared + camera
+
+    @property
+    def basis_dimension(self) -> int:
+        return len(self.basis_names)
+
+    def descriptor(self) -> dict[str, object]:
+        return {
+            "schema": JOINT_VISUAL_BIAS_LAYOUT_SCHEMA,
+            "schema_version": JOINT_VISUAL_BIAS_LAYOUT_VERSION,
+            "camera_ids": list(self.camera_ids),
+            "shared_basis_names": list(self.shared_basis_names),
+            "camera_basis_names": list(self.camera_basis_names),
+            "expanded_basis_names": list(self.basis_names),
+            "basis_order_semantics": JOINT_VISUAL_BIAS_BASIS_ORDER,
+            "claim_boundary": JOINT_VISUAL_BIAS_CLAIM_BOUNDARY,
+        }
+
+    def to_dict(self) -> dict[str, object]:
+        return {**self.descriptor(), "layout_id": self.layout_id}
+
+    @classmethod
+    def from_mapping(cls, value: object) -> JointVisualBiasLayoutV1:
+        if not isinstance(value, Mapping):
+            raise ValueError("joint visual-bias layout must be a JSON object")
+        missing = sorted(_LAYOUT_FIELDS - set(value))
+        extra = sorted(set(value) - _LAYOUT_FIELDS)
+        if missing or extra:
+            raise ValueError(
+                f"joint visual-bias layout fields changed: missing={missing}, extra={extra}"
+            )
+        if value["schema"] != JOINT_VISUAL_BIAS_LAYOUT_SCHEMA:
+            raise ValueError("unsupported joint visual-bias layout schema")
+        if value["schema_version"] != JOINT_VISUAL_BIAS_LAYOUT_VERSION:
+            raise ValueError("unsupported joint visual-bias layout version")
+        if value["basis_order_semantics"] != JOINT_VISUAL_BIAS_BASIS_ORDER:
+            raise ValueError("joint visual-bias basis ordering changed")
+        if value["claim_boundary"] != JOINT_VISUAL_BIAS_CLAIM_BOUNDARY:
+            raise ValueError("joint visual-bias claim boundary changed")
+        layout = cls(
+            camera_ids=_json_string_tuple(
+                value["camera_ids"],
+                name="camera_ids",
+                minimum=2,
+                require_sorted=True,
+            ),
+            shared_basis_names=_json_string_tuple(
+                value["shared_basis_names"],
+                name="shared_basis_names",
+            ),
+            camera_basis_names=_json_string_tuple(
+                value["camera_basis_names"],
+                name="camera_basis_names",
+            ),
+            layout_id=_sha256(value["layout_id"], name="layout_id"),
+        )
+        expanded = _json_nonempty_string_tuple(
+            value["expanded_basis_names"],
+            name="expanded_basis_names",
+        )
+        if layout.basis_names != expanded:
+            raise ValueError("joint visual-bias expanded basis names changed")
+        return layout
+
+
+def expand_joint_visual_bias_jacobian(
+    layout: JointVisualBiasLayoutV1,
+    row_camera_indices: object,
+    shared_bias_jacobian: object,
+    camera_bias_jacobian: object,
+    *,
+    require_all_cameras: bool,
+) -> FloatArray:
+    """Expand shared and camera-local row bases into one complete joint design."""
+
+    if not isinstance(layout, JointVisualBiasLayoutV1):
+        raise TypeError("layout must be JointVisualBiasLayoutV1")
+    indices = immutable_integer_array(row_camera_indices, name="row_camera_indices")
+    if indices.ndim != 1 or indices.size < 1:
+        raise ValueError("row_camera_indices must be a non-empty vector")
+    camera_count = len(layout.camera_ids)
+    if np.any(indices < 0) or np.any(indices >= camera_count):
+        raise ValueError("row_camera_indices refer to an unknown camera")
+    if require_all_cameras and set(int(item) for item in indices) != set(range(camera_count)):
+        raise ValueError("every calibration group must contain rows from every camera")
+    row_count = int(indices.size)
+    shared = _float64_array(
+        shared_bias_jacobian,
+        name="shared_bias_jacobian",
+        shape=(row_count, 3, len(layout.shared_basis_names)),
+    )
+    camera = _float64_array(
+        camera_bias_jacobian,
+        name="camera_bias_jacobian",
+        shape=(row_count, 3, len(layout.camera_basis_names)),
+    )
+    expanded = np.zeros((row_count, 3, layout.basis_dimension), dtype=np.float64)
+    shared_count = len(layout.shared_basis_names)
+    if shared_count:
+        expanded[:, :, :shared_count] = shared
+    for mode_index in range(len(layout.camera_basis_names)):
+        for camera_index in range(camera_count):
+            column = shared_count + mode_index * camera_count + camera_index
+            mask = indices == camera_index
+            expanded[mask, :, column] = camera[mask, :, mode_index]
+    return cast(FloatArray, immutable_array(expanded, dtype=np.float64))
+
+__all__ = ["JointVisualBiasLayoutV1", "expand_joint_visual_bias_jacobian"]

--- a/src/prob4d/joint_visual_bias_calibration.py
+++ b/src/prob4d/joint_visual_bias_calibration.py
@@ -1,0 +1,40 @@
+"""Prospective joint shared and camera-specific visual-bias calibration.
+
+The module constructs one complete bias design across several cameras, then
+reuses the existing source-group fitter and observation-sidecar artifact path.
+The frozen single-scope V1 implementation is not modified.
+"""
+
+from ._joint_visual_bias_calibration import (
+    build_joint_visual_bias_nuisance_from_calibration,
+    fit_joint_visual_bias_calibration,
+    joint_visual_bias_layout_from_calibration,
+    joint_visual_bias_selection_summary,
+)
+from ._joint_visual_bias_common import (
+    JOINT_VISUAL_BIAS_BASIS_ORDER,
+    JOINT_VISUAL_BIAS_CLAIM_BOUNDARY,
+    JOINT_VISUAL_BIAS_COVARIANCE_SEMANTICS,
+    JOINT_VISUAL_BIAS_LAYOUT_SCHEMA,
+    JOINT_VISUAL_BIAS_LAYOUT_VERSION,
+    JOINT_VISUAL_BIAS_METADATA_KEY,
+    JointVisualBiasLayoutV1,
+    expand_joint_visual_bias_jacobian,
+)
+from ._joint_visual_bias_group import JointVisualBiasCalibrationGroupV1
+
+__all__ = [
+    "JOINT_VISUAL_BIAS_BASIS_ORDER",
+    "JOINT_VISUAL_BIAS_CLAIM_BOUNDARY",
+    "JOINT_VISUAL_BIAS_COVARIANCE_SEMANTICS",
+    "JOINT_VISUAL_BIAS_LAYOUT_SCHEMA",
+    "JOINT_VISUAL_BIAS_LAYOUT_VERSION",
+    "JOINT_VISUAL_BIAS_METADATA_KEY",
+    "JointVisualBiasCalibrationGroupV1",
+    "JointVisualBiasLayoutV1",
+    "build_joint_visual_bias_nuisance_from_calibration",
+    "expand_joint_visual_bias_jacobian",
+    "fit_joint_visual_bias_calibration",
+    "joint_visual_bias_layout_from_calibration",
+    "joint_visual_bias_selection_summary",
+]

--- a/src/prob4d/joint_visual_bias_calibration.py
+++ b/src/prob4d/joint_visual_bias_calibration.py
@@ -18,10 +18,12 @@ from ._joint_visual_bias_common import (
     JOINT_VISUAL_BIAS_LAYOUT_SCHEMA,
     JOINT_VISUAL_BIAS_LAYOUT_VERSION,
     JOINT_VISUAL_BIAS_METADATA_KEY,
+)
+from ._joint_visual_bias_group import JointVisualBiasCalibrationGroupV1
+from ._joint_visual_bias_layout import (
     JointVisualBiasLayoutV1,
     expand_joint_visual_bias_jacobian,
 )
-from ._joint_visual_bias_group import JointVisualBiasCalibrationGroupV1
 
 __all__ = [
     "JOINT_VISUAL_BIAS_BASIS_ORDER",

--- a/tests/test_joint_visual_bias_calibration.py
+++ b/tests/test_joint_visual_bias_calibration.py
@@ -1,0 +1,396 @@
+from __future__ import annotations
+
+import copy
+
+import numpy as np
+import pytest
+
+from prob4d.joint_visual_bias_calibration import (
+    JOINT_VISUAL_BIAS_METADATA_KEY,
+    JointVisualBiasCalibrationGroupV1,
+    JointVisualBiasLayoutV1,
+    build_joint_visual_bias_nuisance_from_calibration,
+    expand_joint_visual_bias_jacobian,
+    fit_joint_visual_bias_calibration,
+    joint_visual_bias_layout_from_calibration,
+    joint_visual_bias_selection_summary,
+)
+from prob4d.visual_bias_calibration import (
+    load_visual_bias_calibration,
+    write_visual_bias_calibration,
+)
+
+
+def _full_layout() -> JointVisualBiasLayoutV1:
+    return JointVisualBiasLayoutV1(
+        camera_ids=("camera-0", "camera-1"),
+        shared_basis_names=("shared-depth",),
+        camera_basis_names=("camera-tangent",),
+    )
+
+
+def _designs(
+    layout: JointVisualBiasLayoutV1,
+    row_camera_indices: np.ndarray,
+    *,
+    camera_one_active: bool = True,
+) -> tuple[np.ndarray, np.ndarray]:
+    row_count = row_camera_indices.size
+    shared = np.zeros(
+        (row_count, 3, len(layout.shared_basis_names)),
+        dtype=np.float64,
+    )
+    if layout.shared_basis_names:
+        shared[:, 0, 0] = 1.0
+    camera = np.zeros(
+        (row_count, 3, len(layout.camera_basis_names)),
+        dtype=np.float64,
+    )
+    if layout.camera_basis_names:
+        camera[row_camera_indices == 0, 1, 0] = 1.0
+        if camera_one_active:
+            camera[row_camera_indices == 1, 1, 0] = 1.0
+    return shared, camera
+
+
+def _full_groups() -> tuple[JointVisualBiasCalibrationGroupV1, ...]:
+    layout = _full_layout()
+    generator = np.random.default_rng(4)
+    groups: list[JointVisualBiasCalibrationGroupV1] = []
+    for group_index in range(10):
+        row_camera_indices = np.repeat(np.arange(2, dtype=np.int64), 16)
+        shared, camera = _designs(layout, row_camera_indices)
+        latent = generator.normal(size=3)
+        coefficients = np.asarray(
+            [
+                0.35 * latent[0],
+                0.25 * latent[1],
+                0.18 * latent[1] + 0.12 * latent[2],
+            ],
+            dtype=np.float64,
+        )
+        expanded = expand_joint_visual_bias_jacobian(
+            layout,
+            row_camera_indices,
+            shared,
+            camera,
+            require_all_cameras=True,
+        )
+        residual = np.einsum("ncr,r->nc", expanded, coefficients)
+        residual += generator.normal(scale=0.01, size=residual.shape)
+        covariance = np.repeat(
+            (0.01**2 * np.eye(3, dtype=np.float64))[None],
+            residual.shape[0],
+            axis=0,
+        )
+        groups.append(
+            JointVisualBiasCalibrationGroupV1(
+                group_id=f"object-{group_index:02d}",
+                layout=layout,
+                row_camera_indices=row_camera_indices,
+                residual=np.asarray(residual, dtype=np.float64),
+                shared_bias_jacobian=shared,
+                camera_bias_jacobian=camera,
+                conditional_covariance=covariance,
+                metadata={"episode_count": 2},
+            )
+        )
+    return tuple(groups)
+
+
+def _partial_groups() -> tuple[JointVisualBiasCalibrationGroupV1, ...]:
+    layout = JointVisualBiasLayoutV1(
+        camera_ids=("camera-0", "camera-1"),
+        shared_basis_names=(),
+        camera_basis_names=("camera-local",),
+    )
+    generator = np.random.default_rng(8)
+    groups: list[JointVisualBiasCalibrationGroupV1] = []
+    for group_index in range(8):
+        row_camera_indices = np.repeat(np.arange(2, dtype=np.int64), 12)
+        shared, camera = _designs(
+            layout,
+            row_camera_indices,
+            camera_one_active=False,
+        )
+        coefficients = np.asarray(
+            [0.3 * generator.normal(), 0.0],
+            dtype=np.float64,
+        )
+        expanded = expand_joint_visual_bias_jacobian(
+            layout,
+            row_camera_indices,
+            shared,
+            camera,
+            require_all_cameras=True,
+        )
+        residual = np.einsum("ncr,r->nc", expanded, coefficients)
+        residual += generator.normal(scale=0.01, size=residual.shape)
+        covariance = np.repeat(
+            (0.01**2 * np.eye(3, dtype=np.float64))[None],
+            residual.shape[0],
+            axis=0,
+        )
+        groups.append(
+            JointVisualBiasCalibrationGroupV1(
+                group_id=f"partial-{group_index:02d}",
+                layout=layout,
+                row_camera_indices=row_camera_indices,
+                residual=np.asarray(residual, dtype=np.float64),
+                shared_bias_jacobian=shared,
+                camera_bias_jacobian=camera,
+                conditional_covariance=covariance,
+            )
+        )
+    return tuple(groups)
+
+
+def _fit_full():
+    return fit_joint_visual_bias_calibration(
+        _full_groups(),
+        provider_manifest_id="a" * 64,
+        calibration_source_id="b" * 64,
+        group_definition="complete physical object",
+        residual_definition="metric source minus provider point",
+        uses_truth=True,
+        covariance_shrinkage=0.0,
+        minimum_nll_improvement=0.0,
+    )
+
+
+def test_layout_round_trip_and_tamper_detection() -> None:
+    layout = _full_layout()
+
+    loaded = JointVisualBiasLayoutV1.from_mapping(layout.to_dict())
+
+    assert loaded == layout
+    assert layout.basis_names == (
+        "shared::shared-depth",
+        "camera::camera-tangent::camera-0",
+        "camera::camera-tangent::camera-1",
+    )
+    assert len(layout.layout_id or "") == 64
+
+    tampered = copy.deepcopy(layout.to_dict())
+    tampered["expanded_basis_names"][1] = "camera::changed::camera-0"
+    with pytest.raises(ValueError, match="expanded basis names changed"):
+        JointVisualBiasLayoutV1.from_mapping(tampered)
+
+    coercive = copy.deepcopy(layout.to_dict())
+    coercive["camera_ids"] = "camera-0"
+    with pytest.raises(ValueError, match="JSON array"):
+        JointVisualBiasLayoutV1.from_mapping(coercive)
+
+
+def test_joint_design_expands_shared_and_camera_specific_columns_exactly() -> None:
+    layout = _full_layout()
+    row_camera_indices = np.asarray([0, 1, 0, 1], dtype=np.int64)
+    shared, camera = _designs(layout, row_camera_indices)
+
+    expanded = expand_joint_visual_bias_jacobian(
+        layout,
+        row_camera_indices,
+        shared,
+        camera,
+        require_all_cameras=True,
+    )
+
+    assert expanded.shape == (4, 3, 3)
+    np.testing.assert_array_equal(expanded[:, 0, 0], np.ones(4))
+    np.testing.assert_array_equal(expanded[:, 1, 1], [1.0, 0.0, 1.0, 0.0])
+    np.testing.assert_array_equal(expanded[:, 1, 2], [0.0, 1.0, 0.0, 1.0])
+    assert not expanded.flags.writeable
+    with pytest.raises(ValueError):
+        expanded.setflags(write=True)
+
+    shared[:, :, :] = 7.0
+    assert float(expanded[0, 0, 0]) == 1.0
+
+
+def test_calibration_group_requires_every_camera_and_exact_float64() -> None:
+    layout = _full_layout()
+    row_camera_indices = np.zeros(4, dtype=np.int64)
+    shared, camera = _designs(layout, row_camera_indices)
+    covariance = np.repeat(np.eye(3, dtype=np.float64)[None], 4, axis=0)
+
+    with pytest.raises(ValueError, match="every calibration group"):
+        JointVisualBiasCalibrationGroupV1(
+            group_id="object",
+            layout=layout,
+            row_camera_indices=row_camera_indices,
+            residual=np.zeros((4, 3), dtype=np.float64),
+            shared_bias_jacobian=shared,
+            camera_bias_jacobian=camera,
+            conditional_covariance=covariance,
+        )
+
+    complete_indices = np.asarray([0, 1, 0, 1], dtype=np.int64)
+    complete_shared, complete_camera = _designs(layout, complete_indices)
+    with pytest.raises(ValueError, match="dtype float64"):
+        JointVisualBiasCalibrationGroupV1(
+            group_id="object",
+            layout=layout,
+            row_camera_indices=complete_indices,
+            residual=np.zeros((4, 3), dtype=np.float32),
+            shared_bias_jacobian=complete_shared,
+            camera_bias_jacobian=complete_camera,
+            conditional_covariance=covariance,
+        )
+
+
+def test_group_artifact_identity_binds_camera_row_assignment() -> None:
+    layout = _full_layout()
+    row_camera_indices = np.asarray([0, 1, 0, 1], dtype=np.int64)
+    shared, camera = _designs(layout, row_camera_indices)
+    covariance = np.repeat(np.eye(3, dtype=np.float64)[None], 4, axis=0)
+    first = JointVisualBiasCalibrationGroupV1(
+        group_id="object",
+        layout=layout,
+        row_camera_indices=row_camera_indices,
+        residual=np.zeros((4, 3), dtype=np.float64),
+        shared_bias_jacobian=shared,
+        camera_bias_jacobian=camera,
+        conditional_covariance=covariance,
+    )
+    reversed_indices = np.asarray([1, 0, 1, 0], dtype=np.int64)
+    reversed_shared, reversed_camera = _designs(layout, reversed_indices)
+    second = JointVisualBiasCalibrationGroupV1(
+        group_id="object",
+        layout=layout,
+        row_camera_indices=reversed_indices,
+        residual=np.zeros((4, 3), dtype=np.float64),
+        shared_bias_jacobian=reversed_shared,
+        camera_bias_jacobian=reversed_camera,
+        conditional_covariance=covariance,
+    )
+
+    assert first.group_artifact_id != second.group_artifact_id
+
+
+def test_joint_fit_selects_complete_shared_and_camera_covariance() -> None:
+    calibration = _fit_full()
+
+    assert calibration.selected_rank == 3
+    assert calibration.selected_basis_names == _full_layout().basis_names
+    assert calibration.selected_covariance.shape == (3, 3)
+    assert abs(float(calibration.selected_covariance[1, 2])) > 0.01
+    assert joint_visual_bias_layout_from_calibration(calibration) == _full_layout()
+    summary = joint_visual_bias_selection_summary(calibration)
+    assert summary["complete_camera_mode_boundary"] is True
+    assert summary["complete_camera_basis_names"] == ["camera-tangent"]
+    assert tuple(calibration.group_ids) == tuple(
+        f"object-{group_index:02d}" for group_index in range(10)
+    )
+
+
+def test_joint_nuisance_instantiates_one_latent_across_all_cameras() -> None:
+    calibration = _fit_full()
+    group = _full_groups()[0]
+
+    nuisance = build_joint_visual_bias_nuisance_from_calibration(
+        calibration,
+        observation_artifact_id="c" * 64,
+        observation_identity_sha256="d" * 64,
+        row_camera_indices=group.row_camera_indices,
+        shared_bias_jacobian=group.shared_bias_jacobian,
+        camera_bias_jacobian=group.camera_bias_jacobian,
+        metadata={"case_id": "target-free-example"},
+    )
+
+    assert nuisance.bias_ids == ("joint-visual-cameras",)
+    assert nuisance.basis_names == calibration.selected_basis_names
+    assert nuisance.latent_dimension == 3
+    np.testing.assert_array_equal(
+        nuisance.joint_bias_covariance,
+        calibration.selected_covariance,
+    )
+    np.testing.assert_array_equal(
+        nuisance.row_bias_indices,
+        np.zeros(group.row_camera_indices.size, dtype=np.int64),
+    )
+    joint_metadata = nuisance.metadata[JOINT_VISUAL_BIAS_METADATA_KEY]
+    assert joint_metadata["layout_id"] == _full_layout().layout_id
+    assert joint_metadata["camera_row_counts"] == {
+        "camera-0": 16,
+        "camera-1": 16,
+    }
+
+
+def test_joint_calibration_round_trips_through_existing_artifact_path(tmp_path) -> None:
+    calibration = _fit_full()
+    manifest = tmp_path / "joint-visual-bias.json"
+
+    write_visual_bias_calibration(calibration, manifest)
+    loaded = load_visual_bias_calibration(manifest)
+
+    assert loaded.artifact_id == calibration.artifact_id
+    assert joint_visual_bias_layout_from_calibration(loaded) == _full_layout()
+    np.testing.assert_array_equal(
+        loaded.selected_covariance,
+        calibration.selected_covariance,
+    )
+
+
+def test_partial_camera_mode_is_fail_closed_by_default() -> None:
+    arguments = {
+        "provider_manifest_id": "a" * 64,
+        "calibration_source_id": "b" * 64,
+        "group_definition": "complete physical object",
+        "residual_definition": "metric source minus provider point",
+        "uses_truth": True,
+        "covariance_shrinkage": 0.0,
+        "minimum_nll_improvement": 0.0,
+    }
+
+    with pytest.raises(ValueError, match="cuts through a complete camera mode"):
+        fit_joint_visual_bias_calibration(_partial_groups(), **arguments)
+
+    calibration = fit_joint_visual_bias_calibration(
+        _partial_groups(),
+        allow_partial_camera_mode=True,
+        **arguments,
+    )
+    summary = joint_visual_bias_selection_summary(calibration)
+    assert calibration.selected_rank == 1
+    assert summary["complete_camera_mode_boundary"] is False
+    assert summary["partial_camera_basis_name"] == "camera-local"
+    assert summary["partial_camera_ids"] == ["camera-0"]
+
+
+def test_joint_fit_rejects_layout_mismatch_and_reserved_metadata() -> None:
+    groups = list(_full_groups())
+    alternate = JointVisualBiasLayoutV1(
+        camera_ids=("camera-0", "camera-1"),
+        shared_basis_names=("other-shared",),
+        camera_basis_names=("camera-tangent",),
+    )
+    source = groups[-1]
+    groups[-1] = JointVisualBiasCalibrationGroupV1(
+        group_id=source.group_id,
+        layout=alternate,
+        row_camera_indices=source.row_camera_indices,
+        residual=source.residual,
+        shared_bias_jacobian=source.shared_bias_jacobian,
+        camera_bias_jacobian=source.camera_bias_jacobian,
+        conditional_covariance=source.conditional_covariance,
+    )
+    with pytest.raises(ValueError, match="same layout"):
+        fit_joint_visual_bias_calibration(
+            groups,
+            provider_manifest_id="a" * 64,
+            calibration_source_id="b" * 64,
+            group_definition="complete physical object",
+            residual_definition="metric source minus provider point",
+            uses_truth=True,
+        )
+
+    with pytest.raises(ValueError, match="reserved keys"):
+        fit_joint_visual_bias_calibration(
+            _full_groups(),
+            provider_manifest_id="a" * 64,
+            calibration_source_id="b" * 64,
+            group_definition="complete physical object",
+            residual_definition="metric source minus provider point",
+            uses_truth=True,
+            metadata={"nested": {"uses_target_outcomes": False}},
+        )


### PR DESCRIPTION
## Summary

- add a separately versioned, source/calibration-only joint visual-bias wrapper without modifying the frozen single-scope V1 fitter;
- define a content-addressed `JointVisualBiasLayoutV1` with shared modes followed by complete camera-specific mode blocks in deterministic camera order;
- require every complete calibration object/session to contain rows from every declared camera;
- expand shared and camera-local Jacobians into one complete joint design and reuse the established equal-group leave-one-group-out fitter, gauge projection, covariance estimation, artifact persistence, and sidecar path;
- retain the complete selected coefficient covariance, including shared-to-camera and camera-to-camera covariance blocks;
- instantiate one `VisualBiasNuisanceV1` latent across all camera rows rather than independent per-camera copies;
- fail closed by default when nested prefix rank selection cuts through one camera-specific mode, with an explicit exploratory override for asymmetric studies;
- bind the exact layout, complete group artifact identities, covariance semantics, selection policy, information boundary, and camera row counts into immutable metadata;
- recursively reject metadata that declares target outcomes or downstream physical innovations; and
- extend the existing exact-head visual-bias workflow with Ruff, formatting, MyPy, focused/adjacent tests, distribution auditing, and installed-package smoke.

## Why

Several cameras may agree because they share the same provider, object-category, scale, registration, or reconstruction bias. Treating camera sidecars as independent would multiply evidence that is actually common. The new path represents one joint latent once, allows source-calibrated cross-camera covariance, and keeps independent tactile, depth, LiDAR, force, and robot evidence outside the visual-bias factor so those channels can genuinely break the ambiguity.

## Design boundary

The public latent order is:

```text
shared modes,
then camera-specific mode 1 for every camera,
then camera-specific mode 2 for every camera, ...
```

This keeps the existing prefix-rank fitter reusable while making incomplete camera-mode selection detectable. The ordinary `VisualBiasCalibrationV1` JSON/NPZ contract remains the authoritative persisted calibration; the exact joint layout and source-group identities are bound inside its content-addressed metadata.

## Local validation

- the joint-camera prototype passed **50 focused and adjacent tests** covering layout and group identity, immutable expansion, complete covariance recovery, nonzero cross-camera covariance, existing calibration persistence, one-latent sidecar construction, reserved information-boundary keys, and partial-camera fail-closed behavior;
- Python byte compilation passed;
- all added Python and documentation lines satisfy the repository's 100-column convention;
- the branch is one commit directly on current `main` and changes only the eight intended files.

The exact-head workflow remains authoritative for Ruff lint and formatting, strict MyPy, the expanded visual-bias and observation-binding suites, wheel/sdist construction and contents, installed-layout smoke, dependency consistency, and clean-tree verification.

## Claim boundary

This is prospective source-side nuisance calibration infrastructure. It does not establish that the selected basis is complete, that camera errors are stationary, that target coverage is calibrated, that the real provider is competent, that a BayesianPhysTwin update improves a physical query, that a Causal4D intervention is valid, deployment safety, or state of the art. It opens no sealed target payload and changes no frozen estimator, cohort, guard, or result.