### PR TITLE
Add source-only calibration transport certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ release notes and scientific boundaries live under `docs/releases/`.
 
 ## Unreleased
 
-No changes yet.
+### Added
+
+- A source-only calibration-transport model and replayable target-prefix
+  evidence artifact over complete object/session units, with robust quantile
+  embeddings, finite-source nearest-unit support thresholds, localized feature
+  extrapolation diagnostics, conjunctive unsupported group/row gates, and an
+  explicit exact-fallback claim boundary.
 
 ## 0.4.0 — 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,7 @@ release notes and scientific boundaries live under `docs/releases/`.
 
 ## Unreleased
 
-### Added
-
-- A source-only calibration-transport model and replayable target-prefix
-  evidence artifact over complete object/session units, with robust quantile
-  embeddings, finite-source nearest-unit support thresholds, localized feature
-  extrapolation diagnostics, conjunctive unsupported group/row gates, and an
-  explicit exact-fallback claim boundary.
+No changes yet.
 
 ## 0.4.0 — 2026-08-10
 

--- a/docs/calibration-transport.md
+++ b/docs/calibration-transport.md
@@ -1,0 +1,190 @@
+# Source-only calibration-transport certificate
+
+`prob4d.calibration_transport` is an additive experimental gate for checking
+whether a target prefix lies inside the source-feature regime on which a Prob4D
+reliability or covariance treatment was calibrated. It is evaluated before a
+BayesianPhysTwin likelihood is admitted.
+
+The certificate does **not** use target truth, a BayesianPhysTwin innovation,
+posterior responsibility, accepted-update harm, or a Causal4D outcome. It does
+not prove calibration transfer. It only detects unsupported extrapolation in a
+frozen source-only feature representation and gives the downstream consumer an
+explicit reason to use its exact physical fallback.
+
+## Statistical unit and information order
+
+Each `CalibrationTransportUnitV1` must be one complete independent calibration
+object or acquisition session. A target unit may instead be a predeclared
+camera, spatial cell, or horizon group inside the causal target prefix, provided
+those groups are not treated as independent source replicates during fitting.
+
+The required order is:
+
+1. freeze the source-only feature definition and compute its feature-contract ID;
+2. build complete source units without target access;
+3. freeze the transport policy;
+4. fit and persist the source model;
+5. compute the same features on the target prefix without target residuals;
+6. evaluate and persist the transport evidence; and
+7. admit the visual likelihood only when both this certificate and the separate
+   BayesianPhysTwin guard allow it.
+
+An already-open target cohort cannot be used to change the quantiles, scale
+floors, neighbor count, miscoverage rate, or tolerated unsupported mass.
+
+## Method
+
+For every source unit and feature, the model records the frozen empirical
+quantiles declared in `CalibrationTransportPolicyV1`. Quantiles are flattened in
+feature-major order to form one distributional embedding per complete unit.
+
+Across source-unit embeddings, every coordinate receives a robust diagonal
+scale. The scale is the maximum of:
+
+- normal-consistent median absolute deviation;
+- normal-consistent interquartile range; and
+- the declared absolute plus relative scale floor.
+
+The distance between two unit embeddings is the root mean square standardized
+coordinate difference. A unit's source nonconformity score is the mean distance
+to its `k` nearest *other* source units. Thus no source unit can select itself as
+support.
+
+For `M` source units and declared miscoverage rate `alpha`, the frozen threshold
+uses rank
+
+```text
+min(M, ceil((M + 1) * (1 - alpha)))
+```
+
+of the sorted leave-one-unit-out source scores. The robust scale is source-fitted
+once; each nonconformity score excludes the scored unit from its neighbor set.
+This is a conservative source-only support diagnostic, not a claim of an exact
+distribution-free conformal guarantee.
+
+A target group is supported when its score does not exceed the frozen threshold.
+The evidence also reports a source-support p-value, nearest source units,
+feature-wise standardized distance, and feature-wise excursion beyond the source
+embedding range.
+
+The final decision is conjunctive over two frozen limits:
+
+- maximum unsupported target-group fraction; and
+- maximum unsupported target-row fraction.
+
+This keeps one tiny unsupported group from necessarily vetoing a large target
+prefix when the protocol explicitly permits it, while preventing many tiny
+unsupported groups from being hidden by row weighting.
+
+## Example
+
+```python
+from prob4d.calibration_transport import (
+    CalibrationTransportPolicyV1,
+    CalibrationTransportUnitV1,
+    calibration_transport_feature_contract_id,
+    evaluate_calibration_transport,
+    fit_calibration_transport_model,
+    save_calibration_transport_evidence,
+    save_calibration_transport_model,
+)
+from prob4d.source_reliability import build_source_reliability_features
+
+feature_names = (
+    "has_overlap",
+    "log1p_normalized_overlap_disagreement",
+    "temporal_edge_proximity",
+    "log_relative_total_variance",
+    "has_scene_flow",
+    "log1p_relative_scene_flow",
+    "local_validity_deficit",
+)
+feature_contract_id = calibration_transport_feature_contract_id(
+    feature_names,
+    semantics="prob4d-source-only-reliability-features-v1",
+    configuration={
+        "window_geometry_id": "<frozen SHA-256>",
+        "reliability_feature_builder_revision": "<exact revision>",
+    },
+)
+
+source_units = []
+for source_object in frozen_source_objects:
+    features = build_source_reliability_features(
+        source_object.window,
+        source_object.covariance,
+        source_object.disagreement,
+    )
+    source_units.append(
+        CalibrationTransportUnitV1.from_feature_grid(
+            source_object.object_id,
+            features,
+            feature_contract_id=feature_contract_id,
+            metadata={
+                "source_artifact_id": source_object.artifact_id,
+                "statistical_unit": "complete-object",
+            },
+        )
+    )
+
+policy = CalibrationTransportPolicyV1(
+    quantile_levels=(0.1, 0.25, 0.5, 0.75, 0.9),
+    miscoverage_rate=0.1,
+    minimum_source_units=8,
+    neighbor_count=1,
+    maximum_unsupported_group_fraction=0.0,
+    maximum_unsupported_row_fraction=0.0,
+    absolute_scale_floor=1e-8,
+    relative_scale_floor=1e-6,
+)
+model = fit_calibration_transport_model(
+    source_units,
+    policy=policy,
+    metadata={"split_lock_id": "<frozen split lock SHA-256>"},
+)
+save_calibration_transport_model(model, "calibration-transport-model.json")
+
+# Build target units only from frames before the exclusive causal cutoff.
+evidence = evaluate_calibration_transport(
+    model,
+    frozen_target_prefix_groups,
+    metadata={"causal_cutoff": 134},
+)
+save_calibration_transport_evidence(
+    evidence,
+    "calibration-transport-evidence.json",
+)
+
+if not evidence.accepted:
+    use_exact_physical_fallback()
+```
+
+`from_feature_grid` accepts `SourceReliabilityFeatures` directly through its
+`feature_names` and `flattened()` interface. Per-unit metadata should bind the
+source artifact, object/session identity, camera/horizon grouping, causal cutoff,
+and exact feature-builder configuration.
+
+## Replay and tamper resistance
+
+The model and evidence are strict finite-JSON artifacts. They:
+
+- reject duplicate object keys and non-finite numbers;
+- defensively own immutable arrays and metadata;
+- sort source and target unit IDs before fitting/evaluation;
+- derive all thresholds, diagnostics, decisions, and content IDs from retained
+  embeddings rather than trusting serialized derived fields;
+- reject a changed feature-contract ID or feature ordering;
+- reject target/source unit-ID overlap; and
+- default to atomic no-clobber persistence.
+
+Source-unit order, target-unit order, and feature-row order do not change the
+result. Feature order remains part of the contract and may not be rewritten.
+
+## Interpretation
+
+A passing certificate means only that the target-prefix source-only feature
+summaries are not more isolated than permitted by the source-unit calibration
+cohort. A failing certificate localizes extrapolation by target group and
+feature. Neither result measures point accuracy, covariance coverage, physical
+query improvement, accepted-update harm, or intervention benefit. Those remain
+separate held-out provider and BayesianPhysTwin/Causal4D endpoints.

