### PR TITLE
Add query-space covariance relevance diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,7 @@ release notes and scientific boundaries live under `docs/releases/`.
 
 ## Unreleased
 
-### Added
-
-- A dense-free query-space covariance relevance diagnostic that projects
-  conditional-plus-low-rank Prob4D uncertainty through a consumer-supplied local
-  query Jacobian and reports trace, coordinate, rank, and directional shared-mode
-  contributions without defining downstream admission.
+No changes yet.
 
 ## 0.4.0 — 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ release notes and scientific boundaries live under `docs/releases/`.
 
 ## Unreleased
 
-No changes yet.
+### Added
+
+- A dense-free query-space covariance relevance diagnostic that projects
+  conditional-plus-low-rank Prob4D uncertainty through a consumer-supplied local
+  query Jacobian and reports trace, coordinate, rank, and directional shared-mode
+  contributions without defining downstream admission.
 
 ## 0.4.0 — 2026-08-10
 

--- a/docs/joint-covariance-diagnostics.md
+++ b/docs/joint-covariance-diagnostics.md
@@ -98,5 +98,18 @@ joint-covariance command, evaluates those exact bytes, and publishes its report
 with the same create-if-absent behavior. It is controlled mechanism evidence,
 not permission to reuse or retune an opened target cohort.
 
+## Query-space relevance
+
+Calibration and dependence diagnostics operate in observation space. A separate
+experimental Python diagnostic projects `blockdiag(D_i) + U U^T` through a
+consumer-supplied local query Jacobian without materializing the dense observation
+covariance. It reports trace, coordinate, effective-rank, and generalized
+directional shares of query variance caused by the shared modes. See
+[query-space covariance relevance](query-covariance-relevance.md).
+
+The consumer remains responsible for defining the physical query, freezing any
+selection or practical-equivalence rule on source/calibration groups, and
+preserving exact fallback. Query relevance is not a provider-promotion decision.
+
 This is a calibration diagnostic, not a provider promotion decision. Provider
 competence and guarded BayesianPhysTwin benefit remain separate frozen gates.

--- a/docs/query-covariance-relevance.md
+++ b/docs/query-covariance-relevance.md
@@ -69,6 +69,32 @@ The returned `QueryCovarianceProjectionV1` owns immutable copies of all retained
 arrays and replays every derived rank, trace, fraction, and covariance identity
 when constructed directly.
 
+## Streaming large observations
+
+Dense physical queries can have many observation rows even though their output
+dimension `Q` and shared rank `R` are small. Use
+`project_joint_covariance_blocks_to_query` to avoid retaining a complete
+`Q x N x 3` Jacobian in memory:
+
+```python
+from prob4d.query_covariance_relevance import (
+    project_joint_covariance_blocks_to_query,
+)
+
+projection = project_joint_covariance_blocks_to_query(
+    (
+        (query_jacobian[:, start:stop], local_covariance[start:stop], shared_factor[start:stop])
+        for start, stop in row_blocks
+    )
+)
+```
+
+Each block is validated independently and must use the same query dimension and
+shared-factor rank. The iterable is consumed exactly once. Only compensated
+`Q x Q` and `Q x R` accumulators are retained, so peak memory is independent of
+the total row count apart from the caller-owned current block. Empty streams,
+malformed blocks, and dimension or rank drift fail closed.
+
 ## Reported relevance measures
 
 The compact summary contains:

--- a/docs/query-covariance-relevance.md
+++ b/docs/query-covariance-relevance.md
@@ -1,0 +1,107 @@
+# Query-space covariance relevance
+
+Prob4D preserves conditional observation covariance and shared covariance modes
+separately. A complete joint representation can be scientifically important even
+when it has little effect on one downstream physical query. Conversely, a shared
+mode that appears modest in observation space can dominate the uncertainty of a
+query that is sensitive to that mode.
+
+`prob4d.query_covariance_relevance` provides a neutral, experimental diagnostic
+for this distinction. The downstream consumer supplies its own local query
+Jacobian; Prob4D projects the covariance but does not define the query, choose a
+covariance treatment, or authorize an update.
+
+## Covariance decomposition
+
+For `N` three-dimensional observation rows, let
+
+```text
+C_y = blockdiag(D_1, ..., D_N) + U U^T,
+```
+
+where `D_i` is the conditional covariance of row `i` and `U` contains shared
+uncertainty modes. For a `Q`-dimensional query with block Jacobians `J_i`, the
+module computes
+
+```text
+C_conditional = sum_i J_i D_i J_i^T,
+U_query       = sum_i J_i U_i,
+C_shared      = U_query U_query^T,
+C_total       = C_conditional + C_shared.
+```
+
+The implementation accepts:
+
+| Argument | Shape | Meaning |
+| --- | --- | --- |
+| `query_jacobian` | `Q x N x 3` | local derivative blocks for the query |
+| `local_covariance_m2` | `N x 3 x 3` | conditional row covariance |
+| `low_rank_factor_m` | `N x 3 x R` | shared observation-space covariance factor |
+
+A two-dimensional `N x 3` Jacobian denotes a scalar query. Rank zero is valid.
+The implementation never materializes the dense `3N x 3N` observation covariance
+or a dense `Q x 3N` Jacobian.
+
+## Example
+
+```python
+import numpy as np
+
+from prob4d.query_covariance_relevance import (
+    project_joint_covariance_to_query,
+)
+
+query_jacobian = np.array([[1.0, 0.0, 0.0]])
+local_covariance = np.diag([1.0, 2.0, 3.0])[None, ...]
+shared_factor = np.array([[[2.0], [0.0], [0.0]]])
+
+projection = project_joint_covariance_to_query(
+    query_jacobian,
+    local_covariance,
+    shared_factor,
+)
+
+assert projection.shared_trace_fraction == 0.8
+summary = projection.summary()
+```
+
+The returned `QueryCovarianceProjectionV1` owns immutable copies of all retained
+arrays and replays every derived rank, trace, fraction, and covariance identity
+when constructed directly.
+
+## Reported relevance measures
+
+The compact summary contains:
+
+- conditional, shared, and total query-covariance traces;
+- shared trace fraction;
+- shared-to-total Frobenius-norm fraction;
+- one shared variance fraction per query coordinate;
+- effective total and shared ranks; and
+- minimum, mean, and maximum directional shared fractions on the numerically
+  supported query subspace.
+
+The directional quantities are the generalized eigenvalues of the shared
+component relative to total query covariance after whitening the supported
+subspace. The maximum therefore identifies whether any query direction is
+strongly controlled by shared uncertainty, even when the trace-average fraction
+is small. A query with zero total variance reports fractions as `None` rather
+than inventing a value.
+
+These measures answer different questions. Trace fraction is an average variance
+share in the supplied coordinates. Coordinate fractions are useful for named
+outputs but depend on the coordinate system. Directional fractions are invariant
+to orthogonal changes of query basis. None of them is a selection threshold by
+itself.
+
+## Repository boundary
+
+Prob4D owns the observation covariance decomposition and this projection. A
+BayesianPhysTwin consumer owns the physical query Jacobian, practical-equivalence
+margin, source/calibration study, computational trade-off, and exact fallback
+rule. Causal4D should consume only the accepted physical belief rather than use
+this diagnostic to bypass BayesianPhysTwin admission.
+
+This is mechanism and diagnostic infrastructure. It does not establish provider
+competence, calibrated uncertainty on a fresh cohort, BayesianPhysTwin physical
+benefit, Causal4D intervention benefit, deployment safety, or state of the art.

