### PR TITLE
Add analytic gauge propagation and harden covariance numerics

### DIFF
--- a/docs/analytic-gauge-propagation.md
+++ b/docs/analytic-gauge-propagation.md
@@ -1,0 +1,70 @@
+# Analytic gauge covariance propagation
+
+`prob4d.gauge_analytic` is an additive experimental covariance-propagation path
+for recursive `Sim(3)` gauges. The historical classes in `prob4d.gauge` retain
+their finite-difference behavior so frozen provider-v1 and existing development
+artifacts are not reinterpreted.
+
+## Coordinate convention
+
+Transforms use the seven-vector
+
+```text
+[log_scale, rotation_vector(3), translation(3)].
+```
+
+Composition uses the existing context-local analytic Jacobians from
+`prob4d.composition_jacobian`. Inversion uses the exact derivative of
+
+```text
+scale_inverse       = 1 / scale
+rotation_inverse    = rotation.T
+translation_inverse = -(1 / scale) * rotation.T @ translation.
+```
+
+The principal `SO(3)` logarithm is not differentiable at angle pi. Analytic
+composition or inversion therefore fails closed within the declared branch-cut
+tolerance rather than emitting platform-dependent covariance.
+
+## Public experimental surface
+
+```python
+from prob4d.gauge_analytic import (
+    AnalyticSequentialGaugeEstimatorV2,
+    compose_sim3_with_covariance_analytic,
+    invert_sim3_with_covariance_analytic,
+)
+```
+
+`AnalyticSequentialGaugeEstimatorV2` preserves the historical transform
+initialization and covariance-intersection policy. Only covariance derivatives
+for composition and inversion change. The class records
+`jacobian_method = "analytic_sim3_compose_inverse_v1"` for experiment manifests.
+It is deliberately not exported from the stable `prob4d.api.v2` facade.
+
+## Numerical validation
+
+The focused validation covers:
+
+- analytic inverse derivatives against central finite differences over varied
+  scales, translations, and rotations;
+- analytic composition and inversion covariance against a numerical oracle;
+- exact transform parity with the historical sequential estimator;
+- close covariance parity away from branch cuts;
+- positive-semidefinite output validation; and
+- branch-cut, invalid-covariance, and coercive-parameter rejection.
+
+Dense alignment covariance now obtains IID inverses and cluster-robust sandwich
+terms through Cholesky solves, with a validated eigendecomposition fallback for
+numerically difficult but full-rank information matrices. It no longer uses a
+Moore-Penrose pseudoinverse after declaring the alignment information full rank.
+This changes numerical implementation, not the covariance method labels or
+estimator formula.
+
+## Claim boundary
+
+Analytic first-order derivatives and factorized solves reduce numerical
+approximation and make failure modes explicit. They do not establish target-data
+calibration, provider competence, physical-query benefit, or Causal4D benefit.
+Any promotion requires the same source/calibration separation and held-out
+physical gate as other Prob4D covariance treatments.

--- a/docs/gauge-covariance-contracts.md
+++ b/docs/gauge-covariance-contracts.md
@@ -35,6 +35,18 @@ statistics are formed. Whitening and Mahalanobis computations use the shared
 fail-closed eigendecomposition rather than silently repairing materially invalid
 input.
 
+## Analytic experimental propagation
+
+The additive `prob4d.gauge_analytic` module provides analytic `Sim(3)`
+composition and inverse covariance propagation plus
+`AnalyticSequentialGaugeEstimatorV2`. The historical estimator remains
+unchanged. See [analytic gauge covariance propagation](analytic-gauge-propagation.md).
+
+Alignment covariance for both IID and cluster-robust modes is formed through
+factorized information solves rather than an explicit pseudoinverse after the
+information matrix has passed the existing full-rank check. Method labels and
+statistical formulas remain unchanged.
+
 ## Claim boundary
 
 These checks prevent malformed or caller-mutated uncertainty from entering gauge

--- a/docs/sintel-truth-resampling.md
+++ b/docs/sintel-truth-resampling.md
@@ -1,0 +1,32 @@
+# Sintel truth resampling
+
+The Sintel uncertainty diagnostic sometimes resizes camera-space 3-D truth maps
+to the MotionCrafter output resolution. Invalid points must not be converted to
+zero coordinates and then mixed into valid bilinear samples.
+
+## Mask-normalized interpolation
+
+For a point field `x` and validity mask `m`, Prob4D now computes
+
+```text
+numerator = bilinear_resize(m * x)
+support   = bilinear_resize(m)
+x_resized = numerator / support
+```
+
+where division occurs only for positive support. An output row is valid only
+when `support >= minimum_resize_support`; rejected rows are stored as zero and
+remain excluded by the returned validity mask. The default threshold is `0.5`
+and is an explicit argument of `load_sintel_truth`.
+
+This prevents invalid zero or non-finite coordinates from biasing otherwise
+supported 3-D points while retaining an auditable support rule. Same-resolution
+loads preserve valid values exactly and zero invalid storage rows.
+
+## Scope
+
+The change affects only Sintel truth loading for the diagnostic uncertainty
+analysis. It does not change MotionCrafter predictions, provider-v2 export,
+gauge fitting, the predeclared family split, or any frozen evidence artifact.
+Previously generated Sintel result tables should retain their original code
+revision; new runs must record the updated revision and support threshold.

