### PR TITLE
Add replay-complete held-out provider evidence v2

### DIFF
--- a/.github/workflows/heldout-provider-evidence-v2.yml
+++ b/.github/workflows/heldout-provider-evidence-v2.yml
@@ -1,0 +1,66 @@
+name: Replay-complete held-out provider evidence
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/heldout-provider-evidence-v2.yml"
+      - "docs/heldout-provider-evidence-v2.md"
+      - "src/prob4d/heldout_provider_evidence.py"
+      - "tests/test_heldout_provider_evidence.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: heldout-provider-evidence-v2-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONUNBUFFERED: "1"
+
+jobs:
+  replay-contract:
+    name: Selection, exact bytes, fallback, and promotion replay
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install development environment
+        run: python -m pip install -e ".[dev]"
+      - name: Check focused source quality
+        run: |
+          python -m ruff check \
+            src/prob4d/heldout_provider_evidence.py \
+            tests/test_heldout_provider_evidence.py
+          python -m mypy src/prob4d/heldout_provider_evidence.py
+      - name: Run integrated replay and tamper regressions
+        run: |
+          python -m pytest -q \
+            tests/test_selection_evidence.py \
+            tests/test_heldout_promotion.py \
+            tests/test_heldout_provider_evidence.py
+      - name: Verify installed public module
+        run: |
+          python - <<'PY'
+          from prob4d.heldout_provider_evidence import (
+              HELDOUT_PROVIDER_EVIDENCE_VERSION,
+              HeldoutProviderEvidenceV2,
+              SelectedCandidateBindingV1,
+          )
+
+          assert HELDOUT_PROVIDER_EVIDENCE_VERSION == 2
+          assert HeldoutProviderEvidenceV2.__name__.endswith("V2")
+          assert SelectedCandidateBindingV1.__name__.endswith("V1")
+          PY

--- a/docs/heldout-provider-evidence-v2.md
+++ b/docs/heldout-provider-evidence-v2.md
@@ -1,0 +1,96 @@
+# Replay-complete held-out provider evidence
+
+`prob4d.heldout_provider_evidence` composes the complete target-blind selection
+record and the held-out Prob4D-to-BayesianPhysTwin promotion record into one
+portable evidence-v2 artifact.
+
+The existing artifacts remain authoritative and independently versioned. The
+new artifact does not replace them. It verifies that they belong to the same
+experiment, group split, selected candidate, provider bytes, target decisions,
+bootstrap plan, and deterministic promotion result.
+
+## Bound inputs
+
+A `HeldoutProviderEvidenceV2` embeds and verifies:
+
+- the complete `SelectionEvidenceBundleV2`, including every
+  calibration-group-by-candidate metric row, deterministic ordering, thresholds,
+  constraints, tie breaks, and target deployment decisions;
+- the target-free `HeldoutProviderPromotionLockV1`, including the complete
+  development/calibration/target roster and frozen bootstrap seed and resample
+  count;
+- an explicit binding from the selected candidate and its method identifier to
+  the frozen primary promotion arm;
+- the exact UTF-8 provider-report JSON bytes, not only a parsed mapping;
+- the sealed target group-by-arm `HeldoutPromotionQueryResultsV1`; and
+- the retained `HeldoutProviderPromotionReportV1`.
+
+The resulting descriptor has a content identity. Its compact replay receipt has
+a separate identity.
+
+## Independent replay
+
+Loading the artifact performs all of the following without importing an
+experiment runner:
+
+1. replay the complete calibration candidate order;
+2. verify the calibration roster equals the frozen lock;
+3. verify deployment decisions cover exactly the frozen target groups;
+4. verify the selected candidate binds the declared primary arm and provider or
+   query method;
+5. parse the embedded provider bytes with duplicate-key and non-finite-value
+   rejection;
+6. verify their SHA-256 identity against the retained promotion report;
+7. match every primary-arm acceptance, deployed artifact, fallback artifact, and
+   rejected-update fallback decision to the selection evidence;
+8. recompute the provider and guarded-query gates using the frozen bootstrap
+   settings; and
+9. require byte-for-byte equality with the retained promotion report.
+
+A changed whitespace byte in the embedded provider report changes its digest and
+fails replay even when the parsed JSON values are otherwise identical.
+
+## Pack an artifact
+
+The inputs must already have passed their ordinary validators.
+
+```bash
+python -m prob4d.heldout_provider_evidence pack \
+  --selection-evidence selection-evidence.json \
+  --promotion-lock promotion-lock.json \
+  --provider-report provider-report.json \
+  --query-results query_results.sealed.json \
+  --promotion-report promotion_report.json \
+  --arm-id identity \
+  --method-role provider \
+  --output heldout-provider-evidence-v2.json
+```
+
+`--method-role provider` requires the selected candidate's `method_id` to equal
+the bound arm's `provider_method_id`. Use `query` when calibration selects the
+BayesianPhysTwin query method instead.
+
+Publication is no-clobber by default.
+
+## Verify and print the replay receipt
+
+```bash
+python -m prob4d.heldout_provider_evidence verify \
+  heldout-provider-evidence-v2.json
+```
+
+The receipt reports:
+
+- selection and replay identities;
+- complete candidate order and selected candidate;
+- calibration and target group counts;
+- bootstrap resample count and seed;
+- accepted, rejected, and exact-fallback counts; and
+- provider, query, and overall promotion decisions.
+
+## Claim boundary
+
+A passing replay establishes that the retained target-blind selection and
+held-out decision are internally consistent for the exact frozen cohort and
+artifact bytes. It does not establish Causal4D intervention benefit, deployment
+safety, generalization beyond the cohort, or state of the art.

