### PR TITLE
Use Cholesky solves for sampled Gaussian fusion

### DIFF
--- a/src/prob4d/phystwin_uncertainty.py
+++ b/src/prob4d/phystwin_uncertainty.py
@@ -199,28 +199,76 @@ def calibrate_covariance_scale(errors: FloatArray, covariances: FloatArray) -> f
     return max(scale, np.finfo(np.float64).eps)
 
 
+def _positive_definite_covariance_batch(
+    value: FloatArray,
+    *,
+    count: int,
+    name: str,
+) -> FloatArray:
+    """Broadcast and validate one symmetric positive-definite covariance batch."""
+
+    raw = np.asarray(value, dtype=np.float64)
+    try:
+        covariance = np.broadcast_to(raw, (count, 3, 3))
+    except ValueError as error:
+        raise ValueError(f"{name} must broadcast to shape ({count}, 3, 3)") from error
+    if not np.all(np.isfinite(covariance)):
+        raise ValueError(f"{name} must be finite")
+    symmetric = 0.5 * (covariance + covariance.swapaxes(1, 2))
+    scale = np.maximum(np.max(np.abs(symmetric), axis=(1, 2)), 1.0)
+    if not np.allclose(
+        covariance,
+        symmetric,
+        atol=1e-12 * scale[:, None, None],
+        rtol=1e-10,
+    ):
+        raise ValueError(f"{name} must be symmetric")
+    try:
+        np.linalg.cholesky(symmetric)
+    except np.linalg.LinAlgError as error:
+        raise ValueError(f"{name} must be positive definite") from error
+    return symmetric
+
+
+def _batched_cholesky_solve(cholesky: FloatArray, right_hand_side: FloatArray) -> FloatArray:
+    forward = np.linalg.solve(cholesky, right_hand_side)
+    return np.linalg.solve(cholesky.swapaxes(1, 2), forward)
+
+
 def gaussian_product(
     mean_a: FloatArray,
     covariance_a: FloatArray,
     mean_b: FloatArray,
     covariance_b: FloatArray,
 ) -> tuple[FloatArray, FloatArray]:
-    """Fuse batched independent Gaussian estimates in information form."""
+    """Fuse independent Gaussian estimates without explicit matrix inversion."""
 
     first = np.asarray(mean_a, dtype=np.float64)
     second = np.asarray(mean_b, dtype=np.float64)
     if first.shape != second.shape or first.ndim != 2 or first.shape[1] != 3:
         raise ValueError("means must share shape (N, 3)")