--- a/src/prob4d/_calibration_transport_common.py
+++ b/src/prob4d/_calibration_transport_common.py
@@ -1,0 +1,477 @@
+"""Shared types and validation for calibration-transport certificates."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, Protocol, TypeAlias
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ._immutable_json import frozen_finite_json_mapping, plain_json
+from ._strict_json import (
+    require_exact_fields,
+    require_exact_integer,
+    require_exact_string,
+    require_finite_json_mapping,
+    require_json_number,
+    require_mapping,
+    require_sha256,
+)
+
+FloatArray: TypeAlias = NDArray[np.floating[Any]]
+CALIBRATION_TRANSPORT_MODEL_SCHEMA = "prob4d.calibration-transport-model"
+CALIBRATION_TRANSPORT_EVIDENCE_SCHEMA = "prob4d.calibration-transport-evidence"
+CALIBRATION_TRANSPORT_FEATURE_CONTRACT_SCHEMA = (
+    "prob4d.calibration-transport-feature-contract"
+)
+CALIBRATION_TRANSPORT_VERSION = 1
+CALIBRATION_TRANSPORT_CLAIM_BOUNDARY = (
+    "This source-only certificate measures whether target-prefix feature summaries "
+    "are supported by complete calibration objects or acquisition sessions. It does "
+    "not inspect target truth, downstream physical innovations, or posterior outcomes; "
+    "it does not prove calibration transfer, authorize a BayesianPhysTwin update, or "
+    "establish Prob4D, BayesianPhysTwin, or Causal4D benefit. A rejected certificate "
+    "must be handled by the downstream exact physical fallback."
+)
+
+_MODEL_FIELDS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "model_id",
+        "feature_contract_id",
+        "feature_names",
+        "policy",
+        "source_unit_ids",
+        "source_row_counts",
+        "source_embeddings",
+        "source_metadata",
+        "embedding_center",
+        "embedding_scale",
+        "source_nonconformity_scores",
+        "support_threshold",
+        "threshold_rank",
+        "metadata",
+        "claim_boundary",
+    }
+)
+_EVIDENCE_FIELDS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "evidence_id",
+        "model_id",
+        "feature_contract_id",
+        "feature_names",
+        "target_unit_ids",
+        "target_row_counts",
+        "target_embeddings",
+        "target_metadata",
+        "group_results",
+        "target_group_count",
+        "target_row_count",
+        "supported_group_count",
+        "supported_row_count",
+        "unsupported_group_fraction",
+        "unsupported_row_fraction",
+        "accepted",
+        "decision_reasons",
+        "worst_target_unit_id",
+        "worst_feature_name",
+        "metadata",
+        "claim_boundary",
+    }
+)
+_POLICY_FIELDS = frozenset(
+    {
+        "quantile_levels",
+        "miscoverage_rate",
+        "minimum_source_units",
+        "neighbor_count",
+        "maximum_unsupported_group_fraction",
+        "maximum_unsupported_row_fraction",
+        "absolute_scale_floor",
+        "relative_scale_floor",
+        "distance_semantics",
+        "threshold_semantics",
+    }
+)
+
+_DISTANCE_SEMANTICS = "mean-k-nearest-rms-robust-standardized-quantile-distance-v1"
+_THRESHOLD_SEMANTICS = "finite-source-upper-rank-of-leave-one-unit-out-scores-v1"
+_MAD_NORMAL_SCALE = 1.482602218505602
+_IQR_NORMAL_SCALE = 1.3489795003921634
+
+
+class SourceFeatureGrid(Protocol):
+    """Structural interface implemented by source-only feature grids."""
+
+    feature_names: tuple[str, ...]
+
+    def flattened(self) -> FloatArray:
+        """Return valid feature rows with shape ``(N, F)``."""
+
+        ...
+
+
+def _canonical_json(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        plain_json(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _sha256_json(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json(value)).hexdigest()
+
+
+def _readonly_float(value: object, *, ndim: int, name: str) -> FloatArray:
+    array = np.asarray(value, dtype=np.float64)
+    if array.ndim != ndim:
+        raise ValueError(f"{name} must have {ndim} dimensions")
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} must be finite")
+    result = np.array(array, dtype=np.float64, copy=True, order="C")
+    result.setflags(write=False)
+    return result
+
+
+def _strict_feature_names(value: object, *, name: str = "feature_names") -> tuple[str, ...]:
+    if type(value) is not tuple:
+        raise TypeError(f"{name} must be a canonical tuple")
+    names = tuple(
+        require_exact_string(item, name=f"{name}[{index}]")
+        for index, item in enumerate(value)
+    )
+    if not names:
+        raise ValueError(f"{name} must not be empty")
+    if len(set(names)) != len(names):
+        raise ValueError(f"{name} must be unique")
+    return names
+
+
+def _strict_identifier_tuple(value: object, *, name: str) -> tuple[str, ...]:
+    if type(value) is not tuple:
+        raise TypeError(f"{name} must be a canonical tuple")
+    identifiers = tuple(
+        require_exact_string(item, name=f"{name}[{index}]")
+        for index, item in enumerate(value)
+    )
+    if not identifiers:
+        raise ValueError(f"{name} must not be empty")
+    if len(set(identifiers)) != len(identifiers):
+        raise ValueError(f"{name} must be unique")
+    if identifiers != tuple(sorted(identifiers)):
+        raise ValueError(f"{name} must be sorted")
+    return identifiers
+
+
+def _strict_integer_tuple(value: object, *, name: str, minimum: int) -> tuple[int, ...]:
+    if type(value) is not tuple:
+        raise TypeError(f"{name} must be a canonical tuple")
+    result = tuple(
+        require_exact_integer(item, name=f"{name}[{index}]", minimum=minimum)
+        for index, item in enumerate(value)
+    )
+    if not result:
+        raise ValueError(f"{name} must not be empty")
+    return result
+
+
+def _strict_probability(
+    value: object,
+    *,
+    name: str,
+    lower_open: bool,
+    upper_open: bool,
+) -> float:
+    result = require_json_number(value, name=name)
+    lower_valid = result > 0.0 if lower_open else result >= 0.0
+    upper_valid = result < 1.0 if upper_open else result <= 1.0
+    if not lower_valid or not upper_valid:
+        lower = "(" if lower_open else "["
+        upper = ")" if upper_open else "]"
+        raise ValueError(f"{name} must lie in {lower}0, 1{upper}")
+    return result
+
+
+def _strict_nonnegative_real(value: object, *, name: str) -> float:
+    result = require_json_number(value, name=name)
+    if result < 0.0:
+        raise ValueError(f"{name} must be non-negative")
+    return result
+
+
+def _strict_quantile_levels(value: object) -> tuple[float, ...]:
+    if type(value) is not tuple:
+        raise TypeError("quantile_levels must be a canonical tuple")
+    levels = tuple(
+        _strict_probability(
+            item,
+            name=f"quantile_levels[{index}]",
+            lower_open=True,
+            upper_open=True,
+        )
+        for index, item in enumerate(value)
+    )
+    if not levels:
+        raise ValueError("quantile_levels must not be empty")
+    if levels != tuple(sorted(levels)) or len(set(levels)) != len(levels):
+        raise ValueError("quantile_levels must be strictly increasing")
+    return levels
+
+
+def _strict_metadata_tuple(
+    value: object,
+    *,
+    name: str,
+    expected_length: int,
+) -> tuple[Mapping[str, Any], ...]:
+    if type(value) is not tuple or len(value) != expected_length:
+        raise ValueError(f"{name} must be a tuple with one entry per unit")
+    return tuple(
+        frozen_finite_json_mapping(
+            require_finite_json_mapping(item, name=f"{name}[{index}]"),
+            name=f"{name}[{index}]",
+        )
+        for index, item in enumerate(value)
+    )
+
+
+def calibration_transport_feature_contract_id(
+    feature_names: tuple[str, ...],
+    *,
+    semantics: str,
+    configuration: Mapping[str, Any],
+) -> str:
+    """Return a stable digest for one source-only feature definition."""
+
+    names = _strict_feature_names(feature_names)
+    semantics_value = require_exact_string(semantics, name="semantics")
+    normalized_configuration = frozen_finite_json_mapping(
+        require_finite_json_mapping(configuration, name="configuration"),
+        name="configuration",
+    )
+    payload = {
+        "schema": CALIBRATION_TRANSPORT_FEATURE_CONTRACT_SCHEMA,
+        "schema_version": CALIBRATION_TRANSPORT_VERSION,
+        "feature_names": list(names),
+        "semantics": semantics_value,
+        "configuration": plain_json(normalized_configuration),
+    }
+    return _sha256_json(payload)
+
+
+@dataclass(frozen=True, slots=True)
+class CalibrationTransportUnitV1:
+    """One complete object/session or predeclared target-prefix group."""
+
+    unit_id: str
+    feature_contract_id: str
+    feature_names: tuple[str, ...]
+    feature_values: FloatArray
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        unit_id = require_exact_string(self.unit_id, name="unit_id")
+        contract_id = require_sha256(
+            self.feature_contract_id,
+            name="feature_contract_id",
+        )
+        names = _strict_feature_names(self.feature_names)
+        values = _readonly_float(
+            self.feature_values,
+            ndim=2,
+            name="feature_values",
+        )
+        if values.shape[0] < 1:
+            raise ValueError("feature_values must contain at least one row")
+        if values.shape[1] != len(names):
+            raise ValueError("feature_values column count differs from feature_names")
+        metadata = frozen_finite_json_mapping(
+            require_finite_json_mapping(self.metadata, name="metadata"),
+            name="metadata",
+        )
+        object.__setattr__(self, "unit_id", unit_id)
+        object.__setattr__(self, "feature_contract_id", contract_id)
+        object.__setattr__(self, "feature_names", names)
+        object.__setattr__(self, "feature_values", values)
+        object.__setattr__(self, "metadata", metadata)
+
+    @property
+    def row_count(self) -> int:
+        return int(self.feature_values.shape[0])
+
+    @classmethod
+    def from_feature_grid(
+        cls,
+        unit_id: str,
+        feature_grid: SourceFeatureGrid,
+        *,
+        feature_contract_id: str,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> CalibrationTransportUnitV1:
+        """Build a unit from a ``SourceReliabilityFeatures``-like grid."""
+
+        grid_metadata = getattr(feature_grid, "metadata", {})
+        combined_metadata: dict[str, Any] = {
+            "feature_grid_metadata": plain_json(grid_metadata),
+        }
+        if metadata is not None:
+            combined_metadata["unit_metadata"] = plain_json(metadata)
+        return cls(
+            unit_id=unit_id,
+            feature_contract_id=feature_contract_id,
+            feature_names=tuple(feature_grid.feature_names),
+            feature_values=feature_grid.flattened(),
+            metadata=combined_metadata,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class CalibrationTransportPolicyV1:
+    """Frozen source-only support and target-rejection policy."""
+
+    quantile_levels: tuple[float, ...]
+    miscoverage_rate: float
+    minimum_source_units: int
+    neighbor_count: int
+    maximum_unsupported_group_fraction: float
+    maximum_unsupported_row_fraction: float
+    absolute_scale_floor: float
+    relative_scale_floor: float
+    distance_semantics: str = _DISTANCE_SEMANTICS
+    threshold_semantics: str = _THRESHOLD_SEMANTICS
+
+    def __post_init__(self) -> None:
+        levels = _strict_quantile_levels(self.quantile_levels)
+        miscoverage = _strict_probability(
+            self.miscoverage_rate,
+            name="miscoverage_rate",
+            lower_open=True,
+            upper_open=True,
+        )
+        minimum_source_units = require_exact_integer(
+            self.minimum_source_units,
+            name="minimum_source_units",
+            minimum=3,
+        )
+        neighbor_count = require_exact_integer(
+            self.neighbor_count,
+            name="neighbor_count",
+            minimum=1,
+        )
+        if neighbor_count >= minimum_source_units:
+            raise ValueError("neighbor_count must be smaller than minimum_source_units")
+        maximum_group = _strict_probability(
+            self.maximum_unsupported_group_fraction,
+            name="maximum_unsupported_group_fraction",
+            lower_open=False,
+            upper_open=False,
+        )
+        maximum_row = _strict_probability(
+            self.maximum_unsupported_row_fraction,
+            name="maximum_unsupported_row_fraction",
+            lower_open=False,
+            upper_open=False,
+        )
+        absolute_floor = _strict_nonnegative_real(
+            self.absolute_scale_floor,
+            name="absolute_scale_floor",
+        )
+        relative_floor = _strict_nonnegative_real(
+            self.relative_scale_floor,
+            name="relative_scale_floor",
+        )
+        if absolute_floor == 0.0 and relative_floor == 0.0:
+            raise ValueError("at least one scale floor must be positive")
+        if self.distance_semantics != _DISTANCE_SEMANTICS:
+            raise ValueError(f"distance_semantics must equal {_DISTANCE_SEMANTICS!r}")
+        if self.threshold_semantics != _THRESHOLD_SEMANTICS:
+            raise ValueError(f"threshold_semantics must equal {_THRESHOLD_SEMANTICS!r}")
+        object.__setattr__(self, "quantile_levels", levels)
+        object.__setattr__(self, "miscoverage_rate", miscoverage)
+        object.__setattr__(self, "minimum_source_units", minimum_source_units)
+        object.__setattr__(self, "neighbor_count", neighbor_count)
+        object.__setattr__(
+            self,
+            "maximum_unsupported_group_fraction",
+            maximum_group,
+        )
+        object.__setattr__(
+            self,
+            "maximum_unsupported_row_fraction",
+            maximum_row,
+        )
+        object.__setattr__(self, "absolute_scale_floor", absolute_floor)
+        object.__setattr__(self, "relative_scale_floor", relative_floor)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "quantile_levels": list(self.quantile_levels),
+            "miscoverage_rate": self.miscoverage_rate,
+            "minimum_source_units": self.minimum_source_units,
+            "neighbor_count": self.neighbor_count,
+            "maximum_unsupported_group_fraction": (
+                self.maximum_unsupported_group_fraction
+            ),
+            "maximum_unsupported_row_fraction": self.maximum_unsupported_row_fraction,
+            "absolute_scale_floor": self.absolute_scale_floor,
+            "relative_scale_floor": self.relative_scale_floor,
+            "distance_semantics": self.distance_semantics,
+            "threshold_semantics": self.threshold_semantics,
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> CalibrationTransportPolicyV1:
+        mapping = require_mapping(value, name="calibration transport policy")
+        require_exact_fields(
+            mapping,
+            _POLICY_FIELDS,
+            name="calibration transport policy",
+        )
+        raw_levels = mapping["quantile_levels"]
+        if type(raw_levels) is not list:
+            raise ValueError("quantile_levels must be a JSON array")
+        return cls(
+            quantile_levels=tuple(raw_levels),
+            miscoverage_rate=mapping["miscoverage_rate"],
+            minimum_source_units=mapping["minimum_source_units"],
+            neighbor_count=mapping["neighbor_count"],
+            maximum_unsupported_group_fraction=mapping[
+                "maximum_unsupported_group_fraction"
+            ],
+            maximum_unsupported_row_fraction=mapping[
+                "maximum_unsupported_row_fraction"
+            ],
+            absolute_scale_floor=mapping["absolute_scale_floor"],
+            relative_scale_floor=mapping["relative_scale_floor"],
+            distance_semantics=mapping["distance_semantics"],
+            threshold_semantics=mapping["threshold_semantics"],
+        )
+
+
+def _strict_json_matrix(value: object, *, name: str) -> FloatArray:
+    if type(value) is not list or not value:
+        raise ValueError(f"{name} must be a non-empty JSON matrix")
+    rows: list[list[float]] = []
+    width: int | None = None
+    for row_index, raw_row in enumerate(value):
+        if type(raw_row) is not list or not raw_row:
+            raise ValueError(f"{name}[{row_index}] must be a non-empty JSON array")
+        row = [
+            require_json_number(item, name=f"{name}[{row_index}][{column_index}]")
+            for column_index, item in enumerate(raw_row)
+        ]
+        if width is None:
+            width = len(row)
+        elif len(row) != width:
+            raise ValueError(f"{name} rows must have equal length")
+        rows.append(row)
+    return np.asarray(rows, dtype=np.float64)

--- a/src/prob4d/_calibration_transport_evidence.py
+++ b/src/prob4d/_calibration_transport_evidence.py
@@ -9,10 +9,10 @@ from typing import Any
 import numpy as np
 
 from ._calibration_transport_common import (
+    _EVIDENCE_FIELDS,
     CALIBRATION_TRANSPORT_CLAIM_BOUNDARY,
     CALIBRATION_TRANSPORT_EVIDENCE_SCHEMA,
     CALIBRATION_TRANSPORT_VERSION,
-    _EVIDENCE_FIELDS,
     CalibrationTransportUnitV1,
     FloatArray,
     _readonly_float,

--- a/src/prob4d/_calibration_transport_evidence.py
+++ b/src/prob4d/_calibration_transport_evidence.py
@@ -1,0 +1,309 @@
+"""Target-prefix evaluation for calibration-transport support models."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+from ._calibration_transport_common import (
+    CALIBRATION_TRANSPORT_CLAIM_BOUNDARY,
+    CALIBRATION_TRANSPORT_EVIDENCE_SCHEMA,
+    CALIBRATION_TRANSPORT_VERSION,
+    _EVIDENCE_FIELDS,
+    CalibrationTransportUnitV1,
+    FloatArray,
+    _readonly_float,
+    _sha256_json,
+    _strict_identifier_tuple,
+    _strict_integer_tuple,
+    _strict_json_matrix,
+    _strict_metadata_tuple,
+)
+from ._calibration_transport_group import (
+    CalibrationTransportGroupResultV1,
+    _target_group_result,
+)
+from ._calibration_transport_model import (
+    CalibrationTransportModelV1,
+    _quantile_embedding,
+)
+from ._immutable_json import frozen_finite_json_mapping, plain_json
+from ._strict_json import (
+    require_exact_fields,
+    require_exact_integer,
+    require_finite_json_mapping,
+    require_mapping,
+    require_sha256,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CalibrationTransportEvidenceV1:
+    """Replayable target-prefix support evidence for one frozen source model."""
+
+    model: CalibrationTransportModelV1 = field(repr=False)
+    target_unit_ids: tuple[str, ...]
+    target_row_counts: tuple[int, ...]
+    target_embeddings: FloatArray
+    target_metadata: tuple[Mapping[str, Any], ...]
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    evidence_id: str | None = None
+    group_results: tuple[CalibrationTransportGroupResultV1, ...] = field(init=False)
+    target_group_count: int = field(init=False)
+    target_row_count: int = field(init=False)
+    supported_group_count: int = field(init=False)
+    supported_row_count: int = field(init=False)
+    unsupported_group_fraction: float = field(init=False)
+    unsupported_row_fraction: float = field(init=False)
+    accepted: bool = field(init=False)
+    decision_reasons: tuple[str, ...] = field(init=False)
+    worst_target_unit_id: str = field(init=False)
+    worst_feature_name: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.model, CalibrationTransportModelV1):
+            raise TypeError("model must be a CalibrationTransportModelV1")
+        target_ids = _strict_identifier_tuple(
+            self.target_unit_ids,
+            name="target_unit_ids",
+        )
+        if set(target_ids) & set(self.model.source_unit_ids):
+            raise ValueError("target unit IDs overlap source unit IDs")
+        target_count = len(target_ids)
+        row_counts = _strict_integer_tuple(
+            self.target_row_counts,
+            name="target_row_counts",
+            minimum=1,
+        )
+        if len(row_counts) != target_count:
+            raise ValueError("target_row_counts length differs from target_unit_ids")
+        embeddings = _readonly_float(
+            self.target_embeddings,
+            ndim=2,
+            name="target_embeddings",
+        )
+        if embeddings.shape != (target_count, self.model.embedding_dimension):
+            raise ValueError("target_embeddings shape differs from model")
+        target_metadata = _strict_metadata_tuple(
+            self.target_metadata,
+            name="target_metadata",
+            expected_length=target_count,
+        )
+        metadata = frozen_finite_json_mapping(
+            require_finite_json_mapping(self.metadata, name="metadata"),
+            name="metadata",
+        )
+        results = tuple(
+            _target_group_result(
+                self.model,
+                unit_id=unit_id,
+                row_count=row_count,
+                embedding=embedding,
+                metadata=group_metadata,
+            )
+            for unit_id, row_count, embedding, group_metadata in zip(
+                target_ids,
+                row_counts,
+                embeddings,
+                target_metadata,
+                strict=True,
+            )
+        )
+        total_rows = int(sum(row_counts))
+        supported_group_count = sum(result.supported for result in results)
+        supported_rows = sum(result.row_count for result in results if result.supported)
+        unsupported_group_fraction = 1.0 - supported_group_count / target_count
+        unsupported_row_fraction = 1.0 - supported_rows / total_rows
+        reasons: list[str] = []
+        if (
+            unsupported_group_fraction
+            > self.model.policy.maximum_unsupported_group_fraction
+        ):
+            reasons.append("unsupported-group-fraction")
+        if unsupported_row_fraction > self.model.policy.maximum_unsupported_row_fraction:
+            reasons.append("unsupported-row-fraction")
+        accepted = not reasons
+        worst_result = max(
+            results,
+            key=lambda result: (result.nonconformity_score, result.unit_id),
+        )
+        feature_maxima = {
+            name: max(
+                max(
+                    float(result.feature_distance_rms[name]),
+                    float(result.feature_outside_range_max[name]),
+                )
+                for result in results
+            )
+            for name in self.model.feature_names
+        }
+        worst_feature = max(
+            self.model.feature_names,
+            key=lambda name: (feature_maxima[name], name),
+        )
+
+        object.__setattr__(self, "target_unit_ids", target_ids)
+        object.__setattr__(self, "target_row_counts", row_counts)
+        object.__setattr__(self, "target_embeddings", embeddings)
+        object.__setattr__(self, "target_metadata", target_metadata)
+        object.__setattr__(self, "metadata", metadata)
+        object.__setattr__(self, "group_results", results)
+        object.__setattr__(self, "target_group_count", target_count)
+        object.__setattr__(self, "target_row_count", total_rows)
+        object.__setattr__(self, "supported_group_count", supported_group_count)
+        object.__setattr__(self, "supported_row_count", supported_rows)
+        object.__setattr__(
+            self,
+            "unsupported_group_fraction",
+            float(unsupported_group_fraction),
+        )
+        object.__setattr__(
+            self,
+            "unsupported_row_fraction",
+            float(unsupported_row_fraction),
+        )
+        object.__setattr__(self, "accepted", accepted)
+        object.__setattr__(self, "decision_reasons", tuple(reasons))
+        object.__setattr__(self, "worst_target_unit_id", worst_result.unit_id)
+        object.__setattr__(self, "worst_feature_name", worst_feature)
+
+        computed_id = _sha256_json(self._identity_payload())
+        if self.evidence_id is not None:
+            supplied = require_sha256(self.evidence_id, name="evidence_id")
+            if supplied != computed_id:
+                raise ValueError("evidence_id does not match calibration transport content")
+        object.__setattr__(self, "evidence_id", computed_id)
+
+    def _identity_payload(self) -> dict[str, object]:
+        return {
+            "schema": CALIBRATION_TRANSPORT_EVIDENCE_SCHEMA,
+            "schema_version": CALIBRATION_TRANSPORT_VERSION,
+            "model_id": self.model.model_id,
+            "feature_contract_id": self.model.feature_contract_id,
+            "feature_names": list(self.model.feature_names),
+            "target_unit_ids": list(self.target_unit_ids),
+            "target_row_counts": list(self.target_row_counts),
+            "target_embeddings": self.target_embeddings.tolist(),
+            "target_metadata": [plain_json(item) for item in self.target_metadata],
+            "group_results": [item.to_dict() for item in self.group_results],
+            "target_group_count": self.target_group_count,
+            "target_row_count": self.target_row_count,
+            "supported_group_count": self.supported_group_count,
+            "supported_row_count": self.supported_row_count,
+            "unsupported_group_fraction": self.unsupported_group_fraction,
+            "unsupported_row_fraction": self.unsupported_row_fraction,
+            "accepted": self.accepted,
+            "decision_reasons": list(self.decision_reasons),
+            "worst_target_unit_id": self.worst_target_unit_id,
+            "worst_feature_name": self.worst_feature_name,
+            "metadata": plain_json(self.metadata),
+            "claim_boundary": CALIBRATION_TRANSPORT_CLAIM_BOUNDARY,
+        }
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            **self._identity_payload(),
+            "evidence_id": self.evidence_id,
+        }
+
+    @classmethod
+    def from_dict(
+        cls,
+        value: object,
+        *,
+        model: CalibrationTransportModelV1,
+    ) -> CalibrationTransportEvidenceV1:
+        mapping = require_mapping(value, name="calibration transport evidence")
+        require_exact_fields(
+            mapping,
+            _EVIDENCE_FIELDS,
+            name="calibration transport evidence",
+        )
+        if mapping["schema"] != CALIBRATION_TRANSPORT_EVIDENCE_SCHEMA:
+            raise ValueError("calibration transport evidence schema changed")
+        if require_exact_integer(
+            mapping["schema_version"],
+            name="schema_version",
+            minimum=1,
+        ) != CALIBRATION_TRANSPORT_VERSION:
+            raise ValueError("calibration transport evidence version changed")
+        if mapping["claim_boundary"] != CALIBRATION_TRANSPORT_CLAIM_BOUNDARY:
+            raise ValueError("calibration transport claim boundary changed")
+        if mapping["model_id"] != model.model_id:
+            raise ValueError("calibration transport evidence references another model")
+        if mapping["feature_contract_id"] != model.feature_contract_id:
+            raise ValueError("calibration transport feature contract changed")
+        if mapping["feature_names"] != list(model.feature_names):
+            raise ValueError("calibration transport feature names changed")
+
+        target_ids_value = mapping["target_unit_ids"]
+        row_counts_value = mapping["target_row_counts"]
+        embeddings_value = mapping["target_embeddings"]
+        metadata_value = mapping["target_metadata"]
+        if type(target_ids_value) is not list:
+            raise ValueError("target_unit_ids must be a JSON array")
+        if type(row_counts_value) is not list:
+            raise ValueError("target_row_counts must be a JSON array")
+        if type(embeddings_value) is not list:
+            raise ValueError("target_embeddings must be a JSON matrix")
+        if type(metadata_value) is not list:
+            raise ValueError("target_metadata must be a JSON array")
+        evidence = cls(
+            model=model,
+            target_unit_ids=tuple(target_ids_value),
+            target_row_counts=tuple(row_counts_value),
+            target_embeddings=_strict_json_matrix(
+                embeddings_value,
+                name="target_embeddings",
+            ),
+            target_metadata=tuple(
+                require_mapping(item, name=f"target_metadata[{index}]")
+                for index, item in enumerate(metadata_value)
+            ),
+            metadata=require_mapping(mapping["metadata"], name="metadata"),
+            evidence_id=mapping["evidence_id"],
+        )
+        if evidence.to_dict() != plain_json(mapping):
+            raise ValueError("calibration transport evidence derived fields changed")
+        return evidence
+
+
+def evaluate_calibration_transport(
+    model: CalibrationTransportModelV1,
+    target_units: Sequence[CalibrationTransportUnitV1],
+    *,
+    metadata: Mapping[str, Any] | None = None,
+) -> CalibrationTransportEvidenceV1:
+    """Evaluate target-prefix support without target residuals or outcomes."""
+
+    if not isinstance(model, CalibrationTransportModelV1):
+        raise TypeError("model must be a CalibrationTransportModelV1")
+    if isinstance(target_units, (str, bytes)) or not isinstance(target_units, Sequence):
+        raise TypeError("target_units must be a sequence")
+    units = tuple(target_units)
+    if not units or not all(isinstance(item, CalibrationTransportUnitV1) for item in units):
+        raise ValueError("target_units must contain CalibrationTransportUnitV1 values")
+    ordered = tuple(sorted(units, key=lambda item: item.unit_id))
+    if len({item.unit_id for item in ordered}) != len(ordered):
+        raise ValueError("target unit IDs must be unique")
+    if any(item.feature_contract_id != model.feature_contract_id for item in ordered):
+        raise ValueError("target feature contract differs from source model")
+    if any(item.feature_names != model.feature_names for item in ordered):
+        raise ValueError("target feature names differ from source model")
+    embeddings = np.stack(
+        [
+            _quantile_embedding(item.feature_values, model.policy.quantile_levels)
+            for item in ordered
+        ]
+    )
+    return CalibrationTransportEvidenceV1(
+        model=model,
+        target_unit_ids=tuple(item.unit_id for item in ordered),
+        target_row_counts=tuple(item.row_count for item in ordered),
+        target_embeddings=embeddings,
+        target_metadata=tuple(item.metadata for item in ordered),
+        metadata={} if metadata is None else metadata,
+    )

