### PR TITLE
Make selection-lock publication atomically no-clobber

### DIFF
--- a/.github/workflows/selection-lock.yml
+++ b/.github/workflows/selection-lock.yml
@@ -11,6 +11,7 @@ on:
       - "src/prob4d/_selection_evidence_records.py"
       - "src/prob4d/_selection_evidence_replay.py"
       - "tests/test_selection_lock.py"
+      - "tests/test_selection_lock_publication.py"
       - "tests/test_selection_evidence.py"
   workflow_dispatch:
 
@@ -50,11 +51,13 @@ jobs:
           python -m ruff check \
             src/prob4d/selection_lock.py \
             src/prob4d/deployment_ledger.py \
-            tests/test_selection_lock.py
+            tests/test_selection_lock.py \
+            tests/test_selection_lock_publication.py
           python -m ruff format --check \
             src/prob4d/selection_lock.py \
             src/prob4d/deployment_ledger.py \
-            tests/test_selection_lock.py
+            tests/test_selection_lock.py \
+            tests/test_selection_lock_publication.py
           python -m mypy \
             src/prob4d/selection_lock.py \
             src/prob4d/deployment_ledger.py
@@ -62,6 +65,7 @@ jobs:
         run: >-
           python -m pytest -q
           tests/test_selection_lock.py
+          tests/test_selection_lock_publication.py
           tests/test_selection_evidence.py
       - name: Verify installed public modules
         run: |

