### PR TITLE
Add a direct tree-sparse observation producer path

### DIFF
--- a/docs/sparse-observation-factor-stack.md
+++ b/docs/sparse-observation-factor-stack.md
@@ -129,6 +129,51 @@ tree_stacked = bind_gauge_tree_prior(stacked, prior)
 The caller may retain the old dense stack separately; the returned tree-backed
 object does not reference its dense covariance.
 
+## Direct native construction
+
+A producer that already owns the causal tree factors should not create a dense
+joint covariance merely to pass through schema v4. It can construct the execution
+object directly:
+
+```python
+from prob4d.provider_v2_factors import (
+    build_tree_sparse_observation_factors,
+)
+
+tree_stacked = build_tree_sparse_observation_factors(
+    prior,
+    world_mean_m=world_mean_m,
+    conditional_world_covariance_m2=conditional_world_covariance_m2,
+    local_gauge_jacobian=local_gauge_jacobian,
+    gauge_indices=gauge_indices,
+    association_probability=association_probability,
+    prior_reliability=prior_reliability,
+    prior_nominal_probability=prior_nominal_probability,
+    composite_weight=composite_weight,
+    point_ids=point_ids,
+    frame_indices=frame_indices,
+    view_ids=view_ids,
+    factor_ids=factor_ids,
+    correlation_group_ids=correlation_group_ids,
+    causal_frame_stop=causal_frame_stop,
+)
+```
+
+The direct factory:
+
+- accepts only selected finite execution rows with positive association and
+  reliability;
+- validates covariance geometry, gauge indices, causal timing, probabilities,
+  literal string identities, factor metadata, correlation-group settings, and
+  within-factor point uniqueness;
+- derives `marginal_world_covariance_m2` from the conditional covariance and the
+  tree prior rather than accepting a redundant caller-supplied marginal;
+- copies numerical arrays into immutable storage; and
+- never calls dense prior materialization or dense-covariance verification.
+
+This is the intended in-memory producer boundary for a future tree-native
+portable observation artifact.
+
 ## Constructing the sparse gauge prior
 
 An existing dense bundle can be converted only when its declared parent order is
@@ -159,10 +204,10 @@ dense file and transient loading cost once. The tree-backed stack removes the
 dense prior from the retained execution object; it does not retroactively change
 the bundle bytes or their content identity.
 
-Eliminating the dense prior before initial factor-bundle loading requires a
-separately versioned provider or observation-factor contract. Such a future
-contract should bind the portable prior artifact identity rather than silently
-reinterpret schema v4.
+The direct native factory removes the dense requirement for an in-memory
+producer. Eliminating it from portable observation I/O still requires a
+separately versioned artifact that binds the sparse row arrays to the portable
+prior identity rather than silently reinterpreting schema v4.
 
 ## Compatibility and claim boundary
 

