### PR TITLE
Update dense-memory documentation with completed evidence

### DIFF
--- a/docs/dense-memory.md
+++ b/docs/dense-memory.md
@@ -29,9 +29,9 @@ prob4d benchmark \
 
 The benchmark report stores a deterministic `prediction_dense_storage` summary
 for each completed sample: retained bytes, the all-`float64` equivalent, field
-count, window count, and retained fraction. This is storage accounting rather
-than a process-RSS measurement; allocator, decompression, and NumPy temporaries
-still depend on the host runtime.
+count, window count, and retained fraction. This storage accounting is separate
+from process RSS because allocator, decompression, and NumPy temporaries depend
+on the host runtime.
 
 ## Numerical boundary
 
@@ -42,7 +42,7 @@ or covariance model. Fused artifacts nevertheless record the mode so held-out
 evaluation cannot silently combine benchmark runs produced under different
 execution contracts.
 
-## Frame-local ray access
+## Frame-local rays and structured covariance
 
 Use `PredictionWindow.rays_at(local_index)` when only one frame is needed.
 `rays()` remains available for compatibility, but builds its output frame by
@@ -50,11 +50,109 @@ frame rather than creating another full-size normalization temporary.
 Cross-fitted overlap disagreement retains only rays for valid overlap rows and
 does not materialize complete ray fields for both windows.
 
-## Remaining measurement work
+Dense fusion preserves structured ray-parallel/lateral covariance until a
+representative covariance-intersection sample or active spatial tile is needed.
+CI weights are still optimized once per complete frame and contributor-mask
+pattern, so `fusion_tile_size` changes temporary memory rather than estimator
+semantics. See [tiled dense fusion](tiled-fusion.md).
 
