### PR TITLE
Add prospective provider support design selection

### DIFF
--- a/docs/provider_support_design.md
+++ b/docs/provider_support_design.md
@@ -1,0 +1,131 @@
+# Outcome-blind provider support design
+
+`prob4d.provider_support_design` selects one support configuration from a finite
+candidate set frozen before prediction payloads, provider residuals, or target
+outcomes are opened.
+
+The design step belongs before
+[`ProviderSupportFeasibilityV1`](provider_support_feasibility.md). It prevents a
+provider configuration from being chosen after an expensive residual or target
+run has revealed which camera roster, causal prefix, or geometry route performs
+well. A selected design remains only support infrastructure; it is not evidence
+that the provider is accurate, calibrated, beneficial to BayesianPhysTwin or
+Causal4D, or safe to deploy.
+
+## Candidate boundary
+
+Each candidate embeds one complete, content-addressed
+`ProviderSupportFeasibilityRequestV1`. Candidates must share:
+
+- source, provider, model-set, loader, cohort, and promotion-lock identities;
+- coordinate semantics, admission rule, and technical-exclusion policy;
+- the exact group/stream roster; and
+- each stream's geometry-support threshold and requirements for intrinsics,
+  extrinsics, and metric anchors.
+
+Candidates may differ in their frozen causal interval, required and available
+frames, geometry-supported frames, calibration or anchor identities, technical
+support observations, and descriptive metadata. The complete finite set is
+content-addressed before selection.
+
+A design request explicitly records that prediction payloads were not opened
+and neither provider residuals nor target outcomes were used. The embedded
+feasibility requests enforce the same information boundary independently.
+
+## Deterministic selection
+
+A support-feasible candidate always outranks a support-negative candidate. Within
+the same feasibility class, candidates are ordered by:
+
+1. maximum minimum support fraction over complete frozen groups;
+2. maximum number of groups with at least one supported stream;
+3. maximum number of required camera/frame cells in fully supported streams;
+4. maximum number of geometry-supported required camera/frame cells;
+5. maximum supported-stream count;
+6. minimum maximum causal-prefix span;
+7. minimum total causal-prefix span; and
+8. lexicographically smallest frozen candidate ID.
+
+The result retains every candidate's complete replayed support-feasibility result
+and ranking statistics. Loading the artifact recomputes the entire selection and
+rejects any mismatch.
+
+## Python API
+
+```python
+from pathlib import Path
+
+from prob4d.provider_support_design import (
+    ProviderSupportDesignCandidateV1,
+    ProviderSupportDesignRequestV1,
+    evaluate_provider_support_design,
+    write_provider_support_design,
+    write_provider_support_design_request,
+    write_selected_provider_support_feasibility,
+    write_selected_provider_support_request,
+)
+
+candidate = ProviderSupportDesignCandidateV1(
+    candidate_id="prefix-0-8",
+    feasibility_request=frozen_support_request,
+    metadata={"window_geometry": "25-frame-overlap-8"},
+)
+request = ProviderSupportDesignRequestV1(
+    protocol_id="fresh-provider-support-design-v1",
+    candidates=(candidate,),
+    prediction_payloads_opened=False,
+    residuals_used=False,
+    target_outcomes_used=False,
+)
+
+write_provider_support_design_request(
+    Path("provider-support-design-request.json"),
+    request,
+)
+result = evaluate_provider_support_design(request)
+write_selected_provider_support_request(
+    Path("selected-provider-support-request.json"),
+    result,
+)
+write_selected_provider_support_feasibility(
+    Path("selected-provider-support-result.json"),
+    result,
+)
+write_provider_support_design(
+    Path("provider-support-design-result.json"),
+    result,
+)
+```
+
+The selected request and feasibility result use the unchanged existing schemas.
+They can therefore enter `ProviderPromotionAuthorizationV2` without rewriting
+that authorization or any historical support artifact.
+
+## Command-line selection and replay
+
+The module is executable directly and does not add a legacy console-script alias:
+
+```bash
+python -m prob4d.provider_support_design select \
+  --request provider-support-design-request.json \
+  --output provider-support-design-result.json \
+  --selected-request-output selected-provider-support-request.json \
+  --selected-feasibility-output selected-provider-support-result.json
+
+python -m prob4d.provider_support_design verify \
+  --artifact provider-support-design-result.json
+```
+
+Both commands print a deterministic summary. Exit status `0` means the selected
+candidate is support-feasible. Exit status `2` is a valid result in which every
+frozen candidate is support-negative; the best negative remains selected and
+fully reported. Malformed or tampered artifacts raise validation errors instead
+of being relabelled as support-negative.
+
+## Scientific boundary
+
+This contract does not rescue the completed Deform360 source-support negative or
+permit post-outcome camera deletion, prefix changes, threshold relaxation, or
+partial-stream fitting. A later route must be a separately versioned prospective
+provider experiment whose complete design candidate set is frozen before later
+information is opened.

