### PR TITLE
Add tree-backed sparse observation-factor stacks

### DIFF
--- a/.github/workflows/sparse-gauge-tree-prior.yml
+++ b/.github/workflows/sparse-gauge-tree-prior.yml
@@ -16,10 +16,14 @@ on:
       - "src/prob4d/gauge_tree_prior.py"
       - "src/prob4d/gauge_tree_prior_artifact.py"
       - "src/prob4d/gauge_tree_prior_io.py"
+      - "src/prob4d/provider_v2_factors.py"
+      - "src/prob4d/tree_sparse_observation_factors.py"
       - "tests/test_cli.py"
       - "tests/test_command_registry.py"
       - "tests/test_gauge_tree_*.py"
+      - "tests/test_provider_v2_factors.py"
       - "tests/test_sparse_observation_factors.py"
+      - "tests/test_tree_sparse_observation_factors.py"
   workflow_dispatch:
 
 permissions:
@@ -76,12 +80,16 @@ jobs:
             src/prob4d/gauge_tree_prior.py
             src/prob4d/gauge_tree_prior_artifact.py
             src/prob4d/gauge_tree_prior_io.py
+            src/prob4d/provider_v2_factors.py
+            src/prob4d/tree_sparse_observation_factors.py
             tests/test_cli.py
             tests/test_command_registry.py
             tests/test_gauge_tree_contract.py
             tests/test_gauge_tree_observation.py
             tests/test_gauge_tree_prior.py
             tests/test_gauge_tree_prior_artifact.py
+            tests/test_provider_v2_factors.py
+            tests/test_tree_sparse_observation_factors.py
           )
           python -m ruff check -- "${files[@]}"
           python -m ruff format --check --diff "${files[@]}"
@@ -92,7 +100,9 @@ jobs:
             src/prob4d/command_registry.py \
             src/prob4d/gauge_tree_prior.py \
             src/prob4d/gauge_tree_prior_artifact.py \
-            src/prob4d/gauge_tree_prior_io.py
+            src/prob4d/gauge_tree_prior_io.py \
+            src/prob4d/provider_v2_factors.py \
+            src/prob4d/tree_sparse_observation_factors.py
 
       - name: Run focused and adjacent tests
         run: |
@@ -103,6 +113,8 @@ jobs:
             tests/test_gauge_tree_prior.py \
             tests/test_gauge_tree_prior_artifact.py \
             tests/test_sparse_observation_factors.py \
+            tests/test_tree_sparse_observation_factors.py \
+            tests/test_provider_v2_factors.py \
             tests/test_cli.py \
             tests/test_command_registry.py \
             tests/test_observation_factors.py \

--- a/docs/sparse-observation-factor-stack.md
+++ b/docs/sparse-observation-factor-stack.md
@@ -62,22 +62,74 @@ An estimator that keeps gauge errors explicit must use:
 conditional_world_covariance_m2
 + local_gauge_jacobian
 + gauge_indices
-+ gauge_prior_covariance
++ one gauge prior
 ```
 
 It must not additionally use `marginal_world_covariance_m2`, because that would
-count `J Sigma_gg J^T` twice. The method
+count `J Sigma_gg J^T` twice. The dense sparse stack method
 `gauge_marginal_covariance_m2()` reconstructs that per-row contribution for
 parity tests and diagnostics.
 
-## Sparse gauge prior
+## Tree-backed sparse stack
 
-For the production causal spanning tree, the dense prior can now be represented
-by `prob4d.gauge_tree_prior.GaugeTreeSquareRootPriorV1`. It stores one parent,
-`7 x 7` transition, and `7 x 7` innovation Cholesky factor per gauge. The
-representation applies `Sigma_gg`, its inverse, selected marginals, and
-`H Sigma_gg H^T` without expanding either the row design or the complete gauge
-prior.
+For the production causal spanning tree, the dense prior can be replaced after
+exact verification by `GaugeTreeSquareRootPriorV1`. The tree-backed adapter keeps
+only:
+
+```text
+local_gauge_jacobian: M x 3 x 7
+gauge_indices:        M
+parent_indices:        K
+transition_matrices:   K x 7 x 7
+innovation_scale_tril: K x 7 x 7
+```
+
+Load a portable prior artifact and bind it to a schema-v4 bundle through the
+stable provider-v2 factor facade:
+
+```python
+from prob4d.gauge_tree_prior_io import load_gauge_tree_prior
+from prob4d.provider_v2_factors import (
+    stack_tree_sparse_observation_factors,
+)
+
+prior = load_gauge_tree_prior("outputs/case-a/gauge-tree-prior.json")
+tree_stacked = stack_tree_sparse_observation_factors(bundle, prior)
+
+# These operations use the tree factors and do not retain a dense prior.
+gauge_response = tree_stacked.gauge_covariance_action(gauge_rhs)
+observation_response = tree_stacked.marginal_observation_covariance_action(
+    residual_direction
+)
+```
+
+Before releasing the dense prior, `stack_tree_sparse_observation_factors`
+requires:
+
+- exact gauge-order equality;
+- complete numerical equality between the tree covariance and the schema-v4
+  joint covariance;
+- source-covariance digest equality when the tree prior carries that digest; and
+- row-marginal covariance equality under the tree's diagonal gauge blocks.
+
+A mismatch fails closed. The returned `TreeSparseStackedObservationFactors`
+reuses the already immutable row arrays but contains no
+`gauge_prior_covariance` field. It exposes matrix-free covariance and information
+actions, observation-space gauge covariance, complete marginal observation
+covariance, and explicitly guarded dense materialization for compatibility.
+
+Binding an already-created `SparseStackedObservationFactors` is also available:
+
+```python
+from prob4d.provider_v2_factors import bind_gauge_tree_prior
+
+tree_stacked = bind_gauge_tree_prior(stacked, prior)
+```
+
+The caller may retain the old dense stack separately; the returned tree-backed
+object does not reference its dense covariance.
+
+## Constructing the sparse gauge prior
 
 An existing dense bundle can be converted only when its declared parent order is
 available:
@@ -90,32 +142,36 @@ prior = GaugeTreeSquareRootPriorV1.from_dense_covariance(
     parent_indices=parent_indices,
     joint_covariance=stacked.gauge_prior_covariance,
 )
-
-complete_covariance_action = prior.marginal_observation_covariance_action(
-    stacked.local_gauge_jacobian,
-    stacked.gauge_indices,
-    stacked.conditional_world_covariance_m2,
-    residual_direction,
-)
 ```
 
 The converter reconstructs and verifies the entire dense covariance. It fails
 closed for a wrong parent tree, singular factors, or off-tree conditional
-dependence. See [sparse square-root gauge-tree prior](sparse-gauge-tree-prior.md)
-for the construction and operation contracts.
+dependence. Direct construction from transition and innovation factors plus the
+portable prior artifact is the intended low-memory producer path. See
+[sparse square-root gauge-tree prior](sparse-gauge-tree-prior.md) and
+[portable gauge-tree prior artifacts](gauge-tree-prior-artifact.md).
+
+## Remaining serialization boundary
 
 The current serialized schema-v4 factor bundle still carries the dense prior.
-The new backend therefore reduces retained execution storage after direct sparse
-construction or verified conversion, but does not yet reduce artifact size or
-initial dense-loading peak. Eliminating the dense serialized prior requires a
-future provider or artifact version.
+Consequently, loading schema v4 and converting or binding it incurs the original
+dense file and transient loading cost once. The tree-backed stack removes the
+dense prior from the retained execution object; it does not retroactively change
+the bundle bytes or their content identity.
+
+Eliminating the dense prior before initial factor-bundle loading requires a
+separately versioned provider or observation-factor contract. Such a future
+contract should bind the portable prior artifact identity rather than silently
+reinterpret schema v4.
 
 ## Compatibility and claim boundary
 
-The existing `StackedObservationFactors`, factor-bundle schema v4, provider-v1
-surface, provider-v2 artifacts, and content addresses remain unchanged. Both
-sparse adapters are additive in-memory execution representations.
+The existing `StackedObservationFactors`, `SparseStackedObservationFactors`,
+factor-bundle schema v4, provider-v1 surface, provider-v2 artifacts, and content
+addresses remain unchanged. The tree-backed stack is an additive execution
+representation.
 
