### PR TITLE
[Superseded by #172] Add portable sparse gauge-tree prior artifacts

### DIFF
--- a/.github/workflows/sparse-gauge-tree-prior.yml
+++ b/.github/workflows/sparse-gauge-tree-prior.yml
@@ -109,7 +109,7 @@ jobs:
           assert any(name.endswith("/tests/test_gauge_tree_artifact.py") for name in names)
           assert any(name.endswith("/docs/sparse-gauge-tree-prior.md") for name in names)
           PY
-          python -m venv .artifact-wheel-venv
+          python -m venv --system-site-packages .artifact-wheel-venv
           .artifact-wheel-venv/bin/python -m pip install --no-deps dist/*.whl
           .artifact-wheel-venv/bin/python - <<'PY'
           from prob4d.gauge_tree_artifact import (

--- a/.github/workflows/sparse-gauge-tree-prior.yml
+++ b/.github/workflows/sparse-gauge-tree-prior.yml
@@ -109,14 +109,15 @@ jobs:
           assert any(name.endswith("/tests/test_gauge_tree_artifact.py") for name in names)
           assert any(name.endswith("/docs/sparse-gauge-tree-prior.md") for name in names)
           PY
-          python -m venv --system-site-packages .artifact-wheel-venv
-          .artifact-wheel-venv/bin/python -m pip install --no-deps dist/*.whl
+          python -m venv .artifact-wheel-venv
+          .artifact-wheel-venv/bin/python -m pip install dist/*.whl
           .artifact-wheel-venv/bin/python - <<'PY'
-          from prob4d.gauge_tree_artifact import (
-              load_gauge_tree_prior_artifact,
-              save_gauge_tree_prior_artifact,
-          )
+          from pathlib import Path
 
-          assert callable(load_gauge_tree_prior_artifact)
-          assert callable(save_gauge_tree_prior_artifact)
+          import prob4d.gauge_tree_artifact as artifact
+
+          module_path = Path(artifact.__file__).resolve()
+          assert ".artifact-wheel-venv" in module_path.parts
+          assert callable(artifact.load_gauge_tree_prior_artifact)
+          assert callable(artifact.save_gauge_tree_prior_artifact)
           PY

--- a/.github/workflows/sparse-gauge-tree-prior.yml
+++ b/.github/workflows/sparse-gauge-tree-prior.yml
@@ -8,6 +8,7 @@ on:
       - "docs/sparse-gauge-tree-prior.md"
       - "docs/sparse-observation-factor-stack.md"
       - "src/prob4d/_gauge_tree_*.py"
+      - "src/prob4d/gauge_tree_artifact.py"
       - "src/prob4d/gauge_tree_prior.py"
       - "tests/test_gauge_tree_*.py"
       - "tests/test_sparse_observation_factors.py"
@@ -59,7 +60,9 @@ jobs:
             src/prob4d/_gauge_tree_methods.py
             src/prob4d/_gauge_tree_observation.py
             src/prob4d/_gauge_tree_selection.py
+            src/prob4d/gauge_tree_artifact.py
             src/prob4d/gauge_tree_prior.py
+            tests/test_gauge_tree_artifact.py
             tests/test_gauge_tree_contract.py
             tests/test_gauge_tree_observation.py
             tests/test_gauge_tree_prior.py
@@ -68,12 +71,14 @@ jobs:
           python -m ruff format --check --diff "${files[@]}"
           python -m mypy --python-version 3.12 \
             src/prob4d/_gauge_tree_*.py \
+            src/prob4d/gauge_tree_artifact.py \
             src/prob4d/gauge_tree_prior.py
 
       - name: Run focused and adjacent tests
         run: |
           set -euo pipefail
           python -m pytest -q \
+            tests/test_gauge_tree_artifact.py \
             tests/test_gauge_tree_contract.py \
             tests/test_gauge_tree_observation.py \
             tests/test_gauge_tree_prior.py \
@@ -81,3 +86,37 @@ jobs:
             tests/test_observation_factors.py \
             tests/test_provider_v2_factor_bundle.py
           python -m compileall -q src/prob4d tests
+
+      - name: Build and audit portable distributions
+        run: |
+          set -euo pipefail
+          rm -rf build dist
+          python -m build
+          python - <<'PY'
+          from pathlib import Path
+          import tarfile
+          import zipfile
+
+          wheel = next(Path("dist").glob("*.whl"))
+          with zipfile.ZipFile(wheel) as archive:
+              names = set(archive.namelist())
+          assert "prob4d/gauge_tree_artifact.py" in names
+
+          source = next(Path("dist").glob("*.tar.gz"))
+          with tarfile.open(source, "r:gz") as archive:
+              names = {member.name for member in archive.getmembers()}
+          assert any(name.endswith("/src/prob4d/gauge_tree_artifact.py") for name in names)
+          assert any(name.endswith("/tests/test_gauge_tree_artifact.py") for name in names)
+          assert any(name.endswith("/docs/sparse-gauge-tree-prior.md") for name in names)
+          PY
+          python -m venv .artifact-wheel-venv
+          .artifact-wheel-venv/bin/python -m pip install --no-deps dist/*.whl
+          .artifact-wheel-venv/bin/python - <<'PY'
+          from prob4d.gauge_tree_artifact import (
+              load_gauge_tree_prior_artifact,
+              save_gauge_tree_prior_artifact,
+          )
+
+          assert callable(load_gauge_tree_prior_artifact)
+          assert callable(save_gauge_tree_prior_artifact)
+          PY

--- a/docs/sparse-gauge-tree-prior.md
+++ b/docs/sparse-gauge-tree-prior.md
@@ -5,10 +5,11 @@ causal spanning-tree gauge posterior. It replaces the dense in-memory
 `7K x 7K` covariance with `O(K)` parent, transition, and innovation factors while
 preserving the exact joint Gaussian statistics.
 
-It does **not** change provider-v2, `ObservationFactorBundle` schema v4, or any
-frozen artifact identity. A future portable provider/artifact version is still
-required before Prob4D can omit the dense prior from serialized claim-bearing
-bundles.
+The separately versioned portable artifact in `prob4d.gauge_tree_artifact` stores
+the same factors without materializing the dense prior. It does **not** change
+provider-v2, `ObservationFactorBundle` schema v4, or any frozen artifact identity.
+Current schema-v4 factor bundles still carry the dense compatibility covariance;
+the sparse artifact is an additive hand-off for prospective workflows.
 
 ## Model
 
@@ -98,6 +99,55 @@ tree-structured Gaussian. It must not be forced into this representation; the
 strict converter will reject it when its off-tree conditional structure is
 nonzero.
 
+## Portable sparse artifact
+
+Publish the normalized tree factors as a JSON manifest plus compressed NPZ
+payload:
+
+```python
+from prob4d.gauge_tree_artifact import (
+    load_gauge_tree_prior_artifact,
+    save_gauge_tree_prior_artifact,
+)
+
+manifest_path, payload_path = save_gauge_tree_prior_artifact(
+    "outputs/gauge-prior.json",
+    prior,
+)
+
+recovered = load_gauge_tree_prior_artifact(
+    manifest_path,
+    expected_prior_id=prior.prior_id,
+)
+```
+
+The writer is no-clobber and idempotent. Repeating a write for the same semantic
+prior reuses the validated files; attempting to replace either path with a
+different prior fails. If publication stops after the payload is complete but
+before the manifest is written, a repeated call verifies and reuses that orphan
+payload before publishing the manifest.
+
+The manifest binds:
+
+- schema, version, representation semantics, and ordered gauge identities;
+- the complete parent list and canonical descriptors of both factor tensors;
+- the optional dense-source covariance digest;
+- factor and dense-equivalent storage accounting;
+- the semantic `prior_id` and artifact identity; and
+- the relative payload path, exact payload SHA-256, fixed array inventory, and
+  `allow_pickle=false` declaration.
+
+The artifact identity is computed from the normalized semantic prior and fixed
+storage contract, not from ZIP timestamps or the local path. Two valid transports
+of the same prior therefore have the same identity. The NPZ SHA-256 remains a
+separate byte-level transport-integrity check.
+
+Loading rejects duplicate JSON keys, non-finite constants, unknown manifest or
+payload fields, path traversal, symbolic links, checksum drift, missing or extra
+arrays, changed array descriptors, mismatched storage accounting, and an
+unexpected `prior_id`. Loaded factors pass through the normal immutable prior
+constructor before they are returned.
+
 ## Matrix-free operations
 
 The generative tree gives `Sigma = T D T^T`, where `D` is block diagonal. A
@@ -171,14 +221,17 @@ At 64 gauges this is about 50 KiB instead of 1.53 MiB, before Python-container
 overhead. The advantage grows linearly with `K`. Dense materialization remains
 available only behind an explicit maximum-gauge guard.
 
-This first implementation removes dense prior storage only after direct sparse
-construction or a verified conversion. Serialized schema-v4 bundles still carry
-the dense covariance, so file size and initial load peak are unchanged.
+Direct sparse construction plus the portable artifact avoids dense prior storage
+both in memory and in the standalone file. A verified conversion from an existing
+dense bundle still incurs the original bundle load once. Serialized schema-v4
+observation-factor bundles continue to carry the dense covariance for frozen
+compatibility, so their file size and initial load peak are unchanged.
 
 ## Claim boundary
 
-Exact dense parity, lower memory use, and matrix-free algebra are engineering
-properties. They do not establish provider competence, covariance calibration,
-physical-query identifiability, safe BayesianPhysTwin acceptance, Causal4D
-intervention benefit, deployment safety, or state of the art. Promotion requires
-the separately frozen independent-object provider and guarded-query experiment.
+Exact dense parity, lower memory use, portable factor persistence, and
+matrix-free algebra are engineering properties. They do not establish provider
+competence, covariance calibration, physical-query identifiability, safe
+BayesianPhysTwin acceptance, Causal4D intervention benefit, deployment safety,
+or state of the art. Promotion requires the separately frozen independent-object
+provider and guarded-query experiment.

--- a/src/prob4d/gauge_tree_artifact.py
+++ b/src/prob4d/gauge_tree_artifact.py
@@ -72,9 +72,7 @@ def _require_exact_keys(
     if actual != expected:
         missing = sorted(expected - actual)
         unexpected = sorted(actual - expected)
-        raise ValueError(
-            f"{name} has invalid keys: missing={missing}, unexpected={unexpected}"
-        )
+        raise ValueError(f"{name} has invalid keys: missing={missing}, unexpected={unexpected}")
 
 
 def _require_sha256(value: Any, *, name: str) -> str:
@@ -356,9 +354,7 @@ def save_gauge_tree_prior_artifact(
     if manifest.exists():
         existing = load_gauge_tree_prior_artifact(manifest)
         if existing.prior_id != prior.prior_id:
-            raise FileExistsError(
-                "refusing to overwrite a different sparse gauge-tree artifact"
-            )
+            raise FileExistsError("refusing to overwrite a different sparse gauge-tree artifact")
         record = _load_json(manifest)
         existing_payload = _resolve_payload(manifest, record["payload"]["path"])
         if existing_payload.resolve() != payload.resolve():
@@ -373,9 +369,7 @@ def save_gauge_tree_prior_artifact(
             representation_semantics=prior.representation_semantics,
         )
         if existing.prior_id != prior.prior_id:
-            raise FileExistsError(
-                "refusing to reuse a different sparse gauge-tree payload"
-            )
+            raise FileExistsError("refusing to reuse a different sparse gauge-tree payload")
     else:
         _atomic_write_npz(payload, prior)
 

--- a/src/prob4d/gauge_tree_artifact.py
+++ b/src/prob4d/gauge_tree_artifact.py
@@ -12,6 +12,7 @@ from pathlib import Path, PurePosixPath
 from typing import Any, Final
 
 import numpy as np
+from numpy.lib.npyio import NpzFile
 
 from ._gauge_tree_common import canonical_json_sha256
 from .gauge_tree_prior import GaugeTreeSquareRootPriorV1
@@ -219,6 +220,8 @@ def _load_payload(
         archive = np.load(payload, allow_pickle=False)
     except (OSError, ValueError, EOFError, zipfile.BadZipFile) as error:
         raise ValueError("invalid sparse gauge-tree payload") from error
+    if not isinstance(archive, NpzFile):
+        raise ValueError("sparse gauge-tree payload must be an NPZ archive")
     with archive as arrays:
         if tuple(arrays.files) != _ARRAY_KEYS:
             raise ValueError("sparse gauge-tree payload contains unexpected arrays")

--- a/src/prob4d/gauge_tree_artifact.py
+++ b/src/prob4d/gauge_tree_artifact.py
@@ -1,0 +1,390 @@
+"""Portable sparse artifacts for causal square-root gauge-tree priors."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+import zipfile
+from collections.abc import Mapping
+from pathlib import Path, PurePosixPath
+from typing import Any, Final
+
+import numpy as np
+
+from ._gauge_tree_common import canonical_json_sha256
+from .gauge_tree_prior import GaugeTreeSquareRootPriorV1
+
+GAUGE_TREE_PRIOR_ARTIFACT_SCHEMA: Final = (
+    "prob4d.gauge-tree-square-root-prior-artifact"
+)
+GAUGE_TREE_PRIOR_ARTIFACT_VERSION: Final = 1
+GAUGE_TREE_PRIOR_ARTIFACT_STORAGE: Final = "compressed-npz-v1"
+
+_PARENT_KEY: Final = "parent_indices"
+_TRANSITION_KEY: Final = "transition_matrices"
+_INNOVATION_KEY: Final = "innovation_scale_tril"
+_ARRAY_KEYS: Final = (_PARENT_KEY, _TRANSITION_KEY, _INNOVATION_KEY)
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _reject_nonfinite(value: str) -> Any:
+    raise ValueError(f"non-finite JSON constant: {value}")
+
+
+def _strict_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_strict_object,
+            parse_constant=_reject_nonfinite,
+        )
+    except (OSError, json.JSONDecodeError, ValueError) as error:
+        raise ValueError("invalid sparse gauge-tree artifact manifest") from error
+    if not isinstance(value, dict):
+        raise ValueError("sparse gauge-tree artifact manifest must be a JSON object")
+    return value
+
+
+def _require_exact_keys(
+    value: Mapping[str, Any],
+    expected: set[str],
+    *,
+    name: str,
+) -> None:
+    actual = set(value)
+    if actual != expected:
+        missing = sorted(expected - actual)
+        unexpected = sorted(actual - expected)
+        raise ValueError(
+            f"{name} has invalid keys: missing={missing}, unexpected={unexpected}"
+        )
+
+
+def _require_sha256(value: Any, *, name: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    text = value
+    if len(text) != 64 or any(character not in "0123456789abcdef" for character in text):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return text
+
+
+def _artifact_id(prior_record: Mapping[str, Any]) -> str:
+    return canonical_json_sha256(
+        {
+            "schema": GAUGE_TREE_PRIOR_ARTIFACT_SCHEMA,
+            "version": GAUGE_TREE_PRIOR_ARTIFACT_VERSION,
+            "storage": GAUGE_TREE_PRIOR_ARTIFACT_STORAGE,
+            "array_keys": list(_ARRAY_KEYS),
+            "prior": dict(prior_record),
+        }
+    )
+
+
+def _portable_payload_relative_path(value: Any) -> PurePosixPath:
+    if not isinstance(value, str) or not value:
+        raise ValueError("sparse gauge-tree payload path must be a nonempty string")
+    path = PurePosixPath(value)
+    if path.is_absolute() or ".." in path.parts or path == PurePosixPath("."):
+        raise ValueError("sparse gauge-tree payload path must stay below the manifest directory")
+    return path
+
+
+def _resolve_payload(manifest: Path, value: Any) -> Path:
+    relative = _portable_payload_relative_path(value)
+    root = manifest.parent.resolve()
+    payload = manifest.parent.joinpath(*relative.parts)
+    resolved = payload.resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as error:
+        raise ValueError(
+            "sparse gauge-tree payload resolves outside the manifest directory"
+        ) from error
+    cursor = manifest.parent
+    for part in relative.parts:
+        cursor = cursor / part
+        if cursor.exists() and cursor.is_symlink():
+            raise ValueError("sparse gauge-tree artifact paths must not contain symlinks")
+    return payload
+
+
+def _payload_relative_path(manifest: Path, payload: Path) -> str:
+    root = manifest.parent.resolve()
+    resolved = payload.resolve()
+    try:
+        relative = resolved.relative_to(root)
+    except ValueError as error:
+        raise ValueError(
+            "sparse gauge-tree payload must be stored below the manifest directory"
+        ) from error
+    if payload == manifest:
+        raise ValueError("sparse gauge-tree manifest and payload paths must differ")
+    return PurePosixPath(relative.as_posix()).as_posix()
+
+
+def _atomic_write_npz(path: Path, prior: GaugeTreeSquareRootPriorV1) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle = tempfile.NamedTemporaryFile(
+        mode="w+b",
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        delete=False,
+    )
+    temporary = Path(handle.name)
+    try:
+        with handle:
+            np.savez_compressed(
+                handle,
+                parent_indices=prior.parent_indices,
+                transition_matrices=prior.transition_matrices,
+                innovation_scale_tril=prior.innovation_scale_tril,
+            )
+            handle.flush()
+            os.fsync(handle.fileno())
+        if path.exists():
+            raise FileExistsError(f"refusing to overwrite sparse gauge-tree payload: {path}")
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle = tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        delete=False,
+    )
+    temporary = Path(handle.name)
+    try:
+        with handle:
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        if path.exists():
+            raise FileExistsError(f"refusing to overwrite sparse gauge-tree manifest: {path}")
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _load_payload(
+    payload: Path,
+    *,
+    gauge_ids: tuple[str, ...],
+    source_joint_covariance_sha256: str | None,
+    representation_semantics: str,
+) -> GaugeTreeSquareRootPriorV1:
+    if not payload.is_file():
+        raise ValueError("sparse gauge-tree payload does not exist")
+    if payload.is_symlink():
+        raise ValueError("sparse gauge-tree payload must not be a symbolic link")
+    try:
+        with np.load(payload, allow_pickle=False) as arrays:
+            if set(arrays.files) != set(_ARRAY_KEYS):
+                raise ValueError("sparse gauge-tree payload contains unexpected arrays")
+            return GaugeTreeSquareRootPriorV1(
+                gauge_ids=gauge_ids,
+                parent_indices=arrays[_PARENT_KEY],
+                transition_matrices=arrays[_TRANSITION_KEY],
+                innovation_scale_tril=arrays[_INNOVATION_KEY],
+                source_joint_covariance_sha256=source_joint_covariance_sha256,
+                representation_semantics=representation_semantics,
+            )
+    except (OSError, ValueError, EOFError, zipfile.BadZipFile) as error:
+        raise ValueError("invalid sparse gauge-tree payload") from error
+
+
+def _prior_from_record(
+    payload: Path,
+    prior_record: Mapping[str, Any],
+) -> GaugeTreeSquareRootPriorV1:
+    required_prior_keys = {
+        "schema",
+        "version",
+        "representation_semantics",
+        "gauge_dimension",
+        "gauge_ids",
+        "parent_indices",
+        "transition_matrices",
+        "innovation_scale_tril",
+        "source_joint_covariance_sha256",
+        "prior_id",
+        "gauge_count",
+        "factor_storage_nbytes",
+        "dense_covariance_nbytes",
+    }
+    _require_exact_keys(prior_record, required_prior_keys, name="sparse gauge-tree prior record")
+    raw_gauge_ids = prior_record["gauge_ids"]
+    if not isinstance(raw_gauge_ids, list) or any(
+        not isinstance(value, str) for value in raw_gauge_ids
+    ):
+        raise ValueError("sparse gauge-tree gauge_ids must be a list of strings")
+    source_digest = prior_record["source_joint_covariance_sha256"]
+    if source_digest is not None:
+        source_digest = _require_sha256(
+            source_digest,
+            name="source_joint_covariance_sha256",
+        )
+    prior = _load_payload(
+        payload,
+        gauge_ids=tuple(raw_gauge_ids),
+        source_joint_covariance_sha256=source_digest,
+        representation_semantics=str(prior_record["representation_semantics"]),
+    )
+    if prior.to_dict() != dict(prior_record):
+        raise ValueError("sparse gauge-tree prior record does not match the payload")
+    return prior
+
+
+def load_gauge_tree_prior_artifact(
+    manifest_path: str | Path,
+    *,
+    expected_prior_id: str | None = None,
+) -> GaugeTreeSquareRootPriorV1:
+    """Load and fully validate one portable sparse gauge-tree prior artifact."""
+
+    manifest = Path(manifest_path)
+    if not manifest.is_file() or manifest.is_symlink():
+        raise ValueError("sparse gauge-tree manifest must be a regular file")
+    record = _load_json(manifest)
+    _require_exact_keys(
+        record,
+        {"schema", "version", "prior", "payload", "artifact_id"},
+        name="sparse gauge-tree artifact manifest",
+    )
+    if record["schema"] != GAUGE_TREE_PRIOR_ARTIFACT_SCHEMA:
+        raise ValueError("unsupported sparse gauge-tree artifact schema")
+    if type(record["version"]) is not int or (
+        record["version"] != GAUGE_TREE_PRIOR_ARTIFACT_VERSION
+    ):
+        raise ValueError("unsupported sparse gauge-tree artifact version")
+    prior_record = record["prior"]
+    payload_record = record["payload"]
+    if not isinstance(prior_record, dict) or not isinstance(payload_record, dict):
+        raise ValueError("sparse gauge-tree prior and payload records must be objects")
+    _require_exact_keys(
+        payload_record,
+        {"path", "sha256", "allow_pickle", "storage", "array_keys"},
+        name="sparse gauge-tree payload record",
+    )
+    if payload_record["allow_pickle"] is not False:
+        raise ValueError("sparse gauge-tree payload must declare allow_pickle=false")
+    if payload_record["storage"] != GAUGE_TREE_PRIOR_ARTIFACT_STORAGE:
+        raise ValueError("unsupported sparse gauge-tree payload storage")
+    if payload_record["array_keys"] != list(_ARRAY_KEYS):
+        raise ValueError("sparse gauge-tree payload array keys changed")
+    payload = _resolve_payload(manifest, payload_record["path"])
+    if not payload.is_file() or payload.is_symlink():
+        raise ValueError("sparse gauge-tree payload must be a regular file")
+    expected_payload_sha256 = _require_sha256(
+        payload_record["sha256"],
+        name="sparse gauge-tree payload sha256",
+    )
+    if _sha256(payload) != expected_payload_sha256:
+        raise ValueError("sparse gauge-tree payload checksum mismatch")
+    prior = _prior_from_record(payload, prior_record)
+    artifact_id = _require_sha256(record["artifact_id"], name="sparse gauge-tree artifact_id")
+    if artifact_id != _artifact_id(prior_record):
+        raise ValueError("sparse gauge-tree artifact_id does not match its content")
+    if expected_prior_id is not None:
+        expected = _require_sha256(expected_prior_id, name="expected_prior_id")
+        if prior.prior_id != expected:
+            raise ValueError("sparse gauge-tree prior_id differs from the expected identity")
+    return prior
+
+
+def save_gauge_tree_prior_artifact(
+    manifest_path: str | Path,
+    prior: GaugeTreeSquareRootPriorV1,
+    *,
+    payload_path: str | Path | None = None,
+) -> tuple[Path, Path]:
+    """Publish a portable sparse prior without replacing any different artifact."""
+
+    if not isinstance(prior, GaugeTreeSquareRootPriorV1):
+        raise TypeError("prior must be a GaugeTreeSquareRootPriorV1")
+    manifest = Path(manifest_path)
+    payload = Path(payload_path) if payload_path is not None else manifest.with_suffix(".npz")
+    relative_payload = _payload_relative_path(manifest, payload)
+
+    if manifest.exists():
+        existing = load_gauge_tree_prior_artifact(manifest)
+        if existing.prior_id != prior.prior_id:
+            raise FileExistsError(
+                "refusing to overwrite a different sparse gauge-tree artifact"
+            )
+        record = _load_json(manifest)
+        existing_payload = _resolve_payload(manifest, record["payload"]["path"])
+        if existing_payload.resolve() != payload.resolve():
+            raise FileExistsError("existing sparse gauge-tree artifact uses another payload path")
+        return manifest, existing_payload
+
+    if payload.exists():
+        existing = _load_payload(
+            payload,
+            gauge_ids=prior.gauge_ids,
+            source_joint_covariance_sha256=prior.source_joint_covariance_sha256,
+            representation_semantics=prior.representation_semantics,
+        )
+        if existing.prior_id != prior.prior_id:
+            raise FileExistsError(
+                "refusing to reuse a different sparse gauge-tree payload"
+            )
+    else:
+        _atomic_write_npz(payload, prior)
+
+    prior_record = prior.to_dict()
+    record = {
+        "schema": GAUGE_TREE_PRIOR_ARTIFACT_SCHEMA,
+        "version": GAUGE_TREE_PRIOR_ARTIFACT_VERSION,
+        "prior": prior_record,
+        "payload": {
+            "path": relative_payload,
+            "sha256": _sha256(payload),
+            "allow_pickle": False,
+            "storage": GAUGE_TREE_PRIOR_ARTIFACT_STORAGE,
+            "array_keys": list(_ARRAY_KEYS),
+        },
+        "artifact_id": _artifact_id(prior_record),
+    }
+    _atomic_write_text(
+        manifest,
+        json.dumps(record, indent=2, sort_keys=True, allow_nan=False) + "\n",
+    )
+    loaded = load_gauge_tree_prior_artifact(manifest, expected_prior_id=prior.prior_id)
+    if loaded.prior_id != prior.prior_id:
+        raise RuntimeError("published sparse gauge-tree artifact failed identity replay")
+    return manifest, payload
+
+
+__all__ = [
+    "GAUGE_TREE_PRIOR_ARTIFACT_SCHEMA",
+    "GAUGE_TREE_PRIOR_ARTIFACT_STORAGE",
+    "GAUGE_TREE_PRIOR_ARTIFACT_VERSION",
+    "load_gauge_tree_prior_artifact",
+    "save_gauge_tree_prior_artifact",
+]

--- a/src/prob4d/gauge_tree_artifact.py
+++ b/src/prob4d/gauge_tree_artifact.py
@@ -85,6 +85,12 @@ def _require_sha256(value: Any, *, name: str) -> str:
     return text
 
 
+def _require_exact_int(value: Any, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError(f"{name} must be a genuine integer")
+    return value
+
+
 def _artifact_id(prior_record: Mapping[str, Any]) -> str:
     return canonical_json_sha256(
         {
@@ -139,8 +145,19 @@ def _payload_relative_path(manifest: Path, payload: Path) -> str:
     return PurePosixPath(relative.as_posix()).as_posix()
 
 
+def _link_complete_temporary(temporary: Path, path: Path) -> None:
+    os.link(temporary, path)
+    directory_fd = os.open(path.parent, os.O_RDONLY)
+    try:
+        os.fsync(directory_fd)
+    finally:
+        os.close(directory_fd)
+
+
 def _atomic_write_npz(path: Path, prior: GaugeTreeSquareRootPriorV1) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        raise FileExistsError(f"refusing to overwrite sparse gauge-tree payload: {path}")
     handle = tempfile.NamedTemporaryFile(
         mode="w+b",
         dir=path.parent,
@@ -159,15 +176,15 @@ def _atomic_write_npz(path: Path, prior: GaugeTreeSquareRootPriorV1) -> None:
             )
             handle.flush()
             os.fsync(handle.fileno())
-        if path.exists():
-            raise FileExistsError(f"refusing to overwrite sparse gauge-tree payload: {path}")
-        os.replace(temporary, path)
+        _link_complete_temporary(temporary, path)
     finally:
         temporary.unlink(missing_ok=True)
 
 
 def _atomic_write_text(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        raise FileExistsError(f"refusing to overwrite sparse gauge-tree manifest: {path}")
     handle = tempfile.NamedTemporaryFile(
         mode="w",
         encoding="utf-8",
@@ -182,9 +199,7 @@ def _atomic_write_text(path: Path, content: str) -> None:
             handle.write(content)
             handle.flush()
             os.fsync(handle.fileno())
-        if path.exists():
-            raise FileExistsError(f"refusing to overwrite sparse gauge-tree manifest: {path}")
-        os.replace(temporary, path)
+        _link_complete_temporary(temporary, path)
     finally:
         temporary.unlink(missing_ok=True)
 
@@ -283,9 +298,8 @@ def load_gauge_tree_prior_artifact(
     )
     if record["schema"] != GAUGE_TREE_PRIOR_ARTIFACT_SCHEMA:
         raise ValueError("unsupported sparse gauge-tree artifact schema")
-    if type(record["version"]) is not int or (
-        record["version"] != GAUGE_TREE_PRIOR_ARTIFACT_VERSION
-    ):
+    version = _require_exact_int(record["version"], name="sparse gauge-tree artifact version")
+    if version != GAUGE_TREE_PRIOR_ARTIFACT_VERSION:
         raise ValueError("unsupported sparse gauge-tree artifact version")
     prior_record = record["prior"]
     payload_record = record["payload"]

--- a/src/prob4d/gauge_tree_artifact.py
+++ b/src/prob4d/gauge_tree_artifact.py
@@ -16,9 +16,7 @@ import numpy as np
 from ._gauge_tree_common import canonical_json_sha256
 from .gauge_tree_prior import GaugeTreeSquareRootPriorV1
 
-GAUGE_TREE_PRIOR_ARTIFACT_SCHEMA: Final = (
-    "prob4d.gauge-tree-square-root-prior-artifact"
-)
+GAUGE_TREE_PRIOR_ARTIFACT_SCHEMA: Final = "prob4d.gauge-tree-square-root-prior-artifact"
 GAUGE_TREE_PRIOR_ARTIFACT_VERSION: Final = 1
 GAUGE_TREE_PRIOR_ARTIFACT_STORAGE: Final = "compressed-npz-v1"
 
@@ -136,7 +134,7 @@ def _payload_relative_path(manifest: Path, payload: Path) -> str:
         raise ValueError(
             "sparse gauge-tree payload must be stored below the manifest directory"
         ) from error
-    if payload == manifest:
+    if resolved == manifest.resolve():
         raise ValueError("sparse gauge-tree manifest and payload paths must differ")
     return PurePosixPath(relative.as_posix()).as_posix()
 
@@ -203,19 +201,26 @@ def _load_payload(
     if payload.is_symlink():
         raise ValueError("sparse gauge-tree payload must not be a symbolic link")
     try:
-        with np.load(payload, allow_pickle=False) as arrays:
-            if set(arrays.files) != set(_ARRAY_KEYS):
-                raise ValueError("sparse gauge-tree payload contains unexpected arrays")
-            return GaugeTreeSquareRootPriorV1(
-                gauge_ids=gauge_ids,
-                parent_indices=arrays[_PARENT_KEY],
-                transition_matrices=arrays[_TRANSITION_KEY],
-                innovation_scale_tril=arrays[_INNOVATION_KEY],
-                source_joint_covariance_sha256=source_joint_covariance_sha256,
-                representation_semantics=representation_semantics,
-            )
+        archive = np.load(payload, allow_pickle=False)
     except (OSError, ValueError, EOFError, zipfile.BadZipFile) as error:
         raise ValueError("invalid sparse gauge-tree payload") from error
+    with archive as arrays:
+        if tuple(arrays.files) != _ARRAY_KEYS:
+            raise ValueError("sparse gauge-tree payload contains unexpected arrays")
+        try:
+            parents = arrays[_PARENT_KEY]
+            transitions = arrays[_TRANSITION_KEY]
+            innovation_scale = arrays[_INNOVATION_KEY]
+        except (OSError, ValueError, EOFError, zipfile.BadZipFile) as error:
+            raise ValueError("invalid sparse gauge-tree payload") from error
+        return GaugeTreeSquareRootPriorV1(
+            gauge_ids=gauge_ids,
+            parent_indices=parents,
+            transition_matrices=transitions,
+            innovation_scale_tril=innovation_scale,
+            source_joint_covariance_sha256=source_joint_covariance_sha256,
+            representation_semantics=representation_semantics,
+        )
 
 
 def _prior_from_record(
@@ -255,7 +260,7 @@ def _prior_from_record(
         source_joint_covariance_sha256=source_digest,
         representation_semantics=str(prior_record["representation_semantics"]),
     )
-    if prior.to_dict() != dict(prior_record):
+    if canonical_json_sha256(prior.to_dict()) != canonical_json_sha256(dict(prior_record)):
         raise ValueError("sparse gauge-tree prior record does not match the payload")
     return prior
 

--- a/tests/test_gauge_tree_artifact.py
+++ b/tests/test_gauge_tree_artifact.py
@@ -143,7 +143,7 @@ def test_manifest_and_expected_identity_tampering_fail_closed(tmp_path: Path) ->
         load_gauge_tree_prior_artifact(manifest, expected_prior_id=wrong_prior_id)
 
     record = json.loads(manifest.read_text(encoding="utf-8"))
-    record["prior"]["gauge_count"] = 999
+    record["prior"]["gauge_count"] = True
     manifest.write_text(json.dumps(record), encoding="utf-8")
     with pytest.raises(ValueError, match="does not match the payload"):
         load_gauge_tree_prior_artifact(manifest)

--- a/tests/test_gauge_tree_artifact.py
+++ b/tests/test_gauge_tree_artifact.py
@@ -35,11 +35,7 @@ def _prior(
     for index in range(1, gauge_count):
         transitions[index] = np.eye(7) * (0.7 + 0.02 * index)
         transitions[index, 4:, :3] = 0.01 * index
-        scale = np.diag(
-            np.linspace(0.02, 0.04, 7)
-            * (1.0 + 0.05 * index)
-            * innovation_scale
-        )
+        scale = np.diag(np.linspace(0.02, 0.04, 7) * (1.0 + 0.05 * index) * innovation_scale)
         scale[3, 0] = 0.002 * innovation_scale
         scale[6, 2] = -0.001 * innovation_scale
         scales[index] = scale

--- a/tests/test_gauge_tree_artifact.py
+++ b/tests/test_gauge_tree_artifact.py
@@ -135,6 +135,18 @@ def test_payload_with_unexpected_array_fails_closed(tmp_path: Path) -> None:
         load_gauge_tree_prior_artifact(manifest)
 
 
+def test_non_npz_payload_fails_closed(tmp_path: Path) -> None:
+    manifest, payload = save_gauge_tree_prior_artifact(tmp_path / "prior.json", _prior())
+    with payload.open("wb") as stream:
+        np.save(stream, np.asarray([1.0], dtype=np.float64))
+    record = json.loads(manifest.read_text(encoding="utf-8"))
+    record["payload"]["sha256"] = _sha256(payload)
+    manifest.write_text(json.dumps(record), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="must be an NPZ archive"):
+        load_gauge_tree_prior_artifact(manifest)
+
+
 def test_manifest_and_expected_identity_tampering_fail_closed(tmp_path: Path) -> None:
     prior = _prior()
     manifest, _ = save_gauge_tree_prior_artifact(tmp_path / "prior.json", prior)

--- a/tests/test_gauge_tree_artifact.py
+++ b/tests/test_gauge_tree_artifact.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from prob4d.gauge_tree_artifact import (
+    load_gauge_tree_prior_artifact,
+    save_gauge_tree_prior_artifact,
+)
+from prob4d.gauge_tree_prior import GaugeTreeSquareRootPriorV1
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _prior(
+    *,
+    gauge_count: int = 6,
+    innovation_scale: float = 1.0,
+) -> GaugeTreeSquareRootPriorV1:
+    gauge_ids = tuple(f"window-{index}" for index in range(gauge_count))
+    parents = np.asarray([-1] + [(index - 1) // 2 for index in range(1, gauge_count)])
+    transitions = np.zeros((gauge_count, 7, 7), dtype=np.float64)
+    scales = np.empty_like(transitions)
+    scales[0] = np.diag(np.linspace(0.05, 0.11, 7) * innovation_scale)
+    for index in range(1, gauge_count):
+        transitions[index] = np.eye(7) * (0.7 + 0.02 * index)
+        transitions[index, 4:, :3] = 0.01 * index
+        scale = np.diag(
+            np.linspace(0.02, 0.04, 7)
+            * (1.0 + 0.05 * index)
+            * innovation_scale
+        )
+        scale[3, 0] = 0.002 * innovation_scale
+        scale[6, 2] = -0.001 * innovation_scale
+        scales[index] = scale
+    return GaugeTreeSquareRootPriorV1(
+        gauge_ids=gauge_ids,
+        parent_indices=parents,
+        transition_matrices=transitions,
+        innovation_scale_tril=scales,
+    )
+
+
+def test_portable_sparse_artifact_round_trip_is_immutable(tmp_path: Path) -> None:
+    prior = _prior(gauge_count=64)
+    manifest, payload = save_gauge_tree_prior_artifact(tmp_path / "prior.json", prior)
+    recovered = load_gauge_tree_prior_artifact(
+        manifest,
+        expected_prior_id=prior.prior_id,
+    )
+
+    assert recovered.prior_id == prior.prior_id
+    assert recovered.to_dict() == prior.to_dict()
+    assert not recovered.parent_indices.flags.writeable
+    assert not recovered.transition_matrices.flags.writeable
+    assert not recovered.innovation_scale_tril.flags.writeable
+    assert payload.stat().st_size < prior.dense_covariance_nbytes
+
+
+def test_artifact_identity_is_independent_of_transport_path(tmp_path: Path) -> None:
+    prior = _prior()
+    first_manifest, _ = save_gauge_tree_prior_artifact(tmp_path / "first" / "prior.json", prior)
+    second_manifest, _ = save_gauge_tree_prior_artifact(
+        tmp_path / "second" / "prior.json",
+        prior,
+    )
+
+    first = json.loads(first_manifest.read_text(encoding="utf-8"))
+    second = json.loads(second_manifest.read_text(encoding="utf-8"))
+    assert first["artifact_id"] == second["artifact_id"]
+    assert first["prior"]["prior_id"] == prior.prior_id
+    assert second["prior"]["prior_id"] == prior.prior_id
+
+
+def test_writer_is_idempotent_and_refuses_different_content(tmp_path: Path) -> None:
+    manifest = tmp_path / "prior.json"
+    first = _prior()
+    first_paths = save_gauge_tree_prior_artifact(manifest, first)
+    assert save_gauge_tree_prior_artifact(manifest, first) == first_paths
+
+    with pytest.raises(FileExistsError, match="different sparse gauge-tree artifact"):
+        save_gauge_tree_prior_artifact(
+            manifest,
+            _prior(innovation_scale=1.25),
+        )
+
+
+def test_writer_recovers_a_matching_orphan_payload(tmp_path: Path) -> None:
+    manifest = tmp_path / "prior.json"
+    prior = _prior()
+    _, payload = save_gauge_tree_prior_artifact(manifest, prior)
+    manifest.unlink()
+
+    recovered_manifest, recovered_payload = save_gauge_tree_prior_artifact(manifest, prior)
+    assert recovered_payload == payload
+    assert load_gauge_tree_prior_artifact(recovered_manifest).prior_id == prior.prior_id
+
+
+def test_payload_checksum_tampering_fails_closed(tmp_path: Path) -> None:
+    manifest, payload = save_gauge_tree_prior_artifact(tmp_path / "prior.json", _prior())
+    payload.write_bytes(payload.read_bytes() + b"tampered")
+
+    with pytest.raises(ValueError, match="payload checksum mismatch"):
+        load_gauge_tree_prior_artifact(manifest)
+
+
+def test_payload_with_unexpected_array_fails_closed(tmp_path: Path) -> None:
+    manifest, payload = save_gauge_tree_prior_artifact(tmp_path / "prior.json", _prior())
+    with np.load(payload, allow_pickle=False) as arrays:
+        parents = np.asarray(arrays["parent_indices"])
+        transitions = np.asarray(arrays["transition_matrices"])
+        scales = np.asarray(arrays["innovation_scale_tril"])
+    np.savez_compressed(
+        payload,
+        parent_indices=parents,
+        transition_matrices=transitions,
+        innovation_scale_tril=scales,
+        unexpected=np.asarray([1], dtype=np.int64),
+    )
+    record = json.loads(manifest.read_text(encoding="utf-8"))
+    record["payload"]["sha256"] = _sha256(payload)
+    manifest.write_text(json.dumps(record), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="unexpected arrays"):
+        load_gauge_tree_prior_artifact(manifest)
+
+
+def test_manifest_and_expected_identity_tampering_fail_closed(tmp_path: Path) -> None:
+    prior = _prior()
+    manifest, _ = save_gauge_tree_prior_artifact(tmp_path / "prior.json", prior)
+    wrong_prior_id = "0" * 64 if prior.prior_id != "0" * 64 else "1" * 64
+    with pytest.raises(ValueError, match="expected identity"):
+        load_gauge_tree_prior_artifact(manifest, expected_prior_id=wrong_prior_id)
+
+    record = json.loads(manifest.read_text(encoding="utf-8"))
+    record["prior"]["gauge_count"] = 999
+    manifest.write_text(json.dumps(record), encoding="utf-8")
+    with pytest.raises(ValueError, match="does not match the payload"):
+        load_gauge_tree_prior_artifact(manifest)
+
+
+def test_manifest_rejects_duplicate_keys_and_path_traversal(tmp_path: Path) -> None:
+    duplicate = tmp_path / "duplicate.json"
+    duplicate.write_text('{"schema":"one","schema":"two"}', encoding="utf-8")
+    with pytest.raises(ValueError, match="invalid sparse gauge-tree artifact manifest"):
+        load_gauge_tree_prior_artifact(duplicate)
+
+    manifest, _ = save_gauge_tree_prior_artifact(tmp_path / "prior.json", _prior())
+    record = json.loads(manifest.read_text(encoding="utf-8"))
+    record["payload"]["path"] = "../outside.npz"
+    manifest.write_text(json.dumps(record), encoding="utf-8")
+    with pytest.raises(ValueError, match="below the manifest directory"):
+        load_gauge_tree_prior_artifact(manifest)


### PR DESCRIPTION
## What changed

- add a separately versioned JSON + compressed-NPZ artifact for `GaugeTreeSquareRootPriorV1`;
- preserve the `O(K)` parent, transition, and innovation representation without materializing a dense `7K x 7K` covariance;
- bind the normalized semantic prior, fixed array inventory, optional dense-source digest, storage accounting, semantic artifact identity, relative payload path, and exact payload SHA-256;
- load through the normal immutable prior constructor and reject duplicate JSON keys, non-finite constants, coercive scalar aliases, unknown fields, path traversal, symlinks, checksum drift, non-NPZ payloads, missing or extra arrays, descriptor drift, and unexpected prior identities;
- publish complete temporary files through atomic hard links with directory `fsync`, making publication race-safe, no-clobber, idempotent for the same prior, and recoverable when a valid payload was completed before its manifest;
- add focused round-trip, transport-independence, tamper, no-clobber, interrupted-publication recovery, archive-type, array-inventory, coercive-alias, and path-safety regressions;
- extend the sparse-prior workflow through Ruff, formatting, MyPy, focused/adjacent tests, wheel/sdist content auditing, and an isolated installed-wheel smoke test; and
- document the standalone artifact and its compatibility boundary.

## Why

The sparse gauge-tree backend already reduces retained in-memory prior storage from quadratic to linear in the number of gauges, but the representation had no portable artifact. This prevented prospective workflows from persisting or handing off the sparse factors without retaining a dense compatibility covariance.

The new artifact closes that engineering gap while leaving provider-v2 and observation-factor schema v4 unchanged. Existing frozen bundles and artifact identities are not rewritten.

## Validation performed before publication

A standalone reconstruction of the artifact module passed nine focused tests covering round trip, immutability, transport-independent identity, idempotency, no-clobber behavior, interrupted-publication recovery, checksum tampering, non-NPZ and unexpected-array rejection, manifest tampering, coercive scalar aliases, duplicate keys, and path traversal. Python byte compilation and a 100-column source audit also passed locally.

The exact repository-head workflow is authoritative for Ruff, formatting, MyPy, the real `GaugeTreeSquareRootPriorV1` implementation, adjacent tests, and built-distribution checks.

## Claim boundary

This is portable execution and storage infrastructure. It does not change the estimator, provider-v2 semantics, schema-v4 factor bundles, calibration, held-out cohort, BayesianPhysTwin guard, Causal4D behavior, or any scientific result. It does not establish provider competence, uncertainty calibration, physical-query benefit, deployment safety, or state of the art.