--- a/src/prob4d/_calibration_transport_group.py
+++ b/src/prob4d/_calibration_transport_group.py
@@ -1,0 +1,223 @@
+"""Per-group diagnostics for calibration-transport target support."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from ._calibration_transport_common import (
+    FloatArray,
+    _strict_identifier_tuple,
+    _strict_nonnegative_real,
+    _strict_probability,
+)
+from ._calibration_transport_model import CalibrationTransportModelV1
+from ._immutable_json import frozen_finite_json_mapping, plain_json
+from ._strict_json import (
+    require_exact_integer,
+    require_exact_string,
+    require_finite_json_mapping,
+    require_json_number,
+    require_mapping,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CalibrationTransportGroupResultV1:
+    """One target-prefix support decision and localization diagnostic."""
+
+    unit_id: str
+    row_count: int
+    nonconformity_score: float
+    source_support_p_value: float
+    supported: bool
+    support_margin: float
+    nearest_source_unit_ids: tuple[str, ...]
+    nearest_source_distances: tuple[float, ...]
+    feature_distance_rms: Mapping[str, Any]
+    feature_outside_range_max: Mapping[str, Any]
+    worst_distance_feature: str
+    worst_outside_range_feature: str
+    metadata: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        unit_id = require_exact_string(self.unit_id, name="unit_id")
+        row_count = require_exact_integer(self.row_count, name="row_count", minimum=1)
+        score = _strict_nonnegative_real(
+            self.nonconformity_score,
+            name="nonconformity_score",
+        )
+        p_value = _strict_probability(
+            self.source_support_p_value,
+            name="source_support_p_value",
+            lower_open=True,
+            upper_open=False,
+        )
+        if type(self.supported) is not bool:
+            raise ValueError("supported must be a Boolean")
+        margin = require_json_number(self.support_margin, name="support_margin")
+        if type(self.nearest_source_unit_ids) is not tuple:
+            raise TypeError("nearest_source_unit_ids must be a canonical tuple")
+        nearest_ids = _strict_identifier_tuple(
+            self.nearest_source_unit_ids,
+            name="nearest_source_unit_ids",
+        )
+        if type(self.nearest_source_distances) is not tuple:
+            raise TypeError("nearest_source_distances must be a canonical tuple")
+        distances = tuple(
+            _strict_nonnegative_real(item, name=f"nearest_source_distances[{index}]")
+            for index, item in enumerate(self.nearest_source_distances)
+        )
+        if len(distances) != len(nearest_ids):
+            raise ValueError("nearest source IDs and distances differ in length")
+        distance_mapping = _strict_feature_mapping(
+            self.feature_distance_rms,
+            name="feature_distance_rms",
+        )
+        outside_mapping = _strict_feature_mapping(
+            self.feature_outside_range_max,
+            name="feature_outside_range_max",
+        )
+        if tuple(distance_mapping) != tuple(outside_mapping):
+            raise ValueError("feature diagnostic names changed")
+        worst_distance = require_exact_string(
+            self.worst_distance_feature,
+            name="worst_distance_feature",
+        )
+        worst_outside = require_exact_string(
+            self.worst_outside_range_feature,
+            name="worst_outside_range_feature",
+        )
+        if worst_distance not in distance_mapping or worst_outside not in outside_mapping:
+            raise ValueError("worst feature does not occur in feature diagnostics")
+        metadata = frozen_finite_json_mapping(
+            require_finite_json_mapping(self.metadata, name="metadata"),
+            name="metadata",
+        )
+        object.__setattr__(self, "unit_id", unit_id)
+        object.__setattr__(self, "row_count", row_count)
+        object.__setattr__(self, "nonconformity_score", score)
+        object.__setattr__(self, "source_support_p_value", p_value)
+        object.__setattr__(self, "support_margin", margin)
+        object.__setattr__(self, "nearest_source_unit_ids", nearest_ids)
+        object.__setattr__(self, "nearest_source_distances", distances)
+        object.__setattr__(self, "feature_distance_rms", distance_mapping)
+        object.__setattr__(self, "feature_outside_range_max", outside_mapping)
+        object.__setattr__(self, "worst_distance_feature", worst_distance)
+        object.__setattr__(self, "worst_outside_range_feature", worst_outside)
+        object.__setattr__(self, "metadata", metadata)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "unit_id": self.unit_id,
+            "row_count": self.row_count,
+            "nonconformity_score": self.nonconformity_score,
+            "source_support_p_value": self.source_support_p_value,
+            "supported": self.supported,
+            "support_margin": self.support_margin,
+            "nearest_source_unit_ids": list(self.nearest_source_unit_ids),
+            "nearest_source_distances": list(self.nearest_source_distances),
+            "feature_distance_rms": plain_json(self.feature_distance_rms),
+            "feature_outside_range_max": plain_json(
+                self.feature_outside_range_max
+            ),
+            "worst_distance_feature": self.worst_distance_feature,
+            "worst_outside_range_feature": self.worst_outside_range_feature,
+            "metadata": plain_json(self.metadata),
+        }
+
+
+def _strict_feature_mapping(value: object, *, name: str) -> Mapping[str, Any]:
+    mapping = require_mapping(value, name=name)
+    if not mapping:
+        raise ValueError(f"{name} must not be empty")
+    normalized: dict[str, float] = {}
+    for key, item in mapping.items():
+        feature_name = require_exact_string(key, name=f"{name} key")
+        normalized[feature_name] = _strict_nonnegative_real(
+            item,
+            name=f"{name}[{feature_name!r}]",
+        )
+    return frozen_finite_json_mapping(normalized, name=name)
+
+
+def _target_group_result(
+    model: CalibrationTransportModelV1,
+    *,
+    unit_id: str,
+    row_count: int,
+    embedding: FloatArray,
+    metadata: Mapping[str, Any],
+) -> CalibrationTransportGroupResultV1:
+    standardized = (model.source_embeddings - embedding[None, :]) / model.embedding_scale
+    distances = np.sqrt(np.mean(standardized**2, axis=1))
+    ordered_indices = sorted(
+        range(model.source_unit_count),
+        key=lambda index: (float(distances[index]), model.source_unit_ids[index]),
+    )
+    selected = ordered_indices[: model.policy.neighbor_count]
+    selected_distances = tuple(float(distances[index]) for index in selected)
+    score = float(np.mean(selected_distances))
+    p_value = float(
+        (1 + int(np.count_nonzero(model.source_nonconformity_scores >= score)))
+        / (model.source_unit_count + 1)
+    )
+    supported = score <= model.support_threshold
+
+    feature_count = len(model.feature_names)
+    quantile_count = len(model.policy.quantile_levels)
+    selected_delta = standardized[selected].reshape(
+        len(selected),
+        feature_count,
+        quantile_count,
+    )
+    feature_distance = np.sqrt(np.mean(selected_delta**2, axis=(0, 2)))
+
+    source_minimum = np.min(model.source_embeddings, axis=0)
+    source_maximum = np.max(model.source_embeddings, axis=0)
+    lower_excess = np.maximum(source_minimum - embedding, 0.0)
+    upper_excess = np.maximum(embedding - source_maximum, 0.0)
+    outside = np.maximum(lower_excess, upper_excess) / model.embedding_scale
+    feature_outside = np.max(outside.reshape(feature_count, quantile_count), axis=1)
+
+    distance_mapping = {
+        name: float(feature_distance[index])
+        for index, name in enumerate(model.feature_names)
+    }
+    outside_mapping = {
+        name: float(feature_outside[index])
+        for index, name in enumerate(model.feature_names)
+    }
+    worst_distance = max(
+        model.feature_names,
+        key=lambda name: (distance_mapping[name], name),
+    )
+    worst_outside = max(
+        model.feature_names,
+        key=lambda name: (outside_mapping[name], name),
+    )
+    nearest_pairs = sorted(
+        (
+            (model.source_unit_ids[index], float(distances[index]))
+            for index in selected
+        ),
+        key=lambda item: item[0],
+    )
+    return CalibrationTransportGroupResultV1(
+        unit_id=unit_id,
+        row_count=row_count,
+        nonconformity_score=score,
+        source_support_p_value=p_value,
+        supported=supported,
+        support_margin=float(model.support_threshold - score),
+        nearest_source_unit_ids=tuple(item[0] for item in nearest_pairs),
+        nearest_source_distances=tuple(item[1] for item in nearest_pairs),
+        feature_distance_rms=distance_mapping,
+        feature_outside_range_max=outside_mapping,
+        worst_distance_feature=worst_distance,
+        worst_outside_range_feature=worst_outside,
+        metadata=metadata,
+    )

--- a/src/prob4d/_calibration_transport_io.py
+++ b/src/prob4d/_calibration_transport_io.py
@@ -1,0 +1,109 @@
+"""Strict JSON persistence for calibration-transport artifacts."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from ._calibration_transport_evidence import CalibrationTransportEvidenceV1
+from ._calibration_transport_model import CalibrationTransportModelV1
+from ._immutable_json import plain_json
+from ._strict_json import load_json_object
+
+
+def _fsync_directory(path: Path) -> None:
+    try:
+        descriptor = os.open(path, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(descriptor)
+    except OSError:
+        pass
+    finally:
+        os.close(descriptor)
+
+
+def _atomic_write_json(
+    path: Path,
+    record: Mapping[str, Any],
+    *,
+    overwrite: bool,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(
+                plain_json(record),
+                stream,
+                indent=2,
+                sort_keys=True,
+                allow_nan=False,
+            )
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        if overwrite:
+            os.replace(temporary_name, path)
+        else:
+            try:
+                os.link(temporary_name, path)
+            except FileExistsError:
+                raise FileExistsError(f"refusing to overwrite {path}") from None
+            os.unlink(temporary_name)
+        _fsync_directory(path.parent)
+    finally:
+        if os.path.exists(temporary_name):
+            os.unlink(temporary_name)
+
+
+def save_calibration_transport_model(
+    model: CalibrationTransportModelV1,
+    path: str | Path,
+    *,
+    overwrite: bool = False,
+) -> None:
+    if not isinstance(model, CalibrationTransportModelV1):
+        raise TypeError("model must be a CalibrationTransportModelV1")
+    if type(overwrite) is not bool:
+        raise TypeError("overwrite must be a Boolean")
+    _atomic_write_json(Path(path), model.to_dict(), overwrite=overwrite)
+
+
+def load_calibration_transport_model(path: str | Path) -> CalibrationTransportModelV1:
+    return CalibrationTransportModelV1.from_dict(
+        load_json_object(path, name="calibration transport model")
+    )
+
+
+def save_calibration_transport_evidence(
+    evidence: CalibrationTransportEvidenceV1,
+    path: str | Path,
+    *,
+    overwrite: bool = False,
+) -> None:
+    if not isinstance(evidence, CalibrationTransportEvidenceV1):
+        raise TypeError("evidence must be a CalibrationTransportEvidenceV1")
+    if type(overwrite) is not bool:
+        raise TypeError("overwrite must be a Boolean")
+    _atomic_write_json(Path(path), evidence.to_dict(), overwrite=overwrite)
+
+
+def load_calibration_transport_evidence(
+    path: str | Path,
+    *,
+    model: CalibrationTransportModelV1,
+) -> CalibrationTransportEvidenceV1:
+    return CalibrationTransportEvidenceV1.from_dict(
+        load_json_object(path, name="calibration transport evidence"),
+        model=model,
+    )

--- a/src/prob4d/_calibration_transport_model.py
+++ b/src/prob4d/_calibration_transport_model.py
@@ -10,12 +10,12 @@ from typing import Any
 import numpy as np
 
 from ._calibration_transport_common import (
+    _IQR_NORMAL_SCALE,
+    _MAD_NORMAL_SCALE,
+    _MODEL_FIELDS,
     CALIBRATION_TRANSPORT_CLAIM_BOUNDARY,
     CALIBRATION_TRANSPORT_MODEL_SCHEMA,
     CALIBRATION_TRANSPORT_VERSION,
-    _IQR_NORMAL_SCALE,
-    _MODEL_FIELDS,
-    _MAD_NORMAL_SCALE,
     CalibrationTransportPolicyV1,
     CalibrationTransportUnitV1,
     FloatArray,

--- a/src/prob4d/_calibration_transport_model.py
+++ b/src/prob4d/_calibration_transport_model.py
@@ -1,0 +1,351 @@
+"""Source-only fitting for calibration-transport support models."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+from ._calibration_transport_common import (
+    CALIBRATION_TRANSPORT_CLAIM_BOUNDARY,
+    CALIBRATION_TRANSPORT_MODEL_SCHEMA,
+    CALIBRATION_TRANSPORT_VERSION,
+    _IQR_NORMAL_SCALE,
+    _MODEL_FIELDS,
+    _MAD_NORMAL_SCALE,
+    CalibrationTransportPolicyV1,
+    CalibrationTransportUnitV1,
+    FloatArray,
+    _readonly_float,
+    _sha256_json,
+    _strict_feature_names,
+    _strict_identifier_tuple,
+    _strict_integer_tuple,
+    _strict_json_matrix,
+    _strict_metadata_tuple,
+)
+from ._immutable_json import frozen_finite_json_mapping, plain_json
+from ._strict_json import (
+    require_exact_fields,
+    require_exact_integer,
+    require_finite_json_mapping,
+    require_mapping,
+    require_sha256,
+)
+
+
+def _quantile_embedding(
+    values: FloatArray,
+    quantile_levels: tuple[float, ...],
+) -> FloatArray:
+    quantiles = np.quantile(
+        values,
+        np.asarray(quantile_levels, dtype=np.float64),
+        axis=0,
+        method="linear",
+    )
+    embedding = np.asarray(quantiles.T.reshape(-1), dtype=np.float64)
+    if not np.all(np.isfinite(embedding)):
+        raise ValueError("quantile embedding is non-finite")
+    return embedding
+
+
+def _robust_center_scale(
+    embeddings: FloatArray,
+    policy: CalibrationTransportPolicyV1,
+) -> tuple[FloatArray, FloatArray]:
+    center = np.median(embeddings, axis=0)
+    mad_scale = _MAD_NORMAL_SCALE * np.median(
+        np.abs(embeddings - center[None, :]),
+        axis=0,
+    )
+    quartiles = np.quantile(
+        embeddings,
+        np.asarray([0.25, 0.75]),
+        axis=0,
+        method="linear",
+    )
+    iqr_scale = (quartiles[1] - quartiles[0]) / _IQR_NORMAL_SCALE
+    robust_scale = np.maximum(mad_scale, iqr_scale)
+    reference = np.maximum(
+        np.maximum(np.abs(center), np.max(np.abs(embeddings), axis=0)),
+        1.0,
+    )
+    floor = policy.absolute_scale_floor + policy.relative_scale_floor * reference
+    scale = np.maximum(robust_scale, floor)
+    if not np.all(np.isfinite(center)) or not np.all(np.isfinite(scale)):
+        raise ValueError("calibration transport scaling is non-finite")
+    if np.any(scale <= 0.0):
+        raise ValueError("calibration transport scale must be positive")
+    return np.asarray(center, dtype=np.float64), np.asarray(scale, dtype=np.float64)
+
+
+def _pairwise_distances(embeddings: FloatArray, scale: FloatArray) -> FloatArray:
+    standardized = (embeddings[:, None, :] - embeddings[None, :, :]) / scale
+    distances = np.sqrt(np.mean(standardized**2, axis=2))
+    if not np.all(np.isfinite(distances)):
+        raise ValueError("source pairwise support distance is non-finite")
+    return np.asarray(distances, dtype=np.float64)
+
+
+def _source_nonconformity_scores(
+    pairwise: FloatArray,
+    *,
+    neighbor_count: int,
+) -> FloatArray:
+    source_count = int(pairwise.shape[0])
+    if pairwise.shape != (source_count, source_count):
+        raise ValueError("source pairwise distance matrix must be square")
+    scores = np.empty(source_count, dtype=np.float64)
+    for index in range(source_count):
+        candidates = np.delete(pairwise[index], index)
+        selected = np.partition(candidates, neighbor_count - 1)[:neighbor_count]
+        scores[index] = float(np.mean(selected))
+    if not np.all(np.isfinite(scores)) or np.any(scores < 0.0):
+        raise ValueError("source nonconformity scores must be finite and non-negative")
+    return scores
+
+
+def _threshold_rank(source_count: int, miscoverage_rate: float) -> int:
+    raw_rank = math.ceil((source_count + 1) * (1.0 - miscoverage_rate))
+    return min(source_count, max(1, raw_rank))
+
+
+@dataclass(frozen=True, slots=True)
+class CalibrationTransportModelV1:
+    """Content-addressed source-only support model."""
+
+    feature_contract_id: str
+    feature_names: tuple[str, ...]
+    policy: CalibrationTransportPolicyV1
+    source_unit_ids: tuple[str, ...]
+    source_row_counts: tuple[int, ...]
+    source_embeddings: FloatArray
+    source_metadata: tuple[Mapping[str, Any], ...]
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    model_id: str | None = None
+    embedding_center: FloatArray = field(init=False)
+    embedding_scale: FloatArray = field(init=False)
+    source_nonconformity_scores: FloatArray = field(init=False)
+    support_threshold: float = field(init=False)
+    threshold_rank: int = field(init=False)
+
+    def __post_init__(self) -> None:
+        contract_id = require_sha256(
+            self.feature_contract_id,
+            name="feature_contract_id",
+        )
+        names = _strict_feature_names(self.feature_names)
+        if not isinstance(self.policy, CalibrationTransportPolicyV1):
+            raise TypeError("policy must be a CalibrationTransportPolicyV1")
+        source_ids = _strict_identifier_tuple(
+            self.source_unit_ids,
+            name="source_unit_ids",
+        )
+        source_count = len(source_ids)
+        if source_count < self.policy.minimum_source_units:
+            raise ValueError(
+                "source unit count is below policy.minimum_source_units"
+            )
+        if self.policy.neighbor_count >= source_count:
+            raise ValueError("neighbor_count must be smaller than the source unit count")
+        row_counts = _strict_integer_tuple(
+            self.source_row_counts,
+            name="source_row_counts",
+            minimum=1,
+        )
+        if len(row_counts) != source_count:
+            raise ValueError("source_row_counts length differs from source_unit_ids")
+        embeddings = _readonly_float(
+            self.source_embeddings,
+            ndim=2,
+            name="source_embeddings",
+        )
+        expected_dimension = len(names) * len(self.policy.quantile_levels)
+        if embeddings.shape != (source_count, expected_dimension):
+            raise ValueError(
+                "source_embeddings shape differs from source units and feature policy"
+            )
+        source_metadata = _strict_metadata_tuple(
+            self.source_metadata,
+            name="source_metadata",
+            expected_length=source_count,
+        )
+        metadata = frozen_finite_json_mapping(
+            require_finite_json_mapping(self.metadata, name="metadata"),
+            name="metadata",
+        )
+
+        center, scale = _robust_center_scale(embeddings, self.policy)
+        pairwise = _pairwise_distances(embeddings, scale)
+        scores = _source_nonconformity_scores(
+            pairwise,
+            neighbor_count=self.policy.neighbor_count,
+        )
+        rank = _threshold_rank(source_count, self.policy.miscoverage_rate)
+        threshold = float(np.sort(scores, kind="stable")[rank - 1])
+
+        object.__setattr__(self, "feature_contract_id", contract_id)
+        object.__setattr__(self, "feature_names", names)
+        object.__setattr__(self, "source_unit_ids", source_ids)
+        object.__setattr__(self, "source_row_counts", row_counts)
+        object.__setattr__(self, "source_embeddings", embeddings)
+        object.__setattr__(self, "source_metadata", source_metadata)
+        object.__setattr__(self, "metadata", metadata)
+        object.__setattr__(
+            self,
+            "embedding_center",
+            _readonly_float(center, ndim=1, name="embedding_center"),
+        )
+        object.__setattr__(
+            self,
+            "embedding_scale",
+            _readonly_float(scale, ndim=1, name="embedding_scale"),
+        )
+        object.__setattr__(
+            self,
+            "source_nonconformity_scores",
+            _readonly_float(
+                scores,
+                ndim=1,
+                name="source_nonconformity_scores",
+            ),
+        )
+        object.__setattr__(self, "support_threshold", threshold)
+        object.__setattr__(self, "threshold_rank", rank)
+
+        computed_id = _sha256_json(self._identity_payload())
+        if self.model_id is not None:
+            supplied = require_sha256(self.model_id, name="model_id")
+            if supplied != computed_id:
+                raise ValueError("model_id does not match calibration transport content")
+        object.__setattr__(self, "model_id", computed_id)
+
+    @property
+    def source_unit_count(self) -> int:
+        return len(self.source_unit_ids)
+
+    @property
+    def embedding_dimension(self) -> int:
+        return int(self.source_embeddings.shape[1])
+
+    def _identity_payload(self) -> dict[str, object]:
+        return {
+            "schema": CALIBRATION_TRANSPORT_MODEL_SCHEMA,
+            "schema_version": CALIBRATION_TRANSPORT_VERSION,
+            "feature_contract_id": self.feature_contract_id,
+            "feature_names": list(self.feature_names),
+            "policy": self.policy.to_dict(),
+            "source_unit_ids": list(self.source_unit_ids),
+            "source_row_counts": list(self.source_row_counts),
+            "source_embeddings": self.source_embeddings.tolist(),
+            "source_metadata": [plain_json(item) for item in self.source_metadata],
+            "embedding_center": self.embedding_center.tolist(),
+            "embedding_scale": self.embedding_scale.tolist(),
+            "source_nonconformity_scores": self.source_nonconformity_scores.tolist(),
+            "support_threshold": self.support_threshold,
+            "threshold_rank": self.threshold_rank,
+            "metadata": plain_json(self.metadata),
+            "claim_boundary": CALIBRATION_TRANSPORT_CLAIM_BOUNDARY,
+        }
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            **self._identity_payload(),
+            "model_id": self.model_id,
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> CalibrationTransportModelV1:
+        mapping = require_mapping(value, name="calibration transport model")
+        require_exact_fields(mapping, _MODEL_FIELDS, name="calibration transport model")
+        if mapping["schema"] != CALIBRATION_TRANSPORT_MODEL_SCHEMA:
+            raise ValueError("calibration transport model schema changed")
+        if require_exact_integer(
+            mapping["schema_version"],
+            name="schema_version",
+            minimum=1,
+        ) != CALIBRATION_TRANSPORT_VERSION:
+            raise ValueError("calibration transport model version changed")
+        if mapping["claim_boundary"] != CALIBRATION_TRANSPORT_CLAIM_BOUNDARY:
+            raise ValueError("calibration transport claim boundary changed")
+
+        feature_names_value = mapping["feature_names"]
+        source_ids_value = mapping["source_unit_ids"]
+        row_counts_value = mapping["source_row_counts"]
+        embeddings_value = mapping["source_embeddings"]
+        metadata_value = mapping["source_metadata"]
+        if type(feature_names_value) is not list:
+            raise ValueError("feature_names must be a JSON array")
+        if type(source_ids_value) is not list:
+            raise ValueError("source_unit_ids must be a JSON array")
+        if type(row_counts_value) is not list:
+            raise ValueError("source_row_counts must be a JSON array")
+        if type(embeddings_value) is not list:
+            raise ValueError("source_embeddings must be a JSON matrix")
+        if type(metadata_value) is not list:
+            raise ValueError("source_metadata must be a JSON array")
+
+        model = cls(
+            feature_contract_id=mapping["feature_contract_id"],
+            feature_names=tuple(feature_names_value),
+            policy=CalibrationTransportPolicyV1.from_dict(mapping["policy"]),
+            source_unit_ids=tuple(source_ids_value),
+            source_row_counts=tuple(row_counts_value),
+            source_embeddings=_strict_json_matrix(
+                embeddings_value,
+                name="source_embeddings",
+            ),
+            source_metadata=tuple(
+                require_mapping(item, name=f"source_metadata[{index}]")
+                for index, item in enumerate(metadata_value)
+            ),
+            metadata=require_mapping(mapping["metadata"], name="metadata"),
+            model_id=mapping["model_id"],
+        )
+        if model.to_dict() != plain_json(mapping):
+            raise ValueError("calibration transport model derived fields changed")
+        return model
+
+
+def fit_calibration_transport_model(
+    source_units: Sequence[CalibrationTransportUnitV1],
+    *,
+    policy: CalibrationTransportPolicyV1,
+    metadata: Mapping[str, Any] | None = None,
+) -> CalibrationTransportModelV1:
+    """Fit a support model from complete independent source units only."""
+
+    if isinstance(source_units, (str, bytes)) or not isinstance(source_units, Sequence):
+        raise TypeError("source_units must be a sequence")
+    units = tuple(source_units)
+    if not units or not all(isinstance(item, CalibrationTransportUnitV1) for item in units):
+        raise ValueError("source_units must contain CalibrationTransportUnitV1 values")
+    ordered = tuple(sorted(units, key=lambda item: item.unit_id))
+    if len({item.unit_id for item in ordered}) != len(ordered):
+        raise ValueError("source unit IDs must be unique")
+    contract_ids = {item.feature_contract_id for item in ordered}
+    if len(contract_ids) != 1:
+        raise ValueError("source feature contract IDs changed across units")
+    feature_names = ordered[0].feature_names
+    if any(item.feature_names != feature_names for item in ordered[1:]):
+        raise ValueError("source feature names changed across units")
+    embeddings = np.stack(
+        [
+            _quantile_embedding(item.feature_values, policy.quantile_levels)
+            for item in ordered
+        ]
+    )
+    return CalibrationTransportModelV1(
+        feature_contract_id=ordered[0].feature_contract_id,
+        feature_names=feature_names,
+        policy=policy,
+        source_unit_ids=tuple(item.unit_id for item in ordered),
+        source_row_counts=tuple(item.row_count for item in ordered),
+        source_embeddings=embeddings,
+        source_metadata=tuple(item.metadata for item in ordered),
+        metadata={} if metadata is None else metadata,
+    )

--- a/src/prob4d/calibration_transport.py
+++ b/src/prob4d/calibration_transport.py
@@ -1,0 +1,53 @@
+"""Source-only calibration-transport support certificates.
+
+The module summarizes complete source objects or acquisition sessions with robust
+feature quantiles, calibrates a nearest-source nonconformity threshold from those
+independent units only, and evaluates target-prefix feature support without
+opening target residuals or downstream physical outcomes.
+"""
+
+from ._calibration_transport_common import (
+    CALIBRATION_TRANSPORT_CLAIM_BOUNDARY,
+    CALIBRATION_TRANSPORT_EVIDENCE_SCHEMA,
+    CALIBRATION_TRANSPORT_FEATURE_CONTRACT_SCHEMA,
+    CALIBRATION_TRANSPORT_MODEL_SCHEMA,
+    CALIBRATION_TRANSPORT_VERSION,
+    CalibrationTransportPolicyV1,
+    CalibrationTransportUnitV1,
+    calibration_transport_feature_contract_id,
+)
+from ._calibration_transport_evidence import (
+    CalibrationTransportEvidenceV1,
+    evaluate_calibration_transport,
+)
+from ._calibration_transport_group import CalibrationTransportGroupResultV1
+from ._calibration_transport_io import (
+    load_calibration_transport_evidence,
+    load_calibration_transport_model,
+    save_calibration_transport_evidence,
+    save_calibration_transport_model,
+)
+from ._calibration_transport_model import (
+    CalibrationTransportModelV1,
+    fit_calibration_transport_model,
+)
+
+__all__ = [
+    "CALIBRATION_TRANSPORT_CLAIM_BOUNDARY",
+    "CALIBRATION_TRANSPORT_EVIDENCE_SCHEMA",
+    "CALIBRATION_TRANSPORT_FEATURE_CONTRACT_SCHEMA",
+    "CALIBRATION_TRANSPORT_MODEL_SCHEMA",
+    "CALIBRATION_TRANSPORT_VERSION",
+    "CalibrationTransportEvidenceV1",
+    "CalibrationTransportGroupResultV1",
+    "CalibrationTransportModelV1",
+    "CalibrationTransportPolicyV1",
+    "CalibrationTransportUnitV1",
+    "calibration_transport_feature_contract_id",
+    "evaluate_calibration_transport",
+    "fit_calibration_transport_model",
+    "load_calibration_transport_evidence",
+    "load_calibration_transport_model",
+    "save_calibration_transport_evidence",
+    "save_calibration_transport_model",
+]

--- a/tests/test_calibration_transport.py
+++ b/tests/test_calibration_transport.py
@@ -1,0 +1,415 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from prob4d.calibration_transport import (
+    CALIBRATION_TRANSPORT_CLAIM_BOUNDARY,
+    CALIBRATION_TRANSPORT_EVIDENCE_SCHEMA,
+    CALIBRATION_TRANSPORT_MODEL_SCHEMA,
+    CALIBRATION_TRANSPORT_VERSION,
+    CalibrationTransportEvidenceV1,
+    CalibrationTransportModelV1,
+    CalibrationTransportPolicyV1,
+    CalibrationTransportUnitV1,
+    calibration_transport_feature_contract_id,
+    evaluate_calibration_transport,
+    fit_calibration_transport_model,
+    load_calibration_transport_evidence,
+    load_calibration_transport_model,
+    save_calibration_transport_evidence,
+    save_calibration_transport_model,
+)
+
+FEATURE_NAMES = ("overlap_disagreement", "relative_variance")
+FEATURE_CONTRACT = calibration_transport_feature_contract_id(
+    FEATURE_NAMES,
+    semantics="source-only-reliability-features-v1",
+    configuration={"window_size": 25, "uses_target_truth": False},
+)
+
+
+def policy(
+    *,
+    maximum_unsupported_group_fraction: float = 0.0,
+    maximum_unsupported_row_fraction: float = 0.0,
+) -> CalibrationTransportPolicyV1:
+    return CalibrationTransportPolicyV1(
+        quantile_levels=(0.1, 0.5, 0.9),
+        miscoverage_rate=0.2,
+        minimum_source_units=6,
+        neighbor_count=1,
+        maximum_unsupported_group_fraction=maximum_unsupported_group_fraction,
+        maximum_unsupported_row_fraction=maximum_unsupported_row_fraction,
+        absolute_scale_floor=1e-6,
+        relative_scale_floor=1e-6,
+    )
+
+
+def unit(
+    unit_id: str,
+    center: tuple[float, float],
+    *,
+    seed: int,
+    row_count: int = 101,
+    scale: float = 0.08,
+    feature_names: tuple[str, ...] = FEATURE_NAMES,
+    feature_contract_id: str = FEATURE_CONTRACT,
+) -> CalibrationTransportUnitV1:
+    generator = np.random.default_rng(seed)
+    values = generator.normal(center, scale, size=(row_count, len(feature_names)))
+    return CalibrationTransportUnitV1(
+        unit_id=unit_id,
+        feature_contract_id=feature_contract_id,
+        feature_names=feature_names,
+        feature_values=values,
+        metadata={"seed": seed, "source_only": True},
+    )
+
+
+def source_units() -> tuple[CalibrationTransportUnitV1, ...]:
+    return tuple(
+        unit(
+            f"source-{index:02d}",
+            (-0.15 + 0.05 * index, 0.1 - 0.03 * index),
+            seed=100 + index,
+        )
+        for index in range(8)
+    )
+
+
+def fitted_model(
+    *,
+    selected_policy: CalibrationTransportPolicyV1 | None = None,
+) -> CalibrationTransportModelV1:
+    return fit_calibration_transport_model(
+        source_units(),
+        policy=policy() if selected_policy is None else selected_policy,
+        metadata={"cohort": "source-objects-v1"},
+    )
+
+
+def test_feature_contract_is_deterministic_and_configuration_bound() -> None:
+    repeated = calibration_transport_feature_contract_id(
+        FEATURE_NAMES,
+        semantics="source-only-reliability-features-v1",
+        configuration={"uses_target_truth": False, "window_size": 25},
+    )
+    changed = calibration_transport_feature_contract_id(
+        FEATURE_NAMES,
+        semantics="source-only-reliability-features-v1",
+        configuration={"uses_target_truth": False, "window_size": 26},
+    )
+
+    assert repeated == FEATURE_CONTRACT
+    assert changed != FEATURE_CONTRACT
+    assert len(FEATURE_CONTRACT) == 64
+
+
+def test_in_support_target_is_accepted_and_shift_is_rejected() -> None:
+    model = fitted_model()
+    supported = unit("target-supported", (0.02, -0.01), seed=501)
+    shifted = unit("target-shifted", (4.0, -0.01), seed=502)
+
+    supported_evidence = evaluate_calibration_transport(model, [supported])
+    shifted_evidence = evaluate_calibration_transport(model, [shifted])
+
+    assert supported_evidence.accepted
+    assert supported_evidence.group_results[0].supported
+    assert supported_evidence.group_results[0].support_margin >= 0.0
+    assert not shifted_evidence.accepted
+    assert not shifted_evidence.group_results[0].supported
+    assert shifted_evidence.group_results[0].support_margin < 0.0
+    assert shifted_evidence.worst_feature_name == "overlap_disagreement"
+    assert shifted_evidence.decision_reasons == (
+        "unsupported-group-fraction",
+        "unsupported-row-fraction",
+    )
+
+
+def test_constant_source_dimension_fails_closed_on_target_shift() -> None:
+    sources = []
+    for index in range(8):
+        values = np.column_stack(
+            (
+                np.ones(80),
+                np.linspace(-0.1, 0.1, 80) + 0.01 * index,
+            )
+        )
+        sources.append(
+            CalibrationTransportUnitV1(
+                unit_id=f"constant-source-{index}",
+                feature_contract_id=FEATURE_CONTRACT,
+                feature_names=FEATURE_NAMES,
+                feature_values=values,
+            )
+        )
+    model = fit_calibration_transport_model(sources, policy=policy())
+    target = CalibrationTransportUnitV1(
+        unit_id="constant-target",
+        feature_contract_id=FEATURE_CONTRACT,
+        feature_names=FEATURE_NAMES,
+        feature_values=np.column_stack((np.full(80, 1.01), np.linspace(-0.1, 0.1, 80))),
+    )
+
+    evidence = evaluate_calibration_transport(model, [target])
+
+    assert not evidence.accepted
+    assert evidence.group_results[0].feature_outside_range_max[
+        "overlap_disagreement"
+    ] > 100.0
+
+
+def test_complete_unit_and_row_fraction_gates_are_conjunctive() -> None:
+    permissive_model = fitted_model(
+        selected_policy=policy(
+            maximum_unsupported_group_fraction=0.5,
+            maximum_unsupported_row_fraction=0.02,
+        )
+    )
+    strict_model = fitted_model(
+        selected_policy=policy(
+            maximum_unsupported_group_fraction=0.49,
+            maximum_unsupported_row_fraction=0.02,
+        )
+    )
+    supported = unit("target-large-supported", (0.02, -0.01), seed=601, row_count=100)
+    shifted = unit("target-small-shifted", (4.0, 0.0), seed=602, row_count=1)
+
+    permissive = evaluate_calibration_transport(permissive_model, [shifted, supported])
+    strict = evaluate_calibration_transport(strict_model, [supported, shifted])
+
+    assert permissive.unsupported_group_fraction == pytest.approx(0.5)
+    assert permissive.unsupported_row_fraction == pytest.approx(1.0 / 101.0)
+    assert permissive.accepted
+    assert not strict.accepted
+    assert strict.decision_reasons == ("unsupported-group-fraction",)
+
+
+def test_source_and_row_order_do_not_change_model_identity() -> None:
+    original_units = source_units()
+    reordered_units = []
+    for item in reversed(original_units):
+        reordered_units.append(
+            CalibrationTransportUnitV1(
+                unit_id=item.unit_id,
+                feature_contract_id=item.feature_contract_id,
+                feature_names=item.feature_names,
+                feature_values=item.feature_values[::-1],
+                metadata=item.metadata,
+            )
+        )
+
+    original = fit_calibration_transport_model(original_units, policy=policy())
+    reordered = fit_calibration_transport_model(reordered_units, policy=policy())
+
+    assert original.model_id == reordered.model_id
+    assert original.to_dict() == reordered.to_dict()
+
+
+def test_target_order_does_not_change_evidence_identity() -> None:
+    model = fitted_model()
+    first = unit("target-a", (0.0, 0.0), seed=701)
+    second = unit("target-b", (0.05, -0.02), seed=702)
+
+    left = evaluate_calibration_transport(model, [first, second])
+    right = evaluate_calibration_transport(model, [second, first])
+
+    assert left.evidence_id == right.evidence_id
+    assert left.to_dict() == right.to_dict()
+
+
+def test_model_arrays_and_metadata_are_defensively_immutable() -> None:
+    sources = list(source_units())
+    model = fit_calibration_transport_model(sources, policy=policy())
+    original = model.source_embeddings.copy()
+    sources[0].feature_values.setflags(write=True)
+    sources[0].feature_values[...] = 99.0
+
+    np.testing.assert_array_equal(model.source_embeddings, original)
+    for array in (
+        model.source_embeddings,
+        model.embedding_center,
+        model.embedding_scale,
+        model.source_nonconformity_scores,
+    ):
+        assert not array.flags.writeable
+    with pytest.raises(TypeError):
+        model.metadata["changed"] = True  # type: ignore[index]
+
+
+def test_model_and_evidence_round_trip_with_no_clobber(tmp_path) -> None:
+    model = fitted_model()
+    evidence = evaluate_calibration_transport(
+        model,
+        [unit("target-roundtrip", (0.0, 0.0), seed=801)],
+        metadata={"target_prefix_only": True},
+    )
+    model_path = tmp_path / "model.json"
+    evidence_path = tmp_path / "evidence.json"
+
+    save_calibration_transport_model(model, model_path)
+    save_calibration_transport_evidence(evidence, evidence_path)
+    loaded_model = load_calibration_transport_model(model_path)
+    loaded_evidence = load_calibration_transport_evidence(
+        evidence_path,
+        model=loaded_model,
+    )
+
+    assert loaded_model.to_dict() == model.to_dict()
+    assert loaded_evidence.to_dict() == evidence.to_dict()
+    with pytest.raises(FileExistsError, match="refusing to overwrite"):
+        save_calibration_transport_model(model, model_path)
+    save_calibration_transport_model(model, model_path, overwrite=True)
+
+
+def test_tampered_derived_model_and_evidence_fields_are_rejected() -> None:
+    model = fitted_model()
+    evidence = evaluate_calibration_transport(
+        model,
+        [unit("target-tamper", (0.0, 0.0), seed=901)],
+    )
+    model_record = model.to_dict()
+    model_record["support_threshold"] = float(model.support_threshold) + 1.0
+    evidence_record = evidence.to_dict()
+    evidence_record["accepted"] = not evidence.accepted
+
+    with pytest.raises(ValueError, match="derived fields changed"):
+        CalibrationTransportModelV1.from_dict(model_record)
+    with pytest.raises(ValueError, match="derived fields changed"):
+        CalibrationTransportEvidenceV1.from_dict(evidence_record, model=model)
+
+
+def test_duplicate_json_keys_fail_closed(tmp_path) -> None:
+    model = fitted_model()
+    path = tmp_path / "duplicate.json"
+    record = json.dumps(model.to_dict(), sort_keys=True)
+    path.write_text(record[:-1] + ',"schema":"forged"}', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="duplicate JSON object key 'schema'"):
+        load_calibration_transport_model(path)
+
+
+def test_feature_contract_names_and_unit_identity_boundaries_fail_closed() -> None:
+    model = fitted_model()
+    different_contract = "f" * 64
+    target_contract = unit(
+        "target-contract",
+        (0.0, 0.0),
+        seed=1001,
+        feature_contract_id=different_contract,
+    )
+    target_names = unit(
+        "target-names",
+        (0.0, 0.0),
+        seed=1002,
+        feature_names=("relative_variance", "overlap_disagreement"),
+    )
+    overlapping = unit("source-00", (0.0, 0.0), seed=1003)
+
+    with pytest.raises(ValueError, match="feature contract"):
+        evaluate_calibration_transport(model, [target_contract])
+    with pytest.raises(ValueError, match="feature names"):
+        evaluate_calibration_transport(model, [target_names])
+    with pytest.raises(ValueError, match="overlap source unit IDs"):
+        evaluate_calibration_transport(model, [overlapping])
+
+
+def test_insufficient_or_duplicate_source_units_fail_closed() -> None:
+    sources = source_units()
+    with pytest.raises(ValueError, match="below policy.minimum_source_units"):
+        fit_calibration_transport_model(sources[:5], policy=policy())
+    with pytest.raises(ValueError, match="source unit IDs must be unique"):
+        fit_calibration_transport_model([*sources, sources[0]], policy=policy())
+
+
+def test_policy_rejects_coercive_or_unidentified_configuration() -> None:
+    with pytest.raises(ValueError, match="minimum_source_units"):
+        replace(policy(), minimum_source_units=True)
+    with pytest.raises(ValueError, match="at least one scale floor"):
+        replace(policy(), absolute_scale_floor=0.0, relative_scale_floor=0.0)
+    with pytest.raises(ValueError, match="neighbor_count"):
+        replace(policy(), neighbor_count=6)
+    with pytest.raises(TypeError, match="quantile_levels"):
+        replace(policy(), quantile_levels=[0.1, 0.5, 0.9])  # type: ignore[arg-type]
+
+
+def test_unit_rejects_coercion_nonfinite_values_and_mutable_name_form() -> None:
+    values = np.ones((3, 2))
+    with pytest.raises(TypeError, match="feature_names"):
+        CalibrationTransportUnitV1(
+            unit_id="bad-names",
+            feature_contract_id=FEATURE_CONTRACT,
+            feature_names=list(FEATURE_NAMES),  # type: ignore[arg-type]
+            feature_values=values,
+        )
+    values[0, 0] = np.nan
+    with pytest.raises(ValueError, match="feature_values must be finite"):
+        CalibrationTransportUnitV1(
+            unit_id="bad-values",
+            feature_contract_id=FEATURE_CONTRACT,
+            feature_names=FEATURE_NAMES,
+            feature_values=values,
+        )
+
+
+def test_nonalphabetical_feature_names_are_supported() -> None:
+    names = ("z_feature", "a_feature")
+    contract = calibration_transport_feature_contract_id(
+        names,
+        semantics="source-only-test-v1",
+        configuration={},
+    )
+    sources = tuple(
+        CalibrationTransportUnitV1(
+            unit_id=f"ordered-source-{index}",
+            feature_contract_id=contract,
+            feature_names=names,
+            feature_values=np.column_stack(
+                (
+                    np.linspace(0.0, 1.0, 40) + 0.01 * index,
+                    np.linspace(-1.0, 0.0, 40) - 0.01 * index,
+                )
+            ),
+        )
+        for index in range(6)
+    )
+    model = fit_calibration_transport_model(sources, policy=policy())
+    target = CalibrationTransportUnitV1(
+        unit_id="ordered-target",
+        feature_contract_id=contract,
+        feature_names=names,
+        feature_values=np.column_stack(
+            (np.linspace(0.0, 1.0, 40), np.linspace(-1.0, 0.0, 40))
+        ),
+    )
+
+    evidence = evaluate_calibration_transport(model, [target])
+
+    assert tuple(evidence.group_results[0].feature_distance_rms) == (
+        "a_feature",
+        "z_feature",
+    )
+    assert evidence.accepted
+
+
+def test_records_state_schema_version_and_scientific_boundary() -> None:
+    model = fitted_model()
+    evidence = evaluate_calibration_transport(
+        model,
+        [unit("target-boundary", (0.0, 0.0), seed=1101)],
+    )
+
+    model_record = model.to_dict()
+    evidence_record = evidence.to_dict()
+    assert model_record["schema"] == CALIBRATION_TRANSPORT_MODEL_SCHEMA
+    assert evidence_record["schema"] == CALIBRATION_TRANSPORT_EVIDENCE_SCHEMA
+    assert model_record["schema_version"] == CALIBRATION_TRANSPORT_VERSION
+    assert evidence_record["schema_version"] == CALIBRATION_TRANSPORT_VERSION
+    assert model_record["claim_boundary"] == CALIBRATION_TRANSPORT_CLAIM_BOUNDARY
+    assert evidence_record["claim_boundary"] == CALIBRATION_TRANSPORT_CLAIM_BOUNDARY
+    assert "target truth" in CALIBRATION_TRANSPORT_CLAIM_BOUNDARY
+    assert "BayesianPhysTwin" in CALIBRATION_TRANSPORT_CLAIM_BOUNDARY

--- a/tests/test_gauge_analytic.py
+++ b/tests/test_gauge_analytic.py
@@ -13,12 +13,17 @@ from prob4d.gauge_analytic import (
 )
 from prob4d.sim3 import Sim3
 
+_CENTRAL_DIFFERENCE_RELATIVE_STEP = float(np.cbrt(np.finfo(np.float64).eps))
+
 
 def _central_jacobian(function, vector: np.ndarray) -> np.ndarray:
     baseline = np.asarray(function(vector), dtype=np.float64)
     result = np.empty((baseline.size, vector.size), dtype=np.float64)
     for index in range(vector.size):
-        step = 1e-7 * max(1.0, abs(float(vector[index])))
+        step = _CENTRAL_DIFFERENCE_RELATIVE_STEP * max(
+            1.0,
+            abs(float(vector[index])),
+        )
         plus = vector.copy()
         minus = vector.copy()
         plus[index] += step


### PR DESCRIPTION
## Summary

Adds an experimental, source-only calibration-transport certificate that detects when target-prefix reliability features extrapolate beyond the complete source objects or acquisition sessions used for calibration.

## What changed

- introduces a content-addressed `CalibrationTransportModelV1` over robust per-unit quantile embeddings;
- calibrates a finite-source nearest-unit support threshold while excluding each scored source unit from its own neighbor set;
- evaluates target-prefix groups without target truth, downstream innovations, posterior outcomes, or Causal4D outcomes;
- reports nearest source units, per-feature distance, excursions beyond the source range, supported group/row mass, and explicit decision reasons;
- binds feature semantics/configuration with a SHA-256 feature-contract ID;
- provides strict finite-JSON replay with duplicate-key rejection, recomputed derived fields, atomic no-clobber writes, and content-derived model/evidence IDs;
- documents the information order, claim boundary, exact-fallback behavior, and `SourceReliabilityFeatures` integration;
- stabilizes the pre-existing analytic-Jacobian central-difference test at the declared NumPy 1.24 floor by using the standard cube-root-epsilon step instead of an overly small fixed `1e-7` step. This is test-only and does not change gauge propagation semantics.

## Scientific boundary

A passing certificate only says that frozen target-prefix feature summaries are not more isolated than allowed by the source cohort. It does not prove covariance calibration transfer or authorize a BayesianPhysTwin update. Rejection is explicitly assigned to the downstream exact physical fallback.

The repository's frozen 0.4.0 changelog and version boundary are intentionally unchanged here. Release/version hygiene belongs in a separate coordinated release PR rather than this scientific feature PR.

## Validation

All final-head workflows pass:

- complete suites on Python 3.10, 3.11, 3.12, 3.13, and 3.14;
- complete suite at the declared NumPy 1.24.0 runtime floor;
- repository, release, stable-API, provider-contract, and runtime-revision checks;
- fail-closed Ruff/mypy quality checks;
- security scanning;
- wheel and source-distribution build/validation;
- isolated installed-wheel and installed-sdist CLI smoke tests.

Focused local validation also passed:

- `PYTHONPATH=src python -m pytest -q tests/test_calibration_transport.py` — 16 passed;
- `PYTHONPATH=src python -m compileall -q src tests` — passed.

Adversarial coverage includes ordering invariance, constant-feature extrapolation, contract/identity mismatch, duplicate JSON keys, tampered derived fields, coercive inputs, immutable ownership, no-clobber persistence, and conjunctive group/row gates.