-Lower memory use and exact dense parity are engineering properties. They do not
-establish point-covariance calibration, physical-state identifiability, safe
-BayesianPhysTwin updates, or improved Causal4D predictions.
+Exact dense parity, matrix-free operations, and lower retained memory are
+engineering properties. They do not establish point-covariance calibration,
+physical-state identifiability, safe BayesianPhysTwin updates, improved Causal4D
+predictions, deployment safety, or state of the art.

--- a/src/prob4d/provider_v2_factors.py
+++ b/src/prob4d/provider_v2_factors.py
@@ -1,8 +1,8 @@
 """Stable provider-v2 surface for explicit-gauge observation factors.
 
 This module collects the neutral schema-v4 factor contract, the strict
-claim-bearing provider-v2 envelope, and the sparse in-memory execution adapter in
-one import boundary.  It is additive to :mod:`prob4d.provider_v2`, whose frozen
+claim-bearing provider-v2 envelope, and sparse in-memory execution adapters in
+one import boundary. It is additive to :mod:`prob4d.provider_v2`, whose frozen
 observation-belief and factor-stream symbols remain unchanged.
 """
 
@@ -38,6 +38,11 @@ from .sparse_observation_factors import (
     SparseStackedObservationFactors,
     stack_sparse_observation_factors,
 )
+from .tree_sparse_observation_factors import (
+    TreeSparseStackedObservationFactors,
+    bind_gauge_tree_prior,
+    stack_tree_sparse_observation_factors,
+)
 
 PROVIDER_FACTOR_API_VERSION = 2
 PROB4D_PROVIDER_FACTOR_API_VERSION = PROVIDER_FACTOR_API_VERSION
