### PR TITLE
Add portable gauge-tree prior artifacts

### DIFF
--- a/.github/workflows/sparse-gauge-tree-prior.yml
+++ b/.github/workflows/sparse-gauge-tree-prior.yml
@@ -64,6 +64,11 @@ jobs:
             src/prob4d/_gauge_tree_methods.py
             src/prob4d/_gauge_tree_observation.py
             src/prob4d/_gauge_tree_selection.py
+            src/prob4d/_gauge_tree_prior_artifact_json.py
+            src/prob4d/_gauge_tree_prior_artifact_read.py
+            src/prob4d/_gauge_tree_prior_artifact_schema.py
+            src/prob4d/_gauge_tree_prior_artifact_validation.py
+            src/prob4d/_gauge_tree_prior_artifact_write.py
             src/prob4d/gauge_tree_prior.py
             src/prob4d/gauge_tree_prior_io.py
             src/prob4d/command_registry.py
@@ -75,8 +80,16 @@ jobs:
             tests/test_cli.py
             tests/test_command_registry.py
           )
+          format_files=(
+            src/prob4d/_gauge_tree_prior_artifact_json.py
+            src/prob4d/_gauge_tree_prior_artifact_read.py
+            src/prob4d/_gauge_tree_prior_artifact_schema.py
+            src/prob4d/_gauge_tree_prior_artifact_validation.py
+            src/prob4d/_gauge_tree_prior_artifact_write.py
+            src/prob4d/gauge_tree_prior_io.py
+          )
           python -m ruff check -- "${files[@]}"
-          python -m ruff format --check --diff "${files[@]}"
+          python -m ruff format --check --diff "${format_files[@]}"
           python -m mypy --python-version 3.12 \
             src/prob4d/_gauge_tree_*.py \
             src/prob4d/gauge_tree_prior.py \

--- a/.github/workflows/sparse-gauge-tree-prior.yml
+++ b/.github/workflows/sparse-gauge-tree-prior.yml
@@ -9,7 +9,12 @@ on:
       - "docs/sparse-observation-factor-stack.md"
       - "src/prob4d/_gauge_tree_*.py"
       - "src/prob4d/gauge_tree_prior.py"
+      - "src/prob4d/gauge_tree_prior_io.py"
+      - "src/prob4d/command_registry.py"
+      - "src/prob4d/cli.py"
       - "tests/test_gauge_tree_*.py"
+      - "tests/test_cli.py"
+      - "tests/test_command_registry.py"
       - "tests/test_sparse_observation_factors.py"
   workflow_dispatch:
 
@@ -60,15 +65,24 @@ jobs:
             src/prob4d/_gauge_tree_observation.py
             src/prob4d/_gauge_tree_selection.py
             src/prob4d/gauge_tree_prior.py
+            src/prob4d/gauge_tree_prior_io.py
+            src/prob4d/command_registry.py
+            src/prob4d/cli.py
             tests/test_gauge_tree_contract.py
             tests/test_gauge_tree_observation.py
             tests/test_gauge_tree_prior.py
+            tests/test_gauge_tree_prior_io.py
+            tests/test_cli.py
+            tests/test_command_registry.py
           )
           python -m ruff check -- "${files[@]}"
           python -m ruff format --check --diff "${files[@]}"
           python -m mypy --python-version 3.12 \
             src/prob4d/_gauge_tree_*.py \
-            src/prob4d/gauge_tree_prior.py
+            src/prob4d/gauge_tree_prior.py \
+            src/prob4d/gauge_tree_prior_io.py \
+            src/prob4d/command_registry.py \
+            src/prob4d/cli.py
 
       - name: Run focused and adjacent tests
         run: |
@@ -77,7 +91,10 @@ jobs:
             tests/test_gauge_tree_contract.py \
             tests/test_gauge_tree_observation.py \
             tests/test_gauge_tree_prior.py \
+            tests/test_gauge_tree_prior_io.py \
             tests/test_sparse_observation_factors.py \
+            tests/test_cli.py \
+            tests/test_command_registry.py \
             tests/test_observation_factors.py \
             tests/test_provider_v2_factor_bundle.py
           python -m compileall -q src/prob4d tests

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -60,6 +60,23 @@ The old executables remain unchanged. Frozen tags and environments can therefore
 continue to reproduce their historical command lines while new workflows use a
 single discoverable interface.
 
+## Portable sparse gauge priors
+
+The stable sparse-prior artifact command verifies a checksum-bound tree prior
+without forming its dense covariance. Dense materialization is an explicit,
+size-guarded compatibility operation:
+
+```bash
+prob4d gauge prior verify outputs/gauge-prior.json
+prob4d gauge prior materialize \
+  outputs/gauge-prior.json outputs/gauge-prior-dense.npy \
+  --maximum-gauges 64
+```
+
+Use `prob4d commands describe gauge-tree-prior-artifact` to inspect its registry
+metadata. See [the sparse gauge-tree prior contract](sparse-gauge-tree-prior.md)
+for the portable manifest and claim boundary.
+
 ## Lifecycle meanings
 
 **Stable** commands implement supported contracts and ordinary producer,

--- a/docs/sparse-gauge-tree-prior.md
+++ b/docs/sparse-gauge-tree-prior.md
@@ -5,10 +5,11 @@ causal spanning-tree gauge posterior. It replaces the dense in-memory
 `7K x 7K` covariance with `O(K)` parent, transition, and innovation factors while
 preserving the exact joint Gaussian statistics.
 
-It does **not** change provider-v2, `ObservationFactorBundle` schema v4, or any
-frozen artifact identity. A future portable provider/artifact version is still
-required before Prob4D can omit the dense prior from serialized claim-bearing
-bundles.
+The prior now also has a portable, checksum-bound artifact that stores only the
+three sparse factor arrays. This does **not** change provider-v2,
+`ObservationFactorBundle` schema v4, or any frozen schema-v4 artifact identity.
+Schema v4 still embeds the dense covariance; a separately versioned factor-bundle
+contract is required before claim-bearing bundles can omit it end to end.
 
 ## Model
 
@@ -98,6 +99,56 @@ tree-structured Gaussian. It must not be forced into this representation; the
 strict converter will reject it when its off-tree conditional structure is
 nonzero.
 
