### PR TITLE
Align compatibility documentation with Prob4D 0.4

### DIFF
--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -1,10 +1,10 @@
 # Version and compatibility boundaries
 
-Prob4D versions its Python providers separately from its portable artifact
+Prob4D versions its Python façades separately from portable artifact and wire
 contracts. Exact repository revisions and artifact digests remain mandatory for
-frozen evidence even when package-version ranges are compatible.
+frozen evidence even when released package versions are compatible.
 
-## Prob4D 0.3.x surfaces
+## Prob4D 0.4.x surfaces
 
 | Surface | Version | Intended use |
 | --- | ---: | --- |
@@ -16,12 +16,16 @@ frozen evidence even when package-version ranges are compatible.
 | Prob4D causal stream contract | 2 | Strict causal lineage and joint-gauge semantics |
 | `ObservationFactorBundle` | 4 | Unfused factors with ordered joint gauge covariance |
 | `ObservationFactorStreamV1` | 1 | Append-only sequence of causal schema-v4 delta bundles |
+| `GaugeTreeSquareRootPriorV1` | 1 | Portable causal tree transition/innovation prior |
+| `TreeSparseObservationArtifactV1` | 1 | Portable tree-sparse factor and prior artifact |
+| `ClaimBearingTreeSparseObservationEnvelopeV1` | 1 | Strict tree-sparse admission envelope |
+| `prob4d.provider_v2_factors.v1` | 1 | Normative provider-v2 conformance corpus |
 | MotionCrafter model identifier | 1 / 2 | Legacy common seed / derived per-call seed semantics |
 
 Provider-v1 behavior and the standalone
 `prob4d-export-observation-belief` executable remain available for frozen run
-manifests. New work should choose an explicit provider-v2 export mode and import the
-strict loaders and contracts through `prob4d.api.v2`. Direct imports from
+manifests. New work should choose an explicit provider-v2 export mode and import
+the strict loaders and contracts through `prob4d.api.v2`. Direct imports from
 `prob4d.provider_v2`, `prob4d.provider_v2_factors`, `prob4d.gauge`, or
 `prob4d.sim3` are implementation dependencies rather than the supported
 ecosystem boundary.
@@ -32,6 +36,21 @@ uses `legacy-common`. A run using `derived-per-call` receives a
 `prob4d.motioncrafter-model.v2` identifier, and its source-bound seed schedule is
 validated before claim-bearing calibration compatibility is accepted. See
 [the stochastic seed policy](stochastic-seed-policy.md).
+
+## Normative cross-repository corpora
+
+Prob4D packages two separate data-only interoperability references:
+
+- `phys4d.observation_belief` version 1 fixes the neutral fused-observation wire
+  contract; and
+- `prob4d.provider_v2_factors.v1` fixes the explicit-gauge and tree-sparse
+  provider-v2 construction boundary.
+
+BayesianPhysTwin and Causal4D may carry byte-identical corpus copies while
+retaining independent validators. Exact corpus identity, structural semantics,
+and declared numerical tolerances are conformance evidence. A green corpus does
+not establish provider accuracy, calibration, physical-query benefit, or
+intervention benefit.
 
 ## Grouped CLI migration
 
@@ -63,25 +82,31 @@ the canonical repository separately for navigation. Existing provider-v1,
 causal-stream, and provider-v2 artifact schemas retain their exact historical
 repository semantics. See [repository identity](repository-identity.md).
 
-## Companion projects
+## Companion-project compatibility
 
-At the time Prob4D 0.3.0 was prepared, the companion package versions on their
-main branches were:
+Do not maintain a table of mutable companion-repository branch versions in this
+document. Such a table becomes stale whenever Prob4D, BayesianPhysTwin, or
+Causal4D merges an unrelated change and can be mistaken for frozen scientific
+provenance.
 
-- Bayesian-PhysTwin 0.4.0;
-- Causal4D 0.4.1.
-
-These numbers are development reference points, not substitutes for the
-three-repository installed-wheel golden path. Claim-bearing runs must bind exact
-Prob4D, Bayesian-PhysTwin, and Causal4D commits, wheel hashes, provider
-manifests, artifacts, and protocol identifiers.
+For ordinary development, consume released versioned façades and run the
+three-repository installed-wheel compatibility capsule. For claim-bearing runs,
+bind the exact Prob4D, BayesianPhysTwin, and Causal4D revisions, wheel hashes,
+provider manifests, contract-corpus identities, protocol identifiers, and input
+and output artifact digests inside the owning evidence record.
 
 ## Upgrade rules
 