--- a/src/prob4d/alignment.py
+++ b/src/prob4d/alignment.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections import Counter
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass, field, replace
@@ -227,6 +227,39 @@ class _CovarianceEstimate:
     information_condition: float
 
 
+def _factorized_information_solver(
+    information: FloatArray,
+) -> Callable[[FloatArray], FloatArray]:
+    """Return a solve function for one validated full-rank information matrix."""
+
+    symmetric = 0.5 * (information + information.T)
+    try:
+        cholesky = np.linalg.cholesky(symmetric)
+    except np.linalg.LinAlgError:
+        eigenvalues, eigenvectors = np.linalg.eigh(symmetric)
+        threshold = max(
+            float(np.max(np.abs(eigenvalues), initial=0.0)) * 1e-10,
+            np.finfo(np.float64).eps,
+        )
+        if float(np.min(eigenvalues)) <= threshold:
+            raise ValueError(
+                "alignment information is not numerically positive definite"
+            ) from None
+
+        def solve(right_hand_side: FloatArray) -> FloatArray:
+            right = np.asarray(right_hand_side, dtype=np.float64)
+            projected = eigenvectors.T @ right
+            return eigenvectors @ (projected / eigenvalues[:, None])
+
+        return solve
+
+    def solve(right_hand_side: FloatArray) -> FloatArray:
+        right = np.asarray(right_hand_side, dtype=np.float64)
+        return np.linalg.solve(cholesky.T, np.linalg.solve(cholesky, right))
+
+    return solve
+
+
 def _weighted_umeyama(source: FloatArray, target: FloatArray, weights: FloatArray) -> Sim3:
     weights = np.asarray(weights, dtype=np.float64)
     weight_sum = float(weights.sum())
@@ -310,19 +343,20 @@ def _alignment_covariance_estimate(
             f"alignment geometry is rank-deficient ({information_rank}/7 observable parameters)"
         )
     information_condition = float(singular_values[0] / singular_values[-1])
-    inverse_information = np.linalg.pinv(information, rcond=1e-10)
+    solve_information = _factorized_information_solver(information)
 
     if cluster_scores is None:
         degrees_of_freedom = max(1, 3 * active - 7)
         variance = float(np.sum(weights[:, None] * residuals**2) / degrees_of_freedom)
-        covariance = variance * inverse_information
+        covariance = variance * solve_information(np.eye(7))
         method = "iid_gauss_newton"
     else:
         meat = cluster_scores.T @ cluster_scores
         finite_sample_correction = (num_clusters / (num_clusters - 1)) * (
             (active - 1) / max(active - 7, 1)
         )
-        covariance = finite_sample_correction * inverse_information @ meat @ inverse_information
+        left_solve = solve_information(meat)
+        covariance = finite_sample_correction * solve_information(left_solve.T).T
         method = DENSE_ALIGNMENT_COVARIANCE_METHOD
 
     floor = np.diag([1e-10, 1e-10, 1e-10, 1e-10, 1e-12, 1e-12, 1e-12])

