### PR TITLE
Add spatially stratified tracklets and camera-panel support

### DIFF
--- a/docs/spatial_tracklet_support.md
+++ b/docs/spatial_tracklet_support.md
@@ -91,10 +91,13 @@ variables downstream.
 tracklet sets without averaging their point estimates. For every predeclared
 causal-prefix frame it reports:
 
-- contributing camera views;
-- the union of represented seed cells;
-- seed cells represented by at least the required number of views; and
+- each contributing camera view;
+- the number of represented view-local seed cells in each camera;
+- the cameras that independently meet the frozen per-view cell threshold; and
 - exact failure reasons for insufficient views or spatial support.
+
+Image-cell IDs are view-local. The audit deliberately does not treat the same
+numeric image-cell ID in two cameras as the same physical object region.
 
 ```python
 from prob4d.camera_panel_support import (
@@ -104,8 +107,7 @@ from prob4d.camera_panel_support import (
 
 policy = CameraPanelSupportPolicyV1(
     minimum_view_count=2,
-    minimum_seed_cell_count=8,
-    minimum_views_per_cell=2,
+    minimum_seed_cell_count_per_view=8,
     minimum_supported_frame_fraction=1.0,
     require_all_declared_views=True,
 )
@@ -142,7 +144,7 @@ competence, and the guarded BayesianPhysTwin promotion gate.
 
 ## Claim boundary
 
-Spatial coverage and camera-panel corroboration establish only that the frozen
+Spatial coverage and camera-panel support establish only that the frozen
 causal-prefix provider has distributed support under the declared policy. They
 do not establish calibrated uncertainty, provider competence, physical-state
 identifiability, BayesianPhysTwin benefit, Causal4D intervention benefit,

--- a/docs/spatial_tracklet_support.md
+++ b/docs/spatial_tracklet_support.md
@@ -1,0 +1,149 @@
+# Spatially stratified causal tracklets and camera-panel support
+
+Prob4D can build causal-prefix scene-flow tracklets with spatially balanced seed
+selection and retain the seed-cell lineage of every surviving material track.
+This addresses a specific real-provider failure mode: a stream can contain many
+valid points while those points are concentrated in too few independent image
+regions.
+
+The implementation is additive. The historical regular-grid builder in
+`prob4d.causal_tracklets` remains unchanged. New work can opt into
+`prob4d.spatial_tracklets`.
+
+## Spatial seed selection
+
+`select_spatial_tracklet_seeds` partitions the first retained frame into a fixed
+image-cell grid. In `spatial-stratified` mode it selects at least one valid,
+deforming seed from every occupied cell. Within a cell, deterministic anchors
+are matched to the nearest unused valid pixel, with row/column tie-breaking and
+an optional per-cell quota.
+
+The selector uses only the first causal-prefix frame's validity and deform masks.
+It does not use prediction residuals, metric truth, future frames, target
+outcomes, or downstream BayesianPhysTwin decisions.
+
+```python
+from prob4d.spatial_tracklets import (
+    build_spatially_stratified_scene_flow_tracklets,
+)
+
+tracklets, report = build_spatially_stratified_scene_flow_tracklets(
+    window,
+    causal_frame_stop=134,
+    seed_stride=8,
+    cell_grid_rows=4,
+    cell_grid_columns=4,
+    maximum_seeds_per_cell=4,
+    search_radius_pixels=4,
+    maximum_step_error_local=0.05,
+    minimum_link_probability=0.05,
+    minimum_track_length=2,
+)
+```
+
+The returned `CausalTrackletSet` retains these metadata fields:
+
+- `seed_selection_policy`;
+- requested/effective cell-grid shape and selection summary;
+- one `seed_cell_ids_by_track` entry for every retained track;
+- selected and retained seed-cell counts; and
+- the source-only scientific claim boundary.
+
+`SpatialTrackletReport` keeps the ordinary association/termination report and
+separately reports selected versus retained spatial support. A cell that loses
+all of its tracks is therefore visible rather than being hidden by the total
+track count.
+
+## Spatial correlation groups
+
+Dense neighboring points must not be treated as independent observations merely
+because they have distinct point IDs. Use
+`spatial_tracklets_to_observation_factors` with the default
+`frame-seed-cell` mode to emit one factor per frame and retained seed cell:
+
+```python
+from prob4d.spatial_tracklets import (
+    spatial_tracklets_to_observation_factors,
+)
+
+factors = spatial_tracklets_to_observation_factors(
+    tracklets,
+    covariance,
+    view_id="camera-0",
+    correlation_group_mode="frame-seed-cell",
+    effective_samples_per_group=8.0,
+)
+```
+
+This preserves the original persistent point IDs and gauge ID, while applying
+the generalized-Bayes effective-sample cap separately to each spatial cell.
+`correlation_group_mode="frame"` reproduces the existing frame-level conversion.
+
+The cell split is not a claim that cells are statistically independent. It is a
+more conservative support and likelihood-power boundary than assigning one
+large dense frame group or treating every row independently. Shared gauge,
+provider, camera, clock, and capture bias must still remain explicit nuisance
+variables downstream.
+
+## Camera-panel support audit
+
+`evaluate_camera_panel_tracklet_support` combines several spatially annotated
+tracklet sets without averaging their point estimates. For every predeclared
+causal-prefix frame it reports:
+
+- contributing camera views;
+- the union of represented seed cells;
+- seed cells represented by at least the required number of views; and
+- exact failure reasons for insufficient views or spatial support.
+
+```python
+from prob4d.camera_panel_support import (
+    CameraPanelSupportPolicyV1,
+    evaluate_camera_panel_tracklet_support,
+)
+
+policy = CameraPanelSupportPolicyV1(
+    minimum_view_count=2,
+    minimum_seed_cell_count=8,
+    minimum_views_per_cell=2,
+    minimum_supported_frame_fraction=1.0,
+    require_all_declared_views=True,
+)
+report = evaluate_camera_panel_tracklet_support(
+    {
+        "camera-0": camera_0_tracklets,
+        "camera-1": camera_1_tracklets,
+        "camera-2": camera_2_tracklets,
+    },
+    panel_id="session-17-prefix-panel",
+    required_frame_indices=tuple(range(109, 134)),
+    policy=policy,
+)
+```
+
+The report is content-addressed and invariant to the input mapping order. It is
+a source-only support diagnostic, not a provider-accuracy result. A passing
+panel still requires separate source/calibration fitting, held-out provider
+competence, and the guarded BayesianPhysTwin promotion gate.
+
+## Recommended protocol use
+
+1. Freeze the camera roster, cell grid, seed stride, per-cell quota, required
+   frames, and panel thresholds before source residuals or target outcomes are
+   opened.
+2. Retain support-negative views and frames; do not delete cameras after seeing
+   provider errors.
+3. Fit covariance, association, reliability, camera-bias, and timing priors only
+   on development/calibration objects or sessions.
+4. Keep view-specific and shared visual nuisance variables separate from local
+   point covariance.
+5. Run the existing held-out provider and BayesianPhysTwin promotion workflow
+   once on an unopened object/session cohort.
+
+## Claim boundary
+
+Spatial coverage and camera-panel corroboration establish only that the frozen
+causal-prefix provider has distributed support under the declared policy. They
+do not establish calibrated uncertainty, provider competence, physical-state
+identifiability, BayesianPhysTwin benefit, Causal4D intervention benefit,
+deployment safety, or state of the art.

--- a/docs/spatial_tracklet_support.md
+++ b/docs/spatial_tracklet_support.md
@@ -98,13 +98,20 @@ validated model rather than silently multiplying the frame budget.
 ## Camera-panel support audit
 
 `evaluate_camera_panel_tracklet_support` combines several spatially annotated
-tracklet sets without averaging their point estimates. For every predeclared
-causal-prefix frame it reports:
+tracklet sets without averaging their point estimates. The complete camera
+roster is a separate required input; it is not inferred from whichever mappings
+happen to be supplied at evaluation time. A declared camera missing from
+`tracklets_by_view` contributes zero support on every required frame, and an
+undeclared camera is rejected.
 
+For every predeclared causal-prefix frame the report records:
+
+- the complete frozen camera roster;
 - each contributing camera view;
-- the number of represented view-local seed cells in each camera;
+- the number of represented view-local seed cells in each contributing camera;
 - the cameras that independently meet the frozen per-view cell threshold; and
-- exact failure reasons for insufficient views or spatial support.
+- exact failure reasons for insufficient views, spatial support, or missing
+  declared cameras.
 
 Image-cell IDs are view-local. The audit deliberately does not treat the same
 numeric image-cell ID in two cameras as the same physical object region.
@@ -127,24 +134,28 @@ report = evaluate_camera_panel_tracklet_support(
         "camera-1": camera_1_tracklets,
         "camera-2": camera_2_tracklets,
     },
+    declared_view_ids=("camera-0", "camera-1", "camera-2"),
     panel_id="session-17-prefix-panel",
     required_frame_indices=tuple(range(109, 134)),
     policy=policy,
 )
 ```
 
-The report is content-addressed and invariant to the input mapping order. It is
-a source-only support diagnostic, not a provider-accuracy result. A passing
-panel still requires separate source/calibration fitting, held-out provider
-competence, and the guarded BayesianPhysTwin promotion gate.
+The report is content-addressed and invariant to the input mapping order. Its
+identity includes the complete declared roster, so dropping a camera changes the
+request and cannot masquerade as a replay of the frozen panel. The report is a
+source-only support diagnostic, not a provider-accuracy result. A passing panel
+still requires separate source/calibration fitting, held-out provider competence,
+and the guarded BayesianPhysTwin promotion gate.
 
 ## Recommended protocol use
 
 1. Freeze the camera roster, cell grid, seed stride, per-cell quota, required
    frames, frame-level effective-sample budget, and panel thresholds before
    source residuals or target outcomes are opened.
-2. Retain support-negative views and frames; do not delete cameras after seeing
-   provider errors.
+2. Pass the frozen roster through `declared_view_ids`; retain absent or
+   support-negative cameras instead of deleting them after seeing provider
+   support or errors.
 3. Fit covariance, association, reliability, camera-bias, and timing priors only
    on development/calibration objects or sessions.
 4. Keep view-specific and shared visual nuisance variables separate from local