--- a/src/prob4d/provider_v2_factors.py
+++ b/src/prob4d/provider_v2_factors.py
@@ -41,6 +41,7 @@ from .sparse_observation_factors import (
 from .tree_sparse_observation_factors import (
     TreeSparseStackedObservationFactors,
     bind_gauge_tree_prior,
+    build_tree_sparse_observation_factors,
     stack_tree_sparse_observation_factors,
 )
 
@@ -69,6 +70,7 @@ __all__ = [
     "TreeSparseStackedObservationFactors",
     "ValidatedClaimBearingObservationFactorBundle",
     "bind_gauge_tree_prior",
+    "build_tree_sparse_observation_factors",
     "load_claim_bearing_observation_factor_bundle",
     "load_observation_factor_bundle",
     "seal_claim_bearing_observation_factor_bundle",

--- a/src/prob4d/tree_sparse_observation_factors.py
+++ b/src/prob4d/tree_sparse_observation_factors.py
@@ -133,8 +133,7 @@ def _require_row_metadata_consistency(
         previous_settings = group_settings.setdefault(group_id, settings)
         if previous_settings != settings:
             raise ValueError(
-                "rows in one correlation group must share nominal probability "
-                "and composite weight"
+                "rows in one correlation group must share nominal probability and composite weight"
             )
 
         point_key = (factor_id, int(point_ids[index]))
@@ -381,10 +380,7 @@ class TreeSparseStackedObservationFactors:
     @property
     def dense_gauge_design_nbytes(self) -> int:
         return int(
-            self.observation_count
-            * 3
-            * self.dense_gauge_dimension
-            * np.dtype(np.float64).itemsize
+            self.observation_count * 3 * self.dense_gauge_dimension * np.dtype(np.float64).itemsize
         )
 
     @property

--- a/src/prob4d/tree_sparse_observation_factors.py
+++ b/src/prob4d/tree_sparse_observation_factors.py
@@ -3,7 +3,7 @@
 The historical sparse stack removes the ``M x 3 x 7K`` row expansion but retains
 one dense ``7K x 7K`` gauge covariance. This module binds the same immutable row
 representation to :class:`GaugeTreeSquareRootPriorV1` after exact dense parity
-verification, then drops the retained dense covariance from the returned object.
+verification, or builds it directly from validated row arrays and a tree prior.
 """
 
 from __future__ import annotations
@@ -18,6 +18,10 @@ from .gauge_tree_prior import GaugeTreeSquareRootPriorV1
 from .observation_factors import ObservationFactorBundle
 from .sparse_observation_factors import (
     SparseStackedObservationFactors,
+    _integer_vector,
+    _readonly,
+    _require_row_covariance,
+    _string_tuple,
     stack_sparse_observation_factors,
 )
 
@@ -44,6 +48,226 @@ _TRANSFER_FIELDS = (
     "correlation_group_ids",
     "causal_frame_stop",
 )
+
+
+@dataclass(frozen=True, slots=True)
+class _ValidatedDirectRows:
+    world_mean_m: np.ndarray
+    conditional_world_covariance_m2: np.ndarray
+    marginal_world_covariance_m2: np.ndarray
+    local_gauge_jacobian: np.ndarray
+    gauge_indices: np.ndarray
+    association_probability: np.ndarray
+    prior_reliability: np.ndarray
+    prior_nominal_probability: np.ndarray
+    composite_weight: np.ndarray
+    point_ids: np.ndarray
+    frame_indices: np.ndarray
+    view_ids: tuple[str, ...]
+    factor_ids: tuple[str, ...]
+    correlation_group_ids: tuple[str, ...]
+    causal_frame_stop: int
+
+
+def _probability_vector(
+    value: object,
+    *,
+    name: str,
+    count: int,
+    allow_zero: bool,
+) -> np.ndarray:
+    result = np.asarray(value, dtype=np.float64)
+    if result.shape != (count,):
+        raise ValueError(f"{name} must have shape (M,)")
+    lower = result >= 0.0 if allow_zero else result > 0.0
+    if not np.all(np.isfinite(result)) or not np.all(lower) or np.any(result > 1.0):
+        interval = "[0, 1]" if allow_zero else "(0, 1]"
+        raise ValueError(f"{name} must lie in {interval}")
+    return result
+
+
+def _causal_frame_stop(value: object) -> int:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(
+        value,
+        (int, np.integer),
+    ):
+        raise TypeError("causal_frame_stop must be a genuine integer")
+    result = int(value)
+    if result < 1:
+        raise ValueError("causal_frame_stop must be positive")
+    return result
+
+
+def _require_row_metadata_consistency(
+    *,
+    gauge_indices: np.ndarray,
+    point_ids: np.ndarray,
+    frame_indices: np.ndarray,
+    view_ids: tuple[str, ...],
+    factor_ids: tuple[str, ...],
+    correlation_group_ids: tuple[str, ...],
+    prior_nominal_probability: np.ndarray,
+    composite_weight: np.ndarray,
+) -> None:
+    factor_metadata: dict[str, tuple[object, ...]] = {}
+    group_settings: dict[str, tuple[float, float]] = {}
+    factor_points: set[tuple[str, int]] = set()
+    for index, factor_id in enumerate(factor_ids):
+        metadata = (
+            view_ids[index],
+            int(frame_indices[index]),
+            int(gauge_indices[index]),
+            correlation_group_ids[index],
+            float(prior_nominal_probability[index]),
+            float(composite_weight[index]),
+        )
+        previous_metadata = factor_metadata.setdefault(factor_id, metadata)
+        if previous_metadata != metadata:
+            raise ValueError("rows with one factor_id must share factor metadata")
+
+        group_id = correlation_group_ids[index]
+        settings = (
+            float(prior_nominal_probability[index]),
+            float(composite_weight[index]),
+        )
+        previous_settings = group_settings.setdefault(group_id, settings)
+        if previous_settings != settings:
+            raise ValueError(
+                "rows in one correlation group must share nominal probability "
+                "and composite weight"
+            )
+
+        point_key = (factor_id, int(point_ids[index]))
+        if point_key in factor_points:
+            raise ValueError("point_ids must be unique within each factor")
+        factor_points.add(point_key)
+
+
+def _validate_direct_rows(
+    gauge_tree_prior: GaugeTreeSquareRootPriorV1,
+    *,
+    world_mean_m: object,
+    conditional_world_covariance_m2: object,
+    local_gauge_jacobian: object,
+    gauge_indices: object,
+    association_probability: object,
+    prior_reliability: object,
+    prior_nominal_probability: object,
+    composite_weight: object,
+    point_ids: object,
+    frame_indices: object,
+    view_ids: object,
+    factor_ids: object,
+    correlation_group_ids: object,
+    causal_frame_stop: object,
+) -> _ValidatedDirectRows:
+    mean = np.asarray(world_mean_m, dtype=np.float64)
+    if mean.ndim != 2 or mean.shape[0] < 1 or mean.shape[1] != 3:
+        raise ValueError("world_mean_m must have shape (M, 3) with M >= 1")
+    count = mean.shape[0]
+    conditional = np.asarray(conditional_world_covariance_m2, dtype=np.float64)
+    local_jacobian = np.asarray(local_gauge_jacobian, dtype=np.float64)
+    indices = _integer_vector(np.asarray(gauge_indices), name="gauge_indices")
+    points = _integer_vector(np.asarray(point_ids), name="point_ids")
+    frames = _integer_vector(np.asarray(frame_indices), name="frame_indices")
+
+    if conditional.shape != (count, 3, 3):
+        raise ValueError("conditional_world_covariance_m2 must have shape (M, 3, 3)")
+    if local_jacobian.shape != (count, 3, 7):
+        raise ValueError("local_gauge_jacobian must have shape (M, 3, 7)")
+    if indices.shape != (count,):
+        raise ValueError("gauge_indices must have shape (M,)")
+    if points.shape != (count,) or frames.shape != (count,):
+        raise ValueError("row identity vectors must have shape (M,)")
+    if not np.all(np.isfinite(mean)):
+        raise ValueError("world_mean_m must be finite")
+    if not np.all(np.isfinite(conditional)):
+        raise ValueError("conditional_world_covariance_m2 must be finite")
+    if not np.all(np.isfinite(local_jacobian)):
+        raise ValueError("local_gauge_jacobian must be finite")
+    if np.any(indices < 0) or np.any(indices >= gauge_tree_prior.gauge_count):
+        raise ValueError("gauge_indices reference an unknown gauge")
+
+    _require_row_covariance(
+        conditional,
+        name="conditional_world_covariance_m2",
+    )
+    association = _probability_vector(
+        association_probability,
+        name="association_probability",
+        count=count,
+        allow_zero=False,
+    )
+    reliability = _probability_vector(
+        prior_reliability,
+        name="prior_reliability",
+        count=count,
+        allow_zero=False,
+    )
+    nominal = _probability_vector(
+        prior_nominal_probability,
+        name="prior_nominal_probability",
+        count=count,
+        allow_zero=True,
+    )
+    composite = _probability_vector(
+        composite_weight,
+        name="composite_weight",
+        count=count,
+        allow_zero=False,
+    )
+    stop = _causal_frame_stop(causal_frame_stop)
+    if np.any(frames < 0) or np.any(frames >= stop):
+        raise ValueError("stacked rows cross the exclusive causal frame stop")
+
+    views = _string_tuple(view_ids, name="view_ids", expected_length=count)
+    factors = _string_tuple(factor_ids, name="factor_ids", expected_length=count)
+    groups = _string_tuple(
+        correlation_group_ids,
+        name="correlation_group_ids",
+        expected_length=count,
+    )
+    _require_row_metadata_consistency(
+        gauge_indices=indices,
+        point_ids=points,
+        frame_indices=frames,
+        view_ids=views,
+        factor_ids=factors,
+        correlation_group_ids=groups,
+        prior_nominal_probability=nominal,
+        composite_weight=composite,
+    )
+
+    gauge_marginal = gauge_tree_prior.row_marginal_covariance(
+        local_jacobian,
+        indices,
+    )
+    marginal = conditional + gauge_marginal
+    marginal = 0.5 * (marginal + marginal.swapaxes(1, 2))
+    if not np.all(np.isfinite(marginal)):
+        raise ValueError("derived marginal_world_covariance_m2 must be finite")
+    _require_row_covariance(
+        marginal,
+        name="derived marginal_world_covariance_m2",
+    )
+
+    return _ValidatedDirectRows(
+        world_mean_m=mean,
+        conditional_world_covariance_m2=conditional,
+        marginal_world_covariance_m2=marginal,
+        local_gauge_jacobian=local_jacobian,
+        gauge_indices=indices,
+        association_probability=association,
+        prior_reliability=reliability,
+        prior_nominal_probability=nominal,
+        composite_weight=composite,
+        point_ids=points,
+        frame_indices=frames,
+        view_ids=views,
+        factor_ids=factors,
+        correlation_group_ids=groups,
+        causal_frame_stop=stop,
+    )
 
 
 def _require_marginal_parity(
@@ -77,10 +301,10 @@ def _require_immutable_rows(stacked: SparseStackedObservationFactors) -> None:
 class TreeSparseStackedObservationFactors:
     """Factory-built sparse rows backed by an ``O(K)`` causal gauge-tree prior.
 
-    Construct instances through :func:`bind_gauge_tree_prior` or
-    :func:`stack_tree_sparse_observation_factors`. The factory verifies the tree
-    against the complete dense schema-v4 prior and the retained row marginals
-    before transferring the already immutable row arrays.
+    Direct producers use :func:`build_tree_sparse_observation_factors`. Existing
+    schema-v4 bundles use :func:`bind_gauge_tree_prior` or
+    :func:`stack_tree_sparse_observation_factors`, which verify the tree against
+    the complete dense prior before releasing it.
     """
 
     world_mean_m: FloatArray
@@ -101,7 +325,10 @@ class TreeSparseStackedObservationFactors:
     causal_frame_stop: int
 
     def __init__(self) -> None:
-        raise TypeError("use bind_gauge_tree_prior or stack_tree_sparse_observation_factors")
+        raise TypeError(
+            "use build_tree_sparse_observation_factors, bind_gauge_tree_prior, "
+            "or stack_tree_sparse_observation_factors"
+        )
 
     @classmethod
     def _from_verified_sparse_stack(
@@ -112,6 +339,22 @@ class TreeSparseStackedObservationFactors:
         result = object.__new__(cls)
         for name in _TRANSFER_FIELDS:
             object.__setattr__(result, name, getattr(stacked, name))
+        object.__setattr__(result, "gauge_tree_prior", gauge_tree_prior)
+        return result
+
+    @classmethod
+    def _from_direct_rows(
+        cls,
+        rows: _ValidatedDirectRows,
+        gauge_tree_prior: GaugeTreeSquareRootPriorV1,
+    ) -> TreeSparseStackedObservationFactors:
+        result = object.__new__(cls)
+        for name in _ROW_ARRAY_FIELDS:
+            object.__setattr__(result, name, _readonly(getattr(rows, name)))
+        object.__setattr__(result, "view_ids", rows.view_ids)
+        object.__setattr__(result, "factor_ids", rows.factor_ids)
+        object.__setattr__(result, "correlation_group_ids", rows.correlation_group_ids)
+        object.__setattr__(result, "causal_frame_stop", rows.causal_frame_stop)
         object.__setattr__(result, "gauge_tree_prior", gauge_tree_prior)
         return result
 
@@ -138,7 +381,10 @@ class TreeSparseStackedObservationFactors:
     @property
     def dense_gauge_design_nbytes(self) -> int:
         return int(
-            self.observation_count * 3 * self.dense_gauge_dimension * np.dtype(np.float64).itemsize
+            self.observation_count
+            * 3
+            * self.dense_gauge_dimension
+            * np.dtype(np.float64).itemsize
         )
 
     @property
@@ -230,6 +476,56 @@ class TreeSparseStackedObservationFactors:
         )
 
 
+def build_tree_sparse_observation_factors(
+    gauge_tree_prior: GaugeTreeSquareRootPriorV1,
+    *,
+    world_mean_m: object,
+    conditional_world_covariance_m2: object,
+    local_gauge_jacobian: object,
+    gauge_indices: object,
+    association_probability: object,
+    prior_reliability: object,
+    prior_nominal_probability: object,
+    composite_weight: object,
+    point_ids: object,
+    frame_indices: object,
+    view_ids: object,
+    factor_ids: object,
+    correlation_group_ids: object,
+    causal_frame_stop: object,
+) -> TreeSparseStackedObservationFactors:
+    """Build a tree-backed stack without constructing a dense gauge covariance.
+
+    This is the native producer path. It accepts selected, finite execution rows,
+    validates row and grouping semantics, derives marginal covariance from the
+    sparse prior, and copies every numerical input into an immutable result.
+    """
+
+    if not isinstance(gauge_tree_prior, GaugeTreeSquareRootPriorV1):
+        raise TypeError("gauge_tree_prior must be a GaugeTreeSquareRootPriorV1")
+    rows = _validate_direct_rows(
+        gauge_tree_prior,
+        world_mean_m=world_mean_m,
+        conditional_world_covariance_m2=conditional_world_covariance_m2,
+        local_gauge_jacobian=local_gauge_jacobian,
+        gauge_indices=gauge_indices,
+        association_probability=association_probability,
+        prior_reliability=prior_reliability,
+        prior_nominal_probability=prior_nominal_probability,
+        composite_weight=composite_weight,
+        point_ids=point_ids,
+        frame_indices=frame_indices,
+        view_ids=view_ids,
+        factor_ids=factor_ids,
+        correlation_group_ids=correlation_group_ids,
+        causal_frame_stop=causal_frame_stop,
+    )
+    return TreeSparseStackedObservationFactors._from_direct_rows(
+        rows,
+        gauge_tree_prior,
+    )
+
+
 def bind_gauge_tree_prior(
     stacked: SparseStackedObservationFactors,
     gauge_tree_prior: GaugeTreeSquareRootPriorV1,
@@ -278,5 +574,6 @@ def stack_tree_sparse_observation_factors(
 __all__ = [
     "TreeSparseStackedObservationFactors",
     "bind_gauge_tree_prior",
+    "build_tree_sparse_observation_factors",
     "stack_tree_sparse_observation_factors",
 ]

--- a/tests/test_provider_v2_factors.py
+++ b/tests/test_provider_v2_factors.py
@@ -47,6 +47,10 @@ def test_provider_v2_factor_facade_reexports_one_contract_surface() -> None:
     )
     assert provider.bind_gauge_tree_prior is tree_sparse.bind_gauge_tree_prior
     assert (
+        provider.build_tree_sparse_observation_factors
+        is tree_sparse.build_tree_sparse_observation_factors
+    )
+    assert (
         provider.stack_tree_sparse_observation_factors
         is tree_sparse.stack_tree_sparse_observation_factors
     )

--- a/tests/test_tree_sparse_observation_factors.py
+++ b/tests/test_tree_sparse_observation_factors.py
@@ -13,6 +13,7 @@ from prob4d.sparse_observation_factors import stack_sparse_observation_factors
 from prob4d.tree_sparse_observation_factors import (
     TreeSparseStackedObservationFactors,
     bind_gauge_tree_prior,
+    build_tree_sparse_observation_factors,
     stack_tree_sparse_observation_factors,
 )
 
@@ -103,6 +104,26 @@ def _prior(bundle: ObservationFactorBundle) -> GaugeTreeSquareRootPriorV1:
     )
 
 
+def _direct_inputs(bundle: ObservationFactorBundle) -> dict[str, object]:
+    stacked = stack_sparse_observation_factors(bundle)
+    return {
+        "world_mean_m": stacked.world_mean_m,
+        "conditional_world_covariance_m2": stacked.conditional_world_covariance_m2,
+        "local_gauge_jacobian": stacked.local_gauge_jacobian,
+        "gauge_indices": stacked.gauge_indices,
+        "association_probability": stacked.association_probability,
+        "prior_reliability": stacked.prior_reliability,
+        "prior_nominal_probability": stacked.prior_nominal_probability,
+        "composite_weight": stacked.composite_weight,
+        "point_ids": stacked.point_ids,
+        "frame_indices": stacked.frame_indices,
+        "view_ids": stacked.view_ids,
+        "factor_ids": stacked.factor_ids,
+        "correlation_group_ids": stacked.correlation_group_ids,
+        "causal_frame_stop": stacked.causal_frame_stop,
+    }
+
+
 def test_tree_sparse_stack_matches_dense_prior_and_row_contracts() -> None:
     bundle = _bundle()
     dense_sparse = stack_sparse_observation_factors(bundle)
@@ -132,11 +153,138 @@ def test_tree_sparse_stack_matches_dense_prior_and_row_contracts() -> None:
     )
     assert tree_sparse.gauge_ids == dense_sparse.gauge_ids
     assert (
-        tree_sparse.gauge_prior_storage_nbytes == tree_sparse.gauge_tree_prior.factor_storage_nbytes
+        tree_sparse.gauge_prior_storage_nbytes
+        == tree_sparse.gauge_tree_prior.factor_storage_nbytes
     )
     assert (
-        tree_sparse.dense_gauge_prior_nbytes == tree_sparse.gauge_tree_prior.dense_covariance_nbytes
+        tree_sparse.dense_gauge_prior_nbytes
+        == tree_sparse.gauge_tree_prior.dense_covariance_nbytes
     )
+
+
+def test_direct_tree_sparse_factory_matches_verified_schema_v4_path() -> None:
+    bundle = _bundle()
+    prior = _prior(bundle)
+    direct = build_tree_sparse_observation_factors(
+        prior,
+        **_direct_inputs(bundle),
+    )
+    verified = stack_tree_sparse_observation_factors(bundle, prior)
+
+    for name in (
+        "world_mean_m",
+        "conditional_world_covariance_m2",
+        "marginal_world_covariance_m2",
+        "local_gauge_jacobian",
+        "gauge_indices",
+        "association_probability",
+        "prior_reliability",
+        "prior_nominal_probability",
+        "composite_weight",
+        "point_ids",
+        "frame_indices",
+    ):
+        np.testing.assert_allclose(getattr(direct, name), getattr(verified, name))
+    assert direct.view_ids == verified.view_ids
+    assert direct.factor_ids == verified.factor_ids
+    assert direct.correlation_group_ids == verified.correlation_group_ids
+    assert direct.gauge_tree_prior is prior
+    assert not hasattr(direct, "gauge_prior_covariance")
+
+
+def test_direct_tree_sparse_factory_never_materializes_dense_prior(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bundle = _bundle()
+    prior = _prior(bundle)
+
+    def forbidden(*args: object, **kwargs: object) -> None:
+        raise AssertionError("dense gauge covariance path was used")
+
+    monkeypatch.setattr(
+        GaugeTreeSquareRootPriorV1,
+        "materialize_dense_covariance",
+        forbidden,
+    )
+    monkeypatch.setattr(
+        GaugeTreeSquareRootPriorV1,
+        "verify_dense_covariance",
+        forbidden,
+    )
+
+    direct = build_tree_sparse_observation_factors(
+        prior,
+        **_direct_inputs(bundle),
+    )
+    assert direct.gauge_prior_storage_nbytes == prior.factor_storage_nbytes
+
+
+def test_direct_tree_sparse_factory_copies_and_freezes_inputs() -> None:
+    bundle = _bundle()
+    inputs = _direct_inputs(bundle)
+    mean = np.asarray(inputs["world_mean_m"]).copy()
+    inputs["world_mean_m"] = mean
+    direct = build_tree_sparse_observation_factors(_prior(bundle), **inputs)
+    retained = direct.world_mean_m.copy()
+
+    mean[0] = 99.0
+    np.testing.assert_array_equal(direct.world_mean_m, retained)
+    with pytest.raises(ValueError):
+        direct.world_mean_m[0, 0] = 1.0
+
+
+def test_direct_tree_sparse_factory_rejects_invalid_execution_rows() -> None:
+    bundle = _bundle()
+    prior = _prior(bundle)
+    inputs = _direct_inputs(bundle)
+
+    zero_association = dict(inputs)
+    association = np.asarray(inputs["association_probability"]).copy()
+    association[0] = 0.0
+    zero_association["association_probability"] = association
+    with pytest.raises(ValueError, match="association_probability must lie in"):
+        build_tree_sparse_observation_factors(prior, **zero_association)
+
+    nonfinite_mean = dict(inputs)
+    mean = np.asarray(inputs["world_mean_m"]).copy()
+    mean[0, 0] = np.nan
+    nonfinite_mean["world_mean_m"] = mean
+    with pytest.raises(ValueError, match="world_mean_m must be finite"):
+        build_tree_sparse_observation_factors(prior, **nonfinite_mean)
+
+    wrong_gauge = dict(inputs)
+    indices = np.asarray(inputs["gauge_indices"]).copy()
+    indices[0] = prior.gauge_count
+    wrong_gauge["gauge_indices"] = indices
+    with pytest.raises(ValueError, match="unknown gauge"):
+        build_tree_sparse_observation_factors(prior, **wrong_gauge)
+
+
+def test_direct_tree_sparse_factory_rejects_inconsistent_row_identity() -> None:
+    bundle = _bundle()
+    prior = _prior(bundle)
+    inputs = _direct_inputs(bundle)
+
+    changed_frame = dict(inputs)
+    frames = np.asarray(inputs["frame_indices"]).copy()
+    frames[1] += 1
+    changed_frame["frame_indices"] = frames
+    with pytest.raises(ValueError, match="share factor metadata"):
+        build_tree_sparse_observation_factors(prior, **changed_frame)
+
+    duplicate_point = dict(inputs)
+    points = np.asarray(inputs["point_ids"]).copy()
+    points[1] = points[0]
+    duplicate_point["point_ids"] = points
+    with pytest.raises(ValueError, match="unique within each factor"):
+        build_tree_sparse_observation_factors(prior, **duplicate_point)
+
+    coercive_views = dict(inputs)
+    views = list(inputs["view_ids"])
+    views[0] = 1
+    coercive_views["view_ids"] = tuple(views)
+    with pytest.raises(TypeError, match="literal strings"):
+        build_tree_sparse_observation_factors(prior, **coercive_views)
 
 
 def test_tree_sparse_matrix_free_actions_match_dense_linear_algebra() -> None:
@@ -275,6 +423,11 @@ def test_tree_sparse_contract_rejects_wrong_types() -> None:
         bind_gauge_tree_prior(object(), _prior(bundle))  # type: ignore[arg-type]
     with pytest.raises(TypeError, match="GaugeTreeSquareRootPriorV1"):
         bind_gauge_tree_prior(dense_sparse, object())  # type: ignore[arg-type]
+    with pytest.raises(TypeError, match="GaugeTreeSquareRootPriorV1"):
+        build_tree_sparse_observation_factors(  # type: ignore[arg-type]
+            object(),
+            **_direct_inputs(bundle),
+        )
     with pytest.raises(TypeError, match="ObservationFactorBundle"):
         stack_tree_sparse_observation_factors(  # type: ignore[arg-type]
             object(),

--- a/tests/test_tree_sparse_observation_factors.py
+++ b/tests/test_tree_sparse_observation_factors.py
@@ -153,12 +153,10 @@ def test_tree_sparse_stack_matches_dense_prior_and_row_contracts() -> None:
     )
     assert tree_sparse.gauge_ids == dense_sparse.gauge_ids
     assert (
-        tree_sparse.gauge_prior_storage_nbytes
-        == tree_sparse.gauge_tree_prior.factor_storage_nbytes
+        tree_sparse.gauge_prior_storage_nbytes == tree_sparse.gauge_tree_prior.factor_storage_nbytes
     )
     assert (
-        tree_sparse.dense_gauge_prior_nbytes
-        == tree_sparse.gauge_tree_prior.dense_covariance_nbytes
+        tree_sparse.dense_gauge_prior_nbytes == tree_sparse.gauge_tree_prior.dense_covariance_nbytes
     )
 
 


### PR DESCRIPTION
## Summary

Add the native in-memory producer boundary for tree-backed explicit-gauge observations.

- add `build_tree_sparse_observation_factors`, which constructs `TreeSparseStackedObservationFactors` directly from selected row arrays and `GaugeTreeSquareRootPriorV1`;
- never materialize or verify a dense `7K x 7K` covariance on this path;
- derive each row's marginal covariance from its conditional covariance, local `3 x 7` gauge Jacobian, gauge index, and sparse tree prior rather than accepting a redundant caller-supplied marginal;
- validate finite row geometry, positive association and source reliability, probability ranges, causal timing, gauge references, literal string identities, within-factor point uniqueness, factor metadata consistency, and correlation-group settings;
- copy all numerical inputs into immutable storage;
- retain the existing schema-v4 dense-verification path unchanged for compatibility;
- expose the factory through `prob4d.provider_v2_factors`; and
- add parity, no-densification, immutability, malformed-row, identity, and facade regressions.

## Why

The merged tree-backed stack releases the dense joint gauge covariance after validating an existing schema-v4 bundle. A producer that already owns the causal tree factors still had no public way to construct that execution representation without first manufacturing the dense covariance. This PR closes that in-memory gap and provides the producer object needed for a later tree-native portable observation artifact.

## Compatibility

Existing `ObservationFactorBundle` schema v4, provider-v1/provider-v2 artifacts, dense and sparse stacks, content identities, estimator defaults, frozen experiments, and claim boundaries are unchanged. The direct factory is additive and accepts only selected finite execution rows; the historical `include_invalid=True` diagnostic route remains on the schema-v4 stacker.

## Exact-head validation

Validated on head `76d3546b92b198be338d52c15f2cb63fabaf1eaf`:

- focused sparse gauge-tree lane passed Ruff, canonical formatting, strict MyPy, focused and adjacent tests, byte compilation, and installed command checks;
- complete source suites passed on Python 3.10, 3.11, 3.12, 3.13, and 3.14;
- the declared Python 3.10 / NumPy 1.24 runtime floor passed the complete suite;
- repository, release, provider-manifest, and clean-checkout runtime-attestation checks passed;
- wheel and source distributions built and validated;
- both distributions installed in isolation and passed grouped and legacy CLI smoke tests;
- fail-closed quality passed; and
- CodeQL for Python and Actions plus the resolved-runtime dependency audit passed.

Workflow runs: Tests `31297270583`, Sparse gauge-tree prior `31297270581`, Fail-closed quality `31297270631`, Security scanning `31297270584`.

## Scientific boundary

This is execution-contract and memory-scaling infrastructure. It does not establish provider competence, uncertainty calibration, physical-query identifiability, BayesianPhysTwin benefit, Causal4D intervention benefit, deployment safety, or state of the art.