-These changes halve retained point/flow storage in the benchmark and bound ray
-temporaries in cross-fitted disagreement. Follow-up work under issue #50 should
-preserve structured covariance until selected slices are required, add optional
-memory-mapped loading, and record peak RSS, loading time, disagreement time,
-gauge estimation time, fusion time, and export time for the production
-`25 x 320 x 640` setting before making a runtime or process-memory claim.
+## Memory-mapped prediction stores
+
+Portable prediction members remain compressed NPZ artifacts. For repeated large
+experiments, `prob4d storage materialize` creates a separate content-addressed
+execution cache of ordinary NPY members:
+
+```bash
+prob4d storage materialize \
+  outputs/sequence/predictions.json \
+  outputs/sequence/prediction-store \
+  --dense-storage-dtype float32
+
+prob4d storage validate outputs/sequence/prediction-store
+```
+
+The store verifies the source bundle and every member, publishes atomically,
+and exposes read-only `MMapPredictionWindow` arrays. It does not replace the
+portable provider artifact and may be deleted and regenerated. See
+[memory-mapped prediction execution stores](prediction-store.md).
+
+Run matched loading measurements in separate fresh processes:
+
+```bash
+prob4d storage benchmark outputs/sequence/predictions.json \
+  --backend eager_npz \
+  --dense-storage-dtype float32 \
+  --output-json outputs/sequence/eager-loading.json
+
+prob4d storage benchmark outputs/sequence/prediction-store \
+  --backend mmap_npy \
+  --dense-storage-dtype float32 \
+  --output-json outputs/sequence/mmap-loading.json
+```
+
+## Bounded export and evaluation
+
+The bounded fused-prediction writer stages point and flow arrays in chunks and
+packs symmetric covariance directly into six values per sample. It preserves the
+existing fused-prediction field semantics while trading temporary disk space for
+lower export allocations. See [bounded fused export](bounded-fused-export.md).
+
+Engineering parity and ablation checks may use
+`PredictionWindowTruthView` to reuse one already validated immutable prediction
+window as an explicitly declared internal reference. External truth continues to
+use the defensive `TruthSequence` contract. See
+[zero-copy prediction references](prediction-window-truth-view.md).
+
+Provider metrics and evaluation modes process active rows in bounded chunks. The
+configured chunk size changes temporary memory and timing, not the declared
+metric or estimator semantics. See [streaming evaluation](streaming-evaluation.md).
+
+## Completed full-resolution measurement
+
+Issue #50's frozen real-bundle comparison completed on exact evidence head
+`1e02c868db5e94fb59d60ebab63c0e439a814c81`. It used the non-protected
+Deform360 calibration sequence `002-rope-silk-ep0008`, source frames `[0,59)` at
+`320 x 640`, three 25-frame windows, and two uniform eight-frame overlaps. Eager
+NPZ and mmap NPY arms ran in matched fresh processes.
+
+| Quantity | Eager NPZ | mmap NPY | Change |
+|---|---:|---:|---:|
+| Source-loading peak RSS | 1,766.43 MiB | 1,026.20 MiB | −740.24 MiB (−41.91%) |
+| Maximum process RSS | 5,493.54 MiB | 5,352.92 MiB | −140.62 MiB (−2.56%) |
+| Source-loading time | 6.415 s | 1.257 s | −5.158 s |
+| Total arm wall time | 198.257 s | 188.344 s | −9.913 s (−5.00%) |
+| Persistent input bytes | 855,636,705 | 1,027,712,841 | +172,076,136 bytes |
+
+The total-process peak passed the preregistered 128 MiB absolute-reduction gate
+but not the 10% relative gate. The source-loading peak passed both its 64 MiB
+absolute and 10% relative gates. The locked decision was therefore:
+
+```text
+material_memory_benefit
+```
+
+Every declared semantic comparison passed exactly: source arrays, disagreement
+and uncertainty fields were byte-identical; point, flow, covariance, gauge,
+seam, calibration-state, and provider-evaluation maximum absolute differences
+were zero; and eager/mmap provider exports had equal semantic content and equal
+size. The compact evidence and exact identities are retained on
+[PR #144](https://github.com/IPS-Stuttgart/Prob4D/pull/144).
+
+This is measured backend behavior for one frozen calibration workload. It does
+not establish the same RSS or runtime change on another host, provider, sequence,
+resolution, allocator, compression setting, or model stack.
+
+## Gauge-prior storage
+
+The production causal gauge tree also has an `O(K)` square-root representation.
+It removes the dense prior from runtime algebra after direct sparse construction
+or strict conversion. Existing schema-v4 observation-factor bundles still carry
+the dense covariance and retain their exact identities. See
+[the sparse gauge-tree prior](sparse-gauge-tree-prior.md).
+
+## Claim boundary
+
+Storage accounting, exact parity, and measured RSS/runtime behavior are
+engineering evidence. They do not establish reconstruction accuracy, calibrated
+uncertainty, provider competence, BayesianPhysTwin benefit, Causal4D benefit,
+deployment safety, or state of the art.


### PR DESCRIPTION
## Summary

- replace the stale “remaining measurement work” section with the memory-mapped prediction-store, structured-covariance, tiled-fusion, bounded-export, zero-copy reference, and streaming-evaluation paths already present on `main`;
- document the exact fresh-process commands for eager NPZ and mmap NPY loading benchmarks;
- record issue #50’s frozen full-resolution result on `002-rope-silk-ep0008`, including RSS, loading-time, total-time, persistent-storage, and exact-parity results;
- state the preregistered gate interpretation and locked `material_memory_benefit` decision precisely; and
- retain a strict engineering-only claim boundary.

## Why

`docs/dense-memory.md` still described mmap loading, structured covariance, and production RSS/runtime measurement as future work. Those items have since been implemented and issue #50 completed its frozen evidence run. The stale text could mislead users about the current execution surfaces and the strength and limits of the available measurements.

## Scope

Documentation only. No estimator, artifact, provider, calibration, workflow, package, or frozen result changes.