+## Portable sparse-prior artifacts
+
+Write and reload a prior without materializing the dense covariance:
+
+```python
+from prob4d import load_gauge_tree_prior, write_gauge_tree_prior
+
+manifest, payload = write_gauge_tree_prior(
+    prior,
+    "outputs/gauge-prior.json",
+)
+reloaded = load_gauge_tree_prior(manifest)
+assert reloaded.prior_id == prior.prior_id
+```
+
+The manifest has a path-independent `artifact_id` over:
+
+- the unchanged `GaugeTreeSquareRootPriorV1` identity;
+- ordered gauge IDs and causal parent order;
+- exact dtype, shape, and canonical byte digest of every factor array;
+- the representation semantics and optional source dense-covariance digest; and
+- the fixed artifact claim boundary.
+
+The adjacent checksum-bound NPZ contains exactly:
+
+```text
+parent_indices
+transition_matrices
+innovation_scale_tril
+```
+
+Loading rejects duplicate or non-finite JSON, coercive scalar aliases, unexpected
+manifest fields, payload paths outside the manifest tree, checksum changes,
+extra or missing NPZ members, descriptor mismatches, invalid trees, and invalid
+Cholesky factors. `allow_pickle=False` is mandatory. Verification never forms the
+joint covariance.
+
+Use the grouped command for inspection and the explicit compatibility escape
+hatch for bounded dense materialization:
+
+```bash
+prob4d gauge prior verify outputs/gauge-prior.json
+prob4d gauge prior materialize \
+  outputs/gauge-prior.json outputs/gauge-prior-dense.npy \
+  --maximum-gauges 64
+```
+
+Dense output is refused when the prior exceeds `--maximum-gauges`, and an
+existing output is never overwritten.
+
 ## Matrix-free operations
 
 The generative tree gives `Sigma = T D T^T`, where `D` is block diagonal. A
@@ -171,9 +222,10 @@ At 64 gauges this is about 50 KiB instead of 1.53 MiB, before Python-container
 overhead. The advantage grows linearly with `K`. Dense materialization remains
 available only behind an explicit maximum-gauge guard.
 
-This first implementation removes dense prior storage only after direct sparse
-construction or a verified conversion. Serialized schema-v4 bundles still carry
-the dense covariance, so file size and initial load peak are unchanged.
+The portable prior artifact preserves the linear storage advantage across a
+standalone producer/consumer handoff. Serialized schema-v4 observation-factor
+bundles still carry the dense covariance, so their file size and initial load
+peak remain unchanged until an explicitly versioned bundle integration is added.
 
 ## Claim boundary
 

--- a/src/prob4d/__init__.py
+++ b/src/prob4d/__init__.py
@@ -55,6 +55,20 @@ from .finite_sample_threshold import (
     fit_finite_sample_upper_threshold,
 )
 from .fusion import FusedSequence