--- a/docs/selection-lock.md
+++ b/docs/selection-lock.md
@@ -41,6 +41,11 @@ lock = build_selection_lock(
 write_selection_lock(lock, "evidence/selection-lock.json")
 ```
 
+Selection-lock publication is exactly once. The writer uses a durable atomic
+no-clobber operation: an existing file or a competing writer causes
+`FileExistsError` and leaves the retained bytes unchanged. A changed lock must use
+a separately versioned path rather than replacing the pre-target artifact.
+
 Loading the JSON independently replays the complete candidate order and rejects
 missing matrix rows, duplicate keys, changed candidate order, changed selection,
 noncanonical provenance, altered claim boundaries, or content-ID mismatch.

--- a/src/prob4d/selection_lock.py
+++ b/src/prob4d/selection_lock.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import tempfile
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -44,6 +45,34 @@ SELECTION_LOCK_CLAIM_BOUNDARY = (
     "benefit requires a separately content-addressed deployment ledger and frozen target "
     "analysis."
 )
+
+
+def _atomic_create(path: Path, content: bytes) -> None:
+    """Durably publish one immutable file without replacing a competing writer."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="wb",
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temporary = Path(handle.name)
+            handle.write(content)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.link(temporary, path)
+        directory_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    finally:
+        if temporary is not None:
+            temporary.unlink(missing_ok=True)
 
 
 @dataclass(frozen=True, slots=True)
@@ -267,18 +296,15 @@ def selection_lock_from_dict(value: Any) -> SelectionLockV1:
 
 
 def write_selection_lock(lock: SelectionLockV1, path: str | os.PathLike[str]) -> None:
-    """Write one canonical lock atomically."""
+    """Publish one canonical lock without replacing retained evidence."""
 
     if not isinstance(lock, SelectionLockV1):
         raise ValueError("lock must be a SelectionLockV1")
-    destination = Path(path)
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    temporary = destination.with_name(f".{destination.name}.tmp")
-    temporary.write_text(
-        json.dumps(lock.to_dict(), sort_keys=True, indent=2, allow_nan=False) + "\n",
-        encoding="utf-8",
+    payload = (
+        json.dumps(lock.to_dict(), sort_keys=True, indent=2, allow_nan=False).encode("utf-8")
+        + b"\n"
     )
-    os.replace(temporary, destination)
+    _atomic_create(Path(path), payload)
 
 
 def load_selection_lock(path: str | os.PathLike[str]) -> SelectionLockV1:

--- a/tests/test_selection_lock_publication.py
+++ b/tests/test_selection_lock_publication.py
@@ -1,0 +1,113 @@
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from threading import Barrier
+
+import pytest
+
+from prob4d.selection_lock import (
+    CalibrationMetricRowV1,
+    CandidateSpecV1,
+    MetricOrderV1,
+    SelectionRuleV1,
+    build_selection_lock,
+    load_selection_lock,
+    write_selection_lock,
+)
+
+SOURCE_REVISION = "a" * 40
+
+
+def make_lock(marker: str):
+    candidates = (
+        CandidateSpecV1(
+            candidate_id="fallback",
+            method_id="physical-fallback",
+            complexity_rank=0,
+            parameters={"visual_update": False},
+        ),
+        CandidateSpecV1(
+            candidate_id="candidate",
+            method_id="persistent-explicit-joint-gauge",
+            complexity_rank=1,
+            parameters={"visual_update": True},
+        ),
+    )
+    rows = (
+        CalibrationMetricRowV1(
+            group_id="object-a",
+            candidate_id="fallback",
+            metrics={"rmse_mm": 5.0},
+        ),
+        CalibrationMetricRowV1(
+            group_id="object-a",
+            candidate_id="candidate",
+            metrics={"rmse_mm": 2.0},
+        ),
+        CalibrationMetricRowV1(
+            group_id="object-b",
+            candidate_id="fallback",
+            metrics={"rmse_mm": 5.5},
+        ),
+        CalibrationMetricRowV1(
+            group_id="object-b",
+            candidate_id="candidate",
+            metrics={"rmse_mm": 2.5},
+        ),
+    )
+    return build_selection_lock(
+        experiment_id="selection-lock-publication-v1",
+        source_repository="IPS-Stuttgart/Prob4D",
+        source_revision=SOURCE_REVISION,
+        candidates=candidates,
+        calibration_rows=rows,
+        selection_rule=SelectionRuleV1(
+            primary=MetricOrderV1("rmse_mm", "minimize"),
+        ),
+        metadata={"marker": marker},
+    )
+
+
+def temporary_files(path: Path) -> tuple[Path, ...]:
+    return tuple(path.parent.glob(f".{path.name}.*.tmp"))
+
+
+def test_selection_lock_publication_never_replaces_retained_evidence(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "selection-lock.json"
+    first = make_lock("first")
+    second = make_lock("second")
+
+    write_selection_lock(first, path)
+    retained = path.read_bytes()
+
+    with pytest.raises(FileExistsError):
+        write_selection_lock(second, path)
+
+    assert path.read_bytes() == retained
+    assert load_selection_lock(path).selection_lock_id == first.selection_lock_id
+    assert temporary_files(path) == ()
+
+
+def test_concurrent_selection_lock_publication_has_exactly_one_winner(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "selection-lock.json"
+    locks = (make_lock("left"), make_lock("right"))
+    barrier = Barrier(len(locks))
+
+    def publish(lock) -> str | None:
+        barrier.wait()
+        try:
+            write_selection_lock(lock, path)
+        except FileExistsError:
+            return None
+        return lock.selection_lock_id
+
+    with ThreadPoolExecutor(max_workers=len(locks)) as executor:
+        results = tuple(executor.map(publish, locks))
+
+    winners = tuple(result for result in results if result is not None)
+    assert len(winners) == 1
+    assert load_selection_lock(path).selection_lock_id == winners[0]
+    assert temporary_files(path) == ()


### PR DESCRIPTION
## What changed

- publish `SelectionLockV1` through a unique, fsynced temporary file and an atomic hard-link create;
- fail with `FileExistsError` instead of replacing an existing or concurrently published pre-target lock;
- fsync the containing directory after publication and clean temporary files on both success and failure;
- add deterministic regressions for sequential overwrite attempts and synchronized two-writer races;
- bind the new race regression into the focused selection-lock workflow; and
- document the exactly-once publication contract.

## Root cause

`write_selection_lock` previously wrote to one predictable `.<name>.tmp` path and then called `os.replace`. That made the final rename atomic, but it did not make publication no-clobber: an existing retained lock—or a competing writer that won after a precheck—could be silently replaced. Two writers could also contend for the same temporary name.

A pre-target selection lock is intended to be sealed once and referenced by content identity before target access. Replacing its bytes at the same path weakens that operational evidence boundary even though loading would still validate whichever bytes remained last.

## Validation

Exact validated head: `9ecdffb959084f977d7a1ccba0b7ac0f5df7f683`.

GitHub Actions passed completely:

- **Pre-target selection lock** run `31296640187`: Ruff, Ruff formatting, MyPy, installed-module checks, and **23 focused tests passed**, including the synchronized publication race;
- **Fail-closed quality** run `31296640212`;
- **Tests** run `31296640190`: complete suites on Python 3.10, 3.11, 3.12, 3.13, and 3.14, the declared NumPy 1.24 runtime floor, wheel and source-distribution validation, and isolated installed-wheel and installed-sdist CLI smoke tests; and
- **Security scanning** run `31296640194`: dependency audit plus CodeQL for Python and Actions.

Additional local validation on the exact implementation:

- Python byte compilation and Python 3.10 grammar parsing passed;
- modified Python files contain no lines longer than 100 characters; and
- a 100-iteration two-writer concurrency harness produced exactly one successful publisher in every iteration, retained the winner's complete bytes, and left no temporary files.

## Scientific and information boundary

This changes file-publication integrity only. It does **not** change candidate definitions, calibration rows, deterministic selection, artifact schemas or IDs, provider behavior, uncertainty, BayesianPhysTwin integration, the frozen Deform360 method, cohort membership, or target-data access. No calibration or confirmation payload is opened by this PR.