### PR TITLE
Harden PhysTwin legacy inputs and numerical validation

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,6 +5,21 @@
 Security and integrity fixes are applied to the current `0.3.x` development line.
 Frozen historical revisions remain reproducible but may not receive backports.
 
+## Legacy PhysTwin dataset boundary
+
+The official PhysTwin integration still needs the dataset's historical
+`calibrate.pkl` and `processed_masks.pkl` files. Prob4D loads these only inside
+the dedicated legacy adapter, rejects symbolic-link substitution, and uses a
+restricted unpickler that admits primitive containers plus the minimal NumPy
+array-reconstruction globals. Arbitrary Python globals fail closed. Portable
+Prob4D prediction, calibration, observation, and evidence artifacts never use
+pickle.
+
+The restriction prevents ordinary pickle code execution; it is not a general
+sandbox against malformed or resource-exhausting files. Use only locally
+verified official dataset files and retain their hashes in claim-bearing run
+provenance.
+
 ## Self-hosted workflow boundary
 
 Ordinary pull-request workflows run on GitHub-hosted infrastructure. Pull-request

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,18 +7,20 @@ Frozen historical revisions remain reproducible but may not receive backports.
 
 ## Legacy PhysTwin dataset boundary
 
-The official PhysTwin integration still needs the dataset's historical
-`calibrate.pkl` and `processed_masks.pkl` files. Prob4D loads these only inside
-the dedicated legacy adapter, rejects symbolic-link substitution, and uses a
-restricted unpickler that admits primitive containers plus the minimal NumPy
-array-reconstruction globals. Arbitrary Python globals fail closed. Portable
-Prob4D prediction, calibration, observation, and evidence artifacts never use
-pickle.
+The `PhysTwinCase` directory adapter still needs the official dataset's
+historical `calibrate.pkl` and `processed_masks.pkl` files. Prob4D loads these
+only inside that dedicated legacy adapter, rejects symbolic-link substitution,
+and uses a restricted unpickler that admits primitive containers plus the
+minimal NumPy array-reconstruction globals. Arbitrary Python globals fail
+closed. Portable Prob4D prediction, calibration, observation, and evidence
+artifacts never use pickle.
 
-The restriction prevents ordinary pickle code execution; it is not a general
-sandbox against malformed or resource-exhausting files. Use only locally
-verified official dataset files and retain their hashes in claim-bearing run
-provenance.
+The restriction prevents ordinary pickle code execution through those two
+adapter paths; it is not a general sandbox against malformed or
+resource-exhausting files. Use only locally verified official dataset files and
+retain their hashes in claim-bearing run provenance. Other explicitly diagnostic
+legacy import paths remain trusted-input boundaries unless their own contract
+states otherwise.
 
 ## Self-hosted workflow boundary
 

--- a/docs/observation-contract-conformance.md
+++ b/docs/observation-contract-conformance.md
@@ -17,10 +17,12 @@ The installed package contains a data-only normative bundle under
 - ten invalid mutations covering semantic, closed-schema, dtype, and digest
   failures.
 
