### PR TITLE
Add paired joint-covariance dependence ablations

### DIFF
--- a/docs/joint-covariance-diagnostics.md
+++ b/docs/joint-covariance-diagnostics.md
@@ -52,5 +52,51 @@ their SHA-256. Its report is published with create-if-absent semantics, so a
 concurrent writer cannot be overwritten. The numerical rank tolerance and
 explicit claim boundary are retained in the JSON report.
 
+## Paired dependence ablation
+
+The ordinary diagnostic answers whether one supplied joint covariance is
+calibrated. A separate target-free ablation asks the narrower mechanism question:
+does retaining the cross-row dependence improve a proper score over alternatives
+with the same residuals and grouping?
+
+Run it from an installed package or repository checkout:
+
+```bash
+python -m prob4d.joint_covariance_ablation matched-residuals.npz \
+  --output joint-covariance-ablation.json \
+  --bootstrap-replicates 2000 \
+  --bootstrap-seed 7 \
+  --confidence-level 0.95
+```
+
+It evaluates three arms without constructing a dense joint covariance:
+
+1. **joint:** `blockdiag(D_i) + U U^T`;
+2. **marginal-preserving independence:** `blockdiag(D_i + U_i U_i^T)`, which
+   preserves every 3-D row marginal while deleting all cross-row covariance; and
+3. **conditional only:** `blockdiag(D_i)`, which also removes the shared marginal
+   uncertainty.
+
+The marginal-preserving arm is the primary dependence ablation because it cannot
+win merely by changing individual-row variance. For each independent group, the
+report records:
+
+- the Gaussian NLL-per-dimension advantage of the joint arm;
+- the improvement in absolute normalized-NEES error relative to one; and
+- the corresponding joint and ablation values.
+
+Positive advantages favor the full joint covariance. Summaries use equal group
+weight and include the fraction of groups favoring the joint arm. Percentile
+intervals use a deterministic paired bootstrap over complete
+`factor_group_ids`; rows, points, pixels, and covariance coordinates are never
+resampled as independent units. Bootstrap index generation is chunked and the
+replicate count is bounded, so the diagnostic does not allocate a
+`replicates x groups` array without limit.
+
+The ablation reads and hashes the same strict NPZ schema as the ordinary
+joint-covariance command, evaluates those exact bytes, and publishes its report
+with the same create-if-absent behavior. It is controlled mechanism evidence,
+not permission to reuse or retune an opened target cohort.
+
 This is a calibration diagnostic, not a provider promotion decision. Provider
 competence and guarded BayesianPhysTwin benefit remain separate frozen gates.

