### PR TITLE
Harden sparse observation-factor contracts

### DIFF
--- a/.github/workflows/sparse-gauge-tree-prior.yml
+++ b/.github/workflows/sparse-gauge-tree-prior.yml
@@ -17,6 +17,7 @@ on:
       - "src/prob4d/gauge_tree_prior_artifact.py"
       - "src/prob4d/gauge_tree_prior_io.py"
       - "src/prob4d/provider_v2_factors.py"
+      - "src/prob4d/sparse_observation_factors.py"
       - "src/prob4d/tree_sparse_observation_factors.py"
       - "tests/test_cli.py"
       - "tests/test_command_registry.py"
@@ -81,6 +82,7 @@ jobs:
             src/prob4d/gauge_tree_prior_artifact.py
             src/prob4d/gauge_tree_prior_io.py
             src/prob4d/provider_v2_factors.py
+            src/prob4d/sparse_observation_factors.py
             src/prob4d/tree_sparse_observation_factors.py
             tests/test_cli.py
             tests/test_command_registry.py
@@ -89,6 +91,7 @@ jobs:
             tests/test_gauge_tree_prior.py
             tests/test_gauge_tree_prior_artifact.py
             tests/test_provider_v2_factors.py
+            tests/test_sparse_observation_factors.py
             tests/test_tree_sparse_observation_factors.py
           )
           python -m ruff check -- "${files[@]}"
@@ -102,6 +105,7 @@ jobs:
             src/prob4d/gauge_tree_prior_artifact.py \
             src/prob4d/gauge_tree_prior_io.py \
             src/prob4d/provider_v2_factors.py \
+            src/prob4d/sparse_observation_factors.py \
             src/prob4d/tree_sparse_observation_factors.py
 
       - name: Run focused and adjacent tests

--- a/src/prob4d/sparse_observation_factors.py
+++ b/src/prob4d/sparse_observation_factors.py
@@ -21,6 +21,8 @@ from .observation_factors import ObservationFactorBundle
 FloatArray: TypeAlias = NDArray[np.floating[Any]]
 IntArray: TypeAlias = NDArray[np.integer[Any]]
 
+_VALIDATION_CHUNK_SIZE = 65_536
+
 
 def _readonly(value: np.ndarray, *, dtype: Any | None = None) -> np.ndarray:
     result = np.asarray(value, dtype=dtype).copy()
@@ -73,15 +75,30 @@ def _require_row_covariance(
     name: str,
     tolerance: float = 1e-12,
 ) -> None:
-    finite_rows = np.all(np.isfinite(value), axis=(1, 2))
-    if not np.any(finite_rows):
-        return
-    selected = value[finite_rows]
-    symmetric = 0.5 * (selected + selected.swapaxes(1, 2))
-    if not np.allclose(selected, symmetric, atol=tolerance, rtol=1e-10):
-        raise ValueError(f"{name} finite rows must be symmetric")
-    if np.any(np.linalg.eigvalsh(symmetric) < -tolerance):
-        raise ValueError(f"{name} finite rows must be positive semidefinite")
+    finite_indices = np.flatnonzero(np.all(np.isfinite(value), axis=(1, 2)))
+    for offset in range(0, len(finite_indices), _VALIDATION_CHUNK_SIZE):
+        indices = finite_indices[offset : offset + _VALIDATION_CHUNK_SIZE]
+        selected = value[indices]
+        symmetric = 0.5 * (selected + selected.swapaxes(1, 2))
+        if not np.allclose(selected, symmetric, atol=tolerance, rtol=1e-10):
+            raise ValueError(f"{name} finite rows must be symmetric")
+        if np.any(np.linalg.eigvalsh(symmetric) < -tolerance):
+            raise ValueError(f"{name} finite rows must be positive semidefinite")
+
+
+def _selected_gauge_covariance(
+    local_gauge_jacobian: np.ndarray,
+    gauge_covariance: np.ndarray,
+) -> np.ndarray:
+    with np.errstate(invalid="ignore", over="ignore"):
+        result: FloatArray = np.einsum(
+            "nia,ab,njb->nij",
+            local_gauge_jacobian,
+            gauge_covariance,
+            local_gauge_jacobian,
+            optimize=True,
+        )
+    return 0.5 * (result + result.swapaxes(1, 2))
 
 
 def _row_gauge_marginal_covariance(
@@ -91,26 +108,62 @@ def _row_gauge_marginal_covariance(
     *,
     gauge_count: int,
 ) -> np.ndarray:
-    blocks: FloatArray = np.empty(
-        (len(local_gauge_jacobian), 7, 7),
+    result: FloatArray = np.empty(
+        (len(local_gauge_jacobian), 3, 3),
         dtype=np.float64,
     )
     for gauge_index in range(gauge_count):
-        selected = gauge_indices == gauge_index
+        row_indices = np.flatnonzero(gauge_indices == gauge_index)
         start = 7 * gauge_index
-        blocks[selected] = gauge_prior_covariance[
+        gauge_covariance = gauge_prior_covariance[
             start : start + 7,
             start : start + 7,
         ]
-    with np.errstate(invalid="ignore", over="ignore"):
-        result: FloatArray = np.einsum(
-            "nia,nab,njb->nij",
-            local_gauge_jacobian,
-            blocks,
-            local_gauge_jacobian,
-            optimize=True,
-        )
-    return 0.5 * (result + result.swapaxes(1, 2))
+        for offset in range(0, len(row_indices), _VALIDATION_CHUNK_SIZE):
+            indices = row_indices[offset : offset + _VALIDATION_CHUNK_SIZE]
+            result[indices] = _selected_gauge_covariance(
+                local_gauge_jacobian[indices],
+                gauge_covariance,
+            )
+    return result
+
+
+def _require_marginal_accounting(
+    conditional_covariance: np.ndarray,
+    marginal_covariance: np.ndarray,
+    local_gauge_jacobian: np.ndarray,
+    gauge_indices: np.ndarray,
+    gauge_prior_covariance: np.ndarray,
+    *,
+    gauge_count: int,
+) -> None:
+    for gauge_index in range(gauge_count):
+        row_indices = np.flatnonzero(gauge_indices == gauge_index)
+        start = 7 * gauge_index
+        gauge_covariance = gauge_prior_covariance[
+            start : start + 7,
+            start : start + 7,
+        ]
+        for offset in range(0, len(row_indices), _VALIDATION_CHUNK_SIZE):
+            indices = row_indices[offset : offset + _VALIDATION_CHUNK_SIZE]
+            gauge_marginal = _selected_gauge_covariance(
+                local_gauge_jacobian[indices],
+                gauge_covariance,
+            )
+            with np.errstate(invalid="ignore", over="ignore"):
+                expected = conditional_covariance[indices] + gauge_marginal
+                expected = 0.5 * (expected + expected.swapaxes(1, 2))
+            if not np.allclose(
+                marginal_covariance[indices],
+                expected,
+                atol=1e-12,
+                rtol=1e-10,
+                equal_nan=True,
+            ):
+                raise ValueError(
+                    "marginal_world_covariance_m2 must equal conditional covariance "
+                    "plus the selected gauge-prior contribution"
+                )
 
 
 @dataclass(frozen=True, slots=True)
@@ -201,28 +254,14 @@ class SparseStackedObservationFactors:
             marginal,
             name="marginal_world_covariance_m2",
         )
-        gauge_marginal = _row_gauge_marginal_covariance(
+        _require_marginal_accounting(
+            conditional,
+            marginal,
             local_jacobian,
             gauge_indices,
             gauge_prior,
             gauge_count=gauge_count,
         )
-        with np.errstate(invalid="ignore", over="ignore"):
-            expected_marginal = conditional + gauge_marginal
-            expected_marginal = 0.5 * (
-                expected_marginal + expected_marginal.swapaxes(1, 2)
-            )
-        if not np.allclose(
-            marginal,
-            expected_marginal,
-            atol=1e-12,
-            rtol=1e-10,
-            equal_nan=True,
-        ):
-            raise ValueError(
-                "marginal_world_covariance_m2 must equal conditional covariance "
-                "plus the selected gauge-prior contribution"
-            )
 
         probabilities = (
             ("association_probability", association, True),

--- a/src/prob4d/sparse_observation_factors.py
+++ b/src/prob4d/sparse_observation_factors.py
@@ -223,9 +223,7 @@ class SparseStackedObservationFactors:
         if mean.shape != (count, 3):
             raise ValueError("world_mean_m must have shape (M, 3)")
         if conditional.shape != (count, 3, 3):
-            raise ValueError(
-                "conditional_world_covariance_m2 must have shape (M, 3, 3)"
-            )
+            raise ValueError("conditional_world_covariance_m2 must have shape (M, 3, 3)")
         if marginal.shape != (count, 3, 3):
             raise ValueError("marginal_world_covariance_m2 must have shape (M, 3, 3)")
         if local_jacobian.shape != (count, 3, 7):
@@ -240,8 +238,7 @@ class SparseStackedObservationFactors:
             raise ValueError("gauge_indices reference an unknown gauge")
         if gauge_prior.shape != (gauge_dimension, gauge_dimension):
             raise ValueError(
-                "gauge_prior_covariance must have shape "
-                f"({gauge_dimension}, {gauge_dimension})"
+                f"gauge_prior_covariance must have shape ({gauge_dimension}, {gauge_dimension})"
             )
         if not np.all(np.isfinite(gauge_prior)):
             raise ValueError("gauge_prior_covariance must be finite")
@@ -273,20 +270,15 @@ class SparseStackedObservationFactors:
             if values.shape != (count,):
                 raise ValueError(f"{name} must have shape (M,)")
             lower = values >= 0.0 if allow_zero else values > 0.0
-            if (
-                not np.all(np.isfinite(values))
-                or not np.all(lower)
-                or np.any(values > 1.0)
-            ):
+            if not np.all(np.isfinite(values)) or not np.all(lower) or np.any(values > 1.0):
                 interval = "[0, 1]" if allow_zero else "(0, 1]"
                 raise ValueError(f"{name} must lie in {interval}")
 
         if point_ids.shape != (count,) or frame_indices.shape != (count,):
             raise ValueError("row identity vectors must have shape (M,)")
         raw_causal_frame_stop = self.causal_frame_stop
-        if (
-            isinstance(raw_causal_frame_stop, (bool, np.bool_))
-            or not isinstance(raw_causal_frame_stop, (int, np.integer))
+        if isinstance(raw_causal_frame_stop, (bool, np.bool_)) or not isinstance(
+            raw_causal_frame_stop, (int, np.integer)
         ):
             raise TypeError("causal_frame_stop must be a genuine integer")
         causal_frame_stop = int(raw_causal_frame_stop)
@@ -356,10 +348,7 @@ class SparseStackedObservationFactors:
         """Bytes required by the equivalent float64 dense ``M x 3 x 7K`` design."""
 
         return int(
-            self.observation_count
-            * 3
-            * self.dense_gauge_dimension
-            * np.dtype(np.float64).itemsize
+            self.observation_count * 3 * self.dense_gauge_dimension * np.dtype(np.float64).itemsize
         )
 
     def dense_gauge_jacobian(self) -> FloatArray:
@@ -452,9 +441,7 @@ def stack_sparse_observation_factors(
             continue
         gauge_index = gauge_positions[factor.gauge_id]
         means.append(linearized.world_mean_m[selected])
-        conditional_covariances.append(
-            linearized.conditional_world_covariance_m2[selected]
-        )
+        conditional_covariances.append(linearized.conditional_world_covariance_m2[selected])
         marginal_covariances.append(linearized.marginal_world_covariance_m2[selected])
         local_jacobians.append(linearized.gauge_jacobian[selected])
         gauge_indices.append(np.full(selected_count, gauge_index, dtype=np.int64))
@@ -467,18 +454,12 @@ def stack_sparse_observation_factors(
                 dtype=np.float64,
             )
         )
-        composite_weights.append(
-            np.full(selected_count, factor.composite_weight, dtype=np.float64)
-        )
+        composite_weights.append(np.full(selected_count, factor.composite_weight, dtype=np.float64))
         point_ids.append(factor.point_ids[selected])
-        frame_indices.append(
-            np.full(selected_count, factor.frame_index, dtype=np.int64)
-        )
+        frame_indices.append(np.full(selected_count, factor.frame_index, dtype=np.int64))
         view_ids.extend([factor.view_id] * selected_count)
         factor_ids.extend([factor.factor_id] * selected_count)
-        correlation_group_ids.extend(
-            [factor.correlation_group_id] * selected_count
-        )
+        correlation_group_ids.extend([factor.correlation_group_id] * selected_count)
 
     if not means:
         raise ValueError("observation-factor stack has no selected rows")

--- a/src/prob4d/sparse_observation_factors.py
+++ b/src/prob4d/sparse_observation_factors.py
@@ -11,7 +11,7 @@ statistics while reducing Jacobian storage from ``O(MK)`` to ``O(M)``.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, TypeAlias
+from typing import Any, TypeAlias, cast
 
 import numpy as np
 from numpy.typing import NDArray
@@ -49,14 +49,14 @@ def _string_tuple(
 ) -> tuple[str, ...]:
     if type(value) is not tuple:
         raise TypeError(f"{name} must be a tuple of literal strings")
-    values = value
+    values = cast(tuple[object, ...], value)
     if any(type(item) is not str for item in values):
         raise TypeError(f"{name} must contain literal strings")
     if any(not item for item in values):
         raise ValueError(f"{name} must contain nonempty strings")
     if expected_length is not None and len(values) != expected_length:
         raise ValueError(f"{name} must contain exactly {expected_length} entries")
-    return values
+    return cast(tuple[str, ...], values)
 
 
 def _require_psd(value: np.ndarray, *, name: str, tolerance: float = 1e-12) -> None:

--- a/src/prob4d/sparse_observation_factors.py
+++ b/src/prob4d/sparse_observation_factors.py
@@ -34,7 +34,29 @@ def _integer_vector(value: np.ndarray, *, name: str) -> np.ndarray:
         raise ValueError(f"{name} must be a vector")
     if raw.dtype.kind not in {"i", "u"}:
         raise TypeError(f"{name} must contain genuine integers")
+    if raw.dtype.kind == "u" and raw.size:
+        maximum = int(np.max(raw))
+        if maximum > np.iinfo(np.int64).max:
+            raise ValueError(f"{name} values must fit in the int64 range")
     return np.asarray(raw, dtype=np.int64)
+
+
+def _string_tuple(
+    value: object,
+    *,
+    name: str,
+    expected_length: int | None = None,
+) -> tuple[str, ...]:
+    if type(value) is not tuple:
+        raise TypeError(f"{name} must be a tuple of literal strings")
+    values = value
+    if any(type(item) is not str for item in values):
+        raise TypeError(f"{name} must contain literal strings")
+    if any(not item for item in values):
+        raise ValueError(f"{name} must contain nonempty strings")
+    if expected_length is not None and len(values) != expected_length:
+        raise ValueError(f"{name} must contain exactly {expected_length} entries")
+    return values
 
 
 def _require_psd(value: np.ndarray, *, name: str, tolerance: float = 1e-12) -> None:
@@ -43,6 +65,52 @@ def _require_psd(value: np.ndarray, *, name: str, tolerance: float = 1e-12) -> N
         raise ValueError(f"{name} must be symmetric")
     if np.min(np.linalg.eigvalsh(symmetric), initial=0.0) < -tolerance:
         raise ValueError(f"{name} must be positive semidefinite")
+
+
+def _require_row_covariance(
+    value: np.ndarray,
+    *,
+    name: str,
+    tolerance: float = 1e-12,
+) -> None:
+    finite_rows = np.all(np.isfinite(value), axis=(1, 2))
+    if not np.any(finite_rows):
+        return
+    selected = value[finite_rows]
+    symmetric = 0.5 * (selected + selected.swapaxes(1, 2))
+    if not np.allclose(selected, symmetric, atol=tolerance, rtol=1e-10):
+        raise ValueError(f"{name} finite rows must be symmetric")
+    if np.any(np.linalg.eigvalsh(symmetric) < -tolerance):
+        raise ValueError(f"{name} finite rows must be positive semidefinite")
+
+
+def _row_gauge_marginal_covariance(
+    local_gauge_jacobian: np.ndarray,
+    gauge_indices: np.ndarray,
+    gauge_prior_covariance: np.ndarray,
+    *,
+    gauge_count: int,
+) -> np.ndarray:
+    blocks: FloatArray = np.empty(
+        (len(local_gauge_jacobian), 7, 7),
+        dtype=np.float64,
+    )
+    for gauge_index in range(gauge_count):
+        selected = gauge_indices == gauge_index
+        start = 7 * gauge_index
+        blocks[selected] = gauge_prior_covariance[
+            start : start + 7,
+            start : start + 7,
+        ]
+    with np.errstate(invalid="ignore", over="ignore"):
+        result: FloatArray = np.einsum(
+            "nia,nab,njb->nij",
+            local_gauge_jacobian,
+            blocks,
+            local_gauge_jacobian,
+            optimize=True,
+        )
+    return 0.5 * (result + result.swapaxes(1, 2))
 
 
 @dataclass(frozen=True, slots=True)
@@ -92,7 +160,7 @@ class SparseStackedObservationFactors:
         composite = np.asarray(self.composite_weight, dtype=np.float64)
         point_ids = _integer_vector(self.point_ids, name="point_ids")
         frame_indices = _integer_vector(self.frame_indices, name="frame_indices")
-        gauge_ids = tuple(str(value) for value in self.gauge_ids)
+        gauge_ids = _string_tuple(self.gauge_ids, name="gauge_ids")
         count = len(mean)
         gauge_count = len(gauge_ids)
         gauge_dimension = 7 * gauge_count
@@ -111,8 +179,8 @@ class SparseStackedObservationFactors:
             raise ValueError("local_gauge_jacobian must have shape (M, 3, 7)")
         if gauge_indices.shape != (count,):
             raise ValueError("gauge_indices must have shape (M,)")
-        if not gauge_ids or any(not value for value in gauge_ids):
-            raise ValueError("gauge_ids must contain nonempty strings")
+        if not gauge_ids:
+            raise ValueError("gauge_ids must contain at least one identifier")
         if len(set(gauge_ids)) != gauge_count:
             raise ValueError("gauge_ids must be unique")
         if np.any(gauge_indices < 0) or np.any(gauge_indices >= gauge_count):
@@ -125,6 +193,36 @@ class SparseStackedObservationFactors:
         if not np.all(np.isfinite(gauge_prior)):
             raise ValueError("gauge_prior_covariance must be finite")
         _require_psd(gauge_prior, name="gauge_prior_covariance")
+        _require_row_covariance(
+            conditional,
+            name="conditional_world_covariance_m2",
+        )
+        _require_row_covariance(
+            marginal,
+            name="marginal_world_covariance_m2",
+        )
+        gauge_marginal = _row_gauge_marginal_covariance(
+            local_jacobian,
+            gauge_indices,
+            gauge_prior,
+            gauge_count=gauge_count,
+        )
+        with np.errstate(invalid="ignore", over="ignore"):
+            expected_marginal = conditional + gauge_marginal
+            expected_marginal = 0.5 * (
+                expected_marginal + expected_marginal.swapaxes(1, 2)
+            )
+        if not np.allclose(
+            marginal,
+            expected_marginal,
+            atol=1e-12,
+            rtol=1e-10,
+            equal_nan=True,
+        ):
+            raise ValueError(
+                "marginal_world_covariance_m2 must equal conditional covariance "
+                "plus the selected gauge-prior contribution"
+            )
 
         probabilities = (
             ("association_probability", association, True),
@@ -159,15 +257,22 @@ class SparseStackedObservationFactors:
             raise ValueError("stacked rows cross the exclusive causal frame stop")
 
         string_fields = {
-            "view_ids": tuple(str(value) for value in self.view_ids),
-            "factor_ids": tuple(str(value) for value in self.factor_ids),
-            "correlation_group_ids": tuple(
-                str(value) for value in self.correlation_group_ids
+            "view_ids": _string_tuple(
+                self.view_ids,
+                name="view_ids",
+                expected_length=count,
+            ),
+            "factor_ids": _string_tuple(
+                self.factor_ids,
+                name="factor_ids",
+                expected_length=count,
+            ),
+            "correlation_group_ids": _string_tuple(
+                self.correlation_group_ids,
+                name="correlation_group_ids",
+                expected_length=count,
             ),
         }
-        for name, values in string_fields.items():
-            if len(values) != count or any(not value for value in values):
-                raise ValueError(f"{name} must contain one nonempty string per row")
 
         for name, value in (
             ("world_mean_m", mean),
@@ -257,24 +362,12 @@ class SparseStackedObservationFactors:
     def gauge_marginal_covariance_m2(self) -> FloatArray:
         """Return each row's ``J Sigma_gg J^T`` contribution."""
 
-        blocks: FloatArray = np.empty(
-            (self.observation_count, 7, 7), dtype=np.float64
-        )
-        for gauge_index in range(self.gauge_count):
-            selected = self.gauge_indices == gauge_index
-            start = 7 * gauge_index
-            blocks[selected] = self.gauge_prior_covariance[
-                start : start + 7,
-                start : start + 7,
-            ]
-        result: FloatArray = np.einsum(
-            "nia,nab,njb->nij",
+        return _row_gauge_marginal_covariance(
             self.local_gauge_jacobian,
-            blocks,
-            self.local_gauge_jacobian,
-            optimize=True,
+            self.gauge_indices,
+            self.gauge_prior_covariance,
+            gauge_count=self.gauge_count,
         )
-        return 0.5 * (result + result.swapaxes(1, 2))
 
 
 def stack_sparse_observation_factors(

--- a/tests/test_sparse_observation_factors.py
+++ b/tests/test_sparse_observation_factors.py
@@ -150,8 +150,7 @@ def test_sparse_gauge_operations_match_dense_linear_algebra() -> None:
     )
     np.testing.assert_allclose(
         sparse.gauge_marginal_covariance_m2(),
-        sparse.marginal_world_covariance_m2
-        - sparse.conditional_world_covariance_m2,
+        sparse.marginal_world_covariance_m2 - sparse.conditional_world_covariance_m2,
         atol=1e-15,
         rtol=1e-12,
     )

--- a/tests/test_sparse_observation_factors.py
+++ b/tests/test_sparse_observation_factors.py
@@ -185,6 +185,45 @@ def test_sparse_stack_owns_readonly_arrays_and_rejects_lossy_indices() -> None:
             sparse,
             gauge_indices=sparse.gauge_indices.astype(np.float64),
         )
+    overflow = sparse.point_ids.astype(np.uint64)
+    overflow[0] = np.uint64(2**63)
+    with pytest.raises(ValueError, match="int64 range"):
+        replace(sparse, point_ids=overflow)
+
+
+def test_sparse_stack_rejects_coercive_identifiers() -> None:
+    sparse = stack_sparse_observation_factors(_bundle())
+
+    with pytest.raises(TypeError, match="literal strings"):
+        replace(sparse, gauge_ids=(1, "window-1"))  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="literal strings"):
+        replace(sparse, view_ids=(1,) + sparse.view_ids[1:])  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="tuple of literal strings"):
+        replace(sparse, factor_ids=list(sparse.factor_ids))  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="nonempty strings"):
+        replace(
+            sparse,
+            correlation_group_ids=("",) + sparse.correlation_group_ids[1:],
+        )
+
+
+def test_sparse_stack_rejects_covariance_contract_drift() -> None:
+    sparse = stack_sparse_observation_factors(_bundle())
+
+    asymmetric = sparse.conditional_world_covariance_m2.copy()
+    asymmetric[0, 0, 1] = 1.0e-4
+    with pytest.raises(ValueError, match="finite rows must be symmetric"):
+        replace(sparse, conditional_world_covariance_m2=asymmetric)
+
+    indefinite = sparse.conditional_world_covariance_m2.copy()
+    indefinite[0, 0, 0] = -1.0
+    with pytest.raises(ValueError, match="positive semidefinite"):
+        replace(sparse, conditional_world_covariance_m2=indefinite)
+
+    forged_marginal = sparse.marginal_world_covariance_m2.copy()
+    forged_marginal[0, 0, 0] += 1.0e-4
+    with pytest.raises(ValueError, match="selected gauge-prior contribution"):
+        replace(sparse, marginal_world_covariance_m2=forged_marginal)
 
 
 def test_sparse_stack_reduces_expanded_gauge_design_storage() -> None:

--- a/tests/test_tree_sparse_observation_factors.py
+++ b/tests/test_tree_sparse_observation_factors.py
@@ -132,10 +132,12 @@ def test_tree_sparse_stack_matches_dense_prior_and_row_contracts() -> None:
     )
     assert tree_sparse.gauge_ids == dense_sparse.gauge_ids
     assert (
-        tree_sparse.gauge_prior_storage_nbytes == tree_sparse.gauge_tree_prior.factor_storage_nbytes
+        tree_sparse.gauge_prior_storage_nbytes
+        == tree_sparse.gauge_tree_prior.factor_storage_nbytes
     )
     assert (
-        tree_sparse.dense_gauge_prior_nbytes == tree_sparse.gauge_tree_prior.dense_covariance_nbytes
+        tree_sparse.dense_gauge_prior_nbytes
+        == tree_sparse.gauge_tree_prior.dense_covariance_nbytes
     )
 
 
@@ -241,15 +243,20 @@ def test_binding_rejects_wrong_gauge_order_and_wrong_covariance() -> None:
         bind_gauge_tree_prior(dense_sparse, wrong_covariance)
 
 
-def test_binding_rejects_forged_row_marginal_covariance() -> None:
+def test_binding_rejects_postconstruction_row_marginal_tampering() -> None:
     bundle = _bundle()
     dense_sparse = stack_sparse_observation_factors(bundle)
     changed = dense_sparse.marginal_world_covariance_m2.copy()
     changed[0] += np.eye(3) * 1.0e-4
-    forged = replace(dense_sparse, marginal_world_covariance_m2=changed)
+    changed.setflags(write=False)
+    object.__setattr__(
+        dense_sparse,
+        "marginal_world_covariance_m2",
+        changed,
+    )
 
     with pytest.raises(ValueError, match="does not match the tree gauge prior"):
-        bind_gauge_tree_prior(forged, _prior(bundle))
+        bind_gauge_tree_prior(dense_sparse, _prior(bundle))
 
 
 def test_tree_sparse_result_is_factory_built_and_slotted() -> None:

--- a/tests/test_tree_sparse_observation_factors.py
+++ b/tests/test_tree_sparse_observation_factors.py
@@ -132,12 +132,10 @@ def test_tree_sparse_stack_matches_dense_prior_and_row_contracts() -> None:
     )
     assert tree_sparse.gauge_ids == dense_sparse.gauge_ids
     assert (
-        tree_sparse.gauge_prior_storage_nbytes
-        == tree_sparse.gauge_tree_prior.factor_storage_nbytes
+        tree_sparse.gauge_prior_storage_nbytes == tree_sparse.gauge_tree_prior.factor_storage_nbytes
     )
     assert (
-        tree_sparse.dense_gauge_prior_nbytes
-        == tree_sparse.gauge_tree_prior.dense_covariance_nbytes
+        tree_sparse.dense_gauge_prior_nbytes == tree_sparse.gauge_tree_prior.dense_covariance_nbytes
     )
 
 


### PR DESCRIPTION
## Summary

Harden the direct `SparseStackedObservationFactors` admission boundary used by both dense-prior and tree-backed explicit-gauge execution.

- require gauge, view, factor, and correlation-group identifiers to be genuine nonempty strings in canonical tuples rather than silently applying `str()`;
- reject unsigned integer vectors whose values cannot be represented in `int64` instead of permitting lossy wraparound;
- validate every finite conditional and marginal row covariance for symmetry and positive semidefiniteness;
- independently recompute each row's selected `J Sigma_gg J^T` contribution from the complete joint gauge prior;
- require `marginal_world_covariance_m2` to equal conditional covariance plus that contribution, preventing direct-construction covariance drift or double counting;
- perform covariance geometry and accounting checks in bounded 65,536-row chunks without constructing an `M x 7 x 7` temporary;
- reuse the same bounded per-gauge primitive for public marginal-covariance diagnostics;
- retain defense-in-depth in the tree-backed binder against post-construction object tampering; and
- make the focused sparse-gauge workflow trigger, lint, format-check, type-check, and test the ordinary sparse stack explicitly.

## Why

The ordinary factory creates a valid sparse stack from a validated schema-v4 factor bundle, but the public dataclass can also be constructed or replaced directly. Its previous constructor coerced numeric identifiers to strings, allowed out-of-range unsigned integer conversion, and did not verify row covariance geometry or conditional-versus-marginal accounting. A finite shape-compatible forged stack could therefore reach a downstream estimator without preserving the source bundle's covariance semantics.

A naive strict check would also allocate one complete `7 x 7` gauge block per row. The final implementation validates in bounded chunks and retains only the required `M x 3 x 3` output when a caller explicitly requests the gauge-marginal covariance.

## Compatibility

Factory-produced stacks are unchanged numerically. The `include_invalid=True` diagnostic route remains available: covariance geometry is checked on finite rows, and NaN-bearing inactive diagnostic rows retain the existing parity behavior. This change rejects only malformed or coercion-dependent direct constructions.

No provider-v1/provider-v2 artifact bytes, schema-v4 bundle identity, estimator default, calibration result, held-out cohort, BayesianPhysTwin guard, or Causal4D behavior changes.

## Exact-head validation

Validated on head `2446bfe9563eec854cc9ee1d030a5e007339d8bd`:

- focused sparse gauge-tree workflow: Ruff, canonical formatting, strict MyPy for the ordinary and tree-backed sparse modules, focused/adjacent tests, byte compilation, and installed command checks passed;
- complete source suites passed on Python 3.10, 3.11, 3.12, 3.13, and 3.14;
- the declared Python 3.10 / NumPy 1.24 runtime floor passed the complete suite;
- repository, release, provider-manifest, and clean-checkout runtime-attestation checks passed;
- wheel and source distributions built and validated;
- both distributions installed in isolation and passed grouped and legacy CLI smoke tests;
- fail-closed quality passed; and
- CodeQL for Python and Actions plus the resolved-runtime dependency audit passed.

Workflow runs: Tests `31271057445`, Sparse gauge-tree prior `31271057459`, Fail-closed quality `31271057457`, Security scanning `31271057455`.

## Claim boundary

This is contract, covariance-accounting, and bounded-memory hardening. It does not establish observation accuracy, covariance calibration, physical-query identifiability, BayesianPhysTwin benefit, Causal4D intervention benefit, deployment safety, or state of the art.