--- a/docs/spatial_tracklet_support.md
+++ b/docs/spatial_tracklet_support.md
@@ -71,19 +71,29 @@ factors = spatial_tracklets_to_observation_factors(
     covariance,
     view_id="camera-0",
     correlation_group_mode="frame-seed-cell",
-    effective_samples_per_group=8.0,
+    effective_samples_per_frame=8.0,
 )
 ```
 
-This preserves the original persistent point IDs and gauge ID, while applying
-the generalized-Bayes effective-sample cap separately to each spatial cell.
-`correlation_group_mode="frame"` reproduces the existing frame-level conversion.
+This preserves the original persistent point IDs and gauge ID while retaining a
+separate correlation-group identity for every represented seed cell. All cell
+factors from one frame share one frozen generalized-Bayes budget:
 
-The cell split is not a claim that cells are statistically independent. It is a
-more conservative support and likelihood-power boundary than assigning one
-large dense frame group or treating every row independently. Shared gauge,
-provider, camera, clock, and capture bias must still remain explicit nuisance
-variables downstream.
+```text
+frame weight = min(1, effective_samples_per_frame / retained_rows_in_frame)
+```
+
+Consequently, splitting one frame into cell factors cannot increase its total
+weighted row mass relative to `correlation_group_mode="frame"`. The two modes
+have the same frame-level likelihood-power cap; the cell mode adds spatially
+resolved support and robust-group identities. It remains more conservative than
+treating every row as an independent full-weight observation.
+
+The cell split is not a claim that cells are statistically independent. Shared
+gauge, provider, camera, clock, and capture bias must still remain explicit
+nuisance variables downstream. Increasing total likelihood power based on a
+stronger cell-independence assumption requires a separately declared and
+validated model rather than silently multiplying the frame budget.
 
 ## Camera-panel support audit
 
@@ -131,8 +141,8 @@ competence, and the guarded BayesianPhysTwin promotion gate.
 ## Recommended protocol use
 
 1. Freeze the camera roster, cell grid, seed stride, per-cell quota, required
-   frames, and panel thresholds before source residuals or target outcomes are
-   opened.
+   frames, frame-level effective-sample budget, and panel thresholds before
+   source residuals or target outcomes are opened.
 2. Retain support-negative views and frames; do not delete cameras after seeing
    provider errors.
 3. Fit covariance, association, reliability, camera-bias, and timing priors only

--- a/src/prob4d/camera_panel_support.py
+++ b/src/prob4d/camera_panel_support.py
@@ -1,0 +1,450 @@
+"""Source-only multi-view spatial support diagnostics for causal tracklets."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass, field
+
+import numpy as np
+
+from .causal_tracklets import CausalTrackletSet
+from .spatial_tracklets import (
+    SPATIAL_TRACKLET_CLAIM_BOUNDARY,
+    seed_cell_ids_by_track,
+)
+
+
+def _strict_string(value: object, *, name: str) -> str:
+    if type(value) is not str or not value:
+        raise ValueError(f"{name} must be a non-empty string")
+    return value
+
+
+def _strict_integer(value: object, *, name: str, minimum: int = 0) -> int:
+    if type(value) is not int and not isinstance(value, np.integer):
+        raise ValueError(f"{name} must be an integer")
+    result = int(value)
+    if result < minimum:
+        raise ValueError(f"{name} must be at least {minimum}")
+    return result
+
+
+def _strict_real(
+    value: object,
+    *,
+    name: str,
+    minimum: float = 0.0,
+    maximum: float | None = None,
+) -> float:
+    if type(value) not in {int, float} and not isinstance(value, (np.integer, np.floating)):
+        raise ValueError(f"{name} must be a real number")
+    result = float(value)
+    if not np.isfinite(result) or result < minimum:
+        raise ValueError(f"{name} must be finite and at least {minimum}")
+    if maximum is not None and result > maximum:
+        raise ValueError(f"{name} must be at most {maximum}")
+    return result
+
+
+def _strict_bool(value: object, *, name: str) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be a boolean")
+    return value
+
+
+def _canonical_json_bytes(value: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _sha256_json(value: Mapping[str, object]) -> str:
+    return hashlib.sha256(_canonical_json_bytes(value)).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class CameraPanelSupportPolicyV1:
+    """Frozen thresholds for a source-only multi-view spatial support audit."""
+
+    minimum_view_count: int = 2
+    minimum_seed_cell_count: int = 8
+    minimum_views_per_cell: int = 1
+    minimum_supported_frame_fraction: float = 1.0
+    require_all_declared_views: bool = False
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "minimum_view_count",
+            _strict_integer(
+                self.minimum_view_count,
+                name="minimum_view_count",
+                minimum=1,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "minimum_seed_cell_count",
+            _strict_integer(
+                self.minimum_seed_cell_count,
+                name="minimum_seed_cell_count",
+                minimum=1,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "minimum_views_per_cell",
+            _strict_integer(
+                self.minimum_views_per_cell,
+                name="minimum_views_per_cell",
+                minimum=1,
+            ),
+        )
+        fraction = _strict_real(
+            self.minimum_supported_frame_fraction,
+            name="minimum_supported_frame_fraction",
+            maximum=1.0,
+        )
+        object.__setattr__(self, "minimum_supported_frame_fraction", fraction)
+        object.__setattr__(
+            self,
+            "require_all_declared_views",
+            _strict_bool(
+                self.require_all_declared_views,
+                name="require_all_declared_views",
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CameraPanelFrameSupportV1:
+    """Spatial support decision for one required causal-prefix frame."""
+
+    frame_index: int
+    contributing_view_ids: tuple[str, ...]
+    union_seed_cell_ids: tuple[int, ...]
+    corroborated_seed_cell_ids: tuple[int, ...]
+    supported: bool
+    reason_codes: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "frame_index",
+            _strict_integer(self.frame_index, name="frame_index"),
+        )
+        for name in (
+            "contributing_view_ids",
+            "union_seed_cell_ids",
+            "corroborated_seed_cell_ids",
+            "reason_codes",
+        ):
+            if type(getattr(self, name)) is not tuple:
+                raise ValueError(f"{name} must be a tuple")
+        views = tuple(
+            _strict_string(value, name="contributing_view_id")
+            for value in self.contributing_view_ids
+        )
+        if views != tuple(sorted(set(views))):
+            raise ValueError("contributing_view_ids must be sorted and unique")
+        union = tuple(
+            _strict_integer(value, name="union_seed_cell_id")
+            for value in self.union_seed_cell_ids
+        )
+        corroborated = tuple(
+            _strict_integer(value, name="corroborated_seed_cell_id")
+            for value in self.corroborated_seed_cell_ids
+        )
+        if union != tuple(sorted(set(union))):
+            raise ValueError("union_seed_cell_ids must be sorted and unique")
+        if corroborated != tuple(sorted(set(corroborated))):
+            raise ValueError("corroborated_seed_cell_ids must be sorted and unique")
+        if not set(corroborated).issubset(set(union)):
+            raise ValueError("corroborated seed cells must be in the panel union")
+        supported = _strict_bool(self.supported, name="supported")
+        reasons = tuple(
+            _strict_string(value, name="reason_code") for value in self.reason_codes
+        )
+        if reasons != tuple(sorted(set(reasons))):
+            raise ValueError("reason_codes must be sorted and unique")
+        if supported == bool(reasons):
+            raise ValueError("supported frames must have no reasons and failures must have reasons")
+        object.__setattr__(self, "contributing_view_ids", views)
+        object.__setattr__(self, "union_seed_cell_ids", union)
+        object.__setattr__(self, "corroborated_seed_cell_ids", corroborated)
+        object.__setattr__(self, "supported", supported)
+        object.__setattr__(self, "reason_codes", reasons)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "frame_index": self.frame_index,
+            "contributing_view_ids": list(self.contributing_view_ids),
+            "contributing_view_count": len(self.contributing_view_ids),
+            "union_seed_cell_ids": list(self.union_seed_cell_ids),
+            "union_seed_cell_count": len(self.union_seed_cell_ids),
+            "corroborated_seed_cell_ids": list(self.corroborated_seed_cell_ids),
+            "corroborated_seed_cell_count": len(self.corroborated_seed_cell_ids),
+            "supported": self.supported,
+            "reason_codes": list(self.reason_codes),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CameraPanelSupportReportV1:
+    """Content-addressed target-free support result for one camera panel."""
+
+    panel_id: str
+    causal_frame_stop: int
+    required_frame_indices: tuple[int, ...]
+    declared_view_ids: tuple[str, ...]
+    seed_cell_grid_shape: tuple[int, int]
+    policy: CameraPanelSupportPolicyV1
+    frame_results: tuple[CameraPanelFrameSupportV1, ...]
+    support_feasible: bool
+    decision_reason: str
+    metadata: Mapping[str, object] = field(default_factory=dict)
+    claim_boundary: str = SPATIAL_TRACKLET_CLAIM_BOUNDARY
+    camera_panel_support_id: str | None = None
+
+    def __post_init__(self) -> None:
+        panel = _strict_string(self.panel_id, name="panel_id")
+        cutoff = _strict_integer(
+            self.causal_frame_stop,
+            name="causal_frame_stop",
+            minimum=1,
+        )
+        if type(self.required_frame_indices) is not tuple or not self.required_frame_indices:
+            raise ValueError("required_frame_indices must be a non-empty tuple")
+        required = tuple(
+            _strict_integer(value, name="required_frame_index")
+            for value in self.required_frame_indices
+        )
+        if required != tuple(sorted(set(required))):
+            raise ValueError("required_frame_indices must be sorted and unique")
+        if any(frame >= cutoff for frame in required):
+            raise ValueError("required frames cross the causal frame stop")
+        if type(self.declared_view_ids) is not tuple or not self.declared_view_ids:
+            raise ValueError("declared_view_ids must be a non-empty tuple")
+        views = tuple(
+            _strict_string(value, name="declared_view_id")
+            for value in self.declared_view_ids
+        )
+        if views != tuple(sorted(set(views))):
+            raise ValueError("declared_view_ids must be sorted and unique")
+        if type(self.seed_cell_grid_shape) is not tuple or len(self.seed_cell_grid_shape) != 2:
+            raise ValueError("seed_cell_grid_shape must be a two-element tuple")
+        grid = tuple(
+            _strict_integer(value, name="seed_cell_grid_shape", minimum=1)
+            for value in self.seed_cell_grid_shape
+        )
+        if not isinstance(self.policy, CameraPanelSupportPolicyV1):
+            raise TypeError("policy must be a CameraPanelSupportPolicyV1")
+        if type(self.frame_results) is not tuple:
+            raise ValueError("frame_results must be a tuple")
+        results = self.frame_results
+        if tuple(result.frame_index for result in results) != required:
+            raise ValueError("frame_results must exactly cover required_frame_indices")
+        support = _strict_bool(self.support_feasible, name="support_feasible")
+        supported_count = sum(result.supported for result in results)
+        fraction = supported_count / len(results)
+        expected_support = fraction >= self.policy.minimum_supported_frame_fraction
+        if support is not expected_support:
+            raise ValueError("support_feasible contradicts frame results and policy")
+        reason = _strict_string(self.decision_reason, name="decision_reason")
+        expected_reason = (
+            "camera-panel-spatial-support-feasible"
+            if support
+            else "camera-panel-spatial-support-negative"
+        )
+        if reason != expected_reason:
+            raise ValueError("decision_reason contradicts support_feasible")
+        if self.claim_boundary != SPATIAL_TRACKLET_CLAIM_BOUNDARY:
+            raise ValueError("camera-panel support claim boundary changed")
+        metadata = dict(self.metadata)
+        try:
+            json.dumps(metadata, allow_nan=False)
+        except (TypeError, ValueError) as error:
+            raise ValueError("camera-panel support metadata must be finite JSON") from error
+
+        object.__setattr__(self, "panel_id", panel)
+        object.__setattr__(self, "causal_frame_stop", cutoff)
+        object.__setattr__(self, "required_frame_indices", required)
+        object.__setattr__(self, "declared_view_ids", views)
+        object.__setattr__(self, "seed_cell_grid_shape", grid)
+        object.__setattr__(self, "support_feasible", support)
+        object.__setattr__(self, "decision_reason", reason)
+        object.__setattr__(self, "metadata", metadata)
+        expected_id = _sha256_json(self.identity_record())
+        if self.camera_panel_support_id is not None and self.camera_panel_support_id != expected_id:
+            raise ValueError("camera_panel_support_id mismatch")
+        object.__setattr__(self, "camera_panel_support_id", expected_id)
+
+    @property
+    def supported_frame_count(self) -> int:
+        return sum(result.supported for result in self.frame_results)
+
+    @property
+    def supported_frame_fraction(self) -> float:
+        return self.supported_frame_count / len(self.frame_results)
+
+    def identity_record(self) -> dict[str, object]:
+        return {
+            "schema_name": "prob4d.camera-panel-spatial-support",
+            "schema_version": 1,
+            "panel_id": self.panel_id,
+            "causal_frame_stop": self.causal_frame_stop,
+            "required_frame_indices": list(self.required_frame_indices),
+            "declared_view_ids": list(self.declared_view_ids),
+            "seed_cell_grid_shape": list(self.seed_cell_grid_shape),
+            "policy": asdict(self.policy),
+            "frame_results": [result.to_dict() for result in self.frame_results],
+            "supported_frame_count": self.supported_frame_count,
+            "supported_frame_fraction": self.supported_frame_fraction,
+            "support_feasible": self.support_feasible,
+            "decision_reason": self.decision_reason,
+            "metadata": dict(self.metadata),
+            "claim_boundary": self.claim_boundary,
+        }
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            **self.identity_record(),
+            "camera_panel_support_id": self.camera_panel_support_id,
+        }
+
+
+def _tracklet_grid_shape(tracklets: CausalTrackletSet) -> tuple[int, int]:
+    raw = tracklets.metadata.get("seed_cell_grid_shape")
+    if isinstance(raw, (str, bytes)) or not isinstance(raw, Sequence) or len(raw) != 2:
+        raise ValueError("tracklets do not contain a valid seed_cell_grid_shape")
+    return (
+        _strict_integer(raw[0], name="seed_cell_grid_shape[0]", minimum=1),
+        _strict_integer(raw[1], name="seed_cell_grid_shape[1]", minimum=1),
+    )
+
+
+def evaluate_camera_panel_tracklet_support(
+    tracklets_by_view: Mapping[str, CausalTrackletSet],
+    *,
+    panel_id: str,
+    required_frame_indices: tuple[int, ...],
+    policy: CameraPanelSupportPolicyV1 | None = None,
+    metadata: Mapping[str, object] | None = None,
+) -> CameraPanelSupportReportV1:
+    """Audit distributed and cross-view causal tracklet support per frame."""
+
+    if not isinstance(tracklets_by_view, Mapping) or not tracklets_by_view:
+        raise ValueError("tracklets_by_view must be a non-empty mapping")
+    normalized: dict[str, CausalTrackletSet] = {}
+    for raw_view, tracklets in tracklets_by_view.items():
+        view = _strict_string(raw_view, name="view_id")
+        if not isinstance(tracklets, CausalTrackletSet):
+            raise TypeError("tracklets_by_view values must be CausalTrackletSet instances")
+        normalized[view] = tracklets
+    views = tuple(sorted(normalized))
+    actual_policy = CameraPanelSupportPolicyV1() if policy is None else policy
+    if not isinstance(actual_policy, CameraPanelSupportPolicyV1):
+        raise TypeError("policy must be a CameraPanelSupportPolicyV1")
+    if actual_policy.minimum_view_count > len(views):
+        raise ValueError("minimum_view_count exceeds the declared panel size")
+    if actual_policy.minimum_views_per_cell > len(views):
+        raise ValueError("minimum_views_per_cell exceeds the declared panel size")
+
+    cutoffs = {tracklets.causal_frame_stop for tracklets in normalized.values()}
+    if len(cutoffs) != 1:
+        raise ValueError("camera-panel tracklets must share one causal frame stop")
+    cutoff = next(iter(cutoffs))
+    grids = {_tracklet_grid_shape(tracklets) for tracklets in normalized.values()}
+    if len(grids) != 1:
+        raise ValueError("camera-panel tracklets must share one seed-cell grid")
+    grid = next(iter(grids))
+    required = tuple(
+        _strict_integer(value, name="required_frame_index")
+        for value in required_frame_indices
+    )
+    if not required or required != tuple(sorted(set(required))):
+        raise ValueError("required_frame_indices must be non-empty, sorted, and unique")
+    if any(frame >= cutoff for frame in required):
+        raise ValueError("required frames cross the panel causal frame stop")
+
+    cells_by_view_and_frame: dict[str, dict[int, set[int]]] = {}
+    for view, tracklets in normalized.items():
+        track_cells = seed_cell_ids_by_track(tracklets)
+        row_cells = track_cells[np.asarray(tracklets.track_ids, dtype=np.int64)]
+        per_frame: dict[int, set[int]] = {}
+        for frame in np.unique(tracklets.frame_indices):
+            selected = np.flatnonzero(tracklets.frame_indices == frame)
+            per_frame[int(frame)] = set(int(value) for value in row_cells[selected])
+        cells_by_view_and_frame[view] = per_frame
+
+    frame_results: list[CameraPanelFrameSupportV1] = []
+    for frame in required:
+        per_view = {
+            view: cells_by_view_and_frame[view].get(frame, set()) for view in views
+        }
+        contributing = tuple(sorted(view for view, cells in per_view.items() if cells))
+        counts: dict[int, int] = {}
+        for cells in per_view.values():
+            for cell_id in cells:
+                counts[cell_id] = counts.get(cell_id, 0) + 1
+        union = tuple(sorted(counts))
+        corroborated = tuple(
+            sorted(
+                cell_id
+                for cell_id, count in counts.items()
+                if count >= actual_policy.minimum_views_per_cell
+            )
+        )
+        reasons: list[str] = []
+        if len(contributing) < actual_policy.minimum_view_count:
+            reasons.append("insufficient-contributing-views")
+        if actual_policy.require_all_declared_views and len(contributing) != len(views):
+            reasons.append("missing-declared-view")
+        if len(corroborated) < actual_policy.minimum_seed_cell_count:
+            reasons.append("insufficient-spatial-seed-cells")
+        frame_results.append(
+            CameraPanelFrameSupportV1(
+                frame_index=frame,
+                contributing_view_ids=contributing,
+                union_seed_cell_ids=union,
+                corroborated_seed_cell_ids=corroborated,
+                supported=not reasons,
+                reason_codes=tuple(sorted(reasons)),
+            )
+        )
+
+    supported_count = sum(result.supported for result in frame_results)
+    supported_fraction = supported_count / len(frame_results)
+    support_feasible = (
+        supported_fraction >= actual_policy.minimum_supported_frame_fraction
+    )
+    decision = (
+        "camera-panel-spatial-support-feasible"
+        if support_feasible
+        else "camera-panel-spatial-support-negative"
+    )
+    return CameraPanelSupportReportV1(
+        panel_id=panel_id,
+        causal_frame_stop=cutoff,
+        required_frame_indices=required,
+        declared_view_ids=views,
+        seed_cell_grid_shape=grid,
+        policy=actual_policy,
+        frame_results=tuple(frame_results),
+        support_feasible=support_feasible,
+        decision_reason=decision,
+        metadata={} if metadata is None else metadata,
+    )
+
+
+__all__ = [
+    "CameraPanelFrameSupportV1",
+    "CameraPanelSupportPolicyV1",
+    "CameraPanelSupportReportV1",
+    "evaluate_camera_panel_tracklet_support",
+]

--- a/src/prob4d/camera_panel_support.py
+++ b/src/prob4d/camera_panel_support.py
@@ -73,8 +73,7 @@ class CameraPanelSupportPolicyV1:
     """Frozen thresholds for a source-only multi-view spatial support audit."""
 
     minimum_view_count: int = 2
-    minimum_seed_cell_count: int = 8
-    minimum_views_per_cell: int = 1
+    minimum_seed_cell_count_per_view: int = 8
     minimum_supported_frame_fraction: float = 1.0
     require_all_declared_views: bool = False
 
@@ -90,19 +89,10 @@ class CameraPanelSupportPolicyV1:
         )
         object.__setattr__(
             self,
-            "minimum_seed_cell_count",
+            "minimum_seed_cell_count_per_view",
             _strict_integer(
-                self.minimum_seed_cell_count,
-                name="minimum_seed_cell_count",
-                minimum=1,
-            ),
-        )
-        object.__setattr__(
-            self,
-            "minimum_views_per_cell",
-            _strict_integer(
-                self.minimum_views_per_cell,
-                name="minimum_views_per_cell",
+                self.minimum_seed_cell_count_per_view,
+                name="minimum_seed_cell_count_per_view",
                 minimum=1,
             ),
         )
@@ -111,6 +101,8 @@ class CameraPanelSupportPolicyV1:
             name="minimum_supported_frame_fraction",
             maximum=1.0,
         )
+        if fraction <= 0.0:
+            raise ValueError("minimum_supported_frame_fraction must be positive")
         object.__setattr__(self, "minimum_supported_frame_fraction", fraction)
         object.__setattr__(
             self,
@@ -124,49 +116,49 @@ class CameraPanelSupportPolicyV1:
 
 @dataclass(frozen=True, slots=True)
 class CameraPanelFrameSupportV1:
-    """Spatial support decision for one required causal-prefix frame."""
+    """View-local spatial support decision for one required causal-prefix frame."""
 
     frame_index: int
     contributing_view_ids: tuple[str, ...]
-    union_seed_cell_ids: tuple[int, ...]
-    corroborated_seed_cell_ids: tuple[int, ...]
+    spatially_supported_view_ids: tuple[str, ...]
+    seed_cell_counts_by_view: Mapping[str, int]
     supported: bool
     reason_codes: tuple[str, ...]
 
     def __post_init__(self) -> None:
-        object.__setattr__(
-            self,
-            "frame_index",
-            _strict_integer(self.frame_index, name="frame_index"),
-        )
+        frame = _strict_integer(self.frame_index, name="frame_index")
         for name in (
             "contributing_view_ids",
-            "union_seed_cell_ids",
-            "corroborated_seed_cell_ids",
+            "spatially_supported_view_ids",
             "reason_codes",
         ):
             if type(getattr(self, name)) is not tuple:
                 raise ValueError(f"{name} must be a tuple")
-        views = tuple(
+        contributing = tuple(
             _strict_string(value, name="contributing_view_id")
             for value in self.contributing_view_ids
         )
-        if views != tuple(sorted(set(views))):
+        spatially_supported = tuple(
+            _strict_string(value, name="spatially_supported_view_id")
+            for value in self.spatially_supported_view_ids
+        )
+        if contributing != tuple(sorted(set(contributing))):
             raise ValueError("contributing_view_ids must be sorted and unique")
-        union = tuple(
-            _strict_integer(value, name="union_seed_cell_id")
-            for value in self.union_seed_cell_ids
-        )
-        corroborated = tuple(
-            _strict_integer(value, name="corroborated_seed_cell_id")
-            for value in self.corroborated_seed_cell_ids
-        )
-        if union != tuple(sorted(set(union))):
-            raise ValueError("union_seed_cell_ids must be sorted and unique")
-        if corroborated != tuple(sorted(set(corroborated))):
-            raise ValueError("corroborated_seed_cell_ids must be sorted and unique")
-        if not set(corroborated).issubset(set(union)):
-            raise ValueError("corroborated seed cells must be in the panel union")
+        if spatially_supported != tuple(sorted(set(spatially_supported))):
+            raise ValueError("spatially_supported_view_ids must be sorted and unique")
+        if not set(spatially_supported).issubset(set(contributing)):
+            raise ValueError("spatially supported views must contribute to the frame")
+        if not isinstance(self.seed_cell_counts_by_view, Mapping):
+            raise ValueError("seed_cell_counts_by_view must be a mapping")
+        counts = {
+            _strict_string(view, name="seed-cell count view_id"): _strict_integer(
+                count,
+                name=f"seed_cell_counts_by_view[{view!r}]",
+            )
+            for view, count in self.seed_cell_counts_by_view.items()
+        }
+        if tuple(sorted(counts)) != contributing:
+            raise ValueError("seed_cell_counts_by_view must cover contributing views exactly")
         supported = _strict_bool(self.supported, name="supported")
         reasons = tuple(
             _strict_string(value, name="reason_code") for value in self.reason_codes
@@ -175,9 +167,14 @@ class CameraPanelFrameSupportV1:
             raise ValueError("reason_codes must be sorted and unique")
         if supported == bool(reasons):
             raise ValueError("supported frames must have no reasons and failures must have reasons")
-        object.__setattr__(self, "contributing_view_ids", views)
-        object.__setattr__(self, "union_seed_cell_ids", union)
-        object.__setattr__(self, "corroborated_seed_cell_ids", corroborated)
+        object.__setattr__(self, "frame_index", frame)
+        object.__setattr__(self, "contributing_view_ids", contributing)
+        object.__setattr__(self, "spatially_supported_view_ids", spatially_supported)
+        object.__setattr__(
+            self,
+            "seed_cell_counts_by_view",
+            frozen_finite_json_mapping(counts, name="seed-cell counts by view"),
+        )
         object.__setattr__(self, "supported", supported)
         object.__setattr__(self, "reason_codes", reasons)
 
@@ -186,10 +183,9 @@ class CameraPanelFrameSupportV1:
             "frame_index": self.frame_index,
             "contributing_view_ids": list(self.contributing_view_ids),
             "contributing_view_count": len(self.contributing_view_ids),
-            "union_seed_cell_ids": list(self.union_seed_cell_ids),
-            "union_seed_cell_count": len(self.union_seed_cell_ids),
-            "corroborated_seed_cell_ids": list(self.corroborated_seed_cell_ids),
-            "corroborated_seed_cell_count": len(self.corroborated_seed_cell_ids),
+            "spatially_supported_view_ids": list(self.spatially_supported_view_ids),
+            "spatially_supported_view_count": len(self.spatially_supported_view_ids),
+            "seed_cell_counts_by_view": dict(self.seed_cell_counts_by_view),
             "supported": self.supported,
             "reason_codes": list(self.reason_codes),
         }
@@ -256,6 +252,8 @@ class CameraPanelSupportReportV1:
         if type(self.frame_results) is not tuple:
             raise ValueError("frame_results must be a tuple")
         results = self.frame_results
+        if any(not isinstance(result, CameraPanelFrameSupportV1) for result in results):
+            raise TypeError("frame_results must contain CameraPanelFrameSupportV1 values")
         if tuple(result.frame_index for result in results) != required:
             raise ValueError("frame_results must exactly cover required_frame_indices")
         support = _strict_bool(self.support_feasible, name="support_feasible")
@@ -344,7 +342,7 @@ def evaluate_camera_panel_tracklet_support(
     policy: CameraPanelSupportPolicyV1 | None = None,
     metadata: Mapping[str, object] | None = None,
 ) -> CameraPanelSupportReportV1:
-    """Audit distributed and cross-view causal tracklet support per frame."""
+    """Audit per-view distributed support without equating camera image cells."""
 
     if not isinstance(tracklets_by_view, Mapping) or not tracklets_by_view:
         raise ValueError("tracklets_by_view must be a non-empty mapping")
@@ -360,8 +358,6 @@ def evaluate_camera_panel_tracklet_support(
         raise TypeError("policy must be a CameraPanelSupportPolicyV1")
     if actual_policy.minimum_view_count > len(views):
         raise ValueError("minimum_view_count exceeds the declared panel size")
-    if actual_policy.minimum_views_per_cell > len(views):
-        raise ValueError("minimum_views_per_cell exceeds the declared panel size")
 
     cutoffs = {tracklets.causal_frame_stop for tracklets in normalized.values()}
     if len(cutoffs) != 1:
@@ -371,6 +367,10 @@ def evaluate_camera_panel_tracklet_support(
     if len(grids) != 1:
         raise ValueError("camera-panel tracklets must share one seed-cell grid")
     grid = next(iter(grids))
+    if actual_policy.minimum_seed_cell_count_per_view > grid[0] * grid[1]:
+        raise ValueError(
+            "minimum_seed_cell_count_per_view exceeds the declared seed-cell grid"
+        )
     required = tuple(
         _strict_integer(value, name="required_frame_index")
         for value in required_frame_indices
@@ -392,35 +392,30 @@ def evaluate_camera_panel_tracklet_support(
 
     frame_results: list[CameraPanelFrameSupportV1] = []
     for frame in required:
-        per_view = {
-            view: cells_by_view_and_frame[view].get(frame, set()) for view in views
+        counts = {
+            view: len(cells_by_view_and_frame[view].get(frame, set()))
+            for view in views
         }
-        contributing = tuple(sorted(view for view, cells in per_view.items() if cells))
-        counts: dict[int, int] = {}
-        for cells in per_view.values():
-            for cell_id in cells:
-                counts[cell_id] = counts.get(cell_id, 0) + 1
-        union = tuple(sorted(counts))
-        corroborated = tuple(
+        contributing = tuple(sorted(view for view, count in counts.items() if count > 0))
+        spatially_supported = tuple(
             sorted(
-                cell_id
-                for cell_id, count in counts.items()
-                if count >= actual_policy.minimum_views_per_cell
+                view
+                for view, count in counts.items()
+                if count >= actual_policy.minimum_seed_cell_count_per_view
             )
         )
         reasons: list[str] = []
-        if len(contributing) < actual_policy.minimum_view_count:
-            reasons.append("insufficient-contributing-views")
+        if len(spatially_supported) < actual_policy.minimum_view_count:
+            reasons.append("insufficient-spatially-supported-views")
         if actual_policy.require_all_declared_views and len(contributing) != len(views):
             reasons.append("missing-declared-view")
-        if len(corroborated) < actual_policy.minimum_seed_cell_count:
-            reasons.append("insufficient-spatial-seed-cells")
+        contributing_counts = {view: counts[view] for view in contributing}
         frame_results.append(
             CameraPanelFrameSupportV1(
                 frame_index=frame,
                 contributing_view_ids=contributing,
-                union_seed_cell_ids=union,
-                corroborated_seed_cell_ids=corroborated,
+                spatially_supported_view_ids=spatially_supported,
+                seed_cell_counts_by_view=contributing_counts,
                 supported=not reasons,
                 reason_codes=tuple(sorted(reasons)),
             )

--- a/src/prob4d/camera_panel_support.py
+++ b/src/prob4d/camera_panel_support.py
@@ -183,6 +183,7 @@ class CameraPanelFrameSupportV1:
             _strict_string(view, name="seed-cell count view_id"): _strict_integer(
                 count,
                 name=f"seed_cell_counts_by_view[{view!r}]",
+                minimum=1,
             )
             for view, count in self.seed_cell_counts_by_view.items()
         }
@@ -293,6 +294,17 @@ class CameraPanelSupportReportV1:
                 raise ValueError("frame result contains an undeclared contributing view")
             if not set(result.spatially_supported_view_ids).issubset(declared_set):
                 raise ValueError("frame result contains an undeclared supported view")
+            expected_spatially_supported = tuple(
+                sorted(
+                    view
+                    for view, count in result.seed_cell_counts_by_view.items()
+                    if count >= self.policy.minimum_seed_cell_count_per_view
+                )
+            )
+            if result.spatially_supported_view_ids != expected_spatially_supported:
+                raise ValueError(
+                    "frame supported-view IDs contradict stored seed-cell counts"
+                )
             expected_reasons = _frame_reason_codes(
                 contributing_view_ids=result.contributing_view_ids,
                 spatially_supported_view_ids=result.spatially_supported_view_ids,

--- a/src/prob4d/camera_panel_support.py
+++ b/src/prob4d/camera_panel_support.py
@@ -9,6 +9,7 @@ from dataclasses import asdict, dataclass, field
 
 import numpy as np
 
+from ._immutable_json import frozen_finite_json_mapping
 from .causal_tracklets import CausalTrackletSet
 from .spatial_tracklets import (
     SPATIAL_TRACKLET_CLAIM_BOUNDARY,
@@ -238,9 +239,17 @@ class CameraPanelSupportReportV1:
             raise ValueError("declared_view_ids must be sorted and unique")
         if type(self.seed_cell_grid_shape) is not tuple or len(self.seed_cell_grid_shape) != 2:
             raise ValueError("seed_cell_grid_shape must be a two-element tuple")
-        grid = tuple(
-            _strict_integer(value, name="seed_cell_grid_shape", minimum=1)
-            for value in self.seed_cell_grid_shape
+        grid = (
+            _strict_integer(
+                self.seed_cell_grid_shape[0],
+                name="seed_cell_grid_shape[0]",
+                minimum=1,
+            ),
+            _strict_integer(
+                self.seed_cell_grid_shape[1],
+                name="seed_cell_grid_shape[1]",
+                minimum=1,
+            ),
         )
         if not isinstance(self.policy, CameraPanelSupportPolicyV1):
             raise TypeError("policy must be a CameraPanelSupportPolicyV1")
@@ -265,11 +274,10 @@ class CameraPanelSupportReportV1:
             raise ValueError("decision_reason contradicts support_feasible")
         if self.claim_boundary != SPATIAL_TRACKLET_CLAIM_BOUNDARY:
             raise ValueError("camera-panel support claim boundary changed")
-        metadata = dict(self.metadata)
-        try:
-            json.dumps(metadata, allow_nan=False)
-        except (TypeError, ValueError) as error:
-            raise ValueError("camera-panel support metadata must be finite JSON") from error
+        metadata = frozen_finite_json_mapping(
+            self.metadata,
+            name="camera-panel support metadata",
+        )
 
         object.__setattr__(self, "panel_id", panel)
         object.__setattr__(self, "causal_frame_stop", cutoff)

--- a/src/prob4d/camera_panel_support.py
+++ b/src/prob4d/camera_panel_support.py
@@ -55,6 +55,18 @@ def _strict_bool(value: object, *, name: str) -> bool:
     return value
 
 
+def _canonical_string_tuple(value: object, *, name: str) -> tuple[str, ...]:
+    if type(value) is not tuple or not value:
+        raise ValueError(f"{name} must be a non-empty tuple")
+    result = tuple(
+        _strict_string(item, name=f"{name}[{index}]")
+        for index, item in enumerate(value)
+    )
+    if result != tuple(sorted(set(result))):
+        raise ValueError(f"{name} must be sorted and unique")
+    return result
+
+
 def _canonical_json_bytes(value: Mapping[str, object]) -> bytes:
     return json.dumps(
         value,
@@ -225,14 +237,10 @@ class CameraPanelSupportReportV1:
             raise ValueError("required_frame_indices must be sorted and unique")
         if any(frame >= cutoff for frame in required):
             raise ValueError("required frames cross the causal frame stop")
-        if type(self.declared_view_ids) is not tuple or not self.declared_view_ids:
-            raise ValueError("declared_view_ids must be a non-empty tuple")
-        views = tuple(
-            _strict_string(value, name="declared_view_id")
-            for value in self.declared_view_ids
+        views = _canonical_string_tuple(
+            self.declared_view_ids,
+            name="declared_view_ids",
         )
-        if views != tuple(sorted(set(views))):
-            raise ValueError("declared_view_ids must be sorted and unique")
         if type(self.seed_cell_grid_shape) is not tuple or len(self.seed_cell_grid_shape) != 2:
             raise ValueError("seed_cell_grid_shape must be a two-element tuple")
         grid = (
@@ -337,26 +345,32 @@ def _tracklet_grid_shape(tracklets: CausalTrackletSet) -> tuple[int, int]:
 def evaluate_camera_panel_tracklet_support(
     tracklets_by_view: Mapping[str, CausalTrackletSet],
     *,
+    declared_view_ids: tuple[str, ...],
     panel_id: str,
     required_frame_indices: tuple[int, ...],
     policy: CameraPanelSupportPolicyV1 | None = None,
     metadata: Mapping[str, object] | None = None,
 ) -> CameraPanelSupportReportV1:
-    """Audit per-view distributed support without equating camera image cells."""
+    """Audit a frozen camera roster without equating view-local image cells."""
 
     if not isinstance(tracklets_by_view, Mapping) or not tracklets_by_view:
         raise ValueError("tracklets_by_view must be a non-empty mapping")
+    declared = _canonical_string_tuple(
+        declared_view_ids,
+        name="declared_view_ids",
+    )
     normalized: dict[str, CausalTrackletSet] = {}
     for raw_view, tracklets in tracklets_by_view.items():
         view = _strict_string(raw_view, name="view_id")
+        if view not in declared:
+            raise ValueError("tracklets_by_view contains a view outside declared_view_ids")
         if not isinstance(tracklets, CausalTrackletSet):
             raise TypeError("tracklets_by_view values must be CausalTrackletSet instances")
         normalized[view] = tracklets
-    views = tuple(sorted(normalized))
     actual_policy = CameraPanelSupportPolicyV1() if policy is None else policy
     if not isinstance(actual_policy, CameraPanelSupportPolicyV1):
         raise TypeError("policy must be a CameraPanelSupportPolicyV1")
-    if actual_policy.minimum_view_count > len(views):
+    if actual_policy.minimum_view_count > len(declared):
         raise ValueError("minimum_view_count exceeds the declared panel size")
 
     cutoffs = {tracklets.causal_frame_stop for tracklets in normalized.values()}
@@ -381,7 +395,11 @@ def evaluate_camera_panel_tracklet_support(
         raise ValueError("required frames cross the panel causal frame stop")
 
     cells_by_view_and_frame: dict[str, dict[int, set[int]]] = {}
-    for view, tracklets in normalized.items():
+    for view in declared:
+        tracklets = normalized.get(view)
+        if tracklets is None:
+            cells_by_view_and_frame[view] = {}
+            continue
         track_cells = seed_cell_ids_by_track(tracklets)
         row_cells = track_cells[np.asarray(tracklets.track_ids, dtype=np.int64)]
         per_frame: dict[int, set[int]] = {}
@@ -394,9 +412,11 @@ def evaluate_camera_panel_tracklet_support(
     for frame in required:
         counts = {
             view: len(cells_by_view_and_frame[view].get(frame, set()))
-            for view in views
+            for view in declared
         }
-        contributing = tuple(sorted(view for view, count in counts.items() if count > 0))
+        contributing = tuple(
+            sorted(view for view, count in counts.items() if count > 0)
+        )
         spatially_supported = tuple(
             sorted(
                 view
@@ -407,7 +427,7 @@ def evaluate_camera_panel_tracklet_support(
         reasons: list[str] = []
         if len(spatially_supported) < actual_policy.minimum_view_count:
             reasons.append("insufficient-spatially-supported-views")
-        if actual_policy.require_all_declared_views and len(contributing) != len(views):
+        if actual_policy.require_all_declared_views and len(contributing) != len(declared):
             reasons.append("missing-declared-view")
         contributing_counts = {view: counts[view] for view in contributing}
         frame_results.append(
@@ -435,7 +455,7 @@ def evaluate_camera_panel_tracklet_support(
         panel_id=panel_id,
         causal_frame_stop=cutoff,
         required_frame_indices=required,
-        declared_view_ids=views,
+        declared_view_ids=declared,
         seed_cell_grid_shape=grid,
         policy=actual_policy,
         frame_results=tuple(frame_results),

--- a/src/prob4d/camera_panel_support.py
+++ b/src/prob4d/camera_panel_support.py
@@ -126,6 +126,23 @@ class CameraPanelSupportPolicyV1:
         )
 
 
+def _frame_reason_codes(
+    *,
+    contributing_view_ids: tuple[str, ...],
+    spatially_supported_view_ids: tuple[str, ...],
+    declared_view_ids: tuple[str, ...],
+    policy: CameraPanelSupportPolicyV1,
+) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if len(spatially_supported_view_ids) < policy.minimum_view_count:
+        reasons.append("insufficient-spatially-supported-views")
+    if policy.require_all_declared_views and (
+        len(contributing_view_ids) != len(declared_view_ids)
+    ):
+        reasons.append("missing-declared-view")
+    return tuple(sorted(reasons))
+
+
 @dataclass(frozen=True, slots=True)
 class CameraPanelFrameSupportV1:
     """View-local spatial support decision for one required causal-prefix frame."""
@@ -257,6 +274,12 @@ class CameraPanelSupportReportV1:
         )
         if not isinstance(self.policy, CameraPanelSupportPolicyV1):
             raise TypeError("policy must be a CameraPanelSupportPolicyV1")
+        if self.policy.minimum_view_count > len(views):
+            raise ValueError("minimum_view_count exceeds the declared panel size")
+        if self.policy.minimum_seed_cell_count_per_view > grid[0] * grid[1]:
+            raise ValueError(
+                "minimum_seed_cell_count_per_view exceeds the declared seed-cell grid"
+            )
         if type(self.frame_results) is not tuple:
             raise ValueError("frame_results must be a tuple")
         results = self.frame_results
@@ -264,6 +287,20 @@ class CameraPanelSupportReportV1:
             raise TypeError("frame_results must contain CameraPanelFrameSupportV1 values")
         if tuple(result.frame_index for result in results) != required:
             raise ValueError("frame_results must exactly cover required_frame_indices")
+        declared_set = set(views)
+        for result in results:
+            if not set(result.contributing_view_ids).issubset(declared_set):
+                raise ValueError("frame result contains an undeclared contributing view")
+            if not set(result.spatially_supported_view_ids).issubset(declared_set):
+                raise ValueError("frame result contains an undeclared supported view")
+            expected_reasons = _frame_reason_codes(
+                contributing_view_ids=result.contributing_view_ids,
+                spatially_supported_view_ids=result.spatially_supported_view_ids,
+                declared_view_ids=views,
+                policy=self.policy,
+            )
+            if result.reason_codes != expected_reasons:
+                raise ValueError("frame result contradicts the frozen panel policy")
         support = _strict_bool(self.support_feasible, name="support_feasible")
         supported_count = sum(result.supported for result in results)
         fraction = supported_count / len(results)
@@ -424,11 +461,12 @@ def evaluate_camera_panel_tracklet_support(
                 if count >= actual_policy.minimum_seed_cell_count_per_view
             )
         )
-        reasons: list[str] = []
-        if len(spatially_supported) < actual_policy.minimum_view_count:
-            reasons.append("insufficient-spatially-supported-views")
-        if actual_policy.require_all_declared_views and len(contributing) != len(declared):
-            reasons.append("missing-declared-view")
+        reasons = _frame_reason_codes(
+            contributing_view_ids=contributing,
+            spatially_supported_view_ids=spatially_supported,
+            declared_view_ids=declared,
+            policy=actual_policy,
+        )
         contributing_counts = {view: counts[view] for view in contributing}
         frame_results.append(
             CameraPanelFrameSupportV1(
@@ -437,7 +475,7 @@ def evaluate_camera_panel_tracklet_support(
                 spatially_supported_view_ids=spatially_supported,
                 seed_cell_counts_by_view=contributing_counts,
                 supported=not reasons,
-                reason_codes=tuple(sorted(reasons)),
+                reason_codes=reasons,
             )
         )
 

--- a/src/prob4d/spatial_seed_selection.py
+++ b/src/prob4d/spatial_seed_selection.py
@@ -144,9 +144,9 @@ class SpatialSeedSelection:
     def __post_init__(self) -> None:
         if type(self.image_shape) is not tuple or len(self.image_shape) != 2:
             raise ValueError("image_shape must be a two-element tuple")
-        image_shape = tuple(
-            _strict_integer(value, name=f"image_shape[{index}]", minimum=1)
-            for index, value in enumerate(self.image_shape)
+        image_shape = (
+            _strict_integer(self.image_shape[0], name="image_shape[0]", minimum=1),
+            _strict_integer(self.image_shape[1], name="image_shape[1]", minimum=1),
         )
         for field_name in ("requested_cell_grid_shape", "cell_grid_shape"):
             raw = getattr(self, field_name)

--- a/src/prob4d/spatial_seed_selection.py
+++ b/src/prob4d/spatial_seed_selection.py
@@ -1,0 +1,400 @@
+"""Deterministic spatially stratified seed selection for causal tracklets."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any, Literal, TypeAlias, cast
+
+import numpy as np
+from numpy.typing import NDArray
+
+IntArray: TypeAlias = NDArray[np.integer[Any]]
+BoolArray: TypeAlias = NDArray[np.bool_]
+SeedSelectionPolicy = Literal["regular-grid", "spatial-stratified"]
+
+SPATIAL_TRACKLET_CLAIM_BOUNDARY = (
+    "This source-only diagnostic uses causal-prefix provider support and association "
+    "outputs without truth residuals or target outcomes. Spatial coverage or panel "
+    "support does not establish provider competence, uncertainty calibration, "
+    "BayesianPhysTwin benefit, Causal4D benefit, deployment safety, or state of the art."
+)
+
+
+def _strict_string(value: object, *, name: str) -> str:
+    if type(value) is not str or not value:
+        raise ValueError(f"{name} must be a non-empty string")
+    return value
+
+
+def _strict_integer(value: object, *, name: str, minimum: int = 0) -> int:
+    if type(value) is not int and not isinstance(value, np.integer):
+        raise ValueError(f"{name} must be an integer")
+    result = int(value)
+    if result < minimum:
+        raise ValueError(f"{name} must be at least {minimum}")
+    return result
+
+
+def _optional_positive_integer(value: object, *, name: str) -> int | None:
+    if value is None:
+        return None
+    return _strict_integer(value, name=name, minimum=1)
+
+
+def _selection_policy(value: object) -> SeedSelectionPolicy:
+    policy = _strict_string(value, name="seed_selection_policy")
+    if policy not in {"regular-grid", "spatial-stratified"}:
+        raise ValueError(
+            "seed_selection_policy must be 'regular-grid' or 'spatial-stratified'"
+        )
+    return cast(SeedSelectionPolicy, policy)
+
+
+def _readonly(value: np.ndarray, *, dtype: Any) -> np.ndarray:
+    result = np.asarray(value, dtype=dtype).copy()
+    result.setflags(write=False)
+    return result
+
+
+def _effective_cell_grid(
+    image_shape: tuple[int, int],
+    requested: tuple[int, int],
+) -> tuple[int, int]:
+    height, width = image_shape
+    requested_rows, requested_columns = requested
+    return min(height, requested_rows), min(width, requested_columns)
+
+
+def _cell_boundaries(length: int, count: int) -> np.ndarray:
+    boundaries = np.linspace(0, length, count + 1, dtype=np.int64)
+    if np.any(np.diff(boundaries) <= 0):
+        raise ValueError("spatial cell grid contains an empty cell")
+    return boundaries
+
+
+def _cell_ids_for_coordinates(
+    rows: np.ndarray,
+    columns: np.ndarray,
+    *,
+    image_shape: tuple[int, int],
+    cell_grid_shape: tuple[int, int],
+) -> np.ndarray:
+    row_boundaries = _cell_boundaries(image_shape[0], cell_grid_shape[0])
+    column_boundaries = _cell_boundaries(image_shape[1], cell_grid_shape[1])
+    row_cells = np.searchsorted(row_boundaries[1:], rows, side="right")
+    column_cells = np.searchsorted(column_boundaries[1:], columns, side="right")
+    return row_cells * cell_grid_shape[1] + column_cells
+
+
+def _cell_anchors(start: int, stop: int, stride: int) -> tuple[int, ...]:
+    center = start + (stop - start - 1) // 2
+    offset = min(stride // 2, max(stop - start - 1, 0))
+    regular = tuple(range(start + offset, stop, stride))
+    return (center, *tuple(value for value in regular if value != center))
+
+
+def _select_nearest_unique(
+    candidates: np.ndarray,
+    anchors: Sequence[tuple[int, int]],
+    *,
+    maximum_count: int | None,
+) -> np.ndarray:
+    selected: list[int] = []
+    available = np.ones(len(candidates), dtype=bool)
+    for anchor_row, anchor_column in anchors:
+        if maximum_count is not None and len(selected) >= maximum_count:
+            break
+        remaining = np.flatnonzero(available)
+        if not len(remaining):
+            break
+        remaining_points = candidates[remaining]
+        distance = (
+            (remaining_points[:, 0] - anchor_row) ** 2
+            + (remaining_points[:, 1] - anchor_column) ** 2
+        )
+        order = np.lexsort(
+            (
+                remaining_points[:, 1],
+                remaining_points[:, 0],
+                distance,
+            )
+        )
+        chosen = int(remaining[int(order[0])])
+        selected.append(chosen)
+        available[chosen] = False
+    return np.asarray(selected, dtype=np.int64)
+
+
+@dataclass(frozen=True, slots=True)
+class SpatialSeedSelection:
+    """Deterministic causal-prefix seed coordinates and spatial-cell lineage."""
+
+    image_shape: tuple[int, int]
+    requested_cell_grid_shape: tuple[int, int]
+    cell_grid_shape: tuple[int, int]
+    seed_stride: int
+    seed_selection_policy: SeedSelectionPolicy
+    maximum_seeds_per_cell: int | None
+    rows: IntArray
+    columns: IntArray
+    cell_ids: IntArray
+    occupied_cell_ids: IntArray
+
+    def __post_init__(self) -> None:
+        if type(self.image_shape) is not tuple or len(self.image_shape) != 2:
+            raise ValueError("image_shape must be a two-element tuple")
+        image_shape = tuple(
+            _strict_integer(value, name=f"image_shape[{index}]", minimum=1)
+            for index, value in enumerate(self.image_shape)
+        )
+        for field_name in ("requested_cell_grid_shape", "cell_grid_shape"):
+            raw = getattr(self, field_name)
+            if type(raw) is not tuple or len(raw) != 2:
+                raise ValueError(f"{field_name} must be a two-element tuple")
+            normalized = tuple(
+                _strict_integer(value, name=f"{field_name}[{index}]", minimum=1)
+                for index, value in enumerate(raw)
+            )
+            object.__setattr__(self, field_name, normalized)
+        expected_grid = _effective_cell_grid(image_shape, self.requested_cell_grid_shape)
+        if self.cell_grid_shape != expected_grid:
+            raise ValueError("cell_grid_shape differs from the effective requested grid")
+        stride = _strict_integer(self.seed_stride, name="seed_stride", minimum=1)
+        policy = _selection_policy(self.seed_selection_policy)
+        maximum = _optional_positive_integer(
+            self.maximum_seeds_per_cell,
+            name="maximum_seeds_per_cell",
+        )
+        rows = np.asarray(self.rows)
+        columns = np.asarray(self.columns)
+        cell_ids = np.asarray(self.cell_ids)
+        occupied = np.asarray(self.occupied_cell_ids)
+        for name, value in (
+            ("rows", rows),
+            ("columns", columns),
+            ("cell_ids", cell_ids),
+            ("occupied_cell_ids", occupied),
+        ):
+            if value.dtype.kind not in {"i", "u"} or value.ndim != 1:
+                raise ValueError(f"{name} must be a one-dimensional integer array")
+        rows = np.asarray(rows, dtype=np.int64)
+        columns = np.asarray(columns, dtype=np.int64)
+        cell_ids = np.asarray(cell_ids, dtype=np.int64)
+        occupied = np.asarray(occupied, dtype=np.int64)
+        if not len(rows) or columns.shape != rows.shape or cell_ids.shape != rows.shape:
+            raise ValueError("selected seed arrays must share one non-empty length")
+        if np.any(rows < 0) or np.any(rows >= image_shape[0]):
+            raise ValueError("selected seed rows lie outside image_shape")
+        if np.any(columns < 0) or np.any(columns >= image_shape[1]):
+            raise ValueError("selected seed columns lie outside image_shape")
+        pairs = np.column_stack((rows, columns))
+        if len(np.unique(pairs, axis=0)) != len(rows):
+            raise ValueError("selected seed coordinates must be unique")
+        order = np.lexsort((columns, rows))
+        if not np.array_equal(order, np.arange(len(rows))):
+            raise ValueError("selected seed coordinates must be in row-major order")
+        cell_count = self.cell_grid_shape[0] * self.cell_grid_shape[1]
+        if np.any(cell_ids < 0) or np.any(cell_ids >= cell_count):
+            raise ValueError("selected seed cell IDs lie outside cell_grid_shape")
+        expected_cell_ids = _cell_ids_for_coordinates(
+            rows,
+            columns,
+            image_shape=image_shape,
+            cell_grid_shape=self.cell_grid_shape,
+        )
+        if not np.array_equal(cell_ids, expected_cell_ids):
+            raise ValueError("selected seed cell IDs disagree with their coordinates")
+        if occupied.size == 0:
+            raise ValueError("occupied_cell_ids must not be empty")
+        if np.any(occupied < 0) or np.any(occupied >= cell_count):
+            raise ValueError("occupied seed cell IDs lie outside cell_grid_shape")
+        if not np.array_equal(occupied, np.unique(occupied)):
+            raise ValueError("occupied_cell_ids must be sorted and unique")
+        if not set(np.unique(cell_ids)).issubset(set(occupied)):
+            raise ValueError("selected seed cells must be occupied")
+        if policy == "spatial-stratified" and not np.array_equal(
+            np.unique(cell_ids), occupied
+        ):
+            raise ValueError("spatial-stratified selection must represent every occupied cell")
+        if maximum is not None:
+            occupancy = np.bincount(cell_ids, minlength=cell_count)
+            if np.any(occupancy > maximum):
+                raise ValueError("selected seed cell occupancy exceeds maximum_seeds_per_cell")
+
+        object.__setattr__(self, "image_shape", image_shape)
+        object.__setattr__(self, "seed_stride", stride)
+        object.__setattr__(self, "seed_selection_policy", policy)
+        object.__setattr__(self, "maximum_seeds_per_cell", maximum)
+        object.__setattr__(self, "rows", _readonly(rows, dtype=np.int64))
+        object.__setattr__(self, "columns", _readonly(columns, dtype=np.int64))
+        object.__setattr__(self, "cell_ids", _readonly(cell_ids, dtype=np.int64))
+        object.__setattr__(
+            self,
+            "occupied_cell_ids",
+            _readonly(occupied, dtype=np.int64),
+        )
+
+    @property
+    def seed_count(self) -> int:
+        return int(len(self.rows))
+
+    @property
+    def occupied_cell_count(self) -> int:
+        return int(len(self.occupied_cell_ids))
+
+    @property
+    def selected_cell_count(self) -> int:
+        return int(len(np.unique(self.cell_ids)))
+
+    @property
+    def cell_occupancy(self) -> IntArray:
+        count = self.cell_grid_shape[0] * self.cell_grid_shape[1]
+        result = np.bincount(self.cell_ids, minlength=count).astype(np.int64)
+        result.setflags(write=False)
+        return result
+
+    def summary(self) -> dict[str, object]:
+        occupancy = self.cell_occupancy
+        active = occupancy[occupancy > 0]
+        return {
+            "seed_selection_policy": self.seed_selection_policy,
+            "image_shape": list(self.image_shape),
+            "requested_cell_grid_shape": list(self.requested_cell_grid_shape),
+            "cell_grid_shape": list(self.cell_grid_shape),
+            "seed_stride": self.seed_stride,
+            "maximum_seeds_per_cell": self.maximum_seeds_per_cell,
+            "seed_count": self.seed_count,
+            "occupied_cell_count": self.occupied_cell_count,
+            "selected_cell_count": self.selected_cell_count,
+            "minimum_selected_cell_occupancy": int(np.min(active)),
+            "maximum_selected_cell_occupancy": int(np.max(active)),
+        }
+
+
+def select_spatial_tracklet_seeds(
+    seed_mask: BoolArray,
+    *,
+    seed_stride: int = 8,
+    seed_selection_policy: SeedSelectionPolicy = "spatial-stratified",
+    cell_grid_rows: int = 4,
+    cell_grid_columns: int = 4,
+    maximum_seeds_per_cell: int | None = None,
+) -> SpatialSeedSelection:
+    """Select deterministic seeds while retaining target-free image-cell support."""
+
+    raw_mask = np.asarray(seed_mask)
+    if raw_mask.dtype != np.dtype(bool) or raw_mask.ndim != 2:
+        raise ValueError("seed_mask must be a two-dimensional boolean array")
+    mask = np.asarray(raw_mask, dtype=bool)
+    if not np.any(mask):
+        raise ValueError("seed_mask contains no admissible seed")
+    stride = _strict_integer(seed_stride, name="seed_stride", minimum=1)
+    policy = _selection_policy(seed_selection_policy)
+    requested_grid = (
+        _strict_integer(cell_grid_rows, name="cell_grid_rows", minimum=1),
+        _strict_integer(cell_grid_columns, name="cell_grid_columns", minimum=1),
+    )
+    maximum = _optional_positive_integer(
+        maximum_seeds_per_cell,
+        name="maximum_seeds_per_cell",
+    )
+    image_shape = cast(tuple[int, int], mask.shape)
+    cell_grid = _effective_cell_grid(image_shape, requested_grid)
+    all_rows, all_columns = np.nonzero(mask)
+    all_cell_ids = _cell_ids_for_coordinates(
+        all_rows,
+        all_columns,
+        image_shape=image_shape,
+        cell_grid_shape=cell_grid,
+    )
+    occupied = np.unique(all_cell_ids)
+
+    if policy == "regular-grid":
+        grid = np.zeros(image_shape, dtype=bool)
+        grid[::stride, ::stride] = True
+        selected_rows, selected_columns = np.nonzero(mask & grid)
+        if not len(selected_rows):
+            raise ValueError("regular-grid selection produced no admissible seed")
+        if maximum is not None:
+            regular_cell_ids = _cell_ids_for_coordinates(
+                selected_rows,
+                selected_columns,
+                image_shape=image_shape,
+                cell_grid_shape=cell_grid,
+            )
+            keep = np.zeros(len(selected_rows), dtype=bool)
+            for cell_id in np.unique(regular_cell_ids):
+                selected = np.flatnonzero(regular_cell_ids == cell_id)
+                keep[selected[:maximum]] = True
+            selected_rows = selected_rows[keep]
+            selected_columns = selected_columns[keep]
+    else:
+        row_boundaries = _cell_boundaries(image_shape[0], cell_grid[0])
+        column_boundaries = _cell_boundaries(image_shape[1], cell_grid[1])
+        selected_coordinates: list[tuple[int, int]] = []
+        for row_cell in range(cell_grid[0]):
+            row_start = int(row_boundaries[row_cell])
+            row_stop = int(row_boundaries[row_cell + 1])
+            for column_cell in range(cell_grid[1]):
+                column_start = int(column_boundaries[column_cell])
+                column_stop = int(column_boundaries[column_cell + 1])
+                local_rows, local_columns = np.nonzero(
+                    mask[row_start:row_stop, column_start:column_stop]
+                )
+                if not len(local_rows):
+                    continue
+                candidates = np.column_stack(
+                    (local_rows + row_start, local_columns + column_start)
+                ).astype(np.int64)
+                anchors = tuple(
+                    (row, column)
+                    for row in _cell_anchors(row_start, row_stop, stride)
+                    for column in _cell_anchors(column_start, column_stop, stride)
+                )
+                chosen = _select_nearest_unique(
+                    candidates,
+                    anchors,
+                    maximum_count=maximum,
+                )
+                selected_coordinates.extend(
+                    (int(candidates[index, 0]), int(candidates[index, 1]))
+                    for index in chosen
+                )
+        selected_coordinates.sort()
+        selected_rows = np.asarray(
+            [row for row, _ in selected_coordinates],
+            dtype=np.int64,
+        )
+        selected_columns = np.asarray(
+            [column for _, column in selected_coordinates],
+            dtype=np.int64,
+        )
+
+    selected_cell_ids = _cell_ids_for_coordinates(
+        selected_rows,
+        selected_columns,
+        image_shape=image_shape,
+        cell_grid_shape=cell_grid,
+    )
+    return SpatialSeedSelection(
+        image_shape=image_shape,
+        requested_cell_grid_shape=requested_grid,
+        cell_grid_shape=cell_grid,
+        seed_stride=stride,
+        seed_selection_policy=policy,
+        maximum_seeds_per_cell=maximum,
+        rows=selected_rows,
+        columns=selected_columns,
+        cell_ids=selected_cell_ids,
+        occupied_cell_ids=occupied,
+    )
+
+
+__all__ = [
+    "BoolArray",
+    "SPATIAL_TRACKLET_CLAIM_BOUNDARY",
+    "SeedSelectionPolicy",
+    "SpatialSeedSelection",
+    "select_spatial_tracklet_seeds",
+]

--- a/src/prob4d/spatial_tracklet_builder.py
+++ b/src/prob4d/spatial_tracklet_builder.py
@@ -10,6 +10,7 @@ from typing import Any, TypeAlias
 import numpy as np
 from numpy.typing import NDArray
 
+from ._immutable_json import plain_json
 from .causal_tracklets import (
     CausalTrackletReport,
     CausalTrackletSet,
@@ -228,7 +229,7 @@ def build_spatially_stratified_scene_flow_tracklets(
         }
     )
     try:
-        json.dumps(metadata, allow_nan=False)
+        json.dumps(plain_json(metadata), allow_nan=False)
     except (TypeError, ValueError) as error:
         raise ValueError("spatial tracklet metadata must be finite JSON") from error
     enriched = CausalTrackletSet(

--- a/src/prob4d/spatial_tracklet_builder.py
+++ b/src/prob4d/spatial_tracklet_builder.py
@@ -1,0 +1,261 @@
+"""Spatially stratified wrapper for causal scene-flow tracklets."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from typing import Any, TypeAlias
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .causal_tracklets import (
+    CausalTrackletReport,
+    CausalTrackletSet,
+    TargetDeformMaskPolicy,
+    build_causal_scene_flow_tracklets,
+)
+from .data import PredictionWindow
+from .spatial_seed_selection import (
+    SPATIAL_TRACKLET_CLAIM_BOUNDARY,
+    SeedSelectionPolicy,
+    SpatialSeedSelection,
+    select_spatial_tracklet_seeds,
+)
+
+IntArray: TypeAlias = NDArray[np.integer[Any]]
+
+
+def _strict_integer(value: object, *, name: str, minimum: int = 0) -> int:
+    if type(value) is not int and not isinstance(value, np.integer):
+        raise ValueError(f"{name} must be an integer")
+    result = int(value)
+    if result < minimum:
+        raise ValueError(f"{name} must be at least {minimum}")
+    return result
+
+
+@dataclass(frozen=True, slots=True)
+class SpatialTrackletReport:
+    """Base association audit plus selected and retained spatial support."""
+
+    base_report: CausalTrackletReport
+    seed_selection: SpatialSeedSelection
+    retained_seed_cell_ids: tuple[int, ...]
+    claim_boundary: str = SPATIAL_TRACKLET_CLAIM_BOUNDARY
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.base_report, CausalTrackletReport):
+            raise TypeError("base_report must be a CausalTrackletReport")
+        if not isinstance(self.seed_selection, SpatialSeedSelection):
+            raise TypeError("seed_selection must be a SpatialSeedSelection")
+        if type(self.retained_seed_cell_ids) is not tuple:
+            raise ValueError("retained_seed_cell_ids must be a tuple")
+        retained = tuple(
+            _strict_integer(value, name="retained_seed_cell_id")
+            for value in self.retained_seed_cell_ids
+        )
+        if len(retained) != self.base_report.retained_track_count:
+            raise ValueError("retained_seed_cell_ids must contain one ID per retained track")
+        if not set(retained).issubset(set(self.seed_selection.cell_ids.tolist())):
+            raise ValueError("retained seed cells were not present in the selected seeds")
+        if self.claim_boundary != SPATIAL_TRACKLET_CLAIM_BOUNDARY:
+            raise ValueError("spatial tracklet claim boundary changed")
+        object.__setattr__(self, "retained_seed_cell_ids", retained)
+
+    @property
+    def retained_seed_cell_count(self) -> int:
+        return len(set(self.retained_seed_cell_ids))
+
+    @property
+    def dropped_seed_cell_count(self) -> int:
+        return self.seed_selection.selected_cell_count - self.retained_seed_cell_count
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "base_report": self.base_report.to_dict(),
+            "seed_selection": self.seed_selection.summary(),
+            "retained_seed_cell_ids": list(self.retained_seed_cell_ids),
+            "retained_seed_cell_count": self.retained_seed_cell_count,
+            "dropped_seed_cell_count": self.dropped_seed_cell_count,
+            "claim_boundary": self.claim_boundary,
+        }
+
+
+def _copy_window_with_seed_mask(
+    window: PredictionWindow,
+    *,
+    first_local_index: int,
+    selection: SpatialSeedSelection,
+) -> PredictionWindow:
+    if window.deform_mask is None:
+        raise ValueError("spatial tracklets require deform_mask")
+    deform_mask = np.asarray(window.deform_mask, dtype=bool).copy()
+    deform_mask[first_local_index] = False
+    deform_mask[first_local_index, selection.rows, selection.columns] = True
+    return PredictionWindow(
+        window_id=window.window_id,
+        frame_indices=window.frame_indices,
+        point_map=window.point_map,
+        valid_mask=window.valid_mask,
+        scene_flow=window.scene_flow,
+        deform_mask=deform_mask,
+        ray_directions=window.ray_directions,
+        dense_storage_dtype=window.dense_storage_dtype,
+    )
+
+
+def seed_cell_ids_by_track(tracklets: CausalTrackletSet) -> IntArray:
+    """Return strict per-track spatial cell IDs retained in tracklet metadata."""
+
+    if not isinstance(tracklets, CausalTrackletSet):
+        raise TypeError("tracklets must be a CausalTrackletSet")
+    raw = tracklets.metadata.get("seed_cell_ids_by_track")
+    if isinstance(raw, (str, bytes)) or not isinstance(raw, Sequence):
+        raise ValueError("tracklets do not contain seed_cell_ids_by_track metadata")
+    values = np.asarray(
+        [
+            _strict_integer(value, name=f"seed_cell_ids_by_track[{index}]")
+            for index, value in enumerate(raw)
+        ],
+        dtype=np.int64,
+    )
+    if values.shape != (tracklets.track_count,):
+        raise ValueError("seed_cell_ids_by_track length differs from track_count")
+    grid = tracklets.metadata.get("seed_cell_grid_shape")
+    if (
+        isinstance(grid, (str, bytes))
+        or not isinstance(grid, Sequence)
+        or len(grid) != 2
+    ):
+        raise ValueError("tracklets do not contain a valid seed_cell_grid_shape")
+    rows = _strict_integer(grid[0], name="seed_cell_grid_shape[0]", minimum=1)
+    columns = _strict_integer(grid[1], name="seed_cell_grid_shape[1]", minimum=1)
+    if np.any(values >= rows * columns):
+        raise ValueError("seed_cell_ids_by_track lie outside seed_cell_grid_shape")
+    values.setflags(write=False)
+    return values
+
+
+def build_spatially_stratified_scene_flow_tracklets(
+    window: PredictionWindow,
+    *,
+    causal_frame_stop: int,
+    seed_stride: int = 8,
+    seed_selection_policy: SeedSelectionPolicy = "spatial-stratified",
+    cell_grid_rows: int = 4,
+    cell_grid_columns: int = 4,
+    maximum_seeds_per_cell: int | None = None,
+    search_radius_pixels: int = 4,
+    maximum_step_error_local: float = 0.05,
+    association_sigma_local: float | None = None,
+    minimum_link_probability: float = 0.05,
+    minimum_track_length: int = 2,
+    target_deform_mask_policy: TargetDeformMaskPolicy = "allow",
+) -> tuple[CausalTrackletSet, SpatialTrackletReport]:
+    """Build causal tracklets with deterministic spatially balanced seeds."""
+
+    if not isinstance(window, PredictionWindow):
+        raise TypeError("window must be a PredictionWindow")
+    if window.scene_flow is None or window.deform_mask is None:
+        raise ValueError("spatial scene-flow tracklets require scene_flow and deform_mask")
+    cutoff = _strict_integer(
+        causal_frame_stop,
+        name="causal_frame_stop",
+        minimum=1,
+    )
+    eligible = np.flatnonzero(window.frame_indices < cutoff)
+    if not len(eligible):
+        raise ValueError("window has no frame before causal_frame_stop")
+    first_local = int(eligible[0])
+    seed_mask = window.valid_mask[first_local] & window.deform_mask[first_local]
+    selection = select_spatial_tracklet_seeds(
+        seed_mask,
+        seed_stride=seed_stride,
+        seed_selection_policy=seed_selection_policy,
+        cell_grid_rows=cell_grid_rows,
+        cell_grid_columns=cell_grid_columns,
+        maximum_seeds_per_cell=maximum_seeds_per_cell,
+    )
+    seeded_window = _copy_window_with_seed_mask(
+        window,
+        first_local_index=first_local,
+        selection=selection,
+    )
+    tracklets, base_report = build_causal_scene_flow_tracklets(
+        seeded_window,
+        causal_frame_stop=cutoff,
+        seed_stride=1,
+        search_radius_pixels=search_radius_pixels,
+        maximum_step_error_local=maximum_step_error_local,
+        association_sigma_local=association_sigma_local,
+        minimum_link_probability=minimum_link_probability,
+        minimum_track_length=minimum_track_length,
+        target_deform_mask_policy=target_deform_mask_policy,
+    )
+    base_report = replace(base_report, seed_stride=selection.seed_stride)
+    coordinate_to_cell = {
+        (int(row), int(column)): int(cell_id)
+        for row, column, cell_id in zip(
+            selection.rows,
+            selection.columns,
+            selection.cell_ids,
+            strict=True,
+        )
+    }
+    retained_cell_ids: list[int] = []
+    for track_id in range(tracklets.track_count):
+        first = int(np.flatnonzero(tracklets.track_ids == track_id)[0])
+        coordinate = (int(tracklets.rows[first]), int(tracklets.columns[first]))
+        try:
+            retained_cell_ids.append(coordinate_to_cell[coordinate])
+        except KeyError as error:
+            raise ValueError("retained track does not begin at a selected seed") from error
+
+    metadata = dict(tracklets.metadata)
+    metadata.update(
+        {
+            "method": "spatially-stratified-local-scene-flow-association-v1",
+            "base_method": tracklets.metadata.get("method"),
+            "seed_selection_policy": selection.seed_selection_policy,
+            "seed_selection_summary": selection.summary(),
+            "seed_cell_grid_shape": list(selection.cell_grid_shape),
+            "seed_cell_ids_by_track": retained_cell_ids,
+            "selected_seed_cell_count": selection.selected_cell_count,
+            "retained_seed_cell_count": len(set(retained_cell_ids)),
+            "spatial_support_claim_boundary": SPATIAL_TRACKLET_CLAIM_BOUNDARY,
+        }
+    )
+    try:
+        json.dumps(metadata, allow_nan=False)
+    except (TypeError, ValueError) as error:
+        raise ValueError("spatial tracklet metadata must be finite JSON") from error
+    enriched = CausalTrackletSet(
+        window_id=tracklets.window_id,
+        causal_frame_stop=tracklets.causal_frame_stop,
+        source_shape=tracklets.source_shape,
+        seed_frame_index=tracklets.seed_frame_index,
+        track_ids=tracklets.track_ids,
+        frame_indices=tracklets.frame_indices,
+        local_frame_indices=tracklets.local_frame_indices,
+        rows=tracklets.rows,
+        columns=tracklets.columns,
+        points_local=tracklets.points_local,
+        link_probability=tracklets.link_probability,
+        association_probability=tracklets.association_probability,
+        metadata=metadata,
+    )
+    report = SpatialTrackletReport(
+        base_report=base_report,
+        seed_selection=selection,
+        retained_seed_cell_ids=tuple(retained_cell_ids),
+    )
+    return enriched, report
+
+
+__all__ = [
+    "SpatialTrackletReport",
+    "build_spatially_stratified_scene_flow_tracklets",
+    "seed_cell_ids_by_track",
+]

--- a/src/prob4d/spatial_tracklet_factors.py
+++ b/src/prob4d/spatial_tracklet_factors.py
@@ -1,0 +1,186 @@
+"""Observation-factor conversion with spatial seed-cell likelihood groups."""
+
+from __future__ import annotations
+
+from typing import Any, Literal, TypeAlias, cast
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .causal_tracklets import CausalTrackletSet, tracklets_to_observation_factors
+from .observation_factors import ObservationFactor
+from .spatial_tracklet_builder import seed_cell_ids_by_track
+from .uncertainty import StructuredCovariance
+
+FloatArray: TypeAlias = NDArray[np.floating[Any]]
+CorrelationGroupMode = Literal["frame", "frame-seed-cell"]
+
+
+def _strict_string(value: object, *, name: str) -> str:
+    if type(value) is not str or not value:
+        raise ValueError(f"{name} must be a non-empty string")
+    return value
+
+
+def _strict_real(
+    value: object,
+    *,
+    name: str,
+    minimum: float = 0.0,
+    maximum: float | None = None,
+    strictly_positive: bool = False,
+) -> float:
+    if type(value) not in {int, float} and not isinstance(value, (np.integer, np.floating)):
+        raise ValueError(f"{name} must be a real number")
+    result = float(value)
+    if not np.isfinite(result):
+        raise ValueError(f"{name} must be finite")
+    if (strictly_positive and result <= minimum) or (not strictly_positive and result < minimum):
+        relation = "greater than" if strictly_positive else "at least"
+        raise ValueError(f"{name} must be {relation} {minimum}")
+    if maximum is not None and result > maximum:
+        raise ValueError(f"{name} must be at most {maximum}")
+    return result
+
+
+def _real_array(value: object, *, name: str) -> np.ndarray:
+    raw = np.asarray(value)
+    if raw.dtype.kind not in {"i", "u", "f"}:
+        raise ValueError(f"{name} must contain real numeric values")
+    result = np.asarray(raw, dtype=np.float64).copy()
+    if not np.all(np.isfinite(result)):
+        raise ValueError(f"{name} must be finite")
+    return result
+
+
+def _correlation_group_mode(value: object) -> CorrelationGroupMode:
+    mode = _strict_string(value, name="correlation_group_mode")
+    if mode not in {"frame", "frame-seed-cell"}:
+        raise ValueError(
+            "correlation_group_mode must be 'frame' or 'frame-seed-cell'"
+        )
+    return cast(CorrelationGroupMode, mode)
+
+
+def spatial_tracklets_to_observation_factors(
+    tracklets: CausalTrackletSet,
+    covariance: StructuredCovariance | FloatArray,
+    *,
+    view_id: str,
+    prior_reliability: FloatArray | None = None,
+    prior_nominal_probability: float = 1.0,
+    effective_samples_per_group: float = 64.0,
+    correlation_group_prefix: str = "scene-flow-tracklets",
+    factor_id_prefix: str | None = None,
+    correlation_group_mode: CorrelationGroupMode = "frame-seed-cell",
+) -> tuple[ObservationFactor, ...]:
+    """Convert tracklets while optionally preserving spatial cells as groups."""
+
+    mode = _correlation_group_mode(correlation_group_mode)
+    if mode == "frame":
+        return tracklets_to_observation_factors(
+            tracklets,
+            covariance,
+            view_id=view_id,
+            prior_reliability=prior_reliability,
+            prior_nominal_probability=prior_nominal_probability,
+            effective_samples_per_group=effective_samples_per_group,
+            correlation_group_prefix=correlation_group_prefix,
+            factor_id_prefix=factor_id_prefix,
+        )
+    if not isinstance(tracklets, CausalTrackletSet):
+        raise TypeError("tracklets must be a CausalTrackletSet")
+    view = _strict_string(view_id, name="view_id")
+    group_prefix = _strict_string(
+        correlation_group_prefix,
+        name="correlation_group_prefix",
+    )
+    nominal = _strict_real(
+        prior_nominal_probability,
+        name="prior_nominal_probability",
+        maximum=1.0,
+    )
+    effective = _strict_real(
+        effective_samples_per_group,
+        name="effective_samples_per_group",
+        strictly_positive=True,
+    )
+    cell_by_track = seed_cell_ids_by_track(tracklets)
+    row_cells = cell_by_track[np.asarray(tracklets.track_ids, dtype=np.int64)]
+
+    rays: np.ndarray | None
+    if isinstance(covariance, StructuredCovariance):
+        if covariance.parallel_variance.shape != tracklets.source_shape:
+            raise ValueError("structured covariance shape differs from tracklet source")
+        covariance_grid = covariance.matrices()
+        rays = covariance.ray_directions
+    else:
+        covariance_grid = _real_array(covariance, name="covariance")
+        expected = tracklets.source_shape + (3, 3)
+        if covariance_grid.shape != expected:
+            raise ValueError(f"covariance must have shape {expected}")
+        rays = None
+
+    if prior_reliability is None:
+        reliability_grid = np.ones(tracklets.source_shape, dtype=np.float64)
+    else:
+        reliability_grid = _real_array(
+            prior_reliability,
+            name="prior_reliability",
+        )
+        if reliability_grid.shape != tracklets.source_shape:
+            raise ValueError("prior_reliability must match tracklet source_shape")
+        if np.any((reliability_grid < 0.0) | (reliability_grid > 1.0)):
+            raise ValueError("prior_reliability must lie in [0, 1]")
+
+    prefix = (
+        f"{tracklets.window_id}:{view}:spatial-tracklets"
+        if factor_id_prefix is None
+        else _strict_string(factor_id_prefix, name="factor_id_prefix")
+    )
+    factors: list[ObservationFactor] = []
+    for frame in np.unique(tracklets.frame_indices):
+        frame_rows = np.flatnonzero(tracklets.frame_indices == frame)
+        for cell_id in np.unique(row_cells[frame_rows]):
+            selected = frame_rows[row_cells[frame_rows] == cell_id]
+            local_indices = np.unique(tracklets.local_frame_indices[selected])
+            if len(local_indices) != 1:
+                raise ValueError("one absolute frame maps to multiple local frame indices")
+            local_index = int(local_indices[0])
+            rows = tracklets.rows[selected]
+            columns = tracklets.columns[selected]
+            count = len(selected)
+            composite_weight = min(1.0, effective / count)
+            factors.append(
+                ObservationFactor(
+                    factor_id=(
+                        f"{prefix}:frame-{int(frame)}:seed-cell-{int(cell_id)}"
+                    ),
+                    frame_index=int(frame),
+                    view_id=view,
+                    window_id=tracklets.window_id,
+                    gauge_id=tracklets.window_id,
+                    point_ids=tracklets.track_ids[selected],
+                    points_local_m=tracklets.points_local[selected],
+                    valid_mask=np.ones(count, dtype=bool),
+                    local_covariance_m2=covariance_grid[local_index, rows, columns],
+                    association_probability=tracklets.association_probability[selected],
+                    prior_reliability=reliability_grid[local_index, rows, columns],
+                    prior_nominal_probability=nominal,
+                    composite_weight=composite_weight,
+                    correlation_group_id=(
+                        f"{group_prefix}:frame-{int(frame)}:seed-cell-{int(cell_id)}"
+                    ),
+                    causal_frame_stop=tracklets.causal_frame_stop,
+                    ray_directions_local=(
+                        None if rays is None else rays[local_index, rows, columns]
+                    ),
+                )
+            )
+    return tuple(factors)
+
+
+__all__ = [
+    "CorrelationGroupMode",
+    "spatial_tracklets_to_observation_factors",
+]

--- a/src/prob4d/spatial_tracklet_factors.py
+++ b/src/prob4d/spatial_tracklet_factors.py
@@ -69,12 +69,18 @@ def spatial_tracklets_to_observation_factors(
     view_id: str,
     prior_reliability: FloatArray | None = None,
     prior_nominal_probability: float = 1.0,
-    effective_samples_per_group: float = 64.0,
+    effective_samples_per_frame: float = 64.0,
     correlation_group_prefix: str = "scene-flow-tracklets",
     factor_id_prefix: str | None = None,
     correlation_group_mode: CorrelationGroupMode = "frame-seed-cell",
 ) -> tuple[ObservationFactor, ...]:
-    """Convert tracklets while optionally preserving spatial cells as groups."""
+    """Convert tracklets without amplifying a frame's likelihood-power budget.
+
+    In ``frame-seed-cell`` mode, every cell receives a distinct correlation-group
+    identity, but all factors from one frame share the historical frame-level
+    generalized-Bayes weight. Splitting a frame therefore cannot increase total
+    weighted row mass relative to ``frame`` mode.
+    """
 
     mode = _correlation_group_mode(correlation_group_mode)
     if mode == "frame":
@@ -84,7 +90,7 @@ def spatial_tracklets_to_observation_factors(
             view_id=view_id,
             prior_reliability=prior_reliability,
             prior_nominal_probability=prior_nominal_probability,
-            effective_samples_per_group=effective_samples_per_group,
+            effective_samples_per_group=effective_samples_per_frame,
             correlation_group_prefix=correlation_group_prefix,
             factor_id_prefix=factor_id_prefix,
         )
@@ -101,8 +107,8 @@ def spatial_tracklets_to_observation_factors(
         maximum=1.0,
     )
     effective = _strict_real(
-        effective_samples_per_group,
-        name="effective_samples_per_group",
+        effective_samples_per_frame,
+        name="effective_samples_per_frame",
         strictly_positive=True,
     )
     cell_by_track = seed_cell_ids_by_track(tracklets)
@@ -141,6 +147,7 @@ def spatial_tracklets_to_observation_factors(
     factors: list[ObservationFactor] = []
     for frame in np.unique(tracklets.frame_indices):
         frame_rows = np.flatnonzero(tracklets.frame_indices == frame)
+        frame_weight = min(1.0, effective / len(frame_rows))
         for cell_id in np.unique(row_cells[frame_rows]):
             selected = frame_rows[row_cells[frame_rows] == cell_id]
             local_indices = np.unique(tracklets.local_frame_indices[selected])
@@ -150,7 +157,6 @@ def spatial_tracklets_to_observation_factors(
             rows = tracklets.rows[selected]
             columns = tracklets.columns[selected]
             count = len(selected)
-            composite_weight = min(1.0, effective / count)
             factors.append(
                 ObservationFactor(
                     factor_id=(
@@ -167,7 +173,7 @@ def spatial_tracklets_to_observation_factors(
                     association_probability=tracklets.association_probability[selected],
                     prior_reliability=reliability_grid[local_index, rows, columns],
                     prior_nominal_probability=nominal,
-                    composite_weight=composite_weight,
+                    composite_weight=frame_weight,
                     correlation_group_id=(
                         f"{group_prefix}:frame-{int(frame)}:seed-cell-{int(cell_id)}"
                     ),

--- a/src/prob4d/spatial_tracklets.py
+++ b/src/prob4d/spatial_tracklets.py
@@ -1,0 +1,31 @@
+"""Public additive surface for spatially stratified causal tracklets."""
+
+from .spatial_seed_selection import (
+    SPATIAL_TRACKLET_CLAIM_BOUNDARY,
+    BoolArray,
+    SeedSelectionPolicy,
+    SpatialSeedSelection,
+    select_spatial_tracklet_seeds,
+)
+from .spatial_tracklet_builder import (
+    SpatialTrackletReport,
+    build_spatially_stratified_scene_flow_tracklets,
+    seed_cell_ids_by_track,
+)
+from .spatial_tracklet_factors import (
+    CorrelationGroupMode,
+    spatial_tracklets_to_observation_factors,
+)
+
+__all__ = [
+    "BoolArray",
+    "CorrelationGroupMode",
+    "SPATIAL_TRACKLET_CLAIM_BOUNDARY",
+    "SeedSelectionPolicy",
+    "SpatialSeedSelection",
+    "SpatialTrackletReport",
+    "build_spatially_stratified_scene_flow_tracklets",
+    "seed_cell_ids_by_track",
+    "select_spatial_tracklet_seeds",
+    "spatial_tracklets_to_observation_factors",
+]

--- a/tests/test_camera_panel_support_integrity.py
+++ b/tests/test_camera_panel_support_integrity.py
@@ -1,0 +1,81 @@
+import pytest
+
+from prob4d.camera_panel_support import (
+    CameraPanelFrameSupportV1,
+    CameraPanelSupportPolicyV1,
+    CameraPanelSupportReportV1,
+)
+
+
+def test_frame_rejects_zero_cell_contributors() -> None:
+    with pytest.raises(ValueError, match="at least 1"):
+        CameraPanelFrameSupportV1(
+            frame_index=0,
+            contributing_view_ids=("camera-a",),
+            spatially_supported_view_ids=(),
+            seed_cell_counts_by_view={"camera-a": 0},
+            supported=False,
+            reason_codes=("insufficient-spatially-supported-views",),
+        )
+
+
+def test_report_derives_supported_views_from_stored_cell_counts() -> None:
+    policy = CameraPanelSupportPolicyV1(
+        minimum_view_count=1,
+        minimum_seed_cell_count_per_view=2,
+        minimum_supported_frame_fraction=1.0,
+    )
+    forged = CameraPanelFrameSupportV1(
+        frame_index=0,
+        contributing_view_ids=("camera-a",),
+        spatially_supported_view_ids=("camera-a",),
+        seed_cell_counts_by_view={"camera-a": 1},
+        supported=True,
+        reason_codes=(),
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="supported-view IDs contradict stored seed-cell counts",
+    ):
+        CameraPanelSupportReportV1(
+            panel_id="forged-count-threshold",
+            causal_frame_stop=1,
+            required_frame_indices=(0,),
+            declared_view_ids=("camera-a",),
+            seed_cell_grid_shape=(1, 2),
+            policy=policy,
+            frame_results=(forged,),
+            support_feasible=True,
+            decision_reason="camera-panel-spatial-support-feasible",
+        )
+
+
+def test_report_recomputes_frame_reasons_from_the_frozen_policy() -> None:
+    policy = CameraPanelSupportPolicyV1(
+        minimum_view_count=2,
+        minimum_seed_cell_count_per_view=1,
+        minimum_supported_frame_fraction=1.0,
+        require_all_declared_views=True,
+    )
+    forged = CameraPanelFrameSupportV1(
+        frame_index=0,
+        contributing_view_ids=("camera-a",),
+        spatially_supported_view_ids=("camera-a",),
+        seed_cell_counts_by_view={"camera-a": 1},
+        supported=True,
+        reason_codes=(),
+    )
+
+    with pytest.raises(ValueError, match="contradicts the frozen panel policy"):
+        CameraPanelSupportReportV1(
+            panel_id="forged-policy-result",
+            causal_frame_stop=1,
+            required_frame_indices=(0,),
+            declared_view_ids=("camera-a", "camera-b"),
+            seed_cell_grid_shape=(1, 1),
+            policy=policy,
+            frame_results=(forged,),
+            support_feasible=True,
+            decision_reason="camera-panel-spatial-support-feasible",
+        )

--- a/tests/test_spatial_tracklets.py
+++ b/tests/test_spatial_tracklets.py
@@ -184,7 +184,7 @@ def test_spatial_tracklets_retain_cell_lineage_and_causal_cutoff() -> None:
     assert first.metadata["seed_selection_policy"] == "spatial-stratified"
 
 
-def test_spatial_factor_conversion_preserves_cell_groups_and_point_ids() -> None:
+def test_spatial_factor_conversion_preserves_cell_groups_and_frame_budget() -> None:
     window = moving_window(frames=2, height=2, width=6)
     tracklets, _ = build_spatially_stratified_scene_flow_tracklets(
         window,
@@ -211,21 +211,35 @@ def test_spatial_factor_conversion_preserves_cell_groups_and_point_ids() -> None
         tracklets,
         covariance,
         view_id="camera-0",
-        effective_samples_per_group=0.5,
+        effective_samples_per_frame=0.5,
     )
     framewise = spatial_tracklets_to_observation_factors(
         tracklets,
         covariance,
         view_id="camera-0",
         correlation_group_mode="frame",
-        effective_samples_per_group=0.5,
+        effective_samples_per_frame=0.5,
     )
 
     assert len(spatial) == 4
     assert len(framewise) == 2
     assert all("seed-cell" in factor.correlation_group_id for factor in spatial)
     assert {factor.point_ids[0] for factor in spatial[:2]} == {0, 1}
-    assert all(factor.composite_weight == 0.5 for factor in spatial)
+    assert all(factor.composite_weight == 0.25 for factor in spatial)
+    assert all(factor.composite_weight == 0.25 for factor in framewise)
+    for frame_index in (0, 1):
+        spatial_mass = sum(
+            factor.composite_weight * len(factor.point_ids)
+            for factor in spatial
+            if factor.frame_index == frame_index
+        )
+        framewise_mass = sum(
+            factor.composite_weight * len(factor.point_ids)
+            for factor in framewise
+            if factor.frame_index == frame_index
+        )
+        assert spatial_mass == pytest.approx(0.5)
+        assert spatial_mass == pytest.approx(framewise_mass)
 
 
 def test_camera_panel_support_requires_multiple_spatially_supported_views() -> None:

--- a/tests/test_spatial_tracklets.py
+++ b/tests/test_spatial_tracklets.py
@@ -245,6 +245,7 @@ def test_spatial_factor_conversion_preserves_cell_groups_and_frame_budget() -> N
 def test_camera_panel_support_requires_multiple_spatially_supported_views() -> None:
     first = panel_tracklets((0, 1, 2), window_id="view-a")
     second = panel_tracklets((2, 3), window_id="view-b")
+    declared = ("camera-a", "camera-b")
     policy = CameraPanelSupportPolicyV1(
         minimum_view_count=2,
         minimum_seed_cell_count_per_view=2,
@@ -254,6 +255,7 @@ def test_camera_panel_support_requires_multiple_spatially_supported_views() -> N
 
     report = evaluate_camera_panel_tracklet_support(
         {"camera-a": first, "camera-b": second},
+        declared_view_ids=declared,
         panel_id="panel",
         required_frame_indices=(0, 1),
         policy=policy,
@@ -261,6 +263,7 @@ def test_camera_panel_support_requires_multiple_spatially_supported_views() -> N
     )
 
     assert report.support_feasible
+    assert report.declared_view_ids == declared
     assert report.supported_frame_count == 2
     assert report.frame_results[0].spatially_supported_view_ids == (
         "camera-a",
@@ -273,6 +276,7 @@ def test_camera_panel_support_requires_multiple_spatially_supported_views() -> N
     assert len(report.camera_panel_support_id or "") == 64
     replay = evaluate_camera_panel_tracklet_support(
         {"camera-b": second, "camera-a": first},
+        declared_view_ids=declared,
         panel_id="panel",
         required_frame_indices=(0, 1),
         policy=policy,
@@ -285,6 +289,7 @@ def test_camera_panel_support_requires_multiple_spatially_supported_views() -> N
             "camera-a": first,
             "camera-b": panel_tracklets((0,), window_id="view-b-limited"),
         },
+        declared_view_ids=declared,
         panel_id="panel-limited",
         required_frame_indices=(0, 1),
         policy=policy,
@@ -293,6 +298,42 @@ def test_camera_panel_support_requires_multiple_spatially_supported_views() -> N
     assert support_negative.frame_results[0].reason_codes == (
         "insufficient-spatially-supported-views",
     )
+
+
+def test_camera_panel_support_cannot_drop_a_declared_view() -> None:
+    first = panel_tracklets((0, 1, 2), window_id="view-a")
+    declared = ("camera-a", "camera-b")
+    policy = CameraPanelSupportPolicyV1(
+        minimum_view_count=1,
+        minimum_seed_cell_count_per_view=2,
+        minimum_supported_frame_fraction=1.0,
+        require_all_declared_views=True,
+    )
+
+    report = evaluate_camera_panel_tracklet_support(
+        {"camera-a": first},
+        declared_view_ids=declared,
+        panel_id="missing-camera-b",
+        required_frame_indices=(0, 1),
+        policy=policy,
+    )
+
+    assert not report.support_feasible
+    assert report.declared_view_ids == declared
+    assert report.frame_results[0].contributing_view_ids == ("camera-a",)
+    assert report.frame_results[0].reason_codes == ("missing-declared-view",)
+
+    with pytest.raises(ValueError, match="outside declared_view_ids"):
+        evaluate_camera_panel_tracklet_support(
+            {"camera-c": first},
+            declared_view_ids=("camera-a",),
+            panel_id="unknown-camera",
+            required_frame_indices=(0, 1),
+            policy=CameraPanelSupportPolicyV1(
+                minimum_view_count=1,
+                minimum_seed_cell_count_per_view=1,
+            ),
+        )
 
 
 def test_spatial_contracts_reject_coercive_aliases() -> None:
@@ -313,6 +354,7 @@ def test_spatial_contracts_reject_coercive_aliases() -> None:
     with pytest.raises(ValueError, match="required_frame_indices"):
         evaluate_camera_panel_tracklet_support(
             {"camera-a": panel_tracklets((0,), window_id="view-a")},
+            declared_view_ids=("camera-a",),
             panel_id="panel",
             required_frame_indices=(1, 0),
             policy=CameraPanelSupportPolicyV1(

--- a/tests/test_spatial_tracklets.py
+++ b/tests/test_spatial_tracklets.py
@@ -228,13 +228,12 @@ def test_spatial_factor_conversion_preserves_cell_groups_and_point_ids() -> None
     assert all(factor.composite_weight == 0.5 for factor in spatial)
 
 
-def test_camera_panel_support_requires_cross_view_spatial_corroboration() -> None:
+def test_camera_panel_support_requires_multiple_spatially_supported_views() -> None:
     first = panel_tracklets((0, 1, 2), window_id="view-a")
-    second = panel_tracklets((0, 1, 3), window_id="view-b")
+    second = panel_tracklets((2, 3), window_id="view-b")
     policy = CameraPanelSupportPolicyV1(
         minimum_view_count=2,
-        minimum_seed_cell_count=2,
-        minimum_views_per_cell=2,
+        minimum_seed_cell_count_per_view=2,
         minimum_supported_frame_fraction=1.0,
         require_all_declared_views=True,
     )
@@ -249,7 +248,14 @@ def test_camera_panel_support_requires_cross_view_spatial_corroboration() -> Non
 
     assert report.support_feasible
     assert report.supported_frame_count == 2
-    assert report.frame_results[0].corroborated_seed_cell_ids == (0, 1)
+    assert report.frame_results[0].spatially_supported_view_ids == (
+        "camera-a",
+        "camera-b",
+    )
+    assert dict(report.frame_results[0].seed_cell_counts_by_view) == {
+        "camera-a": 3,
+        "camera-b": 2,
+    }
     assert len(report.camera_panel_support_id or "") == 64
     replay = evaluate_camera_panel_tracklet_support(
         {"camera-b": second, "camera-a": first},
@@ -271,7 +277,7 @@ def test_camera_panel_support_requires_cross_view_spatial_corroboration() -> Non
     )
     assert not support_negative.support_feasible
     assert support_negative.frame_results[0].reason_codes == (
-        "insufficient-spatial-seed-cells",
+        "insufficient-spatially-supported-views",
     )
 
 
@@ -297,6 +303,6 @@ def test_spatial_contracts_reject_coercive_aliases() -> None:
             required_frame_indices=(1, 0),
             policy=CameraPanelSupportPolicyV1(
                 minimum_view_count=1,
-                minimum_seed_cell_count=1,
+                minimum_seed_cell_count_per_view=1,
             ),
         )

--- a/tests/test_spatial_tracklets.py
+++ b/tests/test_spatial_tracklets.py
@@ -1,0 +1,302 @@
+import numpy as np
+import pytest
+
+from prob4d.camera_panel_support import (
+    CameraPanelSupportPolicyV1,
+    evaluate_camera_panel_tracklet_support,
+)
+from prob4d.causal_tracklets import CausalTrackletSet
+from prob4d.data import PredictionWindow
+from prob4d.spatial_tracklets import (
+    build_spatially_stratified_scene_flow_tracklets,
+    seed_cell_ids_by_track,
+    select_spatial_tracklet_seeds,
+    spatial_tracklets_to_observation_factors,
+)
+from prob4d.uncertainty import StructuredCovariance
+
+
+def moving_window(*, frames: int = 4, height: int = 4, width: int = 8) -> PredictionWindow:
+    point_map = np.zeros((frames, height, width, 3), dtype=np.float64)
+    rows, columns = np.meshgrid(
+        np.arange(height),
+        np.arange(width),
+        indexing="ij",
+    )
+    for frame in range(frames):
+        point_map[frame, ..., 0] = columns - frame
+        point_map[frame, ..., 1] = rows
+        point_map[frame, ..., 2] = 1.0
+    valid = np.ones((frames, height, width), dtype=bool)
+    return PredictionWindow(
+        window_id="window",
+        frame_indices=np.arange(frames),
+        point_map=point_map,
+        valid_mask=valid,
+        scene_flow=np.zeros_like(point_map),
+        deform_mask=np.ones_like(valid),
+    )
+
+
+def panel_tracklets(cell_ids: tuple[int, ...], *, window_id: str) -> CausalTrackletSet:
+    track_count = len(cell_ids)
+    track_ids = np.repeat(np.arange(track_count, dtype=np.int64), 2)
+    frame_indices = np.tile(np.array([0, 1], dtype=np.int64), track_count)
+    local_indices = frame_indices.copy()
+    rows = np.repeat(np.arange(track_count, dtype=np.int64), 2)
+    columns = np.zeros(track_count * 2, dtype=np.int64)
+    points = np.zeros((track_count * 2, 3), dtype=np.float64)
+    points[:, 2] = 1.0
+    return CausalTrackletSet(
+        window_id=window_id,
+        causal_frame_stop=2,
+        source_shape=(2, max(track_count, 1), 1),
+        seed_frame_index=0,
+        track_ids=track_ids,
+        frame_indices=frame_indices,
+        local_frame_indices=local_indices,
+        rows=rows,
+        columns=columns,
+        points_local=points,
+        link_probability=np.ones(track_count * 2),
+        association_probability=np.ones(track_count * 2),
+        metadata={
+            "seed_cell_grid_shape": [2, 2],
+            "seed_cell_ids_by_track": list(cell_ids),
+        },
+    )
+
+
+def test_spatial_selection_represents_every_occupied_cell() -> None:
+    mask = np.zeros((8, 8), dtype=bool)
+    mask[0, 0] = True
+    mask[1, 6] = True
+    mask[6, 1] = True
+    mask[6, 6] = True
+
+    regular = select_spatial_tracklet_seeds(
+        mask,
+        seed_stride=4,
+        seed_selection_policy="regular-grid",
+        cell_grid_rows=2,
+        cell_grid_columns=2,
+    )
+    stratified = select_spatial_tracklet_seeds(
+        mask,
+        seed_stride=4,
+        seed_selection_policy="spatial-stratified",
+        cell_grid_rows=2,
+        cell_grid_columns=2,
+        maximum_seeds_per_cell=1,
+    )
+
+    assert regular.seed_count == 1
+    assert regular.selected_cell_count == 1
+    assert stratified.seed_count == 4
+    assert stratified.selected_cell_count == 4
+    assert stratified.occupied_cell_count == 4
+    np.testing.assert_array_equal(stratified.cell_occupancy, [1, 1, 1, 1])
+
+
+def test_spatial_selection_is_deterministic_and_caps_each_cell() -> None:
+    mask = np.ones((8, 8), dtype=bool)
+    first = select_spatial_tracklet_seeds(
+        mask,
+        seed_stride=2,
+        cell_grid_rows=2,
+        cell_grid_columns=2,
+        maximum_seeds_per_cell=2,
+    )
+    second = select_spatial_tracklet_seeds(
+        mask.copy(),
+        seed_stride=2,
+        cell_grid_rows=2,
+        cell_grid_columns=2,
+        maximum_seeds_per_cell=2,
+    )
+
+    np.testing.assert_array_equal(first.rows, second.rows)
+    np.testing.assert_array_equal(first.columns, second.columns)
+    np.testing.assert_array_equal(first.cell_ids, second.cell_ids)
+    assert first.seed_count == 8
+    np.testing.assert_array_equal(first.cell_occupancy, [2, 2, 2, 2])
+    assert not first.rows.flags.writeable
+
+
+def test_spatial_tracklets_retain_cell_lineage_and_causal_cutoff() -> None:
+    original = moving_window(frames=5)
+    changed_points = original.point_map.copy()
+    changed_valid = original.valid_mask.copy()
+    changed_flow = original.scene_flow.copy()
+    changed_deform = original.deform_mask.copy()
+    changed_points[3:] += 1000.0
+    changed_valid[3:] = False
+    changed_flow[3:] = 1000.0
+    changed_deform[3:] = False
+    changed = PredictionWindow(
+        window_id=original.window_id,
+        frame_indices=original.frame_indices,
+        point_map=changed_points,
+        valid_mask=changed_valid,
+        scene_flow=changed_flow,
+        deform_mask=changed_deform,
+    )
+    settings = {
+        "causal_frame_stop": 3,
+        "seed_stride": 2,
+        "cell_grid_rows": 2,
+        "cell_grid_columns": 4,
+        "maximum_seeds_per_cell": 1,
+        "search_radius_pixels": 1,
+        "maximum_step_error_local": 0.2,
+        "association_sigma_local": 0.1,
+        "minimum_link_probability": 0.01,
+        "minimum_track_length": 2,
+    }
+
+    first, first_report = build_spatially_stratified_scene_flow_tracklets(
+        original,
+        **settings,
+    )
+    second, second_report = build_spatially_stratified_scene_flow_tracklets(
+        changed,
+        **settings,
+    )
+
+    for name in (
+        "track_ids",
+        "frame_indices",
+        "local_frame_indices",
+        "rows",
+        "columns",
+        "points_local",
+        "link_probability",
+        "association_probability",
+    ):
+        np.testing.assert_array_equal(getattr(first, name), getattr(second, name))
+    np.testing.assert_array_equal(
+        seed_cell_ids_by_track(first),
+        seed_cell_ids_by_track(second),
+    )
+    assert first_report.to_dict() == second_report.to_dict()
+    assert first_report.seed_selection.selected_cell_count == 8
+    assert first_report.retained_seed_cell_count >= 4
+    assert first.metadata["seed_selection_policy"] == "spatial-stratified"
+
+
+def test_spatial_factor_conversion_preserves_cell_groups_and_point_ids() -> None:
+    window = moving_window(frames=2, height=2, width=6)
+    tracklets, _ = build_spatially_stratified_scene_flow_tracklets(
+        window,
+        causal_frame_stop=2,
+        seed_stride=2,
+        cell_grid_rows=1,
+        cell_grid_columns=2,
+        maximum_seeds_per_cell=1,
+        search_radius_pixels=1,
+        maximum_step_error_local=0.2,
+        association_sigma_local=0.1,
+        minimum_link_probability=0.01,
+        minimum_track_length=2,
+    )
+    rays = np.zeros_like(window.point_map)
+    rays[..., 2] = 1.0
+    covariance = StructuredCovariance(
+        ray_directions=rays,
+        parallel_variance=np.full(window.shape, 0.04),
+        lateral_variance=np.full(window.shape, 0.01),
+    )
+
+    spatial = spatial_tracklets_to_observation_factors(
+        tracklets,
+        covariance,
+        view_id="camera-0",
+        effective_samples_per_group=0.5,
+    )
+    framewise = spatial_tracklets_to_observation_factors(
+        tracklets,
+        covariance,
+        view_id="camera-0",
+        correlation_group_mode="frame",
+        effective_samples_per_group=0.5,
+    )
+
+    assert len(spatial) == 4
+    assert len(framewise) == 2
+    assert all("seed-cell" in factor.correlation_group_id for factor in spatial)
+    assert {factor.point_ids[0] for factor in spatial[:2]} == {0, 1}
+    assert all(factor.composite_weight == 0.5 for factor in spatial)
+
+
+def test_camera_panel_support_requires_cross_view_spatial_corroboration() -> None:
+    first = panel_tracklets((0, 1, 2), window_id="view-a")
+    second = panel_tracklets((0, 1, 3), window_id="view-b")
+    policy = CameraPanelSupportPolicyV1(
+        minimum_view_count=2,
+        minimum_seed_cell_count=2,
+        minimum_views_per_cell=2,
+        minimum_supported_frame_fraction=1.0,
+        require_all_declared_views=True,
+    )
+
+    report = evaluate_camera_panel_tracklet_support(
+        {"camera-a": first, "camera-b": second},
+        panel_id="panel",
+        required_frame_indices=(0, 1),
+        policy=policy,
+        metadata={"source_only": True},
+    )
+
+    assert report.support_feasible
+    assert report.supported_frame_count == 2
+    assert report.frame_results[0].corroborated_seed_cell_ids == (0, 1)
+    assert len(report.camera_panel_support_id or "") == 64
+    replay = evaluate_camera_panel_tracklet_support(
+        {"camera-b": second, "camera-a": first},
+        panel_id="panel",
+        required_frame_indices=(0, 1),
+        policy=policy,
+        metadata={"source_only": True},
+    )
+    assert replay.camera_panel_support_id == report.camera_panel_support_id
+
+    support_negative = evaluate_camera_panel_tracklet_support(
+        {
+            "camera-a": first,
+            "camera-b": panel_tracklets((0,), window_id="view-b-limited"),
+        },
+        panel_id="panel-limited",
+        required_frame_indices=(0, 1),
+        policy=policy,
+    )
+    assert not support_negative.support_feasible
+    assert support_negative.frame_results[0].reason_codes == (
+        "insufficient-spatial-seed-cells",
+    )
+
+
+def test_spatial_contracts_reject_coercive_aliases() -> None:
+    with pytest.raises(ValueError, match="seed_mask"):
+        select_spatial_tracklet_seeds(np.ones((2, 2), dtype=np.int64))
+    with pytest.raises(ValueError, match="seed_stride"):
+        select_spatial_tracklet_seeds(
+            np.ones((2, 2), dtype=bool),
+            seed_stride=True,
+        )
+    with pytest.raises(ValueError, match="seed_selection_policy"):
+        select_spatial_tracklet_seeds(
+            np.ones((2, 2), dtype=bool),
+            seed_selection_policy="adaptive",  # type: ignore[arg-type]
+        )
+    with pytest.raises(ValueError, match="minimum_view_count"):
+        CameraPanelSupportPolicyV1(minimum_view_count=True)
+    with pytest.raises(ValueError, match="required_frame_indices"):
+        evaluate_camera_panel_tracklet_support(
+            {"camera-a": panel_tracklets((0,), window_id="view-a")},
+            panel_id="panel",
+            required_frame_indices=(1, 0),
+            policy=CameraPanelSupportPolicyV1(
+                minimum_view_count=1,
+                minimum_seed_cell_count=1,
+            ),
+        )

--- a/tests/test_spatial_tracklets.py
+++ b/tests/test_spatial_tracklets.py
@@ -1,7 +1,10 @@
+from dataclasses import replace
+
 import numpy as np
 import pytest
 
 from prob4d.camera_panel_support import (
+    CameraPanelFrameSupportV1,
     CameraPanelSupportPolicyV1,
     evaluate_camera_panel_tracklet_support,
 )
@@ -298,6 +301,21 @@ def test_camera_panel_support_requires_multiple_spatially_supported_views() -> N
     assert support_negative.frame_results[0].reason_codes == (
         "insufficient-spatially-supported-views",
     )
+
+    forged = CameraPanelFrameSupportV1(
+        frame_index=0,
+        contributing_view_ids=("camera-a",),
+        spatially_supported_view_ids=("camera-a",),
+        seed_cell_counts_by_view={"camera-a": 3},
+        supported=True,
+        reason_codes=(),
+    )
+    with pytest.raises(ValueError, match="contradicts the frozen panel policy"):
+        replace(
+            report,
+            frame_results=(forged, report.frame_results[1]),
+            camera_panel_support_id=None,
+        )
 
 
 def test_camera_panel_support_cannot_drop_a_declared_view() -> None:


### PR DESCRIPTION
## What changed

- Add deterministic spatially stratified seed selection over the first retained causal-prefix frame.
- Build ordinary causal scene-flow tracklets from those seeds while preserving each retained track's source image-cell lineage.
- Convert retained tracklets into frame/seed-cell correlation groups without increasing the historical frame-level generalized-Bayes likelihood budget.
- Add a source-only camera-panel support audit over an explicit frozen camera roster, required frame set, per-view spatial-support threshold, and panel admission policy.
- Bind the complete declared camera roster into the report identity; missing declared cameras contribute zero support and undeclared cameras are rejected.
- Recompute supported-camera IDs and frame reason codes from retained cell counts plus the frozen policy when constructing the report, so serialized or manually constructed results cannot forge support decisions.
- Add adversarial coverage for zero-cell contributors, count/threshold inconsistencies, policy inconsistencies, camera omission, undeclared cameras, future-frame mutation, deterministic seed selection, likelihood-budget parity, and content identities.
- Document source-only protocol use and the boundary between spatial support, provider competence, and downstream BayesianPhysTwin benefit.

## Why

The previous provider investigations exposed a specific source-side failure mode: a stream can retain many points while those points are concentrated in too few image regions or cameras. Total point count therefore does not establish useful physical support.

This change provides an opt-in, target-free way to require distributed causal-prefix support before covariance fitting or held-out promotion. It does not modify the historical regular-grid tracklet builder or any frozen real-data result.

## Review corrections

Two fail-open issues found during review were fixed before publication:

1. **Likelihood-power amplification:** the initial cell grouping assigned a full effective-sample budget to every seed cell. The final implementation gives all cell factors in a frame the same provider-final per-row weight `min(1, effective_samples_per_frame / retained_rows_in_frame)`, preserving total frame-weighted row mass relative to the historical frame group. The claim-bearing BayesianPhysTwin adapters consume this as provider-final weight rather than applying a second consumer cap.
2. **Camera-roster omission:** the initial panel audit inferred its roster from supplied mapping keys. The final API requires sorted, unique `declared_view_ids`; absent declared cameras remain visible as zero support, and the content identity includes the complete roster.

The report also derives spatially supported views from stored cell counts and recomputes policy reasons, closing a forged-artifact path.

## Compatibility

- Existing causal-tracklet APIs and results are unchanged.
- The new spatial builder and panel audit are additive and opt-in.
- Existing point IDs, gauge IDs, causal frame limits, covariance inputs, and exact fallback contracts are preserved.
- Image-cell IDs remain view-local; matching numeric cell IDs across cameras are not treated as the same physical region.
- No provider residual, metric truth, target outcome, or BayesianPhysTwin result enters seed or support selection.

## Final validation

Exact reviewed head: `98fb2d12cb2000591300b97c72470b8d134b55cd`.

All authoritative pull-request workflows passed:

- fail-closed quality: run `31332722076`;
- security scanning: run `31332722073`; and
- complete tests, Python 3.10–3.14, declared runtime floor, distributions, and isolated wheel/sdist smoke tests: run `31332722095`.

## Scientific boundary

A passing spatial or camera-panel support result establishes only distributed support under the exact frozen causal-prefix policy. It does not establish calibrated uncertainty, provider competence, physical-state identifiability, BayesianPhysTwin benefit, Causal4D intervention benefit, deployment safety, or state of the art.