--- a/src/prob4d/query_covariance_relevance.py
+++ b/src/prob4d/query_covariance_relevance.py
@@ -1,0 +1,385 @@
+"""Project conditional-plus-low-rank observation covariance into query space.
+
+Prob4D owns the structured observation covariance. A downstream consumer owns
+its query Jacobian and any decision about whether joint covariance is worth the
+added inference cost. This module performs only the neutral covariance
+projection and reports how much query-space variance comes from shared modes.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Any, TypeAlias
+
+import numpy as np
+from numpy.typing import NDArray
+
+FloatArray: TypeAlias = NDArray[np.floating[Any]]
+
+QUERY_COVARIANCE_RELEVANCE_SCHEMA = "prob4d.query-covariance-relevance"
+QUERY_COVARIANCE_RELEVANCE_VERSION = 1
+QUERY_COVARIANCE_RELEVANCE_CLAIM_BOUNDARY = (
+    "This diagnostic projects a supplied Prob4D conditional-plus-low-rank "
+    "covariance through a caller-supplied query Jacobian. It does not define "
+    "the physical query, select a covariance treatment, authorize an update, "
+    "or establish BayesianPhysTwin or Causal4D benefit."
+)
+
+
+def _readonly(value: np.ndarray) -> FloatArray:
+    result = np.asarray(value, dtype=np.float64).copy()
+    result.setflags(write=False)
+    return result
+
+
+def _validated_relative_rank_tolerance(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(
+        value,
+        (int, float, np.integer, np.floating),
+    ):
+        raise ValueError("relative_rank_tolerance must be a real scalar")
+    result = float(value)
+    if not math.isfinite(result) or not 0.0 <= result < 1.0:
+        raise ValueError("relative_rank_tolerance must lie in [0, 1)")
+    return result
+
+
+def _strict_positive_integer(value: object, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, (int, np.integer)):
+        raise TypeError(f"{name} must be a genuine integer")
+    result = int(value)
+    if result < 1:
+        raise ValueError(f"{name} must be positive")
+    return result
+
+
+def _validated_covariance(
+    value: object,
+    *,
+    name: str,
+    expected_dimension: int | None = None,
+) -> FloatArray:
+    covariance = np.asarray(value, dtype=np.float64)
+    if covariance.ndim != 2 or covariance.shape[0] != covariance.shape[1]:
+        raise ValueError(f"{name} must be a square matrix")
+    if covariance.shape[0] < 1:
+        raise ValueError(f"{name} must have positive dimension")
+    if expected_dimension is not None and covariance.shape != (
+        expected_dimension,
+        expected_dimension,
+    ):
+        raise ValueError(f"{name} has an invalid shape")
+    if not np.all(np.isfinite(covariance)):
+        raise ValueError(f"{name} must be finite")
+    symmetric = 0.5 * (covariance + covariance.T)
+    scale = max(float(np.max(np.abs(symmetric), initial=0.0)), 1.0)
+    if not np.allclose(covariance, symmetric, atol=1e-12, rtol=1e-10):
+        raise ValueError(f"{name} must be symmetric")
+    if float(np.min(np.linalg.eigvalsh(symmetric), initial=0.0)) < -(
+        1e-12 + 1e-10 * scale
+    ):
+        raise ValueError(f"{name} must be positive semidefinite")
+    return symmetric
+
+
+def _validated_covariance_rows(
+    local_covariance_m2: object,
+    *,
+    sample_count: int,
+) -> FloatArray:
+    local = np.asarray(local_covariance_m2, dtype=np.float64)
+    if local.shape != (sample_count, 3, 3):
+        raise ValueError("local_covariance_m2 must have shape (N, 3, 3)")
+    if not np.all(np.isfinite(local)):
+        raise ValueError("local_covariance_m2 must be finite")
+    symmetric = 0.5 * (local + local.swapaxes(1, 2))
+    scale = np.maximum(np.max(np.abs(symmetric), axis=(1, 2)), 1.0)
+    asymmetry = np.max(np.abs(local - local.swapaxes(1, 2)), axis=(1, 2))
+    if np.any(asymmetry > 1e-12 + 1e-10 * scale):
+        raise ValueError("local_covariance_m2 must be symmetric")
+    minimum = np.min(np.linalg.eigvalsh(symmetric), axis=1)
+    if np.any(minimum < -(1e-12 + 1e-10 * scale)):
+        raise ValueError("local_covariance_m2 must be positive semidefinite")
+    return symmetric
+
+
+def _validated_inputs(
+    query_jacobian: object,
+    local_covariance_m2: object,
+    low_rank_factor_m: object,
+) -> tuple[FloatArray, FloatArray, FloatArray]:
+    jacobian = np.asarray(query_jacobian, dtype=np.float64)
+    if jacobian.ndim == 2:
+        if jacobian.shape[1:] != (3,):
+            raise ValueError("scalar query_jacobian must have shape (N, 3)")
+        jacobian = jacobian[None, ...]
+    elif jacobian.ndim != 3 or jacobian.shape[2] != 3:
+        raise ValueError("query_jacobian must have shape (Q, N, 3) or (N, 3)")
+    if jacobian.shape[0] < 1 or jacobian.shape[1] < 1:
+        raise ValueError("query_jacobian must contain at least one query and one row")
+    if not np.all(np.isfinite(jacobian)):
+        raise ValueError("query_jacobian must be finite")
+
+    sample_count = int(jacobian.shape[1])
+    local = _validated_covariance_rows(
+        local_covariance_m2,
+        sample_count=sample_count,
+    )
+    factor = np.asarray(low_rank_factor_m, dtype=np.float64)
+    if factor.ndim != 3 or factor.shape[:2] != (sample_count, 3):
+        raise ValueError("low_rank_factor_m must have shape (N, 3, R)")
+    if not np.all(np.isfinite(factor)):
+        raise ValueError("low_rank_factor_m must be finite")
+    return jacobian, local, factor
+
+
+def _effective_rank(value: np.ndarray, *, relative_tolerance: float) -> int:
+    eigenvalues = np.linalg.eigvalsh(0.5 * (value + value.T))
+    maximum = float(np.max(eigenvalues, initial=0.0))
+    if maximum <= 0.0:
+        return 0
+    return int(np.count_nonzero(eigenvalues > relative_tolerance * maximum))
+
+
+def _directional_shared_fractions(
+    shared_covariance: np.ndarray,
+    total_covariance: np.ndarray,
+    *,
+    relative_tolerance: float,
+) -> tuple[int, float | None, float | None, float | None]:
+    total_eigenvalues, total_eigenvectors = np.linalg.eigh(total_covariance)
+    maximum = float(np.max(total_eigenvalues, initial=0.0))
+    if maximum <= 0.0:
+        return 0, None, None, None
+    active = total_eigenvalues > relative_tolerance * maximum
+    active_dimension = int(np.count_nonzero(active))
+    if active_dimension == 0:
+        return 0, None, None, None
+
+    basis = total_eigenvectors[:, active]
+    inverse_root = 1.0 / np.sqrt(total_eigenvalues[active])
+    whitened_shared = basis.T @ shared_covariance @ basis
+    whitened_shared = inverse_root[:, None] * whitened_shared * inverse_root[None, :]
+    whitened_shared = 0.5 * (whitened_shared + whitened_shared.T)
+    fractions = np.linalg.eigvalsh(whitened_shared)
+    if np.any(fractions < -1e-10) or np.any(fractions > 1.0 + 1e-10):
+        raise ValueError("shared covariance is not a valid component of total covariance")
+    fractions = np.clip(fractions, 0.0, 1.0)
+    return (
+        active_dimension,
+        float(np.min(fractions)),
+        float(np.mean(fractions)),
+        float(np.max(fractions)),
+    )
+
+
+def _coordinate_shared_fractions(
+    shared_covariance: np.ndarray,
+    total_covariance: np.ndarray,
+) -> tuple[float | None, ...]:
+    shared_diagonal = np.diag(shared_covariance)
+    total_diagonal = np.diag(total_covariance)
+    result: list[float | None] = []
+    for shared, total in zip(shared_diagonal, total_diagonal, strict=True):
+        result.append(None if total <= 0.0 else float(np.clip(shared / total, 0.0, 1.0)))
+    return tuple(result)
+
+
+@dataclass(frozen=True, slots=True)
+class QueryCovarianceProjectionV1:
+    """Immutable query-space decomposition and relevance diagnostics."""
+
+    conditional_covariance: FloatArray
+    shared_query_factor: FloatArray
+    observation_count: int
+    relative_rank_tolerance: float = 1e-10
+    shared_covariance: FloatArray = field(init=False)
+    total_covariance: FloatArray = field(init=False)
+    query_dimension: int = field(init=False)
+    shared_rank_column_count: int = field(init=False)
+    total_effective_rank: int = field(init=False)
+    shared_effective_rank: int = field(init=False)
+    active_query_dimension: int = field(init=False)
+    conditional_trace: float = field(init=False)
+    shared_trace: float = field(init=False)
+    total_trace: float = field(init=False)
+    shared_trace_fraction: float | None = field(init=False)
+    shared_frobenius_fraction: float | None = field(init=False)
+    coordinate_shared_fractions: tuple[float | None, ...] = field(init=False)
+    minimum_directional_shared_fraction: float | None = field(init=False)
+    mean_directional_shared_fraction: float | None = field(init=False)
+    maximum_directional_shared_fraction: float | None = field(init=False)
+
+    def __post_init__(self) -> None:
+        observation_count = _strict_positive_integer(
+            self.observation_count,
+            name="observation_count",
+        )
+        tolerance = _validated_relative_rank_tolerance(self.relative_rank_tolerance)
+        conditional = _validated_covariance(
+            self.conditional_covariance,
+            name="conditional_covariance",
+        )
+        query_dimension = int(conditional.shape[0])
+        shared_factor = np.asarray(self.shared_query_factor, dtype=np.float64)
+        if shared_factor.ndim != 2 or shared_factor.shape[0] != query_dimension:
+            raise ValueError("shared_query_factor must have shape (Q, R)")
+        if not np.all(np.isfinite(shared_factor)):
+            raise ValueError("shared_query_factor must be finite")
+
+        shared = _validated_covariance(
+            shared_factor @ shared_factor.T,
+            name="shared_covariance",
+            expected_dimension=query_dimension,
+        )
+        total = _validated_covariance(
+            conditional + shared,
+            name="total_covariance",
+            expected_dimension=query_dimension,
+        )
+        conditional_trace = float(np.trace(conditional))
+        shared_trace = float(np.trace(shared))
+        total_trace = float(np.trace(total))
+        total_norm = float(np.linalg.norm(total, ord="fro"))
+        shared_trace_fraction = (
+            None
+            if total_trace <= 0.0
+            else float(np.clip(shared_trace / total_trace, 0.0, 1.0))
+        )
+        shared_frobenius_fraction = (
+            None
+            if total_norm == 0.0
+            else float(np.clip(np.linalg.norm(shared, ord="fro") / total_norm, 0.0, 1.0))
+        )
+        (
+            active_dimension,
+            minimum_directional,
+            mean_directional,
+            maximum_directional,
+        ) = _directional_shared_fractions(
+            shared,
+            total,
+            relative_tolerance=tolerance,
+        )
+
+        object.__setattr__(self, "conditional_covariance", _readonly(conditional))
+        object.__setattr__(self, "shared_query_factor", _readonly(shared_factor))
+        object.__setattr__(self, "observation_count", observation_count)
+        object.__setattr__(self, "relative_rank_tolerance", tolerance)
+        object.__setattr__(self, "shared_covariance", _readonly(shared))
+        object.__setattr__(self, "total_covariance", _readonly(total))
+        object.__setattr__(self, "query_dimension", query_dimension)
+        object.__setattr__(self, "shared_rank_column_count", int(shared_factor.shape[1]))
+        object.__setattr__(
+            self,
+            "total_effective_rank",
+            _effective_rank(total, relative_tolerance=tolerance),
+        )
+        object.__setattr__(
+            self,
+            "shared_effective_rank",
+            _effective_rank(shared, relative_tolerance=tolerance),
+        )
+        object.__setattr__(self, "active_query_dimension", active_dimension)
+        object.__setattr__(self, "conditional_trace", conditional_trace)
+        object.__setattr__(self, "shared_trace", shared_trace)
+        object.__setattr__(self, "total_trace", total_trace)
+        object.__setattr__(self, "shared_trace_fraction", shared_trace_fraction)
+        object.__setattr__(self, "shared_frobenius_fraction", shared_frobenius_fraction)
+        object.__setattr__(
+            self,
+            "coordinate_shared_fractions",
+            _coordinate_shared_fractions(shared, total),
+        )
+        object.__setattr__(
+            self,
+            "minimum_directional_shared_fraction",
+            minimum_directional,
+        )
+        object.__setattr__(self, "mean_directional_shared_fraction", mean_directional)
+        object.__setattr__(
+            self,
+            "maximum_directional_shared_fraction",
+            maximum_directional,
+        )
+
+    def summary(self) -> dict[str, object]:
+        """Return a compact JSON-compatible diagnostic summary."""
+
+        return {
+            "schema": QUERY_COVARIANCE_RELEVANCE_SCHEMA,
+            "version": QUERY_COVARIANCE_RELEVANCE_VERSION,
+            "observation_count": self.observation_count,
+            "query_dimension": self.query_dimension,
+            "shared_rank_column_count": self.shared_rank_column_count,
+            "total_effective_rank": self.total_effective_rank,
+            "shared_effective_rank": self.shared_effective_rank,
+            "active_query_dimension": self.active_query_dimension,
+            "conditional_trace": self.conditional_trace,
+            "shared_trace": self.shared_trace,
+            "total_trace": self.total_trace,
+            "shared_trace_fraction": self.shared_trace_fraction,
+            "shared_frobenius_fraction": self.shared_frobenius_fraction,
+            "coordinate_shared_fractions": list(self.coordinate_shared_fractions),
+            "minimum_directional_shared_fraction": (
+                self.minimum_directional_shared_fraction
+            ),
+            "mean_directional_shared_fraction": self.mean_directional_shared_fraction,
+            "maximum_directional_shared_fraction": (
+                self.maximum_directional_shared_fraction
+            ),
+            "relative_rank_tolerance": self.relative_rank_tolerance,
+            "claim_boundary": QUERY_COVARIANCE_RELEVANCE_CLAIM_BOUNDARY,
+        }
+
+
+def project_joint_covariance_to_query(
+    query_jacobian: object,
+    local_covariance_m2: object,
+    low_rank_factor_m: object,
+    *,
+    relative_rank_tolerance: float = 1e-10,
+) -> QueryCovarianceProjectionV1:
+    """Project ``blockdiag(D_i) + U U.T`` through a block query Jacobian.
+
+    ``query_jacobian[q, i, :]`` is the derivative of query coordinate ``q``
+    with respect to observation row ``i``. A two-dimensional ``(N, 3)`` input
+    denotes a scalar query. The implementation never materializes the dense
+    observation covariance or a dense ``Q x 3N`` Jacobian.
+    """
+
+    tolerance = _validated_relative_rank_tolerance(relative_rank_tolerance)
+    jacobian, local, factor = _validated_inputs(
+        query_jacobian,
+        local_covariance_m2,
+        low_rank_factor_m,
+    )
+    conditional = np.einsum(
+        "qni,nij,rnj->qr",
+        jacobian,
+        local,
+        jacobian,
+        optimize=True,
+    )
+    shared_query_factor = np.einsum(
+        "qni,nik->qk",
+        jacobian,
+        factor,
+        optimize=True,
+    )
+    return QueryCovarianceProjectionV1(
+        conditional_covariance=conditional,
+        shared_query_factor=shared_query_factor,
+        observation_count=int(jacobian.shape[1]),
+        relative_rank_tolerance=tolerance,
+    )
+
+
+__all__ = [
+    "QUERY_COVARIANCE_RELEVANCE_CLAIM_BOUNDARY",
+    "QUERY_COVARIANCE_RELEVANCE_SCHEMA",
+    "QUERY_COVARIANCE_RELEVANCE_VERSION",
+    "QueryCovarianceProjectionV1",
+    "project_joint_covariance_to_query",
+]

--- a/src/prob4d/query_covariance_relevance.py
+++ b/src/prob4d/query_covariance_relevance.py
@@ -9,6 +9,7 @@ projection and reports how much query-space variance comes from shared modes.
 from __future__ import annotations
 
 import math
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from typing import Any, TypeAlias
 
@@ -16,6 +17,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 FloatArray: TypeAlias = NDArray[np.floating[Any]]
+QueryCovarianceBlock: TypeAlias = tuple[object, object, object]
 
 QUERY_COVARIANCE_RELEVANCE_SCHEMA = "prob4d.query-covariance-relevance"
 QUERY_COVARIANCE_RELEVANCE_VERSION = 1
@@ -186,6 +188,23 @@ def _coordinate_shared_fractions(
     return tuple(result)
 
 
+def _compensated_add(
+    total: FloatArray,
+    correction: FloatArray,
+    increment: FloatArray,
+) -> tuple[FloatArray, FloatArray]:
+    """Accumulate one array with a Neumaier correction."""
+
+    updated = total + increment
+    larger_total = np.abs(total) >= np.abs(increment)
+    correction += np.where(
+        larger_total,
+        (total - updated) + increment,
+        (increment - updated) + total,
+    )
+    return updated, correction
+
+
 @dataclass(frozen=True, slots=True)
 class QueryCovarianceProjectionV1:
     """Immutable query-space decomposition and relevance diagnostics."""
@@ -334,6 +353,92 @@ class QueryCovarianceProjectionV1:
         }
 
 
+def project_joint_covariance_blocks_to_query(
+    blocks: Iterable[QueryCovarianceBlock],
+    *,
+    relative_rank_tolerance: float = 1e-10,
+) -> QueryCovarianceProjectionV1:
+    """Project a stream of observation blocks without retaining all rows.
+
+    Every block is a three-tuple ``(query_jacobian, local_covariance_m2,
+    low_rank_factor_m)`` with the same query dimension and shared-factor rank.
+    Blocks are consumed exactly once. The routine retains only ``Q x Q`` and
+    ``Q x R`` accumulators, so peak memory is independent of the total number of
+    observation rows apart from the caller-owned current block.
+    """
+
+    tolerance = _validated_relative_rank_tolerance(relative_rank_tolerance)
+    conditional: FloatArray | None = None
+    conditional_correction: FloatArray | None = None
+    shared_query_factor: FloatArray | None = None
+    shared_correction: FloatArray | None = None
+    query_dimension: int | None = None
+    shared_rank: int | None = None
+    observation_count = 0
+
+    for block_index, block in enumerate(blocks):
+        if not isinstance(block, tuple) or len(block) != 3:
+            raise TypeError(
+                f"blocks[{block_index}] must be a three-tuple of Jacobian, "
+                "local covariance, and low-rank factor"
+            )
+        jacobian, local, factor = _validated_inputs(*block)
+        block_query_dimension = int(jacobian.shape[0])
+        block_shared_rank = int(factor.shape[2])
+        if query_dimension is None:
+            query_dimension = block_query_dimension
+            shared_rank = block_shared_rank
+            conditional = np.zeros((query_dimension, query_dimension), dtype=np.float64)
+            conditional_correction = np.zeros_like(conditional)
+            shared_query_factor = np.zeros((query_dimension, shared_rank), dtype=np.float64)
+            shared_correction = np.zeros_like(shared_query_factor)
+        else:
+            if block_query_dimension != query_dimension:
+                raise ValueError("all blocks must use the same query dimension")
+            if block_shared_rank != shared_rank:
+                raise ValueError("all blocks must use the same shared-factor rank")
+
+        block_conditional = np.einsum(
+            "qni,nij,rnj->qr",
+            jacobian,
+            local,
+            jacobian,
+            optimize=True,
+        )
+        block_shared = np.einsum(
+            "qni,nik->qk",
+            jacobian,
+            factor,
+            optimize=True,
+        )
+        assert conditional is not None
+        assert conditional_correction is not None
+        assert shared_query_factor is not None
+        assert shared_correction is not None
+        conditional, conditional_correction = _compensated_add(
+            conditional,
+            conditional_correction,
+            block_conditional,
+        )
+        shared_query_factor, shared_correction = _compensated_add(
+            shared_query_factor,
+            shared_correction,
+            block_shared,
+        )
+        observation_count += int(jacobian.shape[1])
+
+    if conditional is None or shared_query_factor is None:
+        raise ValueError("blocks must contain at least one observation block")
+    assert conditional_correction is not None
+    assert shared_correction is not None
+    return QueryCovarianceProjectionV1(
+        conditional_covariance=conditional + conditional_correction,
+        shared_query_factor=shared_query_factor + shared_correction,
+        observation_count=observation_count,
+        relative_rank_tolerance=tolerance,
+    )
+
+
 def project_joint_covariance_to_query(
     query_jacobian: object,
     local_covariance_m2: object,
@@ -349,30 +454,9 @@ def project_joint_covariance_to_query(
     observation covariance or a dense ``Q x 3N`` Jacobian.
     """
 