--- a/src/prob4d/provider_support_design.py
+++ b/src/prob4d/provider_support_design.py
@@ -1,0 +1,710 @@
+"""Outcome-blind selection among frozen provider-support designs.
+
+A design request contains a finite candidate set of complete
+:class:`~prob4d.provider_support_feasibility.ProviderSupportFeasibilityRequestV1`
+objects. Selection uses only causal-prefix support metadata. Prediction payloads,
+provider residuals, and target outcomes remain closed.
+
+The selected request and result retain their existing version-1 schemas, so
+current promotion authorization consumes them without a compatibility change.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from fractions import Fraction
+from pathlib import Path
+from typing import Any
+
+from ._heldout_promotion_common import _atomic_write_json, _load_json
+from ._immutable_json import frozen_finite_json_mapping, plain_json
+from ._selection_evidence_common import (
+    _SHA256,
+    _exact_keys,
+    _sha256_json,
+    _strict_bool,
+    _strict_digest,
+    _strict_list,
+    _strict_mapping,
+    _strict_string,
+)
+from .provider_support_feasibility import (
+    ProviderSupportFeasibilityRequestV1,
+    ProviderSupportFeasibilityV1,
+    ProviderSupportStreamV1,
+    evaluate_provider_support_feasibility,
+    write_provider_support_feasibility,
+    write_provider_support_feasibility_request,
+)
+
+PROVIDER_SUPPORT_DESIGN_REQUEST_SCHEMA = "prob4d.provider-support-design-request"
+PROVIDER_SUPPORT_DESIGN_REQUEST_VERSION = 1
+PROVIDER_SUPPORT_DESIGN_SCHEMA = "prob4d.provider-support-design"
+PROVIDER_SUPPORT_DESIGN_VERSION = 1
+PROVIDER_SUPPORT_DESIGN_SELECTION_RULE = (
+    "support-feasible-then-maximin-group-support-then-supported-frame-cells-"
+    "then-shortest-causal-span-v1"
+)
+PROVIDER_SUPPORT_DESIGN_CLAIM_BOUNDARY = (
+    "This artifact selects one exact provider-support configuration from a finite "
+    "candidate set frozen before prediction payloads, provider residuals, or target "
+    "outcomes are opened. Selection uses only causal-prefix metadata, geometry, "
+    "camera-calibration, metric-anchor, and predeclared technical-support evidence. "
+    "A selected support-feasible design does not establish provider competence, "
+    "calibrated uncertainty, BayesianPhysTwin benefit, Causal4D benefit, deployment "
+    "safety, or state of the art."
+)
+
+_CANDIDATE_FIELDS = {"candidate_id", "feasibility_request", "metadata"}
+_REQUEST_FIELDS = {
+    "schema_name",
+    "schema_version",
+    "protocol_id",
+    "selection_rule",
+    "prediction_payloads_opened",
+    "residuals_used",
+    "target_outcomes_used",
+    "candidates",
+    "metadata",
+    "claim_boundary",
+    "request_id",
+}
+_RESULT_FIELDS = {
+    "schema_name",
+    "schema_version",
+    "request",
+    "candidate_evaluations",
+    "feasible_candidate_count",
+    "selected_candidate_id",
+    "selected_support_request_id",
+    "selected_support_feasibility_id",
+    "support_design_feasible",
+    "decision_reason",
+    "claim_boundary",
+    "provider_support_design_id",
+}
+_COMMON_REQUEST_FIELDS = (
+    "source_repository",
+    "source_revision",
+    "provider_family",
+    "provider_repository",
+    "provider_revision",
+    "model_set_id",
+    "loader_id",
+    "cohort_binding_id",
+    "promotion_lock_id",
+    "coordinate_semantics",
+    "admission_rule",
+    "minimum_supported_fraction",
+    "permitted_technical_exclusion_codes",
+    "maximum_technical_exclusions",
+)
+
+
+def _strict_false(value: object, *, name: str) -> bool:
+    result = _strict_bool(value, name=name)
+    if result:
+        raise ValueError(f"{name} must be false for provider support design")
+    return result
+
+
+def _request_signature(
+    request: ProviderSupportFeasibilityRequestV1,
+) -> tuple[object, ...]:
+    return tuple(getattr(request, name) for name in _COMMON_REQUEST_FIELDS)
+
+
+def _stream_requirement_signature(stream: ProviderSupportStreamV1) -> tuple[object, ...]:
+    return (
+        stream.key,
+        stream.minimum_geometry_support_fraction,
+        stream.intrinsics_required,
+        stream.extrinsics_required,
+        stream.metric_anchor_required,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderSupportDesignCandidateV1:
+    """One prospectively frozen provider-support configuration."""
+
+    candidate_id: str
+    feasibility_request: ProviderSupportFeasibilityRequestV1
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "candidate_id",
+            _strict_string(self.candidate_id, name="candidate_id"),
+        )
+        if not isinstance(
+            self.feasibility_request,
+            ProviderSupportFeasibilityRequestV1,
+        ):
+            raise TypeError(
+                "feasibility_request must be ProviderSupportFeasibilityRequestV1"
+            )
+        object.__setattr__(
+            self,
+            "metadata",
+            frozen_finite_json_mapping(
+                self.metadata,
+                name="provider support design candidate metadata",
+            ),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "candidate_id": self.candidate_id,
+            "feasibility_request": self.feasibility_request.to_dict(),
+            "metadata": plain_json(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> ProviderSupportDesignCandidateV1:
+        mapping = _strict_mapping(value, name="provider support design candidate")
+        _exact_keys(
+            mapping,
+            _CANDIDATE_FIELDS,
+            name="provider support design candidate",
+        )
+        return cls(
+            candidate_id=mapping["candidate_id"],
+            feasibility_request=ProviderSupportFeasibilityRequestV1.from_dict(
+                mapping["feasibility_request"]
+            ),
+            metadata=_strict_mapping(mapping["metadata"], name="metadata"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderSupportDesignRequestV1:
+    """Finite, outcome-blind candidate set and deterministic selection rule."""
+
+    protocol_id: str
+    candidates: tuple[ProviderSupportDesignCandidateV1, ...]
+    prediction_payloads_opened: bool = False
+    residuals_used: bool = False
+    target_outcomes_used: bool = False
+    selection_rule: str = PROVIDER_SUPPORT_DESIGN_SELECTION_RULE
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "protocol_id",
+            _strict_string(self.protocol_id, name="protocol_id"),
+        )
+        rule = _strict_string(self.selection_rule, name="selection_rule")
+        if rule != PROVIDER_SUPPORT_DESIGN_SELECTION_RULE:
+            raise ValueError("unsupported provider support design selection rule")
+        object.__setattr__(self, "selection_rule", rule)
+        for name in (
+            "prediction_payloads_opened",
+            "residuals_used",
+            "target_outcomes_used",
+        ):
+            object.__setattr__(self, name, _strict_false(getattr(self, name), name=name))
+        if type(self.candidates) is not tuple or not self.candidates:
+            raise ValueError(
+                "candidates must be a nonempty tuple of "
+                "ProviderSupportDesignCandidateV1"
+            )
+        if not all(
+            isinstance(candidate, ProviderSupportDesignCandidateV1)
+            for candidate in self.candidates
+        ):
+            raise ValueError(
+                "candidates must contain only ProviderSupportDesignCandidateV1"
+            )
+        candidates = tuple(
+            sorted(self.candidates, key=lambda candidate: candidate.candidate_id)
+        )
+        candidate_ids = tuple(candidate.candidate_id for candidate in candidates)
+        if len(candidate_ids) != len(set(candidate_ids)):
+            raise ValueError("candidate_id values must be unique")
+        request_ids = tuple(
+            candidate.feasibility_request.request_id for candidate in candidates
+        )
+        if len(request_ids) != len(set(request_ids)):
+            raise ValueError("candidate feasibility requests must be unique")
+        first = candidates[0].feasibility_request
+        signature = _request_signature(first)
+        roster = tuple(stream.key for stream in first.streams)
+        requirements = tuple(
+            _stream_requirement_signature(stream) for stream in first.streams
+        )
+        for candidate in candidates[1:]:
+            request = candidate.feasibility_request
+            if _request_signature(request) != signature:
+                raise ValueError(
+                    "candidate feasibility requests must share provider, cohort, "
+                    "promotion-lock, admission, and exclusion identities"
+                )
+            if tuple(stream.key for stream in request.streams) != roster:
+                raise ValueError(
+                    "candidate feasibility requests must share the exact stream roster"
+                )
+            if tuple(
+                _stream_requirement_signature(stream) for stream in request.streams
+            ) != requirements:
+                raise ValueError(
+                    "candidate feasibility requests must not change support thresholds "
+                    "or required calibration classes"
+                )
+        object.__setattr__(self, "candidates", candidates)
+        object.__setattr__(
+            self,
+            "metadata",
+            frozen_finite_json_mapping(
+                self.metadata,
+                name="provider support design request metadata",
+            ),
+        )
+
+    def _identity_dict(self) -> dict[str, object]:
+        return {
+            "schema_name": PROVIDER_SUPPORT_DESIGN_REQUEST_SCHEMA,
+            "schema_version": PROVIDER_SUPPORT_DESIGN_REQUEST_VERSION,
+            "protocol_id": self.protocol_id,
+            "selection_rule": self.selection_rule,
+            "prediction_payloads_opened": self.prediction_payloads_opened,
+            "residuals_used": self.residuals_used,
+            "target_outcomes_used": self.target_outcomes_used,
+            "candidates": [candidate.to_dict() for candidate in self.candidates],
+            "metadata": plain_json(self.metadata),
+            "claim_boundary": PROVIDER_SUPPORT_DESIGN_CLAIM_BOUNDARY,
+        }
+
+    @property
+    def request_id(self) -> str:
+        return _sha256_json(self._identity_dict())
+
+    def to_dict(self) -> dict[str, object]:
+        return {**self._identity_dict(), "request_id": self.request_id}
+
+    @classmethod
+    def from_dict(cls, value: object) -> ProviderSupportDesignRequestV1:
+        mapping = _strict_mapping(value, name="provider support design request")
+        _exact_keys(mapping, _REQUEST_FIELDS, name="provider support design request")
+        if mapping["schema_name"] != PROVIDER_SUPPORT_DESIGN_REQUEST_SCHEMA:
+            raise ValueError("unsupported provider support design request schema")
+        if mapping["schema_version"] != PROVIDER_SUPPORT_DESIGN_REQUEST_VERSION:
+            raise ValueError("unsupported provider support design request version")
+        if mapping["claim_boundary"] != PROVIDER_SUPPORT_DESIGN_CLAIM_BOUNDARY:
+            raise ValueError("provider support design claim boundary changed")
+        request = cls(
+            protocol_id=mapping["protocol_id"],
+            candidates=tuple(
+                ProviderSupportDesignCandidateV1.from_dict(candidate)
+                for candidate in _strict_list(mapping["candidates"], name="candidates")
+            ),
+            prediction_payloads_opened=mapping["prediction_payloads_opened"],
+            residuals_used=mapping["residuals_used"],
+            target_outcomes_used=mapping["target_outcomes_used"],
+            selection_rule=mapping["selection_rule"],
+            metadata=_strict_mapping(mapping["metadata"], name="metadata"),
+        )
+        identifier = _strict_digest(
+            mapping["request_id"],
+            name="request_id",
+            pattern=_SHA256,
+        )
+        if identifier != request.request_id:
+            raise ValueError("provider support design request identity mismatch")
+        return request
+
+
+@dataclass(frozen=True, slots=True)
+class _CandidateEvaluation:
+    candidate_id: str
+    support_feasibility: ProviderSupportFeasibilityV1
+    group_count: int
+    supported_group_count: int
+    minimum_group_support_fraction: float
+    supported_required_frame_count: int
+    geometry_supported_required_frame_count: int
+    required_frame_count: int
+    maximum_causal_span_frames: int
+    total_causal_span_frames: int
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "candidate_id": self.candidate_id,
+            "support_feasibility": self.support_feasibility.to_dict(),
+            "group_count": self.group_count,
+            "supported_group_count": self.supported_group_count,
+            "minimum_group_support_fraction": self.minimum_group_support_fraction,
+            "supported_required_frame_count": self.supported_required_frame_count,
+            "geometry_supported_required_frame_count": (
+                self.geometry_supported_required_frame_count
+            ),
+            "required_frame_count": self.required_frame_count,
+            "maximum_causal_span_frames": self.maximum_causal_span_frames,
+            "total_causal_span_frames": self.total_causal_span_frames,
+        }
+
+
+def _group_counts(
+    result: ProviderSupportFeasibilityV1,
+) -> tuple[tuple[str, int, int], ...]:
+    counts: dict[str, list[int]] = {}
+    for stream in result.stream_results:
+        values = counts.setdefault(stream.group_id, [0, 0])
+        if not stream.excluded_from_admission:
+            values[1] += 1
+            if stream.supported:
+                values[0] += 1
+    return tuple(
+        (group_id, values[0], values[1])
+        for group_id, values in sorted(counts.items())
+    )
+
+
+def _evaluate_candidate(candidate: ProviderSupportDesignCandidateV1) -> _CandidateEvaluation:
+    result = evaluate_provider_support_feasibility(candidate.feasibility_request)
+    groups = _group_counts(result)
+    fractions = tuple(
+        Fraction(supported, evaluable) if evaluable else Fraction(0, 1)
+        for _, supported, evaluable in groups
+    )
+    spans = tuple(
+        stream.causal_frame_stop_exclusive - stream.causal_frame_start
+        for stream in result.request.streams
+    )
+    return _CandidateEvaluation(
+        candidate_id=candidate.candidate_id,
+        support_feasibility=result,
+        group_count=len(groups),
+        supported_group_count=sum(supported > 0 for _, supported, _ in groups),
+        minimum_group_support_fraction=float(min(fractions)),
+        supported_required_frame_count=sum(
+            item.required_frame_count for item in result.stream_results if item.supported
+        ),
+        geometry_supported_required_frame_count=sum(
+            item.geometry_supported_required_frame_count
+            for item in result.stream_results
+            if not item.excluded_from_admission
+        ),
+        required_frame_count=sum(
+            item.required_frame_count
+            for item in result.stream_results
+            if not item.excluded_from_admission
+        ),
+        maximum_causal_span_frames=max(spans),
+        total_causal_span_frames=sum(spans),
+    )
+
+
+def _selection_key(
+    evaluation: _CandidateEvaluation,
+) -> tuple[bool, float, int, int, int, int, int, int, str]:
+    return (
+        not evaluation.support_feasibility.support_feasible,
+        -evaluation.minimum_group_support_fraction,
+        -evaluation.supported_group_count,
+        -evaluation.supported_required_frame_count,
+        -evaluation.geometry_supported_required_frame_count,
+        -evaluation.support_feasibility.supported_stream_count,
+        evaluation.maximum_causal_span_frames,
+        evaluation.total_causal_span_frames,
+        evaluation.candidate_id,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderSupportDesignV1:
+    """Replayable selection from one exact frozen support-design request."""
+
+    request: ProviderSupportDesignRequestV1
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.request, ProviderSupportDesignRequestV1):
+            raise TypeError("request must be ProviderSupportDesignRequestV1")
+
+    @property
+    def candidate_evaluations(self) -> tuple[_CandidateEvaluation, ...]:
+        return tuple(_evaluate_candidate(candidate) for candidate in self.request.candidates)
+
+    @property
+    def selected_evaluation(self) -> _CandidateEvaluation:
+        return min(self.candidate_evaluations, key=_selection_key)
+
+    @property
+    def feasible_candidate_count(self) -> int:
+        return sum(
+            item.support_feasibility.support_feasible
+            for item in self.candidate_evaluations
+        )
+
+    @property
+    def selected_candidate_id(self) -> str:
+        return self.selected_evaluation.candidate_id
+
+    @property
+    def selected_support_request(self) -> ProviderSupportFeasibilityRequestV1:
+        return self.selected_evaluation.support_feasibility.request
+
+    @property
+    def selected_support_request_id(self) -> str:
+        return self.selected_support_request.request_id
+
+    @property
+    def selected_support_feasibility(self) -> ProviderSupportFeasibilityV1:
+        return self.selected_evaluation.support_feasibility
+
+    @property
+    def selected_support_feasibility_id(self) -> str:
+        return self.selected_support_feasibility.provider_support_feasibility_id
+
+    @property
+    def support_design_feasible(self) -> bool:
+        return self.selected_support_feasibility.support_feasible
+
+    @property
+    def decision_reason(self) -> str:
+        return (
+            "selected-support-feasible"
+            if self.support_design_feasible
+            else "no-support-feasible-candidate"
+        )
+
+    def _identity_dict(self) -> dict[str, object]:
+        return {
+            "schema_name": PROVIDER_SUPPORT_DESIGN_SCHEMA,
+            "schema_version": PROVIDER_SUPPORT_DESIGN_VERSION,
+            "request": self.request.to_dict(),
+            "candidate_evaluations": [
+                item.to_dict() for item in self.candidate_evaluations
+            ],
+            "feasible_candidate_count": self.feasible_candidate_count,
+            "selected_candidate_id": self.selected_candidate_id,
+            "selected_support_request_id": self.selected_support_request_id,
+            "selected_support_feasibility_id": self.selected_support_feasibility_id,
+            "support_design_feasible": self.support_design_feasible,
+            "decision_reason": self.decision_reason,
+            "claim_boundary": PROVIDER_SUPPORT_DESIGN_CLAIM_BOUNDARY,
+        }
+
+    @property
+    def provider_support_design_id(self) -> str:
+        return _sha256_json(self._identity_dict())
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            **self._identity_dict(),
+            "provider_support_design_id": self.provider_support_design_id,
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> ProviderSupportDesignV1:
+        mapping = _strict_mapping(value, name="provider support design")
+        _exact_keys(mapping, _RESULT_FIELDS, name="provider support design")
+        if mapping["schema_name"] != PROVIDER_SUPPORT_DESIGN_SCHEMA:
+            raise ValueError("unsupported provider support design schema")
+        if mapping["schema_version"] != PROVIDER_SUPPORT_DESIGN_VERSION:
+            raise ValueError("unsupported provider support design version")
+        if mapping["claim_boundary"] != PROVIDER_SUPPORT_DESIGN_CLAIM_BOUNDARY:
+            raise ValueError("provider support design claim boundary changed")
+        expected = cls(ProviderSupportDesignRequestV1.from_dict(mapping["request"]))
+        identifier = _strict_digest(
+            mapping["provider_support_design_id"],
+            name="provider_support_design_id",
+            pattern=_SHA256,
+        )
+        if identifier != expected.provider_support_design_id:
+            raise ValueError("provider support design identity mismatch")
+        if plain_json(mapping) != expected.to_dict():
+            raise ValueError("provider support design does not replay from its request")
+        return expected
+
+
+def evaluate_provider_support_design(
+    request: ProviderSupportDesignRequestV1,
+) -> ProviderSupportDesignV1:
+    """Select one exact candidate with the frozen outcome-blind ranking rule."""
+
+    if not isinstance(request, ProviderSupportDesignRequestV1):
+        raise TypeError("request must be ProviderSupportDesignRequestV1")
+    return ProviderSupportDesignV1(request)
+
+
+def write_provider_support_design_request(
+    path: Path,
+    request: ProviderSupportDesignRequestV1,
+    *,
+    overwrite: bool = False,
+) -> None:
+    if not isinstance(request, ProviderSupportDesignRequestV1):
+        raise TypeError("request must be ProviderSupportDesignRequestV1")
+    _atomic_write_json(path, request.to_dict(), overwrite=overwrite)
+
+
+def load_provider_support_design_request(path: Path) -> ProviderSupportDesignRequestV1:
+    value, _ = _load_json(path, name="provider support design request")
+    return ProviderSupportDesignRequestV1.from_dict(value)
+
+
+def write_provider_support_design(
+    path: Path,
+    result: ProviderSupportDesignV1,
+    *,
+    overwrite: bool = False,
+) -> None:
+    if not isinstance(result, ProviderSupportDesignV1):
+        raise TypeError("result must be ProviderSupportDesignV1")
+    _atomic_write_json(path, result.to_dict(), overwrite=overwrite)
+
+
+def load_provider_support_design(path: Path) -> ProviderSupportDesignV1:
+    value, _ = _load_json(path, name="provider support design")
+    return ProviderSupportDesignV1.from_dict(value)
+
+
+def write_selected_provider_support_request(
+    path: Path,
+    result: ProviderSupportDesignV1,
+    *,
+    overwrite: bool = False,
+) -> None:
+    if not isinstance(result, ProviderSupportDesignV1):
+        raise TypeError("result must be ProviderSupportDesignV1")
+    write_provider_support_feasibility_request(
+        path,
+        result.selected_support_request,
+        overwrite=overwrite,
+    )
+
+
+def write_selected_provider_support_feasibility(
+    path: Path,
+    result: ProviderSupportDesignV1,
+    *,
+    overwrite: bool = False,
+) -> None:
+    if not isinstance(result, ProviderSupportDesignV1):
+        raise TypeError("result must be ProviderSupportDesignV1")
+    write_provider_support_feasibility(
+        path,
+        result.selected_support_feasibility,
+        overwrite=overwrite,
+    )
+
+
+def _summary(result: ProviderSupportDesignV1) -> dict[str, object]:
+    selected = result.selected_evaluation
+    return {
+        "provider_support_design_id": result.provider_support_design_id,
+        "request_id": result.request.request_id,
+        "support_design_feasible": result.support_design_feasible,
+        "decision_reason": result.decision_reason,
+        "candidate_count": len(result.candidate_evaluations),
+        "feasible_candidate_count": result.feasible_candidate_count,
+        "selected_candidate_id": result.selected_candidate_id,
+        "selected_support_request_id": result.selected_support_request_id,
+        "selected_support_feasibility_id": result.selected_support_feasibility_id,
+        "minimum_group_support_fraction": (
+            selected.minimum_group_support_fraction
+        ),
+        "supported_required_frame_count": (
+            selected.supported_required_frame_count
+        ),
+        "maximum_causal_span_frames": selected.maximum_causal_span_frames,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    select = subparsers.add_parser(
+        "select",
+        help="select and persist one frozen support design",
+    )
+    select.add_argument("--request", type=Path, required=True)
+    select.add_argument("--output", type=Path, required=True)
+    select.add_argument("--selected-request-output", type=Path)
+    select.add_argument("--selected-feasibility-output", type=Path)
+    select.add_argument("--overwrite", action="store_true")
+    select.add_argument("--compact", action="store_true")
+    verify = subparsers.add_parser(
+        "verify",
+        help="verify and replay a provider support design",
+    )
+    verify.add_argument("--artifact", type=Path, required=True)
+    verify.add_argument("--compact", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.command == "select":
+        request = load_provider_support_design_request(args.request)
+        result = evaluate_provider_support_design(request)
+        paths = tuple(
+            path
+            for path in (
+                args.output,
+                args.selected_request_output,
+                args.selected_feasibility_output,
+            )
+            if path is not None
+        )
+        resolved = tuple(path.resolve(strict=False) for path in paths)
+        if len(resolved) != len(set(resolved)):
+            raise ValueError("provider support design output paths must be distinct")
+        if not args.overwrite:
+            existing = [path for path in paths if path.exists()]
+            if existing:
+                raise FileExistsError(existing[0])
+        if args.selected_request_output is not None:
+            write_selected_provider_support_request(
+                args.selected_request_output,
+                result,
+                overwrite=args.overwrite,
+            )
+        if args.selected_feasibility_output is not None:
+            write_selected_provider_support_feasibility(
+                args.selected_feasibility_output,
+                result,
+                overwrite=args.overwrite,
+            )
+        write_provider_support_design(args.output, result, overwrite=args.overwrite)
+    else:
+        result = load_provider_support_design(args.artifact)
+    print(
+        json.dumps(
+            _summary(result),
+            sort_keys=True,
+            separators=(",", ":") if args.compact else None,
+        )
+    )
+    return 0 if result.support_design_feasible else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "PROVIDER_SUPPORT_DESIGN_CLAIM_BOUNDARY",
+    "PROVIDER_SUPPORT_DESIGN_REQUEST_SCHEMA",
+    "PROVIDER_SUPPORT_DESIGN_REQUEST_VERSION",
+    "PROVIDER_SUPPORT_DESIGN_SCHEMA",
+    "PROVIDER_SUPPORT_DESIGN_SELECTION_RULE",
+    "PROVIDER_SUPPORT_DESIGN_VERSION",
+    "ProviderSupportDesignCandidateV1",
+    "ProviderSupportDesignRequestV1",
+    "ProviderSupportDesignV1",
+    "evaluate_provider_support_design",
+    "load_provider_support_design",
+    "load_provider_support_design_request",
+    "main",
+    "write_provider_support_design",
+    "write_provider_support_design_request",
+    "write_selected_provider_support_feasibility",
+    "write_selected_provider_support_request",
+]

--- a/tests/test_provider_support_design.py
+++ b/tests/test_provider_support_design.py
@@ -1,0 +1,419 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from prob4d.provider_support_design import (
+    PROVIDER_SUPPORT_DESIGN_CLAIM_BOUNDARY,
+    ProviderSupportDesignCandidateV1,
+    ProviderSupportDesignRequestV1,
+    evaluate_provider_support_design,
+    load_provider_support_design,
+    load_provider_support_design_request,
+    main,
+    write_provider_support_design,
+    write_provider_support_design_request,
+    write_selected_provider_support_feasibility,
+    write_selected_provider_support_request,
+)
+from prob4d.provider_support_feasibility import (
+    ProviderSupportFeasibilityRequestV1,
+    ProviderSupportStreamV1,
+    load_provider_support_feasibility,
+    load_provider_support_feasibility_request,
+)
+
+SOURCE_REVISION = "a" * 40
+PROVIDER_REVISION = "b" * 40
+DIGESTS = {
+    "model": "1" * 64,
+    "loader": "2" * 64,
+    "cohort": "3" * 64,
+    "lock": "4" * 64,
+    "intrinsics": "5" * 64,
+    "extrinsics": "6" * 64,
+    "anchor": "7" * 64,
+}
+ROSTER = (
+    ("group-0", "camera-0"),
+    ("group-0", "camera-1"),
+    ("group-1", "camera-0"),
+    ("group-1", "camera-1"),
+)
+
+
+def _stream(
+    group_id: str,
+    stream_id: str,
+    *,
+    frame_count: int = 4,
+    causal_span: int | None = None,
+    supported: bool = True,
+    **changes: object,
+) -> ProviderSupportStreamV1:
+    span = frame_count if causal_span is None else causal_span
+    required = tuple(range(frame_count))
+    values: dict[str, object] = {
+        "group_id": group_id,
+        "stream_id": stream_id,
+        "causal_frame_start": 0,
+        "causal_frame_stop_exclusive": span,
+        "required_frame_ids": required,
+        "available_frame_ids": required,
+        "geometry_supported_frame_ids": required if supported else (),
+        "minimum_geometry_support_fraction": 1.0,
+        "intrinsics_required": True,
+        "intrinsics_id": DIGESTS["intrinsics"],
+        "extrinsics_required": True,
+        "extrinsics_id": DIGESTS["extrinsics"],
+        "metric_anchor_required": True,
+        "metric_anchor_id": DIGESTS["anchor"],
+        "technical_failure_code": None,
+        "metadata": {"source": "geometry-only"},
+    }
+    values.update(changes)
+    return ProviderSupportStreamV1(**values)  # type: ignore[arg-type]
+
+
+def _feasibility_request(
+    candidate_id: str,
+    supported_keys: set[tuple[str, str]],
+    *,
+    frame_count: int = 4,
+    causal_span: int | None = None,
+    admission_rule: str = "minimum-stream-fraction",
+    minimum_supported_fraction: float = 0.5,
+    streams: tuple[ProviderSupportStreamV1, ...] | None = None,
+    **changes: object,
+) -> ProviderSupportFeasibilityRequestV1:
+    values: dict[str, object] = {
+        "protocol_id": f"provider-support-{candidate_id}",
+        "source_repository": "IPS-Stuttgart/Prob4D",
+        "source_revision": SOURCE_REVISION,
+        "provider_family": "external-4d-provider",
+        "provider_repository": "example/provider",
+        "provider_revision": PROVIDER_REVISION,
+        "model_set_id": DIGESTS["model"],
+        "loader_id": DIGESTS["loader"],
+        "cohort_binding_id": DIGESTS["cohort"],
+        "promotion_lock_id": DIGESTS["lock"],
+        "coordinate_semantics": "metric-world-frame",
+        "admission_rule": admission_rule,
+        "minimum_supported_fraction": minimum_supported_fraction,
+        "permitted_technical_exclusion_codes": (),
+        "maximum_technical_exclusions": 0,
+        "prediction_payloads_opened": False,
+        "residuals_used": False,
+        "target_outcomes_used": False,
+        "streams": streams
+        or tuple(
+            _stream(
+                group_id,
+                stream_id,
+                frame_count=frame_count,
+                causal_span=causal_span,
+                supported=(group_id, stream_id) in supported_keys,
+            )
+            for group_id, stream_id in ROSTER
+        ),
+        "metadata": {"candidate": candidate_id},
+    }
+    values.update(changes)
+    return ProviderSupportFeasibilityRequestV1(**values)  # type: ignore[arg-type]
+
+
+def _candidate(
+    candidate_id: str,
+    supported_keys: set[tuple[str, str]],
+    **changes: object,
+) -> ProviderSupportDesignCandidateV1:
+    request_changes = dict(changes)
+    metadata = request_changes.pop("candidate_metadata", {"frozen": True})
+    return ProviderSupportDesignCandidateV1(
+        candidate_id=candidate_id,
+        feasibility_request=_feasibility_request(
+            candidate_id,
+            supported_keys,
+            **request_changes,
+        ),
+        metadata=metadata,  # type: ignore[arg-type]
+    )
+
+
+def _design_request(
+    candidates: tuple[ProviderSupportDesignCandidateV1, ...],
+    **changes: object,
+) -> ProviderSupportDesignRequestV1:
+    values: dict[str, object] = {
+        "protocol_id": "provider-support-design-test-v1",
+        "candidates": candidates,
+        "prediction_payloads_opened": False,
+        "residuals_used": False,
+        "target_outcomes_used": False,
+        "metadata": {"phase": "pre-residual"},
+    }
+    values.update(changes)
+    return ProviderSupportDesignRequestV1(**values)  # type: ignore[arg-type]
+
+
+def test_selects_support_feasible_candidate_before_negative_candidate() -> None:
+    negative = _candidate("negative", {ROSTER[0]})
+    feasible = _candidate("feasible", {ROSTER[0], ROSTER[2]})
+    result = evaluate_provider_support_design(_design_request((negative, feasible)))
+
+    assert result.support_design_feasible
+    assert result.selected_candidate_id == "feasible"
+    assert result.feasible_candidate_count == 1
+    assert result.selected_support_feasibility.support_feasible
+    assert result.selected_support_request.request_id == (
+        result.selected_support_request_id
+    )
+    assert result.to_dict()["claim_boundary"] == (
+        PROVIDER_SUPPORT_DESIGN_CLAIM_BOUNDARY
+    )
+
+
+def test_maximin_group_support_precedes_other_ranking_terms() -> None:
+    imbalanced = _candidate(
+        "imbalanced",
+        {ROSTER[0], ROSTER[1]},
+        minimum_supported_fraction=0.25,
+    )
+    balanced = _candidate(
+        "balanced",
+        {ROSTER[0], ROSTER[2]},
+        minimum_supported_fraction=0.25,
+    )
+    result = evaluate_provider_support_design(
+        _design_request((imbalanced, balanced))
+    )
+
+    assert result.selected_candidate_id == "balanced"
+    assert result.selected_evaluation.minimum_group_support_fraction == 0.5
+    other = next(
+        item
+        for item in result.candidate_evaluations
+        if item.candidate_id == "imbalanced"
+    )
+    assert other.minimum_group_support_fraction == 0.0
+    assert other.support_feasibility.supported_stream_count == 2
+
+
+def test_supported_frame_cells_precede_shorter_causal_span() -> None:
+    supported = {ROSTER[0], ROSTER[2]}
+    longer = _candidate(
+        "longer-more-cells",
+        supported,
+        frame_count=6,
+        causal_span=6,
+    )
+    shorter = _candidate(
+        "shorter-fewer-cells",
+        supported,
+        frame_count=4,
+        causal_span=4,
+    )
+    result = evaluate_provider_support_design(_design_request((shorter, longer)))
+
+    assert result.selected_candidate_id == "longer-more-cells"
+    assert result.selected_evaluation.supported_required_frame_count == 12
+
+
+def test_shorter_span_and_candidate_id_are_deterministic_tiebreakers() -> None:
+    supported = {ROSTER[0], ROSTER[2]}
+    loose = _candidate("loose", supported, frame_count=4, causal_span=8)
+    tight_z = _candidate("tight-z", supported, frame_count=4, causal_span=4)
+    tight_a = _candidate("tight-a", supported, frame_count=4, causal_span=4)
+    result = evaluate_provider_support_design(
+        _design_request((tight_z, loose, tight_a))
+    )
+
+    assert result.selected_candidate_id == "tight-a"
+    assert result.selected_evaluation.maximum_causal_span_frames == 4
+
+
+def test_candidate_set_requires_common_identity_roster_and_requirements() -> None:
+    first = _candidate("first", {ROSTER[0], ROSTER[2]})
+    changed_model = _candidate(
+        "changed-model",
+        {ROSTER[0], ROSTER[2]},
+        model_set_id="8" * 64,
+    )
+    with pytest.raises(ValueError, match="share provider, cohort"):
+        _design_request((first, changed_model))
+
+    reduced_roster = _candidate(
+        "reduced-roster",
+        {ROSTER[0]},
+        streams=first.feasibility_request.streams[:-1],
+    )
+    with pytest.raises(ValueError, match="exact stream roster"):
+        _design_request((first, reduced_roster))
+
+    changed_threshold_streams = tuple(
+        replace(stream, minimum_geometry_support_fraction=0.5)
+        if stream.key == ROSTER[0]
+        else stream
+        for stream in first.feasibility_request.streams
+    )
+    changed_threshold = _candidate(
+        "changed-threshold",
+        {ROSTER[0], ROSTER[2]},
+        streams=changed_threshold_streams,
+    )
+    with pytest.raises(ValueError, match="must not change support thresholds"):
+        _design_request((first, changed_threshold))
+
+
+@pytest.mark.parametrize(
+    "field_name",
+    ["prediction_payloads_opened", "residuals_used", "target_outcomes_used"],
+)
+def test_design_request_rejects_late_information(field_name: str) -> None:
+    candidate = _candidate("candidate", {ROSTER[0], ROSTER[2]})
+    with pytest.raises(ValueError, match=f"{field_name} must be false"):
+        _design_request((candidate,), **{field_name: True})
+
+
+def test_all_negative_candidates_retain_best_valid_negative() -> None:
+    one_group = _candidate("one-group", {ROSTER[0]})
+    no_groups = _candidate("no-groups", set())
+    result = evaluate_provider_support_design(
+        _design_request((no_groups, one_group))
+    )
+
+    assert not result.support_design_feasible
+    assert result.decision_reason == "no-support-feasible-candidate"
+    assert result.selected_candidate_id == "one-group"
+    assert result.feasible_candidate_count == 0
+
+
+def test_round_trip_selected_artifacts_and_tamper_detection(tmp_path: Path) -> None:
+    request = _design_request(
+        (
+            _candidate("candidate-b", {ROSTER[0]}),
+            _candidate("candidate-a", {ROSTER[0], ROSTER[2]}),
+        )
+    )
+    request_path = tmp_path / "design-request.json"
+    result_path = tmp_path / "design-result.json"
+    selected_request_path = tmp_path / "selected-request.json"
+    selected_result_path = tmp_path / "selected-result.json"
+    write_provider_support_design_request(request_path, request)
+    loaded_request = load_provider_support_design_request(request_path)
+    assert loaded_request == request
+
+    result = evaluate_provider_support_design(loaded_request)
+    write_selected_provider_support_request(selected_request_path, result)
+    write_selected_provider_support_feasibility(selected_result_path, result)
+    write_provider_support_design(result_path, result)
+
+    assert load_provider_support_design(result_path) == result
+    assert (
+        load_provider_support_feasibility_request(selected_request_path)
+        == result.selected_support_request
+    )
+    assert (
+        load_provider_support_feasibility(selected_result_path)
+        == result.selected_support_feasibility
+    )
+
+    payload = json.loads(result_path.read_text(encoding="utf-8"))
+    payload["selected_candidate_id"] = "candidate-b"
+    result_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError, match="identity mismatch|does not replay"):
+        load_provider_support_design(result_path)
+
+
+def test_cli_selects_writes_replays_and_returns_negative_status(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    passing_request_path = tmp_path / "passing-request.json"
+    passing_result_path = tmp_path / "passing-result.json"
+    selected_request_path = tmp_path / "selected-request.json"
+    selected_result_path = tmp_path / "selected-result.json"
+    passing = _design_request(
+        (_candidate("candidate", {ROSTER[0], ROSTER[2]}),)
+    )
+    write_provider_support_design_request(passing_request_path, passing)
+
+    assert (
+        main(
+            [
+                "select",
+                "--request",
+                str(passing_request_path),
+                "--output",
+                str(passing_result_path),
+                "--selected-request-output",
+                str(selected_request_path),
+                "--selected-feasibility-output",
+                str(selected_result_path),
+                "--compact",
+            ]
+        )
+        == 0
+    )
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["support_design_feasible"] is True
+    assert summary["selected_candidate_id"] == "candidate"
+    assert main(["verify", "--artifact", str(passing_result_path)]) == 0
+    assert json.loads(capsys.readouterr().out)["selected_candidate_id"] == (
+        "candidate"
+    )
+
+    negative_request_path = tmp_path / "negative-request.json"
+    negative_result_path = tmp_path / "negative-result.json"
+    negative = _design_request((_candidate("negative", set()),))
+    write_provider_support_design_request(negative_request_path, negative)
+    assert (
+        main(
+            [
+                "select",
+                "--request",
+                str(negative_request_path),
+                "--output",
+                str(negative_result_path),
+            ]
+        )
+        == 2
+    )
+    assert json.loads(capsys.readouterr().out)["support_design_feasible"] is False
+
+
+def test_cli_rejects_colliding_or_existing_outputs(tmp_path: Path) -> None:
+    request_path = tmp_path / "request.json"
+    output_path = tmp_path / "output.json"
+    request = _design_request(
+        (_candidate("candidate", {ROSTER[0], ROSTER[2]}),)
+    )
+    write_provider_support_design_request(request_path, request)
+
+    with pytest.raises(ValueError, match="output paths must be distinct"):
+        main(
+            [
+                "select",
+                "--request",
+                str(request_path),
+                "--output",
+                str(output_path),
+                "--selected-request-output",
+                str(output_path),
+            ]
+        )
+
+    output_path.write_text("occupied", encoding="utf-8")
+    with pytest.raises(FileExistsError):
+        main(
+            [
+                "select",
+                "--request",
+                str(request_path),
+                "--output",
+                str(output_path),
+            ]
+        )


### PR DESCRIPTION
## What changed

- add a content-addressed `ProviderSupportDesignRequestV1` over a finite candidate set frozen before prediction payload, residual, or target access;
- require all candidates to share the exact provider/cohort/promotion identities, admission and exclusion policies, stream roster, support thresholds, and required calibration classes;
- replay every candidate through the existing `ProviderSupportFeasibilityRequestV1` evaluator;
- select deterministically by support feasibility, maximin complete-group support, supported camera/frame cells, supported streams, causal span, and frozen candidate ID;
- retain every candidate result and ranking statistic in a replay-complete `ProviderSupportDesignV1` artifact;
- emit the selected ordinary support request and feasibility result without changing their existing schemas, so `ProviderPromotionAuthorizationV2` remains unchanged;
- return exit status 2 while retaining the best valid negative when every frozen candidate is support-negative; and
- document the information order and the prohibition on using this path to repair the completed Deform360 result.

## Why

The completed official-Hub route established that support must be tested before residual fitting. A later provider should also freeze a finite set of technically plausible causal-prefix configurations before support metadata are evaluated, rather than changing the prefix or geometry route after an expensive run. This change makes that prospective selection replayable while preventing camera-roster deletion, threshold relaxation, or provider/model substitution inside one design request.

## Compatibility

- Existing `ProviderSupportFeasibilityRequestV1`, `ProviderSupportFeasibilityV1`, and `ProviderPromotionAuthorizationV2` schemas and identities are unchanged.
- The selected request/result are ordinary existing feasibility artifacts.
- No estimator, calibration method, provider output, target cohort, frozen negative result, or scientific threshold is changed.
- The module is invoked with `python -m prob4d.provider_support_design`; no new legacy console-script alias is installed.

## Validation

Local validation against the 0.4.0 source boundary:

- `pytest -q tests/test_provider_support_design.py`: 12 passed;
- Python compilation passed for the source and focused tests;
- source and tests satisfy the repository's 100-column convention; and
- module help and both valid-positive and valid-negative CLI paths were exercised.

The pull-request workflows remain authoritative for Ruff, the complete Python 3.10–3.14 suite, the NumPy 1.24 floor, distribution builds, and installed-artifact checks.

## Scientific boundary

This is target-free design and information-order infrastructure. It does not establish provider competence, uncertainty calibration, BayesianPhysTwin benefit, Causal4D intervention benefit, deployment safety, or state of the art. It cannot be used to relabel or rescue the completed Deform360 source-support negative.