--- a/src/prob4d/gauge_analytic.py
+++ b/src/prob4d/gauge_analytic.py
@@ -1,0 +1,248 @@
+"""Explicit analytic covariance propagation for recursive ``Sim(3)`` gauges.
+
+The historical estimator in :mod:`prob4d.gauge` retains finite-difference
+covariance propagation for compatibility. This additive module exposes an
+experimental version-2 estimator whose composition and inversion derivatives
+are analytic and fail closed at the SO(3) logarithm branch cut.
+"""
+
+from __future__ import annotations
+
+from numbers import Real
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ._gauge_ci import fuse_sim3_covariance_intersection
+from .composition_jacobian import analytic_sim3_compose_jacobians
+from .covariance import validated_covariance_psd
+from .gauge import GaugeEstimate, RelativeGaugeConstraint
+from .sim3 import Sim3, skew, so3_log, so3_right_jacobian
+
+FloatArray = NDArray[np.floating]
+
+ANALYTIC_GAUGE_PROPAGATION_METHOD = "analytic_sim3_compose_inverse_v1"
+ANALYTIC_GAUGE_PROPAGATION_VERSION = 1
+
+
+def _finite_nonnegative_real(value: object, *, name: str) -> float:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+        raise TypeError(f"{name} must be a real scalar")
+    result = float(value)
+    if not np.isfinite(result):
+        raise ValueError(f"{name} must be finite")
+    if result < 0.0:
+        raise ValueError(f"{name} must be non-negative")
+    return result
+
+
+def analytic_sim3_inverse_jacobian(
+    transform: Sim3,
+    *,
+    branch_cut_tolerance: float = 1e-7,
+) -> FloatArray:
+    """Return the exact derivative of ``transform.inverse().as_vector()``.
+
+    Coordinates are ``[log_scale, rotation_vector(3), translation(3)]``. The
+    principal SO(3) logarithm is non-differentiable at rotations of angle pi, so
+    those inputs fail closed instead of producing platform-dependent covariance.
+    """
+
+    tolerance = _finite_nonnegative_real(
+        branch_cut_tolerance,
+        name="branch_cut_tolerance",
+    )
+    rotation_vector = so3_log(transform.rotation)
+    if np.pi - float(np.linalg.norm(rotation_vector)) <= tolerance:
+        raise ValueError("Sim(3) inverse Jacobian is undefined at the SO(3) log branch cut")
+
+    inverse = transform.inverse()
+    jacobian = np.zeros((7, 7), dtype=np.float64)
+    jacobian[0, 0] = -1.0
+    jacobian[1:4, 1:4] = -np.eye(3)
+    jacobian[4:7, 0] = -inverse.translation
+    jacobian[4:7, 1:4] = skew(inverse.translation) @ so3_right_jacobian(rotation_vector)
+    jacobian[4:7, 4:7] = -(1.0 / transform.scale) * transform.rotation.T
+    if not np.all(np.isfinite(jacobian)):
+        raise ValueError("analytic Sim(3) inverse Jacobian is non-finite")
+    return jacobian
+
+
+def compose_sim3_with_covariance_analytic(
+    first: Sim3,
+    first_covariance: FloatArray,
+    second: Sim3,
+    second_covariance: FloatArray,
+    *,
+    branch_cut_tolerance: float = 1e-7,
+) -> tuple[Sim3, FloatArray]:
+    """Compose independent uncertain transforms with analytic first derivatives."""
+
+    first_covariance = validated_covariance_psd(
+        first_covariance,
+        name="first gauge covariance",
+        shape=(7, 7),
+        readonly=False,
+    )
+    second_covariance = validated_covariance_psd(
+        second_covariance,
+        name="second gauge covariance",
+        shape=(7, 7),
+        readonly=False,
+    )
+    first_jacobian, second_jacobian = analytic_sim3_compose_jacobians(
+        first,
+        second,
+        branch_cut_tolerance=branch_cut_tolerance,
+    )
+    output = first.compose(second)
+    covariance = (
+        first_jacobian @ first_covariance @ first_jacobian.T
+        + second_jacobian @ second_covariance @ second_jacobian.T
+    )
+    return output, validated_covariance_psd(
+        0.5 * (covariance + covariance.T),
+        name="composed gauge covariance",
+        shape=(7, 7),
+        readonly=False,
+    )
+
+
+def invert_sim3_with_covariance_analytic(
+    transform: Sim3,
+    covariance: FloatArray,
+    *,
+    branch_cut_tolerance: float = 1e-7,
+) -> tuple[Sim3, FloatArray]:
+    """Invert one uncertain transform with an analytic first derivative."""
+
+    covariance = validated_covariance_psd(
+        covariance,
+        name="gauge covariance",
+        shape=(7, 7),
+        readonly=False,
+    )
+    jacobian = analytic_sim3_inverse_jacobian(
+        transform,
+        branch_cut_tolerance=branch_cut_tolerance,
+    )
+    inverse = transform.inverse()
+    inverse_covariance = jacobian @ covariance @ jacobian.T
+    return inverse, validated_covariance_psd(
+        0.5 * (inverse_covariance + inverse_covariance.T),
+        name="inverse gauge covariance",
+        shape=(7, 7),
+        readonly=False,
+    )
+
+
+class AnalyticSequentialGaugeEstimatorV2:
+    """Sequential gauge initialization with analytic covariance propagation.
+
+    Transform estimation and covariance-intersection semantics match
+    :class:`prob4d.gauge.SequentialGaugeEstimator`; only composition and inverse
+    covariance derivatives change. The historical estimator remains untouched.
+    """
+
+    jacobian_method = ANALYTIC_GAUGE_PROPAGATION_METHOD
+
+    def __init__(
+        self,
+        *,
+        covariance_intersection_grid_size: int = 21,
+        branch_cut_tolerance: float = 1e-7,
+    ) -> None:
+        if isinstance(covariance_intersection_grid_size, bool) or not isinstance(
+            covariance_intersection_grid_size,
+            (int, np.integer),
+        ):
+            raise TypeError("covariance_intersection_grid_size must be a genuine integer")
+        if covariance_intersection_grid_size < 3:
+            raise ValueError("covariance_intersection_grid_size must be at least three")
+        self.covariance_intersection_grid_size = int(covariance_intersection_grid_size)
+        self.branch_cut_tolerance = _finite_nonnegative_real(
+            branch_cut_tolerance,
+            name="branch_cut_tolerance",
+        )
+
+    def estimate(
+        self,
+        ordered_window_ids: list[str],
+        constraints: list[RelativeGaugeConstraint],
+        *,
+        initial_transform: Sim3 | None = None,
+        initial_covariance: FloatArray | None = None,
+    ) -> dict[str, GaugeEstimate]:
+        if not ordered_window_ids:
+            raise ValueError("ordered_window_ids must not be empty")
+        if len(set(ordered_window_ids)) != len(ordered_window_ids):
+            raise ValueError("window IDs must be unique")
+        first_id = ordered_window_ids[0]
+        first_transform = initial_transform or Sim3.identity()
+        first_covariance = (
+            np.diag([1e-10] * 7)
+            if initial_covariance is None
+            else validated_covariance_psd(
+                initial_covariance,
+                name="initial gauge covariance",
+                shape=(7, 7),
+                readonly=False,
+            )
+        )
+        estimates = {first_id: GaugeEstimate(first_id, first_transform, first_covariance)}
+
+        for window_id in ordered_window_ids[1:]:
+            candidates: list[tuple[Sim3, FloatArray]] = []
+            for constraint in constraints:
+                if constraint.moving_id == window_id and constraint.reference_id in estimates:
+                    reference = estimates[constraint.reference_id]
+                    candidates.append(
+                        compose_sim3_with_covariance_analytic(
+                            reference.global_from_local,
+                            reference.covariance,
+                            constraint.reference_from_moving,
+                            constraint.covariance,
+                            branch_cut_tolerance=self.branch_cut_tolerance,
+                        )
+                    )
+                elif constraint.reference_id == window_id and constraint.moving_id in estimates:
+                    moving = estimates[constraint.moving_id]
+                    inverse, inverse_covariance = invert_sim3_with_covariance_analytic(
+                        constraint.reference_from_moving,
+                        constraint.covariance,
+                        branch_cut_tolerance=self.branch_cut_tolerance,
+                    )
+                    candidates.append(
+                        compose_sim3_with_covariance_analytic(
+                            moving.global_from_local,
+                            moving.covariance,
+                            inverse,
+                            inverse_covariance,
+                            branch_cut_tolerance=self.branch_cut_tolerance,
+                        )
+                    )
+            if not candidates:
+                raise ValueError(f"window {window_id!r} has no constraint to an initialized gauge")
+
+            minimum_weight = min(0.05, 0.5 / len(candidates))
+            transform, covariance, _ = fuse_sim3_covariance_intersection(
+                candidates,
+                minimum_weight=minimum_weight,
+                max_sweeps=max(16, self.covariance_intersection_grid_size),
+                line_search_iterations=max(
+                    32,
+                    2 * self.covariance_intersection_grid_size,
+                ),
+            )
+            estimates[window_id] = GaugeEstimate(window_id, transform, covariance)
+        return estimates
+
+
+__all__ = [
+    "ANALYTIC_GAUGE_PROPAGATION_METHOD",
+    "ANALYTIC_GAUGE_PROPAGATION_VERSION",
+    "AnalyticSequentialGaugeEstimatorV2",
+    "analytic_sim3_inverse_jacobian",
+    "compose_sim3_with_covariance_analytic",
+    "invert_sim3_with_covariance_analytic",
+]