--- a/src/prob4d/joint_covariance_ablation.py
+++ b/src/prob4d/joint_covariance_ablation.py
@@ -1,0 +1,417 @@
+"""Paired dependence ablations for Prob4D conditional plus low-rank covariance."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import math
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from .joint_covariance_metrics import (
+    _write_text_exclusive,
+    evaluate_joint_gaussian_groups,
+)
+
+JOINT_COVARIANCE_ABLATION_SCHEMA = "prob4d.joint-covariance-ablation"
+JOINT_COVARIANCE_ABLATION_VERSION = 1
+JOINT_COVARIANCE_ABLATION_CLAIM_BOUNDARY = (
+    "This target-free diagnostic compares the supplied full joint covariance with "
+    "marginal-preserving and conditional-only dependence ablations on the same "
+    "matched residual groups. It does not establish real provider competence, "
+    "BayesianPhysTwin benefit, Causal4D intervention benefit, or deployment safety."
+)
+MAX_BOOTSTRAP_REPLICATES = 100_000
+_BOOTSTRAP_INDEX_BUDGET = 1_000_000
+_POSITIVE_FAVORS_JOINT = (
+    "Positive paired advantages favor the full joint covariance over the named ablation."
+)
+_ARM_DEFINITIONS = {
+    "joint": "blockdiag(D_i) + U U^T",
+    "marginal_preserving_independence": "blockdiag(D_i + U_i U_i^T)",
+    "conditional_only": "blockdiag(D_i)",
+}
+_COMPARISON_METRICS = (
+    "gaussian_nll_per_dimension_advantage",
+    "normalized_nees_absolute_error_advantage",
+)
+
+
+def _validated_bootstrap_replicates(value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, (int, np.integer)):
+        raise ValueError("bootstrap_replicates must be a nonnegative integer")
+    result = int(value)
+    if not 0 <= result <= MAX_BOOTSTRAP_REPLICATES:
+        raise ValueError(
+            "bootstrap_replicates must lie in "
+            f"[0, {MAX_BOOTSTRAP_REPLICATES}]"
+        )
+    return result
+
+
+def _validated_seed(value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, (int, np.integer)):
+        raise ValueError("bootstrap_seed must be an integer")
+    result = int(value)
+    if not 0 <= result <= np.iinfo(np.uint32).max:
+        raise ValueError("bootstrap_seed must lie in [0, 2**32 - 1]")
+    return result
+
+
+def _validated_confidence_level(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(
+        value,
+        (int, float, np.integer, np.floating),
+    ):
+        raise ValueError("confidence_level must be a real scalar")
+    result = float(value)
+    if not math.isfinite(result) or not 0.0 < result < 1.0:
+        raise ValueError("confidence_level must lie in (0, 1)")
+    return result
+
+
+def _marginal_preserving_local_covariance(
+    local_covariance_m2: np.ndarray,
+    low_rank_factor_m: np.ndarray,
+) -> np.ndarray:
+    local = np.asarray(local_covariance_m2, dtype=np.float64)
+    factor = np.asarray(low_rank_factor_m, dtype=np.float64)
+    if local.ndim != 3 or local.shape[1:] != (3, 3):
+        raise ValueError("local_covariance_m2 must have shape (N, 3, 3)")
+    if factor.ndim != 3 or factor.shape[:2] != local.shape[:2]:
+        raise ValueError("low_rank_factor_m must have shape (N, 3, R)")
+    return local + np.einsum("nir,njr->nij", factor, factor, optimize=True)
+
+
+def _zero_shared_factor(sample_count: int) -> np.ndarray:
+    return np.empty((sample_count, 3, 0), dtype=np.float64)
+
+
+def _group_key(value: object) -> tuple[str, int | str]:
+    if isinstance(value, (int, np.integer)) and not isinstance(value, bool):
+        return ("int", int(value))
+    return ("str", str(value))
+
+
+def _paired_comparison(
+    joint_groups: Sequence[Mapping[str, Any]],
+    ablation_groups: Sequence[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    ablation_by_id = {
+        _group_key(group["factor_group_id"]): group for group in ablation_groups
+    }
+    if len(ablation_by_id) != len(ablation_groups):
+        raise ValueError("ablation group identifiers must be unique")
+
+    records: list[dict[str, Any]] = []
+    for joint in joint_groups:
+        group_id = joint["factor_group_id"]
+        key = _group_key(group_id)
+        if key not in ablation_by_id:
+            raise ValueError("joint and ablation group identifiers differ")
+        ablation = ablation_by_id.pop(key)
+        if int(joint["dimension"]) != int(ablation["dimension"]):
+            raise ValueError("joint and ablation group dimensions differ")
+        joint_nll = float(joint["gaussian_nll_per_dimension"])
+        ablation_nll = float(ablation["gaussian_nll_per_dimension"])
+        joint_nees = float(joint["normalized_nees"])
+        ablation_nees = float(ablation["normalized_nees"])
+        records.append(
+            {
+                "factor_group_id": group_id,
+                "dimension": int(joint["dimension"]),
+                "gaussian_nll_per_dimension_advantage": ablation_nll - joint_nll,
+                "normalized_nees_absolute_error_advantage": (
+                    abs(ablation_nees - 1.0) - abs(joint_nees - 1.0)
+                ),
+                "joint_gaussian_nll_per_dimension": joint_nll,
+                "ablation_gaussian_nll_per_dimension": ablation_nll,
+                "joint_normalized_nees": joint_nees,
+                "ablation_normalized_nees": ablation_nees,
+            }
+        )
+    if ablation_by_id:
+        raise ValueError("joint and ablation group identifiers differ")
+    return records
+
+
+def _metric_values(
+    records: Sequence[Mapping[str, Any]],
+) -> np.ndarray:
+    if not records:
+        raise ValueError("at least one independent factor group is required")
+    return np.asarray(
+        [
+            [float(record[metric]) for metric in _COMPARISON_METRICS]
+            for record in records
+        ],
+        dtype=np.float64,
+    )
+
+
+def _bootstrap_summary(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    bootstrap_replicates: int,
+    bootstrap_seed: int,
+    confidence_level: float,
+) -> dict[str, Any]:
+    values = _metric_values(records)
+    group_count = int(values.shape[0])
+    means = np.mean(values, axis=0)
+    mean_payload = {
+        metric: {"mean": float(means[index])}
+        for index, metric in enumerate(_COMPARISON_METRICS)
+    }
+    if bootstrap_replicates == 0:
+        return {
+            "available": False,
+            "reason": "bootstrap-disabled",
+            "unit": "factor_group",
+            "group_count": group_count,
+            "replicates": 0,
+            "seed": bootstrap_seed,
+            "confidence_level": confidence_level,
+            "metrics": mean_payload,
+        }
+    if group_count < 2:
+        return {
+            "available": False,
+            "reason": "fewer-than-two-independent-groups",
+            "unit": "factor_group",
+            "group_count": group_count,
+            "replicates": bootstrap_replicates,
+            "seed": bootstrap_seed,
+            "confidence_level": confidence_level,
+            "metrics": mean_payload,
+        }
+
+    generator = np.random.default_rng(bootstrap_seed)
+    bootstrap_means = np.empty(
+        (bootstrap_replicates, len(_COMPARISON_METRICS)),
+        dtype=np.float64,
+    )
+    chunk_size = max(
+        1,
+        min(
+            bootstrap_replicates,
+            _BOOTSTRAP_INDEX_BUDGET // group_count,
+        ),
+    )
+    for start in range(0, bootstrap_replicates, chunk_size):
+        stop = min(start + chunk_size, bootstrap_replicates)
+        indices = generator.integers(
+            0,
+            group_count,
+            size=(stop - start, group_count),
+            endpoint=False,
+        )
+        bootstrap_means[start:stop] = np.mean(values[indices], axis=1)
+
+    tail = 0.5 * (1.0 - confidence_level)
+    quantiles = np.quantile(bootstrap_means, [tail, 1.0 - tail], axis=0)
+    result_metrics = {
+        metric: {
+            "mean": float(means[index]),
+            "lower": float(quantiles[0, index]),
+            "upper": float(quantiles[1, index]),
+        }
+        for index, metric in enumerate(_COMPARISON_METRICS)
+    }
+    return {
+        "available": True,
+        "reason": None,
+        "unit": "factor_group",
+        "group_count": group_count,
+        "replicates": bootstrap_replicates,
+        "seed": bootstrap_seed,
+        "confidence_level": confidence_level,
+        "metrics": result_metrics,
+    }
+
+
+def _descriptive_comparison_summary(
+    records: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    values = _metric_values(records)
+    return {
+        "equal_group_mean": {
+            metric: float(np.mean(values[:, index]))
+            for index, metric in enumerate(_COMPARISON_METRICS)
+        },
+        "joint_better_group_fraction": {
+            metric: float(np.mean(values[:, index] > 0.0))
+            for index, metric in enumerate(_COMPARISON_METRICS)
+        },
+    }
+
+
+def compare_joint_covariance_ablations(
+    residual_xyz_m: np.ndarray,
+    local_covariance_m2: np.ndarray,
+    low_rank_factor_m: np.ndarray,
+    *,
+    factor_group_ids: np.ndarray | None = None,
+    relative_rank_tolerance: float = 1e-10,
+    bootstrap_replicates: int = 2_000,
+    bootstrap_seed: int = 7,
+    confidence_level: float = 0.95,
+) -> dict[str, Any]:
+    """Compare full dependence with marginal-preserving and conditional-only arms."""
+
+    replicates = _validated_bootstrap_replicates(bootstrap_replicates)
+    seed = _validated_seed(bootstrap_seed)
+    level = _validated_confidence_level(confidence_level)
+
+    residual = np.asarray(residual_xyz_m, dtype=np.float64)
+    local = np.asarray(local_covariance_m2, dtype=np.float64)
+    factor = np.asarray(low_rank_factor_m, dtype=np.float64)
+    sample_count = int(residual.shape[0]) if residual.ndim else 0
+    zero_factor = _zero_shared_factor(sample_count)
+    marginal_local = _marginal_preserving_local_covariance(local, factor)
+
+    arms = {
+        "joint": evaluate_joint_gaussian_groups(
+            residual,
+            local,
+            factor,
+            factor_group_ids=factor_group_ids,
+            relative_rank_tolerance=relative_rank_tolerance,
+        ),
+        "marginal_preserving_independence": evaluate_joint_gaussian_groups(
+            residual,
+            marginal_local,
+            zero_factor,
+            factor_group_ids=factor_group_ids,
+            relative_rank_tolerance=relative_rank_tolerance,
+        ),
+        "conditional_only": evaluate_joint_gaussian_groups(
+            residual,
+            local,
+            zero_factor,
+            factor_group_ids=factor_group_ids,
+            relative_rank_tolerance=relative_rank_tolerance,
+        ),
+    }
+
+    comparisons: dict[str, Any] = {}
+    for ablation_name in ("marginal_preserving_independence", "conditional_only"):
+        records = _paired_comparison(
+            arms["joint"]["groups"],
+            arms[ablation_name]["groups"],
+        )
+        comparisons[ablation_name] = {
+            "interpretation": _POSITIVE_FAVORS_JOINT,
+            "groups": records,
+            **_descriptive_comparison_summary(records),
+            "paired_group_bootstrap": _bootstrap_summary(
+                records,
+                bootstrap_replicates=replicates,
+                bootstrap_seed=seed,
+                confidence_level=level,
+            ),
+        }
+
+    return {
+        "sample_count": arms["joint"]["sample_count"],
+        "group_count": arms["joint"]["group_count"],
+        "arm_definitions": dict(_ARM_DEFINITIONS),
+        "arms": arms,
+        "comparisons": comparisons,
+        "bootstrap": {
+            "unit": "factor_group",
+            "replicates": replicates,
+            "seed": seed,
+            "confidence_level": level,
+        },
+    }
+
+
+def run_joint_covariance_ablation(
+    input_path: str | Path,
+    output_path: str | Path,
+    *,
+    relative_rank_tolerance: float = 1e-10,
+    bootstrap_replicates: int = 2_000,
+    bootstrap_seed: int = 7,
+    confidence_level: float = 0.95,
+) -> dict[str, Any]:
+    """Evaluate exact NPZ bytes and publish one no-clobber ablation report."""
+
+    source = Path(input_path)
+    payload = source.read_bytes()
+    with np.load(io.BytesIO(payload), allow_pickle=False) as data:
+        required = {"residual_xyz_m", "local_covariance_m2", "low_rank_factor_m"}
+        allowed = required | {"factor_group_ids"}
+        missing = sorted(required - set(data.files))
+        extra = sorted(set(data.files) - allowed)
+        if missing or extra:
+            raise ValueError(
+                "joint-covariance ablation input fields changed; "
+                f"missing={missing}, extra={extra}"
+            )
+        evaluation = compare_joint_covariance_ablations(
+            data["residual_xyz_m"],
+            data["local_covariance_m2"],
+            data["low_rank_factor_m"],
+            factor_group_ids=(
+                data["factor_group_ids"] if "factor_group_ids" in data else None
+            ),
+            relative_rank_tolerance=relative_rank_tolerance,
+            bootstrap_replicates=bootstrap_replicates,
+            bootstrap_seed=bootstrap_seed,
+            confidence_level=confidence_level,
+        )
+
+    report = {
+        "schema_name": JOINT_COVARIANCE_ABLATION_SCHEMA,
+        "schema_version": JOINT_COVARIANCE_ABLATION_VERSION,
+        "source_path": str(source.resolve()),
+        "source_sha256": hashlib.sha256(payload).hexdigest(),
+        "evaluation": evaluation,
+        "claim_boundary": JOINT_COVARIANCE_ABLATION_CLAIM_BOUNDARY,
+    }
+    destination = Path(output_path)
+    encoded = json.dumps(report, sort_keys=True, indent=2, allow_nan=False) + "\n"
+    _write_text_exclusive(destination, encoded)
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("input", type=Path)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--relative-rank-tolerance", type=float, default=1e-10)
+    parser.add_argument("--bootstrap-replicates", type=int, default=2_000)
+    parser.add_argument("--bootstrap-seed", type=int, default=7)
+    parser.add_argument("--confidence-level", type=float, default=0.95)
+    arguments = parser.parse_args(argv)
+    run_joint_covariance_ablation(
+        arguments.input,
+        arguments.output,
+        relative_rank_tolerance=arguments.relative_rank_tolerance,
+        bootstrap_replicates=arguments.bootstrap_replicates,
+        bootstrap_seed=arguments.bootstrap_seed,
+        confidence_level=arguments.confidence_level,
+    )
+    print(arguments.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "JOINT_COVARIANCE_ABLATION_CLAIM_BOUNDARY",
+    "JOINT_COVARIANCE_ABLATION_SCHEMA",
+    "JOINT_COVARIANCE_ABLATION_VERSION",
+    "MAX_BOOTSTRAP_REPLICATES",
+    "compare_joint_covariance_ablations",
+    "run_joint_covariance_ablation",
+]

--- a/tests/test_joint_covariance_ablation.py
+++ b/tests/test_joint_covariance_ablation.py
@@ -1,0 +1,325 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import prob4d.joint_covariance_ablation as ablation
+from prob4d.joint_covariance_ablation import (
+    JOINT_COVARIANCE_ABLATION_SCHEMA,
+    MAX_BOOTSTRAP_REPLICATES,
+    compare_joint_covariance_ablations,
+    run_joint_covariance_ablation,
+)
+
+
+def _correlated_groups(
+    *,
+    group_count: int = 48,
+    rows_per_group: int = 6,
+    rank: int = 2,
+    seed: int = 3,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    generator = np.random.default_rng(seed)
+    residuals: list[np.ndarray] = []
+    local_covariances: list[np.ndarray] = []
+    factors: list[np.ndarray] = []
+    group_ids: list[int] = []
+    for group_id in range(group_count):
+        local = np.repeat((0.4 * np.eye(3))[None], rows_per_group, axis=0)
+        factor = generator.normal(scale=0.45, size=(rows_per_group, 3, rank))
+        dense_local = np.zeros((3 * rows_per_group, 3 * rows_per_group))
+        for row in range(rows_per_group):
+            dense_local[
+                3 * row : 3 * row + 3,
+                3 * row : 3 * row + 3,
+            ] = local[row]
+        dense_factor = factor.reshape(3 * rows_per_group, rank)
+        covariance = dense_local + dense_factor @ dense_factor.T
+        residual = generator.multivariate_normal(
+            np.zeros(3 * rows_per_group),
+            covariance,
+        ).reshape(rows_per_group, 3)
+        residuals.append(residual)
+        local_covariances.append(local)
+        factors.append(factor)
+        group_ids.extend([group_id] * rows_per_group)
+    return (
+        np.concatenate(residuals),
+        np.concatenate(local_covariances),
+        np.concatenate(factors),
+        np.asarray(group_ids, dtype=np.int64),
+    )
+
+
+def test_marginal_preserving_ablation_keeps_every_row_marginal() -> None:
+    generator = np.random.default_rng(11)
+    local_basis = generator.normal(size=(5, 3, 3))
+    local = local_basis @ np.swapaxes(local_basis, -1, -2) + 0.2 * np.eye(3)
+    factor = generator.normal(scale=0.3, size=(5, 3, 4))
+
+    actual = ablation._marginal_preserving_local_covariance(local, factor)
+    expected = local + np.einsum("nir,njr->nij", factor, factor)
+
+    np.testing.assert_allclose(actual, expected)
+
+
+def test_joint_proper_score_beats_dependence_ablations() -> None:
+    residual, local, factor, groups = _correlated_groups()
+
+    result = compare_joint_covariance_ablations(
+        residual,
+        local,
+        factor,
+        factor_group_ids=groups,
+        bootstrap_replicates=500,
+        bootstrap_seed=17,
+    )
+
+    marginal = result["comparisons"]["marginal_preserving_independence"]
+    conditional = result["comparisons"]["conditional_only"]
+    marginal_nll = marginal["equal_group_mean"][
+        "gaussian_nll_per_dimension_advantage"
+    ]
+    marginal_interval = marginal["paired_group_bootstrap"]["metrics"][
+        "gaussian_nll_per_dimension_advantage"
+    ]
+
+    assert marginal_nll > 0.0
+    assert marginal_interval["lower"] > 0.0
+    assert (
+        marginal["joint_better_group_fraction"][
+            "gaussian_nll_per_dimension_advantage"
+        ]
+        > 0.5
+    )
+    assert (
+        conditional["equal_group_mean"]["gaussian_nll_per_dimension_advantage"]
+        > 0.0
+    )
+    assert 0.75 < result["arms"]["joint"]["equal_group_mean"]["normalized_nees"] < 1.25
+
+
+def test_zero_shared_factor_makes_all_arms_identical() -> None:
+    generator = np.random.default_rng(19)
+    residual = generator.normal(size=(8, 3))
+    local = np.repeat(np.eye(3)[None], 8, axis=0)
+    factor = np.empty((8, 3, 0))
+    groups = np.repeat(np.arange(4), 2)
+
+    result = compare_joint_covariance_ablations(
+        residual,
+        local,
+        factor,
+        factor_group_ids=groups,
+        bootstrap_replicates=50,
+    )
+
+    for name in ("marginal_preserving_independence", "conditional_only"):
+        comparison = result["comparisons"][name]
+        assert comparison["equal_group_mean"][
+            "gaussian_nll_per_dimension_advantage"
+        ] == pytest.approx(0.0)
+        assert comparison["equal_group_mean"][
+            "normalized_nees_absolute_error_advantage"
+        ] == pytest.approx(0.0)
+
+
+def test_bootstrap_is_paired_equal_group_and_deterministic() -> None:
+    residual, local, factor, groups = _correlated_groups(
+        group_count=7,
+        rows_per_group=3,
+        seed=29,
+    )
+
+    first = compare_joint_covariance_ablations(
+        residual,
+        local,
+        factor,
+        factor_group_ids=groups,
+        bootstrap_replicates=80,
+        bootstrap_seed=23,
+    )
+    second = compare_joint_covariance_ablations(
+        residual,
+        local,
+        factor,
+        factor_group_ids=groups,
+        bootstrap_replicates=80,
+        bootstrap_seed=23,
+    )
+
+    comparison = first["comparisons"]["marginal_preserving_independence"]
+    group_values = [
+        row["gaussian_nll_per_dimension_advantage"]
+        for row in comparison["groups"]
+    ]
+    assert comparison["equal_group_mean"][
+        "gaussian_nll_per_dimension_advantage"
+    ] == pytest.approx(float(np.mean(group_values)))
+    assert first["bootstrap"]["unit"] == "factor_group"
+    assert first == second
+
+
+def test_unavailable_bootstrap_reasons_are_explicit() -> None:
+    residual = np.zeros((2, 3))
+    local = np.repeat(np.eye(3)[None], 2, axis=0)
+    factor = np.zeros((2, 3, 1))
+
+    single_group = compare_joint_covariance_ablations(
+        residual,
+        local,
+        factor,
+        bootstrap_replicates=20,
+    )
+    disabled = compare_joint_covariance_ablations(
+        residual,
+        local,
+        factor,
+        bootstrap_replicates=0,
+    )
+
+    single_summary = single_group["comparisons"]["conditional_only"][
+        "paired_group_bootstrap"
+    ]
+    disabled_summary = disabled["comparisons"]["conditional_only"][
+        "paired_group_bootstrap"
+    ]
+    assert single_summary["available"] is False
+    assert single_summary["reason"] == "fewer-than-two-independent-groups"
+    assert disabled_summary["available"] is False
+    assert disabled_summary["reason"] == "bootstrap-disabled"
+
+
+def test_report_is_bound_to_the_exact_bytes_read(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "matched.npz"
+    replacement = tmp_path / "replacement.npz"
+    output = tmp_path / "report.json"
+    local = np.repeat(np.eye(3)[None], 2, axis=0)
+    factor = np.zeros((2, 3, 1))
+    np.savez(
+        source,
+        residual_xyz_m=np.zeros((2, 3)),
+        local_covariance_m2=local,
+        low_rank_factor_m=factor,
+    )
+    np.savez(
+        replacement,
+        residual_xyz_m=np.ones((2, 3)),
+        local_covariance_m2=local,
+        low_rank_factor_m=factor,
+    )
+    original_read_bytes = Path.read_bytes
+    original_payload = original_read_bytes(source)
+    replacement_payload = original_read_bytes(replacement)
+    replaced = False
+
+    def read_then_replace(path: Path) -> bytes:
+        nonlocal replaced
+        payload = original_read_bytes(path)
+        if path == source and not replaced:
+            source.write_bytes(replacement_payload)
+            replaced = True
+        return payload
+
+    monkeypatch.setattr(Path, "read_bytes", read_then_replace)
+    report = run_joint_covariance_ablation(
+        source,
+        output,
+        bootstrap_replicates=0,
+    )
+
+    assert report["source_sha256"] == hashlib.sha256(original_payload).hexdigest()
+    assert report["evaluation"]["arms"]["joint"]["equal_group_mean"][
+        "normalized_nees"
+    ] == pytest.approx(0.0)
+
+
+def test_cli_report_is_strict_and_no_clobber(tmp_path: Path) -> None:
+    residual, local, factor, groups = _correlated_groups(
+        group_count=3,
+        rows_per_group=2,
+    )
+    source = tmp_path / "matched.npz"
+    output = tmp_path / "report.json"
+    np.savez(
+        source,
+        residual_xyz_m=residual,
+        local_covariance_m2=local,
+        low_rank_factor_m=factor,
+        factor_group_ids=groups,
+    )
+
+    assert (
+        ablation.main(
+            [
+                str(source),
+                "--output",
+                str(output),
+                "--bootstrap-replicates",
+                "20",
+            ]
+        )
+        == 0
+    )
+    report = json.loads(output.read_text(encoding="utf-8"))
+    assert report["schema_name"] == JOINT_COVARIANCE_ABLATION_SCHEMA
+    assert report["source_sha256"] == hashlib.sha256(source.read_bytes()).hexdigest()
+    assert report["evaluation"]["group_count"] == 3
+    with pytest.raises(FileExistsError):
+        run_joint_covariance_ablation(source, output)
+
+
+def test_rejects_unknown_npz_members(tmp_path: Path) -> None:
+    source = tmp_path / "matched.npz"
+    np.savez(
+        source,
+        residual_xyz_m=np.zeros((1, 3)),
+        local_covariance_m2=np.eye(3)[None],
+        low_rank_factor_m=np.zeros((1, 3, 0)),
+        unexpected=np.asarray(1),
+    )
+
+    with pytest.raises(ValueError, match="extra=.*unexpected"):
+        run_joint_covariance_ablation(source, tmp_path / "report.json")
+
+
+def test_rejects_invalid_bootstrap_controls() -> None:
+    residual = np.zeros((1, 3))
+    local = np.eye(3)[None]
+    factor = np.zeros((1, 3, 0))
+
+    with pytest.raises(ValueError, match="bootstrap_replicates"):
+        compare_joint_covariance_ablations(
+            residual,
+            local,
+            factor,
+            bootstrap_replicates=-1,
+        )
+    with pytest.raises(ValueError, match="bootstrap_replicates"):
+        compare_joint_covariance_ablations(
+            residual,
+            local,
+            factor,
+            bootstrap_replicates=MAX_BOOTSTRAP_REPLICATES + 1,
+        )
+    with pytest.raises(ValueError, match="bootstrap_seed"):
+        compare_joint_covariance_ablations(
+            residual,
+            local,
+            factor,
+            bootstrap_seed=-1,
+        )
+    with pytest.raises(ValueError, match="confidence_level"):
+        compare_joint_covariance_ablations(
+            residual,
+            local,
+            factor,
+            confidence_level=1.0,
+        )


### PR DESCRIPTION
## What changed

- add a target-free `prob4d.joint_covariance_ablation` diagnostic for matched residual bundles;
- compare the full `blockdiag(D_i) + U U^T` covariance with two paired controls:
  - `blockdiag(D_i + U_i U_i^T)`, which preserves every 3-D marginal but removes cross-row dependence;
  - `blockdiag(D_i)`, which also removes shared marginal uncertainty;
- report groupwise Gaussian NLL-per-dimension advantage and normalized-NEES closeness advantage, where positive values favor the full joint covariance;
- aggregate with equal independent-group weight and a deterministic paired bootstrap over complete `factor_group_ids`;
- bound and chunk bootstrap index generation;
- read and evaluate the exact NPZ bytes whose SHA-256 is reported;
- reject unknown NPZ members and publish through the existing atomic no-clobber path; and
- document the mechanism claim and its limits.

## Why

The existing joint-covariance diagnostic establishes whether one supplied conditional-plus-low-rank covariance is calibrated. It does not isolate whether the cross-observation dependence itself adds value beyond the individual 3-D marginals.

The marginal-preserving independence arm is the key control: it has exactly the same covariance for every individual row as the joint arm, so a proper-score difference is attributable to retained cross-row dependence rather than wider or narrower marginal uncertainty.

This strengthens Prob4D's core controlled evidence without reusing or retuning the opened Deform360 target cohort. It is deliberately orthogonal to the completed Deform360 v1/v2/v3 support terminals and to the active prior-aware IRLS fixes.

## Scientific boundary

This is target-free mechanism evidence only. It does not establish real MotionCrafter provider competence, independent-object transfer, BayesianPhysTwin query benefit, Causal4D intervention benefit, deployment safety, benchmark parity, or state of the art. It opens no target payload and authorizes no held-out evaluation.

## Validation

- isolated numerical and artifact harness: 9 tests passed;
- dense correlated draws verify a positive joint Gaussian proper-score advantage over both controls;
- zero-rank factors give exact arm parity;
- exact-byte, unknown-member, no-clobber, deterministic-bootstrap, finite-group, and invalid-control regressions are included;
- exact-head repository CI remains authoritative.

Relates to #49.