-- A breaking Python signature requires a new provider module.
+- A breaking stable Python signature requires a new `prob4d.api.vN` façade.
+- A breaking provider implementation signature that remains outside the stable
+  façade requires a new provider module or an explicit internal migration.
 - A breaking Prob4D-specific interpretation of an observation artifact requires
   a new causal-stream contract version.
 - A breaking factor-bundle representation requires a new bundle schema.
+- A changed tree-prior or tree-sparse representation requires a new artifact
+  schema and corresponding provider capability.
+- A changed normative corpus requires a new corpus version and bundle identity;
+  one repository must not silently edit its local validator or vectors.
 - A changed stream hash or interval interpretation requires a new factor-stream
   schema.
 - A changed covariance or reliability fitting method requires regenerated,
@@ -92,4 +117,5 @@ manifests, artifacts, and protocol identifiers.
   source-repository field.
 
 Passing compatibility tests is infrastructure evidence. It does not establish
-accuracy, calibration, transfer, intervention benefit, or safety.
+accuracy, calibration, transfer, intervention benefit, deployment safety, or
+state of the art.

--- a/tests/test_release_040_boundary.py
+++ b/tests/test_release_040_boundary.py
@@ -76,6 +76,25 @@ def test_release_changelog_and_claim_boundary_are_published() -> None:
     assert "313/324" in normalized_boundary
 
 
+def test_compatibility_guide_matches_the_040_surface() -> None:
+    compatibility = (ROOT / "docs" / "compatibility.md").read_text(
+        encoding="utf-8"
+    )
+
+    assert "## Prob4D 0.4.x surfaces" in compatibility
+    assert "## Prob4D 0.3.x surfaces" not in compatibility
+    for surface in (
+        "`prob4d.api.v2`",
+        "`GaugeTreeSquareRootPriorV1`",
+        "`TreeSparseObservationArtifactV1`",
+        "`ClaimBearingTreeSparseObservationEnvelopeV1`",
+        "`prob4d.provider_v2_factors.v1`",
+    ):
+        assert surface in compatibility
+    assert "At the time Prob4D 0.3.0 was prepared" not in compatibility
+    assert "Do not maintain a table of mutable companion-repository" in compatibility
+
+
 def test_v1_v2_and_tree_sparse_manifest_boundaries_remain_distinct() -> None:
     revision = "a" * 40
     provider_v1 = prob4d_provider_manifest(provider_revision=revision)


### PR DESCRIPTION
## What changed

- rename the documented compatibility surface from stale `0.3.x` wording to `0.4.x`;
- add the stable `prob4d.api.v2`, gauge-tree, tree-sparse artifact, claim-bearing envelope, and normative provider-v2 corpus boundaries to the version table;
- document the separate neutral observation-belief and provider-v2 factor conformance corpora;
- remove mutable companion-branch version snapshots that had already become stale;
- direct ordinary development to released façades and the installed-wheel capsule while retaining exact revision and artifact binding for claim-bearing evidence;
- extend the upgrade rules to cover stable API façades, tree-sparse schemas, provider capabilities, and normative corpus versioning; and
- add a release-policy regression that checks the current 0.4 heading, advanced surfaces, and removal of the old companion-version snapshot.

## Why

The compatibility guide still labelled the current release surface as `Prob4D 0.3.x` and listed companion versions captured when 0.3.0 was prepared. Those mutable snapshots conflict with the repository's current evidence policy and obscure the stable 0.4 API/tree-sparse boundaries now present on `main`.

## Validation

All authoritative workflows passed on exact head `74e6f878068777d701f4b8b2b6bb3b302831499a`:

- complete Python 3.10–3.14 suites, NumPy 1.24 floor, release-policy tests, distribution builds, and isolated wheel/sdist installation: run `31456674577`;
- fail-closed Ruff and MyPy: run `31456674588`; and
- security scanning: run `31456674582`.

The policy test binds the 0.4 heading, `prob4d.api.v2`, tree-prior/tree-sparse contracts, provider-v2 corpus, and absence of the historical mutable snapshot.

## Scientific boundary

This is documentation and compatibility-policy guidance only. It changes no runtime estimator, artifact byte, provider semantics, experiment, target access boundary, or scientific result.