--- a/src/prob4d/sintel_uncertainty.py
+++ b/src/prob4d/sintel_uncertainty.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import numpy as np
 
+from ._scientific_scalars import require_finite_real
 from .experiments import (
     _baseline_sequence,
     _build_alignments,
@@ -67,11 +68,51 @@ def _resize_nearest(mask: np.ndarray, output_shape: tuple[int, int]) -> np.ndarr
     return mask[:, rows[:, None], columns[None, :]]
 
 
+def _resize_masked_bilinear(
+    values: np.ndarray,
+    mask: np.ndarray,
+    output_shape: tuple[int, int],
+    *,
+    minimum_support: float = 0.5,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Resize values without allowing invalid coordinates to leak into results."""
+
+    if values.ndim != 4 or values.shape[-1] < 1:
+        raise ValueError("values must have shape (T, H, W, C)")
+    if mask.shape != values.shape[:3]:
+        raise ValueError("mask must have shape values.shape[:3]")
+    support_threshold = require_finite_real(
+        minimum_support,
+        name="minimum_support",
+        minimum=0.0,
+        maximum=1.0,
+        minimum_inclusive=False,
+    )
+    if values.shape[1:3] == output_shape:
+        output = np.asarray(values).copy()
+        output[~mask] = 0.0
+        return output, np.asarray(mask, dtype=bool).copy()
+
+    finite_values = np.where(mask[..., None], values, 0.0)
+    numerator = _resize_bilinear(finite_values, output_shape)
+    support = _resize_bilinear(mask[..., None].astype(np.float32), output_shape)[..., 0]
+    output = np.divide(
+        numerator,
+        support[..., None],
+        out=np.zeros_like(numerator),
+        where=support[..., None] > np.finfo(np.float32).eps,
+    )
+    output_mask = support >= support_threshold
+    output[~output_mask] = 0.0
+    return output, output_mask
+
+
 def load_sintel_truth(
     path: Path,
     *,
     output_shape: tuple[int, int] = (320, 640),
     max_depth: float = 70.0,
+    minimum_resize_support: float = 0.5,
 ) -> TruthSequence:
     """Load camera-space Sintel HDF5 truth and return first-pose world coordinates."""
 
@@ -86,9 +127,13 @@ def load_sintel_truth(
         poses = handle["camera_pose"][:].astype(np.float64)
     finite = np.isfinite(points).all(axis=-1)
     mask &= finite & (points[..., 2] > 1e-5) & (points[..., 2] < max_depth)
-    points = np.nan_to_num(points)
-    points = _resize_bilinear(points, output_shape)
-    mask = _resize_nearest(mask, output_shape)
+    points = np.where(mask[..., None], points, 0.0)
+    points, mask = _resize_masked_bilinear(
+        points,
+        mask,
+        output_shape,
+        minimum_support=minimum_resize_support,
+    )
 
     poses = np.linalg.inv(poses[0])[None] @ poses
     world = np.einsum("tij,thwj->thwi", poses[:, :3, :3], points)

--- a/tests/test_alignment_factorized_solver.py
+++ b/tests/test_alignment_factorized_solver.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import numpy as np
+
+import prob4d.alignment as alignment
+from prob4d.alignment import (
+    DENSE_ALIGNMENT_COVARIANCE_METHOD,
+    estimate_sim3_robust,
+)
+from prob4d.sim3 import Sim3
+
+
+def _problem(seed: int = 31) -> tuple[np.ndarray, np.ndarray]:
+    generator = np.random.default_rng(seed)
+    source = generator.normal(size=(480, 3))
+    transform = Sim3.from_vector(
+        np.array([0.08, 0.12, -0.04, 0.06, 0.5, -0.3, 0.2])
+    )
+    target = transform.transform_points(source)
+    target += generator.normal(scale=0.01, size=target.shape)
+    return source, target
+
+
+def test_alignment_covariance_uses_factorized_solves(monkeypatch) -> None:
+    source, target = _problem()
+
+    def forbidden_pseudoinverse(*args, **kwargs):
+        raise AssertionError("alignment covariance must not use np.linalg.pinv")
+
+    monkeypatch.setattr(alignment.np.linalg, "pinv", forbidden_pseudoinverse)
+    result = estimate_sim3_robust(source, target)
+
+    assert result.covariance_method == "iid_gauss_newton"
+    assert np.all(np.isfinite(result.covariance))
+    np.testing.assert_allclose(result.covariance, result.covariance.T, atol=1e-14)
+    assert float(np.min(np.linalg.eigvalsh(result.covariance))) >= -1e-12
+
+
+def test_cluster_robust_sandwich_uses_factorized_solves(monkeypatch) -> None:
+    source, target = _problem(41)
+    cluster_ids = np.arange(source.shape[0], dtype=np.int64) // 12
+
+    def forbidden_pseudoinverse(*args, **kwargs):
+        raise AssertionError("alignment covariance must not use np.linalg.pinv")
+
+    monkeypatch.setattr(alignment.np.linalg, "pinv", forbidden_pseudoinverse)
+    result = estimate_sim3_robust(
+        source,
+        target,
+        covariance_cluster_ids=cluster_ids,
+    )
+
+    assert result.covariance_method == DENSE_ALIGNMENT_COVARIANCE_METHOD
+    assert result.num_covariance_clusters == 40
+    assert result.information_rank == 7
+    assert np.all(np.isfinite(result.covariance))
+    np.testing.assert_allclose(result.covariance, result.covariance.T, atol=1e-14)
+    assert float(np.min(np.linalg.eigvalsh(result.covariance))) >= -1e-12
+
+
+def test_factorized_solver_has_valid_eigendecomposition_fallback(monkeypatch) -> None:
+    information = np.diag(np.linspace(1.0, 7.0, 7))
+    right_hand_side = np.arange(49, dtype=np.float64).reshape(7, 7)
+
+    def fail_cholesky(*args, **kwargs):
+        raise np.linalg.LinAlgError("forced fallback")
+
+    monkeypatch.setattr(alignment.np.linalg, "cholesky", fail_cholesky)
+    solve = alignment._factorized_information_solver(information)
+
+    np.testing.assert_allclose(
+        solve(right_hand_side),
+        np.linalg.solve(information, right_hand_side),
+    )

--- a/tests/test_gauge_analytic.py
+++ b/tests/test_gauge_analytic.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from prob4d.gauge import RelativeGaugeConstraint, SequentialGaugeEstimator
+from prob4d.gauge_analytic import (
+    ANALYTIC_GAUGE_PROPAGATION_METHOD,
+    AnalyticSequentialGaugeEstimatorV2,
+    analytic_sim3_inverse_jacobian,
+    compose_sim3_with_covariance_analytic,
+    invert_sim3_with_covariance_analytic,
+)
+from prob4d.sim3 import Sim3
+
+
+def _central_jacobian(function, vector: np.ndarray) -> np.ndarray:
+    baseline = np.asarray(function(vector), dtype=np.float64)
+    result = np.empty((baseline.size, vector.size), dtype=np.float64)
+    for index in range(vector.size):
+        step = 1e-7 * max(1.0, abs(float(vector[index])))
+        plus = vector.copy()
+        minus = vector.copy()
+        plus[index] += step
+        minus[index] -= step
+        result[:, index] = (function(plus) - function(minus)) / (2.0 * step)
+    return result
+
+
+@pytest.mark.parametrize("seed", range(12))
+def test_analytic_inverse_jacobian_matches_central_difference(seed: int) -> None:
+    generator = np.random.default_rng(seed)
+    rotation = generator.normal(size=3)
+    rotation *= generator.uniform(0.0, 2.7) / max(np.linalg.norm(rotation), 1e-12)
+    vector = np.concatenate(
+        ([generator.uniform(-2.0, 2.0)], rotation, generator.normal(size=3))
+    )
+    transform = Sim3.from_vector(vector)
+
+    analytic = analytic_sim3_inverse_jacobian(transform)
+    numerical = _central_jacobian(
+        lambda value: Sim3.from_vector(value).inverse().as_vector(),
+        vector,
+    )
+
+    np.testing.assert_allclose(analytic, numerical, rtol=2e-7, atol=2e-8)
+
+
+def test_analytic_covariance_propagation_matches_central_difference() -> None:
+    first = Sim3.from_vector(np.array([0.3, 0.2, -0.1, 0.15, 1.0, -2.0, 0.5]))
+    second = Sim3.from_vector(np.array([-0.4, -0.1, 0.25, 0.05, -0.2, 0.4, 1.2]))
+    first_covariance = np.diag(np.linspace(0.01, 0.07, 7))
+    second_covariance = np.diag(np.linspace(0.02, 0.08, 7))
+
+    output, covariance = compose_sim3_with_covariance_analytic(
+        first,
+        first_covariance,
+        second,
+        second_covariance,
+    )
+    first_jacobian = _central_jacobian(
+        lambda value: Sim3.from_vector(value).compose(second).as_vector(),
+        first.as_vector(),
+    )
+    second_jacobian = _central_jacobian(
+        lambda value: first.compose(Sim3.from_vector(value)).as_vector(),
+        second.as_vector(),
+    )
+    expected = (
+        first_jacobian @ first_covariance @ first_jacobian.T
+        + second_jacobian @ second_covariance @ second_jacobian.T
+    )
+
+    np.testing.assert_allclose(output.as_vector(), first.compose(second).as_vector())
+    np.testing.assert_allclose(covariance, expected, rtol=2e-6, atol=2e-8)
+
+    inverse, inverse_covariance = invert_sim3_with_covariance_analytic(
+        first,
+        first_covariance,
+    )
+    inverse_jacobian = _central_jacobian(
+        lambda value: Sim3.from_vector(value).inverse().as_vector(),
+        first.as_vector(),
+    )
+    np.testing.assert_allclose(inverse.as_vector(), first.inverse().as_vector())
+    np.testing.assert_allclose(
+        inverse_covariance,
+        inverse_jacobian @ first_covariance @ inverse_jacobian.T,
+        rtol=2e-6,
+        atol=2e-8,
+    )
+
+
+def test_analytic_estimator_preserves_legacy_transform_semantics() -> None:
+    first_relative = Sim3.from_vector(
+        np.array([0.05, 0.1, -0.05, 0.02, 0.3, -0.1, 0.2])
+    )
+    second_relative = Sim3.from_vector(
+        np.array([-0.02, -0.04, 0.08, 0.03, -0.2, 0.4, 0.1])
+    )
+    constraints = [
+        RelativeGaugeConstraint(
+            "w0",
+            "w1",
+            first_relative,
+            np.diag(np.linspace(1e-4, 7e-4, 7)),
+        ),
+        RelativeGaugeConstraint(
+            "w1",
+            "w2",
+            second_relative,
+            np.diag(np.linspace(2e-4, 8e-4, 7)),
+        ),
+    ]
+    initial_covariance = np.diag(np.linspace(1e-5, 7e-5, 7))
+
+    legacy = SequentialGaugeEstimator().estimate(
+        ["w0", "w1", "w2"],
+        constraints,
+        initial_covariance=initial_covariance,
+    )
+    analytic_estimator = AnalyticSequentialGaugeEstimatorV2()
+    analytic = analytic_estimator.estimate(
+        ["w0", "w1", "w2"],
+        constraints,
+        initial_covariance=initial_covariance,
+    )
+
+    assert analytic_estimator.jacobian_method == ANALYTIC_GAUGE_PROPAGATION_METHOD
+    for window_id in ("w0", "w1", "w2"):
+        np.testing.assert_allclose(
+            analytic[window_id].global_from_local.as_vector(),
+            legacy[window_id].global_from_local.as_vector(),
+            atol=1e-12,
+        )
+        np.testing.assert_allclose(
+            analytic[window_id].covariance,
+            legacy[window_id].covariance,
+            rtol=3e-5,
+            atol=2e-9,
+        )
+
+
+def test_analytic_gauge_propagation_fails_closed() -> None:
+    branch_cut = Sim3.from_vector(np.array([0.0, np.pi, 0.0, 0.0, 0.0, 0.0, 0.0]))
+    with pytest.raises(ValueError, match="branch cut"):
+        analytic_sim3_inverse_jacobian(branch_cut)
+    with pytest.raises(ValueError, match="positive semidefinite"):
+        invert_sim3_with_covariance_analytic(
+            Sim3.identity(),
+            np.diag([1.0, 1.0, 1.0, 1.0, 1.0, 1.0, -0.1]),
+        )
+    with pytest.raises(TypeError, match="genuine integer"):
+        AnalyticSequentialGaugeEstimatorV2(covariance_intersection_grid_size=True)

--- a/tests/test_sintel_masked_resize.py
+++ b/tests/test_sintel_masked_resize.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-import h5py
 import numpy as np
 import pytest
 
@@ -69,6 +68,7 @@ def test_mask_normalized_resize_rejects_invalid_support(value: object) -> None:
 
 
 def test_load_sintel_truth_uses_mask_normalized_resize(tmp_path: Path) -> None:
+    h5py = pytest.importorskip("h5py")
     path = tmp_path / "truth.hdf5"
     points = np.zeros((1, 2, 2, 3), dtype=np.float32)
     points[..., 2] = 10.0

--- a/tests/test_sintel_masked_resize.py
+++ b/tests/test_sintel_masked_resize.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import h5py
+import numpy as np
+import pytest
+
+from prob4d.sintel_uncertainty import _resize_masked_bilinear, load_sintel_truth
+
+
+def _corner_problem() -> tuple[np.ndarray, np.ndarray]:
+    values = np.full((1, 2, 2, 3), 10.0, dtype=np.float32)
+    values[0, 1, 1] = np.array([0.0, 0.0, 0.0])
+    mask = np.array([[[True, True], [True, False]]])
+    return values, mask
+
+
+def test_mask_normalized_resize_prevents_zero_fill_leakage() -> None:
+    values, mask = _corner_problem()
+
+    resized, resized_mask = _resize_masked_bilinear(
+        values,
+        mask,
+        (3, 3),
+        minimum_support=0.5,
+    )
+
+    assert resized_mask[0, 1, 1]
+    np.testing.assert_allclose(resized[0, 1, 1], [10.0, 10.0, 10.0])
+    assert not resized_mask[0, 2, 2]
+    np.testing.assert_array_equal(resized[0, 2, 2], np.zeros(3))
+
+
+def test_mask_normalized_resize_applies_declared_support_threshold() -> None:
+    values, mask = _corner_problem()
+
+    resized, resized_mask = _resize_masked_bilinear(
+        values,
+        mask,
+        (3, 3),
+        minimum_support=0.8,
+    )
+
+    assert not resized_mask[0, 1, 1]
+    np.testing.assert_array_equal(resized[0, 1, 1], np.zeros(3))
+
+
+def test_mask_normalized_resize_same_shape_preserves_valid_values() -> None:
+    values, mask = _corner_problem()
+
+    resized, resized_mask = _resize_masked_bilinear(values, mask, (2, 2))
+
+    np.testing.assert_array_equal(resized_mask, mask)
+    np.testing.assert_array_equal(resized[mask], values[mask])
+    np.testing.assert_array_equal(resized[~mask], np.zeros((1, 3)))
+
+
+@pytest.mark.parametrize("value", [True, 0.0, 1.1, np.nan, "0.5"])
+def test_mask_normalized_resize_rejects_invalid_support(value: object) -> None:
+    values, mask = _corner_problem()
+    with pytest.raises((TypeError, ValueError), match="minimum_support"):
+        _resize_masked_bilinear(
+            values,
+            mask,
+            (3, 3),
+            minimum_support=value,  # type: ignore[arg-type]
+        )
+
+
+def test_load_sintel_truth_uses_mask_normalized_resize(tmp_path: Path) -> None:
+    path = tmp_path / "truth.hdf5"
+    points = np.zeros((1, 2, 2, 3), dtype=np.float32)
+    points[..., 2] = 10.0
+    points[0, 1, 1] = np.array([np.nan, np.nan, np.nan], dtype=np.float32)
+    mask = np.ones((1, 2, 2), dtype=np.uint8)
+    poses = np.eye(4, dtype=np.float64)[None, ...]
+    with h5py.File(path, "w") as handle:
+        handle.create_dataset("point_map", data=points)
+        handle.create_dataset("valid_mask", data=mask)
+        handle.create_dataset("camera_pose", data=poses)
+
+    truth = load_sintel_truth(
+        path,
+        output_shape=(3, 3),
+        minimum_resize_support=0.5,
+    )
+
+    assert truth.valid_mask[0, 1, 1]
+    np.testing.assert_allclose(truth.point_map[0, 1, 1], [0.0, 0.0, 10.0])
+    assert not truth.valid_mask[0, 2, 2]
+    assert np.all(np.isfinite(truth.point_map))


### PR DESCRIPTION
## What changed

- add the experimental `prob4d.gauge_analytic` module with exact first-order `Sim(3)` composition and inverse covariance propagation;
- add `AnalyticSequentialGaugeEstimatorV2`, preserving the historical transform initialization and covariance-intersection policy while leaving `SequentialGaugeEstimator` unchanged;
- fail closed at the principal `SO(3)` logarithm branch cut and on invalid covariance or coercive configuration values;
- replace the explicit Moore–Penrose pseudoinverse in full-rank alignment covariance with Cholesky solves and a validated eigendecomposition fallback;
- form both IID covariance and the cluster-robust sandwich through solves without changing their statistical formulas or method labels;
- replace zero-filled Cartesian interpolation in the Sintel diagnostic with mask-normalized bilinear resampling and an explicit minimum-support threshold; and
- document the numerical, compatibility, and scientific boundaries.

## Why

The provider-v2 path already has analytic `Sim(3)` composition derivatives, while the reusable sequential gauge estimator still propagated composition and inverse covariance through forward finite differences. This PR provides an explicit additive v2 path instead of silently changing frozen behavior.

Alignment covariance declares the information matrix full rank before inversion. Using factorized solves is more stable and avoids constructing a pseudoinverse for a positive-definite system. Sintel truth loading previously replaced invalid points by zero before bilinear interpolation, allowing those coordinates to bias otherwise supported resized points near invalid regions.

## Validation

Local focused validation against the exact pushed file bytes:

- 15 analytic-gauge tests pass, including 12 randomized inverse-Jacobian finite-difference comparisons, composition/inversion covariance parity, historical transform parity, PSD validation, and branch-cut rejection;
- 3 factorized-alignment tests pass, including explicit prohibition of `np.linalg.pinv` in IID and cluster-robust paths and the eigendecomposition fallback;
- 9 masked-Sintel tests pass, including zero-fill leakage prevention, support-threshold behavior, same-resolution behavior, strict scalar validation, and HDF5 loading;
- the existing gauge, alignment, and Sintel focused suites pass unchanged;
- `python -m compileall -q src` passes; and
- the Git blob IDs for the two replaced source files match the locally tested files exactly.

GitHub Actions on the exact pull-request head remain authoritative for the complete Python-version matrix, Ruff, MyPy, packaging, installed-command smoke tests, release policies, and security scanning.

## Compatibility and scientific boundary

- No provider-v1/provider-v2, factor-bundle, calibration-artifact, tree-sparse, stream, stable `prob4d.api.v2`, or CLI contract changes.
- The analytic estimator is experimental and is not exported through the stable facade.
- Existing finite-difference gauge classes remain unchanged.
- Alignment method labels and covariance formulas remain unchanged; only the linear algebra implementation changes.
- The Sintel change affects diagnostic truth resampling only and does not alter provider export or frozen evidence.
- This is numerical and diagnostic infrastructure. It does not establish real-provider competence, target-data calibration, BayesianPhysTwin physical-query benefit, Causal4D intervention benefit, deployment safety, or state of the art.