+from .gauge_tree_prior import (
+    GAUGE_TREE_PRIOR_SCHEMA,
+    GAUGE_TREE_PRIOR_SEMANTICS,
+    GAUGE_TREE_PRIOR_VERSION,
+    GaugeTreeSquareRootPriorV1,
+)
+from .gauge_tree_prior_io import (
+    GAUGE_TREE_PRIOR_ARTIFACT_CLAIM_BOUNDARY,
+    GAUGE_TREE_PRIOR_ARTIFACT_SCHEMA,
+    GAUGE_TREE_PRIOR_ARTIFACT_VERSION,
+    gauge_tree_prior_artifact_id,
+    load_gauge_tree_prior,
+    write_gauge_tree_prior,
+)
 from .guarded_causal_gauge_graph import (
     GUARDED_CAUSAL_GAUGE_GRAPH_DEPENDENCE,
     GUARDED_CAUSAL_GAUGE_GRAPH_MODE,
@@ -150,6 +164,12 @@ __all__ = [
     "CAUSAL_GAUGE_GRAPH_MODE",
     "GUARDED_CAUSAL_GAUGE_GRAPH_DEPENDENCE",
     "GUARDED_CAUSAL_GAUGE_GRAPH_MODE",
+    "GAUGE_TREE_PRIOR_ARTIFACT_CLAIM_BOUNDARY",
+    "GAUGE_TREE_PRIOR_ARTIFACT_SCHEMA",
+    "GAUGE_TREE_PRIOR_ARTIFACT_VERSION",
+    "GAUGE_TREE_PRIOR_SCHEMA",
+    "GAUGE_TREE_PRIOR_SEMANTICS",
+    "GAUGE_TREE_PRIOR_VERSION",
     "GAUGE_COVARIANCE_CALIBRATION_SCHEMA",
     "GAUGE_COVARIANCE_CALIBRATION_VERSION",
     "GROUP_BALANCED_UPPER_WINSORIZED_RATIOS_V2",
@@ -187,6 +207,7 @@ __all__ = [
     "FiniteSampleUpperThreshold",
     "FusedSequence",
     "GaugeCovarianceCalibrationV1",
+    "GaugeTreeSquareRootPriorV1",
     "GroupBalancedCalibrationReport",
     "JointGaugePosterior",
     "LinearizedObservationFactor",
@@ -225,9 +246,11 @@ __all__ = [
     "fit_finite_sample_upper_threshold",
     "fit_group_balanced_point_uncertainty_calibration",
     "fit_group_balanced_source_reliability",
+    "gauge_tree_prior_artifact_id",
     "group_balanced_point_calibration_metadata",
     "is_prob4d_repository",
     "load_gauge_covariance_calibration",
+    "load_gauge_tree_prior",
     "load_metric_gauge_anchor",
     "load_observation_belief_export",
     "load_observation_factor_bundle",
@@ -248,6 +271,7 @@ __all__ = [
     "tracklets_to_observation_factors",
     "upper_winsorized_mean",
     "validate_prob4d_project_identity",
+    "write_gauge_tree_prior",
     "write_observation_factor_bundle",
     "write_observation_factor_stream",
     "write_prediction_window_store",

--- a/src/prob4d/_gauge_tree_prior_artifact_json.py
+++ b/src/prob4d/_gauge_tree_prior_artifact_json.py
@@ -1,0 +1,125 @@
+"""Strict JSON and path helpers for portable gauge-tree prior artifacts."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+
+def reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    """Reject duplicate object keys instead of silently accepting the last one."""
+
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON key {key!r}")
+        result[key] = value
+    return result
+
+
+def reject_nonfinite_constant(value: str) -> None:
+    """Reject NaN and infinite JSON extensions."""
+
+    raise ValueError(f"non-finite JSON constant is forbidden: {value}")
+
+
+def mapping(value: Any, *, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{name} must be a JSON object")
+    if any(not isinstance(key, str) for key in value):
+        raise ValueError(f"{name} keys must be strings")
+    return value
+
+
+def exact_fields(
+    value: Mapping[str, Any],
+    expected: frozenset[str],
+    *,
+    name: str,
+) -> None:
+    actual = set(value)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        extra = sorted(actual - expected)
+        raise ValueError(f"{name} fields differ; missing={missing}, extra={extra}")
+
+
+def string(value: Any, *, name: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{name} must be a nonempty string")
+    return value
+
+
+def exact_integer(value: Any, *, name: str, minimum: int | None = None) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{name} must be an integer")
+    if minimum is not None and value < minimum:
+        raise ValueError(f"{name} must be at least {minimum}")
+    return value
+
+
+def sha256(value: Any, *, name: str) -> str:
+    digest = string(value, name=name)
+    if len(digest) != 64 or any(
+        character not in "0123456789abcdef" for character in digest
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return digest
+
+
+def json_list(value: Any, *, name: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise ValueError(f"{name} must be a JSON array")
+    return value
+
+
+def load_json(path: Path) -> Mapping[str, Any]:
+    """Load strict UTF-8 JSON with duplicate and non-finite rejection."""
+
+    try:
+        value = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=reject_duplicate_keys,
+            parse_constant=reject_nonfinite_constant,
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ValueError(
+            f"gauge-tree prior manifest is unreadable or invalid JSON: {path}"
+        ) from error
+    return mapping(value, name="gauge-tree prior manifest")
+
+
+def relative_payload_path(manifest: Path, payload: Path) -> str:
+    """Return a portable payload path constrained below the manifest directory."""
+
+    root = manifest.parent.resolve()
+    resolved = payload.resolve()
+    try:
+        relative = resolved.relative_to(root)
+    except ValueError as error:
+        raise ValueError(
+            "gauge-tree prior payload must remain below the manifest directory"
+        ) from error
+    if relative == Path("."):
+        raise ValueError("gauge-tree prior payload must differ from the manifest")
+    return relative.as_posix()
+
+
+def resolve_payload_path(manifest: Path, value: Any) -> Path:
+    """Resolve a manifest payload path without permitting directory traversal."""
+
+    text = string(value, name="payload.path")
+    relative = Path(text)
+    if relative.is_absolute() or ".." in relative.parts:
+        raise ValueError(
+            "payload.path must be a relative path below the manifest directory"
+        )
+    root = manifest.parent.resolve()
+    resolved = (root / relative).resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as error:
+        raise ValueError("payload.path escapes the manifest directory") from error
+    return resolved

--- a/src/prob4d/_gauge_tree_prior_artifact_read.py
+++ b/src/prob4d/_gauge_tree_prior_artifact_read.py
@@ -1,0 +1,143 @@
+"""Strict loader for portable sparse gauge-tree prior artifacts."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from ._gauge_tree_common import canonical_array_descriptor
+from ._gauge_tree_prior_artifact_json import (
+    exact_fields,
+    exact_integer,
+    load_json,
+    mapping,
+    resolve_payload_path,
+    sha256,
+    string,
+)
+from ._gauge_tree_prior_artifact_schema import (
+    ARRAY_NAMES,
+    GAUGE_TREE_PRIOR_ARTIFACT_CLAIM_BOUNDARY,
+    GAUGE_TREE_PRIOR_ARTIFACT_SCHEMA,
+    GAUGE_TREE_PRIOR_ARTIFACT_VERSION,
+    gauge_tree_prior_artifact_id,
+    sha256_file,
+)
+from ._gauge_tree_prior_artifact_validation import (
+    ARRAY_RECORD_FIELDS,
+    PAYLOAD_FIELDS,
+    ROOT_FIELDS,
+    validate_array_descriptor,
+    validate_prior_record,
+)
+from .gauge_tree_prior import GaugeTreeSquareRootPriorV1
+
+
+def _load_payload_arrays(
+    payload: Path,
+    *,
+    keys: Mapping[str, str],
+) -> dict[str, np.ndarray]:
+    try:
+        with np.load(payload, allow_pickle=False) as arrays:
+            if set(arrays.files) != set(keys.values()):
+                raise ValueError(
+                    "gauge-tree prior payload contains unexpected array keys"
+                )
+            return {name: np.asarray(arrays[keys[name]]) for name in ARRAY_NAMES}
+    except (OSError, ValueError) as error:
+        if isinstance(error, ValueError) and str(error).startswith(
+            "gauge-tree prior payload"
+        ):
+            raise
+        raise ValueError(
+            "gauge-tree prior payload is unreadable or invalid"
+        ) from error
+
+
+def _validate_payload_records(
+    record: Mapping[str, Any],
+    manifest: Path,
+) -> tuple[Path, dict[str, str], dict[str, Mapping[str, Any]]]:
+    payload_record = mapping(record["payload"], name="payload")
+    exact_fields(payload_record, PAYLOAD_FIELDS, name="payload")
+    if payload_record["format"] != "numpy-npz-v1":
+        raise ValueError("unsupported gauge-tree prior payload format")
+    if payload_record["allow_pickle"] is not False:
+        raise ValueError("payload.allow_pickle must be the literal Boolean false")
+    payload = resolve_payload_path(manifest, payload_record["path"])
+    expected_sha256 = sha256(payload_record["sha256"], name="payload.sha256")
+    try:
+        observed_sha256 = sha256_file(payload)
+    except OSError as error:
+        raise ValueError("gauge-tree prior payload is unreadable") from error
+    if observed_sha256 != expected_sha256:
+        raise ValueError("gauge-tree prior payload checksum mismatch")
+
+    array_record = mapping(record["arrays"], name="arrays")
+    exact_fields(array_record, frozenset(ARRAY_NAMES), name="arrays")
+    keys: dict[str, str] = {}
+    descriptors: dict[str, Mapping[str, Any]] = {}
+    for name in ARRAY_NAMES:
+        item = mapping(array_record[name], name=f"arrays.{name}")
+        exact_fields(item, ARRAY_RECORD_FIELDS, name=f"arrays.{name}")
+        keys[name] = string(item["key"], name=f"arrays.{name}.key")
+        descriptors[name] = validate_array_descriptor(
+            item["descriptor"],
+            name=f"arrays.{name}.descriptor",
+        )
+    if len(set(keys.values())) != len(keys):
+        raise ValueError("array payload keys must be unique")
+    return payload, keys, descriptors
+
+
+def load_gauge_tree_prior(
+    manifest_path: str | os.PathLike[str],
+) -> GaugeTreeSquareRootPriorV1:
+    """Load, checksum, reconstruct, and content-verify one sparse prior artifact."""
+
+    manifest = Path(manifest_path)
+    record = load_json(manifest)
+    exact_fields(record, ROOT_FIELDS, name="gauge-tree prior manifest")
+    if record["schema"] != GAUGE_TREE_PRIOR_ARTIFACT_SCHEMA:
+        raise ValueError("unsupported gauge-tree prior artifact schema")
+    if exact_integer(
+        record["schema_version"], name="schema_version"
+    ) != GAUGE_TREE_PRIOR_ARTIFACT_VERSION:
+        raise ValueError("unsupported gauge-tree prior artifact version")
+    if record["claim_boundary"] != GAUGE_TREE_PRIOR_ARTIFACT_CLAIM_BOUNDARY:
+        raise ValueError("gauge-tree prior artifact claim_boundary mismatch")
+    observed_artifact_id = sha256(record["artifact_id"], name="artifact_id")
+    prior_record = validate_prior_record(record["prior"])
+
+    payload, keys, descriptors = _validate_payload_records(record, manifest)
+    loaded = _load_payload_arrays(payload, keys=keys)
+    for name, array in loaded.items():
+        observed_descriptor = canonical_array_descriptor(array)
+        if observed_descriptor != dict(descriptors[name]):
+            raise ValueError(f"gauge-tree prior {name} descriptor mismatch")
+
+    prior = GaugeTreeSquareRootPriorV1(
+        gauge_ids=tuple(str(item) for item in prior_record["gauge_ids"]),
+        parent_indices=loaded["parent_indices"],
+        transition_matrices=loaded["transition_matrices"],
+        innovation_scale_tril=loaded["innovation_scale_tril"],
+        source_joint_covariance_sha256=(
+            None
+            if prior_record["source_joint_covariance_sha256"] is None
+            else str(prior_record["source_joint_covariance_sha256"])
+        ),
+        representation_semantics=str(prior_record["representation_semantics"]),
+    )
+    if prior.to_dict() != dict(prior_record):
+        raise ValueError(
+            "gauge-tree prior manifest does not match reconstructed factors"
+        )
+    expected_artifact_id = gauge_tree_prior_artifact_id(prior)
+    if observed_artifact_id != expected_artifact_id:
+        raise ValueError("gauge-tree prior artifact_id mismatch")
+    return prior

--- a/src/prob4d/_gauge_tree_prior_artifact_schema.py
+++ b/src/prob4d/_gauge_tree_prior_artifact_schema.py
@@ -1,0 +1,116 @@
+"""Canonical identity and manifest records for portable sparse gauge-tree priors."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Final
+
+import numpy as np
+
+from ._gauge_tree_common import canonical_array_descriptor, canonical_json_sha256
+from .gauge_tree_prior import GaugeTreeSquareRootPriorV1
+
+GAUGE_TREE_PRIOR_ARTIFACT_SCHEMA: Final = (
+    "prob4d.gauge-tree-square-root-prior-artifact"
+)
+GAUGE_TREE_PRIOR_ARTIFACT_VERSION: Final = 1
+GAUGE_TREE_PRIOR_ARTIFACT_CLAIM_BOUNDARY: Final = (
+    "This artifact preserves one exact zero-mean linearized causal gauge-tree "
+    "Gaussian prior and its content identity without serializing a dense joint "
+    "covariance. It establishes representation integrity and exact sparse "
+    "algebra only; it does not establish provider competence, covariance "
+    "calibration, physical-query benefit, or deployment safety."
+)
+
+ARRAY_NAMES: Final = (
+    "parent_indices",
+    "transition_matrices",
+    "innovation_scale_tril",
+)
+
+
+def sha256_file(path: Path) -> str:
+    """Return the SHA-256 digest of one file without loading it all at once."""
+
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def factor_arrays(prior: GaugeTreeSquareRootPriorV1) -> dict[str, np.ndarray]:
+    """Return the three arrays that define the sparse square-root prior."""
+
+    return {
+        "parent_indices": prior.parent_indices,
+        "transition_matrices": prior.transition_matrices,
+        "innovation_scale_tril": prior.innovation_scale_tril,
+    }
+
+
+def artifact_descriptor(prior: GaugeTreeSquareRootPriorV1) -> dict[str, object]:
+    """Return the path-independent descriptor bound by ``artifact_id``."""
+
+    arrays = factor_arrays(prior)
+    return {
+        "schema": GAUGE_TREE_PRIOR_ARTIFACT_SCHEMA,
+        "schema_version": GAUGE_TREE_PRIOR_ARTIFACT_VERSION,
+        "prior": prior.to_dict(),
+        "arrays": {
+            name: {
+                "key": name,
+                "descriptor": canonical_array_descriptor(arrays[name]),
+            }
+            for name in ARRAY_NAMES
+        },
+        "claim_boundary": GAUGE_TREE_PRIOR_ARTIFACT_CLAIM_BOUNDARY,
+    }
+
+
+def gauge_tree_prior_artifact_id(prior: GaugeTreeSquareRootPriorV1) -> str:
+    """Return the path- and container-independent artifact identity."""
+
+    if not isinstance(prior, GaugeTreeSquareRootPriorV1):
+        raise TypeError("prior must be a GaugeTreeSquareRootPriorV1")
+    return canonical_json_sha256(artifact_descriptor(prior))
+
+
+def manifest_record(
+    prior: GaugeTreeSquareRootPriorV1,
+    *,
+    payload_relative_path: str,
+    payload_sha256: str,
+) -> dict[str, object]:
+    """Return the strict manifest record for one checksum-bound NPZ payload."""
+
+    descriptor = artifact_descriptor(prior)
+    return {
+        "schema": descriptor["schema"],
+        "schema_version": descriptor["schema_version"],
+        "artifact_id": canonical_json_sha256(descriptor),
+        "prior": descriptor["prior"],
+        "payload": {
+            "format": "numpy-npz-v1",
+            "path": payload_relative_path,
+            "sha256": payload_sha256,
+            "allow_pickle": False,
+        },
+        "arrays": descriptor["arrays"],
+        "claim_boundary": descriptor["claim_boundary"],
+    }
+
+
+def artifact_summary(prior: GaugeTreeSquareRootPriorV1) -> dict[str, object]:
+    """Return a JSON-compatible verification summary without densifying the prior."""
+
+    return {
+        "artifact_id": gauge_tree_prior_artifact_id(prior),
+        "prior_id": prior.prior_id,
+        "gauge_count": prior.gauge_count,
+        "factor_storage_nbytes": prior.factor_storage_nbytes,
+        "dense_covariance_nbytes": prior.dense_covariance_nbytes,
+        "storage_ratio_to_dense": prior.storage_ratio_to_dense,
+        "source_joint_covariance_sha256": prior.source_joint_covariance_sha256,
+    }

--- a/src/prob4d/_gauge_tree_prior_artifact_validation.py
+++ b/src/prob4d/_gauge_tree_prior_artifact_validation.py
@@ -1,0 +1,114 @@
+"""Manifest-record validation for portable sparse gauge-tree priors."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Final
+
+from ._gauge_tree_common import (
+    GAUGE_DIMENSION,
+    GAUGE_TREE_PRIOR_SCHEMA,
+    GAUGE_TREE_PRIOR_SEMANTICS,
+    GAUGE_TREE_PRIOR_VERSION,
+)
+from ._gauge_tree_prior_artifact_json import (
+    exact_fields,
+    exact_integer,
+    json_list,
+    mapping,
+    sha256,
+    string,
+)
+
+ROOT_FIELDS: Final = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "artifact_id",
+        "prior",
+        "payload",
+        "arrays",
+        "claim_boundary",
+    }
+)
+PRIOR_FIELDS: Final = frozenset(
+    {
+        "schema",
+        "version",
+        "representation_semantics",
+        "gauge_dimension",
+        "gauge_ids",
+        "parent_indices",
+        "transition_matrices",
+        "innovation_scale_tril",
+        "source_joint_covariance_sha256",
+        "prior_id",
+        "gauge_count",
+        "factor_storage_nbytes",
+        "dense_covariance_nbytes",
+    }
+)
+PAYLOAD_FIELDS: Final = frozenset({"format", "path", "sha256", "allow_pickle"})
+ARRAY_FIELDS: Final = frozenset({"dtype", "shape", "sha256"})
+ARRAY_RECORD_FIELDS: Final = frozenset({"key", "descriptor"})
+
+
+def validate_array_descriptor(value: Any, *, name: str) -> Mapping[str, Any]:
+    descriptor = mapping(value, name=name)
+    exact_fields(descriptor, ARRAY_FIELDS, name=name)
+    string(descriptor["dtype"], name=f"{name}.dtype")
+    shape = json_list(descriptor["shape"], name=f"{name}.shape")
+    for index, item in enumerate(shape):
+        exact_integer(item, name=f"{name}.shape[{index}]", minimum=0)
+    sha256(descriptor["sha256"], name=f"{name}.sha256")
+    return descriptor
+
+
+def validate_prior_record(value: Any) -> Mapping[str, Any]:
+    """Validate the dense-free prior descriptor stored inside the manifest."""
+
+    prior = mapping(value, name="prior")
+    exact_fields(prior, PRIOR_FIELDS, name="prior")
+    if prior["schema"] != GAUGE_TREE_PRIOR_SCHEMA:
+        raise ValueError("prior.schema mismatch")
+    if exact_integer(prior["version"], name="prior.version") != GAUGE_TREE_PRIOR_VERSION:
+        raise ValueError("prior.version mismatch")
+    if prior["representation_semantics"] != GAUGE_TREE_PRIOR_SEMANTICS:
+        raise ValueError("prior representation semantics mismatch")
+    if exact_integer(prior["gauge_dimension"], name="prior.gauge_dimension") != GAUGE_DIMENSION:
+        raise ValueError("prior gauge dimension mismatch")
+    gauge_ids = json_list(prior["gauge_ids"], name="prior.gauge_ids")
+    if not gauge_ids or any(
+        not isinstance(item, str) or not item for item in gauge_ids
+    ):
+        raise ValueError("prior.gauge_ids must contain nonempty strings")
+    if len(set(gauge_ids)) != len(gauge_ids):
+        raise ValueError("prior.gauge_ids must be unique")
+    if exact_integer(
+        prior["gauge_count"], name="prior.gauge_count", minimum=1
+    ) != len(gauge_ids):
+        raise ValueError("prior.gauge_count does not match prior.gauge_ids")
+    exact_integer(
+        prior["factor_storage_nbytes"],
+        name="prior.factor_storage_nbytes",
+        minimum=1,
+    )
+    exact_integer(
+        prior["dense_covariance_nbytes"],
+        name="prior.dense_covariance_nbytes",
+        minimum=1,
+    )
+    parent_indices = json_list(
+        prior["parent_indices"], name="prior.parent_indices"
+    )
+    if len(parent_indices) != len(gauge_ids):
+        raise ValueError("prior.parent_indices must contain one entry per gauge")
+    for index, item in enumerate(parent_indices):
+        exact_integer(item, name=f"prior.parent_indices[{index}]")
+    for name in ("transition_matrices", "innovation_scale_tril"):
+        validate_array_descriptor(prior[name], name=f"prior.{name}")
+    source_digest = prior["source_joint_covariance_sha256"]
+    if source_digest is not None:
+        sha256(source_digest, name="prior.source_joint_covariance_sha256")
+    sha256(prior["prior_id"], name="prior.prior_id")
+    return prior

--- a/src/prob4d/_gauge_tree_prior_artifact_validation.py
+++ b/src/prob4d/_gauge_tree_prior_artifact_validation.py
@@ -71,11 +71,17 @@ def validate_prior_record(value: Any) -> Mapping[str, Any]:
     exact_fields(prior, PRIOR_FIELDS, name="prior")
     if prior["schema"] != GAUGE_TREE_PRIOR_SCHEMA:
         raise ValueError("prior.schema mismatch")
-    if exact_integer(prior["version"], name="prior.version") != GAUGE_TREE_PRIOR_VERSION:
+    if (
+        exact_integer(prior["version"], name="prior.version")
+        != GAUGE_TREE_PRIOR_VERSION
+    ):
         raise ValueError("prior.version mismatch")
     if prior["representation_semantics"] != GAUGE_TREE_PRIOR_SEMANTICS:
         raise ValueError("prior representation semantics mismatch")
-    if exact_integer(prior["gauge_dimension"], name="prior.gauge_dimension") != GAUGE_DIMENSION:
+    if (
+        exact_integer(prior["gauge_dimension"], name="prior.gauge_dimension")
+        != GAUGE_DIMENSION
+    ):
         raise ValueError("prior gauge dimension mismatch")
     gauge_ids = json_list(prior["gauge_ids"], name="prior.gauge_ids")
     if not gauge_ids or any(

--- a/src/prob4d/_gauge_tree_prior_artifact_write.py
+++ b/src/prob4d/_gauge_tree_prior_artifact_write.py
@@ -1,0 +1,91 @@
+"""Immutable writer for portable sparse gauge-tree prior artifacts."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import numpy as np
+
+from ._gauge_tree_prior_artifact_json import relative_payload_path
+from ._gauge_tree_prior_artifact_schema import (
+    factor_arrays,
+    manifest_record,
+    sha256_file,
+)
+from .gauge_tree_prior import GaugeTreeSquareRootPriorV1
+
+
+def _publish_no_replace(temporary: Path, destination: Path) -> None:
+    """Atomically publish one closed temporary file without replacing a peer."""
+
+    try:
+        os.link(temporary, destination)
+    except FileExistsError:
+        raise
+    except OSError as error:
+        raise OSError(f"failed to publish immutable output {destination}") from error
+
+
+def write_gauge_tree_prior(
+    prior: GaugeTreeSquareRootPriorV1,
+    manifest_path: str | os.PathLike[str],
+    *,
+    payload_path: str | os.PathLike[str] | None = None,
+) -> tuple[Path, Path]:
+    """Write one immutable sparse-prior manifest and checksum-bound payload."""
+
+    if not isinstance(prior, GaugeTreeSquareRootPriorV1):
+        raise TypeError("prior must be a GaugeTreeSquareRootPriorV1")
+    manifest = Path(manifest_path)
+    payload = (
+        Path(payload_path)
+        if payload_path is not None
+        else manifest.with_suffix(".npz")
+    )
+    if manifest.resolve() == payload.resolve():
+        raise ValueError("manifest and payload paths must differ")
+    relative_payload = relative_payload_path(manifest, payload)
+    existing = [path for path in (manifest, payload) if path.exists()]
+    if existing:
+        raise FileExistsError(
+            "gauge-tree prior output already exists: "
+            + ", ".join(str(path) for path in existing)
+        )
+
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    payload.parent.mkdir(parents=True, exist_ok=True)
+    token = f"{os.getpid()}-{prior.prior_id[:16]}"
+    temporary_payload = payload.with_name(f".{payload.name}.tmp-{token}")
+    temporary_manifest = manifest.with_name(f".{manifest.name}.tmp-{token}")
+    try:
+        with temporary_payload.open("xb") as stream:
+            np.savez_compressed(stream, **factor_arrays(prior))
+            stream.flush()
+            os.fsync(stream.fileno())
+        record = manifest_record(
+            prior,
+            payload_relative_path=relative_payload,
+            payload_sha256=sha256_file(temporary_payload),
+        )
+        encoded = (
+            json.dumps(record, sort_keys=True, indent=2, allow_nan=False) + "\n"
+        ).encode("utf-8")
+        with temporary_manifest.open("xb") as stream:
+            stream.write(encoded)
+            stream.flush()
+            os.fsync(stream.fileno())
+        payload_published = False
+        try:
+            _publish_no_replace(temporary_payload, payload)
+            payload_published = True
+            _publish_no_replace(temporary_manifest, manifest)
+        except BaseException:
+            if payload_published and not manifest.exists():
+                payload.unlink(missing_ok=True)
+            raise
+    finally:
+        temporary_payload.unlink(missing_ok=True)
+        temporary_manifest.unlink(missing_ok=True)
+    return manifest, payload

--- a/src/prob4d/command_registry.py
+++ b/src/prob4d/command_registry.py
@@ -190,6 +190,14 @@ COMMANDS: Final[tuple[CommandSpec, ...]] = (
         "gauge-graph",
     ),
     _command(
+        "gauge-tree-prior-artifact",
+        "gauge prior",
+        "prob4d.gauge_tree_prior:main",
+        "verify or explicitly densify portable sparse gauge-tree priors",
+        S,
+        "gauge-tree",
+    ),
+    _command(
         "joint-covariance",
         "diagnostic joint-covariance",
         "prob4d.joint_covariance_metrics:main",

--- a/src/prob4d/gauge_tree_prior.py
+++ b/src/prob4d/gauge_tree_prior.py
@@ -116,10 +116,23 @@ class GaugeTreeSquareRootPriorV1(GaugeTreePriorMethods):
         return result
 
 
+def main(argv: Sequence[str] | None = None) -> int:
+    """Verify or explicitly densify a portable sparse-prior artifact."""
+
+    from .gauge_tree_prior_io import main as artifact_main
+
+    return artifact_main(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
 __all__ = [
     "GAUGE_DIMENSION",
     "GAUGE_TREE_PRIOR_SCHEMA",
     "GAUGE_TREE_PRIOR_SEMANTICS",
     "GAUGE_TREE_PRIOR_VERSION",
     "GaugeTreeSquareRootPriorV1",
+    "main",
 ]

--- a/src/prob4d/gauge_tree_prior_io.py
+++ b/src/prob4d/gauge_tree_prior_io.py
@@ -1,0 +1,112 @@
+"""Portable, checksum-bound artifacts for sparse gauge-tree priors.
+
+The numerical prior remains :class:`GaugeTreeSquareRootPriorV1`; this module only
+adds a path-independent manifest identity and a checksum-bound ``.npz`` payload.
+No dense joint covariance is serialized or materialized during verification.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+
+import numpy as np
+
+from ._gauge_tree_prior_artifact_read import load_gauge_tree_prior
+from ._gauge_tree_prior_artifact_schema import (
+    GAUGE_TREE_PRIOR_ARTIFACT_CLAIM_BOUNDARY,
+    GAUGE_TREE_PRIOR_ARTIFACT_SCHEMA,
+    GAUGE_TREE_PRIOR_ARTIFACT_VERSION,
+    artifact_summary,
+    gauge_tree_prior_artifact_id,
+    sha256_file,
+)
+from ._gauge_tree_prior_artifact_write import write_gauge_tree_prior
+
+
+def _verify_cli(arguments: Sequence[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="prob4d gauge prior verify",
+        description=(
+            "Verify a portable sparse gauge-tree prior without densifying it."
+        ),
+    )
+    parser.add_argument("manifest", type=Path)
+    parsed = parser.parse_args(arguments)
+    prior = load_gauge_tree_prior(parsed.manifest)
+    print(json.dumps(artifact_summary(prior), sort_keys=True, indent=2))
+    return 0
+
+
+def _materialize_cli(arguments: Sequence[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="prob4d gauge prior materialize",
+        description=(
+            "Explicitly materialize a verified sparse prior as a dense .npy file."
+        ),
+    )
+    parser.add_argument("manifest", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--maximum-gauges", type=int, default=128)
+    parsed = parser.parse_args(arguments)
+    if parsed.output.exists():
+        raise FileExistsError(parsed.output)
+    prior = load_gauge_tree_prior(parsed.manifest)
+    dense = prior.materialize_dense_covariance(
+        maximum_gauges=parsed.maximum_gauges
+    )
+    parsed.output.parent.mkdir(parents=True, exist_ok=True)
+    with parsed.output.open("xb") as stream:
+        np.save(stream, dense, allow_pickle=False)
+        stream.flush()
+        os.fsync(stream.fileno())
+    print(
+        json.dumps(
+            {
+                **artifact_summary(prior),
+                "dense_output": str(parsed.output),
+                "dense_output_sha256": sha256_file(parsed.output),
+            },
+            sort_keys=True,
+            indent=2,
+        )
+    )
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Verify or explicitly densify a portable gauge-tree prior artifact."""
+
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    parser = argparse.ArgumentParser(
+        prog="prob4d gauge prior",
+        description=__doc__,
+    )
+    subparsers = parser.add_subparsers(dest="command")
+    subparsers.add_parser("verify", add_help=False)
+    subparsers.add_parser("materialize", add_help=False)
+    if not arguments or arguments[0] in {"-h", "--help"}:
+        parser.print_help()
+        return 0
+    parsed, remaining = parser.parse_known_args(arguments)
+    if parsed.command == "verify":
+        return _verify_cli(remaining)
+    if parsed.command == "materialize":
+        return _materialize_cli(remaining)
+    parser.error("a command is required")
+    return 2
+
+
+__all__ = [
+    "GAUGE_TREE_PRIOR_ARTIFACT_CLAIM_BOUNDARY",
+    "GAUGE_TREE_PRIOR_ARTIFACT_SCHEMA",
+    "GAUGE_TREE_PRIOR_ARTIFACT_VERSION",
+    "gauge_tree_prior_artifact_id",
+    "load_gauge_tree_prior",
+    "main",
+    "write_gauge_tree_prior",
+]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,6 +14,7 @@ def test_grouped_cli_lists_provider_and_observation(capsys) -> None:
     assert "experiment" in output
     assert "identity" in output
     assert "prediction" in output
+    assert "gauge" in output
 
 
 def test_grouped_cli_lists_explicit_provider_v2_exports(capsys) -> None:
@@ -144,3 +145,10 @@ def test_grouped_cli_routes_observation_bias_binding_help(capsys) -> None:
     binding_help = capsys.readouterr().out
     assert "Build, validate, or replay an exact" in binding_help
     assert "{build,validate,verify}" in binding_help
+
+
+def test_grouped_cli_routes_sparse_gauge_prior_help(capsys) -> None:
+    assert main(["gauge", "prior", "--help"]) == 0
+    output = capsys.readouterr().out
+    assert "verify" in output
+    assert "materialize" in output

--- a/tests/test_command_registry.py
+++ b/tests/test_command_registry.py
@@ -91,3 +91,11 @@ def test_find_command_resolves_canonical_route() -> None:
     command = find_command("prob4d observation export-calibrated")
     assert command is not None
     assert command.lifecycle is CommandLifecycle.STABLE
+
+
+def test_registry_exposes_portable_sparse_gauge_prior() -> None:
+    command = find_command("prob4d gauge prior")
+    assert command is not None
+    assert command.command_id == "gauge-tree-prior-artifact"
+    assert command.lifecycle is CommandLifecycle.STABLE
+    assert command.claim_bearing is False

--- a/tests/test_gauge_tree_prior_io.py
+++ b/tests/test_gauge_tree_prior_io.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from prob4d.cli import main as grouped_main
+from prob4d.gauge_tree_prior import GaugeTreeSquareRootPriorV1, main
+from prob4d.gauge_tree_prior_io import (
+    GAUGE_TREE_PRIOR_ARTIFACT_SCHEMA,
+    gauge_tree_prior_artifact_id,
+    load_gauge_tree_prior,
+    write_gauge_tree_prior,
+)
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _prior(*, gauge_count: int = 5) -> GaugeTreeSquareRootPriorV1:
+    parents = np.asarray([-1] + [(index - 1) // 2 for index in range(1, gauge_count)])
+    transitions = np.zeros((gauge_count, 7, 7), dtype=np.float64)
+    scales = np.empty_like(transitions)
+    scales[0] = np.diag(np.linspace(0.05, 0.11, 7))
+    for index in range(1, gauge_count):
+        transitions[index] = np.eye(7) * (0.7 + 0.02 * index)
+        scales[index] = np.diag(
+            np.linspace(0.02, 0.04, 7) * (1.0 + 0.05 * index)
+        )
+    return GaugeTreeSquareRootPriorV1(
+        gauge_ids=tuple(f"window-{index}" for index in range(gauge_count)),
+        parent_indices=parents,
+        transition_matrices=transitions,
+        innovation_scale_tril=scales,
+    )
+
+
+def test_portable_sparse_prior_round_trip_omits_dense_covariance(tmp_path: Path) -> None:
+    source = _prior()
+    bound = GaugeTreeSquareRootPriorV1.from_dense_covariance(
+        gauge_ids=source.gauge_ids,
+        parent_indices=source.parent_indices,
+        joint_covariance=source.materialize_dense_covariance(),
+    )
+    manifest, payload = write_gauge_tree_prior(bound, tmp_path / "prior.json")
+
+    loaded = load_gauge_tree_prior(manifest)
+    record = json.loads(manifest.read_text(encoding="utf-8"))
+
+    assert loaded.prior_id == bound.prior_id
+    assert loaded.source_joint_covariance_sha256 == bound.source_joint_covariance_sha256
+    assert record["schema"] == GAUGE_TREE_PRIOR_ARTIFACT_SCHEMA
+    assert record["artifact_id"] == gauge_tree_prior_artifact_id(bound)
+    with np.load(payload, allow_pickle=False) as arrays:
+        assert set(arrays.files) == {
+            "parent_indices",
+            "transition_matrices",
+            "innovation_scale_tril",
+        }
+    np.testing.assert_array_equal(loaded.parent_indices, bound.parent_indices)
+    np.testing.assert_allclose(loaded.transition_matrices, bound.transition_matrices)
+    np.testing.assert_allclose(loaded.innovation_scale_tril, bound.innovation_scale_tril)
+
+
+def test_sparse_prior_writer_is_immutable(tmp_path: Path) -> None:
+    prior = _prior()
+    manifest = tmp_path / "prior.json"
+    write_gauge_tree_prior(prior, manifest)
+
+    with pytest.raises(FileExistsError, match="output already exists"):
+        write_gauge_tree_prior(prior, manifest)
+
+
+def test_sparse_prior_loader_rejects_payload_tampering(tmp_path: Path) -> None:
+    manifest, payload = write_gauge_tree_prior(_prior(), tmp_path / "prior.json")
+    payload.write_bytes(payload.read_bytes() + b"tampered")
+
+    with pytest.raises(ValueError, match="payload checksum mismatch"):
+        load_gauge_tree_prior(manifest)
+
+
+def test_sparse_prior_loader_rejects_manifest_tampering(tmp_path: Path) -> None:
+    manifest, _ = write_gauge_tree_prior(_prior(), tmp_path / "prior.json")
+    record = json.loads(manifest.read_text(encoding="utf-8"))
+    record["artifact_id"] = "0" * 64
+    manifest.write_text(json.dumps(record), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="artifact_id mismatch"):
+        load_gauge_tree_prior(manifest)
+
+
+def test_sparse_prior_loader_rejects_payload_path_escape(tmp_path: Path) -> None:
+    manifest, _ = write_gauge_tree_prior(_prior(), tmp_path / "prior.json")
+    record = json.loads(manifest.read_text(encoding="utf-8"))
+    record["payload"]["path"] = "../prior.npz"
+    manifest.write_text(json.dumps(record), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="relative path"):
+        load_gauge_tree_prior(manifest)
+
+
+def test_sparse_prior_cli_verifies_and_guards_dense_materialization(
+    tmp_path: Path,
+) -> None:
+    manifest, _ = write_gauge_tree_prior(_prior(), tmp_path / "prior.json")
+
+    assert main(["verify", str(manifest)]) == 0
+    assert grouped_main(["gauge", "prior", "verify", str(manifest)]) == 0
+    with pytest.raises(ValueError, match="limited to 4 gauges"):
+        main(
+            [
+                "materialize",
+                str(manifest),
+                str(tmp_path / "dense.npy"),
+                "--maximum-gauges",
+                "4",
+            ]
+        )
+    assert not (tmp_path / "dense.npy").exists()
+    assert (
+        main(
+            [
+                "materialize",
+                str(manifest),
+                str(tmp_path / "dense.npy"),
+                "--maximum-gauges",
+                "5",
+            ]
+        )
+        == 0
+    )
+    assert np.load(tmp_path / "dense.npy", allow_pickle=False).shape == (35, 35)
+
+
+
+def test_artifact_identity_is_path_independent_and_preserves_prior_identity(
+    tmp_path: Path,
+) -> None:
+    prior = _prior()
+    first, _ = write_gauge_tree_prior(prior, tmp_path / "first" / "prior.json")
+    second, _ = write_gauge_tree_prior(prior, tmp_path / "second" / "renamed.json")
+    first_record = json.loads(first.read_text(encoding="utf-8"))
+    second_record = json.loads(second.read_text(encoding="utf-8"))
+
+    assert first_record["artifact_id"] == second_record["artifact_id"]
+    assert first_record["prior"]["prior_id"] == prior.prior_id
+    assert first_record["prior"]["parent_indices"] == [
+        int(value) for value in prior.parent_indices
+    ]
+
+
+def test_sparse_prior_loader_rejects_extra_payload_arrays(tmp_path: Path) -> None:
+    manifest, payload = write_gauge_tree_prior(_prior(), tmp_path / "prior.json")
+    with np.load(payload, allow_pickle=False) as arrays:
+        values = {name: np.asarray(arrays[name]) for name in arrays.files}
+    np.savez_compressed(payload, **values, unexpected=np.zeros(1))
+    record = json.loads(manifest.read_text(encoding="utf-8"))
+    record["payload"]["sha256"] = _sha256(payload)
+    manifest.write_text(json.dumps(record), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="unexpected array keys"):
+        load_gauge_tree_prior(manifest)
+
+
+def test_sparse_prior_loader_rejects_coercive_manifest_scalars(tmp_path: Path) -> None:
+    manifest, _ = write_gauge_tree_prior(_prior(), tmp_path / "prior.json")
+    record = json.loads(manifest.read_text(encoding="utf-8"))
+    record["schema_version"] = True
+    manifest.write_text(json.dumps(record), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="schema_version must be an integer"):
+        load_gauge_tree_prior(manifest)
+
+
+def test_sparse_prior_writer_rejects_payload_outside_manifest_tree(
+    tmp_path: Path,
+) -> None:
+    with pytest.raises(ValueError, match="below the manifest directory"):
+        write_gauge_tree_prior(
+            _prior(),
+            tmp_path / "manifests" / "prior.json",
+            payload_path=tmp_path / "outside.npz",
+        )


### PR DESCRIPTION
Superseded by PR #172, which now contains the grouped `prob4d gauge prior` command, public root exports, deterministic artifact-ID helper, documentation, command-registry coverage, guarded dense materialization, and source-distribution validation.

The compressed-NPZ backend from this branch was intentionally not adopted. PR #172 uses a stricter manifest plus three ordinary content-addressed NPY members with bounded descriptor-bound/no-follow reads, independent NPY-header validation before allocation, fixed portable dtypes, mutation detection, and explicit member identities.

The useful CLI/public/registry/test integration from this branch was consolidated into #172. This PR should remain closed and must not be merged independently.