-    tolerance = _validated_relative_rank_tolerance(relative_rank_tolerance)
-    jacobian, local, factor = _validated_inputs(
-        query_jacobian,
-        local_covariance_m2,
-        low_rank_factor_m,
-    )
-    conditional = np.einsum(
-        "qni,nij,rnj->qr",
-        jacobian,
-        local,
-        jacobian,
-        optimize=True,
-    )
-    shared_query_factor = np.einsum(
-        "qni,nik->qk",
-        jacobian,
-        factor,
-        optimize=True,
-    )
-    return QueryCovarianceProjectionV1(
-        conditional_covariance=conditional,
-        shared_query_factor=shared_query_factor,
-        observation_count=int(jacobian.shape[1]),
-        relative_rank_tolerance=tolerance,
+    return project_joint_covariance_blocks_to_query(
+        ((query_jacobian, local_covariance_m2, low_rank_factor_m),),
+        relative_rank_tolerance=relative_rank_tolerance,
     )
 
 
@@ -380,6 +464,8 @@ __all__ = [
     "QUERY_COVARIANCE_RELEVANCE_CLAIM_BOUNDARY",
     "QUERY_COVARIANCE_RELEVANCE_SCHEMA",
     "QUERY_COVARIANCE_RELEVANCE_VERSION",
+    "QueryCovarianceBlock",
     "QueryCovarianceProjectionV1",
+    "project_joint_covariance_blocks_to_query",
     "project_joint_covariance_to_query",
 ]

--- a/tests/test_query_covariance_relevance.py
+++ b/tests/test_query_covariance_relevance.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from prob4d.query_covariance_relevance import (
+    QUERY_COVARIANCE_RELEVANCE_CLAIM_BOUNDARY,
+    QUERY_COVARIANCE_RELEVANCE_SCHEMA,
+    QUERY_COVARIANCE_RELEVANCE_VERSION,
+    QueryCovarianceProjectionV1,
+    project_joint_covariance_to_query,
+)
+
+
+def test_scalar_query_has_analytic_shared_fraction() -> None:
+    jacobian = np.array([[1.0, 0.0, 0.0]])
+    local = np.diag([1.0, 2.0, 3.0])[None, ...]
+    factor = np.array([[[2.0], [0.0], [0.0]]])
+
+    result = project_joint_covariance_to_query(jacobian, local, factor)
+
+    np.testing.assert_allclose(result.conditional_covariance, [[1.0]])
+    np.testing.assert_allclose(result.shared_query_factor, [[2.0]])
+    np.testing.assert_allclose(result.shared_covariance, [[4.0]])
+    np.testing.assert_allclose(result.total_covariance, [[5.0]])
+    assert result.shared_trace_fraction == pytest.approx(0.8)
+    assert result.shared_frobenius_fraction == pytest.approx(0.8)
+    assert result.coordinate_shared_fractions == pytest.approx((0.8,))
+    assert result.minimum_directional_shared_fraction == pytest.approx(0.8)
+    assert result.mean_directional_shared_fraction == pytest.approx(0.8)
+    assert result.maximum_directional_shared_fraction == pytest.approx(0.8)
+
+
+def test_multirow_query_retains_shared_cross_coordinate_covariance() -> None:
+    jacobian = np.zeros((2, 2, 3), dtype=np.float64)
+    jacobian[0, 0, 0] = 1.0
+    jacobian[1, 1, 0] = 1.0
+    local = np.repeat(np.eye(3)[None, ...], 2, axis=0)
+    factor = np.zeros((2, 3, 1), dtype=np.float64)
+    factor[:, 0, 0] = 1.0
+
+    result = project_joint_covariance_to_query(jacobian, local, factor)
+
+    np.testing.assert_allclose(result.conditional_covariance, np.eye(2))
+    np.testing.assert_allclose(result.shared_covariance, np.ones((2, 2)))
+    np.testing.assert_allclose(result.total_covariance, [[2.0, 1.0], [1.0, 2.0]])
+    assert result.shared_trace_fraction == pytest.approx(0.5)
+    assert result.shared_effective_rank == 1
+    assert result.total_effective_rank == 2
+    assert result.minimum_directional_shared_fraction == pytest.approx(0.0)
+    assert result.mean_directional_shared_fraction == pytest.approx(1.0 / 3.0)
+    assert result.maximum_directional_shared_fraction == pytest.approx(2.0 / 3.0)
+
+
+def test_projection_matches_dense_covariance_oracle() -> None:
+    generator = np.random.default_rng(17)
+    sample_count = 5
+    query_dimension = 3
+    rank = 4
+    jacobian = generator.normal(size=(query_dimension, sample_count, 3))
+    roots = generator.normal(size=(sample_count, 3, 3))
+    local = np.einsum("nij,nkj->nik", roots, roots) + 0.1 * np.eye(3)[None, ...]
+    factor = generator.normal(size=(sample_count, 3, rank))
+
+    result = project_joint_covariance_to_query(jacobian, local, factor)
+
+    dense_jacobian = jacobian.reshape(query_dimension, 3 * sample_count)
+    dense_local = np.zeros((3 * sample_count, 3 * sample_count), dtype=np.float64)
+    for index in range(sample_count):
+        start = 3 * index
+        dense_local[start : start + 3, start : start + 3] = local[index]
+    dense_factor = factor.reshape(3 * sample_count, rank)
+    expected_conditional = dense_jacobian @ dense_local @ dense_jacobian.T
+    expected_shared = dense_jacobian @ dense_factor @ dense_factor.T @ dense_jacobian.T
+
+    np.testing.assert_allclose(result.conditional_covariance, expected_conditional)
+    np.testing.assert_allclose(result.shared_covariance, expected_shared)
+    np.testing.assert_allclose(
+        result.total_covariance,
+        expected_conditional + expected_shared,
+    )
+
+
+def test_low_rank_basis_rotation_preserves_query_relevance() -> None:
+    generator = np.random.default_rng(23)
+    jacobian = generator.normal(size=(3, 4, 3))
+    local = np.repeat(np.eye(3)[None, ...], 4, axis=0)
+    factor = generator.normal(size=(4, 3, 3))
+    orthogonal, _ = np.linalg.qr(generator.normal(size=(3, 3)))
+
+    original = project_joint_covariance_to_query(jacobian, local, factor)
+    rotated = project_joint_covariance_to_query(
+        jacobian,
+        local,
+        np.einsum("nir,rs->nis", factor, orthogonal),
+    )
+
+    np.testing.assert_allclose(original.shared_covariance, rotated.shared_covariance)
+    np.testing.assert_allclose(original.total_covariance, rotated.total_covariance)
+    assert original.shared_trace_fraction == pytest.approx(rotated.shared_trace_fraction)
+    assert original.maximum_directional_shared_fraction == pytest.approx(
+        rotated.maximum_directional_shared_fraction
+    )
+
+
+def test_query_scaling_preserves_fractional_relevance() -> None:
+    generator = np.random.default_rng(29)
+    jacobian = generator.normal(size=(2, 3, 3))
+    local = np.repeat(np.eye(3)[None, ...], 3, axis=0)
+    factor = generator.normal(size=(3, 3, 2))
+
+    original = project_joint_covariance_to_query(jacobian, local, factor)
+    scaled = project_joint_covariance_to_query(7.0 * jacobian, local, factor)
+
+    assert original.shared_trace_fraction == pytest.approx(scaled.shared_trace_fraction)
+    assert original.shared_frobenius_fraction == pytest.approx(
+        scaled.shared_frobenius_fraction
+    )
+    assert original.maximum_directional_shared_fraction == pytest.approx(
+        scaled.maximum_directional_shared_fraction
+    )
+
+
+def test_zero_shared_factor_reports_zero_relevance() -> None:
+    jacobian = np.eye(3)[None, ...].reshape(3, 1, 3)
+    local = np.eye(3)[None, ...]
+    factor = np.empty((1, 3, 0), dtype=np.float64)
+
+    result = project_joint_covariance_to_query(jacobian, local, factor)
+
+    np.testing.assert_array_equal(result.shared_covariance, np.zeros((3, 3)))
+    assert result.shared_trace_fraction == 0.0
+    assert result.shared_frobenius_fraction == 0.0
+    assert result.coordinate_shared_fractions == (0.0, 0.0, 0.0)
+    assert result.shared_effective_rank == 0
+    assert result.minimum_directional_shared_fraction == 0.0
+    assert result.maximum_directional_shared_fraction == 0.0
+
+
+def test_zero_query_variance_is_explicitly_unidentified() -> None:
+    jacobian = np.zeros((2, 1, 3), dtype=np.float64)
+    local = np.zeros((1, 3, 3), dtype=np.float64)
+    factor = np.zeros((1, 3, 1), dtype=np.float64)
+
+    result = project_joint_covariance_to_query(jacobian, local, factor)
+
+    assert result.total_trace == 0.0
+    assert result.shared_trace_fraction is None
+    assert result.shared_frobenius_fraction is None
+    assert result.coordinate_shared_fractions == (None, None)
+    assert result.active_query_dimension == 0
+    assert result.minimum_directional_shared_fraction is None
+    assert result.maximum_directional_shared_fraction is None
+
+
+def test_projection_defensively_owns_immutable_arrays() -> None:
+    jacobian = np.array([[1.0, 0.0, 0.0]])
+    local = np.eye(3)[None, ...]
+    factor = np.ones((1, 3, 1), dtype=np.float64)
+
+    result = project_joint_covariance_to_query(jacobian, local, factor)
+    local[...] = 9.0
+    factor[...] = 9.0
+
+    np.testing.assert_allclose(result.conditional_covariance, [[1.0]])
+    np.testing.assert_allclose(result.shared_covariance, [[1.0]])
+    for value in (
+        result.conditional_covariance,
+        result.shared_query_factor,
+        result.shared_covariance,
+        result.total_covariance,
+    ):
+        assert not value.flags.writeable
+
+
+def test_summary_is_compact_and_states_the_scientific_boundary() -> None:
+    result = project_joint_covariance_to_query(
+        np.array([[1.0, 0.0, 0.0]]),
+        np.eye(3)[None, ...],
+        np.empty((1, 3, 0), dtype=np.float64),
+    )
+
+    summary = result.summary()
+
+    assert summary["schema"] == QUERY_COVARIANCE_RELEVANCE_SCHEMA
+    assert summary["version"] == QUERY_COVARIANCE_RELEVANCE_VERSION
+    assert summary["claim_boundary"] == QUERY_COVARIANCE_RELEVANCE_CLAIM_BOUNDARY
+    assert "conditional_covariance" not in summary
+    assert "total_covariance" not in summary
+
+
+def test_direct_construction_recomputes_all_derived_fields() -> None:
+    projected = project_joint_covariance_to_query(
+        np.array([[1.0, 0.0, 0.0]]),
+        np.eye(3)[None, ...],
+        np.ones((1, 3, 1), dtype=np.float64),
+    )
+
+    reconstructed = QueryCovarianceProjectionV1(
+        conditional_covariance=projected.conditional_covariance,
+        shared_query_factor=projected.shared_query_factor,
+        observation_count=projected.observation_count,
+    )
+
+    assert reconstructed.summary() == projected.summary()
+    np.testing.assert_array_equal(
+        reconstructed.total_covariance,
+        projected.total_covariance,
+    )
+
+
+def test_constructor_rejects_coercive_or_invalid_inputs() -> None:
+    result = project_joint_covariance_to_query(
+        np.array([[1.0, 0.0, 0.0]]),
+        np.eye(3)[None, ...],
+        np.ones((1, 3, 1), dtype=np.float64),
+    )
+
+    with pytest.raises(TypeError, match="observation_count"):
+        replace(result, observation_count=True)
+    with pytest.raises(ValueError, match="relative_rank_tolerance"):
+        replace(result, relative_rank_tolerance=np.nan)
+
+    asymmetric = result.conditional_covariance.copy()
+    asymmetric[0, 0] = np.nan
+    with pytest.raises(ValueError, match="conditional_covariance must be finite"):
+        replace(result, conditional_covariance=asymmetric)
+
+
+@pytest.mark.parametrize(
+    ("jacobian", "local", "factor", "message"),
+    [
+        (np.ones((2, 2)), np.eye(3)[None, ...], np.ones((1, 3, 1)), "query_jacobian"),
+        (
+            np.ones((1, 1, 3)),
+            np.ones((1, 2, 2)),
+            np.ones((1, 3, 1)),
+            "local_covariance_m2",
+        ),
+        (
+            np.ones((1, 1, 3)),
+            np.eye(3)[None, ...],
+            np.ones((2, 3, 1)),
+            "low_rank_factor_m",
+        ),
+    ],
+)
+def test_shape_mismatches_fail_closed(
+    jacobian: np.ndarray,
+    local: np.ndarray,
+    factor: np.ndarray,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        project_joint_covariance_to_query(jacobian, local, factor)
+
+
+def test_invalid_covariance_and_nonfinite_inputs_fail_closed() -> None:
+    jacobian = np.ones((1, 1, 3), dtype=np.float64)
+    factor = np.ones((1, 3, 1), dtype=np.float64)
+
+    asymmetric = np.eye(3)[None, ...]
+    asymmetric[0, 0, 1] = 0.1
+    with pytest.raises(ValueError, match="symmetric"):
+        project_joint_covariance_to_query(jacobian, asymmetric, factor)
+
+    indefinite = np.diag([1.0, 1.0, -0.1])[None, ...]
+    with pytest.raises(ValueError, match="positive semidefinite"):
+        project_joint_covariance_to_query(jacobian, indefinite, factor)
+
+    nonfinite_jacobian = jacobian.copy()
+    nonfinite_jacobian[0, 0, 0] = np.nan
+    with pytest.raises(ValueError, match="query_jacobian must be finite"):
+        project_joint_covariance_to_query(nonfinite_jacobian, np.eye(3)[None, ...], factor)
+
+    nonfinite_factor = factor.copy()
+    nonfinite_factor[0, 0, 0] = np.inf
+    with pytest.raises(ValueError, match="low_rank_factor_m must be finite"):
+        project_joint_covariance_to_query(jacobian, np.eye(3)[None, ...], nonfinite_factor)
+
+
+@pytest.mark.parametrize("value", [True, -0.1, 1.0, np.nan, "1e-10"])
+def test_invalid_rank_tolerance_fails_closed(value: object) -> None:
+    with pytest.raises(ValueError, match="relative_rank_tolerance"):
+        project_joint_covariance_to_query(
+            np.ones((1, 1, 3)),
+            np.eye(3)[None, ...],
+            np.ones((1, 3, 1)),
+            relative_rank_tolerance=value,  # type: ignore[arg-type]
+        )

--- a/tests/test_query_covariance_relevance_streaming.py
+++ b/tests/test_query_covariance_relevance_streaming.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from prob4d.query_covariance_relevance import (
+    project_joint_covariance_blocks_to_query,
+    project_joint_covariance_to_query,
+)
+
+
+def _random_problem() -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    generator = np.random.default_rng(991)
+    jacobian = generator.normal(size=(4, 11, 3))
+    roots = generator.normal(size=(11, 3, 3))
+    local = np.einsum("nij,nkj->nik", roots, roots) + 0.05 * np.eye(3)[None, ...]
+    factor = generator.normal(size=(11, 3, 5))
+    return jacobian, local, factor
+
+
+def test_streaming_projection_matches_monolithic_and_reverse_order() -> None:
+    jacobian, local, factor = _random_problem()
+    expected = project_joint_covariance_to_query(jacobian, local, factor)
+    blocks = (
+        (jacobian[:, :2], local[:2], factor[:2]),
+        (jacobian[:, 2:7], local[2:7], factor[2:7]),
+        (jacobian[:, 7:], local[7:], factor[7:]),
+    )
+
+    streamed = project_joint_covariance_blocks_to_query(iter(blocks))
+    reversed_streamed = project_joint_covariance_blocks_to_query(iter(reversed(blocks)))
+
+    for actual in (streamed, reversed_streamed):
+        assert actual.observation_count == 11
+        np.testing.assert_allclose(
+            actual.conditional_covariance,
+            expected.conditional_covariance,
+        )
+        np.testing.assert_allclose(
+            actual.shared_query_factor,
+            expected.shared_query_factor,
+        )
+        np.testing.assert_allclose(actual.shared_covariance, expected.shared_covariance)
+        np.testing.assert_allclose(actual.total_covariance, expected.total_covariance)
+
+
+def test_streaming_projection_accepts_scalar_query_blocks_and_rank_zero() -> None:
+    blocks = (
+        (
+            np.array([[1.0, 0.0, 0.0], [0.0, 1.0, 0.0]]),
+            np.repeat(np.eye(3)[None, ...], 2, axis=0),
+            np.empty((2, 3, 0)),
+        ),
+        (
+            np.array([[0.0, 0.0, 2.0]]),
+            np.diag([1.0, 2.0, 3.0])[None, ...],
+            np.empty((1, 3, 0)),
+        ),
+    )
+
+    result = project_joint_covariance_blocks_to_query(blocks)
+
+    assert result.query_dimension == 1
+    assert result.observation_count == 3
+    assert result.shared_rank_column_count == 0
+    np.testing.assert_allclose(result.conditional_covariance, [[14.0]])
+    assert result.shared_trace_fraction == 0.0
+
+
+def test_streaming_projection_consumes_iterable_once() -> None:
+    jacobian, local, factor = _random_problem()
+
+    class OnePass:
+        def __init__(self) -> None:
+            self.iterations = 0
+
+        def __iter__(self):
+            self.iterations += 1
+            if self.iterations > 1:
+                raise AssertionError("block stream was iterated more than once")
+            yield jacobian[:, :5], local[:5], factor[:5]
+            yield jacobian[:, 5:], local[5:], factor[5:]
+
+    blocks = OnePass()
+    result = project_joint_covariance_blocks_to_query(blocks)
+
+    assert blocks.iterations == 1
+    assert result.observation_count == 11
+
+
+def test_streaming_projection_rejects_empty_or_malformed_blocks() -> None:
+    with pytest.raises(ValueError, match="at least one observation block"):
+        project_joint_covariance_blocks_to_query(())
+    with pytest.raises(TypeError, match="three-tuple"):
+        project_joint_covariance_blocks_to_query(
+            [(np.ones((1, 3)), np.eye(3)[None])]
+        )
+
+
+def test_streaming_projection_rejects_dimension_or_rank_drift() -> None:
+    local = np.eye(3)[None, ...]
+    with pytest.raises(ValueError, match="same query dimension"):
+        project_joint_covariance_blocks_to_query(
+            (
+                (np.ones((1, 1, 3)), local, np.ones((1, 3, 2))),
+                (np.ones((2, 1, 3)), local, np.ones((1, 3, 2))),
+            )
+        )
+    with pytest.raises(ValueError, match="same shared-factor rank"):
+        project_joint_covariance_blocks_to_query(
+            (
+                (np.ones((1, 1, 3)), local, np.ones((1, 3, 2))),
+                (np.ones((1, 1, 3)), local, np.ones((1, 3, 3))),
+            )
+        )


### PR DESCRIPTION
## What changed

- add the experimental `prob4d.query_covariance_relevance` module;
- project `blockdiag(D_i) + U U^T` through a consumer-supplied block query Jacobian without materializing a dense `3N x 3N` covariance or `Q x 3N` Jacobian;
- retain immutable conditional, shared, and total query covariance plus the projected shared factor;
- report shared trace and Frobenius fractions, coordinate-wise fractions, effective ranks, and minimum/mean/maximum generalized directional shared-variance fractions;
- treat a zero-variance query as explicitly unidentified rather than inventing a fraction;
- provide a one-pass streaming block API for large observations that retains only compensated `Q x Q` and `Q x R` accumulators;
- require every streamed block to preserve the query dimension and shared-factor rank and fail closed on empty, malformed, or drifting streams;
- validate genuine metadata types, finite inputs, covariance symmetry and positive semidefiniteness, rank-zero factors, and direct-construction replay;
- document the ownership boundary between Prob4D covariance projection, BayesianPhysTwin query/admission policy, and Causal4D consumption; and
- link the diagnostic from the existing joint-covariance guide.

## Why

Observation-space covariance fidelity does not by itself establish that full joint uncertainty matters for a particular physical query. A shared mode can dominate one query while being modest on average, or be large in observation space while lying mostly in a query-insensitive subspace.

This diagnostic provides the missing neutral projection. Prob4D supplies the conditional-plus-low-rank covariance; BayesianPhysTwin supplies the physical query Jacobian and remains responsible for any source-calibrated selection rule, practical-equivalence margin, computational trade-off, and exact fallback.

The streaming path additionally avoids retaining a complete query Jacobian when the observation count is large while query dimension and shared rank remain small.

## Numerical formulation

For local query blocks `J_i`, conditional row covariances `D_i`, and shared factor blocks `U_i`, the module computes

```text
C_conditional = sum_i J_i D_i J_i^T
U_query       = sum_i J_i U_i
C_shared      = U_query U_query^T
C_total       = C_conditional + C_shared
```

Directional fractions are the generalized shared-versus-total covariance eigenvalues on the numerically supported total-query subspace.

## Validation

Exact validated head: `10776cedd8cde2e0ab174d741004ea1632b87956`.

- all 25 focused query-relevance and streaming tests pass;
- the complete repository suite passes on Python 3.10, 3.11, 3.12, 3.13, and 3.14;
- the complete suite passes at the declared Python 3.10 / NumPy 1.24 runtime floor;
- dense covariance oracle parity, low-rank basis-rotation invariance, query-scaling invariance, rank-zero factors, zero-query variance, immutable ownership, and direct-construction replay pass;
- the streaming path matches monolithic projection, remains stable under block-order reversal, accepts scalar/rank-zero blocks, consumes a one-pass iterable exactly once, and rejects empty, malformed, query-dimension-drifting, and rank-drifting streams;
- malformed shape, non-finite, asymmetric, indefinite, coercive metadata, and invalid rank-tolerance cases fail closed;
- authoritative Ruff and MyPy pass;
- repository, release, API, provider, and source-distribution policies pass;
- wheel and source distributions build and validate;
- both artifacts install in isolation and pass grouped and legacy CLI smoke tests; and
- dependency audit and CodeQL security scanning pass.

The first matrix exposed only an unrelated changelog-policy mismatch. The repository intentionally freezes `CHANGELOG.md` at `Unreleased / No changes yet.` for the 0.4 release boundary, so that edit was removed before the validated branch. The subsequent streaming commits are included in the exact validated head above.

## Compatibility and scientific boundary

- No provider-v1/provider-v2, factor-bundle, tree-sparse, calibration, stream, evidence, release, or stable `prob4d.api.v2` contract changes.
- The module is deliberately experimental and is not exported from the stable package façade.
- No physical query, threshold, covariance-treatment selection, target cohort, or recorded result is changed.
- This is diagnostic infrastructure. It does not establish provider competence, calibrated uncertainty on a fresh cohort, BayesianPhysTwin benefit, Causal4D intervention benefit, deployment safety, or state of the art.