--- a/src/prob4d/heldout_provider_evidence.py
+++ b/src/prob4d/heldout_provider_evidence.py
@@ -1,0 +1,654 @@
+"""Self-contained replay for held-out Prob4D provider promotion evidence.
+
+This artifact composes the already versioned target-blind selection evidence,
+target-free promotion lock, exact provider-report bytes, sealed target query rows,
+and deterministic promotion report. Loading replays both candidate selection and
+the held-out provider/query decision without importing experiment runners.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal, cast
+
+from ._heldout_promotion_common import (
+    _SHA256,
+    _atomic_write_json,
+    _exact_keys,
+    _load_json,
+    _strict_digest,
+    _strict_mapping,
+    _strict_string,
+)
+from ._heldout_promotion_lock import (
+    HeldoutProviderPromotionLockV1,
+    load_promotion_lock,
+    promotion_lock_from_dict,
+)
+from ._heldout_promotion_query import (
+    HeldoutPromotionQueryResultsV1,
+    load_query_results,
+    query_results_from_dict,
+)
+from ._heldout_promotion_report import (
+    HeldoutProviderPromotionReportV1,
+    evaluate_heldout_promotion,
+    load_promotion_report,
+    promotion_report_from_dict,
+)
+from ._immutable_json import frozen_finite_json_mapping, plain_json
+from ._provider_evaluation_manifest import validate_finite_json
+from ._selection_evidence_common import _sha256_json
+from .selection_evidence import (
+    SelectionEvidenceBundleV2,
+    load_selection_evidence,
+    selection_evidence_from_dict,
+)
+
+HELDOUT_PROVIDER_EVIDENCE_SCHEMA = "prob4d.heldout-provider-evidence"
+HELDOUT_PROVIDER_EVIDENCE_VERSION = 2
+HELDOUT_PROVIDER_EVIDENCE_REPLAY_SCHEMA = "prob4d.heldout-provider-evidence-replay"
+HELDOUT_PROVIDER_EVIDENCE_CLAIM_BOUNDARY = (
+    "This artifact makes target-blind candidate selection and the frozen held-out "
+    "Prob4D-to-BayesianPhysTwin promotion decision independently replayable for "
+    "the exact retained calibration groups, target groups, provider bytes, and "
+    "bootstrap plan. A passing replay establishes only integrity of those frozen "
+    "decisions; it does not establish Causal4D intervention benefit, deployment "
+    "safety, generalization beyond the declared cohort, or state of the art."
+)
+
+MethodRole = Literal["provider", "query"]
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON key {key!r}")
+        result[key] = value
+    return result
+
+
+def _reject_nonfinite_constant(value: str) -> None:
+    raise ValueError(f"non-finite JSON constant is forbidden: {value}")
+
+
+def _provider_report_text(value: Any) -> str:
+    if type(value) is not str or not value:
+        raise ValueError("provider_report_json must be a nonempty UTF-8 JSON string")
+    try:
+        value.encode("utf-8")
+    except UnicodeError as error:
+        raise ValueError("provider_report_json must be valid UTF-8 text") from error
+    return value
+
+
+def _decode_provider_report(value: str) -> Mapping[str, Any]:
+    text = _provider_report_text(value)
+    try:
+        decoded = json.loads(
+            text,
+            object_pairs_hook=_reject_duplicate_keys,
+            parse_constant=_reject_nonfinite_constant,
+        )
+    except json.JSONDecodeError as error:
+        raise ValueError("provider_report_json is invalid JSON") from error
+    mapping = _strict_mapping(decoded, name="provider report")
+    validate_finite_json(mapping, name="provider report")
+    return mapping
+
+
+def _provider_report_sha256(value: str) -> str:
+    return hashlib.sha256(_provider_report_text(value).encode("utf-8")).hexdigest()
+
+
+def _read_exact_utf8(path: Path, *, name: str) -> str:
+    try:
+        return path.read_bytes().decode("utf-8")
+    except (OSError, UnicodeError) as error:
+        raise ValueError(f"{name} is unreadable or not UTF-8: {path}") from error
+
+
+@dataclass(frozen=True, slots=True)
+class SelectedCandidateBindingV1:
+    """Bind the selected calibration candidate to one frozen promotion arm."""
+
+    candidate_id: str
+    arm_id: str
+    method_role: MethodRole
+    method_id: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "candidate_id",
+            _strict_string(self.candidate_id, name="candidate_id"),
+        )
+        object.__setattr__(
+            self,
+            "arm_id",
+            _strict_string(self.arm_id, name="arm_id"),
+        )
+        role = _strict_string(self.method_role, name="method_role")
+        if role not in {"provider", "query"}:
+            raise ValueError("method_role must be 'provider' or 'query'")
+        object.__setattr__(self, "method_role", cast(MethodRole, role))
+        object.__setattr__(
+            self,
+            "method_id",
+            _strict_string(self.method_id, name="method_id"),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "candidate_id": self.candidate_id,
+            "arm_id": self.arm_id,
+            "method_role": self.method_role,
+            "method_id": self.method_id,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Any) -> SelectedCandidateBindingV1:
+        mapping = _strict_mapping(value, name="selected candidate binding")
+        _exact_keys(
+            mapping,
+            {"candidate_id", "arm_id", "method_role", "method_id"},
+            name="selected candidate binding",
+        )
+        return cls(
+            candidate_id=mapping["candidate_id"],
+            arm_id=mapping["arm_id"],
+            method_role=mapping["method_role"],
+            method_id=mapping["method_id"],
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class HeldoutProviderEvidenceReplayV2:
+    """Compact independent replay receipt for a complete evidence artifact."""
+
+    evidence_id: str
+    selection_artifact_id: str
+    selection_replay_digest: str
+    promotion_lock_id: str
+    provider_report_sha256: str
+    query_results_id: str
+    promotion_report_id: str
+    selected_candidate_id: str
+    selected_arm_id: str
+    candidate_order: tuple[str, ...]
+    calibration_group_count: int
+    target_group_count: int
+    bootstrap_resamples: int
+    bootstrap_seed: int
+    accepted_update_count: int
+    fallback_update_count: int
+    exact_fallback_count: int
+    provider_passed: bool
+    query_passed: bool
+    overall_passed: bool
+
+    def descriptor(self) -> dict[str, object]:
+        return {
+            "schema_name": HELDOUT_PROVIDER_EVIDENCE_REPLAY_SCHEMA,
+            "schema_version": HELDOUT_PROVIDER_EVIDENCE_VERSION,
+            "evidence_id": self.evidence_id,
+            "selection_artifact_id": self.selection_artifact_id,
+            "selection_replay_digest": self.selection_replay_digest,
+            "promotion_lock_id": self.promotion_lock_id,
+            "provider_report_sha256": self.provider_report_sha256,
+            "query_results_id": self.query_results_id,
+            "promotion_report_id": self.promotion_report_id,
+            "selected_candidate_id": self.selected_candidate_id,
+            "selected_arm_id": self.selected_arm_id,
+            "candidate_order": list(self.candidate_order),
+            "calibration_group_count": self.calibration_group_count,
+            "target_group_count": self.target_group_count,
+            "bootstrap_resamples": self.bootstrap_resamples,
+            "bootstrap_seed": self.bootstrap_seed,
+            "accepted_update_count": self.accepted_update_count,
+            "fallback_update_count": self.fallback_update_count,
+            "exact_fallback_count": self.exact_fallback_count,
+            "provider_passed": self.provider_passed,
+            "query_passed": self.query_passed,
+            "overall_passed": self.overall_passed,
+        }
+
+    @property
+    def replay_id(self) -> str:
+        return _sha256_json(self.descriptor())
+
+    def to_dict(self) -> dict[str, object]:
+        return {**self.descriptor(), "replay_id": self.replay_id}
+
+
+@dataclass(frozen=True, slots=True)
+class HeldoutProviderEvidenceV2:
+    """Replay-complete selection, target, provider, bootstrap, and report evidence."""
+
+    selection_evidence: SelectionEvidenceBundleV2
+    promotion_lock: HeldoutProviderPromotionLockV1
+    selected_candidate_binding: SelectedCandidateBindingV1
+    provider_report_json: str
+    query_results: HeldoutPromotionQueryResultsV1
+    promotion_report: HeldoutProviderPromotionReportV1
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.selection_evidence, SelectionEvidenceBundleV2):
+            raise ValueError("selection_evidence must be SelectionEvidenceBundleV2")
+        if not isinstance(self.promotion_lock, HeldoutProviderPromotionLockV1):
+            raise ValueError("promotion_lock must be HeldoutProviderPromotionLockV1")
+        if not isinstance(self.selected_candidate_binding, SelectedCandidateBindingV1):
+            raise ValueError(
+                "selected_candidate_binding must be SelectedCandidateBindingV1"
+            )
+        if not isinstance(self.query_results, HeldoutPromotionQueryResultsV1):
+            raise ValueError("query_results must be HeldoutPromotionQueryResultsV1")
+        if not isinstance(self.promotion_report, HeldoutProviderPromotionReportV1):
+            raise ValueError(
+                "promotion_report must be HeldoutProviderPromotionReportV1"
+            )
+
+        selection = self.selection_evidence
+        lock = self.promotion_lock
+        binding = self.selected_candidate_binding
+        query = self.query_results
+        report = self.promotion_report
+
+        if selection.experiment_id != lock.experiment_id:
+            raise ValueError("selection and promotion experiment_id values differ")
+        if selection.source_repository != lock.source_repository:
+            raise ValueError("selection and promotion source repositories differ")
+        if selection.source_revision != lock.source_revision:
+            raise ValueError("selection and promotion source revisions differ")
+
+        calibration_groups = tuple(
+            sorted({row.group_id for row in selection.calibration_rows})
+        )
+        if calibration_groups != lock.calibration_group_ids:
+            raise ValueError(
+                "selection calibration groups do not match the frozen promotion lock"
+            )
+        deployment_groups = tuple(
+            decision.group_id for decision in selection.deployment_decisions
+        )
+        if deployment_groups != lock.target_group_ids:
+            raise ValueError(
+                "selection deployment groups do not match the frozen target groups"
+            )
+
+        if binding.candidate_id != selection.selected_candidate_id:
+            raise ValueError("selected candidate binding does not match selection replay")
+        if binding.arm_id != lock.primary_query_arm_id:
+            raise ValueError("selected candidate must bind the primary query arm")
+        candidates_by_id = {
+            candidate.candidate_id: candidate for candidate in selection.candidates
+        }
+        candidate = candidates_by_id[binding.candidate_id]
+        if candidate.method_id != binding.method_id:
+            raise ValueError("selected candidate binding method_id changed")
+        arm = lock.arms_by_id[binding.arm_id]
+        expected_method = (
+            arm.provider_method_id
+            if binding.method_role == "provider"
+            else arm.query_method_id
+        )
+        if expected_method is None or binding.method_id != expected_method:
+            raise ValueError(
+                "selected candidate method does not match the bound promotion arm"
+            )
+
+        provider_text = _provider_report_text(self.provider_report_json)
+        provider_mapping = _decode_provider_report(provider_text)
+        provider_sha = _provider_report_sha256(provider_text)
+        object.__setattr__(self, "provider_report_json", provider_text)
+
+        if query.promotion_lock_id != lock.promotion_lock_id:
+            raise ValueError("query results reference a different promotion lock")
+        if report.promotion_lock_id != lock.promotion_lock_id:
+            raise ValueError("promotion report references a different promotion lock")
+        if report.query_results_id != query.query_results_id:
+            raise ValueError("promotion report references different query results")
+        if report.provider_report_sha256 != provider_sha:
+            raise ValueError("promotion report does not bind exact provider-report bytes")
+        if (
+            report.provider_evaluation_manifest_sha256
+            != lock.provider_evaluation_manifest_sha256
+        ):
+            raise ValueError(
+                "promotion report references a different provider evaluation manifest"
+            )
+
+        primary_rows = {
+            row.group_id: row
+            for row in query.rows
+            if row.arm_id == binding.arm_id
+        }
+        if tuple(sorted(primary_rows)) != lock.target_group_ids:
+            raise ValueError(
+                "query results do not contain one primary-arm row per target group"
+            )
+        decisions = {
+            decision.group_id: decision
+            for decision in selection.deployment_decisions
+        }
+        for group_id in lock.target_group_ids:
+            decision = decisions[group_id]
+            row = primary_rows[group_id]
+            if row.accepted is None or row.accepted != decision.accepted:
+                raise ValueError(
+                    f"selection/query acceptance mismatch for target group {group_id!r}"
+                )
+            if row.deployed_artifact_id != decision.deployed_artifact_id:
+                raise ValueError(
+                    f"selection/query deployed artifact mismatch for {group_id!r}"
+                )
+            if row.fallback_artifact_id != decision.fallback_artifact_id:
+                raise ValueError(
+                    f"selection/query fallback artifact mismatch for {group_id!r}"
+                )
+            if not decision.accepted and row.exact_fallback_reproduced is not True:
+                raise ValueError(
+                    f"rejected target group {group_id!r} lacks exact fallback evidence"
+                )
+
+        replayed_report = evaluate_heldout_promotion(
+            lock,
+            query,
+            provider_mapping,
+            provider_report_sha256=provider_sha,
+        )
+        if replayed_report.to_dict() != report.to_dict():
+            raise ValueError(
+                "promotion report does not match deterministic evidence replay"
+            )
+        object.__setattr__(
+            self,
+            "metadata",
+            frozen_finite_json_mapping(self.metadata, name="evidence metadata"),
+        )
+
+    def descriptor(self) -> dict[str, object]:
+        return {
+            "schema_name": HELDOUT_PROVIDER_EVIDENCE_SCHEMA,
+            "schema_version": HELDOUT_PROVIDER_EVIDENCE_VERSION,
+            "selection_evidence": self.selection_evidence.to_dict(),
+            "promotion_lock": self.promotion_lock.to_dict(),
+            "selected_candidate_binding": self.selected_candidate_binding.to_dict(),
+            "provider_report_json": self.provider_report_json,
+            "query_results": self.query_results.to_dict(),
+            "promotion_report": self.promotion_report.to_dict(),
+            "metadata": plain_json(self.metadata),
+            "claim_boundary": HELDOUT_PROVIDER_EVIDENCE_CLAIM_BOUNDARY,
+        }
+
+    @property
+    def evidence_id(self) -> str:
+        return _sha256_json(self.descriptor())
+
+    def replay_report(self) -> HeldoutProviderEvidenceReplayV2:
+        selection_replay = self.selection_evidence.replay_report()
+        return HeldoutProviderEvidenceReplayV2(
+            evidence_id=self.evidence_id,
+            selection_artifact_id=self.selection_evidence.artifact_id,
+            selection_replay_digest=selection_replay.replay_digest,
+            promotion_lock_id=self.promotion_lock.promotion_lock_id,
+            provider_report_sha256=_provider_report_sha256(self.provider_report_json),
+            query_results_id=self.query_results.query_results_id,
+            promotion_report_id=self.promotion_report.report_id,
+            selected_candidate_id=self.selection_evidence.selected_candidate_id,
+            selected_arm_id=self.selected_candidate_binding.arm_id,
+            candidate_order=self.selection_evidence.selection_order,
+            calibration_group_count=len(self.promotion_lock.calibration_group_ids),
+            target_group_count=len(self.promotion_lock.target_group_ids),
+            bootstrap_resamples=self.promotion_lock.bootstrap_resamples,
+            bootstrap_seed=self.promotion_lock.bootstrap_seed,
+            accepted_update_count=selection_replay.accepted_update_count,
+            fallback_update_count=selection_replay.fallback_update_count,
+            exact_fallback_count=selection_replay.exact_fallback_count,
+            provider_passed=self.promotion_report.provider_decision.get(
+                "overall_passed"
+            )
+            is True,
+            query_passed=self.promotion_report.query_decision.get("overall_passed")
+            is True,
+            overall_passed=self.promotion_report.overall_passed,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        replay = self.replay_report()
+        return {
+            **self.descriptor(),
+            "evidence_id": self.evidence_id,
+            "replay_id": replay.replay_id,
+        }
+
+
+_EVIDENCE_FIELDS = {
+    "schema_name",
+    "schema_version",
+    "selection_evidence",
+    "promotion_lock",
+    "selected_candidate_binding",
+    "provider_report_json",
+    "query_results",
+    "promotion_report",
+    "metadata",
+    "claim_boundary",
+    "evidence_id",
+    "replay_id",
+}
+
+
+def build_heldout_provider_evidence(
+    *,
+    selection_evidence: SelectionEvidenceBundleV2,
+    promotion_lock: HeldoutProviderPromotionLockV1,
+    selected_candidate_binding: SelectedCandidateBindingV1,
+    provider_report_json: str,
+    query_results: HeldoutPromotionQueryResultsV1,
+    promotion_report: HeldoutProviderPromotionReportV1 | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> HeldoutProviderEvidenceV2:
+    """Build a canonical artifact and independently replay the promotion report."""
+
+    provider_mapping = _decode_provider_report(provider_report_json)
+    provider_sha = _provider_report_sha256(provider_report_json)
+    observed_report = (
+        evaluate_heldout_promotion(
+            promotion_lock,
+            query_results,
+            provider_mapping,
+            provider_report_sha256=provider_sha,
+        )
+        if promotion_report is None
+        else promotion_report
+    )
+    return HeldoutProviderEvidenceV2(
+        selection_evidence=selection_evidence,
+        promotion_lock=promotion_lock,
+        selected_candidate_binding=selected_candidate_binding,
+        provider_report_json=provider_report_json,
+        query_results=query_results,
+        promotion_report=observed_report,
+        metadata={} if metadata is None else metadata,
+    )
+
+
+def heldout_provider_evidence_from_dict(value: Any) -> HeldoutProviderEvidenceV2:
+    """Parse, validate, and independently replay one evidence-v2 artifact."""
+
+    mapping = _strict_mapping(value, name="held-out provider evidence")
+    _exact_keys(mapping, _EVIDENCE_FIELDS, name="held-out provider evidence")
+    if mapping["schema_name"] != HELDOUT_PROVIDER_EVIDENCE_SCHEMA:
+        raise ValueError("unsupported held-out provider evidence schema")
+    if (
+        type(mapping["schema_version"]) is not int
+        or mapping["schema_version"] != HELDOUT_PROVIDER_EVIDENCE_VERSION
+    ):
+        raise ValueError("unsupported held-out provider evidence version")
+    if mapping["claim_boundary"] != HELDOUT_PROVIDER_EVIDENCE_CLAIM_BOUNDARY:
+        raise ValueError("held-out provider evidence claim boundary changed")
+
+    evidence = HeldoutProviderEvidenceV2(
+        selection_evidence=selection_evidence_from_dict(
+            mapping["selection_evidence"]
+        ),
+        promotion_lock=promotion_lock_from_dict(mapping["promotion_lock"]),
+        selected_candidate_binding=SelectedCandidateBindingV1.from_dict(
+            mapping["selected_candidate_binding"]
+        ),
+        provider_report_json=_provider_report_text(mapping["provider_report_json"]),
+        query_results=query_results_from_dict(mapping["query_results"]),
+        promotion_report=promotion_report_from_dict(mapping["promotion_report"]),
+        metadata=_strict_mapping(mapping["metadata"], name="evidence metadata"),
+    )
+    supplied_evidence_id = _strict_digest(
+        mapping["evidence_id"],
+        name="evidence_id",
+        pattern=_SHA256,
+    )
+    supplied_replay_id = _strict_digest(
+        mapping["replay_id"],
+        name="replay_id",
+        pattern=_SHA256,
+    )
+    if supplied_evidence_id != evidence.evidence_id:
+        raise ValueError("held-out provider evidence_id mismatch")
+    if supplied_replay_id != evidence.replay_report().replay_id:
+        raise ValueError("held-out provider replay_id mismatch")
+    return evidence
+
+
+def write_heldout_provider_evidence(
+    evidence: HeldoutProviderEvidenceV2,
+    path: str | Path,
+    *,
+    overwrite: bool = False,
+) -> None:
+    """Publish one canonical evidence artifact through the no-clobber JSON path."""
+
+    if not isinstance(evidence, HeldoutProviderEvidenceV2):
+        raise ValueError("evidence must be HeldoutProviderEvidenceV2")
+    _atomic_write_json(Path(path), evidence.to_dict(), overwrite=overwrite)
+
+
+def load_heldout_provider_evidence(path: str | Path) -> HeldoutProviderEvidenceV2:
+    """Load and independently replay one complete evidence artifact."""
+
+    mapping, _ = _load_json(Path(path), name="held-out provider evidence")
+    return heldout_provider_evidence_from_dict(mapping)
+
+
+def _pack(arguments: Sequence[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m prob4d.heldout_provider_evidence pack",
+        description="Compose existing selection and held-out artifacts into evidence v2.",
+    )
+    parser.add_argument("--selection-evidence", type=Path, required=True)
+    parser.add_argument("--promotion-lock", type=Path, required=True)
+    parser.add_argument("--provider-report", type=Path, required=True)
+    parser.add_argument("--query-results", type=Path, required=True)
+    parser.add_argument("--promotion-report", type=Path, required=True)
+    parser.add_argument("--arm-id", required=True)
+    parser.add_argument(
+        "--method-role",
+        choices=("provider", "query"),
+        required=True,
+    )
+    parser.add_argument("--output", type=Path, required=True)
+    parsed = parser.parse_args(arguments)
+
+    selection = load_selection_evidence(parsed.selection_evidence)
+    lock = load_promotion_lock(parsed.promotion_lock)
+    query = load_query_results(parsed.query_results)
+    report = load_promotion_report(parsed.promotion_report)
+    provider_text = _read_exact_utf8(parsed.provider_report, name="provider report")
+    selected = next(
+        candidate
+        for candidate in selection.candidates
+        if candidate.candidate_id == selection.selected_candidate_id
+    )
+    binding = SelectedCandidateBindingV1(
+        candidate_id=selected.candidate_id,
+        arm_id=parsed.arm_id,
+        method_role=cast(MethodRole, parsed.method_role),
+        method_id=selected.method_id,
+    )
+    evidence = build_heldout_provider_evidence(
+        selection_evidence=selection,
+        promotion_lock=lock,
+        selected_candidate_binding=binding,
+        provider_report_json=provider_text,
+        query_results=query,
+        promotion_report=report,
+    )
+    write_heldout_provider_evidence(evidence, parsed.output)
+    print(evidence.evidence_id)
+    return 0
+
+
+def _verify(arguments: Sequence[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m prob4d.heldout_provider_evidence verify",
+        description="Independently replay one complete held-out evidence artifact.",
+    )
+    parser.add_argument("evidence", type=Path)
+    parsed = parser.parse_args(arguments)
+    evidence = load_heldout_provider_evidence(parsed.evidence)
+    print(
+        json.dumps(
+            evidence.replay_report().to_dict(),
+            sort_keys=True,
+            indent=2,
+            allow_nan=False,
+        )
+    )
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Pack or independently verify a complete held-out provider evidence artifact."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("pack", add_help=False)
+    subparsers.add_parser("verify", add_help=False)
+    arguments = list(sys.argv[1:] if argv is None else argv)
+    if not arguments:
+        parser.print_help()
+        return 0
+    parsed, remaining = parser.parse_known_args(arguments)
+    if parsed.command == "pack":
+        return _pack(remaining)
+    if parsed.command == "verify":
+        return _verify(remaining)
+    raise AssertionError("unreachable evidence command")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "HELDOUT_PROVIDER_EVIDENCE_CLAIM_BOUNDARY",
+    "HELDOUT_PROVIDER_EVIDENCE_REPLAY_SCHEMA",
+    "HELDOUT_PROVIDER_EVIDENCE_SCHEMA",
+    "HELDOUT_PROVIDER_EVIDENCE_VERSION",
+    "HeldoutProviderEvidenceReplayV2",
+    "HeldoutProviderEvidenceV2",
+    "MethodRole",
+    "SelectedCandidateBindingV1",
+    "build_heldout_provider_evidence",
+    "heldout_provider_evidence_from_dict",
+    "load_heldout_provider_evidence",
+    "main",
+    "write_heldout_provider_evidence",
+]

--- a/tests/test_heldout_provider_evidence.py
+++ b/tests/test_heldout_provider_evidence.py
@@ -1,0 +1,532 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from prob4d._heldout_promotion_lock import (
+    HeldoutProviderPromotionLockV1,
+    promotion_lock_from_config,
+    write_promotion_lock,
+)
+from prob4d._heldout_promotion_query import (
+    PromotionQueryRowV1,
+    build_query_results,
+    write_query_results,
+)
+from prob4d._heldout_promotion_report import (
+    HeldoutProviderPromotionReportV1,
+    evaluate_heldout_promotion,
+    write_promotion_report,
+)
+from prob4d.heldout_provider_evidence import (
+    HeldoutProviderEvidenceV2,
+    SelectedCandidateBindingV1,
+    build_heldout_provider_evidence,
+    heldout_provider_evidence_from_dict,
+    load_heldout_provider_evidence,
+    main,
+    write_heldout_provider_evidence,
+)
+from prob4d.selection_evidence import (
+    CalibrationMetricRowV1,
+    CandidateSpecV1,
+    DeploymentDecisionV1,
+    MetricConstraintV1,
+    MetricOrderV1,
+    SelectionEvidenceBundleV2,
+    SelectionRuleV1,
+    build_selection_evidence_bundle,
+    write_selection_evidence,
+)
+
+ROLES = (
+    ("fallback", "physical_fallback", None, "bpt-fallback", False),
+    ("visual", "visual_baseline", "provider-visual", "bpt-visual", False),
+    (
+        "rowwise",
+        "rowwise_gauge_marginalized",
+        "provider-rowwise",
+        "bpt-rowwise",
+        False,
+    ),
+    (
+        "framewise",
+        "framewise_explicit_joint_gauge",
+        "provider-framewise",
+        "bpt-framewise",
+        False,
+    ),
+    (
+        "persistent",
+        "persistent_explicit_joint_gauge",
+        "provider-persistent",
+        "bpt-persistent",
+        False,
+    ),
+    (
+        "identity",
+        "cross_window_identity_marginalized",
+        "provider-identity",
+        "bpt-identity",
+        False,
+    ),
+    ("sensor", "sensor_assisted", "provider-sensor", "bpt-sensor", True),
+)
+
+
+def _arm_values() -> list[dict[str, object]]:
+    return [
+        {
+            "arm_id": arm_id,
+            "role": role,
+            "query_method_id": query_method,
+            "provider_method_id": provider_method,
+            "sensor_assisted": sensor_assisted,
+            "metadata": {},
+        }
+        for arm_id, role, provider_method, query_method, sensor_assisted in ROLES
+    ]
+
+
+def _lock() -> HeldoutProviderPromotionLockV1:
+    return promotion_lock_from_config(
+        {
+            "experiment_id": "integrated-heldout-evidence-v2",
+            "source_repository": "IPS-Stuttgart/Prob4D",
+            "source_revision": "a" * 40,
+            "bayesian_phystwin_repository": "IPS-Stuttgart/BayesianPhysTwin",
+            "bayesian_phystwin_revision": "b" * 40,
+            "motioncrafter_revision": "c" * 40,
+            "model_set_id": "d" * 64,
+            "prediction_run_spec_id": "e" * 64,
+            "provider_evaluation_manifest_sha256": "f" * 64,
+            "frozen_artifact_ids": {
+                "provider_configuration": "0" * 64,
+                "gauge_calibration": "1" * 64,
+                "point_calibration": "2" * 64,
+                "source_reliability_calibration": "3" * 64,
+                "material_identity_calibration": "4" * 64,
+                "selection_lock": "5" * 64,
+                "bayesian_guard_configuration": "6" * 64,
+            },
+            "development_group_ids": ["development-1"],
+            "calibration_group_ids": ["calibration-1", "calibration-2"],
+            "target_group_ids": ["target-1", "target-2", "target-3"],
+            "arms": _arm_values(),
+            "provider_reference_arm_id": "visual",
+            "primary_query_arm_id": "identity",
+            "bootstrap_resamples": 500,
+            "bootstrap_seed": 17,
+            "minimum_target_group_count": 3,
+            "query_superiority_margin_mm": 0.0,
+            "harmful_update_margin_mm": 0.0,
+            "maximum_harmful_accepted_updates": 0,
+            "maximum_worst_group_regression_mm": 0.0,
+            "maximum_technical_failures": 0,
+            "minimum_mean_accepted_coverage": 0.9,
+            "metadata": {},
+        }
+    )
+
+
+def _candidate_artifact(group_id: str) -> str:
+    return hashlib.sha256(f"candidate-{group_id}".encode()).hexdigest()
+
+
+def _fallback_artifact(group_id: str) -> str:
+    return hashlib.sha256(f"fallback-{group_id}".encode()).hexdigest()
+
+
+def _selection(
+    lock: HeldoutProviderPromotionLockV1,
+    *,
+    calibration_groups: tuple[str, ...] | None = None,
+) -> SelectionEvidenceBundleV2:
+    groups = lock.calibration_group_ids if calibration_groups is None else calibration_groups
+    candidates = (
+        CandidateSpecV1(
+            candidate_id="fallback",
+            method_id="physical-fallback",
+            complexity_rank=0,
+        ),
+        CandidateSpecV1(
+            candidate_id="identity",
+            method_id="provider-identity",
+            complexity_rank=2,
+            parameters={"minimum_track_length": 3},
+        ),
+    )
+    rows: list[CalibrationMetricRowV1] = []
+    for group_id in groups:
+        rows.extend(
+            (
+                CalibrationMetricRowV1(
+                    group_id=group_id,
+                    candidate_id="fallback",
+                    metrics={"rmse_mm": 5.0, "coverage": 1.0},
+                ),
+                CalibrationMetricRowV1(
+                    group_id=group_id,
+                    candidate_id="identity",
+                    metrics={"rmse_mm": 2.0, "coverage": 0.95},
+                ),
+            )
+        )
+    rule = SelectionRuleV1(
+        primary=MetricOrderV1("rmse_mm", "minimize"),
+        constraints=(MetricConstraintV1("coverage", "at_least", 0.9),),
+    )
+    decisions = tuple(
+        DeploymentDecisionV1(
+            group_id=group_id,
+            candidate_id="identity",
+            accepted=group_id != "target-3",
+            guard_name="source-frozen-regret-guard-v1",
+            guard_value=0.1 if group_id != "target-3" else 0.9,
+            candidate_artifact_id=_candidate_artifact(group_id),
+            fallback_artifact_id=_fallback_artifact(group_id),
+            deployed_artifact_id=(
+                _candidate_artifact(group_id)
+                if group_id != "target-3"
+                else _fallback_artifact(group_id)
+            ),
+            reason="accepted" if group_id != "target-3" else "exact fallback",
+        )
+        for group_id in lock.target_group_ids
+    )
+    return build_selection_evidence_bundle(
+        experiment_id=lock.experiment_id,
+        source_repository=lock.source_repository,
+        source_revision=lock.source_revision,
+        candidates=candidates,
+        calibration_rows=rows,
+        selection_rule=rule,
+        deployment_decisions=decisions,
+    )
+
+
+def _provider_report(lock: HeldoutProviderPromotionLockV1) -> dict[str, object]:
+    cases = [
+        {
+            "case_id": f"{group_id}-case",
+            "group_id": group_id,
+            "method_id": method_id,
+        }
+        for group_id in lock.target_group_ids
+        for method_id in lock.provider_method_ids
+    ]
+    return {
+        "schema_name": "prob4d.provider-evaluation-report",
+        "schema_version": 3,
+        "source_manifest": "/sealed/provider-manifest.json",
+        "source_manifest_sha256": lock.provider_evaluation_manifest_sha256,
+        "primary_mode": "metric",
+        "primary_support": "common_across_registered_methods",
+        "secondary_support": "native_per_method",
+        "reference_method": lock.provider_reference_method_id,
+        "bootstrap_resamples": lock.bootstrap_resamples,
+        "bootstrap_seed": lock.bootstrap_seed,
+        "legacy_artifacts_allowed": False,
+        "evaluation_chunk_size": 4096,
+        "manifest_metadata": {},
+        "method_metadata": {},
+        "cases": cases,
+        "aggregate": {},
+        "comparisons": {},
+        "decision_policy": {},
+        "decision": {
+            "policy_id": "provider-gate-v1",
+            "overall_passed": True,
+            "group_count_passed": True,
+            "rules": [],
+        },
+        "support_semantics": "common support",
+        "claim_boundary": "provider only",
+    }
+
+
+def _provider_text(lock: HeldoutProviderPromotionLockV1) -> str:
+    return json.dumps(
+        _provider_report(lock),
+        sort_keys=True,
+        separators=(",", ":"),
+    ) + "\n"
+
+
+def _query_rows(lock: HeldoutProviderPromotionLockV1) -> tuple[PromotionQueryRowV1, ...]:
+    rows: list[PromotionQueryRowV1] = []
+    for group_id in lock.target_group_ids:
+        fallback_id = _fallback_artifact(group_id)
+        rows.append(
+            PromotionQueryRowV1(
+                group_id=group_id,
+                arm_id="fallback",
+                query_rmse_mm=5.0,
+                deployed_artifact_id=fallback_id,
+                fallback_artifact_id=fallback_id,
+                accepted=None,
+                exact_fallback_reproduced=None,
+                accepted_coverage=None,
+                accepted_width_mm=None,
+            )
+        )
+        for arm in lock.arms:
+            if arm.role == "physical_fallback":
+                continue
+            primary = arm.arm_id == lock.primary_query_arm_id
+            rejected = primary and group_id == "target-3"
+            deployed = (
+                _fallback_artifact(group_id)
+                if rejected
+                else (
+                    _candidate_artifact(group_id)
+                    if primary
+                    else hashlib.sha256(
+                        f"deployed-{group_id}-{arm.arm_id}".encode()
+                    ).hexdigest()
+                )
+            )
+            rows.append(
+                PromotionQueryRowV1(
+                    group_id=group_id,
+                    arm_id=arm.arm_id,
+                    query_rmse_mm=5.0 if rejected else (4.0 if primary else 4.5),
+                    deployed_artifact_id=deployed,
+                    fallback_artifact_id=fallback_id,
+                    accepted=not rejected,
+                    exact_fallback_reproduced=True if rejected else None,
+                    accepted_coverage=None if rejected else 0.95,
+                    accepted_width_mm=None if rejected else 1.0,
+                )
+            )
+    return tuple(rows)
+
+
+def _binding() -> SelectedCandidateBindingV1:
+    return SelectedCandidateBindingV1(
+        candidate_id="identity",
+        arm_id="identity",
+        method_role="provider",
+        method_id="provider-identity",
+    )
+
+
+def _evidence() -> HeldoutProviderEvidenceV2:
+    lock = _lock()
+    selection = _selection(lock)
+    query = build_query_results(lock, rows=_query_rows(lock))
+    provider_text = _provider_text(lock)
+    report = evaluate_heldout_promotion(
+        lock,
+        query,
+        _provider_report(lock),
+        provider_report_sha256=hashlib.sha256(provider_text.encode()).hexdigest(),
+    )
+    return build_heldout_provider_evidence(
+        selection_evidence=selection,
+        promotion_lock=lock,
+        selected_candidate_binding=_binding(),
+        provider_report_json=provider_text,
+        query_results=query,
+        promotion_report=report,
+    )
+
+
+def test_complete_evidence_replays_selection_target_and_bootstrap_plan() -> None:
+    evidence = _evidence()
+    replay = evidence.replay_report()
+
+    assert replay.selected_candidate_id == "identity"
+    assert replay.selected_arm_id == "identity"
+    assert replay.candidate_order == ("identity", "fallback")
+    assert replay.calibration_group_count == 2
+    assert replay.target_group_count == 3
+    assert replay.bootstrap_resamples == 500
+    assert replay.bootstrap_seed == 17
+    assert replay.accepted_update_count == 2
+    assert replay.fallback_update_count == 1
+    assert replay.exact_fallback_count == 1
+    assert replay.provider_passed
+    assert replay.query_passed
+    assert replay.overall_passed
+    assert len(replay.replay_id) == 64
+
+
+def test_round_trip_is_self_contained_and_no_clobber(tmp_path: Path) -> None:
+    evidence = _evidence()
+    path = tmp_path / "heldout-evidence-v2.json"
+
+    write_heldout_provider_evidence(evidence, path)
+    loaded = load_heldout_provider_evidence(path)
+
+    assert loaded.to_dict() == evidence.to_dict()
+    with pytest.raises(FileExistsError):
+        write_heldout_provider_evidence(evidence, path)
+
+
+def test_exact_provider_report_bytes_are_bound() -> None:
+    evidence = _evidence()
+    payload = copy.deepcopy(evidence.to_dict())
+    payload["provider_report_json"] += " "
+
+    with pytest.raises(ValueError, match="exact provider-report bytes"):
+        heldout_provider_evidence_from_dict(payload)
+
+
+def test_calibration_roster_must_equal_frozen_lock() -> None:
+    lock = _lock()
+    query = build_query_results(lock, rows=_query_rows(lock))
+    provider_text = _provider_text(lock)
+    report = evaluate_heldout_promotion(
+        lock,
+        query,
+        _provider_report(lock),
+        provider_report_sha256=hashlib.sha256(provider_text.encode()).hexdigest(),
+    )
+
+    with pytest.raises(ValueError, match="calibration groups"):
+        build_heldout_provider_evidence(
+            selection_evidence=_selection(
+                lock,
+                calibration_groups=("other-1", "other-2"),
+            ),
+            promotion_lock=lock,
+            selected_candidate_binding=_binding(),
+            provider_report_json=provider_text,
+            query_results=query,
+            promotion_report=report,
+        )
+
+
+def test_selected_candidate_must_bind_primary_arm_method() -> None:
+    evidence = _evidence()
+    bad_binding = SelectedCandidateBindingV1(
+        candidate_id="identity",
+        arm_id="identity",
+        method_role="query",
+        method_id="provider-identity",
+    )
+
+    with pytest.raises(ValueError, match="bound promotion arm"):
+        build_heldout_provider_evidence(
+            selection_evidence=evidence.selection_evidence,
+            promotion_lock=evidence.promotion_lock,
+            selected_candidate_binding=bad_binding,
+            provider_report_json=evidence.provider_report_json,
+            query_results=evidence.query_results,
+            promotion_report=evidence.promotion_report,
+        )
+
+
+def test_selection_and_query_artifact_decisions_must_match() -> None:
+    evidence = _evidence()
+    rows = list(evidence.query_results.rows)
+    index = next(
+        index
+        for index, row in enumerate(rows)
+        if row.group_id == "target-1" and row.arm_id == "identity"
+    )
+    rows[index] = replace(
+        rows[index],
+        deployed_artifact_id=hashlib.sha256(b"different-candidate").hexdigest(),
+    )
+    changed_query = build_query_results(evidence.promotion_lock, rows=rows)
+
+    with pytest.raises(ValueError, match="deployed artifact mismatch"):
+        build_heldout_provider_evidence(
+            selection_evidence=evidence.selection_evidence,
+            promotion_lock=evidence.promotion_lock,
+            selected_candidate_binding=evidence.selected_candidate_binding,
+            provider_report_json=evidence.provider_report_json,
+            query_results=changed_query,
+        )
+
+
+def test_retained_promotion_report_must_equal_replay() -> None:
+    evidence = _evidence()
+    report = evidence.promotion_report
+    changed = HeldoutProviderPromotionReportV1(
+        promotion_lock_id=report.promotion_lock_id,
+        query_results_id=report.query_results_id,
+        provider_report_sha256=report.provider_report_sha256,
+        provider_evaluation_manifest_sha256=(
+            report.provider_evaluation_manifest_sha256
+        ),
+        provider_audit=report.provider_audit,
+        provider_decision=report.provider_decision,
+        query_aggregate=report.query_aggregate,
+        query_decision=report.query_decision,
+        overall_passed=not report.overall_passed,
+    )
+
+    with pytest.raises(ValueError, match="deterministic evidence replay"):
+        build_heldout_provider_evidence(
+            selection_evidence=evidence.selection_evidence,
+            promotion_lock=evidence.promotion_lock,
+            selected_candidate_binding=evidence.selected_candidate_binding,
+            provider_report_json=evidence.provider_report_json,
+            query_results=evidence.query_results,
+            promotion_report=changed,
+        )
+
+
+def test_duplicate_keys_inside_embedded_provider_report_fail_closed() -> None:
+    evidence = _evidence()
+
+    with pytest.raises(ValueError, match="duplicate JSON key"):
+        build_heldout_provider_evidence(
+            selection_evidence=evidence.selection_evidence,
+            promotion_lock=evidence.promotion_lock,
+            selected_candidate_binding=evidence.selected_candidate_binding,
+            provider_report_json='{"schema_name":"one","schema_name":"two"}',
+            query_results=evidence.query_results,
+            promotion_report=evidence.promotion_report,
+        )
+
+
+def test_pack_and_verify_cli(tmp_path: Path) -> None:
+    evidence = _evidence()
+    selection_path = tmp_path / "selection.json"
+    lock_path = tmp_path / "lock.json"
+    provider_path = tmp_path / "provider.json"
+    query_path = tmp_path / "query.json"
+    report_path = tmp_path / "report.json"
+    output_path = tmp_path / "evidence.json"
+
+    write_selection_evidence(evidence.selection_evidence, selection_path)
+    write_promotion_lock(evidence.promotion_lock, lock_path)
+    provider_path.write_bytes(evidence.provider_report_json.encode("utf-8"))
+    write_query_results(evidence.query_results, query_path)
+    write_promotion_report(evidence.promotion_report, report_path)
+
+    assert (
+        main(
+            [
+                "pack",
+                "--selection-evidence",
+                str(selection_path),
+                "--promotion-lock",
+                str(lock_path),
+                "--provider-report",
+                str(provider_path),
+                "--query-results",
+                str(query_path),
+                "--promotion-report",
+                str(report_path),
+                "--arm-id",
+                "identity",
+                "--method-role",
+                "provider",
+                "--output",
+                str(output_path),
+            ]
+        )
+        == 0
+    )
+    assert main(["verify", str(output_path)]) == 0
+    assert load_heldout_provider_evidence(output_path).evidence_id == evidence.evidence_id


### PR DESCRIPTION
## What changed

- Add a self-contained `HeldoutProviderEvidenceV2` artifact that embeds the complete selection-evidence v2 bundle, target-free promotion lock, exact UTF-8 provider-report JSON bytes, sealed target query rows, selected-candidate/arm binding, and retained promotion report.
- Replay calibration candidate ordering, complete calibration and target rosters, selected method binding, exact provider bytes, primary-arm acceptance/fallback decisions, frozen bootstrap settings, and the complete provider/query promotion result while loading.
- Reject duplicate or non-finite provider JSON, changed provider whitespace bytes, group drift, selected-method drift, artifact-decision drift, missing exact fallback evidence, changed report identities, and any promotion report that differs from deterministic replay.
- Add no-clobber persistence plus `pack` and `verify` module commands.
- Add focused tamper, round-trip, exact-byte, fallback, roster, method-binding, report-replay, and CLI tests.
- Document how this composes the existing authoritative artifacts without replacing their versioned contracts.

## Why

The repository already retained complete target-blind selection evidence and a separately replayable held-out promotion report. An independent verifier still had to discover and coordinate several files manually. This change adds one content-addressed artifact that proves those files describe the same frozen experiment and makes the complete selection-to-target decision replayable from one input.

## Compatibility

- Existing selection-evidence, promotion-lock, query-results, provider-report, and promotion-report schemas are unchanged.
- Existing recorded scientific results and target cohorts are unchanged.
- The new artifact is additive and uses the existing evaluation and replay functions.
- No new estimator, provider, threshold, graph, or target-data path is introduced.

## Final validation

Exact reviewed head: `3d6e5be874f19d2c55b334ab4e2eb4b7e9943a70`.

All authoritative pull-request workflows passed:

- replay-complete held-out provider evidence: run `31330999933`;
- fail-closed quality: run `31330999919`;
- security scanning, including CodeQL for Python and Actions plus dependency audit: run `31330999918`; and
- complete tests: run `31330999926`, including Python 3.10–3.14, the declared NumPy runtime floor, distribution builds, and isolated wheel/sdist CLI smoke tests.

## Claim boundary

A passing replay establishes integrity and consistency of the exact retained calibration selection, target decisions, provider bytes, bootstrap plan, and held-out report. It does not establish Causal4D intervention benefit, deployment safety, generalization beyond the frozen cohort, or state of the art.