-The canonical repository is `FlorianPfaff/Prob4D`. Every participating
-repository carries a byte-identical copy so ordinary installation and CI remain
-offline and do not require access to another private repository. The copies are
-bound by the bundle SHA-256
+The canonical development repository is `IPS-Stuttgart/Prob4D`. The normative
+bundle was originally frozen under `FlorianPfaff/Prob4D`, and historical
+content-addressed artifacts may correctly retain that repository identity.
+Every participating repository carries a byte-identical copy so ordinary
+installation and CI remain offline and do not require access to another private
+repository. The copies are bound by the bundle SHA-256
 
 ```text
 a62c693a14c227daa1f4c8db850e691a1d0081df0c853cf0174c33d0b8504ce9

--- a/docs/streaming-evaluation.md
+++ b/docs/streaming-evaluation.md
@@ -88,13 +88,18 @@ processes used Python 3.13.5, NumPy 2.3.5, Linux 6.12.13 x86-64, three
 
 This is synthetic engineering evidence for one host and process configuration,
 not a runtime guarantee or a reconstruction-accuracy, uncertainty-calibration,
-Bayesian-PhysTwin, or Causal4D result.
+BayesianPhysTwin, or Causal4D result.
 
-## Remaining memory work
+## Current memory boundary
 
-The evaluator still requires the dense immutable prediction and truth inputs,
-and exact ranking diagnostics still retain three scalar values per evaluated
-point. Issue #50 continues to track memory-mapped prediction loading,
-export-stage streaming, and production-host profiling at the full
-`25 x 320 x 640` setting. Any such mode must remain explicit and must not alter
-frozen provider semantics silently.
+Issue #50 is complete. Its frozen real-bundle comparison verified exact semantic
+parity and measured materially lower source-loading memory and runtime for the
+memory-mapped execution store; the total-process peak improved more modestly.
+See [dense-memory execution](dense-memory.md) for the retained measurements,
+identities, and claim boundary.
+
+The evaluator still requires dense immutable prediction and truth inputs, and
+exact ranking diagnostics still retain three scalar values per evaluated point.
+A later optimization should be opened separately only when a matched production
+profile identifies a specific remaining bottleneck. Any such mode must remain
+explicit and must not silently alter frozen provider semantics.

--- a/src/prob4d/covariance.py
+++ b/src/prob4d/covariance.py
@@ -2,10 +2,34 @@
 
 from __future__ import annotations
 
+from numbers import Real
+
 import numpy as np
 from numpy.typing import NDArray
 
 FloatArray = NDArray[np.floating]
+
+
+def _finite_nonnegative_real(value: float, *, name: str) -> float:
+    """Return one finite non-negative real scalar without coercive aliases."""
+
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+        raise TypeError(f"{name} must be a real scalar")
+    result = float(value)
+    if not np.isfinite(result):
+        raise ValueError(f"{name} must be finite")
+    if result < 0.0:
+        raise ValueError(f"{name} must be non-negative")
+    return result
+
+
+def _finite_positive_real(value: float, *, name: str) -> float:
+    """Return one finite positive real scalar without coercive aliases."""
+
+    result = _finite_nonnegative_real(value, name=name)
+    if result <= 0.0:
+        raise ValueError(f"{name} must be positive")
+    return result
 
 
 def _validated_eigendecomposition(
@@ -22,8 +46,16 @@ def _validated_eigendecomposition(
         raise ValueError(f"{name} must contain nonempty square matrices")
     if not np.all(np.isfinite(values)):
         raise ValueError(f"{name} must be finite")
-    if absolute_negative_tolerance < 0.0 or relative_negative_tolerance < 0.0:
-        raise ValueError("negative-eigenvalue tolerances must be non-negative")
+    absolute_negative_tolerance = _finite_nonnegative_real(
+        absolute_negative_tolerance,
+        name="absolute_negative_tolerance",
+    )
+    relative_negative_tolerance = _finite_nonnegative_real(
+        relative_negative_tolerance,
+        name="relative_negative_tolerance",
+    )
+    symmetry_atol = _finite_nonnegative_real(symmetry_atol, name="symmetry_atol")
+    symmetry_rtol = _finite_nonnegative_real(symmetry_rtol, name="symmetry_rtol")
 
     transposed = np.swapaxes(values, -1, -2)
     symmetric = 0.5 * (values + transposed)
@@ -116,8 +148,7 @@ def covariance_eigendecomposition(
     well defined.
     """
 
-    if not np.isfinite(eigenvalue_floor) or eigenvalue_floor <= 0.0:
-        raise ValueError("eigenvalue_floor must be finite and positive")
+    eigenvalue_floor = _finite_positive_real(eigenvalue_floor, name="eigenvalue_floor")
     symmetric, eigenvalues, eigenvectors = _validated_eigendecomposition(
         covariance,
         name=name,

--- a/src/prob4d/phystwin.py
+++ b/src/prob4d/phystwin.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import importlib
 import json
 import pickle
+import warnings
 from dataclasses import asdict, dataclass
+from numbers import Integral, Real
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 from numpy.typing import NDArray
@@ -14,6 +18,124 @@ from .metrics import TruthSequence
 
 FloatArray = NDArray[np.floating]
 BoolArray = NDArray[np.bool_]
+
+
+def _integer_at_least(value: int, *, name: str, minimum: int) -> int:
+    """Return a non-coercive integer that satisfies a lower bound."""
+
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Integral):
+        raise TypeError(f"{name} must be an integer")
+    result = int(value)
+    if result < minimum:
+        comparator = "positive" if minimum == 1 else f"at least {minimum}"
+        raise ValueError(f"{name} must be {comparator}")
+    return result
+
+
+def _positive_real(value: float, *, name: str) -> float:
+    """Return a finite positive real scalar without accepting Boolean aliases."""
+
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+        raise TypeError(f"{name} must be a real scalar")
+    result = float(value)
+    if not np.isfinite(result) or result <= 0.0:
+        raise ValueError(f"{name} must be finite and positive")
+    return result
+
+
+def _strict_json_object(path: Path) -> dict[str, Any]:
+    """Load one finite JSON object while rejecting duplicate keys and symlinks."""
+
+    if path.is_symlink():
+        raise ValueError(f"refusing symbolic-link metadata path: {path}")
+
+    def reject_constant(value: str) -> None:
+        raise ValueError(f"non-finite JSON constant is not allowed: {value}")
+
+    def reject_duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError(f"duplicate JSON key: {key}")
+            result[key] = value
+        return result
+
+    loaded = json.loads(
+        path.read_text(encoding="utf-8"),
+        parse_constant=reject_constant,
+        object_pairs_hook=reject_duplicates,
+    )
+    if not isinstance(loaded, dict):
+        raise ValueError(f"{path} must contain one JSON object")
+    return loaded
+
+
+def _legacy_numpy_pickle_globals() -> dict[tuple[str, str], Any]:
+    """Return the minimal NumPy globals required by official legacy artifacts."""
+
+    allowed: dict[tuple[str, str], Any] = {
+        ("numpy", "dtype"): np.dtype,
+        ("numpy", "ndarray"): np.ndarray,
+    }
+    module_attributes = {
+        "numpy.core.multiarray": ("_reconstruct", "scalar"),
+        "numpy._core.multiarray": ("_reconstruct", "scalar"),
+        "numpy.core.numeric": ("_frombuffer",),
+        "numpy._core.numeric": ("_frombuffer",),
+    }
+    for module_name, attributes in module_attributes.items():
+        try:
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+                module = importlib.import_module(module_name)
+                values = tuple(getattr(module, attribute, None) for attribute in attributes)
+        except ImportError:
+            continue
+        for attribute, value in zip(attributes, values, strict=True):
+            if value is not None:
+                allowed[(module_name, attribute)] = value
+    return allowed
+
+
+_LEGACY_NUMPY_PICKLE_GLOBALS = _legacy_numpy_pickle_globals()
+
+
+class _RestrictedLegacyUnpickler(pickle.Unpickler):
+    """Unpickle only primitive containers and the NumPy array reconstruction API."""
+
+    def find_class(self, module: str, name: str) -> Any:
+        allowed = _LEGACY_NUMPY_PICKLE_GLOBALS.get((module, name))
+        if allowed is None:
+            raise pickle.UnpicklingError(
+                f"legacy PhysTwin pickle requests forbidden global {module}.{name}"
+            )
+        return allowed
+
+
+def _load_trusted_legacy_pickle(path: Path, *, description: str) -> Any:
+    """Load a legacy official dataset pickle through a restricted unpickler.
+
+    The old PhysTwin dataset stores calibration and mask arrays as pickles. This
+    adapter permits only NumPy's array reconstruction primitives; arbitrary
+    globals and symbolic-link substitution fail closed. Portable Prob4D artifacts
+    never use pickle.
+    """
+
+    if path.is_symlink():
+        raise ValueError(f"refusing symbolic-link {description} path: {path}")
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    try:
+        with path.open("rb") as handle:
+            return _RestrictedLegacyUnpickler(handle).load()
+    except (pickle.UnpicklingError, AttributeError, EOFError, TypeError, ValueError) as error:
+        raise ValueError(f"invalid or unsafe {description} pickle: {path}") from error
+
+
+def _readonly_float64(value: Any) -> FloatArray:
+    array = np.asarray(value, dtype=np.float64).copy()
+    array.setflags(write=False)
+    return array
 
 
 @dataclass(frozen=True)
@@ -37,9 +159,26 @@ class CoverResizeCrop:
         target_height: int,
         target_width: int,
     ) -> CoverResizeCrop:
-        values = (source_height, source_width, target_height, target_width)
-        if any(value < 1 for value in values):
-            raise ValueError("source and target image dimensions must be positive")
+        source_height = _integer_at_least(
+            source_height,
+            name="source_height",
+            minimum=1,
+        )
+        source_width = _integer_at_least(
+            source_width,
+            name="source_width",
+            minimum=1,
+        )
+        target_height = _integer_at_least(
+            target_height,
+            name="target_height",
+            minimum=1,
+        )
+        target_width = _integer_at_least(
+            target_width,
+            name="target_width",
+            minimum=1,
+        )
         scale = max(target_height / source_height, target_width / source_width)
         resized_height = int(round(source_height * scale))
         resized_width = int(round(source_width * scale))
@@ -58,7 +197,7 @@ class CoverResizeCrop:
         """Map target pixel centers to continuous source pixel coordinates."""
 
         coordinates = np.asarray(target_xy, dtype=np.float64)
-        if coordinates.shape[-1] != 2:
+        if coordinates.ndim == 0 or coordinates.shape[-1] != 2:
             raise ValueError("pixel coordinates must end in (x, y)")
         result = np.empty_like(coordinates)
         result[..., 0] = (
@@ -79,7 +218,7 @@ class CoverResizeCrop:
         """Map source pixel centers into MotionCrafter's cropped image."""
 
         coordinates = np.asarray(source_xy, dtype=np.float64)
-        if coordinates.shape[-1] != 2:
+        if coordinates.ndim == 0 or coordinates.shape[-1] != 2:
             raise ValueError("pixel coordinates must end in (x, y)")
         result = np.empty_like(coordinates)
         result[..., 0] = (
@@ -119,7 +258,7 @@ class CoverResizeCrop:
 
 @dataclass(frozen=True)
 class PhysTwinCase:
-    """A calibrated official PhysTwin RGB-D interaction."""
+    """A validated calibrated official PhysTwin RGB-D interaction."""
 
     root: Path
     intrinsics: FloatArray
@@ -136,21 +275,74 @@ class PhysTwinCase:
         calibration_path = path / "calibrate.pkl"
         if not metadata_path.is_file() or not calibration_path.is_file():
             raise ValueError(f"{path} is not a calibrated PhysTwin case")
-        metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
-        with calibration_path.open("rb") as handle:
-            camera_to_world = np.asarray(pickle.load(handle), dtype=np.float64)
+        metadata = _strict_json_object(metadata_path)
+        required = {"intrinsics", "WH", "frame_num", "fps"}
+        missing = sorted(required - metadata.keys())
+        if missing:
+            raise ValueError(f"PhysTwin metadata is missing required fields: {missing}")
+
+        wh = metadata["WH"]
+        if not isinstance(wh, list) or len(wh) != 2:
+            raise ValueError("PhysTwin WH must be a two-element JSON array")
+        width = _integer_at_least(wh[0], name="PhysTwin width", minimum=1)
+        height = _integer_at_least(wh[1], name="PhysTwin height", minimum=1)
+        frame_count = _integer_at_least(
+            metadata["frame_num"],
+            name="PhysTwin frame_num",
+            minimum=1,
+        )
+        fps = _positive_real(metadata["fps"], name="PhysTwin fps")
+
+        camera_to_world = np.asarray(
+            _load_trusted_legacy_pickle(
+                calibration_path,
+                description="PhysTwin calibration",
+            ),
+            dtype=np.float64,
+        )
         intrinsics = np.asarray(metadata["intrinsics"], dtype=np.float64)
-        width, height = (int(value) for value in metadata["WH"])
         if intrinsics.ndim != 3 or intrinsics.shape[1:] != (3, 3):
             raise ValueError("PhysTwin intrinsics must have shape (C, 3, 3)")
+        if intrinsics.shape[0] == 0:
+            raise ValueError("PhysTwin must contain at least one camera")
         if camera_to_world.shape != (intrinsics.shape[0], 4, 4):
             raise ValueError("PhysTwin camera calibration count is inconsistent")
+        if not np.all(np.isfinite(intrinsics)):
+            raise ValueError("PhysTwin intrinsics must be finite")
+        if not np.all(np.isfinite(camera_to_world)):
+            raise ValueError("PhysTwin camera transforms must be finite")
+        if np.any(intrinsics[:, 0, 0] <= 0.0) or np.any(intrinsics[:, 1, 1] <= 0.0):
+            raise ValueError("PhysTwin focal lengths must be positive")
+        expected_intrinsic_row = np.array([0.0, 0.0, 1.0])
+        if not np.allclose(
+            intrinsics[:, 2, :],
+            expected_intrinsic_row,
+            atol=1e-10,
+            rtol=0.0,
+        ):
+            raise ValueError("PhysTwin intrinsics must use a homogeneous final row")
+        expected_transform_row = np.array([0.0, 0.0, 0.0, 1.0])
+        if not np.allclose(
+            camera_to_world[:, 3, :],
+            expected_transform_row,
+            atol=1e-8,
+            rtol=0.0,
+        ):
+            raise ValueError("PhysTwin camera transforms must be homogeneous")
+        rotations = camera_to_world[:, :3, :3]
+        gram = np.einsum("...ji,...jk->...ik", rotations, rotations)
+        if not np.allclose(gram, np.eye(3), atol=1e-5, rtol=1e-5):
+            raise ValueError("PhysTwin camera rotations must be orthonormal")
+        determinants = np.linalg.det(rotations)
+        if not np.allclose(determinants, 1.0, atol=1e-5, rtol=1e-5):
+            raise ValueError("PhysTwin camera rotations must be proper")
+
         return cls(
             root=path,
-            intrinsics=intrinsics,
-            camera_to_world=camera_to_world,
-            frame_count=int(metadata["frame_num"]),
-            fps=float(metadata["fps"]),
+            intrinsics=_readonly_float64(intrinsics),
+            camera_to_world=_readonly_float64(camera_to_world),
+            frame_count=frame_count,
+            fps=fps,
             source_width=width,
             source_height=height,
         )
@@ -160,11 +352,13 @@ class PhysTwinCase:
         return int(self.intrinsics.shape[0])
 
     def _validate_camera(self, camera: int) -> None:
-        if not 0 <= camera < self.camera_count:
+        camera = _integer_at_least(camera, name="camera", minimum=0)
+        if camera >= self.camera_count:
             raise ValueError(f"camera must be between 0 and {self.camera_count - 1}")
 
     def _validate_frame(self, frame: int) -> None:
-        if not 0 <= frame < self.frame_count:
+        frame = _integer_at_least(frame, name="frame", minimum=0)
+        if frame >= self.frame_count:
             raise ValueError(f"frame must be between 0 and {self.frame_count - 1}")
 
     def color_video(self, camera: int) -> Path:
@@ -178,20 +372,29 @@ class PhysTwinCase:
         self._validate_frame(frame)
         self._validate_camera(camera)
         path = self.root / "depth" / str(camera) / f"{frame}.npy"
-        depth = np.asarray(np.load(path), dtype=np.float64) / 1000.0
+        depth = np.asarray(np.load(path, allow_pickle=False), dtype=np.float64) / 1000.0
         if depth.shape != (self.source_height, self.source_width):
             raise ValueError(f"unexpected depth shape in {path}")
         return depth
 
-    def load_processed_masks(self) -> dict:
+    def load_processed_masks(self) -> dict | list | tuple:
         path = self.root / "mask" / "processed_masks.pkl"
-        with path.open("rb") as handle:
-            masks = pickle.load(handle)
+        masks = _load_trusted_legacy_pickle(
+            path,
+            description="PhysTwin processed-mask",
+        )
+        if not isinstance(masks, (dict, list, tuple)):
+            raise ValueError("processed masks must be an indexed mapping or sequence")
         if len(masks) != self.frame_count:
             raise ValueError("processed mask frame count is inconsistent")
         return masks
 
-    def object_mask(self, masks: dict, frame: int, camera: int) -> BoolArray:
+    def object_mask(
+        self,
+        masks: dict | list | tuple,
+        frame: int,
+        camera: int,
+    ) -> BoolArray:
         self._validate_frame(frame)
         self._validate_camera(camera)
         mask = np.asarray(masks[frame][camera]["object"], dtype=bool)
@@ -205,7 +408,7 @@ class PhysTwinCase:
         camera: int,
         crop: CoverResizeCrop,
         *,
-        masks: dict | None = None,
+        masks: dict | list | tuple | None = None,
         object_only: bool = True,
         minimum_depth_m: float = 0.2,
         maximum_depth_m: float = 1.5,
@@ -214,6 +417,10 @@ class PhysTwinCase:
 
         if crop.source_height != self.source_height or crop.source_width != self.source_width:
             raise ValueError("crop source geometry does not match PhysTwin metadata")
+        minimum_depth_m = _positive_real(minimum_depth_m, name="minimum_depth_m")
+        maximum_depth_m = _positive_real(maximum_depth_m, name="maximum_depth_m")
+        if maximum_depth_m <= minimum_depth_m:
+            raise ValueError("maximum_depth_m must exceed minimum_depth_m")
         depth = crop.sample_nearest(self.load_depth_m(frame, camera))
         valid = np.isfinite(depth) & (depth > minimum_depth_m) & (depth < maximum_depth_m)
         if object_only:
@@ -246,9 +453,14 @@ class PhysTwinCase:
         *,
         object_only: bool = True,
     ) -> TruthSequence:
-        frames = np.asarray(frame_indices, dtype=np.int64)
+        raw_frames = np.asarray(frame_indices)
+        if not np.issubdtype(raw_frames.dtype, np.integer):
+            raise ValueError("frame_indices must contain integers")
+        frames = np.asarray(raw_frames, dtype=np.int64)
         if frames.ndim != 1 or frames.size == 0:
             raise ValueError("frame_indices must be a non-empty vector")
+        if np.any(frames < 0) or np.any(frames >= self.frame_count):
+            raise ValueError("frame_indices lie outside the PhysTwin case")
         masks = self.load_processed_masks() if object_only else None
         point_maps = []
         valid_masks = []
@@ -269,16 +481,21 @@ class PhysTwinCase:
         )
 
     def project_world(self, points: FloatArray, camera: int) -> tuple[FloatArray, FloatArray]:
-        """Project world points to source pixels and return positive camera depth."""
+        """Project finite world points to source pixels and positive camera depth."""
 
         self._validate_camera(camera)
         points = np.asarray(points, dtype=np.float64)
-        if points.shape[-1] != 3:
+        if points.ndim == 0 or points.shape[-1] != 3:
             raise ValueError("world points must end in three coordinates")
-        world_to_camera = np.linalg.inv(self.camera_to_world[camera])
+        if not np.all(np.isfinite(points)):
+            raise ValueError("world points must be finite")
+        rotation = self.camera_to_world[camera, :3, :3]
+        translation = self.camera_to_world[camera, :3, 3]
         camera_points = np.einsum(
-            "ij,...j->...i", world_to_camera[:3, :3], points
-        ) + world_to_camera[:3, 3]
+            "ji,...j->...i",
+            rotation,
+            points - translation,
+        )
         depth = camera_points[..., 2]
         intrinsic = self.intrinsics[camera]
         safe_depth = np.where(np.abs(depth) > 1e-12, depth, 1.0)
@@ -304,6 +521,8 @@ def sample_vector_field_nearest(
     coordinates = np.asarray(coordinates_xy, dtype=np.float64)
     if values.ndim != 3 or values.shape[-1] != 3:
         raise ValueError("field must have shape (H, W, 3)")
+    if values.shape[0] == 0 or values.shape[1] == 0:
+        raise ValueError("field spatial dimensions must be nonempty")
     if coordinates.ndim != 2 or coordinates.shape[1] != 2:
         raise ValueError("coordinates must have shape (N, 2)")
     finite = np.all(np.isfinite(coordinates), axis=1)
@@ -337,8 +556,13 @@ def deterministic_subsample(
     points = np.asarray(points, dtype=np.float64)
     if points.ndim != 2 or points.shape[1] != 3:
         raise ValueError("point sets must have shape (N, 3)")
-    if maximum_points < 1:
-        raise ValueError("maximum_points must be positive")
+    if not np.all(np.isfinite(points)):
+        raise ValueError("point sets must be finite")
+    maximum_points = _integer_at_least(
+        maximum_points,
+        name="maximum_points",
+        minimum=1,
+    )
     if points.shape[0] <= maximum_points:
         return points
     generator = np.random.default_rng(seed)
@@ -375,6 +599,9 @@ def nearest_neighbor_indices(
         raise ValueError("source and target must have shape (N, 3)")
     if source.shape[0] == 0 or target.shape[0] == 0:
         raise ValueError("point sets must not be empty")
+    if not np.all(np.isfinite(source)) or not np.all(np.isfinite(target)):
+        raise ValueError("source and target point sets must be finite")
+    chunk_size = _integer_at_least(chunk_size, name="chunk_size", minimum=1)
     indices = np.empty(source.shape[0], dtype=np.int64)
     distances = np.empty(source.shape[0], dtype=np.float64)
     for start in range(0, source.shape[0], chunk_size):

--- a/src/prob4d/phystwin.py
+++ b/src/prob4d/phystwin.py
@@ -481,14 +481,12 @@ class PhysTwinCase:
         )
 
     def project_world(self, points: FloatArray, camera: int) -> tuple[FloatArray, FloatArray]:
-        """Project finite world points to source pixels and positive camera depth."""
+        """Project world points to source pixels and return camera depth."""
 
         self._validate_camera(camera)
         points = np.asarray(points, dtype=np.float64)
         if points.ndim == 0 or points.shape[-1] != 3:
             raise ValueError("world points must end in three coordinates")
-        if not np.all(np.isfinite(points)):
-            raise ValueError("world points must be finite")
         rotation = self.camera_to_world[camera, :3, :3]
         translation = self.camera_to_world[camera, :3, 3]
         camera_points = np.einsum(

--- a/tests/test_covariance_hardening.py
+++ b/tests/test_covariance_hardening.py
@@ -1,0 +1,42 @@
+import numpy as np
+import pytest
+
+from prob4d.covariance import covariance_eigendecomposition, validated_covariance_psd
+
+
+@pytest.mark.parametrize(
+    ("keyword", "value", "exception"),
+    [
+        ("absolute_negative_tolerance", np.nan, ValueError),
+        ("relative_negative_tolerance", np.inf, ValueError),
+        ("symmetry_atol", -1.0, ValueError),
+        ("symmetry_rtol", True, TypeError),
+    ],
+)
+def test_covariance_validation_rejects_invalid_tolerances(
+    keyword: str,
+    value: object,
+    exception: type[Exception],
+) -> None:
+    arguments = {keyword: value}
+
+    with pytest.raises(exception):
+        validated_covariance_psd(np.eye(2), **arguments)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("invalid", [np.nan, np.inf, 0.0, -1.0, True])
+def test_covariance_eigenvalue_floor_must_be_finite_positive(invalid: object) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        covariance_eigendecomposition(
+            np.eye(2),
+            eigenvalue_floor=invalid,  # type: ignore[arg-type]
+        )
+
+
+def test_covariance_validation_still_projects_tiny_negative_roundoff() -> None:
+    covariance = np.diag([1.0, -1e-15])
+
+    validated = validated_covariance_psd(covariance)
+
+    np.testing.assert_allclose(validated, np.diag([1.0, 0.0]))
+    assert not validated.flags.writeable

--- a/tests/test_phystwin.py
+++ b/tests/test_phystwin.py
@@ -104,6 +104,18 @@ def test_phystwin_metric_point_map_and_projection_round_trip(tmp_path: Path) -> 
     assert not case.camera_to_world.flags.writeable
 
 
+def test_phystwin_projection_preserves_nonfinite_track_placeholders(tmp_path: Path) -> None:
+    case = make_case(tmp_path)
+    points = np.array([[0.0, 0.0, 1.0], [np.nan, np.nan, np.nan]])
+
+    pixels, depth = case.project_world(points, 0)
+
+    np.testing.assert_allclose(pixels[0], [1.5, 1.0])
+    assert depth[0] == pytest.approx(1.0)
+    assert np.all(np.isnan(pixels[1]))
+    assert np.isnan(depth[1])
+
+
 def test_phystwin_metric_truth_preserves_absolute_frames(tmp_path: Path) -> None:
     case = make_case(tmp_path)
     crop = CoverResizeCrop.from_shapes(3, 4, 3, 4)

--- a/tests/test_phystwin.py
+++ b/tests/test_phystwin.py
@@ -9,25 +9,51 @@ from prob4d.phystwin import (
     CoverResizeCrop,
     PhysTwinCase,
     directed_nearest_distances,
+    nearest_neighbor_indices,
     point_set_metrics,
     sample_vector_field_nearest,
 )
 
 
-def make_case(tmp_path: Path) -> PhysTwinCase:
+def mark_pickle_execution(path: str) -> None:
+    Path(path).write_text("executed", encoding="utf-8")
+
+
+class UnsafePicklePayload:
+    def __init__(self, marker: Path) -> None:
+        self.marker = marker
+
+    def __reduce__(self) -> tuple[object, tuple[str]]:
+        return mark_pickle_execution, (str(self.marker),)
+
+
+def write_case(
+    tmp_path: Path,
+    *,
+    intrinsics: object | None = None,
+    camera_to_world: object | None = None,
+    metadata_overrides: dict[str, object] | None = None,
+) -> Path:
     root = tmp_path / "case"
     (root / "depth" / "0").mkdir(parents=True)
     (root / "mask").mkdir()
     (root / "color").mkdir()
-    metadata = {
-        "intrinsics": [[[2.0, 0.0, 1.5], [0.0, 2.0, 1.0], [0.0, 0.0, 1.0]]],
+    metadata: dict[str, object] = {
+        "intrinsics": (
+            [[[2.0, 0.0, 1.5], [0.0, 2.0, 1.0], [0.0, 0.0, 1.0]]]
+            if intrinsics is None
+            else intrinsics
+        ),
         "WH": [4, 3],
         "frame_num": 2,
         "fps": 30,
     }
+    if metadata_overrides is not None:
+        metadata.update(metadata_overrides)
     (root / "metadata.json").write_text(json.dumps(metadata), encoding="utf-8")
+    calibration = np.eye(4)[None] if camera_to_world is None else camera_to_world
     with (root / "calibrate.pkl").open("wb") as handle:
-        pickle.dump(np.eye(4)[None], handle)
+        pickle.dump(calibration, handle, protocol=pickle.HIGHEST_PROTOCOL)
     depth_mm = np.full((3, 4), 1000.0)
     np.save(root / "depth" / "0" / "0.npy", depth_mm)
     np.save(root / "depth" / "0" / "1.npy", depth_mm)
@@ -37,8 +63,12 @@ def make_case(tmp_path: Path) -> PhysTwinCase:
         for frame in range(2)
     }
     with (root / "mask" / "processed_masks.pkl").open("wb") as handle:
-        pickle.dump(masks, handle)
-    return PhysTwinCase.from_directory(root)
+        pickle.dump(masks, handle, protocol=pickle.HIGHEST_PROTOCOL)
+    return root
+
+
+def make_case(tmp_path: Path) -> PhysTwinCase:
+    return PhysTwinCase.from_directory(write_case(tmp_path))
 
 
 def test_cover_crop_coordinate_round_trip() -> None:
@@ -53,6 +83,12 @@ def test_cover_crop_coordinate_round_trip() -> None:
     assert crop.crop_row == 21
 
 
+@pytest.mark.parametrize("invalid", [True, 0, -1, 1.5])
+def test_cover_crop_rejects_coercive_or_invalid_dimensions(invalid: object) -> None:
+    with pytest.raises((TypeError, ValueError)):
+        CoverResizeCrop.from_shapes(invalid, 848, 320, 640)  # type: ignore[arg-type]
+
+
 def test_phystwin_metric_point_map_and_projection_round_trip(tmp_path: Path) -> None:
     case = make_case(tmp_path)
     crop = CoverResizeCrop.from_shapes(3, 4, 3, 4)
@@ -64,6 +100,8 @@ def test_phystwin_metric_point_map_and_projection_round_trip(tmp_path: Path) -> 
     assert np.allclose(depth, 1.0)
     source_grid = crop.target_source_grid()[valid]
     np.testing.assert_allclose(pixels, source_grid, atol=1e-7)
+    assert not case.intrinsics.flags.writeable
+    assert not case.camera_to_world.flags.writeable
 
 
 def test_phystwin_metric_truth_preserves_absolute_frames(tmp_path: Path) -> None:
@@ -77,6 +115,69 @@ def test_phystwin_metric_truth_preserves_absolute_frames(tmp_path: Path) -> None
     assert np.all(truth.valid_mask)
 
 
+def test_phystwin_rejects_nonintegral_frame_indices(tmp_path: Path) -> None:
+    case = make_case(tmp_path)
+    crop = CoverResizeCrop.from_shapes(3, 4, 3, 4)
+
+    with pytest.raises(ValueError, match="must contain integers"):
+        case.metric_truth(np.array([1.0]), 0, crop)
+
+
+def test_phystwin_rejects_invalid_camera_geometry(tmp_path: Path) -> None:
+    transform = np.eye(4)[None]
+    transform[0, 0, 0] = 2.0
+    root = write_case(tmp_path, camera_to_world=transform)
+
+    with pytest.raises(ValueError, match="rotations must be orthonormal"):
+        PhysTwinCase.from_directory(root)
+
+
+def test_phystwin_rejects_nonfinite_camera_transforms(tmp_path: Path) -> None:
+    transform = np.eye(4)[None]
+    transform[0, 0, 3] = np.nan
+    root = write_case(tmp_path, camera_to_world=transform)
+
+    with pytest.raises(ValueError, match="camera transforms must be finite"):
+        PhysTwinCase.from_directory(root)
+
+
+def test_phystwin_rejects_executable_legacy_pickle(tmp_path: Path) -> None:
+    root = write_case(tmp_path)
+    marker = tmp_path / "pickle-executed"
+    with (root / "calibrate.pkl").open("wb") as handle:
+        pickle.dump(UnsafePicklePayload(marker), handle)
+
+    with pytest.raises(ValueError, match="invalid or unsafe PhysTwin calibration pickle"):
+        PhysTwinCase.from_directory(root)
+    assert not marker.exists()
+
+
+def test_phystwin_rejects_nonfinite_json_constants(tmp_path: Path) -> None:
+    root = write_case(tmp_path)
+    metadata_path = root / "metadata.json"
+    metadata_path.write_text(
+        '{"intrinsics": [[[2, 0, 1.5], [0, 2, 1], [0, 0, 1]]], '
+        '"WH": [4, 3], "frame_num": 2, "fps": NaN}',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="non-finite JSON constant"):
+        PhysTwinCase.from_directory(root)
+
+
+def test_phystwin_rejects_duplicate_metadata_keys(tmp_path: Path) -> None:
+    root = write_case(tmp_path)
+    metadata_path = root / "metadata.json"
+    metadata_path.write_text(
+        '{"intrinsics": [[[2, 0, 1.5], [0, 2, 1], [0, 0, 1]]], '
+        '"WH": [4, 3], "frame_num": 2, "fps": 30, "fps": 60}',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="duplicate JSON key: fps"):
+        PhysTwinCase.from_directory(root)
+
+
 def test_nearest_field_sampling_reports_out_of_bounds() -> None:
     rows, columns = np.meshgrid(np.arange(2), np.arange(3), indexing="ij")
     field = np.stack((columns, rows, np.ones_like(rows)), axis=-1).astype(float)
@@ -88,6 +189,32 @@ def test_nearest_field_sampling_reports_out_of_bounds() -> None:
 
     np.testing.assert_allclose(sampled[[0, 2]], [[1.0, 0.0, 1.0], [2.0, 1.0, 1.0]])
     np.testing.assert_array_equal(active, [True, False, True, False])
+
+
+def test_nearest_neighbor_rejects_invalid_chunk_sizes() -> None:
+    points = np.zeros((1, 3))
+
+    for invalid in (True, 0, -1, 1.5):
+        with pytest.raises((TypeError, ValueError)):
+            nearest_neighbor_indices(points, points, chunk_size=invalid)  # type: ignore[arg-type]
+
+    indices, distances = nearest_neighbor_indices(
+        points,
+        points,
+        chunk_size=np.int64(1),
+    )
+    np.testing.assert_array_equal(indices, [0])
+    np.testing.assert_array_equal(distances, [0.0])
+
+
+def test_nearest_neighbor_rejects_nonfinite_points() -> None:
+    finite = np.zeros((1, 3))
+    nonfinite = np.array([[np.nan, 0.0, 0.0]])
+
+    with pytest.raises(ValueError, match="point sets must be finite"):
+        nearest_neighbor_indices(nonfinite, finite)
+    with pytest.raises(ValueError, match="point sets must be finite"):
+        nearest_neighbor_indices(finite, nonfinite)
 
 
 def test_point_set_metrics_are_symmetric_and_metric() -> None:


### PR DESCRIPTION
## What changed

- replace unrestricted loading of the official PhysTwin calibration and mask pickles with a restricted NumPy-only legacy unpickler;
- reject symlink substitution, duplicate metadata keys, non-finite JSON constants, coercive scalar controls, malformed intrinsics, and invalid rigid camera transforms;
- keep validated camera arrays immutable and use the analytic rigid-transform inverse for world-to-camera projection;
- require finite point sets and a strict positive integer nearest-neighbor chunk size, preventing negative chunk sizes from returning uninitialized output arrays;
- reject NaN, infinity, negative, and Boolean covariance tolerance controls before symmetry or PSD admission;
- add adversarial regressions for executable pickle globals, malformed camera geometry, non-finite point sets, coercive chunk sizes, invalid covariance controls, and manual-track NaN placeholders;
- correct the canonical-versus-historical repository wording in the observation contract guide and update the completed memory-profiling status;
- document the precisely scoped legacy PhysTwin dataset security boundary.

## Why

Three fail-closed gaps were present in diagnostic integration code:

1. `nearest_neighbor_indices(..., chunk_size=-1)` performed no loop iterations and could return uninitialized `np.empty` arrays;
2. non-finite tolerance controls could weaken covariance validation comparisons; and
3. ordinary `pickle.load` admitted arbitrary Python globals from the legacy calibration and mask files.

The PR closes these boundaries without changing estimator mathematics or portable provider artifacts.

## Compatibility and scientific boundary

- no provider-v1/provider-v2, observation-belief, factor-bundle, calibration, or evidence schema changes;
- official NumPy-array PhysTwin calibration and mask pickles remain readable through the restricted adapter;
- manual-track NaN placeholders remain supported until the existing visibility mask removes them;
- malformed, coercive, executable, non-finite, or non-rigid inputs now fail closed at their owning boundary;
- other explicitly diagnostic legacy pickle paths remain trusted-input boundaries and are not relabelled as hardened by this PR;
- this is implementation and input-integrity work only; it does not create new reconstruction, calibration, BayesianPhysTwin, Causal4D, or held-out physical evidence.

## Validation

Exact validated head: `f6b5b6ae7bc8ebe62c54d65735c33a79ad1ea109`.

Focused local validation:

- `python -m compileall -q src tests`;
- `pytest -q`: **28 passed**;
- explicit line-length inspection for the modified Python files;
- source-level review against the existing manual-track visibility path.

GitHub-hosted validation passed completely:

- **Fail-closed quality** run `31270857541`: Ruff, stable-interface mypy, repository/release policies, runtime-revision attestation, and provider manifests;
- **Tests** run `31270857524`: complete suites on Python 3.10, 3.11, 3.12, 3.13, and 3.14, including the exact NumPy 1.24 runtime floor;
- wheel and source-distribution build and validation;
- isolated installed wheel and installed sdist CLI smoke tests;
- **Security scanning** run `31270857542`: CodeQL for Python and Actions plus the resolved dependency audit.