@@ -61,13 +66,16 @@ __all__ = [
     "PROVIDER_FACTOR_API_VERSION",
     "SparseStackedObservationFactors",
     "StackedObservationFactors",
+    "TreeSparseStackedObservationFactors",
     "ValidatedClaimBearingObservationFactorBundle",
+    "bind_gauge_tree_prior",
     "load_claim_bearing_observation_factor_bundle",
     "load_observation_factor_bundle",
     "seal_claim_bearing_observation_factor_bundle",
     "sim3_point_jacobian",
     "stack_observation_factors",
     "stack_sparse_observation_factors",
+    "stack_tree_sparse_observation_factors",
     "validate_claim_bearing_observation_factor_bundle",
     "write_claim_bearing_observation_factor_bundle",
     "write_observation_factor_bundle",

--- a/src/prob4d/tree_sparse_observation_factors.py
+++ b/src/prob4d/tree_sparse_observation_factors.py
@@ -24,44 +24,65 @@ from .sparse_observation_factors import (
 FloatArray: TypeAlias = NDArray[np.floating[Any]]
 IntArray: TypeAlias = NDArray[np.integer[Any]]
 
+_ROW_ARRAY_FIELDS = (
+    "world_mean_m",
+    "conditional_world_covariance_m2",
+    "marginal_world_covariance_m2",
+    "local_gauge_jacobian",
+    "gauge_indices",
+    "association_probability",
+    "prior_reliability",
+    "prior_nominal_probability",
+    "composite_weight",
+    "point_ids",
+    "frame_indices",
+)
+_TRANSFER_FIELDS = (
+    *_ROW_ARRAY_FIELDS,
+    "view_ids",
+    "factor_ids",
+    "correlation_group_ids",
+    "causal_frame_stop",
+)
 
-def _readonly(value: np.ndarray, *, dtype: Any | None = None) -> np.ndarray:
-    result = np.asarray(value, dtype=dtype).copy()
-    result.setflags(write=False)
-    return result
 
-
-def _integer_vector(value: np.ndarray, *, name: str) -> np.ndarray:
-    raw = np.asarray(value)
-    if raw.ndim != 1:
-        raise ValueError(f"{name} must be a vector")
-    if raw.dtype.kind not in {"i", "u"}:
-        raise TypeError(f"{name} must contain genuine integers")
-    return np.asarray(raw, dtype=np.int64)
-
-
-def _validate_covariance_rows(value: np.ndarray, *, name: str) -> None:
-    symmetric = 0.5 * (value + value.swapaxes(1, 2))
-    scale = np.maximum(np.max(np.abs(symmetric), axis=(1, 2), initial=0.0), 1.0)
+def _require_marginal_parity(
+    stacked: SparseStackedObservationFactors,
+    gauge_tree_prior: GaugeTreeSquareRootPriorV1,
+) -> None:
+    with np.errstate(invalid="ignore", over="ignore"):
+        gauge_marginal = gauge_tree_prior.row_marginal_covariance(
+            stacked.local_gauge_jacobian,
+            stacked.gauge_indices,
+        )
+        expected = stacked.conditional_world_covariance_m2 + gauge_marginal
+        expected = 0.5 * (expected + expected.swapaxes(1, 2))
     if not np.allclose(
-        value,
-        symmetric,
-        atol=1e-12 * scale[:, None, None],
+        stacked.marginal_world_covariance_m2,
+        expected,
+        atol=1e-12,
         rtol=1e-10,
+        equal_nan=True,
     ):
-        raise ValueError(f"{name} must be symmetric")
-    if np.any(np.min(np.linalg.eigvalsh(symmetric), axis=1) < -1e-12 * scale):
-        raise ValueError(f"{name} must be positive semidefinite")
+        raise ValueError(
+            "marginal_world_covariance_m2 does not match the tree gauge prior"
+        )
 
 
-@dataclass(frozen=True, slots=True)
+def _require_immutable_rows(stacked: SparseStackedObservationFactors) -> None:
+    for name in _ROW_ARRAY_FIELDS:
+        if np.asarray(getattr(stacked, name)).flags.writeable:
+            raise ValueError(f"stacked {name} must be immutable")
+
+
+@dataclass(frozen=True, slots=True, init=False)
 class TreeSparseStackedObservationFactors:
-    """Sparse observation rows backed by an ``O(K)`` causal gauge-tree prior.
+    """Factory-built sparse rows backed by an ``O(K)`` causal gauge-tree prior.
 
-    ``conditional_world_covariance_m2`` is the covariance for explicit-gauge
-    inference. ``marginal_world_covariance_m2`` is retained only for diagnostics
-    and parity checks; adding it to an explicit gauge design would count the
-    gauge uncertainty twice.
+    Construct instances through :func:`bind_gauge_tree_prior` or
+    :func:`stack_tree_sparse_observation_factors`. The factory verifies the tree
+    against the complete dense schema-v4 prior and the retained row marginals
+    before transferring the already immutable row arrays.
     """
 
     world_mean_m: FloatArray
@@ -81,148 +102,10 @@ class TreeSparseStackedObservationFactors:
     correlation_group_ids: tuple[str, ...]
     causal_frame_stop: int
 
-    def __post_init__(self) -> None:
-        if not isinstance(self.gauge_tree_prior, GaugeTreeSquareRootPriorV1):
-            raise TypeError("gauge_tree_prior must be a GaugeTreeSquareRootPriorV1")
-        mean = np.asarray(self.world_mean_m, dtype=np.float64)
-        conditional = np.asarray(
-            self.conditional_world_covariance_m2,
-            dtype=np.float64,
+    def __init__(self) -> None:
+        raise TypeError(
+            "use bind_gauge_tree_prior or stack_tree_sparse_observation_factors"
         )
-        marginal = np.asarray(
-            self.marginal_world_covariance_m2,
-            dtype=np.float64,
-        )
-        local_jacobian = np.asarray(self.local_gauge_jacobian, dtype=np.float64)
-        gauge_indices = _integer_vector(self.gauge_indices, name="gauge_indices")
-        association = np.asarray(self.association_probability, dtype=np.float64)
-        reliability = np.asarray(self.prior_reliability, dtype=np.float64)
-        nominal = np.asarray(self.prior_nominal_probability, dtype=np.float64)
-        composite = np.asarray(self.composite_weight, dtype=np.float64)
-        point_ids = _integer_vector(self.point_ids, name="point_ids")
-        frame_indices = _integer_vector(self.frame_indices, name="frame_indices")
-        count = len(mean)
-        gauge_count = self.gauge_tree_prior.gauge_count
-
-        if count < 1:
-            raise ValueError("tree-sparse observation-factor stack must contain rows")
-        if mean.shape != (count, 3):
-            raise ValueError("world_mean_m must have shape (M, 3)")
-        if conditional.shape != (count, 3, 3):
-            raise ValueError(
-                "conditional_world_covariance_m2 must have shape (M, 3, 3)"
-            )
-        if marginal.shape != (count, 3, 3):
-            raise ValueError("marginal_world_covariance_m2 must have shape (M, 3, 3)")
-        if local_jacobian.shape != (count, 3, 7):
-            raise ValueError("local_gauge_jacobian must have shape (M, 3, 7)")
-        if gauge_indices.shape != (count,):
-            raise ValueError("gauge_indices must have shape (M,)")
-        if np.any(gauge_indices < 0) or np.any(gauge_indices >= gauge_count):
-            raise ValueError("gauge_indices reference an unknown gauge")
-
-        for name, values in (
-            ("world_mean_m", mean),
-            ("conditional_world_covariance_m2", conditional),
-            ("marginal_world_covariance_m2", marginal),
-            ("local_gauge_jacobian", local_jacobian),
-        ):
-            if not np.all(np.isfinite(values)):
-                raise ValueError(f"{name} must be finite")
-        _validate_covariance_rows(
-            conditional,
-            name="conditional_world_covariance_m2",
-        )
-        _validate_covariance_rows(
-            marginal,
-            name="marginal_world_covariance_m2",
-        )
-
-        probabilities = (
-            ("association_probability", association, True),
-            ("prior_reliability", reliability, True),
-            ("prior_nominal_probability", nominal, True),
-            ("composite_weight", composite, False),
-        )
-        for name, values, allow_zero in probabilities:
-            if values.shape != (count,):
-                raise ValueError(f"{name} must have shape (M,)")
-            lower = values >= 0.0 if allow_zero else values > 0.0
-            if (
-                not np.all(np.isfinite(values))
-                or not np.all(lower)
-                or np.any(values > 1.0)
-            ):
-                interval = "[0, 1]" if allow_zero else "(0, 1]"
-                raise ValueError(f"{name} must lie in {interval}")
-
-        if point_ids.shape != (count,) or frame_indices.shape != (count,):
-            raise ValueError("row identity vectors must have shape (M,)")
-        if np.any(frame_indices < 0):
-            raise ValueError("frame identities must be nonnegative")
-        raw_causal_frame_stop = self.causal_frame_stop
-        if (
-            isinstance(raw_causal_frame_stop, (bool, np.bool_))
-            or not isinstance(raw_causal_frame_stop, (int, np.integer))
-        ):
-            raise TypeError("causal_frame_stop must be a genuine integer")
-        causal_frame_stop = int(raw_causal_frame_stop)
-        if causal_frame_stop < 1:
-            raise ValueError("causal_frame_stop must be positive")
-        if np.any(frame_indices >= causal_frame_stop):
-            raise ValueError("stacked rows cross the exclusive causal frame stop")
-
-        string_fields = {
-            "view_ids": self.view_ids,
-            "factor_ids": self.factor_ids,
-            "correlation_group_ids": self.correlation_group_ids,
-        }
-        normalized_strings: dict[str, tuple[str, ...]] = {}
-        for name, raw_values in string_fields.items():
-            if not isinstance(raw_values, tuple) or any(
-                not isinstance(value, str) for value in raw_values
-            ):
-                raise TypeError(f"{name} must be a tuple of strings")
-            values = tuple(raw_values)
-            if len(values) != count or any(not value for value in values):
-                raise ValueError(f"{name} must contain one nonempty string per row")
-            normalized_strings[name] = values
-
-        gauge_marginal = self.gauge_tree_prior.row_marginal_covariance(
-            local_jacobian,
-            gauge_indices,
-        )
-        expected_marginal = conditional + gauge_marginal
-        expected_marginal = 0.5 * (
-            expected_marginal + expected_marginal.swapaxes(1, 2)
-        )
-        if not np.allclose(
-            marginal,
-            expected_marginal,
-            atol=1e-12,
-            rtol=1e-10,
-        ):
-            raise ValueError(
-                "marginal_world_covariance_m2 does not match the tree gauge prior"
-            )
-
-        for name, value in (
-            ("world_mean_m", mean),
-            ("conditional_world_covariance_m2", conditional),
-            ("marginal_world_covariance_m2", marginal),
-            ("local_gauge_jacobian", local_jacobian),
-            ("gauge_indices", gauge_indices),
-            ("association_probability", association),
-            ("prior_reliability", reliability),
-            ("prior_nominal_probability", nominal),
-            ("composite_weight", composite),
-            ("point_ids", point_ids),
-            ("frame_indices", frame_indices),
-        ):
-            object.__setattr__(self, name, _readonly(value))
-        for name, values in normalized_strings.items():
-            object.__setattr__(self, name, values)
-        object.__setattr__(self, "causal_frame_stop", causal_frame_stop)
 
     @classmethod
     def _from_verified_sparse_stack(
@@ -230,26 +113,8 @@ class TreeSparseStackedObservationFactors:
         stacked: SparseStackedObservationFactors,
         gauge_tree_prior: GaugeTreeSquareRootPriorV1,
     ) -> TreeSparseStackedObservationFactors:
-        """Transfer immutable row arrays after exact dense-prior verification."""
-
         result = object.__new__(cls)
-        for name in (
-            "world_mean_m",
-            "conditional_world_covariance_m2",
-            "marginal_world_covariance_m2",
-            "local_gauge_jacobian",
-            "gauge_indices",
-            "association_probability",
-            "prior_reliability",
-            "prior_nominal_probability",
-            "composite_weight",
-            "point_ids",
-            "frame_indices",
-            "view_ids",
-            "factor_ids",
-            "correlation_group_ids",
-            "causal_frame_stop",
-        ):
+        for name in _TRANSFER_FIELDS:
             object.__setattr__(result, name, getattr(stacked, name))
         object.__setattr__(result, "gauge_tree_prior", gauge_tree_prior)
         return result
@@ -296,6 +161,8 @@ class TreeSparseStackedObservationFactors:
         return self.gauge_tree_prior.storage_ratio_to_dense
 
     def dense_gauge_jacobian(self) -> FloatArray:
+        """Materialize the historical dense row design as a compatibility copy."""
+
         result: FloatArray = np.zeros(
             (self.observation_count, 3, self.dense_gauge_dimension),
             dtype=np.float64,
@@ -307,6 +174,8 @@ class TreeSparseStackedObservationFactors:
         return result
 
     def apply_gauge_delta(self, gauge_delta: FloatArray) -> FloatArray:
+        """Apply one flat or block-shaped gauge perturbation to every row."""
+
         delta = np.asarray(gauge_delta, dtype=np.float64)
         blocks: FloatArray
         if delta.shape == (self.dense_gauge_dimension,):
@@ -328,6 +197,8 @@ class TreeSparseStackedObservationFactors:
         )
 
     def gauge_marginal_covariance_m2(self) -> FloatArray:
+        """Return each row's ``J Sigma_gg J^T`` contribution."""
+
         return self.gauge_tree_prior.row_marginal_covariance(
             self.local_gauge_jacobian,
             self.gauge_indices,
@@ -359,6 +230,8 @@ class TreeSparseStackedObservationFactors:
         *,
         maximum_gauges: int = 128,
     ) -> FloatArray:
+        """Explicitly materialize the dense prior behind the existing size guard."""
+
         return self.gauge_tree_prior.materialize_dense_covariance(
             maximum_gauges=maximum_gauges,
         )
@@ -386,6 +259,8 @@ def bind_gauge_tree_prior(
             gauge_tree_prior.source_joint_covariance_sha256 is not None
         ),
     )
+    _require_immutable_rows(stacked)
+    _require_marginal_parity(stacked, gauge_tree_prior)
     return TreeSparseStackedObservationFactors._from_verified_sparse_stack(
         stacked,
         gauge_tree_prior,

--- a/src/prob4d/tree_sparse_observation_factors.py
+++ b/src/prob4d/tree_sparse_observation_factors.py
@@ -64,9 +64,7 @@ def _require_marginal_parity(
         rtol=1e-10,
         equal_nan=True,
     ):
-        raise ValueError(
-            "marginal_world_covariance_m2 does not match the tree gauge prior"
-        )
+        raise ValueError("marginal_world_covariance_m2 does not match the tree gauge prior")
 
 
 def _require_immutable_rows(stacked: SparseStackedObservationFactors) -> None:
@@ -103,9 +101,7 @@ class TreeSparseStackedObservationFactors:
     causal_frame_stop: int
 
     def __init__(self) -> None:
-        raise TypeError(
-            "use bind_gauge_tree_prior or stack_tree_sparse_observation_factors"
-        )
+        raise TypeError("use bind_gauge_tree_prior or stack_tree_sparse_observation_factors")
 
     @classmethod
     def _from_verified_sparse_stack(
@@ -142,10 +138,7 @@ class TreeSparseStackedObservationFactors:
     @property
     def dense_gauge_design_nbytes(self) -> int:
         return int(
-            self.observation_count
-            * 3
-            * self.dense_gauge_dimension
-            * np.dtype(np.float64).itemsize
+            self.observation_count * 3 * self.dense_gauge_dimension * np.dtype(np.float64).itemsize
         )
 
     @property
@@ -255,9 +248,7 @@ def bind_gauge_tree_prior(
         raise ValueError("gauge-tree prior order does not match the sparse stack")
     gauge_tree_prior.verify_dense_covariance(
         stacked.gauge_prior_covariance,
-        require_source_digest=(
-            gauge_tree_prior.source_joint_covariance_sha256 is not None
-        ),
+        require_source_digest=(gauge_tree_prior.source_joint_covariance_sha256 is not None),
     )
     _require_immutable_rows(stacked)
     _require_marginal_parity(stacked, gauge_tree_prior)

--- a/src/prob4d/tree_sparse_observation_factors.py
+++ b/src/prob4d/tree_sparse_observation_factors.py
@@ -1,0 +1,416 @@
+"""Tree-backed sparse stacking for explicit-gauge observation-factor updates.
+
+The historical sparse stack removes the ``M x 3 x 7K`` row expansion but retains
+one dense ``7K x 7K`` gauge covariance. This module binds the same immutable row
+representation to :class:`GaugeTreeSquareRootPriorV1` after exact dense parity
+verification, then drops the retained dense covariance from the returned object.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, TypeAlias
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .gauge_tree_prior import GaugeTreeSquareRootPriorV1
+from .observation_factors import ObservationFactorBundle
+from .sparse_observation_factors import (
+    SparseStackedObservationFactors,
+    stack_sparse_observation_factors,
+)
+
+FloatArray: TypeAlias = NDArray[np.floating[Any]]
+IntArray: TypeAlias = NDArray[np.integer[Any]]
+
+
+def _readonly(value: np.ndarray, *, dtype: Any | None = None) -> np.ndarray:
+    result = np.asarray(value, dtype=dtype).copy()
+    result.setflags(write=False)
+    return result
+
+
+def _integer_vector(value: np.ndarray, *, name: str) -> np.ndarray:
+    raw = np.asarray(value)
+    if raw.ndim != 1:
+        raise ValueError(f"{name} must be a vector")
+    if raw.dtype.kind not in {"i", "u"}:
+        raise TypeError(f"{name} must contain genuine integers")
+    return np.asarray(raw, dtype=np.int64)
+
+
+def _validate_covariance_rows(value: np.ndarray, *, name: str) -> None:
+    symmetric = 0.5 * (value + value.swapaxes(1, 2))
+    scale = np.maximum(np.max(np.abs(symmetric), axis=(1, 2), initial=0.0), 1.0)
+    if not np.allclose(
+        value,
+        symmetric,
+        atol=1e-12 * scale[:, None, None],
+        rtol=1e-10,
+    ):
+        raise ValueError(f"{name} must be symmetric")
+    if np.any(np.min(np.linalg.eigvalsh(symmetric), axis=1) < -1e-12 * scale):
+        raise ValueError(f"{name} must be positive semidefinite")
+
+
+@dataclass(frozen=True, slots=True)
+class TreeSparseStackedObservationFactors:
+    """Sparse observation rows backed by an ``O(K)`` causal gauge-tree prior.
+
+    ``conditional_world_covariance_m2`` is the covariance for explicit-gauge
+    inference. ``marginal_world_covariance_m2`` is retained only for diagnostics
+    and parity checks; adding it to an explicit gauge design would count the
+    gauge uncertainty twice.
+    """
+
+    world_mean_m: FloatArray
+    conditional_world_covariance_m2: FloatArray
+    marginal_world_covariance_m2: FloatArray
+    local_gauge_jacobian: FloatArray
+    gauge_indices: IntArray
+    gauge_tree_prior: GaugeTreeSquareRootPriorV1
+    association_probability: FloatArray
+    prior_reliability: FloatArray
+    prior_nominal_probability: FloatArray
+    composite_weight: FloatArray
+    point_ids: IntArray
+    frame_indices: IntArray
+    view_ids: tuple[str, ...]
+    factor_ids: tuple[str, ...]
+    correlation_group_ids: tuple[str, ...]
+    causal_frame_stop: int
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.gauge_tree_prior, GaugeTreeSquareRootPriorV1):
+            raise TypeError("gauge_tree_prior must be a GaugeTreeSquareRootPriorV1")
+        mean = np.asarray(self.world_mean_m, dtype=np.float64)
+        conditional = np.asarray(
+            self.conditional_world_covariance_m2,
+            dtype=np.float64,
+        )
+        marginal = np.asarray(
+            self.marginal_world_covariance_m2,
+            dtype=np.float64,
+        )
+        local_jacobian = np.asarray(self.local_gauge_jacobian, dtype=np.float64)
+        gauge_indices = _integer_vector(self.gauge_indices, name="gauge_indices")
+        association = np.asarray(self.association_probability, dtype=np.float64)
+        reliability = np.asarray(self.prior_reliability, dtype=np.float64)
+        nominal = np.asarray(self.prior_nominal_probability, dtype=np.float64)
+        composite = np.asarray(self.composite_weight, dtype=np.float64)
+        point_ids = _integer_vector(self.point_ids, name="point_ids")
+        frame_indices = _integer_vector(self.frame_indices, name="frame_indices")
+        count = len(mean)
+        gauge_count = self.gauge_tree_prior.gauge_count
+
+        if count < 1:
+            raise ValueError("tree-sparse observation-factor stack must contain rows")
+        if mean.shape != (count, 3):
+            raise ValueError("world_mean_m must have shape (M, 3)")
+        if conditional.shape != (count, 3, 3):
+            raise ValueError(
+                "conditional_world_covariance_m2 must have shape (M, 3, 3)"
+            )
+        if marginal.shape != (count, 3, 3):
+            raise ValueError("marginal_world_covariance_m2 must have shape (M, 3, 3)")
+        if local_jacobian.shape != (count, 3, 7):
+            raise ValueError("local_gauge_jacobian must have shape (M, 3, 7)")
+        if gauge_indices.shape != (count,):
+            raise ValueError("gauge_indices must have shape (M,)")
+        if np.any(gauge_indices < 0) or np.any(gauge_indices >= gauge_count):
+            raise ValueError("gauge_indices reference an unknown gauge")
+
+        for name, values in (
+            ("world_mean_m", mean),
+            ("conditional_world_covariance_m2", conditional),
+            ("marginal_world_covariance_m2", marginal),
+            ("local_gauge_jacobian", local_jacobian),
+        ):
+            if not np.all(np.isfinite(values)):
+                raise ValueError(f"{name} must be finite")
+        _validate_covariance_rows(
+            conditional,
+            name="conditional_world_covariance_m2",
+        )
+        _validate_covariance_rows(
+            marginal,
+            name="marginal_world_covariance_m2",
+        )
+
+        probabilities = (
+            ("association_probability", association, True),
+            ("prior_reliability", reliability, True),
+            ("prior_nominal_probability", nominal, True),
+            ("composite_weight", composite, False),
+        )
+        for name, values, allow_zero in probabilities:
+            if values.shape != (count,):
+                raise ValueError(f"{name} must have shape (M,)")
+            lower = values >= 0.0 if allow_zero else values > 0.0
+            if (
+                not np.all(np.isfinite(values))
+                or not np.all(lower)
+                or np.any(values > 1.0)
+            ):
+                interval = "[0, 1]" if allow_zero else "(0, 1]"
+                raise ValueError(f"{name} must lie in {interval}")
+
+        if point_ids.shape != (count,) or frame_indices.shape != (count,):
+            raise ValueError("row identity vectors must have shape (M,)")
+        if np.any(frame_indices < 0):
+            raise ValueError("frame identities must be nonnegative")
+        raw_causal_frame_stop = self.causal_frame_stop
+        if (
+            isinstance(raw_causal_frame_stop, (bool, np.bool_))
+            or not isinstance(raw_causal_frame_stop, (int, np.integer))
+        ):
+            raise TypeError("causal_frame_stop must be a genuine integer")
+        causal_frame_stop = int(raw_causal_frame_stop)
+        if causal_frame_stop < 1:
+            raise ValueError("causal_frame_stop must be positive")
+        if np.any(frame_indices >= causal_frame_stop):
+            raise ValueError("stacked rows cross the exclusive causal frame stop")
+
+        string_fields = {
+            "view_ids": self.view_ids,
+            "factor_ids": self.factor_ids,
+            "correlation_group_ids": self.correlation_group_ids,
+        }
+        normalized_strings: dict[str, tuple[str, ...]] = {}
+        for name, raw_values in string_fields.items():
+            if not isinstance(raw_values, tuple) or any(
+                not isinstance(value, str) for value in raw_values
+            ):
+                raise TypeError(f"{name} must be a tuple of strings")
+            values = tuple(raw_values)
+            if len(values) != count or any(not value for value in values):
+                raise ValueError(f"{name} must contain one nonempty string per row")
+            normalized_strings[name] = values
+
+        gauge_marginal = self.gauge_tree_prior.row_marginal_covariance(
+            local_jacobian,
+            gauge_indices,
+        )
+        expected_marginal = conditional + gauge_marginal
+        expected_marginal = 0.5 * (
+            expected_marginal + expected_marginal.swapaxes(1, 2)
+        )
+        if not np.allclose(
+            marginal,
+            expected_marginal,
+            atol=1e-12,
+            rtol=1e-10,
+        ):
+            raise ValueError(
+                "marginal_world_covariance_m2 does not match the tree gauge prior"
+            )
+
+        for name, value in (
+            ("world_mean_m", mean),
+            ("conditional_world_covariance_m2", conditional),
+            ("marginal_world_covariance_m2", marginal),
+            ("local_gauge_jacobian", local_jacobian),
+            ("gauge_indices", gauge_indices),
+            ("association_probability", association),
+            ("prior_reliability", reliability),
+            ("prior_nominal_probability", nominal),
+            ("composite_weight", composite),
+            ("point_ids", point_ids),
+            ("frame_indices", frame_indices),
+        ):
+            object.__setattr__(self, name, _readonly(value))
+        for name, values in normalized_strings.items():
+            object.__setattr__(self, name, values)
+        object.__setattr__(self, "causal_frame_stop", causal_frame_stop)
+
+    @classmethod
+    def _from_verified_sparse_stack(
+        cls,
+        stacked: SparseStackedObservationFactors,
+        gauge_tree_prior: GaugeTreeSquareRootPriorV1,
+    ) -> TreeSparseStackedObservationFactors:
+        """Transfer immutable row arrays after exact dense-prior verification."""
+
+        result = object.__new__(cls)
+        for name in (
+            "world_mean_m",
+            "conditional_world_covariance_m2",
+            "marginal_world_covariance_m2",
+            "local_gauge_jacobian",
+            "gauge_indices",
+            "association_probability",
+            "prior_reliability",
+            "prior_nominal_probability",
+            "composite_weight",
+            "point_ids",
+            "frame_indices",
+            "view_ids",
+            "factor_ids",
+            "correlation_group_ids",
+            "causal_frame_stop",
+        ):
+            object.__setattr__(result, name, getattr(stacked, name))
+        object.__setattr__(result, "gauge_tree_prior", gauge_tree_prior)
+        return result
+
+    @property
+    def observation_count(self) -> int:
+        return len(self.world_mean_m)
+
+    @property
+    def gauge_ids(self) -> tuple[str, ...]:
+        return self.gauge_tree_prior.gauge_ids
+
+    @property
+    def gauge_count(self) -> int:
+        return self.gauge_tree_prior.gauge_count
+
+    @property
+    def dense_gauge_dimension(self) -> int:
+        return self.gauge_tree_prior.dimension
+
+    @property
+    def sparse_gauge_design_nbytes(self) -> int:
+        return int(self.local_gauge_jacobian.nbytes + self.gauge_indices.nbytes)
+
+    @property
+    def dense_gauge_design_nbytes(self) -> int:
+        return int(
+            self.observation_count
+            * 3
+            * self.dense_gauge_dimension
+            * np.dtype(np.float64).itemsize
+        )
+
+    @property
+    def gauge_prior_storage_nbytes(self) -> int:
+        return self.gauge_tree_prior.factor_storage_nbytes
+
+    @property
+    def dense_gauge_prior_nbytes(self) -> int:
+        return self.gauge_tree_prior.dense_covariance_nbytes
+
+    @property
+    def gauge_prior_storage_ratio_to_dense(self) -> float:
+        return self.gauge_tree_prior.storage_ratio_to_dense
+
+    def dense_gauge_jacobian(self) -> FloatArray:
+        result: FloatArray = np.zeros(
+            (self.observation_count, 3, self.dense_gauge_dimension),
+            dtype=np.float64,
+        )
+        for gauge_index in range(self.gauge_count):
+            selected = self.gauge_indices == gauge_index
+            start = 7 * gauge_index
+            result[selected, :, start : start + 7] = self.local_gauge_jacobian[selected]
+        return result
+
+    def apply_gauge_delta(self, gauge_delta: FloatArray) -> FloatArray:
+        delta = np.asarray(gauge_delta, dtype=np.float64)
+        blocks: FloatArray
+        if delta.shape == (self.dense_gauge_dimension,):
+            blocks = delta.reshape(self.gauge_count, 7)
+        elif delta.shape == (self.gauge_count, 7):
+            blocks = delta
+        else:
+            raise ValueError(
+                "gauge_delta must have shape "
+                f"({self.dense_gauge_dimension},) or ({self.gauge_count}, 7)"
+            )
+        if not np.all(np.isfinite(blocks)):
+            raise ValueError("gauge_delta must be finite")
+        return np.einsum(
+            "nij,nj->ni",
+            self.local_gauge_jacobian,
+            blocks[self.gauge_indices],
+            optimize=True,
+        )
+
+    def gauge_marginal_covariance_m2(self) -> FloatArray:
+        return self.gauge_tree_prior.row_marginal_covariance(
+            self.local_gauge_jacobian,
+            self.gauge_indices,
+        )
+
+    def gauge_covariance_action(self, value: Any) -> FloatArray:
+        return self.gauge_tree_prior.covariance_action(value)
+
+    def gauge_information_action(self, value: Any) -> FloatArray:
+        return self.gauge_tree_prior.information_action(value)
+
+    def observation_gauge_covariance_action(self, value: Any) -> FloatArray:
+        return self.gauge_tree_prior.observation_covariance_action(
+            self.local_gauge_jacobian,
+            self.gauge_indices,
+            value,
+        )
+
+    def marginal_observation_covariance_action(self, value: Any) -> FloatArray:
+        return self.gauge_tree_prior.marginal_observation_covariance_action(
+            self.local_gauge_jacobian,
+            self.gauge_indices,
+            self.conditional_world_covariance_m2,
+            value,
+        )
+
+    def materialize_dense_gauge_prior(
+        self,
+        *,
+        maximum_gauges: int = 128,
+    ) -> FloatArray:
+        return self.gauge_tree_prior.materialize_dense_covariance(
+            maximum_gauges=maximum_gauges,
+        )
+
+
+def bind_gauge_tree_prior(
+    stacked: SparseStackedObservationFactors,
+    gauge_tree_prior: GaugeTreeSquareRootPriorV1,
+) -> TreeSparseStackedObservationFactors:
+    """Verify a sparse tree against a dense stack and release the dense prior.
+
+    The returned object reuses the stack's already immutable row arrays. It does
+    not retain ``stacked.gauge_prior_covariance``.
+    """
+
+    if not isinstance(stacked, SparseStackedObservationFactors):
+        raise TypeError("stacked must be a SparseStackedObservationFactors")
+    if not isinstance(gauge_tree_prior, GaugeTreeSquareRootPriorV1):
+        raise TypeError("gauge_tree_prior must be a GaugeTreeSquareRootPriorV1")
+    if gauge_tree_prior.gauge_ids != stacked.gauge_ids:
+        raise ValueError("gauge-tree prior order does not match the sparse stack")
+    gauge_tree_prior.verify_dense_covariance(
+        stacked.gauge_prior_covariance,
+        require_source_digest=(
+            gauge_tree_prior.source_joint_covariance_sha256 is not None
+        ),
+    )
+    return TreeSparseStackedObservationFactors._from_verified_sparse_stack(
+        stacked,
+        gauge_tree_prior,
+    )
+
+
+def stack_tree_sparse_observation_factors(
+    bundle: ObservationFactorBundle,
+    gauge_tree_prior: GaugeTreeSquareRootPriorV1,
+    *,
+    include_invalid: bool = False,
+) -> TreeSparseStackedObservationFactors:
+    """Stack rows, verify the tree prior, and retain no dense gauge covariance."""
+
+    if not isinstance(bundle, ObservationFactorBundle):
+        raise TypeError("bundle must be an ObservationFactorBundle")
+    stacked = stack_sparse_observation_factors(
+        bundle,
+        include_invalid=include_invalid,
+    )
+    return bind_gauge_tree_prior(stacked, gauge_tree_prior)
+
+
+__all__ = [
+    "TreeSparseStackedObservationFactors",
+    "bind_gauge_tree_prior",
+    "stack_tree_sparse_observation_factors",
+]

--- a/tests/test_provider_v2_factors.py
+++ b/tests/test_provider_v2_factors.py
@@ -39,14 +39,8 @@ def test_provider_v2_factor_facade_reexports_one_contract_surface() -> None:
         is strict.write_claim_bearing_observation_factor_bundle
     )
 
-    assert (
-        provider.SparseStackedObservationFactors
-        is sparse.SparseStackedObservationFactors
-    )
-    assert (
-        provider.stack_sparse_observation_factors
-        is sparse.stack_sparse_observation_factors
-    )
+    assert provider.SparseStackedObservationFactors is sparse.SparseStackedObservationFactors
+    assert provider.stack_sparse_observation_factors is sparse.stack_sparse_observation_factors
     assert (
         provider.TreeSparseStackedObservationFactors
         is tree_sparse.TreeSparseStackedObservationFactors

--- a/tests/test_provider_v2_factors.py
+++ b/tests/test_provider_v2_factors.py
@@ -6,6 +6,7 @@ import sys
 import prob4d.observation_factors as neutral
 import prob4d.provider_v2_factor_bundle as strict
 import prob4d.sparse_observation_factors as sparse
+import prob4d.tree_sparse_observation_factors as tree_sparse
 from prob4d import provider_v2_factors as provider
 
 
@@ -45,6 +46,15 @@ def test_provider_v2_factor_facade_reexports_one_contract_surface() -> None:
     assert (
         provider.stack_sparse_observation_factors
         is sparse.stack_sparse_observation_factors
+    )
+    assert (
+        provider.TreeSparseStackedObservationFactors
+        is tree_sparse.TreeSparseStackedObservationFactors
+    )
+    assert provider.bind_gauge_tree_prior is tree_sparse.bind_gauge_tree_prior
+    assert (
+        provider.stack_tree_sparse_observation_factors
+        is tree_sparse.stack_tree_sparse_observation_factors
     )
 
 

--- a/tests/test_tree_sparse_observation_factors.py
+++ b/tests/test_tree_sparse_observation_factors.py
@@ -36,8 +36,6 @@ def _bundle(*, with_invalid_row: bool = False) -> ObservationFactorBundle:
         2,
         axis=0,
     )
-    if with_invalid_row:
-        local_covariance[1] = np.nan
     common = {
         "valid_mask": np.asarray([True, not with_invalid_row]),
         "local_covariance_m2": local_covariance,
@@ -58,7 +56,7 @@ def _bundle(*, with_invalid_row: bool = False) -> ObservationFactorBundle:
             points_local_m=np.asarray(
                 [
                     [0.0, 0.0, 1.0],
-                    [np.nan, np.nan, np.nan] if with_invalid_row else [0.2, 0.0, 1.1],
+                    [0.2, 0.0, 1.1],
                 ],
                 dtype=np.float64,
             ),
@@ -75,7 +73,7 @@ def _bundle(*, with_invalid_row: bool = False) -> ObservationFactorBundle:
             points_local_m=np.asarray(
                 [
                     [0.1, 0.2, 1.2],
-                    [np.nan, np.nan, np.nan] if with_invalid_row else [0.3, 0.1, 1.3],
+                    [0.3, 0.1, 1.3],
                 ],
                 dtype=np.float64,
             ),
@@ -217,8 +215,11 @@ def test_tree_sparse_stack_preserves_include_invalid_semantics() -> None:
 
     assert default.observation_count == 2
     assert complete.observation_count == 4
-    assert np.isnan(complete.world_mean_m[1]).all()
-    assert np.isnan(complete.conditional_world_covariance_m2[1]).all()
+    np.testing.assert_array_equal(default.point_ids, np.asarray([10, 20], dtype=np.int64))
+    np.testing.assert_array_equal(
+        complete.point_ids,
+        np.asarray([10, 11, 20, 21], dtype=np.int64),
+    )
 
 
 def test_binding_rejects_wrong_gauge_order_and_wrong_covariance() -> None:

--- a/tests/test_tree_sparse_observation_factors.py
+++ b/tests/test_tree_sparse_observation_factors.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from prob4d.gauge import GaugeEstimate
+from prob4d.gauge_tree_prior import GaugeTreeSquareRootPriorV1
+from prob4d.observation_factors import ObservationFactor, ObservationFactorBundle
+from prob4d.sim3 import Sim3
+from prob4d.sparse_observation_factors import stack_sparse_observation_factors
+from prob4d.tree_sparse_observation_factors import (
+    TreeSparseStackedObservationFactors,
+    bind_gauge_tree_prior,
+    stack_tree_sparse_observation_factors,
+)
+
+
+def _bundle(*, with_invalid_row: bool = False) -> ObservationFactorBundle:
+    covariance_0 = np.eye(7, dtype=np.float64) * 2.0e-4
+    covariance_1 = np.eye(7, dtype=np.float64) * 3.0e-4
+    cross = np.eye(7, dtype=np.float64) * 5.0e-5
+    joint = np.block(
+        [
+            [covariance_0, cross],
+            [cross, covariance_1],
+        ]
+    )
+    gauges = (
+        GaugeEstimate("window-0", Sim3.identity(), covariance_0),
+        GaugeEstimate("window-1", Sim3.identity(), covariance_1),
+    )
+    common = {
+        "valid_mask": np.asarray([True, not with_invalid_row]),
+        "local_covariance_m2": np.repeat(
+            np.eye(3, dtype=np.float64)[None] * 1.0e-3,
+            2,
+            axis=0,
+        ),
+        "association_probability": np.asarray([0.9, 0.8]),
+        "prior_reliability": np.asarray([0.85, 0.75]),
+        "prior_nominal_probability": 0.95,
+        "composite_weight": 0.5,
+        "causal_frame_stop": 6,
+    }
+    factors = (
+        ObservationFactor(
+            factor_id="factor-0",
+            frame_index=2,
+            view_id="camera-0",
+            window_id="window-0",
+            gauge_id="window-0",
+            point_ids=np.asarray([10, 11], dtype=np.int64),
+            points_local_m=np.asarray(
+                [[0.0, 0.0, 1.0], [0.2, 0.0, 1.1]],
+                dtype=np.float64,
+            ),
+            correlation_group_id="camera-0:frame-2",
+            **common,
+        ),
+        ObservationFactor(
+            factor_id="factor-1",
+            frame_index=4,
+            view_id="camera-0",
+            window_id="window-1",
+            gauge_id="window-1",
+            point_ids=np.asarray([20, 21], dtype=np.int64),
+            points_local_m=np.asarray(
+                [[0.1, 0.2, 1.2], [0.3, 0.1, 1.3]],
+                dtype=np.float64,
+            ),
+            correlation_group_id="camera-0:frame-4",
+            **common,
+        ),
+    )
+    return ObservationFactorBundle(
+        sequence_id="sequence-a",
+        case_id="case-a",
+        stream_id="prob4d:explicit-gauge:camera-0",
+        factors=factors,
+        gauges=gauges,
+        source_repository="FlorianPfaff/Prob4D",
+        source_revision="a" * 40,
+        causal_frame_stop=6,
+        joint_gauge_covariance=joint,
+        gauge_covariance_semantics="joint-cross-window",
+    )
+
+
+def _prior(bundle: ObservationFactorBundle) -> GaugeTreeSquareRootPriorV1:
+    return GaugeTreeSquareRootPriorV1.from_dense_covariance(
+        gauge_ids=tuple(gauge.window_id for gauge in bundle.gauges),
+        parent_indices=np.asarray([-1, 0], dtype=np.int64),
+        joint_covariance=bundle.joint_gauge_covariance,
+    )
+
+
+def test_tree_sparse_stack_matches_dense_prior_and_row_contracts() -> None:
+    bundle = _bundle()
+    dense_sparse = stack_sparse_observation_factors(bundle)
+    tree_sparse = stack_tree_sparse_observation_factors(bundle, _prior(bundle))
+
+    assert isinstance(tree_sparse, TreeSparseStackedObservationFactors)
+    np.testing.assert_allclose(tree_sparse.world_mean_m, dense_sparse.world_mean_m)
+    np.testing.assert_allclose(
+        tree_sparse.conditional_world_covariance_m2,
+        dense_sparse.conditional_world_covariance_m2,
+    )
+    np.testing.assert_allclose(
+        tree_sparse.marginal_world_covariance_m2,
+        dense_sparse.marginal_world_covariance_m2,
+    )
+    np.testing.assert_allclose(
+        tree_sparse.dense_gauge_jacobian(),
+        dense_sparse.dense_gauge_jacobian(),
+    )
+    np.testing.assert_allclose(
+        tree_sparse.materialize_dense_gauge_prior(maximum_gauges=2),
+        dense_sparse.gauge_prior_covariance,
+    )
+    np.testing.assert_allclose(
+        tree_sparse.gauge_marginal_covariance_m2(),
+        dense_sparse.gauge_marginal_covariance_m2(),
+    )
+    assert tree_sparse.gauge_ids == dense_sparse.gauge_ids
+    assert tree_sparse.gauge_prior_storage_nbytes < tree_sparse.dense_gauge_prior_nbytes
+
+
+def test_tree_sparse_matrix_free_actions_match_dense_linear_algebra() -> None:
+    bundle = _bundle()
+    dense_sparse = stack_sparse_observation_factors(bundle)
+    tree_sparse = stack_tree_sparse_observation_factors(bundle, _prior(bundle))
+    prior = dense_sparse.gauge_prior_covariance
+    gauge_direction = np.linspace(-0.02, 0.03, 14, dtype=np.float64)
+
+    np.testing.assert_allclose(
+        tree_sparse.gauge_covariance_action(gauge_direction),
+        prior @ gauge_direction,
+    )
+    np.testing.assert_allclose(
+        tree_sparse.gauge_information_action(gauge_direction),
+        np.linalg.solve(prior, gauge_direction),
+    )
+
+    row_direction = np.linspace(
+        -0.03,
+        0.04,
+        tree_sparse.observation_count * 3,
+        dtype=np.float64,
+    ).reshape(tree_sparse.observation_count, 3)
+    dense_design = dense_sparse.dense_gauge_jacobian()
+    gauge_rhs = np.einsum(
+        "mij,mi->j",
+        dense_design,
+        row_direction,
+        optimize=True,
+    )
+    gauge_expected = np.einsum(
+        "mij,j->mi",
+        dense_design,
+        prior @ gauge_rhs,
+        optimize=True,
+    )
+    local_expected = np.einsum(
+        "mij,mj->mi",
+        tree_sparse.conditional_world_covariance_m2,
+        row_direction,
+        optimize=True,
+    )
+    np.testing.assert_allclose(
+        tree_sparse.observation_gauge_covariance_action(row_direction),
+        gauge_expected,
+    )
+    np.testing.assert_allclose(
+        tree_sparse.marginal_observation_covariance_action(row_direction),
+        gauge_expected + local_expected,
+    )
+
+
+def test_binding_reuses_immutable_rows_and_releases_dense_prior() -> None:
+    bundle = _bundle()
+    dense_sparse = stack_sparse_observation_factors(bundle)
+    tree_sparse = bind_gauge_tree_prior(dense_sparse, _prior(bundle))
+
+    assert tree_sparse.world_mean_m is dense_sparse.world_mean_m
+    assert tree_sparse.local_gauge_jacobian is dense_sparse.local_gauge_jacobian
+    assert tree_sparse.gauge_indices is dense_sparse.gauge_indices
+    assert not hasattr(tree_sparse, "gauge_prior_covariance")
+    with pytest.raises(ValueError):
+        tree_sparse.local_gauge_jacobian[0, 0, 0] = 1.0
+
+
+def test_tree_sparse_stack_preserves_include_invalid_semantics() -> None:
+    bundle = _bundle(with_invalid_row=True)
+    prior = _prior(bundle)
+    default = stack_tree_sparse_observation_factors(bundle, prior)
+    complete = stack_tree_sparse_observation_factors(
+        bundle,
+        prior,
+        include_invalid=True,
+    )
+
+    assert default.observation_count == 2
+    assert complete.observation_count == 4
+
+
+def test_binding_rejects_wrong_gauge_order_and_wrong_covariance() -> None:
+    bundle = _bundle()
+    dense_sparse = stack_sparse_observation_factors(bundle)
+    prior = _prior(bundle)
+    wrong_order = replace(prior, gauge_ids=("window-1", "window-0"))
+
+    with pytest.raises(ValueError, match="order does not match"):
+        bind_gauge_tree_prior(dense_sparse, wrong_order)
+
+    wrong_covariance = GaugeTreeSquareRootPriorV1.from_transition_covariances(
+        gauge_ids=prior.gauge_ids,
+        parent_indices=prior.parent_indices,
+        transition_matrices=prior.transition_matrices,
+        innovation_covariances=prior.innovation_covariance_blocks() * 1.2,
+    )
+    with pytest.raises(ValueError):
+        bind_gauge_tree_prior(dense_sparse, wrong_covariance)
+
+
+def test_public_constructor_rejects_marginal_covariance_drift() -> None:
+    bundle = _bundle()
+    tree_sparse = stack_tree_sparse_observation_factors(bundle, _prior(bundle))
+    changed = tree_sparse.marginal_world_covariance_m2.copy()
+    changed[0] += np.eye(3) * 1.0e-4
+
+    with pytest.raises(ValueError, match="does not match the tree gauge prior"):
+        replace(tree_sparse, marginal_world_covariance_m2=changed)
+
+
+def test_tree_sparse_contract_rejects_wrong_types() -> None:
+    bundle = _bundle()
+    dense_sparse = stack_sparse_observation_factors(bundle)
+
+    with pytest.raises(TypeError, match="SparseStackedObservationFactors"):
+        bind_gauge_tree_prior(object(), _prior(bundle))  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="GaugeTreeSquareRootPriorV1"):
+        bind_gauge_tree_prior(dense_sparse, object())  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="ObservationFactorBundle"):
+        stack_tree_sparse_observation_factors(  # type: ignore[arg-type]
+            object(),
+            _prior(bundle),
+        )

--- a/tests/test_tree_sparse_observation_factors.py
+++ b/tests/test_tree_sparse_observation_factors.py
@@ -134,12 +134,10 @@ def test_tree_sparse_stack_matches_dense_prior_and_row_contracts() -> None:
     )
     assert tree_sparse.gauge_ids == dense_sparse.gauge_ids
     assert (
-        tree_sparse.gauge_prior_storage_nbytes
-        == tree_sparse.gauge_tree_prior.factor_storage_nbytes
+        tree_sparse.gauge_prior_storage_nbytes == tree_sparse.gauge_tree_prior.factor_storage_nbytes
     )
     assert (
-        tree_sparse.dense_gauge_prior_nbytes
-        == tree_sparse.gauge_tree_prior.dense_covariance_nbytes
+        tree_sparse.dense_gauge_prior_nbytes == tree_sparse.gauge_tree_prior.dense_covariance_nbytes
     )
 
 

--- a/tests/test_tree_sparse_observation_factors.py
+++ b/tests/test_tree_sparse_observation_factors.py
@@ -58,9 +58,7 @@ def _bundle(*, with_invalid_row: bool = False) -> ObservationFactorBundle:
             points_local_m=np.asarray(
                 [
                     [0.0, 0.0, 1.0],
-                    [np.nan, np.nan, np.nan]
-                    if with_invalid_row
-                    else [0.2, 0.0, 1.1],
+                    [np.nan, np.nan, np.nan] if with_invalid_row else [0.2, 0.0, 1.1],
                 ],
                 dtype=np.float64,
             ),
@@ -77,9 +75,7 @@ def _bundle(*, with_invalid_row: bool = False) -> ObservationFactorBundle:
             points_local_m=np.asarray(
                 [
                     [0.1, 0.2, 1.2],
-                    [np.nan, np.nan, np.nan]
-                    if with_invalid_row
-                    else [0.3, 0.1, 1.3],
+                    [np.nan, np.nan, np.nan] if with_invalid_row else [0.3, 0.1, 1.3],
                 ],
                 dtype=np.float64,
             ),
@@ -137,7 +133,14 @@ def test_tree_sparse_stack_matches_dense_prior_and_row_contracts() -> None:
         dense_sparse.gauge_marginal_covariance_m2(),
     )
     assert tree_sparse.gauge_ids == dense_sparse.gauge_ids
-    assert tree_sparse.gauge_prior_storage_nbytes < tree_sparse.dense_gauge_prior_nbytes
+    assert (
+        tree_sparse.gauge_prior_storage_nbytes
+        == tree_sparse.gauge_tree_prior.factor_storage_nbytes
+    )
+    assert (
+        tree_sparse.dense_gauge_prior_nbytes
+        == tree_sparse.gauge_tree_prior.dense_covariance_nbytes
+    )
 
 
 def test_tree_sparse_matrix_free_actions_match_dense_linear_algebra() -> None:

--- a/tests/test_tree_sparse_observation_factors.py
+++ b/tests/test_tree_sparse_observation_factors.py
@@ -31,13 +31,16 @@ def _bundle(*, with_invalid_row: bool = False) -> ObservationFactorBundle:
         GaugeEstimate("window-0", Sim3.identity(), covariance_0),
         GaugeEstimate("window-1", Sim3.identity(), covariance_1),
     )
+    local_covariance = np.repeat(
+        np.eye(3, dtype=np.float64)[None] * 1.0e-3,
+        2,
+        axis=0,
+    )
+    if with_invalid_row:
+        local_covariance[1] = np.nan
     common = {
         "valid_mask": np.asarray([True, not with_invalid_row]),
-        "local_covariance_m2": np.repeat(
-            np.eye(3, dtype=np.float64)[None] * 1.0e-3,
-            2,
-            axis=0,
-        ),
+        "local_covariance_m2": local_covariance,
         "association_probability": np.asarray([0.9, 0.8]),
         "prior_reliability": np.asarray([0.85, 0.75]),
         "prior_nominal_probability": 0.95,
@@ -53,7 +56,12 @@ def _bundle(*, with_invalid_row: bool = False) -> ObservationFactorBundle:
             gauge_id="window-0",
             point_ids=np.asarray([10, 11], dtype=np.int64),
             points_local_m=np.asarray(
-                [[0.0, 0.0, 1.0], [0.2, 0.0, 1.1]],
+                [
+                    [0.0, 0.0, 1.0],
+                    [np.nan, np.nan, np.nan]
+                    if with_invalid_row
+                    else [0.2, 0.0, 1.1],
+                ],
                 dtype=np.float64,
             ),
             correlation_group_id="camera-0:frame-2",
@@ -67,7 +75,12 @@ def _bundle(*, with_invalid_row: bool = False) -> ObservationFactorBundle:
             gauge_id="window-1",
             point_ids=np.asarray([20, 21], dtype=np.int64),
             points_local_m=np.asarray(
-                [[0.1, 0.2, 1.2], [0.3, 0.1, 1.3]],
+                [
+                    [0.1, 0.2, 1.2],
+                    [np.nan, np.nan, np.nan]
+                    if with_invalid_row
+                    else [0.3, 0.1, 1.3],
+                ],
                 dtype=np.float64,
             ),
             correlation_group_id="camera-0:frame-4",
@@ -203,6 +216,8 @@ def test_tree_sparse_stack_preserves_include_invalid_semantics() -> None:
 
     assert default.observation_count == 2
     assert complete.observation_count == 4
+    assert np.isnan(complete.world_mean_m[1]).all()
+    assert np.isnan(complete.conditional_world_covariance_m2[1]).all()
 
 
 def test_binding_rejects_wrong_gauge_order_and_wrong_covariance() -> None:
@@ -224,14 +239,25 @@ def test_binding_rejects_wrong_gauge_order_and_wrong_covariance() -> None:
         bind_gauge_tree_prior(dense_sparse, wrong_covariance)
 
 
-def test_public_constructor_rejects_marginal_covariance_drift() -> None:
+def test_binding_rejects_forged_row_marginal_covariance() -> None:
     bundle = _bundle()
-    tree_sparse = stack_tree_sparse_observation_factors(bundle, _prior(bundle))
-    changed = tree_sparse.marginal_world_covariance_m2.copy()
+    dense_sparse = stack_sparse_observation_factors(bundle)
+    changed = dense_sparse.marginal_world_covariance_m2.copy()
     changed[0] += np.eye(3) * 1.0e-4
+    forged = replace(dense_sparse, marginal_world_covariance_m2=changed)
 
     with pytest.raises(ValueError, match="does not match the tree gauge prior"):
-        replace(tree_sparse, marginal_world_covariance_m2=changed)
+        bind_gauge_tree_prior(forged, _prior(bundle))
+
+
+def test_tree_sparse_result_is_factory_built_and_slotted() -> None:
+    with pytest.raises(TypeError, match="bind_gauge_tree_prior"):
+        TreeSparseStackedObservationFactors()
+
+    bundle = _bundle()
+    tree_sparse = stack_tree_sparse_observation_factors(bundle, _prior(bundle))
+    with pytest.raises((AttributeError, TypeError)):
+        tree_sparse.new_attribute = 1  # type: ignore[misc]
 
 
 def test_tree_sparse_contract_rejects_wrong_types() -> None:


### PR DESCRIPTION
## Summary

Add an additive tree-backed execution representation for explicit-gauge Prob4D factors.

- bind an existing `SparseStackedObservationFactors` to `GaugeTreeSquareRootPriorV1` only after exact gauge-order and complete dense-covariance verification;
- require the source dense-covariance digest when the tree prior carries one;
- verify retained row marginals against the tree prior and require immutable source arrays before transfer;
- reuse the existing stack's immutable row arrays without retaining its dense `7K x 7K` covariance;
- expose matrix-free gauge covariance/information actions, observation-space gauge covariance, complete marginal observation covariance, and guarded dense compatibility materialization;
- add a one-call `stack_tree_sparse_observation_factors` adapter for schema-v4 bundles;
- export the new surface through `prob4d.provider_v2_factors`;
- add dense-parity, action-parity, immutability, invalid-row selection, gauge-order, covariance-drift, forged-marginal, factory-only, and type-contract tests; and
- document the exact retained-memory and serialization boundaries.

## Why

The merged sparse row stack removes the `M x 3 x 7K` zero-block expansion, and the merged portable gauge-tree artifact stores the production causal prior in `O(K)`. The remaining in-memory adapter still retained the dense joint gauge covariance. This change connects those two existing contracts without changing schema-v4 bytes or any frozen artifact identity.

## Compatibility boundary

Schema-v4 bundles still contain and initially load the dense prior. This PR verifies that prior once, then returns an execution object that no longer references it. Removing the dense prior before initial loading requires a separately versioned bundle/provider contract.

Existing dense and sparse stacks, provider-v1/provider-v2 artifacts, content identities, estimators, defaults, and frozen evidence remain unchanged.

## Exact-head validation

Head `b72a333aa5843a1ecd00a9f57d8ede84c1dcffe0` passed:

- repository-wide complete tests on Python 3.10, 3.11, 3.12, 3.13, and 3.14;
- the declared NumPy 1.24 runtime floor on Python 3.10;
- repository quality, provider-contract, clean-checkout attestation, and release-policy checks;
- the focused sparse-prior lane: Ruff, canonical formatting, MyPy, 107 focused and adjacent tests, byte compilation, and CLI help smoke;
- security scanning;
- wheel and source-distribution builds and validation; and
- isolated installed-wheel and installed-sdist CLI smoke tests.

All four exact-head workflows completed successfully: `Tests`, `Fail-closed quality`, `Sparse gauge-tree prior`, and `Security scanning`.

## Claim boundary

This is exact-parity and retained-memory infrastructure. It does not establish provider competence, covariance calibration, physical-query identifiability, BayesianPhysTwin acceptance or benefit, Causal4D intervention benefit, deployment safety, or state of the art.