### PR TITLE
Add source-fitted correlation-group robust likelihood

### DIFF
--- a/docs/correlation-group-robust-likelihood.md
+++ b/docs/correlation-group-robust-likelihood.md
@@ -1,0 +1,153 @@
+# Correlation-group robust likelihood
+
+Prob4D factors can contain many rows produced by one shared visual event: a
+tracklet, a camera/frame cell, or another declared correlation group. A local
+failure in that event should not create hundreds of apparently independent
+outlier decisions. `prob4d.correlation_group_robust_likelihood` therefore uses
+one latent contamination state for the complete group.
+
+The module is experimental source-side infrastructure. It does not change the
+provider-v2 factor contract, association probabilities, prior reliability,
+BayesianPhysTwin admission, or exact physical fallback.
+
+## Group-level likelihood
+
+For one complete group, Prob4D already represents the covariance as
+
+```text
+C = blockdiag(D_1, ..., D_N) + U U^T.
+```
+
+The robust candidate is
+
+```text
+p(r) = (1 - rho) N(r; 0, C) + rho N(r; 0, lambda C),
+```
+
+with `0 < rho < 1` and `lambda > 1`. The Gaussian fallback is represented
+exactly by `rho = 0` and `lambda = 1`.
+
+Scaling the complete covariance gives
+
+```text
+log det(lambda C) = log det(C) + d log(lambda)
+q_lambda          = q / lambda,
+```
+
+where `d = 3N` and `q = r^T C^-1 r`. The implementation reuses Prob4D's
+Woodbury joint-covariance evaluator and never materializes the dense `3N x 3N`
+covariance.
+
+```python
+import numpy as np
+
+from prob4d.correlation_group_robust_likelihood import (
+    CorrelationGroupContaminationSpecV1,
+    CorrelationGroupResidualV1,
+    evaluate_correlation_group_mixture,
+)
+
+group = CorrelationGroupResidualV1(
+    group_id="camera-0:frame-12:cell-3",
+    residual_xyz_m=np.array([[7.0, 0.0, 0.0]]),
+    local_covariance_m2=np.eye(3)[None, ...],
+    low_rank_factor_m=np.empty((1, 3, 0)),
+)
+spec = CorrelationGroupContaminationSpecV1(
+    contamination_probability=0.1,
+    inflation_factor=25.0,
+)
+evaluation = evaluate_correlation_group_mixture(group, spec)
+```
+
+The result reports one posterior contamination probability for the complete
+group and the posterior expected inverse-scale multiplier
+
+```text
+(1 - gamma) + gamma / lambda.
+```
+
+That multiplier is a likelihood diagnostic. It is deliberately not named or
+stored as association probability, prior reliability, or deployment acceptance.
+
+## Source-only finite-grid selection
+
+`select_source_correlation_group_mixture` evaluates a finite candidate grid on
+complete independent source groups. One exact Gaussian fallback is mandatory.
+Candidate and group input order are canonicalized, and every source bundle is
+bound by a digest over the normalized arrays.
+
+Selection uses nested leave-one-group-out evaluation:
+
+1. hold out one complete source object/session/group;
+2. choose a candidate from the remaining groups by equal-group mean Gaussian
+   mixture NLL per dimension;
+3. score that candidate on the held-out group against the Gaussian fallback;
+4. repeat for every group; and
+5. select the full-source candidate only when the frozen support gates pass.
+
+The gates are explicit:
+
+- minimum independent source-group count;
+- minimum mean held-out NLL advantage per dimension;
+- maximum tolerated held-out NLL harm per dimension before a group is classified
+  as harmful;
+- maximum harmful-group fraction; and
+- minimum fraction of folds selecting the final full-source candidate.
+
+A failed gate returns the exact Gaussian likelihood specification rather than a
+partially robust configuration. Insufficient group count is retained as a valid
+negative source result.
+
+```python
+from prob4d.correlation_group_robust_likelihood import (
+    GAUSSIAN_GROUP_LIKELIHOOD_V1,
+    select_source_correlation_group_mixture,
+)
+
+selection = select_source_correlation_group_mixture(
+    source_groups,
+    (
+        GAUSSIAN_GROUP_LIKELIHOOD_V1,
+        CorrelationGroupContaminationSpecV1(0.05, 10.0),
+        CorrelationGroupContaminationSpecV1(0.10, 25.0),
+    ),
+    minimum_group_count=8,
+    minimum_mean_heldout_advantage_per_dimension=0.0,
+    maximum_heldout_nll_harm_per_dimension=0.1,
+    maximum_harmful_group_fraction=0.0,
+    minimum_final_candidate_fold_fraction=0.5,
+)
+```
+
+The selection object retains the complete candidate-by-group proper-score
+matrix, every held-out decision, source identities, thresholds, selected and
+unconstrained specifications, reasons for Gaussian fallback, and a deterministic
+selection identity. It does not retain or inspect target outcomes.
+
+## Statistical unit and grouping
+
+The group must correspond to the shared failure mechanism represented by one
+latent scale. Suitable examples include a complete correlation group already
+retained by provider-v2 factors or a complete independent calibration unit when
+all rows share one acquisition-level contamination event.
+
+Do not split one coherent factor across several IDs merely to create more
+replicates. Do not join unrelated objects or sessions into one group merely to
+obtain a stronger outlier decision. Source model selection should use the object
+or acquisition session as the independent outer statistical unit.
+
+## Boundaries
+
+Association probability answers whether a row corresponds to the intended
+physical point or identity. Prior reliability is a source-calibrated probability
+that an admitted observation is nominal before seeing a downstream residual.
+Posterior contamination responsibility is the likelihood's response to the
+complete matched residual group. These quantities are not interchangeable.
+
+BayesianPhysTwin remains responsible for deciding whether a physical update is
+identifiable and beneficial and for returning the exact physical fallback on
+rejection. Causal4D should consume only the accepted physical belief. A robust
+source likelihood does not establish provider competence, fresh-object
+calibration, physical-query benefit, intervention benefit, deployment safety, or
+state of the art.

--- a/docs/correlation-group-robust-likelihood.md
+++ b/docs/correlation-group-robust-likelihood.md
@@ -1,10 +1,17 @@
 # Correlation-group robust likelihood
 
-Prob4D factors can contain many rows produced by one shared visual event: a
-tracklet, a camera/frame cell, or another declared correlation group. A local
-failure in that event should not create hundreds of apparently independent
-outlier decisions. `prob4d.correlation_group_robust_likelihood` therefore uses
-one latent contamination state for the complete group.
+Prob4D factors can contain many rows produced by one coherent visual event: a
+tracklet, a camera/frame cell, or another declared correlation group. One local
+failure should not create hundreds of apparently independent outlier decisions.
+`prob4d.correlation_group_robust_likelihood` therefore assigns one latent
+contamination state to the complete correlation group.
+
+Correlation groups and statistical units are deliberately separate:
+
+- a `CorrelationGroupResidualV1` is one inner likelihood group that shares a
+  contamination state; and
+- a `SourceCorrelationGroupUnitV1` is one independent outer source object or
+  acquisition session used for selection and leave-one-unit-out evaluation.
 
 The module is experimental source-side infrastructure. It does not change the
 provider-v2 factor contract, association probabilities, prior reliability,
@@ -12,7 +19,7 @@ BayesianPhysTwin admission, or exact physical fallback.
 
 ## Group-level likelihood
 
-For one complete group, Prob4D already represents the covariance as
+For one complete correlation group, Prob4D represents the covariance as
 
 ```text
 C = blockdiag(D_1, ..., D_N) + U U^T.
@@ -25,7 +32,8 @@ p(r) = (1 - rho) N(r; 0, C) + rho N(r; 0, lambda C),
 ```
 
 with `0 < rho < 1` and `lambda > 1`. The Gaussian fallback is represented
-exactly by `rho = 0` and `lambda = 1`.
+exactly by `rho = 0` and `lambda = 1`. Here, `lambda` multiplies covariance, not
+standard deviation.
 
 Scaling the complete covariance gives
 
@@ -47,21 +55,24 @@ from prob4d.correlation_group_robust_likelihood import (
     evaluate_correlation_group_mixture,
 )
 