-    cov_a = np.broadcast_to(np.asarray(covariance_a, dtype=np.float64), (first.shape[0], 3, 3))
-    cov_b = np.broadcast_to(np.asarray(covariance_b, dtype=np.float64), (first.shape[0], 3, 3))
-    precision_a = np.linalg.inv(cov_a)
-    precision_b = np.linalg.inv(cov_b)
-    covariance = np.linalg.inv(precision_a + precision_b)
-    information = (
-        np.einsum("nij,nj->ni", precision_a, first)
-        + np.einsum("nij,nj->ni", precision_b, second)
+    if not np.all(np.isfinite(first)) or not np.all(np.isfinite(second)):
+        raise ValueError("means must be finite")
+    cov_a = _positive_definite_covariance_batch(
+        covariance_a,
+        count=first.shape[0],
+        name="covariance_a",
     )
-    mean = np.einsum("nij,nj->ni", covariance, information)
+    cov_b = _positive_definite_covariance_batch(
+        covariance_b,
+        count=first.shape[0],
+        name="covariance_b",
+    )
+
+    summed = cov_a + cov_b
+    cholesky = np.linalg.cholesky(summed)
+    innovation = (second - first)[..., None]
+    solved_innovation = _batched_cholesky_solve(cholesky, innovation)[..., 0]
+    mean = first + np.einsum("nij,nj->ni", cov_a, solved_innovation)
+
+    solved_b = _batched_cholesky_solve(cholesky, cov_b)
+    covariance = np.einsum("nij,njk->nik", cov_a, solved_b)
+    covariance = 0.5 * (covariance + covariance.swapaxes(1, 2))
     return mean, covariance
 
 

--- a/tests/test_phystwin_uncertainty.py
+++ b/tests/test_phystwin_uncertainty.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from prob4d.phystwin_experiment import ManualFlowSamples
 from prob4d.phystwin_uncertainty import (
@@ -23,6 +24,26 @@ def _manual_samples(frames: list[int], tracks: list[int], offset: float) -> Manu
     )
 
 
+def _inverse_gaussian_product_oracle(
+    mean_a: np.ndarray,
+    covariance_a: np.ndarray,
+    mean_b: np.ndarray,
+    covariance_b: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    count = mean_a.shape[0]
+    cov_a = np.broadcast_to(covariance_a, (count, 3, 3))
+    cov_b = np.broadcast_to(covariance_b, (count, 3, 3))
+    precision_a = np.linalg.inv(cov_a)
+    precision_b = np.linalg.inv(cov_b)
+    covariance = np.linalg.inv(precision_a + precision_b)
+    information = (
+        np.einsum("nij,nj->ni", precision_a, mean_a)
+        + np.einsum("nij,nj->ni", precision_b, mean_b)
+    )
+    mean = np.einsum("nij,nj->ni", covariance, information)
+    return mean, covariance
+
+
 def test_intersection_uses_frame_and_track_identity() -> None:
     first = _manual_samples([1, 1, 2], [0, 1, 0], 0.1)
     second = _manual_samples([2, 1, 3], [0, 1, 0], 0.2)
@@ -31,7 +52,10 @@ def test_intersection_uses_frame_and_track_identity() -> None:
 
     np.testing.assert_array_equal(result.frame_indices, [1, 2])
     np.testing.assert_array_equal(result.track_indices, [1, 0])
-    np.testing.assert_allclose(result.visual_flow_samples[:, :, 0], [[1.1, 1.1], [1.2, 1.2]])
+    np.testing.assert_allclose(
+        result.visual_flow_samples[:, :, 0],
+        [[1.1, 1.1], [1.2, 1.2]],
+    )
 
 
 def test_sample_covariance_is_positive_definite_and_train_scalable() -> None:
@@ -58,4 +82,87 @@ def test_gaussian_product_matches_scalar_precision_weighting() -> None:
     mean, covariance = gaussian_product(mean_a, covariance_a, mean_b, covariance_b)
 
     np.testing.assert_allclose(mean, 0.5)
-    np.testing.assert_allclose(covariance, np.broadcast_to(0.75 * np.eye(3), (2, 3, 3)))
+    np.testing.assert_allclose(
+        covariance,
+        np.broadcast_to(0.75 * np.eye(3), (2, 3, 3)),
+    )
+
+
+def test_gaussian_product_matches_inverse_oracle_for_noncommuting_batches() -> None:
+    mean_a = np.array([[0.5, -1.0, 2.0], [-0.2, 0.4, 1.1]])
+    mean_b = np.array([[1.2, 0.3, -0.7], [1.0, -0.5, 0.2]])
+    covariance_a = np.array(
+        [
+            [[2.0, 0.3, 0.1], [0.3, 1.2, 0.2], [0.1, 0.2, 0.8]],
+            [[1.1, -0.2, 0.05], [-0.2, 1.6, 0.25], [0.05, 0.25, 0.9]],
+        ]
+    )
+    covariance_b = np.array(
+        [
+            [[0.7, -0.15, 0.05], [-0.15, 2.2, 0.4], [0.05, 0.4, 1.4]],
+            [[2.0, 0.1, -0.3], [0.1, 0.8, 0.05], [-0.3, 0.05, 1.3]],
+        ]
+    )
+    expected_mean, expected_covariance = _inverse_gaussian_product_oracle(
+        mean_a,
+        covariance_a,
+        mean_b,
+        covariance_b,
+    )
+
+    mean, covariance = gaussian_product(mean_a, covariance_a, mean_b, covariance_b)
+
+    np.testing.assert_allclose(mean, expected_mean, rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(
+        covariance,
+        expected_covariance,
+        rtol=1e-12,
+        atol=1e-12,
+    )
+    np.testing.assert_allclose(covariance, covariance.swapaxes(1, 2), atol=1e-14)
+    assert np.all(np.linalg.eigvalsh(covariance) > 0.0)
+
+
+def test_gaussian_product_does_not_use_explicit_inverse(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fail_inverse(*args: object, **kwargs: object) -> None:
+        raise AssertionError("explicit inverse was called")
+
+    monkeypatch.setattr(np.linalg, "inv", fail_inverse)
+
+    gaussian_product(
+        np.zeros((1, 3)),
+        np.eye(3),
+        np.ones((1, 3)),
+        2.0 * np.eye(3),
+    )
+
+
+@pytest.mark.parametrize(
+    ("covariance", "message"),
+    [
+        (np.array([[1.0, 0.2, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]), "symmetric"),
+        (np.diag([1.0, 1.0, 0.0]), "positive definite"),
+        (np.diag([1.0, 1.0, np.nan]), "finite"),
+    ],
+)
+def test_gaussian_product_rejects_invalid_covariance(
+    covariance: np.ndarray,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        gaussian_product(
+            np.zeros((1, 3)),
+            covariance,
+            np.ones((1, 3)),
+            np.eye(3),
+        )
+
+
+def test_gaussian_product_rejects_nonfinite_mean() -> None:
+    with pytest.raises(ValueError, match="means must be finite"):
+        gaussian_product(
+            np.array([[np.nan, 0.0, 0.0]]),
+            np.eye(3),
+            np.ones((1, 3)),
+            np.eye(3),
+        )


### PR DESCRIPTION
## What changed

- replace the three explicit batched matrix inverses in `phystwin_uncertainty.gaussian_product` with Cholesky-based linear solves;
- preserve the exact independent-Gaussian product semantics, including batched and broadcast covariance inputs;
- fail closed on non-finite means, non-finite covariances, materially asymmetric covariances, and non-positive-definite covariances;
- explicitly symmetrize the roundoff-level posterior covariance; and
- add parity, positive-definiteness, no-`inv`, and adversarial input regressions.

## Numerical formulation

For independent estimates `(a, A)` and `(b, B)`, the implementation now evaluates

```text
m = a + A (A + B)^-1 (b - a)
P = A (A + B)^-1 B
```

through Cholesky solves of `A + B`. The test-only oracle retains the historical information-form inverse expression and verifies parity for noncommuting SPD covariance batches.

## Validation

Focused validation against the current source boundary:

- `9 passed` in the focused local suite;
- scalar precision-weighting parity;
- batched noncommuting-SPD parity to the historical inverse oracle at `1e-12` tolerance;
- symmetric positive-definite output checks;
- a regression that makes any production call to `np.linalg.inv` fail; and
- rejection tests for asymmetric, singular, non-finite covariance and non-finite means.

All authoritative pull-request workflows passed on exact head `3f0dc723b4b9a697420bb2ac067e7cb644d96052`:

- fail-closed Ruff and MyPy: run `31456493045`;
- complete Python 3.10–3.14 suites, NumPy 1.24 floor, distribution builds, and isolated wheel/sdist CLI smoke: run `31456493049`; and
- security scanning: run `31456493067`.

## Compatibility and scientific boundary

This changes only the numerical implementation and validation of the diagnostic sampled-flow Gaussian product. It changes no provider API, artifact schema, calibration protocol, target split, registered evidence, or claim boundary. It does not establish provider competence, uncertainty calibration on a fresh cohort, BayesianPhysTwin benefit, Causal4D intervention benefit, deployment safety, or state of the art.