-group = CorrelationGroupResidualV1(
+correlation_group = CorrelationGroupResidualV1(
     group_id="camera-0:frame-12:cell-3",
     residual_xyz_m=np.array([[7.0, 0.0, 0.0]]),
     local_covariance_m2=np.eye(3)[None, ...],
     low_rank_factor_m=np.empty((1, 3, 0)),
 )
-spec = CorrelationGroupContaminationSpecV1(
+specification = CorrelationGroupContaminationSpecV1(
     contamination_probability=0.1,
     inflation_factor=25.0,
 )
-evaluation = evaluate_correlation_group_mixture(group, spec)
+evaluation = evaluate_correlation_group_mixture(
+    correlation_group,
+    specification,
+)
 ```
 
 The result reports one posterior contamination probability for the complete
-group and the posterior expected inverse-scale multiplier
+correlation group and the posterior expected inverse-scale multiplier
 
 ```text
 (1 - gamma) + gamma / lambda.
@@ -70,34 +81,62 @@ group and the posterior expected inverse-scale multiplier
 That multiplier is a likelihood diagnostic. It is deliberately not named or
 stored as association probability, prior reliability, or deployment acceptance.
 
+## Independent source units
+
+A source object or acquisition session can contain several correlation groups.
+They are nested inside one `SourceCorrelationGroupUnitV1`:
+
+```python
+from prob4d.correlation_group_robust_likelihood import (
+    SourceCorrelationGroupUnitV1,
+)
+
+source_unit = SourceCorrelationGroupUnitV1(
+    source_unit_id="calibration-object-01",
+    correlation_groups=(
+        camera_0_frame_12_cell_3,
+        camera_0_frame_12_cell_4,
+        camera_1_frame_12_cell_2,
+    ),
+)
+```
+
+Within one source unit, candidate log likelihoods are summed over its complete
+correlation groups and divided by the total retained residual dimension. Across
+source units, the resulting scores receive equal weight. Thus, a dense object or
+session cannot dominate method selection solely because it contributes more
+rows, while the proper likelihood still accounts for all declared inner groups.
+
+Correlation-group input order is canonicalized inside each source unit. The
+source-unit identity binds its ID and every inner group ID and content identity.
+
 ## Source-only finite-grid selection
 
 `select_source_correlation_group_mixture` evaluates a finite candidate grid on
-complete independent source groups. One exact Gaussian fallback is mandatory.
-Candidate and group input order are canonicalized, and every source bundle is
-bound by a digest over the normalized arrays.
+complete independent source units. One exact Gaussian fallback is mandatory.
+Candidate and source-unit input order are canonicalized.
 
-Selection uses nested leave-one-group-out evaluation:
+Selection uses nested leave-one-source-unit-out evaluation:
 
-1. hold out one complete source object/session/group;
-2. choose a candidate from the remaining groups by equal-group mean Gaussian
-   mixture NLL per dimension;
-3. score that candidate on the held-out group against the Gaussian fallback;
-4. repeat for every group; and
-5. select the full-source candidate only when the frozen support gates pass.
+1. hold out one complete source object or acquisition session;
+2. choose a candidate from the remaining units by equal-source-unit mean mixture
+   NLL per residual dimension;
+3. score that candidate on the held-out unit against the Gaussian fallback;
+4. repeat for every source unit; and
+5. retain the full-source candidate only when all frozen support gates pass.
 
 The gates are explicit:
 
-- minimum independent source-group count;
+- minimum independent source-unit count;
 - minimum mean held-out NLL advantage per dimension;
-- maximum tolerated held-out NLL harm per dimension before a group is classified
-  as harmful;
-- maximum harmful-group fraction; and
+- maximum tolerated held-out NLL harm per dimension before a source unit is
+  classified as harmful;
+- maximum harmful-source-unit fraction; and
 - minimum fraction of folds selecting the final full-source candidate.
 
 A failed gate returns the exact Gaussian likelihood specification rather than a
-partially robust configuration. Insufficient group count is retained as a valid
-negative source result.
+partially robust configuration. Insufficient independent source units are
+retained as valid negative source evidence.
 
 ```python
 from prob4d.correlation_group_robust_likelihood import (
@@ -106,44 +145,61 @@ from prob4d.correlation_group_robust_likelihood import (
 )
 
 selection = select_source_correlation_group_mixture(
-    source_groups,
+    source_units,
     (
         GAUSSIAN_GROUP_LIKELIHOOD_V1,
         CorrelationGroupContaminationSpecV1(0.05, 10.0),
         CorrelationGroupContaminationSpecV1(0.10, 25.0),
     ),
-    minimum_group_count=8,
+    minimum_source_unit_count=8,
     minimum_mean_heldout_advantage_per_dimension=0.0,
     maximum_heldout_nll_harm_per_dimension=0.1,
-    maximum_harmful_group_fraction=0.0,
+    maximum_harmful_source_unit_fraction=0.0,
     minimum_final_candidate_fold_fraction=0.5,
 )
 ```
 
-The selection object retains the complete candidate-by-group proper-score
-matrix, every held-out decision, source identities, thresholds, selected and
-unconstrained specifications, reasons for Gaussian fallback, and a deterministic
-selection identity. It does not retain or inspect target outcomes.
+The selection object retains:
 
-## Statistical unit and grouping
+- the complete candidate-by-source-unit proper-score matrix;
+- source-unit content identities;
+- every held-out selection and score comparison;
+- all thresholds;
+- the unconstrained and deployed specifications;
+- explicit reasons for Gaussian fallback; and
+- a deterministic selection identity that binds the claim boundary.
 
-The group must correspond to the shared failure mechanism represented by one
-latent scale. Suitable examples include a complete correlation group already
-retained by provider-v2 factors or a complete independent calibration unit when
-all rows share one acquisition-level contamination event.
+It does not retain or inspect target outcomes.
 
-Do not split one coherent factor across several IDs merely to create more
-replicates. Do not join unrelated objects or sessions into one group merely to
-obtain a stronger outlier decision. Source model selection should use the object
-or acquisition session as the independent outer statistical unit.
+## Grouping rules
+
+The inner correlation group must correspond to the shared failure mechanism
+represented by one latent scale. Suitable examples include an existing
+provider-v2 correlation group, one complete causal tracklet group, or one
+camera/frame cell whose rows share one visual failure mode.
+
+The outer source unit must be the independent replication unit used for the
+scientific source study, normally a complete physical object or acquisition
+session.
+
+Do not:
+
+- split one coherent factor across several correlation-group IDs merely to
+  create more apparent outlier decisions;
+- treat several correlation groups from one object as independent outer
+  replicates;
+- join unrelated objects or sessions into one source unit merely to obtain a
+  stronger likelihood result; or
+- select `rho`, `lambda`, or support thresholds from target outcomes.
 
 ## Boundaries
 
 Association probability answers whether a row corresponds to the intended
 physical point or identity. Prior reliability is a source-calibrated probability
 that an admitted observation is nominal before seeing a downstream residual.
-Posterior contamination responsibility is the likelihood's response to the
-complete matched residual group. These quantities are not interchangeable.
+Posterior contamination responsibility is the likelihood's response to one
+complete matched residual correlation group. These quantities are not
+interchangeable.
 
 BayesianPhysTwin remains responsible for deciding whether a physical update is
 identifiable and beneficial and for returning the exact physical fallback on

--- a/src/prob4d/correlation_group_robust_likelihood.py
+++ b/src/prob4d/correlation_group_robust_likelihood.py
@@ -1,0 +1,741 @@
+"""Source-fitted contaminated-Gaussian likelihood for complete correlation groups.
+
+One latent contamination state is shared by every row in a declared correlation
+or statistical group. Association probability and prior reliability remain
+separate inputs owned by their existing contracts; the posterior contamination
+responsibility produced here is a likelihood diagnostic, not a replacement for
+either quantity.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, TypeAlias
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .joint_covariance_metrics import evaluate_joint_gaussian_group
+
+FloatArray: TypeAlias = NDArray[np.floating[Any]]
+
+CORRELATION_GROUP_ROBUST_SCHEMA = "prob4d.correlation-group-robust-likelihood"
+CORRELATION_GROUP_ROBUST_VERSION = 1
+CORRELATION_GROUP_ROBUST_CLAIM_BOUNDARY = (
+    "This source-side diagnostic fits a finite contaminated-Gaussian candidate grid "
+    "over complete independent groups. Posterior contamination responsibility is "
+    "distinct from association probability and prior reliability. The result does "
+    "not authorize a BayesianPhysTwin update, replace exact fallback, establish "
+    "target calibration, or establish Causal4D intervention benefit."
+)
+
+
+def _strict_real(value: object, *, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(
+        value,
+        (int, float, np.integer, np.floating),
+    ):
+        raise TypeError(f"{name} must be a genuine real scalar")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"{name} must be finite")
+    return result
+
+
+def _strict_integer(value: object, *, name: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, (int, np.integer)):
+        raise TypeError(f"{name} must be a genuine integer")
+    return int(value)
+
+
+def _strict_group_id(value: object, *, name: str = "group_id") -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{name} must be a string")
+    if not value:
+        raise ValueError(f"{name} must not be empty")
+    return value
+
+
+def _readonly(value: object, *, dtype: Any = np.float64) -> np.ndarray:
+    result = np.asarray(value, dtype=dtype).copy()
+    result.setflags(write=False)
+    return result
+
+
+def _canonical_json(value: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _array_digest(digest: Any, name: str, value: np.ndarray) -> None:
+    array = np.ascontiguousarray(value)
+    digest.update(name.encode("utf-8"))
+    digest.update(array.dtype.str.encode("ascii"))
+    digest.update(json.dumps(array.shape, separators=(",", ":")).encode("ascii"))
+    digest.update(array.view(np.uint8))
+
+
+def _logaddexp(left: float, right: float) -> float:
+    maximum = max(left, right)
+    return maximum + math.log(math.exp(left - maximum) + math.exp(right - maximum))
+
+
+@dataclass(frozen=True, slots=True)
+class CorrelationGroupContaminationSpecV1:
+    """One frozen group-level contaminated-Gaussian candidate."""
+
+    contamination_probability: float
+    inflation_factor: float
+    spec_id: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        probability = _strict_real(
+            self.contamination_probability,
+            name="contamination_probability",
+        )
+        inflation = _strict_real(self.inflation_factor, name="inflation_factor")
+        if not 0.0 <= probability < 1.0:
+            raise ValueError("contamination_probability must lie in [0, 1)")
+        if probability == 0.0:
+            if inflation != 1.0:
+                raise ValueError("the Gaussian fallback must use inflation_factor=1")
+        elif inflation <= 1.0:
+            raise ValueError("a contaminated candidate must use inflation_factor > 1")
+        identity = {
+            "schema": CORRELATION_GROUP_ROBUST_SCHEMA,
+            "version": CORRELATION_GROUP_ROBUST_VERSION,
+            "contamination_probability_hex": probability.hex(),
+            "inflation_factor_hex": inflation.hex(),
+        }
+        object.__setattr__(self, "contamination_probability", probability)
+        object.__setattr__(self, "inflation_factor", inflation)
+        object.__setattr__(self, "spec_id", hashlib.sha256(_canonical_json(identity)).hexdigest())
+
+    @property
+    def is_gaussian_fallback(self) -> bool:
+        return self.contamination_probability == 0.0
+
+    def summary(self) -> dict[str, object]:
+        return {
+            "spec_id": self.spec_id,
+            "contamination_probability": self.contamination_probability,
+            "inflation_factor": self.inflation_factor,
+            "is_gaussian_fallback": self.is_gaussian_fallback,
+        }
+
+
+GAUSSIAN_GROUP_LIKELIHOOD_V1 = CorrelationGroupContaminationSpecV1(0.0, 1.0)
+
+
+@dataclass(frozen=True, slots=True)
+class CorrelationGroupResidualV1:
+    """Immutable matched residual bundle for one complete independent group."""
+
+    group_id: str
+    residual_xyz_m: FloatArray
+    local_covariance_m2: FloatArray
+    low_rank_factor_m: FloatArray
+    source_id: str = field(init=False)
+    sample_count: int = field(init=False)
+    dimension: int = field(init=False)
+
+    def __post_init__(self) -> None:
+        group_id = _strict_group_id(self.group_id)
+        residual = np.asarray(self.residual_xyz_m, dtype=np.float64)
+        local = np.asarray(self.local_covariance_m2, dtype=np.float64)
+        factor = np.asarray(self.low_rank_factor_m, dtype=np.float64)
+        if residual.ndim != 2 or residual.shape[1:] != (3,) or residual.shape[0] < 1:
+            raise ValueError("residual_xyz_m must have nonempty shape (N, 3)")
+        if local.shape != (residual.shape[0], 3, 3):
+            raise ValueError("local_covariance_m2 must have shape (N, 3, 3)")
+        if factor.ndim != 3 or factor.shape[:2] != residual.shape:
+            raise ValueError("low_rank_factor_m must have shape (N, 3, R)")
+        if not np.all(np.isfinite(residual)):
+            raise ValueError("residual_xyz_m must be finite")
+        if not np.all(np.isfinite(local)):
+            raise ValueError("local_covariance_m2 must be finite")
+        if not np.all(np.isfinite(factor)):
+            raise ValueError("low_rank_factor_m must be finite")
+        evaluate_joint_gaussian_group(residual, local, factor)
+        symmetric = 0.5 * (local + local.swapaxes(1, 2))
+
+        residual_owned = _readonly(residual)
+        local_owned = _readonly(symmetric)
+        factor_owned = _readonly(factor)
+        digest = hashlib.sha256()
+        digest.update(CORRELATION_GROUP_ROBUST_SCHEMA.encode("ascii"))
+        digest.update(str(CORRELATION_GROUP_ROBUST_VERSION).encode("ascii"))
+        digest.update(group_id.encode("utf-8"))
+        _array_digest(digest, "residual_xyz_m", residual_owned)
+        _array_digest(digest, "local_covariance_m2", local_owned)
+        _array_digest(digest, "low_rank_factor_m", factor_owned)
+
+        object.__setattr__(self, "group_id", group_id)
+        object.__setattr__(self, "residual_xyz_m", residual_owned)
+        object.__setattr__(self, "local_covariance_m2", local_owned)
+        object.__setattr__(self, "low_rank_factor_m", factor_owned)
+        object.__setattr__(self, "source_id", digest.hexdigest())
+        object.__setattr__(self, "sample_count", int(residual.shape[0]))
+        object.__setattr__(self, "dimension", int(3 * residual.shape[0]))
+
+
+@dataclass(frozen=True, slots=True)
+class CorrelationGroupMixtureEvaluationV1:
+    """Likelihood and one shared posterior contamination responsibility."""
+
+    group_id: str
+    source_id: str
+    spec: CorrelationGroupContaminationSpecV1
+    sample_count: int
+    dimension: int
+    mahalanobis_squared: float
+    joint_log_determinant: float
+    gaussian_nll: float
+    inflated_nll: float
+    mixture_nll: float
+    posterior_contamination_probability: float
+    posterior_expected_precision_multiplier: float
+
+    @property
+    def mixture_nll_per_dimension(self) -> float:
+        return self.mixture_nll / self.dimension
+
+    @property
+    def gaussian_nll_per_dimension(self) -> float:
+        return self.gaussian_nll / self.dimension
+
+    @property
+    def nll_advantage_over_gaussian_per_dimension(self) -> float:
+        return (self.gaussian_nll - self.mixture_nll) / self.dimension
+
+    def summary(self) -> dict[str, object]:
+        return {
+            "group_id": self.group_id,
+            "source_id": self.source_id,
+            "spec_id": self.spec.spec_id,
+            "sample_count": self.sample_count,
+            "dimension": self.dimension,
+            "mahalanobis_squared": self.mahalanobis_squared,
+            "joint_log_determinant": self.joint_log_determinant,
+            "gaussian_nll": self.gaussian_nll,
+            "inflated_nll": self.inflated_nll,
+            "mixture_nll": self.mixture_nll,
+            "mixture_nll_per_dimension": self.mixture_nll_per_dimension,
+            "nll_advantage_over_gaussian_per_dimension": (
+                self.nll_advantage_over_gaussian_per_dimension
+            ),
+            "posterior_contamination_probability": (
+                self.posterior_contamination_probability
+            ),
+            "posterior_expected_precision_multiplier": (
+                self.posterior_expected_precision_multiplier
+            ),
+        }
+
+
+def evaluate_correlation_group_mixture(
+    group: CorrelationGroupResidualV1,
+    spec: CorrelationGroupContaminationSpecV1,
+    *,
+    relative_rank_tolerance: float = 1e-10,
+) -> CorrelationGroupMixtureEvaluationV1:
+    """Evaluate a group-shared two-scale Gaussian mixture without densification."""
+
+    if not isinstance(group, CorrelationGroupResidualV1):
+        raise TypeError("group must be CorrelationGroupResidualV1")
+    if not isinstance(spec, CorrelationGroupContaminationSpecV1):
+        raise TypeError("spec must be CorrelationGroupContaminationSpecV1")
+    metrics = evaluate_joint_gaussian_group(
+        group.residual_xyz_m,
+        group.local_covariance_m2,
+        group.low_rank_factor_m,
+        relative_rank_tolerance=relative_rank_tolerance,
+    )
+    dimension = int(metrics["dimension"])
+    mahalanobis = float(metrics["mahalanobis_squared"])
+    log_determinant = float(metrics["joint_log_determinant"])
+    gaussian_nll = float(metrics["gaussian_nll"])
+
+    if spec.is_gaussian_fallback:
+        inflated_nll = gaussian_nll
+        mixture_nll = gaussian_nll
+        posterior_contamination_probability = 0.0
+        expected_precision = 1.0
+    else:
+        inflation = spec.inflation_factor
+        inflated_nll = 0.5 * (
+            dimension * math.log(2.0 * math.pi)
+            + log_determinant
+            + dimension * math.log(inflation)
+            + mahalanobis / inflation
+        )
+        nominal_log_component = math.log1p(-spec.contamination_probability) - gaussian_nll
+        contaminated_log_component = (
+            math.log(spec.contamination_probability) - inflated_nll
+        )
+        mixture_log_likelihood = _logaddexp(
+            nominal_log_component,
+            contaminated_log_component,
+        )
+        mixture_nll = -mixture_log_likelihood
+        posterior_contamination_probability = math.exp(
+            contaminated_log_component - mixture_log_likelihood
+        )
+        expected_precision = (
+            1.0 - posterior_contamination_probability
+            + posterior_contamination_probability / inflation
+        )
+
+    return CorrelationGroupMixtureEvaluationV1(
+        group_id=group.group_id,
+        source_id=group.source_id,
+        spec=spec,
+        sample_count=group.sample_count,
+        dimension=dimension,
+        mahalanobis_squared=mahalanobis,
+        joint_log_determinant=log_determinant,
+        gaussian_nll=gaussian_nll,
+        inflated_nll=inflated_nll,
+        mixture_nll=mixture_nll,
+        posterior_contamination_probability=posterior_contamination_probability,
+        posterior_expected_precision_multiplier=expected_precision,
+    )
+
+
+def _validated_probability(value: object, *, name: str) -> float:
+    result = _strict_real(value, name=name)
+    if not 0.0 <= result <= 1.0:
+        raise ValueError(f"{name} must lie in [0, 1]")
+    return result
+
+
+def _candidate_complexity_key(
+    spec: CorrelationGroupContaminationSpecV1,
+) -> tuple[int, float, float, str]:
+    return (
+        0 if spec.is_gaussian_fallback else 1,
+        spec.contamination_probability,
+        spec.inflation_factor,
+        spec.spec_id,
+    )
+
+
+def _choose_candidate(
+    scores: np.ndarray,
+    candidates: tuple[CorrelationGroupContaminationSpecV1, ...],
+    *,
+    tie_tolerance: float,
+) -> int:
+    best = float(np.min(scores))
+    eligible = [
+        index
+        for index, score in enumerate(scores)
+        if float(score) <= best + tie_tolerance
+    ]
+    return min(eligible, key=lambda index: _candidate_complexity_key(candidates[index]))
+
+
+@dataclass(frozen=True, slots=True)
+class CorrelationGroupSelectionFoldV1:
+    heldout_group_id: str
+    selected_spec_id: str
+    selected_is_robust: bool
+    heldout_selected_nll_per_dimension: float
+    heldout_gaussian_nll_per_dimension: float
+    heldout_nll_advantage_per_dimension: float
+    harmful_relative_to_gaussian: bool
+
+    def summary(self) -> dict[str, object]:
+        return {
+            "heldout_group_id": self.heldout_group_id,
+            "selected_spec_id": self.selected_spec_id,
+            "selected_is_robust": self.selected_is_robust,
+            "heldout_selected_nll_per_dimension": (
+                self.heldout_selected_nll_per_dimension
+            ),
+            "heldout_gaussian_nll_per_dimension": (
+                self.heldout_gaussian_nll_per_dimension
+            ),
+            "heldout_nll_advantage_per_dimension": (
+                self.heldout_nll_advantage_per_dimension
+            ),
+            "harmful_relative_to_gaussian": self.harmful_relative_to_gaussian,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class SourceCorrelationGroupMixtureSelectionV1:
+    """Replayable source-only selection over a finite frozen candidate grid."""
+
+    group_ids: tuple[str, ...]
+    group_source_ids: tuple[str, ...]
+    candidates: tuple[CorrelationGroupContaminationSpecV1, ...]
+    nll_per_dimension: FloatArray
+    minimum_group_count: int = 4
+    minimum_mean_heldout_advantage_per_dimension: float = 0.0
+    maximum_heldout_nll_harm_per_dimension: float = 0.1
+    maximum_harmful_group_fraction: float = 0.0
+    minimum_final_candidate_fold_fraction: float = 0.5
+    tie_tolerance: float = 1e-12
+    relative_rank_tolerance: float = 1e-10
+    unconstrained_spec_id: str = field(init=False)
+    selected_spec_id: str = field(init=False)
+    robust_supported: bool = field(init=False)
+    decision_reasons: tuple[str, ...] = field(init=False)
+    candidate_equal_group_mean_nll_per_dimension: tuple[float, ...] = field(init=False)
+    folds: tuple[CorrelationGroupSelectionFoldV1, ...] = field(init=False)
+    mean_heldout_advantage_per_dimension: float = field(init=False)
+    harmful_group_fraction: float = field(init=False)
+    final_candidate_fold_fraction: float = field(init=False)
+    selection_id: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        group_ids = tuple(
+            _strict_group_id(value, name=f"group_ids[{index}]")
+            for index, value in enumerate(self.group_ids)
+        )
+        if len(group_ids) < 2:
+            raise ValueError("at least two independent groups are required")
+        if tuple(sorted(group_ids)) != group_ids:
+            raise ValueError("group_ids must be sorted")
+        if len(set(group_ids)) != len(group_ids):
+            raise ValueError("group_ids must be unique")
+        source_ids = tuple(self.group_source_ids)
+        if len(source_ids) != len(group_ids):
+            raise ValueError("group_source_ids must match group_ids")
+        for index, value in enumerate(source_ids):
+            if (
+                not isinstance(value, str)
+                or len(value) != 64
+                or value != value.lower()
+            ):
+                raise ValueError(f"group_source_ids[{index}] must be SHA-256 text")
+            try:
+                int(value, 16)
+            except ValueError as error:
+                raise ValueError(
+                    f"group_source_ids[{index}] must be SHA-256 text"
+                ) from error
+
+        raw_candidates = tuple(self.candidates)
+        if not raw_candidates:
+            raise ValueError("candidates must not be empty")
+        if not all(
+            isinstance(value, CorrelationGroupContaminationSpecV1)
+            for value in raw_candidates
+        ):
+            raise TypeError("candidates must contain contamination specifications")
+        candidate_order = tuple(
+            sorted(range(len(raw_candidates)), key=lambda index: raw_candidates[index].spec_id)
+        )
+        candidates = tuple(raw_candidates[index] for index in candidate_order)
+        if len({item.spec_id for item in candidates}) != len(candidates):
+            raise ValueError("candidate specifications must be unique")
+        gaussian_indices = [
+            index for index, item in enumerate(candidates) if item.is_gaussian_fallback
+        ]
+        if len(gaussian_indices) != 1:
+            raise ValueError("the candidate grid must contain one Gaussian fallback")
+        gaussian_index = gaussian_indices[0]
+
+        raw_scores = np.asarray(self.nll_per_dimension, dtype=np.float64)
+        if raw_scores.shape != (len(candidates), len(group_ids)):
+            raise ValueError("nll_per_dimension must have shape (candidate_count, group_count)")
+        if not np.all(np.isfinite(raw_scores)):
+            raise ValueError("nll_per_dimension must be finite")
+        scores = raw_scores[np.asarray(candidate_order, dtype=np.int64)]
+
+        minimum_group_count = _strict_integer(
+            self.minimum_group_count,
+            name="minimum_group_count",
+        )
+        if minimum_group_count < 2:
+            raise ValueError("minimum_group_count must be at least two")
+        minimum_advantage = _strict_real(
+            self.minimum_mean_heldout_advantage_per_dimension,
+            name="minimum_mean_heldout_advantage_per_dimension",
+        )
+        if minimum_advantage < 0.0:
+            raise ValueError(
+                "minimum_mean_heldout_advantage_per_dimension must be nonnegative"
+            )
+        maximum_harm_amount = _strict_real(
+            self.maximum_heldout_nll_harm_per_dimension,
+            name="maximum_heldout_nll_harm_per_dimension",
+        )
+        if maximum_harm_amount < 0.0:
+            raise ValueError(
+                "maximum_heldout_nll_harm_per_dimension must be nonnegative"
+            )
+        maximum_harm = _validated_probability(
+            self.maximum_harmful_group_fraction,
+            name="maximum_harmful_group_fraction",
+        )
+        minimum_fold_fraction = _validated_probability(
+            self.minimum_final_candidate_fold_fraction,
+            name="minimum_final_candidate_fold_fraction",
+        )
+        tie_tolerance = _strict_real(self.tie_tolerance, name="tie_tolerance")
+        if tie_tolerance < 0.0:
+            raise ValueError("tie_tolerance must be nonnegative")
+        relative_rank_tolerance = _strict_real(
+            self.relative_rank_tolerance,
+            name="relative_rank_tolerance",
+        )
+        if not 0.0 <= relative_rank_tolerance < 1.0:
+            raise ValueError("relative_rank_tolerance must lie in [0, 1)")
+
+        candidate_means = tuple(float(np.mean(row)) for row in scores)
+        unconstrained_index = _choose_candidate(
+            np.asarray(candidate_means),
+            candidates,
+            tie_tolerance=tie_tolerance,
+        )
+        folds: list[CorrelationGroupSelectionFoldV1] = []
+        selected_indices: list[int] = []
+        advantages: list[float] = []
+        harmful_count = 0
+        for heldout_index, group_id in enumerate(group_ids):
+            retained = np.ones(len(group_ids), dtype=bool)
+            retained[heldout_index] = False
+            training_scores = np.mean(scores[:, retained], axis=1)
+            selected_index = _choose_candidate(
+                training_scores,
+                candidates,
+                tie_tolerance=tie_tolerance,
+            )
+            selected_indices.append(selected_index)
+            selected_score = float(scores[selected_index, heldout_index])
+            gaussian_score = float(scores[gaussian_index, heldout_index])
+            advantage = gaussian_score - selected_score
+            harmful = advantage < -(maximum_harm_amount + tie_tolerance)
+            harmful_count += int(harmful)
+            advantages.append(advantage)
+            folds.append(
+                CorrelationGroupSelectionFoldV1(
+                    heldout_group_id=group_id,
+                    selected_spec_id=candidates[selected_index].spec_id,
+                    selected_is_robust=not candidates[selected_index].is_gaussian_fallback,
+                    heldout_selected_nll_per_dimension=selected_score,
+                    heldout_gaussian_nll_per_dimension=gaussian_score,
+                    heldout_nll_advantage_per_dimension=advantage,
+                    harmful_relative_to_gaussian=harmful,
+                )
+            )
+
+        mean_advantage = float(np.mean(advantages))
+        harmful_fraction = harmful_count / len(group_ids)
+        final_fold_fraction = selected_indices.count(unconstrained_index) / len(group_ids)
+        reasons: list[str] = []
+        if len(group_ids) < minimum_group_count:
+            reasons.append("insufficient-independent-source-groups")
+        if candidates[unconstrained_index].is_gaussian_fallback:
+            reasons.append("full-source-selection-is-gaussian")
+        if mean_advantage + tie_tolerance < minimum_advantage:
+            reasons.append("heldout-mean-nll-advantage-below-minimum")
+        if harmful_fraction > maximum_harm + tie_tolerance:
+            reasons.append("harmful-heldout-group-fraction-exceeds-maximum")
+        if final_fold_fraction + tie_tolerance < minimum_fold_fraction:
+            reasons.append("final-candidate-fold-fraction-below-minimum")
+        robust_supported = not reasons
+        selected_index = unconstrained_index if robust_supported else gaussian_index
+
+        identity = {
+            "schema": CORRELATION_GROUP_ROBUST_SCHEMA,
+            "version": CORRELATION_GROUP_ROBUST_VERSION,
+            "group_ids": list(group_ids),
+            "group_source_ids": list(source_ids),
+            "candidates": [item.summary() for item in candidates],
+            "nll_per_dimension": [
+                [float(value).hex() for value in row] for row in scores
+            ],
+            "minimum_group_count": minimum_group_count,
+            "minimum_mean_heldout_advantage_per_dimension_hex": minimum_advantage.hex(),
+            "maximum_heldout_nll_harm_per_dimension_hex": (
+                maximum_harm_amount.hex()
+            ),
+            "maximum_harmful_group_fraction_hex": maximum_harm.hex(),
+            "minimum_final_candidate_fold_fraction_hex": minimum_fold_fraction.hex(),
+            "tie_tolerance_hex": tie_tolerance.hex(),
+            "relative_rank_tolerance_hex": relative_rank_tolerance.hex(),
+        }
+
+        object.__setattr__(self, "group_ids", group_ids)
+        object.__setattr__(self, "group_source_ids", source_ids)
+        object.__setattr__(self, "candidates", candidates)
+        object.__setattr__(self, "nll_per_dimension", _readonly(scores))
+        object.__setattr__(self, "minimum_group_count", minimum_group_count)
+        object.__setattr__(
+            self,
+            "minimum_mean_heldout_advantage_per_dimension",
+            minimum_advantage,
+        )
+        object.__setattr__(
+            self,
+            "maximum_heldout_nll_harm_per_dimension",
+            maximum_harm_amount,
+        )
+        object.__setattr__(self, "maximum_harmful_group_fraction", maximum_harm)
+        object.__setattr__(
+            self,
+            "minimum_final_candidate_fold_fraction",
+            minimum_fold_fraction,
+        )
+        object.__setattr__(self, "tie_tolerance", tie_tolerance)
+        object.__setattr__(self, "relative_rank_tolerance", relative_rank_tolerance)
+        object.__setattr__(
+            self,
+            "unconstrained_spec_id",
+            candidates[unconstrained_index].spec_id,
+        )
+        object.__setattr__(self, "selected_spec_id", candidates[selected_index].spec_id)
+        object.__setattr__(self, "robust_supported", robust_supported)
+        object.__setattr__(self, "decision_reasons", tuple(reasons))
+        object.__setattr__(
+            self,
+            "candidate_equal_group_mean_nll_per_dimension",
+            candidate_means,
+        )
+        object.__setattr__(self, "folds", tuple(folds))
+        object.__setattr__(self, "mean_heldout_advantage_per_dimension", mean_advantage)
+        object.__setattr__(self, "harmful_group_fraction", harmful_fraction)
+        object.__setattr__(self, "final_candidate_fold_fraction", final_fold_fraction)
+        object.__setattr__(
+            self,
+            "selection_id",
+            hashlib.sha256(_canonical_json(identity)).hexdigest(),
+        )
+
+    @property
+    def selected_spec(self) -> CorrelationGroupContaminationSpecV1:
+        return next(item for item in self.candidates if item.spec_id == self.selected_spec_id)
+
+    @property
+    def unconstrained_spec(self) -> CorrelationGroupContaminationSpecV1:
+        return next(
+            item for item in self.candidates if item.spec_id == self.unconstrained_spec_id
+        )
+
+    def summary(self) -> dict[str, object]:
+        return {
+            "schema": CORRELATION_GROUP_ROBUST_SCHEMA,
+            "version": CORRELATION_GROUP_ROBUST_VERSION,
+            "selection_id": self.selection_id,
+            "group_ids": list(self.group_ids),
+            "group_source_ids": list(self.group_source_ids),
+            "candidate_specs": [item.summary() for item in self.candidates],
+            "candidate_equal_group_mean_nll_per_dimension": list(
+                self.candidate_equal_group_mean_nll_per_dimension
+            ),
+            "candidate_by_group_nll_per_dimension": self.nll_per_dimension.tolist(),
+            "unconstrained_spec_id": self.unconstrained_spec_id,
+            "selected_spec_id": self.selected_spec_id,
+            "robust_supported": self.robust_supported,
+            "decision_reasons": list(self.decision_reasons),
+            "mean_heldout_advantage_per_dimension": (
+                self.mean_heldout_advantage_per_dimension
+            ),
+            "harmful_group_fraction": self.harmful_group_fraction,
+            "final_candidate_fold_fraction": self.final_candidate_fold_fraction,
+            "minimum_group_count": self.minimum_group_count,
+            "minimum_mean_heldout_advantage_per_dimension": (
+                self.minimum_mean_heldout_advantage_per_dimension
+            ),
+            "maximum_heldout_nll_harm_per_dimension": (
+                self.maximum_heldout_nll_harm_per_dimension
+            ),
+            "maximum_harmful_group_fraction": self.maximum_harmful_group_fraction,
+            "minimum_final_candidate_fold_fraction": (
+                self.minimum_final_candidate_fold_fraction
+            ),
+            "tie_tolerance": self.tie_tolerance,
+            "relative_rank_tolerance": self.relative_rank_tolerance,
+            "folds": [fold.summary() for fold in self.folds],
+            "claim_boundary": CORRELATION_GROUP_ROBUST_CLAIM_BOUNDARY,
+        }
+
+
+def select_source_correlation_group_mixture(
+    groups: Sequence[CorrelationGroupResidualV1],
+    candidates: Sequence[CorrelationGroupContaminationSpecV1],
+    *,
+    minimum_group_count: int = 4,
+    minimum_mean_heldout_advantage_per_dimension: float = 0.0,
+    maximum_heldout_nll_harm_per_dimension: float = 0.1,
+    maximum_harmful_group_fraction: float = 0.0,
+    minimum_final_candidate_fold_fraction: float = 0.5,
+    tie_tolerance: float = 1e-12,
+    relative_rank_tolerance: float = 1e-10,
+) -> SourceCorrelationGroupMixtureSelectionV1:
+    """Select or reject a robust group likelihood using source groups only."""
+
+    if isinstance(groups, (str, bytes)) or not isinstance(groups, Sequence):
+        raise TypeError("groups must be a sequence")
+    raw_groups = tuple(groups)
+    if not all(isinstance(item, CorrelationGroupResidualV1) for item in raw_groups):
+        raise TypeError("groups must contain CorrelationGroupResidualV1 values")
+    ordered_groups = tuple(sorted(raw_groups, key=lambda item: item.group_id))
+    if len(ordered_groups) < 2:
+        raise ValueError("at least two independent groups are required")
+    if len({item.group_id for item in ordered_groups}) != len(ordered_groups):
+        raise ValueError("group IDs must be unique")
+    if isinstance(candidates, (str, bytes)) or not isinstance(candidates, Sequence):
+        raise TypeError("candidates must be a sequence")
+    raw_candidates = tuple(candidates)
+    if not all(
+        isinstance(item, CorrelationGroupContaminationSpecV1)
+        for item in raw_candidates
+    ):
+        raise TypeError("candidates must contain contamination specifications")
+    ordered_candidates = tuple(sorted(raw_candidates, key=lambda item: item.spec_id))
+
+    scores = np.empty((len(ordered_candidates), len(ordered_groups)), dtype=np.float64)
+    for candidate_index, candidate in enumerate(ordered_candidates):
+        for group_index, group in enumerate(ordered_groups):
+            evaluation = evaluate_correlation_group_mixture(
+                group,
+                candidate,
+                relative_rank_tolerance=relative_rank_tolerance,
+            )
+            scores[candidate_index, group_index] = evaluation.mixture_nll_per_dimension
+
+    return SourceCorrelationGroupMixtureSelectionV1(
+        group_ids=tuple(item.group_id for item in ordered_groups),
+        group_source_ids=tuple(item.source_id for item in ordered_groups),
+        candidates=ordered_candidates,
+        nll_per_dimension=scores,
+        minimum_group_count=minimum_group_count,
+        minimum_mean_heldout_advantage_per_dimension=(
+            minimum_mean_heldout_advantage_per_dimension
+        ),
+        maximum_heldout_nll_harm_per_dimension=(
+            maximum_heldout_nll_harm_per_dimension
+        ),
+        maximum_harmful_group_fraction=maximum_harmful_group_fraction,
+        minimum_final_candidate_fold_fraction=minimum_final_candidate_fold_fraction,
+        tie_tolerance=tie_tolerance,
+        relative_rank_tolerance=relative_rank_tolerance,
+    )
+
+
+__all__ = [
+    "CORRELATION_GROUP_ROBUST_CLAIM_BOUNDARY",
+    "CORRELATION_GROUP_ROBUST_SCHEMA",
+    "CORRELATION_GROUP_ROBUST_VERSION",
+    "GAUSSIAN_GROUP_LIKELIHOOD_V1",
+    "CorrelationGroupContaminationSpecV1",
+    "CorrelationGroupMixtureEvaluationV1",
+    "CorrelationGroupResidualV1",
+    "CorrelationGroupSelectionFoldV1",
+    "SourceCorrelationGroupMixtureSelectionV1",
+    "evaluate_correlation_group_mixture",
+    "select_source_correlation_group_mixture",
+]

--- a/src/prob4d/correlation_group_robust_likelihood.py
+++ b/src/prob4d/correlation_group_robust_likelihood.py
@@ -1,10 +1,9 @@
-"""Source-fitted contaminated-Gaussian likelihood for complete correlation groups.
+"""Source-fitted contaminated-Gaussian likelihood for correlation groups.
 
-One latent contamination state is shared by every row in a declared correlation
-or statistical group. Association probability and prior reliability remain
-separate inputs owned by their existing contracts; the posterior contamination
-responsibility produced here is a likelihood diagnostic, not a replacement for
-either quantity.
+One latent contamination state is shared by every row in one coherent correlation
+group. Independent source objects or sessions remain the outer statistical units.
+Association probability and prior reliability remain separate from the posterior
+contamination responsibility computed here.
 """
 
 from __future__ import annotations
@@ -27,9 +26,10 @@ CORRELATION_GROUP_ROBUST_SCHEMA = "prob4d.correlation-group-robust-likelihood"
 CORRELATION_GROUP_ROBUST_VERSION = 1
 CORRELATION_GROUP_ROBUST_CLAIM_BOUNDARY = (
     "This source-side diagnostic fits a finite contaminated-Gaussian candidate grid "
-    "over complete independent groups. Posterior contamination responsibility is "
-    "distinct from association probability and prior reliability. The result does "
-    "not authorize a BayesianPhysTwin update, replace exact fallback, establish "
+    "over correlation groups nested inside independent source objects or sessions. "
+    "Posterior contamination responsibility is distinct from association probability "
+    "and prior reliability. The result does not authorize a BayesianPhysTwin "
+    "update, replace exact fallback, establish "
     "target calibration, or establish Causal4D intervention benefit."
 )
 
@@ -117,7 +117,11 @@ class CorrelationGroupContaminationSpecV1:
         }
         object.__setattr__(self, "contamination_probability", probability)
         object.__setattr__(self, "inflation_factor", inflation)
-        object.__setattr__(self, "spec_id", hashlib.sha256(_canonical_json(identity)).hexdigest())
+        object.__setattr__(
+            self,
+            "spec_id",
+            hashlib.sha256(_canonical_json(identity)).hexdigest(),
+        )
 
     @property
     def is_gaussian_fallback(self) -> bool:
@@ -137,7 +141,7 @@ GAUSSIAN_GROUP_LIKELIHOOD_V1 = CorrelationGroupContaminationSpecV1(0.0, 1.0)
 
 @dataclass(frozen=True, slots=True)
 class CorrelationGroupResidualV1:
-    """Immutable matched residual bundle for one complete independent group."""
+    """Immutable matched residual bundle for one coherent correlation group."""
 
     group_id: str
     residual_xyz_m: FloatArray
@@ -171,9 +175,16 @@ class CorrelationGroupResidualV1:
         local_owned = _readonly(symmetric)
         factor_owned = _readonly(factor)
         digest = hashlib.sha256()
-        digest.update(CORRELATION_GROUP_ROBUST_SCHEMA.encode("ascii"))
-        digest.update(str(CORRELATION_GROUP_ROBUST_VERSION).encode("ascii"))
-        digest.update(group_id.encode("utf-8"))
+        digest.update(
+            _canonical_json(
+                {
+                    "schema": CORRELATION_GROUP_ROBUST_SCHEMA,
+                    "version": CORRELATION_GROUP_ROBUST_VERSION,
+                    "record": "correlation-group-residual",
+                    "group_id": group_id,
+                }
+            )
+        )
         _array_digest(digest, "residual_xyz_m", residual_owned)
         _array_digest(digest, "local_covariance_m2", local_owned)
         _array_digest(digest, "low_rank_factor_m", factor_owned)
@@ -185,6 +196,61 @@ class CorrelationGroupResidualV1:
         object.__setattr__(self, "source_id", digest.hexdigest())
         object.__setattr__(self, "sample_count", int(residual.shape[0]))
         object.__setattr__(self, "dimension", int(3 * residual.shape[0]))
+
+
+@dataclass(frozen=True, slots=True)
+class SourceCorrelationGroupUnitV1:
+    """One independent source object/session containing correlation groups."""
+
+    source_unit_id: str
+    correlation_groups: tuple[CorrelationGroupResidualV1, ...]
+    source_id: str = field(init=False)
+    correlation_group_count: int = field(init=False)
+    sample_count: int = field(init=False)
+    dimension: int = field(init=False)
+
+    def __post_init__(self) -> None:
+        source_unit_id = _strict_group_id(
+            self.source_unit_id,
+            name="source_unit_id",
+        )
+        groups = tuple(self.correlation_groups)
+        if not groups:
+            raise ValueError("correlation_groups must not be empty")
+        if not all(isinstance(item, CorrelationGroupResidualV1) for item in groups):
+            raise TypeError(
+                "correlation_groups must contain CorrelationGroupResidualV1 values"
+            )
+        groups = tuple(sorted(groups, key=lambda item: item.group_id))
+        if len({item.group_id for item in groups}) != len(groups):
+            raise ValueError("correlation-group IDs must be unique within a source unit")
+
+        identity = {
+            "schema": CORRELATION_GROUP_ROBUST_SCHEMA,
+            "version": CORRELATION_GROUP_ROBUST_VERSION,
+            "record": "source-correlation-group-unit",
+            "source_unit_id": source_unit_id,
+            "correlation_groups": [
+                {"group_id": group.group_id, "source_id": group.source_id}
+                for group in groups
+            ],
+        }
+        source_id = hashlib.sha256(_canonical_json(identity)).hexdigest()
+
+        object.__setattr__(self, "source_unit_id", source_unit_id)
+        object.__setattr__(self, "correlation_groups", groups)
+        object.__setattr__(self, "source_id", source_id)
+        object.__setattr__(self, "correlation_group_count", len(groups))
+        object.__setattr__(
+            self,
+            "sample_count",
+            sum(item.sample_count for item in groups),
+        )
+        object.__setattr__(
+            self,
+            "dimension",
+            sum(item.dimension for item in groups),
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -340,12 +406,15 @@ def _choose_candidate(
         for index, score in enumerate(scores)
         if float(score) <= best + tie_tolerance
     ]
-    return min(eligible, key=lambda index: _candidate_complexity_key(candidates[index]))
+    return min(
+        eligible,
+        key=lambda index: _candidate_complexity_key(candidates[index]),
+    )
 
 
 @dataclass(frozen=True, slots=True)
-class CorrelationGroupSelectionFoldV1:
-    heldout_group_id: str
+class SourceUnitSelectionFoldV1:
+    heldout_source_unit_id: str
     selected_spec_id: str
     selected_is_robust: bool
     heldout_selected_nll_per_dimension: float
@@ -355,7 +424,7 @@ class CorrelationGroupSelectionFoldV1:
 
     def summary(self) -> dict[str, object]:
         return {
-            "heldout_group_id": self.heldout_group_id,
+            "heldout_source_unit_id": self.heldout_source_unit_id,
             "selected_spec_id": self.selected_spec_id,
             "selected_is_robust": self.selected_is_robust,
             "heldout_selected_nll_per_dimension": (
@@ -375,14 +444,14 @@ class CorrelationGroupSelectionFoldV1:
 class SourceCorrelationGroupMixtureSelectionV1:
     """Replayable source-only selection over a finite frozen candidate grid."""
 
-    group_ids: tuple[str, ...]
-    group_source_ids: tuple[str, ...]
+    source_unit_ids: tuple[str, ...]
+    source_unit_source_ids: tuple[str, ...]
     candidates: tuple[CorrelationGroupContaminationSpecV1, ...]
     nll_per_dimension: FloatArray
-    minimum_group_count: int = 4
+    minimum_source_unit_count: int = 4
     minimum_mean_heldout_advantage_per_dimension: float = 0.0
     maximum_heldout_nll_harm_per_dimension: float = 0.1
-    maximum_harmful_group_fraction: float = 0.0
+    maximum_harmful_source_unit_fraction: float = 0.0
     minimum_final_candidate_fold_fraction: float = 0.5
     tie_tolerance: float = 1e-12
     relative_rank_tolerance: float = 1e-10
@@ -390,39 +459,41 @@ class SourceCorrelationGroupMixtureSelectionV1:
     selected_spec_id: str = field(init=False)
     robust_supported: bool = field(init=False)
     decision_reasons: tuple[str, ...] = field(init=False)
-    candidate_equal_group_mean_nll_per_dimension: tuple[float, ...] = field(init=False)
-    folds: tuple[CorrelationGroupSelectionFoldV1, ...] = field(init=False)
+    candidate_equal_source_unit_mean_nll_per_dimension: tuple[float, ...] = field(
+        init=False
+    )
+    folds: tuple[SourceUnitSelectionFoldV1, ...] = field(init=False)
     mean_heldout_advantage_per_dimension: float = field(init=False)
-    harmful_group_fraction: float = field(init=False)
+    harmful_source_unit_fraction: float = field(init=False)
     final_candidate_fold_fraction: float = field(init=False)
     selection_id: str = field(init=False)
 
     def __post_init__(self) -> None:
-        group_ids = tuple(
-            _strict_group_id(value, name=f"group_ids[{index}]")
-            for index, value in enumerate(self.group_ids)
+        source_unit_ids = tuple(
+            _strict_group_id(value, name=f"source_unit_ids[{index}]")
+            for index, value in enumerate(self.source_unit_ids)
         )
-        if len(group_ids) < 2:
-            raise ValueError("at least two independent groups are required")
-        if tuple(sorted(group_ids)) != group_ids:
-            raise ValueError("group_ids must be sorted")
-        if len(set(group_ids)) != len(group_ids):
-            raise ValueError("group_ids must be unique")
-        source_ids = tuple(self.group_source_ids)
-        if len(source_ids) != len(group_ids):
-            raise ValueError("group_source_ids must match group_ids")
+        if len(source_unit_ids) < 2:
+            raise ValueError("at least two independent source units are required")
+        if tuple(sorted(source_unit_ids)) != source_unit_ids:
+            raise ValueError("source_unit_ids must be sorted")
+        if len(set(source_unit_ids)) != len(source_unit_ids):
+            raise ValueError("source_unit_ids must be unique")
+        source_ids = tuple(self.source_unit_source_ids)
+        if len(source_ids) != len(source_unit_ids):
+            raise ValueError("source_unit_source_ids must match source_unit_ids")
         for index, value in enumerate(source_ids):
             if (
                 not isinstance(value, str)
                 or len(value) != 64
                 or value != value.lower()
             ):
-                raise ValueError(f"group_source_ids[{index}] must be SHA-256 text")
+                raise ValueError(f"source_unit_source_ids[{index}] must be SHA-256 text")
             try:
                 int(value, 16)
             except ValueError as error:
                 raise ValueError(
-                    f"group_source_ids[{index}] must be SHA-256 text"
+                    f"source_unit_source_ids[{index}] must be SHA-256 text"
                 ) from error
 
         raw_candidates = tuple(self.candidates)
@@ -434,7 +505,10 @@ class SourceCorrelationGroupMixtureSelectionV1:
         ):
             raise TypeError("candidates must contain contamination specifications")
         candidate_order = tuple(
-            sorted(range(len(raw_candidates)), key=lambda index: raw_candidates[index].spec_id)
+            sorted(
+                range(len(raw_candidates)),
+                key=lambda index: raw_candidates[index].spec_id,
+            )
         )
         candidates = tuple(raw_candidates[index] for index in candidate_order)
         if len({item.spec_id for item in candidates}) != len(candidates):
@@ -447,18 +521,21 @@ class SourceCorrelationGroupMixtureSelectionV1:
         gaussian_index = gaussian_indices[0]
 
         raw_scores = np.asarray(self.nll_per_dimension, dtype=np.float64)
-        if raw_scores.shape != (len(candidates), len(group_ids)):
-            raise ValueError("nll_per_dimension must have shape (candidate_count, group_count)")
+        if raw_scores.shape != (len(candidates), len(source_unit_ids)):
+            raise ValueError(
+                "nll_per_dimension must have shape "
+                "(candidate_count, source_unit_count)"
+            )
         if not np.all(np.isfinite(raw_scores)):
             raise ValueError("nll_per_dimension must be finite")
         scores = raw_scores[np.asarray(candidate_order, dtype=np.int64)]
 
-        minimum_group_count = _strict_integer(
-            self.minimum_group_count,
-            name="minimum_group_count",
+        minimum_source_unit_count = _strict_integer(
+            self.minimum_source_unit_count,
+            name="minimum_source_unit_count",
         )
-        if minimum_group_count < 2:
-            raise ValueError("minimum_group_count must be at least two")
+        if minimum_source_unit_count < 2:
+            raise ValueError("minimum_source_unit_count must be at least two")
         minimum_advantage = _strict_real(
             self.minimum_mean_heldout_advantage_per_dimension,
             name="minimum_mean_heldout_advantage_per_dimension",
@@ -476,8 +553,8 @@ class SourceCorrelationGroupMixtureSelectionV1:
                 "maximum_heldout_nll_harm_per_dimension must be nonnegative"
             )
         maximum_harm = _validated_probability(
-            self.maximum_harmful_group_fraction,
-            name="maximum_harmful_group_fraction",
+            self.maximum_harmful_source_unit_fraction,
+            name="maximum_harmful_source_unit_fraction",
         )
         minimum_fold_fraction = _validated_probability(
             self.minimum_final_candidate_fold_fraction,
@@ -499,12 +576,12 @@ class SourceCorrelationGroupMixtureSelectionV1:
             candidates,
             tie_tolerance=tie_tolerance,
         )
-        folds: list[CorrelationGroupSelectionFoldV1] = []
+        folds: list[SourceUnitSelectionFoldV1] = []
         selected_indices: list[int] = []
         advantages: list[float] = []
         harmful_count = 0
-        for heldout_index, group_id in enumerate(group_ids):
-            retained = np.ones(len(group_ids), dtype=bool)
+        for heldout_index, source_unit_id in enumerate(source_unit_ids):
+            retained = np.ones(len(source_unit_ids), dtype=bool)
             retained[heldout_index] = False
             training_scores = np.mean(scores[:, retained], axis=1)
             selected_index = _choose_candidate(
@@ -520,10 +597,12 @@ class SourceCorrelationGroupMixtureSelectionV1:
             harmful_count += int(harmful)
             advantages.append(advantage)
             folds.append(
-                CorrelationGroupSelectionFoldV1(
-                    heldout_group_id=group_id,
+                SourceUnitSelectionFoldV1(
+                    heldout_source_unit_id=source_unit_id,
                     selected_spec_id=candidates[selected_index].spec_id,
-                    selected_is_robust=not candidates[selected_index].is_gaussian_fallback,
+                    selected_is_robust=(
+                        not candidates[selected_index].is_gaussian_fallback
+                    ),
                     heldout_selected_nll_per_dimension=selected_score,
                     heldout_gaussian_nll_per_dimension=gaussian_score,
                     heldout_nll_advantage_per_dimension=advantage,
@@ -532,17 +611,19 @@ class SourceCorrelationGroupMixtureSelectionV1:
             )
 
         mean_advantage = float(np.mean(advantages))
-        harmful_fraction = harmful_count / len(group_ids)
-        final_fold_fraction = selected_indices.count(unconstrained_index) / len(group_ids)
+        harmful_fraction = harmful_count / len(source_unit_ids)
+        final_fold_fraction = (
+            selected_indices.count(unconstrained_index) / len(source_unit_ids)
+        )
         reasons: list[str] = []
-        if len(group_ids) < minimum_group_count:
-            reasons.append("insufficient-independent-source-groups")
+        if len(source_unit_ids) < minimum_source_unit_count:
+            reasons.append("insufficient-independent-source-units")
         if candidates[unconstrained_index].is_gaussian_fallback:
             reasons.append("full-source-selection-is-gaussian")
         if mean_advantage + tie_tolerance < minimum_advantage:
             reasons.append("heldout-mean-nll-advantage-below-minimum")
         if harmful_fraction > maximum_harm + tie_tolerance:
-            reasons.append("harmful-heldout-group-fraction-exceeds-maximum")
+            reasons.append("harmful-heldout-source-unit-fraction-exceeds-maximum")
         if final_fold_fraction + tie_tolerance < minimum_fold_fraction:
             reasons.append("final-candidate-fold-fraction-below-minimum")
         robust_supported = not reasons
@@ -551,28 +632,33 @@ class SourceCorrelationGroupMixtureSelectionV1:
         identity = {
             "schema": CORRELATION_GROUP_ROBUST_SCHEMA,
             "version": CORRELATION_GROUP_ROBUST_VERSION,
-            "group_ids": list(group_ids),
-            "group_source_ids": list(source_ids),
-            "candidates": [item.summary() for item in candidates],
+            "source_unit_ids": list(source_unit_ids),
+            "source_unit_source_ids": list(source_ids),
+            "candidate_spec_ids": [item.spec_id for item in candidates],
             "nll_per_dimension": [
                 [float(value).hex() for value in row] for row in scores
             ],
-            "minimum_group_count": minimum_group_count,
+            "minimum_source_unit_count": minimum_source_unit_count,
             "minimum_mean_heldout_advantage_per_dimension_hex": minimum_advantage.hex(),
             "maximum_heldout_nll_harm_per_dimension_hex": (
                 maximum_harm_amount.hex()
             ),
-            "maximum_harmful_group_fraction_hex": maximum_harm.hex(),
+            "maximum_harmful_source_unit_fraction_hex": maximum_harm.hex(),
             "minimum_final_candidate_fold_fraction_hex": minimum_fold_fraction.hex(),
             "tie_tolerance_hex": tie_tolerance.hex(),
             "relative_rank_tolerance_hex": relative_rank_tolerance.hex(),
+            "claim_boundary": CORRELATION_GROUP_ROBUST_CLAIM_BOUNDARY,
         }
 
-        object.__setattr__(self, "group_ids", group_ids)
-        object.__setattr__(self, "group_source_ids", source_ids)
+        object.__setattr__(self, "source_unit_ids", source_unit_ids)
+        object.__setattr__(self, "source_unit_source_ids", source_ids)
         object.__setattr__(self, "candidates", candidates)
         object.__setattr__(self, "nll_per_dimension", _readonly(scores))
-        object.__setattr__(self, "minimum_group_count", minimum_group_count)
+        object.__setattr__(
+            self,
+            "minimum_source_unit_count",
+            minimum_source_unit_count,
+        )
         object.__setattr__(
             self,
             "minimum_mean_heldout_advantage_per_dimension",
@@ -583,7 +669,11 @@ class SourceCorrelationGroupMixtureSelectionV1:
             "maximum_heldout_nll_harm_per_dimension",
             maximum_harm_amount,
         )
-        object.__setattr__(self, "maximum_harmful_group_fraction", maximum_harm)
+        object.__setattr__(
+            self,
+            "maximum_harmful_source_unit_fraction",
+            maximum_harm,
+        )
         object.__setattr__(
             self,
             "minimum_final_candidate_fold_fraction",
@@ -596,18 +686,34 @@ class SourceCorrelationGroupMixtureSelectionV1:
             "unconstrained_spec_id",
             candidates[unconstrained_index].spec_id,
         )
-        object.__setattr__(self, "selected_spec_id", candidates[selected_index].spec_id)
+        object.__setattr__(
+            self,
+            "selected_spec_id",
+            candidates[selected_index].spec_id,
+        )
         object.__setattr__(self, "robust_supported", robust_supported)
         object.__setattr__(self, "decision_reasons", tuple(reasons))
         object.__setattr__(
             self,
-            "candidate_equal_group_mean_nll_per_dimension",
+            "candidate_equal_source_unit_mean_nll_per_dimension",
             candidate_means,
         )
         object.__setattr__(self, "folds", tuple(folds))
-        object.__setattr__(self, "mean_heldout_advantage_per_dimension", mean_advantage)
-        object.__setattr__(self, "harmful_group_fraction", harmful_fraction)
-        object.__setattr__(self, "final_candidate_fold_fraction", final_fold_fraction)
+        object.__setattr__(
+            self,
+            "mean_heldout_advantage_per_dimension",
+            mean_advantage,
+        )
+        object.__setattr__(
+            self,
+            "harmful_source_unit_fraction",
+            harmful_fraction,
+        )
+        object.__setattr__(
+            self,
+            "final_candidate_fold_fraction",
+            final_fold_fraction,
+        )
         object.__setattr__(
             self,
             "selection_id",
@@ -616,7 +722,9 @@ class SourceCorrelationGroupMixtureSelectionV1:
 
     @property
     def selected_spec(self) -> CorrelationGroupContaminationSpecV1:
-        return next(item for item in self.candidates if item.spec_id == self.selected_spec_id)
+        return next(
+            item for item in self.candidates if item.spec_id == self.selected_spec_id
+        )
 
     @property
     def unconstrained_spec(self) -> CorrelationGroupContaminationSpecV1:
@@ -629,13 +737,15 @@ class SourceCorrelationGroupMixtureSelectionV1:
             "schema": CORRELATION_GROUP_ROBUST_SCHEMA,
             "version": CORRELATION_GROUP_ROBUST_VERSION,
             "selection_id": self.selection_id,
-            "group_ids": list(self.group_ids),
-            "group_source_ids": list(self.group_source_ids),
+            "source_unit_ids": list(self.source_unit_ids),
+            "source_unit_source_ids": list(self.source_unit_source_ids),
             "candidate_specs": [item.summary() for item in self.candidates],
-            "candidate_equal_group_mean_nll_per_dimension": list(
-                self.candidate_equal_group_mean_nll_per_dimension
+            "candidate_equal_source_unit_mean_nll_per_dimension": list(
+                self.candidate_equal_source_unit_mean_nll_per_dimension
             ),
-            "candidate_by_group_nll_per_dimension": self.nll_per_dimension.tolist(),
+            "candidate_by_source_unit_nll_per_dimension": (
+                self.nll_per_dimension.tolist()
+            ),
             "unconstrained_spec_id": self.unconstrained_spec_id,
             "selected_spec_id": self.selected_spec_id,
             "robust_supported": self.robust_supported,
@@ -643,16 +753,18 @@ class SourceCorrelationGroupMixtureSelectionV1:
             "mean_heldout_advantage_per_dimension": (
                 self.mean_heldout_advantage_per_dimension
             ),
-            "harmful_group_fraction": self.harmful_group_fraction,
+            "harmful_source_unit_fraction": self.harmful_source_unit_fraction,
             "final_candidate_fold_fraction": self.final_candidate_fold_fraction,
-            "minimum_group_count": self.minimum_group_count,
+            "minimum_source_unit_count": self.minimum_source_unit_count,
             "minimum_mean_heldout_advantage_per_dimension": (
                 self.minimum_mean_heldout_advantage_per_dimension
             ),
             "maximum_heldout_nll_harm_per_dimension": (
                 self.maximum_heldout_nll_harm_per_dimension
             ),
-            "maximum_harmful_group_fraction": self.maximum_harmful_group_fraction,
+            "maximum_harmful_source_unit_fraction": (
+                self.maximum_harmful_source_unit_fraction
+            ),
             "minimum_final_candidate_fold_fraction": (
                 self.minimum_final_candidate_fold_fraction
             ),
@@ -664,29 +776,40 @@ class SourceCorrelationGroupMixtureSelectionV1:
 
 
 def select_source_correlation_group_mixture(
-    groups: Sequence[CorrelationGroupResidualV1],
+    source_units: Sequence[SourceCorrelationGroupUnitV1],
     candidates: Sequence[CorrelationGroupContaminationSpecV1],
     *,
-    minimum_group_count: int = 4,
+    minimum_source_unit_count: int = 4,
     minimum_mean_heldout_advantage_per_dimension: float = 0.0,
     maximum_heldout_nll_harm_per_dimension: float = 0.1,
-    maximum_harmful_group_fraction: float = 0.0,
+    maximum_harmful_source_unit_fraction: float = 0.0,
     minimum_final_candidate_fold_fraction: float = 0.5,
     tie_tolerance: float = 1e-12,
     relative_rank_tolerance: float = 1e-10,
 ) -> SourceCorrelationGroupMixtureSelectionV1:
-    """Select or reject a robust group likelihood using source groups only."""
+    """Select or reject a robust likelihood using independent source units."""
 
-    if isinstance(groups, (str, bytes)) or not isinstance(groups, Sequence):
-        raise TypeError("groups must be a sequence")
-    raw_groups = tuple(groups)
-    if not all(isinstance(item, CorrelationGroupResidualV1) for item in raw_groups):
-        raise TypeError("groups must contain CorrelationGroupResidualV1 values")
-    ordered_groups = tuple(sorted(raw_groups, key=lambda item: item.group_id))
-    if len(ordered_groups) < 2:
-        raise ValueError("at least two independent groups are required")
-    if len({item.group_id for item in ordered_groups}) != len(ordered_groups):
-        raise ValueError("group IDs must be unique")
+    if isinstance(source_units, (str, bytes)) or not isinstance(
+        source_units,
+        Sequence,
+    ):
+        raise TypeError("source_units must be a sequence")
+    raw_source_units = tuple(source_units)
+    if not all(
+        isinstance(item, SourceCorrelationGroupUnitV1) for item in raw_source_units
+    ):
+        raise TypeError(
+            "source_units must contain SourceCorrelationGroupUnitV1 values"
+        )
+    ordered_source_units = tuple(
+        sorted(raw_source_units, key=lambda item: item.source_unit_id)
+    )
+    if len(ordered_source_units) < 2:
+        raise ValueError("at least two independent source units are required")
+    if len({item.source_unit_id for item in ordered_source_units}) != len(
+        ordered_source_units
+    ):
+        raise ValueError("source-unit IDs must be unique")
     if isinstance(candidates, (str, bytes)) or not isinstance(candidates, Sequence):
         raise TypeError("candidates must be a sequence")
     raw_candidates = tuple(candidates)
@@ -695,31 +818,43 @@ def select_source_correlation_group_mixture(
         for item in raw_candidates
     ):
         raise TypeError("candidates must contain contamination specifications")
-    ordered_candidates = tuple(sorted(raw_candidates, key=lambda item: item.spec_id))
+    ordered_candidates = tuple(
+        sorted(raw_candidates, key=lambda item: item.spec_id)
+    )
 
-    scores = np.empty((len(ordered_candidates), len(ordered_groups)), dtype=np.float64)
+    scores = np.empty(
+        (len(ordered_candidates), len(ordered_source_units)),
+        dtype=np.float64,
+    )
     for candidate_index, candidate in enumerate(ordered_candidates):
-        for group_index, group in enumerate(ordered_groups):
-            evaluation = evaluate_correlation_group_mixture(
-                group,
-                candidate,
-                relative_rank_tolerance=relative_rank_tolerance,
-            )
-            scores[candidate_index, group_index] = evaluation.mixture_nll_per_dimension
+        for source_index, source_unit in enumerate(ordered_source_units):
+            total_nll = 0.0
+            total_dimension = 0
+            for group in source_unit.correlation_groups:
+                evaluation = evaluate_correlation_group_mixture(
+                    group,
+                    candidate,
+                    relative_rank_tolerance=relative_rank_tolerance,
+                )
+                total_nll += evaluation.mixture_nll
+                total_dimension += evaluation.dimension
+            scores[candidate_index, source_index] = total_nll / total_dimension
 
     return SourceCorrelationGroupMixtureSelectionV1(
-        group_ids=tuple(item.group_id for item in ordered_groups),
-        group_source_ids=tuple(item.source_id for item in ordered_groups),
+        source_unit_ids=tuple(item.source_unit_id for item in ordered_source_units),
+        source_unit_source_ids=tuple(
+            item.source_id for item in ordered_source_units
+        ),
         candidates=ordered_candidates,
         nll_per_dimension=scores,
-        minimum_group_count=minimum_group_count,
+        minimum_source_unit_count=minimum_source_unit_count,
         minimum_mean_heldout_advantage_per_dimension=(
             minimum_mean_heldout_advantage_per_dimension
         ),
         maximum_heldout_nll_harm_per_dimension=(
             maximum_heldout_nll_harm_per_dimension
         ),
-        maximum_harmful_group_fraction=maximum_harmful_group_fraction,
+        maximum_harmful_source_unit_fraction=maximum_harmful_source_unit_fraction,
         minimum_final_candidate_fold_fraction=minimum_final_candidate_fold_fraction,
         tie_tolerance=tie_tolerance,
         relative_rank_tolerance=relative_rank_tolerance,
@@ -734,8 +869,9 @@ __all__ = [
     "CorrelationGroupContaminationSpecV1",
     "CorrelationGroupMixtureEvaluationV1",
     "CorrelationGroupResidualV1",
-    "CorrelationGroupSelectionFoldV1",
+    "SourceUnitSelectionFoldV1",
     "SourceCorrelationGroupMixtureSelectionV1",
+    "SourceCorrelationGroupUnitV1",
     "evaluate_correlation_group_mixture",
     "select_source_correlation_group_mixture",
 ]

--- a/tests/test_correlation_group_robust_likelihood.py
+++ b/tests/test_correlation_group_robust_likelihood.py
@@ -1,0 +1,404 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from prob4d.correlation_group_robust_likelihood import (
+    CORRELATION_GROUP_ROBUST_CLAIM_BOUNDARY,
+    CORRELATION_GROUP_ROBUST_SCHEMA,
+    CORRELATION_GROUP_ROBUST_VERSION,
+    GAUSSIAN_GROUP_LIKELIHOOD_V1,
+    CorrelationGroupContaminationSpecV1,
+    CorrelationGroupResidualV1,
+    SourceCorrelationGroupMixtureSelectionV1,
+    evaluate_correlation_group_mixture,
+    select_source_correlation_group_mixture,
+)
+
+
+def _group(
+    group_id: str,
+    residual_x: float,
+    *,
+    sample_count: int = 1,
+    rank: int = 0,
+) -> CorrelationGroupResidualV1:
+    residual = np.zeros((sample_count, 3), dtype=np.float64)
+    residual[:, 0] = residual_x
+    local = np.repeat(np.eye(3, dtype=np.float64)[None, ...], sample_count, axis=0)
+    factor = np.zeros((sample_count, 3, rank), dtype=np.float64)
+    if rank:
+        factor[:, 0, 0] = 0.5
+    return CorrelationGroupResidualV1(group_id, residual, local, factor)
+
+
+def _robust_spec() -> CorrelationGroupContaminationSpecV1:
+    return CorrelationGroupContaminationSpecV1(0.2, 25.0)
+
+
+def _mixed_source_groups() -> tuple[CorrelationGroupResidualV1, ...]:
+    values = (0.0, 0.2, -0.2, 0.1, 0.3, -0.1, 8.0, 9.0)
+    return tuple(_group(f"group-{index:02d}", value) for index, value in enumerate(values))
+
+
+def test_spec_identity_and_gaussian_fallback_are_deterministic() -> None:
+    first = CorrelationGroupContaminationSpecV1(0.2, 25.0)
+    second = CorrelationGroupContaminationSpecV1(np.float64(0.2), np.float64(25.0))
+
+    assert first == second
+    assert first.spec_id == second.spec_id
+    assert not first.is_gaussian_fallback
+    assert GAUSSIAN_GROUP_LIKELIHOOD_V1.is_gaussian_fallback
+    assert first.summary()["contamination_probability"] == 0.2
+
+
+@pytest.mark.parametrize(
+    ("probability", "inflation", "message"),
+    [
+        (True, 1.0, "genuine real"),
+        (-0.1, 2.0, "must lie"),
+        (1.0, 2.0, "must lie"),
+        (0.0, 2.0, "Gaussian fallback"),
+        (0.2, 1.0, "inflation_factor > 1"),
+        (0.2, np.nan, "finite"),
+    ],
+)
+def test_invalid_specs_fail_closed(
+    probability: object,
+    inflation: object,
+    message: str,
+) -> None:
+    with pytest.raises((TypeError, ValueError), match=message):
+        CorrelationGroupContaminationSpecV1(probability, inflation)  # type: ignore[arg-type]
+
+
+def test_group_owns_normalized_immutable_arrays_and_content_identity() -> None:
+    residual = np.array([[1.0, 0.0, 0.0]])
+    local = np.eye(3)[None, ...]
+    local[0, 0, 1] = 1e-14
+    factor = np.ones((1, 3, 1), dtype=np.float64)
+
+    group = CorrelationGroupResidualV1("group-a", residual, local, factor)
+    residual[...] = 9.0
+    local[...] = 9.0
+    factor[...] = 9.0
+
+    np.testing.assert_allclose(group.residual_xyz_m, [[1.0, 0.0, 0.0]])
+    np.testing.assert_allclose(group.local_covariance_m2, np.eye(3)[None, ...], atol=1e-13)
+    np.testing.assert_allclose(group.low_rank_factor_m, np.ones((1, 3, 1)))
+    for value in (
+        group.residual_xyz_m,
+        group.local_covariance_m2,
+        group.low_rank_factor_m,
+    ):
+        assert not value.flags.writeable
+    assert len(group.source_id) == 64
+    assert group.sample_count == 1
+    assert group.dimension == 3
+
+    changed = _group("group-a", 1.1, rank=1)
+    assert changed.source_id != group.source_id
+
+
+def test_group_rejects_invalid_geometry_and_nonfinite_values() -> None:
+    with pytest.raises(TypeError, match="group_id"):
+        _group(1, 0.0)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="must not be empty"):
+        _group("", 0.0)
+    with pytest.raises(ValueError, match="residual_xyz_m"):
+        CorrelationGroupResidualV1(
+            "a",
+            np.ones((1, 2)),
+            np.eye(3)[None, ...],
+            np.empty((1, 3, 0)),
+        )
+    indefinite = np.diag([1.0, 1.0, -1.0])[None, ...]
+    with pytest.raises(ValueError, match="positive definite"):
+        CorrelationGroupResidualV1(
+            "a",
+            np.zeros((1, 3)),
+            indefinite,
+            np.empty((1, 3, 0)),
+        )
+    asymmetric = np.eye(3)[None, ...]
+    asymmetric[0, 0, 1] = 0.1
+    with pytest.raises(ValueError, match="symmetric"):
+        CorrelationGroupResidualV1(
+            "a",
+            np.zeros((1, 3)),
+            asymmetric,
+            np.empty((1, 3, 0)),
+        )
+    residual = np.zeros((1, 3))
+    residual[0, 0] = np.nan
+    with pytest.raises(ValueError, match="finite"):
+        CorrelationGroupResidualV1(
+            "a",
+            residual,
+            np.eye(3)[None, ...],
+            np.empty((1, 3, 0)),
+        )
+
+
+def test_mixture_matches_dense_scaled_gaussian_formula() -> None:
+    group = _group("group-a", 4.0, sample_count=2, rank=1)
+    spec = _robust_spec()
+
+    evaluation = evaluate_correlation_group_mixture(group, spec)
+
+    local = np.zeros((6, 6), dtype=np.float64)
+    local[:3, :3] = np.eye(3)
+    local[3:, 3:] = np.eye(3)
+    factor = group.low_rank_factor_m.reshape(6, 1)
+    covariance = local + factor @ factor.T
+    residual = group.residual_xyz_m.reshape(6)
+    sign, log_determinant = np.linalg.slogdet(covariance)
+    assert sign == 1.0
+    mahalanobis = float(residual @ np.linalg.solve(covariance, residual))
+    gaussian_nll = 0.5 * (
+        6 * np.log(2.0 * np.pi) + log_determinant + mahalanobis
+    )
+    inflated_nll = 0.5 * (
+        6 * np.log(2.0 * np.pi)
+        + log_determinant
+        + 6 * np.log(spec.inflation_factor)
+        + mahalanobis / spec.inflation_factor
+    )
+    expected_log_likelihood = np.logaddexp(
+        np.log1p(-spec.contamination_probability) - gaussian_nll,
+        np.log(spec.contamination_probability) - inflated_nll,
+    )
+
+    assert evaluation.mahalanobis_squared == pytest.approx(mahalanobis)
+    assert evaluation.joint_log_determinant == pytest.approx(log_determinant)
+    assert evaluation.gaussian_nll == pytest.approx(gaussian_nll)
+    assert evaluation.inflated_nll == pytest.approx(inflated_nll)
+    assert evaluation.mixture_nll == pytest.approx(-expected_log_likelihood)
+
+
+def test_posterior_responsibility_is_group_shared_and_bounded() -> None:
+    spec = _robust_spec()
+    nominal = evaluate_correlation_group_mixture(_group("nominal", 0.0), spec)
+    contaminated = evaluate_correlation_group_mixture(_group("outlier", 8.0), spec)
+
+    assert nominal.posterior_contamination_probability < 0.01
+    assert contaminated.posterior_contamination_probability > 0.999
+    assert nominal.posterior_expected_precision_multiplier > 0.99
+    assert contaminated.posterior_expected_precision_multiplier == pytest.approx(
+        1.0 / spec.inflation_factor,
+        rel=1e-3,
+    )
+    for result in (nominal, contaminated):
+        assert 0.0 <= result.posterior_contamination_probability <= 1.0
+        assert 1.0 / spec.inflation_factor <= (
+            result.posterior_expected_precision_multiplier
+        ) <= 1.0
+
+
+def test_gaussian_fallback_is_exact() -> None:
+    evaluation = evaluate_correlation_group_mixture(
+        _group("group-a", 3.0, rank=1),
+        GAUSSIAN_GROUP_LIKELIHOOD_V1,
+    )
+
+    assert evaluation.mixture_nll == evaluation.gaussian_nll
+    assert evaluation.inflated_nll == evaluation.gaussian_nll
+    assert evaluation.posterior_contamination_probability == 0.0
+    assert evaluation.posterior_expected_precision_multiplier == 1.0
+    assert evaluation.nll_advantage_over_gaussian_per_dimension == 0.0
+
+
+def test_source_selection_promotes_robust_candidate_for_repeated_outlier_groups() -> None:
+    robust = _robust_spec()
+
+    selection = select_source_correlation_group_mixture(
+        _mixed_source_groups(),
+        (GAUSSIAN_GROUP_LIKELIHOOD_V1, robust),
+    )
+
+    assert selection.robust_supported
+    assert selection.selected_spec_id == robust.spec_id
+    assert selection.unconstrained_spec_id == robust.spec_id
+    assert selection.decision_reasons == ()
+    assert selection.mean_heldout_advantage_per_dimension > 2.0
+    assert selection.harmful_group_fraction == 0.0
+    assert selection.final_candidate_fold_fraction == 1.0
+    assert all(fold.selected_is_robust for fold in selection.folds)
+
+
+def test_clean_source_prefers_gaussian_by_deterministic_complexity_tie_break() -> None:
+    groups = tuple(_group(f"group-{index:02d}", 0.0) for index in range(8))
+
+    selection = select_source_correlation_group_mixture(
+        groups,
+        (GAUSSIAN_GROUP_LIKELIHOOD_V1, _robust_spec()),
+    )
+
+    assert not selection.robust_supported
+    assert selection.selected_spec.is_gaussian_fallback
+    assert selection.unconstrained_spec.is_gaussian_fallback
+    assert selection.decision_reasons == ("full-source-selection-is-gaussian",)
+    assert all(not fold.selected_is_robust for fold in selection.folds)
+
+
+def test_small_nominal_harm_margin_is_explicit_and_can_force_fallback() -> None:
+    robust = _robust_spec()
+
+    selection = select_source_correlation_group_mixture(
+        _mixed_source_groups(),
+        (GAUSSIAN_GROUP_LIKELIHOOD_V1, robust),
+        maximum_heldout_nll_harm_per_dimension=0.01,
+        maximum_harmful_group_fraction=0.0,
+    )
+
+    assert not selection.robust_supported
+    assert selection.unconstrained_spec_id == robust.spec_id
+    assert selection.selected_spec.is_gaussian_fallback
+    assert selection.harmful_group_fraction == pytest.approx(0.75)
+    assert selection.decision_reasons == (
+        "harmful-heldout-group-fraction-exceeds-maximum",
+    )
+
+
+def test_nested_heldout_score_can_reject_one_outlier_despite_full_source_fit() -> None:
+    values = (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 8.0)
+    groups = tuple(_group(f"group-{index:02d}", value) for index, value in enumerate(values))
+    robust = CorrelationGroupContaminationSpecV1(0.1, 25.0)
+
+    selection = select_source_correlation_group_mixture(
+        groups,
+        (GAUSSIAN_GROUP_LIKELIHOOD_V1, robust),
+        maximum_harmful_group_fraction=1.0,
+    )
+
+    assert selection.unconstrained_spec_id == robust.spec_id
+    assert not selection.robust_supported
+    assert selection.selected_spec.is_gaussian_fallback
+    assert selection.mean_heldout_advantage_per_dimension < 0.0
+    assert "heldout-mean-nll-advantage-below-minimum" in selection.decision_reasons
+
+
+def test_insufficient_group_count_is_valid_negative_evidence() -> None:
+    robust = _robust_spec()
+    groups = (_group("a", 8.0), _group("b", 9.0))
+
+    selection = select_source_correlation_group_mixture(
+        groups,
+        (GAUSSIAN_GROUP_LIKELIHOOD_V1, robust),
+        minimum_group_count=4,
+        maximum_harmful_group_fraction=1.0,
+        minimum_final_candidate_fold_fraction=0.0,
+    )
+
+    assert not selection.robust_supported
+    assert selection.selected_spec.is_gaussian_fallback
+    assert "insufficient-independent-source-groups" in selection.decision_reasons
+
+
+def test_group_and_candidate_input_order_do_not_change_selection_identity() -> None:
+    groups = _mixed_source_groups()
+    robust = _robust_spec()
+
+    forward = select_source_correlation_group_mixture(
+        groups,
+        (GAUSSIAN_GROUP_LIKELIHOOD_V1, robust),
+    )
+    reversed_input = select_source_correlation_group_mixture(
+        tuple(reversed(groups)),
+        (robust, GAUSSIAN_GROUP_LIKELIHOOD_V1),
+    )
+
+    assert forward.selection_id == reversed_input.selection_id
+    assert forward.summary() == reversed_input.summary()
+    np.testing.assert_array_equal(
+        forward.nll_per_dimension,
+        reversed_input.nll_per_dimension,
+    )
+
+
+def test_direct_selection_construction_reorders_candidate_rows_and_replays() -> None:
+    original = select_source_correlation_group_mixture(
+        _mixed_source_groups(),
+        (GAUSSIAN_GROUP_LIKELIHOOD_V1, _robust_spec()),
+    )
+    reversed_candidates = tuple(reversed(original.candidates))
+    reversed_scores = original.nll_per_dimension[::-1]
+
+    reconstructed = SourceCorrelationGroupMixtureSelectionV1(
+        group_ids=original.group_ids,
+        group_source_ids=original.group_source_ids,
+        candidates=reversed_candidates,
+        nll_per_dimension=reversed_scores,
+        minimum_group_count=original.minimum_group_count,
+        minimum_mean_heldout_advantage_per_dimension=(
+            original.minimum_mean_heldout_advantage_per_dimension
+        ),
+        maximum_heldout_nll_harm_per_dimension=(
+            original.maximum_heldout_nll_harm_per_dimension
+        ),
+        maximum_harmful_group_fraction=original.maximum_harmful_group_fraction,
+        minimum_final_candidate_fold_fraction=(
+            original.minimum_final_candidate_fold_fraction
+        ),
+        tie_tolerance=original.tie_tolerance,
+        relative_rank_tolerance=original.relative_rank_tolerance,
+    )
+
+    assert reconstructed.selection_id == original.selection_id
+    assert reconstructed.summary() == original.summary()
+    assert not reconstructed.nll_per_dimension.flags.writeable
+
+
+def test_duplicate_groups_or_candidate_grid_without_one_fallback_fail_closed() -> None:
+    duplicate_groups = (_group("a", 0.0), _group("a", 8.0))
+    robust = _robust_spec()
+    with pytest.raises(ValueError, match="group IDs must be unique"):
+        select_source_correlation_group_mixture(
+            duplicate_groups,
+            (GAUSSIAN_GROUP_LIKELIHOOD_V1, robust),
+        )
+    groups = (_group("a", 0.0), _group("b", 8.0))
+    with pytest.raises(ValueError, match="one Gaussian fallback"):
+        select_source_correlation_group_mixture(groups, (robust,))
+    with pytest.raises(ValueError, match="unique"):
+        select_source_correlation_group_mixture(
+            groups,
+            (GAUSSIAN_GROUP_LIKELIHOOD_V1, GAUSSIAN_GROUP_LIKELIHOOD_V1),
+        )
+
+
+def test_selection_thresholds_reject_coercive_or_out_of_range_values() -> None:
+    selection = select_source_correlation_group_mixture(
+        _mixed_source_groups(),
+        (GAUSSIAN_GROUP_LIKELIHOOD_V1, _robust_spec()),
+    )
+
+    with pytest.raises(TypeError, match="minimum_group_count"):
+        replace(selection, minimum_group_count=True)
+    with pytest.raises(ValueError, match="must be nonnegative"):
+        replace(selection, maximum_heldout_nll_harm_per_dimension=-0.1)
+    with pytest.raises(ValueError, match="must lie"):
+        replace(selection, maximum_harmful_group_fraction=1.1)
+    with pytest.raises(ValueError, match="must be finite"):
+        replace(selection, tie_tolerance=np.nan)
+    with pytest.raises(ValueError, match="must lie"):
+        replace(selection, relative_rank_tolerance=1.0)
+
+
+def test_summary_keeps_responsibility_separate_and_states_claim_boundary() -> None:
+    evaluation = evaluate_correlation_group_mixture(_group("a", 8.0), _robust_spec())
+    selection = select_source_correlation_group_mixture(
+        _mixed_source_groups(),
+        (GAUSSIAN_GROUP_LIKELIHOOD_V1, _robust_spec()),
+    )
+
+    evaluation_summary = evaluation.summary()
+    selection_summary = selection.summary()
+    assert "posterior_contamination_probability" in evaluation_summary
+    assert "association_probability" not in evaluation_summary
+    assert "prior_reliability" not in evaluation_summary
+    assert selection_summary["schema"] == CORRELATION_GROUP_ROBUST_SCHEMA
+    assert selection_summary["version"] == CORRELATION_GROUP_ROBUST_VERSION
+    assert selection_summary["claim_boundary"] == CORRELATION_GROUP_ROBUST_CLAIM_BOUNDARY

--- a/tests/test_correlation_group_robust_likelihood.py
+++ b/tests/test_correlation_group_robust_likelihood.py
@@ -13,6 +13,7 @@ from prob4d.correlation_group_robust_likelihood import (
     CorrelationGroupContaminationSpecV1,
     CorrelationGroupResidualV1,
     SourceCorrelationGroupMixtureSelectionV1,
+    SourceCorrelationGroupUnitV1,
     evaluate_correlation_group_mixture,
     select_source_correlation_group_mixture,
 )
@@ -34,13 +35,35 @@ def _group(
     return CorrelationGroupResidualV1(group_id, residual, local, factor)
 
 
+def _unit(
+    source_unit_id: str,
+    residual_x: float,
+    *,
+    correlation_group_count: int = 1,
+    sample_count: int = 1,
+    rank: int = 0,
+) -> SourceCorrelationGroupUnitV1:
+    return SourceCorrelationGroupUnitV1(
+        source_unit_id=source_unit_id,
+        correlation_groups=tuple(
+            _group(
+                f"{source_unit_id}:correlation-{index:02d}",
+                residual_x,
+                sample_count=sample_count,
+                rank=rank,
+            )
+            for index in range(correlation_group_count)
+        ),
+    )
+
+
 def _robust_spec() -> CorrelationGroupContaminationSpecV1:
     return CorrelationGroupContaminationSpecV1(0.2, 25.0)
 
 
-def _mixed_source_groups() -> tuple[CorrelationGroupResidualV1, ...]:
+def _mixed_source_units() -> tuple[SourceCorrelationGroupUnitV1, ...]:
     values = (0.0, 0.2, -0.2, 0.1, 0.3, -0.1, 8.0, 9.0)
-    return tuple(_group(f"group-{index:02d}", value) for index, value in enumerate(values))
+    return tuple(_unit(f"source-{index:02d}", value) for index, value in enumerate(values))
 
 
 def test_spec_identity_and_gaussian_fallback_are_deterministic() -> None:
@@ -142,6 +165,69 @@ def test_group_rejects_invalid_geometry_and_nonfinite_values() -> None:
         )
 
 
+def test_source_unit_canonicalizes_correlation_groups_and_binds_identity() -> None:
+    first = _group("corr-b", 1.0)
+    second = _group("corr-a", 2.0, sample_count=2)
+
+    unit = SourceCorrelationGroupUnitV1("source-a", (first, second))
+    reversed_unit = SourceCorrelationGroupUnitV1("source-a", (second, first))
+
+    assert tuple(item.group_id for item in unit.correlation_groups) == (
+        "corr-a",
+        "corr-b",
+    )
+    assert unit.source_id == reversed_unit.source_id
+    assert unit.correlation_group_count == 2
+    assert unit.sample_count == 3
+    assert unit.dimension == 9
+
+
+def test_source_unit_rejects_empty_duplicate_or_invalid_correlation_groups() -> None:
+    with pytest.raises(ValueError, match="must not be empty"):
+        SourceCorrelationGroupUnitV1("source-a", ())
+    group = _group("corr-a", 0.0)
+    with pytest.raises(ValueError, match="must be unique"):
+        SourceCorrelationGroupUnitV1("source-a", (group, group))
+    with pytest.raises(TypeError, match="CorrelationGroupResidualV1"):
+        SourceCorrelationGroupUnitV1("source-a", (object(),))  # type: ignore[arg-type]
+
+
+def test_source_scores_are_dimension_weighted_inside_and_equal_across_units() -> None:
+    robust = _robust_spec()
+    unit_a = SourceCorrelationGroupUnitV1(
+        "source-a",
+        (_group("a-clean", 0.0), _group("a-outlier", 8.0)),
+    )
+    unit_b = SourceCorrelationGroupUnitV1(
+        "source-b",
+        (_group("b-clean", 0.0, sample_count=2),),
+    )
+
+    selection = select_source_correlation_group_mixture(
+        (unit_a, unit_b),
+        (GAUSSIAN_GROUP_LIKELIHOOD_V1, robust),
+        minimum_source_unit_count=2,
+        maximum_harmful_source_unit_fraction=1.0,
+        minimum_final_candidate_fold_fraction=0.0,
+    )
+
+    candidate_index = next(
+        index for index, item in enumerate(selection.candidates) if item.spec_id == robust.spec_id
+    )
+    a_clean = evaluate_correlation_group_mixture(unit_a.correlation_groups[0], robust)
+    a_outlier = evaluate_correlation_group_mixture(unit_a.correlation_groups[1], robust)
+    b_clean = evaluate_correlation_group_mixture(unit_b.correlation_groups[0], robust)
+    expected_a = (a_clean.mixture_nll + a_outlier.mixture_nll) / (
+        a_clean.dimension + a_outlier.dimension
+    )
+    expected_b = b_clean.mixture_nll / b_clean.dimension
+    assert selection.nll_per_dimension[candidate_index, 0] == pytest.approx(expected_a)
+    assert selection.nll_per_dimension[candidate_index, 1] == pytest.approx(expected_b)
+    assert selection.candidate_equal_source_unit_mean_nll_per_dimension[candidate_index] == (
+        pytest.approx(0.5 * (expected_a + expected_b))
+    )
+
+
 def test_mixture_matches_dense_scaled_gaussian_formula() -> None:
     group = _group("group-a", 4.0, sample_count=2, rank=1)
     spec = _robust_spec()
@@ -214,7 +300,7 @@ def test_source_selection_promotes_robust_candidate_for_repeated_outlier_groups(
     robust = _robust_spec()
 
     selection = select_source_correlation_group_mixture(
-        _mixed_source_groups(),
+        _mixed_source_units(),
         (GAUSSIAN_GROUP_LIKELIHOOD_V1, robust),
     )
 
@@ -223,13 +309,13 @@ def test_source_selection_promotes_robust_candidate_for_repeated_outlier_groups(
     assert selection.unconstrained_spec_id == robust.spec_id
     assert selection.decision_reasons == ()
     assert selection.mean_heldout_advantage_per_dimension > 2.0
-    assert selection.harmful_group_fraction == 0.0
+    assert selection.harmful_source_unit_fraction == 0.0
     assert selection.final_candidate_fold_fraction == 1.0
     assert all(fold.selected_is_robust for fold in selection.folds)
 
 
 def test_clean_source_prefers_gaussian_by_deterministic_complexity_tie_break() -> None:
-    groups = tuple(_group(f"group-{index:02d}", 0.0) for index in range(8))
+    groups = tuple(_unit(f"source-{index:02d}", 0.0) for index in range(8))
 
     selection = select_source_correlation_group_mixture(
         groups,
@@ -247,30 +333,30 @@ def test_small_nominal_harm_margin_is_explicit_and_can_force_fallback() -> None:
     robust = _robust_spec()
 
     selection = select_source_correlation_group_mixture(
-        _mixed_source_groups(),
+        _mixed_source_units(),
         (GAUSSIAN_GROUP_LIKELIHOOD_V1, robust),
         maximum_heldout_nll_harm_per_dimension=0.01,
-        maximum_harmful_group_fraction=0.0,
+        maximum_harmful_source_unit_fraction=0.0,
     )
 
     assert not selection.robust_supported
     assert selection.unconstrained_spec_id == robust.spec_id
     assert selection.selected_spec.is_gaussian_fallback
-    assert selection.harmful_group_fraction == pytest.approx(0.75)
+    assert selection.harmful_source_unit_fraction == pytest.approx(0.75)
     assert selection.decision_reasons == (
-        "harmful-heldout-group-fraction-exceeds-maximum",
+        "harmful-heldout-source-unit-fraction-exceeds-maximum",
     )
 
 
 def test_nested_heldout_score_can_reject_one_outlier_despite_full_source_fit() -> None:
     values = (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 8.0)
-    groups = tuple(_group(f"group-{index:02d}", value) for index, value in enumerate(values))
+    groups = tuple(_unit(f"source-{index:02d}", value) for index, value in enumerate(values))
     robust = CorrelationGroupContaminationSpecV1(0.1, 25.0)
 
     selection = select_source_correlation_group_mixture(
         groups,
         (GAUSSIAN_GROUP_LIKELIHOOD_V1, robust),
-        maximum_harmful_group_fraction=1.0,
+        maximum_harmful_source_unit_fraction=1.0,
     )
 
     assert selection.unconstrained_spec_id == robust.spec_id
@@ -282,23 +368,23 @@ def test_nested_heldout_score_can_reject_one_outlier_despite_full_source_fit() -
 
 def test_insufficient_group_count_is_valid_negative_evidence() -> None:
     robust = _robust_spec()
-    groups = (_group("a", 8.0), _group("b", 9.0))
+    groups = (_unit("a", 8.0), _unit("b", 9.0))
 
     selection = select_source_correlation_group_mixture(
         groups,
         (GAUSSIAN_GROUP_LIKELIHOOD_V1, robust),
-        minimum_group_count=4,
-        maximum_harmful_group_fraction=1.0,
+        minimum_source_unit_count=4,
+        maximum_harmful_source_unit_fraction=1.0,
         minimum_final_candidate_fold_fraction=0.0,
     )
 
     assert not selection.robust_supported
     assert selection.selected_spec.is_gaussian_fallback
-    assert "insufficient-independent-source-groups" in selection.decision_reasons
+    assert "insufficient-independent-source-units" in selection.decision_reasons
 
 
 def test_group_and_candidate_input_order_do_not_change_selection_identity() -> None:
-    groups = _mixed_source_groups()
+    groups = _mixed_source_units()
     robust = _robust_spec()
 
     forward = select_source_correlation_group_mixture(
@@ -320,25 +406,25 @@ def test_group_and_candidate_input_order_do_not_change_selection_identity() -> N
 
 def test_direct_selection_construction_reorders_candidate_rows_and_replays() -> None:
     original = select_source_correlation_group_mixture(
-        _mixed_source_groups(),
+        _mixed_source_units(),
         (GAUSSIAN_GROUP_LIKELIHOOD_V1, _robust_spec()),
     )
     reversed_candidates = tuple(reversed(original.candidates))
     reversed_scores = original.nll_per_dimension[::-1]
 
     reconstructed = SourceCorrelationGroupMixtureSelectionV1(
-        group_ids=original.group_ids,
-        group_source_ids=original.group_source_ids,
+        source_unit_ids=original.source_unit_ids,
+        source_unit_source_ids=original.source_unit_source_ids,
         candidates=reversed_candidates,
         nll_per_dimension=reversed_scores,
-        minimum_group_count=original.minimum_group_count,
+        minimum_source_unit_count=original.minimum_source_unit_count,
         minimum_mean_heldout_advantage_per_dimension=(
             original.minimum_mean_heldout_advantage_per_dimension
         ),
         maximum_heldout_nll_harm_per_dimension=(
             original.maximum_heldout_nll_harm_per_dimension
         ),
-        maximum_harmful_group_fraction=original.maximum_harmful_group_fraction,
+        maximum_harmful_source_unit_fraction=original.maximum_harmful_source_unit_fraction,
         minimum_final_candidate_fold_fraction=(
             original.minimum_final_candidate_fold_fraction
         ),
@@ -352,14 +438,14 @@ def test_direct_selection_construction_reorders_candidate_rows_and_replays() -> 
 
 
 def test_duplicate_groups_or_candidate_grid_without_one_fallback_fail_closed() -> None:
-    duplicate_groups = (_group("a", 0.0), _group("a", 8.0))
+    duplicate_groups = (_unit("a", 0.0), _unit("a", 8.0))
     robust = _robust_spec()
-    with pytest.raises(ValueError, match="group IDs must be unique"):
+    with pytest.raises(ValueError, match="source-unit IDs must be unique"):
         select_source_correlation_group_mixture(
             duplicate_groups,
             (GAUSSIAN_GROUP_LIKELIHOOD_V1, robust),
         )
-    groups = (_group("a", 0.0), _group("b", 8.0))
+    groups = (_unit("a", 0.0), _unit("b", 8.0))
     with pytest.raises(ValueError, match="one Gaussian fallback"):
         select_source_correlation_group_mixture(groups, (robust,))
     with pytest.raises(ValueError, match="unique"):
@@ -371,16 +457,16 @@ def test_duplicate_groups_or_candidate_grid_without_one_fallback_fail_closed() -
 
 def test_selection_thresholds_reject_coercive_or_out_of_range_values() -> None:
     selection = select_source_correlation_group_mixture(
-        _mixed_source_groups(),
+        _mixed_source_units(),
         (GAUSSIAN_GROUP_LIKELIHOOD_V1, _robust_spec()),
     )
 
-    with pytest.raises(TypeError, match="minimum_group_count"):
-        replace(selection, minimum_group_count=True)
+    with pytest.raises(TypeError, match="minimum_source_unit_count"):
+        replace(selection, minimum_source_unit_count=True)
     with pytest.raises(ValueError, match="must be nonnegative"):
         replace(selection, maximum_heldout_nll_harm_per_dimension=-0.1)
     with pytest.raises(ValueError, match="must lie"):
-        replace(selection, maximum_harmful_group_fraction=1.1)
+        replace(selection, maximum_harmful_source_unit_fraction=1.1)
     with pytest.raises(ValueError, match="must be finite"):
         replace(selection, tie_tolerance=np.nan)
     with pytest.raises(ValueError, match="must lie"):
@@ -390,7 +476,7 @@ def test_selection_thresholds_reject_coercive_or_out_of_range_values() -> None:
 def test_summary_keeps_responsibility_separate_and_states_claim_boundary() -> None:
     evaluation = evaluate_correlation_group_mixture(_group("a", 8.0), _robust_spec())
     selection = select_source_correlation_group_mixture(
-        _mixed_source_groups(),
+        _mixed_source_units(),
         (GAUSSIAN_GROUP_LIKELIHOOD_V1, _robust_spec()),
     )
 


### PR DESCRIPTION
## What changed

- add experimental `prob4d.correlation_group_robust_likelihood` infrastructure;
- model one latent contamination state for each complete declared correlation group rather than assigning independent outlier decisions to every row;
- keep correlation groups as inner likelihood units and complete source objects or acquisition sessions as independent outer selection units;
- evaluate `(1-rho) N(0, C) + rho N(0, lambda C)` for `C = blockdiag(D_i) + U U^T` without materializing a dense covariance;
- retain an exact Gaussian fallback at `rho=0`, `lambda=1`;
- report one posterior contamination responsibility and expected inverse-scale multiplier per complete correlation group while keeping association probability and prior reliability separate;
- aggregate complete correlation-group log likelihoods within each source unit by retained residual dimension, then weight source units equally;
- select a finite candidate grid using nested leave-one-source-unit-out evaluation;
- require explicit minimum source-unit count, held-out mean advantage, tolerated per-unit harm, harmful-unit fraction, and final-candidate fold-support gates;
- return the exact Gaussian specification whenever any support gate fails;
- bind normalized correlation-group arrays, source-unit composition and identities, candidate specifications, the complete candidate-by-source-unit score matrix, thresholds, fold decisions, claim boundary, and selection identity; and
- document statistical-unit, information-order, BayesianPhysTwin, and Causal4D boundaries.

## Why

A visual tracklet, camera/frame cell, or other provider-v2 correlation group can fail coherently. Per-row robustification would turn one shared visual failure into many apparently independent outlier decisions and could multiply evidence. Treating several correlation groups from one object as independent outer replicates would create a second pseudoreplication path.

The final design therefore has two explicit levels:

1. `CorrelationGroupResidualV1`: one coherent inner likelihood group sharing one contamination state; and
2. `SourceCorrelationGroupUnitV1`: one independent source object/session containing one or more correlation groups and receiving one vote in method selection.

## Likelihood

For one complete correlation group with dimension `d=3N`, joint covariance `C`, Mahalanobis energy `q`, and frozen candidate `(rho, lambda)`:

```text
p(r) = (1-rho) N(r; 0, C) + rho N(r; 0, lambda C)
log det(lambda C) = log det(C) + d log(lambda)
q_lambda = q / lambda
```

The implementation reuses the existing Woodbury joint-covariance evaluator. It does not construct `C` densely. `lambda` scales covariance, not standard deviation.

## Source selection

For every held-out source object/session, the implementation:

1. sums candidate log likelihoods over all complete inner correlation groups in each retained source unit;
2. divides by that unit's total residual dimension;
3. chooses a candidate by equal-source-unit mean proper score;
4. evaluates it on the complete held-out source unit against the Gaussian fallback; and
5. retains the complete fold record.

A robust full-source candidate is admitted only when all frozen support gates pass. Insufficient independent source units are retained as valid negative evidence.

## Validation

Exact validated head: `5d3ad8d9eb84ae1163b14a453b99c35987625713`.

- all 25 focused tests pass;
- 50 randomized variable-size/rank source-unit trials pass;
- the complete repository suite passes on Python 3.10, 3.11, 3.12, 3.13, and 3.14;
- the complete suite passes at the declared Python 3.10 / NumPy 1.24 runtime floor;
- dense scaled-Gaussian and mixture-log-likelihood oracle parity passes;
- nominal and extreme correlation-group posterior-responsibility limits pass;
- exact Gaussian fallback passes;
- robust promotion on repeated contaminated source units and deterministic Gaussian preference on clean source units pass;
- nested held-out rejection, explicit source-unit harm-margin rejection, and insufficient-unit fallback pass;
- correlation-group order, source-unit order, and candidate order invariant content and selection identities pass;
- source scoring is dimension-weighted within source units and equal-weighted across independent source units;
- direct construction reorders candidate rows and deterministically replays selection;
- immutable defensive array ownership plus correlation-group and source-unit content identities pass;
- malformed shape, non-finite, asymmetric, indefinite, duplicate inner group, duplicate source unit, duplicate candidate, missing fallback, coercive threshold, and invalid rank-tolerance cases fail closed;
- Python 3.10 grammar parsing, duplicate-dictionary-key inspection, and byte compilation pass;
- authoritative Ruff and MyPy pass;
- repository, release, API, provider, and source-distribution policies pass;
- wheel and source distributions build and validate;
- both artifacts install in isolation and pass grouped and legacy CLI smoke tests; and
- dependency audit and CodeQL security scanning pass.

## Compatibility and scientific boundary

- No provider-v1/provider-v2, factor-bundle, association, reliability, calibration, stream, evidence, release, or stable API contract changes.
- The robust posterior responsibility is not association probability, source prior reliability, or BayesianPhysTwin deployment acceptance.
- The module is experimental and is not exported through the stable package façade.
- It does not inspect target outcomes, alter a physical posterior, authorize an update, or weaken exact fallback.
- This is source-side likelihood and selection infrastructure. It does not establish real-provider competence, fresh-object calibration, BayesianPhysTwin physical benefit, Causal4D intervention benefit, deployment safety, or state of the art.