### PR TITLE
Add fresh-provider readiness and query preservation

### DIFF
--- a/docs/fresh-provider-readiness.md
+++ b/docs/fresh-provider-readiness.md
@@ -1,0 +1,150 @@
+# Fresh-provider readiness and failure localization
+
+`prob4d.fresh_provider_readiness` implements the pre-target orchestration needed
+before one frozen real-provider evaluation. It composes existing support,
+calibration, identity, covariance, query, and fallback evidence without changing
+the stable provider-v2 or held-out promotion contracts.
+
+## Cohort lock
+
+`FreshProviderCohortLockV1` binds:
+
+- exact Prob4D and provider repositories and revisions;
+- model-set, loader, cohort, and held-out promotion-lock identities;
+- the BayesianPhysTwin-owned query definition and exact fallback identity;
+- pairwise-disjoint development, calibration, target, and optional confirmation
+  object/session rosters; and
+- explicit declarations that target and confirmation payloads and outcomes are
+  still closed.
+
+Every roster is sorted, unique, and disjoint. A lock cannot be constructed after
+protected data have been opened.
+
+## Prospective gate order
+
+A readiness request contains exactly seven gates in this order:
+
+1. `support-feasibility`;
+2. `source-mean`;
+3. `identity-reliability`;
+4. `gauge-dependence`;
+5. `point-covariance`;
+6. `query-relevance`; and
+7. `exact-fallback`.
+
+Each gate is `pass`, `fail`, `technical-failure`, or `not-evaluated`. After the
+first terminal result, every later gate must remain `not-evaluated`. Conversely,
+an unevaluated gate after all earlier gates passed is invalid rather than being
+silently interpreted as a negative result.
+
+## Terminal decisions
+
+| First terminal gate | Classification | Authorized next step |
+| --- | --- | --- |
+| support feasibility | `support-negative` | stop before predictions or residuals |
+| source mean | `source-mean-negative` | stop; do not fit richer covariance |
+| identity/reliability | `identity-or-association-negative` | improve source-only identities |
+| gauge/dependence | `gauge-or-dependence-negative` | localize shared uncertainty |
+| point covariance | `point-covariance-localized` | source-only uncertainty development |
+| query relevance | `query-irrelevant-or-nonidentifiable` | exact physical fallback |
+| exact fallback | `technical-failure` | repair under a new reviewed execution |
+| all gates pass | `ready-for-one-target-evaluation` | one bound target evaluation |
+
+Any explicit technical failure produces `technical-failure` at its exact stage.
+
+Only `point-covariance-localized` sets
+`authorize_point_uncertainty_development=true`. This authorization is possible
+only after source means, identities, and gauge/dependence have passed.
+
+Only `ready-for-one-target-evaluation` sets
+`authorize_target_evaluation=true` and `target_evaluation_budget=1`.
+`FreshProviderTargetAuthorizationV1` binds that one-shot budget to the exact
+target roster and still requires the target to be unopened at authorization.
+
+## Python example
+
+```python
+from prob4d.fresh_provider_readiness import (
+    FreshProviderCohortLockV1,
+    FreshProviderReadinessRequestV1,
+    ReadinessGateV1,
+    authorize_fresh_provider_target,
+    evaluate_fresh_provider_readiness,
+)
+
+lock = FreshProviderCohortLockV1(
+    protocol_id="fresh-provider-v1",
+    source_repository="IPS-Stuttgart/Prob4D",
+    source_revision=prob4d_revision,
+    provider_repository=provider_repository,
+    provider_revision=provider_revision,
+    model_set_id=model_set_id,
+    loader_id=loader_id,
+    cohort_binding_id=cohort_binding_id,
+    promotion_lock_id=promotion_lock_id,
+    query_definition_id=query_definition_id,
+    fallback_identity_id=fallback_identity_id,
+    development_group_ids=development_ids,
+    calibration_group_ids=calibration_ids,
+    target_group_ids=target_ids,
+)
+
+request = FreshProviderReadinessRequestV1(
+    cohort_lock=lock,
+    gates=(
+        support_gate,
+        source_mean_gate,
+        identity_gate,
+        gauge_gate,
+        point_covariance_gate,
+        query_gate,
+        fallback_gate,
+    ),
+)
+decision = evaluate_fresh_provider_readiness(request)
+
+if decision.authorize_target_evaluation:
+    authorization = authorize_fresh_provider_target(decision)
+```
+
+The support adapter accepts a validated
+`ProviderSupportFeasibilityV1`-like result. The source-competence adapter accepts
+`SourceProviderCompetenceReportV1` and preserves the rule that identity is not
+evaluated after a source-mean failure.
+
+## Command-line replay
+
+The module provides a grouped module command without adding another historical
+console-script alias:
+
+```bash
+python -m prob4d.fresh_provider_readiness evaluate \
+  --request readiness-request.json \
+  --output readiness-decision.json
+
+python -m prob4d.fresh_provider_readiness verify-decision \
+  --artifact readiness-decision.json
+
+python -m prob4d.fresh_provider_readiness authorize-target \
+  --decision readiness-decision.json \
+  --output target-authorization.json
+
+python -m prob4d.fresh_provider_readiness verify-authorization \
+  --artifact target-authorization.json
+```
+
+A valid non-ready decision returns exit status 2 from `evaluate`; a target-ready
+decision returns 0. Invalid or tampered artifacts fail validation rather than
+being converted into scientific negatives.
+
+## Repository boundary
+
+Prob4D owns provider-side support, source competence, covariance diagnostics,
+and this readiness composition. BayesianPhysTwin owns the physical query,
+practical-equivalence margins, update admission, and exact fallback. Causal4D
+consumes only the BayesianPhysTwin belief selected after that admission.
+
+A positive readiness authorization is not empirical evidence. The later target
+result must still pass the existing held-out provider-competence and guarded
+physical-query gates and must retain a valid negative result without retuning the
+same target cohort.

--- a/docs/query-covariance-preservation.md
+++ b/docs/query-covariance-preservation.md
@@ -1,0 +1,116 @@
+# Query-space covariance preservation
+
+`prob4d.query_covariance_preservation` compares full-joint and simplified
+covariance treatments after they have been projected into a frozen physical
+query. This distinguishes mathematical completeness in observation space from
+whether a covariance representation materially affects the quantity consumed by
+BayesianPhysTwin.
+
+## Inputs
+
+A `QueryCovariancePreservationCertificateV1` binds:
+
+- the exact BayesianPhysTwin-owned query-definition identity;
+- the exact Prob4D observation artifact;
+- one positive-trace reference query covariance;
+- one or more candidate query covariances;
+- a consumer-frozen distortion policy; and
+- optional memory and runtime evidence for each candidate.
+
+Candidates can represent, for example:
+
+- the complete explicit joint covariance;
+- a rank-capped joint factor;
+- a tree-sparse reconstruction;
+- block-diagonal gauge covariance;
+- marginal-preserving independent rows; or
+- conditional-only covariance.
+
+The certificate does not choose among preserved candidates. Computational and
+scientific selection remains with the downstream consumer.
+
+## Distortion measures
+
+For reference query covariance `C` and candidate `C_hat`, the certificate reports:
+
+- relative trace distortion;
+- relative Frobenius distortion;
+- minimum, mean, and maximum directional variance ratios on the numerically
+  supported reference subspace;
+- maximum absolute directional ratio error; and
+- candidate trace placed in a reference-null query direction.
+
+Let
+
+```text
+C = V Lambda V^T
+```
+
+on the supported reference subspace. Directional ratios are the eigenvalues of
+
+```text
+Lambda^(-1/2) V^T C_hat V Lambda^(-1/2).
+```
+
+A value below one understates uncertainty in at least one supported direction; a
+value above one overstates it. Trace in the orthogonal reference-null subspace is
+reported separately instead of being hidden by the supported-direction ratios.
+
+## Example from existing projections
+
+```python
+from prob4d.query_covariance_preservation import (
+    QueryCovariancePreservationCertificateV1,
+    QueryCovariancePreservationPolicyV1,
+)
+
+policy = QueryCovariancePreservationPolicyV1(
+    relative_rank_tolerance=1e-10,
+    maximum_relative_trace_distortion=0.05,
+    maximum_relative_frobenius_distortion=0.05,
+    minimum_directional_variance_ratio=0.9,
+    maximum_directional_variance_ratio=1.1,
+    maximum_unsupported_trace_fraction=0.0,
+)
+
+certificate = QueryCovariancePreservationCertificateV1.from_projections(
+    query_definition_id=query_definition_id,
+    observation_artifact_id=observation_artifact_id,
+    reference_representation="full-joint",
+    reference_projection=full_joint_projection,
+    candidate_projections={
+        "tree-sparse": tree_sparse_projection,
+        "block-diagonal": block_diagonal_projection,
+        "independent-rows": independent_rows_projection,
+    },
+    policy=policy,
+)
+```
+
+The projection objects can come directly from
+`prob4d.query_covariance_relevance`; only their immutable `total_covariance`
+matrices are consumed.
+
+## Persistence and replay
+
+```python
+from prob4d.query_covariance_preservation import (
+    load_query_covariance_preservation,
+    write_query_covariance_preservation,
+)
+
+write_query_covariance_preservation("query-preservation.json", certificate)
+replayed = load_query_covariance_preservation("query-preservation.json")
+```
+
+The loader recomputes every eigensystem-derived ratio, distortion, failure reason,
+acceptance bit, summary, and content identity. Candidate order is canonicalized
+by candidate ID. Covariance matrices must be finite, symmetric, and positive
+semidefinite.
+
+## Decision boundary
+
+A preserved candidate is only numerically equivalent under the exact registered
+query and tolerances. The result does not prove provider competence, target
+calibration, physical-query improvement, safe update admission, Causal4D
+intervention benefit, deployment safety, or state of the art.

--- a/docs/source-provider-competence.md
+++ b/docs/source-provider-competence.md
@@ -1,0 +1,131 @@
+# Source-only provider competence
+
+`prob4d.source_provider_competence` evaluates whether an observation provider has
+useful source-side means and sufficiently reliable identities before a richer
+point-covariance model can be considered.
+
+The registered statistical unit is one complete physical object or acquisition
+session. Frames, pixels, cameras, tracks, and points remain nested observations;
+they are not counted as independent source replicates.
+
+## Why this gate exists
+
+A downstream physical update can fail for several different reasons:
+
+1. the provider mean is inaccurate or drifts;
+2. material identities or associations are unreliable;
+3. the shared gauge/dependence model is wrong;
+4. conditional point covariance is miscalibrated despite useful means and
+   identities; or
+5. the downstream physical query is not identifiable or is insensitive to the
+   observation.
+
+Only case 4 authorizes richer point-uncertainty development. The source report
+therefore produces two separate decisions:
+
+- `mean_quality_status`; and
+- `identity_reliability_status`.
+
+A failing mean-quality gate must not be relabelled as a covariance problem.
+
+## Group record
+
+Each `SourceProviderGroupResultV1` contains equal-unit metrics for one complete
+object/session:
+
+- candidate and baseline proper scores;
+- point and endpoint RMSE;
+- absolute drift slope;
+- overlap-seam RMSE;
+- association precision;
+- identity retention; and
+- support retention.
+
+A technical-failure group contains only its predeclared failure code and
+metadata. It cannot mix a failure disposition with scored metrics.
+
+## Frozen policy
+
+`SourceProviderCompetencePolicyV1` freezes:
+
+- the minimum number of evaluable groups;
+- permitted technical-failure codes and their maximum count;
+- mean proper-score, point-RMSE, endpoint-RMSE, drift, and seam limits;
+- a worst-group point-RMSE limit;
+- mean-quality group-pass coverage;
+- association, identity-retention, and support-retention minima; and
+- identity group-pass coverage.
+
+All aggregate quantities are equal-group means. Large objects, long videos, or
+dense cameras cannot dominate by contributing more rows.
+
+## Example
+
+```python
+from prob4d.source_provider_competence import (
+    SourceProviderCompetencePolicyV1,
+    SourceProviderCompetenceReportV1,
+    SourceProviderGroupResultV1,
+    write_source_provider_competence,
+)
+
+policy = SourceProviderCompetencePolicyV1(
+    minimum_evaluable_groups=8,
+    maximum_technical_failures=0,
+    permitted_technical_failure_codes=(),
+    maximum_mean_proper_score_delta=0.0,
+    maximum_mean_point_rmse_ratio=1.0,
+    maximum_mean_endpoint_rmse_ratio=1.0,
+    maximum_worst_group_point_rmse_ratio=1.2,
+    maximum_mean_absolute_drift_slope_m_per_frame=0.001,
+    maximum_mean_seam_rmse_m=0.01,
+    minimum_mean_quality_group_pass_fraction=0.75,
+    minimum_mean_association_precision=0.9,
+    minimum_mean_identity_retention=0.8,
+    minimum_mean_support_retention=0.8,
+    minimum_identity_group_pass_fraction=0.75,
+)
+
+report = SourceProviderCompetenceReportV1(
+    provider_manifest_id=provider_manifest_id,
+    cohort_binding_id=source_cohort_binding_id,
+    group_definition="complete-physical-object-v1",
+    policy=policy,
+    groups=tuple(
+        SourceProviderGroupResultV1(
+            group_id=result.object_id,
+            candidate_proper_score=result.provider_proper_score,
+            baseline_proper_score=result.baseline_proper_score,
+            candidate_point_rmse_m=result.provider_point_rmse_m,
+            baseline_point_rmse_m=result.baseline_point_rmse_m,
+            candidate_endpoint_rmse_m=result.provider_endpoint_rmse_m,
+            baseline_endpoint_rmse_m=result.baseline_endpoint_rmse_m,
+            absolute_drift_slope_m_per_frame=abs(result.drift_slope_m_per_frame),
+            seam_rmse_m=result.seam_rmse_m,
+            association_precision=result.association_precision,
+            identity_retention=result.identity_retention,
+            support_retention=result.support_retention,
+            metadata={"session_ids": result.session_ids},
+        )
+        for result in frozen_source_results
+    ),
+)
+write_source_provider_competence("source-competence.json", report)
+```
+
+Construction rejects target payload or target outcome access. Loading the JSON
+recomputes every aggregate, decision, reason code, and content identity.
+
+## Readiness integration
+
+`prob4d.fresh_provider_readiness.source_competence_gates()` converts a report
+into the ordered source-mean and identity/reliability gates. When mean quality
+fails, identity is left `not-evaluated`; downstream evidence cannot be used to
+rescue the terminal source-mean-negative result.
+
+## Claim boundary
+
+A passing source report establishes only source-side competence under the exact
+provider, cohort, and frozen policy. It does not prove target transfer,
+calibrated uncertainty, BayesianPhysTwin benefit, Causal4D benefit, deployment
+safety, or state of the art.

--- a/src/prob4d/fresh_provider_readiness.py
+++ b/src/prob4d/fresh_provider_readiness.py
@@ -1,0 +1,1179 @@
+"""Prospective fresh-provider readiness and failure localization.
+
+This module composes already-frozen support, source competence, covariance,
+query-relevance, and fallback evidence into one terminal decision before a protected
+target cohort is opened. It does not replace the existing held-out promotion gate;
+it supplies the missing pre-target authorization and explicit stop classification.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal, cast
+
+from ._immutable_json import frozen_finite_json_mapping, plain_json
+from ._strict_json import (
+    load_json_object,
+    require_exact_fields,
+    require_exact_integer,
+    require_exact_string,
+    require_finite_json_mapping,
+    require_mapping,
+    require_revision,
+    require_sha256,
+)
+from .source_provider_competence import SourceProviderCompetenceReportV1
+
+FRESH_PROVIDER_COHORT_LOCK_SCHEMA = "prob4d.fresh-provider-cohort-lock"
+FRESH_PROVIDER_READINESS_REQUEST_SCHEMA = "prob4d.fresh-provider-readiness-request"
+FRESH_PROVIDER_READINESS_DECISION_SCHEMA = "prob4d.fresh-provider-readiness-decision"
+FRESH_PROVIDER_TARGET_AUTHORIZATION_SCHEMA = (
+    "prob4d.fresh-provider-target-authorization"
+)
+FRESH_PROVIDER_READINESS_VERSION = 1
+FRESH_PROVIDER_READINESS_CLAIM_BOUNDARY = (
+    "This artifact composes target-free support and source/calibration evidence into "
+    "one terminal readiness or failure-localization decision for an exact frozen "
+    "provider route. It does not establish real-provider competence, target benefit, "
+    "BayesianPhysTwin benefit, Causal4D intervention benefit, deployment safety, or "
+    "state of the art. A target authorization permits exactly one evaluation of the "
+    "bound unopened target roster and does not permit target-side retuning."
+)
+
+GateName = Literal[
+    "support-feasibility",
+    "source-mean",
+    "identity-reliability",
+    "gauge-dependence",
+    "point-covariance",
+    "query-relevance",
+    "exact-fallback",
+]
+GateStatus = Literal["pass", "fail", "not-evaluated", "technical-failure"]
+ReadinessClassification = Literal[
+    "support-negative",
+    "source-mean-negative",
+    "identity-or-association-negative",
+    "gauge-or-dependence-negative",
+    "point-covariance-localized",
+    "query-irrelevant-or-nonidentifiable",
+    "ready-for-one-target-evaluation",
+    "technical-failure",
+]
+
+_GATE_ORDER: tuple[GateName, ...] = (
+    "support-feasibility",
+    "source-mean",
+    "identity-reliability",
+    "gauge-dependence",
+    "point-covariance",
+    "query-relevance",
+    "exact-fallback",
+)
+_GATE_FAILURE_CLASSIFICATION: dict[GateName, ReadinessClassification] = {
+    "support-feasibility": "support-negative",
+    "source-mean": "source-mean-negative",
+    "identity-reliability": "identity-or-association-negative",
+    "gauge-dependence": "gauge-or-dependence-negative",
+    "point-covariance": "point-covariance-localized",
+    "query-relevance": "query-irrelevant-or-nonidentifiable",
+    "exact-fallback": "technical-failure",
+}
+_NEXT_ACTION: dict[ReadinessClassification, str] = {
+    "support-negative": "stop-provider-version-before-opening-predictions-or-residuals",
+    "source-mean-negative": "stop-provider-version-without-richer-covariance",
+    "identity-or-association-negative": "improve-identities-or-association-on-source-only",
+    "gauge-or-dependence-negative": "localize-gauge-or-dependence-on-source-only",
+    "point-covariance-localized": "authorize-source-only-point-uncertainty-development",
+    "query-irrelevant-or-nonidentifiable": "retain-exact-physical-fallback",
+    "ready-for-one-target-evaluation": "open-exactly-one-bound-target-evaluation",
+    "technical-failure": "retain-evidence-and-repair-only-under-a-new-reviewed-execution",
+}
+
+_LOCK_FIELDS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "protocol_id",
+        "source_repository",
+        "source_revision",
+        "provider_repository",
+        "provider_revision",
+        "model_set_id",
+        "loader_id",
+        "cohort_binding_id",
+        "promotion_lock_id",
+        "query_definition_id",
+        "fallback_identity_id",
+        "development_group_ids",
+        "calibration_group_ids",
+        "target_group_ids",
+        "confirmation_group_ids",
+        "target_payloads_opened",
+        "target_outcomes_opened",
+        "confirmation_payloads_opened",
+        "metadata",
+        "claim_boundary",
+        "fresh_provider_cohort_lock_id",
+    }
+)
+_GATE_FIELDS = frozenset(
+    {
+        "gate_name",
+        "status",
+        "evidence_id",
+        "reason_codes",
+        "metadata",
+    }
+)
+_REQUEST_FIELDS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "cohort_lock",
+        "gates",
+        "metadata",
+        "claim_boundary",
+        "fresh_provider_readiness_request_id",
+    }
+)
+_DECISION_FIELDS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "request",
+        "classification",
+        "terminal_gate",
+        "decision_reasons",
+        "next_action",
+        "authorize_point_uncertainty_development",
+        "authorize_target_evaluation",
+        "target_evaluation_budget",
+        "claim_boundary",
+        "fresh_provider_readiness_decision_id",
+    }
+)
+_AUTHORIZATION_FIELDS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "decision",
+        "target_group_ids",
+        "target_evaluation_budget",
+        "target_payloads_opened_at_authorization",
+        "target_outcomes_opened_at_authorization",
+        "claim_boundary",
+        "fresh_provider_target_authorization_id",
+    }
+)
+
+
+def _strict_bool(value: object, *, name: str) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be a Boolean")
+    return value
+
+
+def _repository(value: object, *, name: str) -> str:
+    result = require_exact_string(value, name=name)
+    if result.count("/") != 1 or result.startswith("/") or result.endswith("/"):
+        raise ValueError(f"{name} must use canonical owner/name form")
+    return result
+
+
+def _sorted_unique_strings(
+    value: object,
+    *,
+    name: str,
+    allow_empty: bool,
+) -> tuple[str, ...]:
+    if type(value) is not tuple:
+        raise ValueError(f"{name} must be a canonical tuple")
+    result = tuple(
+        require_exact_string(item, name=f"{name}[{index}]")
+        for index, item in enumerate(value)
+    )
+    if not allow_empty and not result:
+        raise ValueError(f"{name} must not be empty")
+    if result != tuple(sorted(result)) or len(result) != len(set(result)):
+        raise ValueError(f"{name} must be sorted and unique")
+    return result
+
+
+def _strings_from_json(value: object, *, name: str, allow_empty: bool) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise ValueError(f"{name} must be a JSON array")
+    return _sorted_unique_strings(tuple(value), name=name, allow_empty=allow_empty)
+
+
+def _canonical_json_bytes(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        plain_json(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _sha256_json(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json_bytes(value)).hexdigest()
+
+
+def _atomic_write_json(
+    path: str | Path,
+    value: Mapping[str, Any],
+    *,
+    overwrite: bool,
+) -> None:
+    destination = Path(path)
+    if type(overwrite) is not bool:
+        raise ValueError("overwrite must be a Boolean")
+    if destination.exists() and not overwrite:
+        raise FileExistsError(destination)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(
+        plain_json(value),
+        sort_keys=True,
+        indent=2,
+        allow_nan=False,
+    ) + "\n"
+    temporary = destination.with_name(
+        f".{destination.name}.tmp-{os.getpid()}-"
+        f"{hashlib.sha256(payload.encode()).hexdigest()[:16]}"
+    )
+    try:
+        with temporary.open("x", encoding="utf-8") as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        if destination.exists() and not overwrite:
+            raise FileExistsError(destination)
+        os.replace(temporary, destination)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _gate_name(value: object) -> GateName:
+    result = require_exact_string(value, name="gate_name")
+    if result not in _GATE_ORDER:
+        raise ValueError(f"gate_name must be one of {list(_GATE_ORDER)}")
+    return cast(GateName, result)
+
+
+def _gate_status(value: object) -> GateStatus:
+    result = require_exact_string(value, name="status")
+    if result not in {"pass", "fail", "not-evaluated", "technical-failure"}:
+        raise ValueError("status is not a supported readiness gate status")
+    return cast(GateStatus, result)
+
+
+@dataclass(frozen=True, slots=True)
+class FreshProviderCohortLockV1:
+    """Target-closed binding of the complete prospective provider study."""
+
+    protocol_id: str
+    source_repository: str
+    source_revision: str
+    provider_repository: str
+    provider_revision: str
+    model_set_id: str
+    loader_id: str
+    cohort_binding_id: str
+    promotion_lock_id: str
+    query_definition_id: str
+    fallback_identity_id: str
+    development_group_ids: tuple[str, ...]
+    calibration_group_ids: tuple[str, ...]
+    target_group_ids: tuple[str, ...]
+    confirmation_group_ids: tuple[str, ...] = ()
+    target_payloads_opened: bool = False
+    target_outcomes_opened: bool = False
+    confirmation_payloads_opened: bool = False
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    fresh_provider_cohort_lock_id: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "protocol_id",
+            require_exact_string(self.protocol_id, name="protocol_id"),
+        )
+        object.__setattr__(
+            self,
+            "source_repository",
+            _repository(self.source_repository, name="source_repository"),
+        )
+        object.__setattr__(
+            self,
+            "source_revision",
+            require_revision(self.source_revision, name="source_revision"),
+        )
+        object.__setattr__(
+            self,
+            "provider_repository",
+            _repository(self.provider_repository, name="provider_repository"),
+        )
+        object.__setattr__(
+            self,
+            "provider_revision",
+            require_revision(self.provider_revision, name="provider_revision"),
+        )
+        for name in (
+            "model_set_id",
+            "loader_id",
+            "cohort_binding_id",
+            "promotion_lock_id",
+            "query_definition_id",
+            "fallback_identity_id",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                require_sha256(getattr(self, name), name=name),
+            )
+        rosters = {
+            "development_group_ids": _sorted_unique_strings(
+                self.development_group_ids,
+                name="development_group_ids",
+                allow_empty=False,
+            ),
+            "calibration_group_ids": _sorted_unique_strings(
+                self.calibration_group_ids,
+                name="calibration_group_ids",
+                allow_empty=False,
+            ),
+            "target_group_ids": _sorted_unique_strings(
+                self.target_group_ids,
+                name="target_group_ids",
+                allow_empty=False,
+            ),
+            "confirmation_group_ids": _sorted_unique_strings(
+                self.confirmation_group_ids,
+                name="confirmation_group_ids",
+                allow_empty=True,
+            ),
+        }
+        roster_names = tuple(rosters)
+        for index, first_name in enumerate(roster_names):
+            first = set(rosters[first_name])
+            for second_name in roster_names[index + 1 :]:
+                overlap = first & set(rosters[second_name])
+                if overlap:
+                    raise ValueError(
+                        f"{first_name} and {second_name} overlap: {sorted(overlap)}"
+                    )
+        for name, roster in rosters.items():
+            object.__setattr__(self, name, roster)
+        target_payloads_opened = _strict_bool(
+            self.target_payloads_opened,
+            name="target_payloads_opened",
+        )
+        target_outcomes_opened = _strict_bool(
+            self.target_outcomes_opened,
+            name="target_outcomes_opened",
+        )
+        confirmation_payloads_opened = _strict_bool(
+            self.confirmation_payloads_opened,
+            name="confirmation_payloads_opened",
+        )
+        if target_payloads_opened or target_outcomes_opened or confirmation_payloads_opened:
+            raise ValueError("fresh-provider readiness requires unopened protected cohorts")
+        object.__setattr__(self, "target_payloads_opened", target_payloads_opened)
+        object.__setattr__(self, "target_outcomes_opened", target_outcomes_opened)
+        object.__setattr__(
+            self,
+            "confirmation_payloads_opened",
+            confirmation_payloads_opened,
+        )
+        object.__setattr__(
+            self,
+            "metadata",
+            frozen_finite_json_mapping(self.metadata, name="cohort-lock metadata"),
+        )
+        object.__setattr__(
+            self,
+            "fresh_provider_cohort_lock_id",
+            _sha256_json(self._content_dict()),
+        )
+
+    def _content_dict(self) -> dict[str, object]:
+        return {
+            "schema": FRESH_PROVIDER_COHORT_LOCK_SCHEMA,
+            "schema_version": FRESH_PROVIDER_READINESS_VERSION,
+            "protocol_id": self.protocol_id,
+            "source_repository": self.source_repository,
+            "source_revision": self.source_revision,
+            "provider_repository": self.provider_repository,
+            "provider_revision": self.provider_revision,
+            "model_set_id": self.model_set_id,
+            "loader_id": self.loader_id,
+            "cohort_binding_id": self.cohort_binding_id,
+            "promotion_lock_id": self.promotion_lock_id,
+            "query_definition_id": self.query_definition_id,
+            "fallback_identity_id": self.fallback_identity_id,
+            "development_group_ids": list(self.development_group_ids),
+            "calibration_group_ids": list(self.calibration_group_ids),
+            "target_group_ids": list(self.target_group_ids),
+            "confirmation_group_ids": list(self.confirmation_group_ids),
+            "target_payloads_opened": self.target_payloads_opened,
+            "target_outcomes_opened": self.target_outcomes_opened,
+            "confirmation_payloads_opened": self.confirmation_payloads_opened,
+            "metadata": plain_json(self.metadata),
+            "claim_boundary": FRESH_PROVIDER_READINESS_CLAIM_BOUNDARY,
+        }
+
+    def to_dict(self) -> dict[str, object]:
+        result = self._content_dict()
+        result["fresh_provider_cohort_lock_id"] = self.fresh_provider_cohort_lock_id
+        return result
+
+    @classmethod
+    def from_dict(cls, value: object) -> FreshProviderCohortLockV1:
+        mapping = require_mapping(value, name="fresh provider cohort lock")
+        require_exact_fields(mapping, _LOCK_FIELDS, name="fresh provider cohort lock")
+        if mapping["schema"] != FRESH_PROVIDER_COHORT_LOCK_SCHEMA:
+            raise ValueError("fresh provider cohort lock schema changed")
+        if mapping["schema_version"] != FRESH_PROVIDER_READINESS_VERSION:
+            raise ValueError("fresh provider cohort lock version changed")
+        if mapping["claim_boundary"] != FRESH_PROVIDER_READINESS_CLAIM_BOUNDARY:
+            raise ValueError("fresh provider cohort lock claim boundary changed")
+        result = cls(
+            protocol_id=mapping["protocol_id"],
+            source_repository=mapping["source_repository"],
+            source_revision=mapping["source_revision"],
+            provider_repository=mapping["provider_repository"],
+            provider_revision=mapping["provider_revision"],
+            model_set_id=mapping["model_set_id"],
+            loader_id=mapping["loader_id"],
+            cohort_binding_id=mapping["cohort_binding_id"],
+            promotion_lock_id=mapping["promotion_lock_id"],
+            query_definition_id=mapping["query_definition_id"],
+            fallback_identity_id=mapping["fallback_identity_id"],
+            development_group_ids=_strings_from_json(
+                mapping["development_group_ids"],
+                name="development_group_ids",
+                allow_empty=False,
+            ),
+            calibration_group_ids=_strings_from_json(
+                mapping["calibration_group_ids"],
+                name="calibration_group_ids",
+                allow_empty=False,
+            ),
+            target_group_ids=_strings_from_json(
+                mapping["target_group_ids"],
+                name="target_group_ids",
+                allow_empty=False,
+            ),
+            confirmation_group_ids=_strings_from_json(
+                mapping["confirmation_group_ids"],
+                name="confirmation_group_ids",
+                allow_empty=True,
+            ),
+            target_payloads_opened=mapping["target_payloads_opened"],
+            target_outcomes_opened=mapping["target_outcomes_opened"],
+            confirmation_payloads_opened=mapping["confirmation_payloads_opened"],
+            metadata=require_finite_json_mapping(
+                mapping["metadata"], name="cohort-lock metadata"
+            ),
+        )
+        if plain_json(result.to_dict()) != plain_json(mapping):
+            raise ValueError("fresh provider cohort lock derived fields changed")
+        return result
+
+
+@dataclass(frozen=True, slots=True)
+class ReadinessGateV1:
+    """One evidence-bound gate in the prospective information order."""
+
+    gate_name: GateName
+    status: GateStatus
+    evidence_id: str | None
+    reason_codes: tuple[str, ...] = ()
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        name = _gate_name(self.gate_name)
+        status = _gate_status(self.status)
+        evidence_id = (
+            None
+            if self.evidence_id is None
+            else require_sha256(self.evidence_id, name="evidence_id")
+        )
+        reasons = _sorted_unique_strings(
+            self.reason_codes,
+            name="reason_codes",
+            allow_empty=True,
+        )
+        if status == "not-evaluated":
+            if evidence_id is not None or reasons:
+                raise ValueError("not-evaluated gates must not carry evidence or reasons")
+        else:
+            if evidence_id is None:
+                raise ValueError("evaluated gates require evidence_id")
+            if status == "pass" and reasons:
+                raise ValueError("passing gates must not carry failure reasons")
+            if status != "pass" and not reasons:
+                raise ValueError("failed gates require at least one reason code")
+        object.__setattr__(self, "gate_name", name)
+        object.__setattr__(self, "status", status)
+        object.__setattr__(self, "evidence_id", evidence_id)
+        object.__setattr__(self, "reason_codes", reasons)
+        object.__setattr__(
+            self,
+            "metadata",
+            frozen_finite_json_mapping(self.metadata, name="gate metadata"),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "gate_name": self.gate_name,
+            "status": self.status,
+            "evidence_id": self.evidence_id,
+            "reason_codes": list(self.reason_codes),
+            "metadata": plain_json(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> ReadinessGateV1:
+        mapping = require_mapping(value, name="readiness gate")
+        require_exact_fields(mapping, _GATE_FIELDS, name="readiness gate")
+        return cls(
+            gate_name=mapping["gate_name"],
+            status=mapping["status"],
+            evidence_id=mapping["evidence_id"],
+            reason_codes=_strings_from_json(
+                mapping["reason_codes"],
+                name="reason_codes",
+                allow_empty=True,
+            ),
+            metadata=require_finite_json_mapping(
+                mapping["metadata"], name="gate metadata"
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class FreshProviderReadinessRequestV1:
+    """Complete ordered evidence request for one pre-target decision."""
+
+    cohort_lock: FreshProviderCohortLockV1
+    gates: tuple[ReadinessGateV1, ...]
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    fresh_provider_readiness_request_id: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.cohort_lock, FreshProviderCohortLockV1):
+            raise TypeError("cohort_lock must be FreshProviderCohortLockV1")
+        if type(self.gates) is not tuple or len(self.gates) != len(_GATE_ORDER):
+            raise ValueError("gates must contain the complete canonical gate order")
+        if any(not isinstance(gate, ReadinessGateV1) for gate in self.gates):
+            raise TypeError("gates must contain ReadinessGateV1 values")
+        if tuple(gate.gate_name for gate in self.gates) != _GATE_ORDER:
+            raise ValueError("gates must follow the canonical prospective order")
+        object.__setattr__(
+            self,
+            "metadata",
+            frozen_finite_json_mapping(self.metadata, name="readiness metadata"),
+        )
+        object.__setattr__(
+            self,
+            "fresh_provider_readiness_request_id",
+            _sha256_json(self._content_dict()),
+        )
+
+    def _content_dict(self) -> dict[str, object]:
+        return {
+            "schema": FRESH_PROVIDER_READINESS_REQUEST_SCHEMA,
+            "schema_version": FRESH_PROVIDER_READINESS_VERSION,
+            "cohort_lock": self.cohort_lock.to_dict(),
+            "gates": [gate.to_dict() for gate in self.gates],
+            "metadata": plain_json(self.metadata),
+            "claim_boundary": FRESH_PROVIDER_READINESS_CLAIM_BOUNDARY,
+        }
+
+    def to_dict(self) -> dict[str, object]:
+        result = self._content_dict()
+        result["fresh_provider_readiness_request_id"] = (
+            self.fresh_provider_readiness_request_id
+        )
+        return result
+
+    @classmethod
+    def from_dict(cls, value: object) -> FreshProviderReadinessRequestV1:
+        mapping = require_mapping(value, name="fresh provider readiness request")
+        require_exact_fields(
+            mapping,
+            _REQUEST_FIELDS,
+            name="fresh provider readiness request",
+        )
+        if mapping["schema"] != FRESH_PROVIDER_READINESS_REQUEST_SCHEMA:
+            raise ValueError("fresh provider readiness request schema changed")
+        if mapping["schema_version"] != FRESH_PROVIDER_READINESS_VERSION:
+            raise ValueError("fresh provider readiness request version changed")
+        if mapping["claim_boundary"] != FRESH_PROVIDER_READINESS_CLAIM_BOUNDARY:
+            raise ValueError("fresh provider readiness request claim boundary changed")
+        raw_gates = mapping["gates"]
+        if not isinstance(raw_gates, list):
+            raise ValueError("gates must be a JSON array")
+        result = cls(
+            cohort_lock=FreshProviderCohortLockV1.from_dict(mapping["cohort_lock"]),
+            gates=tuple(ReadinessGateV1.from_dict(item) for item in raw_gates),
+            metadata=require_finite_json_mapping(
+                mapping["metadata"], name="readiness metadata"
+            ),
+        )
+        if plain_json(result.to_dict()) != plain_json(mapping):
+            raise ValueError("fresh provider readiness request derived fields changed")
+        return result
+
+
+@dataclass(frozen=True, slots=True)
+class FreshProviderReadinessDecisionV1:
+    """Terminal pre-target decision derived from one complete request."""
+
+    request: FreshProviderReadinessRequestV1
+    classification: ReadinessClassification
+    terminal_gate: GateName
+    decision_reasons: tuple[str, ...]
+    next_action: str
+    authorize_point_uncertainty_development: bool
+    authorize_target_evaluation: bool
+    target_evaluation_budget: int
+    fresh_provider_readiness_decision_id: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.request, FreshProviderReadinessRequestV1):
+            raise TypeError("request must be FreshProviderReadinessRequestV1")
+        classification = require_exact_string(
+            self.classification,
+            name="classification",
+        )
+        if classification not in _NEXT_ACTION:
+            raise ValueError("classification is not a supported terminal decision")
+        terminal_gate = _gate_name(self.terminal_gate)
+        reasons = _sorted_unique_strings(
+            self.decision_reasons,
+            name="decision_reasons",
+            allow_empty=False,
+        )
+        next_action = require_exact_string(self.next_action, name="next_action")
+        point_development = _strict_bool(
+            self.authorize_point_uncertainty_development,
+            name="authorize_point_uncertainty_development",
+        )
+        target = _strict_bool(
+            self.authorize_target_evaluation,
+            name="authorize_target_evaluation",
+        )
+        budget = require_exact_integer(
+            self.target_evaluation_budget,
+            name="target_evaluation_budget",
+            minimum=0,
+        )
+        expected_point = classification == "point-covariance-localized"
+        expected_target = classification == "ready-for-one-target-evaluation"
+        if point_development != expected_point:
+            raise ValueError("point-uncertainty authorization changed")
+        if target != expected_target or budget != (1 if expected_target else 0):
+            raise ValueError("target-evaluation authorization changed")
+        if next_action != _NEXT_ACTION[classification]:
+            raise ValueError("next_action changed")
+        object.__setattr__(
+            self,
+            "classification",
+            cast(ReadinessClassification, classification),
+        )
+        object.__setattr__(self, "terminal_gate", terminal_gate)
+        object.__setattr__(self, "decision_reasons", reasons)
+        object.__setattr__(self, "next_action", next_action)
+        object.__setattr__(
+            self,
+            "authorize_point_uncertainty_development",
+            point_development,
+        )
+        object.__setattr__(self, "authorize_target_evaluation", target)
+        object.__setattr__(self, "target_evaluation_budget", budget)
+        object.__setattr__(
+            self,
+            "fresh_provider_readiness_decision_id",
+            _sha256_json(self._content_dict()),
+        )
+
+    def _content_dict(self) -> dict[str, object]:
+        return {
+            "schema": FRESH_PROVIDER_READINESS_DECISION_SCHEMA,
+            "schema_version": FRESH_PROVIDER_READINESS_VERSION,
+            "request": self.request.to_dict(),
+            "classification": self.classification,
+            "terminal_gate": self.terminal_gate,
+            "decision_reasons": list(self.decision_reasons),
+            "next_action": self.next_action,
+            "authorize_point_uncertainty_development": (
+                self.authorize_point_uncertainty_development
+            ),
+            "authorize_target_evaluation": self.authorize_target_evaluation,
+            "target_evaluation_budget": self.target_evaluation_budget,
+            "claim_boundary": FRESH_PROVIDER_READINESS_CLAIM_BOUNDARY,
+        }
+
+    def to_dict(self) -> dict[str, object]:
+        result = self._content_dict()
+        result["fresh_provider_readiness_decision_id"] = (
+            self.fresh_provider_readiness_decision_id
+        )
+        return result
+
+    @classmethod
+    def from_dict(cls, value: object) -> FreshProviderReadinessDecisionV1:
+        mapping = require_mapping(value, name="fresh provider readiness decision")
+        require_exact_fields(
+            mapping,
+            _DECISION_FIELDS,
+            name="fresh provider readiness decision",
+        )
+        if mapping["schema"] != FRESH_PROVIDER_READINESS_DECISION_SCHEMA:
+            raise ValueError("fresh provider readiness decision schema changed")
+        if mapping["schema_version"] != FRESH_PROVIDER_READINESS_VERSION:
+            raise ValueError("fresh provider readiness decision version changed")
+        if mapping["claim_boundary"] != FRESH_PROVIDER_READINESS_CLAIM_BOUNDARY:
+            raise ValueError("fresh provider readiness decision claim boundary changed")
+        result = cls(
+            request=FreshProviderReadinessRequestV1.from_dict(mapping["request"]),
+            classification=mapping["classification"],
+            terminal_gate=mapping["terminal_gate"],
+            decision_reasons=_strings_from_json(
+                mapping["decision_reasons"],
+                name="decision_reasons",
+                allow_empty=False,
+            ),
+            next_action=mapping["next_action"],
+            authorize_point_uncertainty_development=mapping[
+                "authorize_point_uncertainty_development"
+            ],
+            authorize_target_evaluation=mapping["authorize_target_evaluation"],
+            target_evaluation_budget=mapping["target_evaluation_budget"],
+        )
+        expected = evaluate_fresh_provider_readiness(result.request)
+        if plain_json(result.to_dict()) != plain_json(mapping):
+            raise ValueError("fresh provider readiness decision derived fields changed")
+        if result.fresh_provider_readiness_decision_id != (
+            expected.fresh_provider_readiness_decision_id
+        ):
+            raise ValueError("fresh provider readiness decision replay changed")
+        return result
+
+
+@dataclass(frozen=True, slots=True)
+class FreshProviderTargetAuthorizationV1:
+    """One-shot authorization for the exact unopened target roster."""
+
+    decision: FreshProviderReadinessDecisionV1
+    target_group_ids: tuple[str, ...]
+    target_evaluation_budget: int = 1
+    target_payloads_opened_at_authorization: bool = False
+    target_outcomes_opened_at_authorization: bool = False
+    fresh_provider_target_authorization_id: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.decision, FreshProviderReadinessDecisionV1):
+            raise TypeError("decision must be FreshProviderReadinessDecisionV1")
+        if not self.decision.authorize_target_evaluation:
+            raise ValueError("decision does not authorize target evaluation")
+        target_ids = _sorted_unique_strings(
+            self.target_group_ids,
+            name="target_group_ids",
+            allow_empty=False,
+        )
+        if target_ids != self.decision.request.cohort_lock.target_group_ids:
+            raise ValueError("target_group_ids changed from the cohort lock")
+        budget = require_exact_integer(
+            self.target_evaluation_budget,
+            name="target_evaluation_budget",
+            minimum=1,
+        )
+        if budget != 1:
+            raise ValueError("fresh provider authorization permits exactly one evaluation")
+        payloads = _strict_bool(
+            self.target_payloads_opened_at_authorization,
+            name="target_payloads_opened_at_authorization",
+        )
+        outcomes = _strict_bool(
+            self.target_outcomes_opened_at_authorization,
+            name="target_outcomes_opened_at_authorization",
+        )
+        if payloads or outcomes:
+            raise ValueError("target must still be unopened when authorization is created")
+        object.__setattr__(self, "target_group_ids", target_ids)
+        object.__setattr__(self, "target_evaluation_budget", budget)
+        object.__setattr__(self, "target_payloads_opened_at_authorization", payloads)
+        object.__setattr__(self, "target_outcomes_opened_at_authorization", outcomes)
+        object.__setattr__(
+            self,
+            "fresh_provider_target_authorization_id",
+            _sha256_json(self._content_dict()),
+        )
+
+    def _content_dict(self) -> dict[str, object]:
+        return {
+            "schema": FRESH_PROVIDER_TARGET_AUTHORIZATION_SCHEMA,
+            "schema_version": FRESH_PROVIDER_READINESS_VERSION,
+            "decision": self.decision.to_dict(),
+            "target_group_ids": list(self.target_group_ids),
+            "target_evaluation_budget": self.target_evaluation_budget,
+            "target_payloads_opened_at_authorization": (
+                self.target_payloads_opened_at_authorization
+            ),
+            "target_outcomes_opened_at_authorization": (
+                self.target_outcomes_opened_at_authorization
+            ),
+            "claim_boundary": FRESH_PROVIDER_READINESS_CLAIM_BOUNDARY,
+        }
+
+    def to_dict(self) -> dict[str, object]:
+        result = self._content_dict()
+        result["fresh_provider_target_authorization_id"] = (
+            self.fresh_provider_target_authorization_id
+        )
+        return result
+
+    @classmethod
+    def from_dict(cls, value: object) -> FreshProviderTargetAuthorizationV1:
+        mapping = require_mapping(value, name="fresh provider target authorization")
+        require_exact_fields(
+            mapping,
+            _AUTHORIZATION_FIELDS,
+            name="fresh provider target authorization",
+        )
+        if mapping["schema"] != FRESH_PROVIDER_TARGET_AUTHORIZATION_SCHEMA:
+            raise ValueError("fresh provider target authorization schema changed")
+        if mapping["schema_version"] != FRESH_PROVIDER_READINESS_VERSION:
+            raise ValueError("fresh provider target authorization version changed")
+        if mapping["claim_boundary"] != FRESH_PROVIDER_READINESS_CLAIM_BOUNDARY:
+            raise ValueError("fresh provider target authorization claim boundary changed")
+        result = cls(
+            decision=FreshProviderReadinessDecisionV1.from_dict(mapping["decision"]),
+            target_group_ids=_strings_from_json(
+                mapping["target_group_ids"],
+                name="target_group_ids",
+                allow_empty=False,
+            ),
+            target_evaluation_budget=mapping["target_evaluation_budget"],
+            target_payloads_opened_at_authorization=mapping[
+                "target_payloads_opened_at_authorization"
+            ],
+            target_outcomes_opened_at_authorization=mapping[
+                "target_outcomes_opened_at_authorization"
+            ],
+        )
+        if plain_json(result.to_dict()) != plain_json(mapping):
+            raise ValueError("fresh provider target authorization derived fields changed")
+        return result
+
+
+def evaluate_fresh_provider_readiness(
+    request: FreshProviderReadinessRequestV1,
+) -> FreshProviderReadinessDecisionV1:
+    """Replay the strict information order and return exactly one terminal decision."""
+
+    if not isinstance(request, FreshProviderReadinessRequestV1):
+        raise TypeError("request must be FreshProviderReadinessRequestV1")
+    classification: ReadinessClassification | None = None
+    terminal_gate: GateName | None = None
+    reasons: tuple[str, ...] = ()
+    for index, gate in enumerate(request.gates):
+        if gate.status == "not-evaluated":
+            raise ValueError(
+                f"gate {gate.gate_name!r} is unevaluated after every earlier gate passed"
+            )
+        if gate.status == "technical-failure":
+            classification = "technical-failure"
+            terminal_gate = gate.gate_name
+            reasons = tuple(
+                sorted(f"{gate.gate_name}:{reason}" for reason in gate.reason_codes)
+            )
+        elif gate.status == "fail":
+            classification = _GATE_FAILURE_CLASSIFICATION[gate.gate_name]
+            terminal_gate = gate.gate_name
+            reasons = tuple(
+                sorted(f"{gate.gate_name}:{reason}" for reason in gate.reason_codes)
+            )
+        if classification is not None:
+            for later in request.gates[index + 1 :]:
+                if later.status != "not-evaluated":
+                    raise ValueError(
+                        "gates after the first terminal result must remain not-evaluated"
+                    )
+            break
+    if classification is None:
+        classification = "ready-for-one-target-evaluation"
+        terminal_gate = "exact-fallback"
+        reasons = ("all-source-and-calibration-gates-passed",)
+    assert terminal_gate is not None
+    return FreshProviderReadinessDecisionV1(
+        request=request,
+        classification=classification,
+        terminal_gate=terminal_gate,
+        decision_reasons=reasons,
+        next_action=_NEXT_ACTION[classification],
+        authorize_point_uncertainty_development=(
+            classification == "point-covariance-localized"
+        ),
+        authorize_target_evaluation=(
+            classification == "ready-for-one-target-evaluation"
+        ),
+        target_evaluation_budget=(
+            1 if classification == "ready-for-one-target-evaluation" else 0
+        ),
+    )
+
+
+def authorize_fresh_provider_target(
+    decision: FreshProviderReadinessDecisionV1,
+) -> FreshProviderTargetAuthorizationV1:
+    """Create the one-shot target authorization for a passing decision."""
+
+    return FreshProviderTargetAuthorizationV1(
+        decision=decision,
+        target_group_ids=decision.request.cohort_lock.target_group_ids,
+    )
+
+
+def support_gate_from_result(result: object) -> ReadinessGateV1:
+    """Adapt a validated ProviderSupportFeasibilityV1-like result."""
+
+    evidence_id = require_sha256(
+        getattr(result, "provider_support_feasibility_id", None),
+        name="provider_support_feasibility_id",
+    )
+    support_feasible = _strict_bool(
+        getattr(result, "support_feasible", None),
+        name="support_feasible",
+    )
+    if support_feasible:
+        return ReadinessGateV1(
+            gate_name="support-feasibility",
+            status="pass",
+            evidence_id=evidence_id,
+        )
+    reason = require_exact_string(
+        getattr(result, "decision_reason", None),
+        name="decision_reason",
+    )
+    return ReadinessGateV1(
+        gate_name="support-feasibility",
+        status="fail",
+        evidence_id=evidence_id,
+        reason_codes=(reason,),
+    )
+
+
+def source_competence_gates(
+    report: SourceProviderCompetenceReportV1,
+) -> tuple[ReadinessGateV1, ReadinessGateV1]:
+    """Adapt one source report without evaluating identity after a mean failure."""
+
+    if not isinstance(report, SourceProviderCompetenceReportV1):
+        raise TypeError("report must be SourceProviderCompetenceReportV1")
+    report_id = report.source_provider_competence_id
+    mean_gate = ReadinessGateV1(
+        gate_name="source-mean",
+        status=report.mean_quality_status,
+        evidence_id=report_id,
+        reason_codes=(
+            () if report.mean_quality_status == "pass" else report.mean_quality_reasons
+        ),
+    )
+    if mean_gate.status != "pass":
+        return (
+            mean_gate,
+            ReadinessGateV1(
+                gate_name="identity-reliability",
+                status="not-evaluated",
+                evidence_id=None,
+            ),
+        )
+    identity_gate = ReadinessGateV1(
+        gate_name="identity-reliability",
+        status=report.identity_reliability_status,
+        evidence_id=report_id,
+        reason_codes=(
+            ()
+            if report.identity_reliability_status == "pass"
+            else report.identity_reliability_reasons
+        ),
+    )
+    return mean_gate, identity_gate
+
+
+def unevaluated_gate(name: GateName) -> ReadinessGateV1:
+    return ReadinessGateV1(gate_name=name, status="not-evaluated", evidence_id=None)
+
+
+def write_fresh_provider_readiness_request(
+    path: str | Path,
+    request: FreshProviderReadinessRequestV1,
+    *,
+    overwrite: bool = False,
+) -> None:
+    _atomic_write_json(path, request.to_dict(), overwrite=overwrite)
+
+
+def load_fresh_provider_readiness_request(
+    path: str | Path,
+) -> FreshProviderReadinessRequestV1:
+    return FreshProviderReadinessRequestV1.from_dict(
+        load_json_object(path, name="fresh provider readiness request")
+    )
+
+
+def write_fresh_provider_readiness_decision(
+    path: str | Path,
+    decision: FreshProviderReadinessDecisionV1,
+    *,
+    overwrite: bool = False,
+) -> None:
+    _atomic_write_json(path, decision.to_dict(), overwrite=overwrite)
+
+
+def load_fresh_provider_readiness_decision(
+    path: str | Path,
+) -> FreshProviderReadinessDecisionV1:
+    return FreshProviderReadinessDecisionV1.from_dict(
+        load_json_object(path, name="fresh provider readiness decision")
+    )
+
+
+def write_fresh_provider_target_authorization(
+    path: str | Path,
+    authorization: FreshProviderTargetAuthorizationV1,
+    *,
+    overwrite: bool = False,
+) -> None:
+    _atomic_write_json(path, authorization.to_dict(), overwrite=overwrite)
+
+
+def load_fresh_provider_target_authorization(
+    path: str | Path,
+) -> FreshProviderTargetAuthorizationV1:
+    return FreshProviderTargetAuthorizationV1.from_dict(
+        load_json_object(path, name="fresh provider target authorization")
+    )
+
+
+def _summary(value: Mapping[str, Any]) -> None:
+    print(json.dumps(plain_json(value), sort_keys=True, allow_nan=False))
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    evaluate = subparsers.add_parser("evaluate")
+    evaluate.add_argument("--request", type=Path, required=True)
+    evaluate.add_argument("--output", type=Path, required=True)
+    evaluate.add_argument("--overwrite", action="store_true")
+
+    verify_request = subparsers.add_parser("verify-request")
+    verify_request.add_argument("--artifact", type=Path, required=True)
+
+    verify_decision = subparsers.add_parser("verify-decision")
+    verify_decision.add_argument("--artifact", type=Path, required=True)
+
+    authorize = subparsers.add_parser("authorize-target")
+    authorize.add_argument("--decision", type=Path, required=True)
+    authorize.add_argument("--output", type=Path, required=True)
+    authorize.add_argument("--overwrite", action="store_true")
+
+    verify_authorization = subparsers.add_parser("verify-authorization")
+    verify_authorization.add_argument("--artifact", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _parser().parse_args(argv)
+    if arguments.command == "evaluate":
+        request = load_fresh_provider_readiness_request(arguments.request)
+        decision = evaluate_fresh_provider_readiness(request)
+        write_fresh_provider_readiness_decision(
+            arguments.output,
+            decision,
+            overwrite=arguments.overwrite,
+        )
+        _summary(
+            {
+                "classification": decision.classification,
+                "decision_id": decision.fresh_provider_readiness_decision_id,
+                "target_evaluation_budget": decision.target_evaluation_budget,
+            }
+        )
+        return 0 if decision.authorize_target_evaluation else 2
+    if arguments.command == "verify-request":
+        request = load_fresh_provider_readiness_request(arguments.artifact)
+        _summary({"request_id": request.fresh_provider_readiness_request_id})
+        return 0
+    if arguments.command == "verify-decision":
+        decision = load_fresh_provider_readiness_decision(arguments.artifact)
+        _summary(
+            {
+                "classification": decision.classification,
+                "decision_id": decision.fresh_provider_readiness_decision_id,
+            }
+        )
+        return 0
+    if arguments.command == "authorize-target":
+        decision = load_fresh_provider_readiness_decision(arguments.decision)
+        authorization = authorize_fresh_provider_target(decision)
+        write_fresh_provider_target_authorization(
+            arguments.output,
+            authorization,
+            overwrite=arguments.overwrite,
+        )
+        _summary(
+            {
+                "authorization_id": (
+                    authorization.fresh_provider_target_authorization_id
+                ),
+                "target_evaluation_budget": authorization.target_evaluation_budget,
+            }
+        )
+        return 0
+    authorization = load_fresh_provider_target_authorization(arguments.artifact)
+    _summary(
+        {
+            "authorization_id": authorization.fresh_provider_target_authorization_id,
+            "target_evaluation_budget": authorization.target_evaluation_budget,
+        }
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+
+
+__all__ = [
+    "FRESH_PROVIDER_READINESS_CLAIM_BOUNDARY",
+    "FRESH_PROVIDER_READINESS_VERSION",
+    "FreshProviderCohortLockV1",
+    "FreshProviderReadinessDecisionV1",
+    "FreshProviderReadinessRequestV1",
+    "FreshProviderTargetAuthorizationV1",
+    "ReadinessGateV1",
+    "authorize_fresh_provider_target",
+    "evaluate_fresh_provider_readiness",
+    "load_fresh_provider_readiness_decision",
+    "load_fresh_provider_readiness_request",
+    "load_fresh_provider_target_authorization",
+    "source_competence_gates",
+    "support_gate_from_result",
+    "unevaluated_gate",
+    "write_fresh_provider_readiness_decision",
+    "write_fresh_provider_readiness_request",
+    "write_fresh_provider_target_authorization",
+]

--- a/src/prob4d/query_covariance_preservation.py
+++ b/src/prob4d/query_covariance_preservation.py
@@ -1,0 +1,795 @@
+"""Certify query-space preservation under covariance approximations.
+
+Prob4D can represent the same observation uncertainty with full joint, sparse,
+rank-capped, block-diagonal, or marginal-only treatments. This module compares
+those treatments only after projection into a downstream consumer's frozen physical
+query. The consumer still owns the query, tolerances, computational selection, and
+update admission.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, TypeAlias
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ._immutable_json import frozen_finite_json_mapping, plain_json
+from ._strict_json import (
+    load_json_object,
+    require_exact_fields,
+    require_exact_integer,
+    require_exact_string,
+    require_finite_json_mapping,
+    require_json_number,
+    require_mapping,
+    require_sha256,
+)
+
+FloatArray: TypeAlias = NDArray[np.floating[Any]]
+
+QUERY_COVARIANCE_PRESERVATION_SCHEMA = "prob4d.query-covariance-preservation"
+QUERY_COVARIANCE_PRESERVATION_VERSION = 1
+QUERY_COVARIANCE_PRESERVATION_CLAIM_BOUNDARY = (
+    "This certificate compares supplied covariance treatments in one exact "
+    "consumer-defined query space. It does not define the query, select a treatment, "
+    "authorize a BayesianPhysTwin update, prove provider competence or calibration, "
+    "establish Causal4D benefit, deployment safety, or state of the art."
+)
+
+_POLICY_FIELDS = frozenset(
+    {
+        "relative_rank_tolerance",
+        "maximum_relative_trace_distortion",
+        "maximum_relative_frobenius_distortion",
+        "minimum_directional_variance_ratio",
+        "maximum_directional_variance_ratio",
+        "maximum_unsupported_trace_fraction",
+    }
+)
+_CANDIDATE_FIELDS = frozenset(
+    {
+        "candidate_id",
+        "representation",
+        "covariance",
+        "estimated_memory_bytes",
+        "estimated_runtime_seconds",
+        "metadata",
+    }
+)
+_RESULT_FIELDS = frozenset(
+    {
+        "candidate_id",
+        "representation",
+        "relative_trace_distortion",
+        "relative_frobenius_distortion",
+        "minimum_directional_variance_ratio",
+        "mean_directional_variance_ratio",
+        "maximum_directional_variance_ratio",
+        "maximum_directional_variance_ratio_error",
+        "unsupported_trace_fraction",
+        "preserved",
+        "failure_reasons",
+        "estimated_memory_bytes",
+        "estimated_runtime_seconds",
+    }
+)
+_CERTIFICATE_FIELDS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "query_definition_id",
+        "observation_artifact_id",
+        "reference_representation",
+        "reference_covariance",
+        "query_dimension",
+        "reference_effective_rank",
+        "policy",
+        "candidates",
+        "results",
+        "preserved_candidate_ids",
+        "any_preserved",
+        "all_preserved",
+        "metadata",
+        "claim_boundary",
+        "query_covariance_preservation_id",
+    }
+)
+
+
+def _readonly(value: object) -> FloatArray:
+    result = np.array(value, dtype=np.float64, copy=True, order="C")
+    result.setflags(write=False)
+    return result
+
+
+def _nonnegative(value: object, *, name: str) -> float:
+    result = require_json_number(value, name=name)
+    if result < 0.0:
+        raise ValueError(f"{name} must be non-negative")
+    return result
+
+
+def _probability(value: object, *, name: str) -> float:
+    result = require_json_number(value, name=name)
+    if not 0.0 <= result <= 1.0:
+        raise ValueError(f"{name} must lie in [0, 1]")
+    return result
+
+
+def _optional_nonnegative_integer(value: object, *, name: str) -> int | None:
+    if value is None:
+        return None
+    return require_exact_integer(value, name=name, minimum=0)
+
+
+def _optional_nonnegative_number(value: object, *, name: str) -> float | None:
+    if value is None:
+        return None
+    return _nonnegative(value, name=name)
+
+
+def _validated_covariance(
+    value: object,
+    *,
+    name: str,
+    expected_dimension: int | None = None,
+    require_positive_trace: bool = False,
+) -> FloatArray:
+    covariance = np.asarray(value, dtype=np.float64)
+    if covariance.ndim != 2 or covariance.shape[0] != covariance.shape[1]:
+        raise ValueError(f"{name} must be a square matrix")
+    if covariance.shape[0] < 1:
+        raise ValueError(f"{name} must have positive dimension")
+    if expected_dimension is not None and covariance.shape != (
+        expected_dimension,
+        expected_dimension,
+    ):
+        raise ValueError(f"{name} has an invalid shape")
+    if not np.all(np.isfinite(covariance)):
+        raise ValueError(f"{name} must be finite")
+    symmetric = 0.5 * (covariance + covariance.T)
+    scale = max(float(np.max(np.abs(symmetric), initial=0.0)), 1.0)
+    if not np.allclose(covariance, symmetric, atol=1e-12, rtol=1e-10):
+        raise ValueError(f"{name} must be symmetric")
+    if float(np.min(np.linalg.eigvalsh(symmetric), initial=0.0)) < -(
+        1e-12 + 1e-10 * scale
+    ):
+        raise ValueError(f"{name} must be positive semidefinite")
+    if require_positive_trace and float(np.trace(symmetric)) <= 0.0:
+        raise ValueError(f"{name} must have positive trace")
+    return _readonly(symmetric)
+
+
+def _relative_rank_tolerance(value: object) -> float:
+    result = require_json_number(value, name="relative_rank_tolerance")
+    if not 0.0 <= result < 1.0:
+        raise ValueError("relative_rank_tolerance must lie in [0, 1)")
+    return result
+
+
+def _canonical_json_bytes(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        plain_json(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _sha256_json(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json_bytes(value)).hexdigest()
+
+
+def _atomic_write_json(
+    path: str | Path,
+    value: Mapping[str, Any],
+    *,
+    overwrite: bool,
+) -> None:
+    destination = Path(path)
+    if type(overwrite) is not bool:
+        raise ValueError("overwrite must be a Boolean")
+    if destination.exists() and not overwrite:
+        raise FileExistsError(destination)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(
+        plain_json(value),
+        sort_keys=True,
+        indent=2,
+        allow_nan=False,
+    ) + "\n"
+    temporary = destination.with_name(
+        f".{destination.name}.tmp-{os.getpid()}-"
+        f"{hashlib.sha256(payload.encode()).hexdigest()[:16]}"
+    )
+    try:
+        with temporary.open("x", encoding="utf-8") as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        if destination.exists() and not overwrite:
+            raise FileExistsError(destination)
+        os.replace(temporary, destination)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+@dataclass(frozen=True, slots=True)
+class QueryCovariancePreservationPolicyV1:
+    """Consumer-frozen tolerances for one query-space comparison."""
+
+    relative_rank_tolerance: float
+    maximum_relative_trace_distortion: float
+    maximum_relative_frobenius_distortion: float
+    minimum_directional_variance_ratio: float
+    maximum_directional_variance_ratio: float
+    maximum_unsupported_trace_fraction: float
+
+    def __post_init__(self) -> None:
+        tolerance = _relative_rank_tolerance(self.relative_rank_tolerance)
+        trace = _nonnegative(
+            self.maximum_relative_trace_distortion,
+            name="maximum_relative_trace_distortion",
+        )
+        frobenius = _nonnegative(
+            self.maximum_relative_frobenius_distortion,
+            name="maximum_relative_frobenius_distortion",
+        )
+        minimum_ratio = _nonnegative(
+            self.minimum_directional_variance_ratio,
+            name="minimum_directional_variance_ratio",
+        )
+        maximum_ratio = _nonnegative(
+            self.maximum_directional_variance_ratio,
+            name="maximum_directional_variance_ratio",
+        )
+        if maximum_ratio < minimum_ratio:
+            raise ValueError(
+                "maximum_directional_variance_ratio must not be below the minimum"
+            )
+        unsupported = _probability(
+            self.maximum_unsupported_trace_fraction,
+            name="maximum_unsupported_trace_fraction",
+        )
+        object.__setattr__(self, "relative_rank_tolerance", tolerance)
+        object.__setattr__(self, "maximum_relative_trace_distortion", trace)
+        object.__setattr__(self, "maximum_relative_frobenius_distortion", frobenius)
+        object.__setattr__(self, "minimum_directional_variance_ratio", minimum_ratio)
+        object.__setattr__(self, "maximum_directional_variance_ratio", maximum_ratio)
+        object.__setattr__(self, "maximum_unsupported_trace_fraction", unsupported)
+
+    def to_dict(self) -> dict[str, float]:
+        return {
+            "relative_rank_tolerance": self.relative_rank_tolerance,
+            "maximum_relative_trace_distortion": (
+                self.maximum_relative_trace_distortion
+            ),
+            "maximum_relative_frobenius_distortion": (
+                self.maximum_relative_frobenius_distortion
+            ),
+            "minimum_directional_variance_ratio": (
+                self.minimum_directional_variance_ratio
+            ),
+            "maximum_directional_variance_ratio": (
+                self.maximum_directional_variance_ratio
+            ),
+            "maximum_unsupported_trace_fraction": (
+                self.maximum_unsupported_trace_fraction
+            ),
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> QueryCovariancePreservationPolicyV1:
+        mapping = require_mapping(value, name="query covariance preservation policy")
+        require_exact_fields(
+            mapping,
+            _POLICY_FIELDS,
+            name="query covariance preservation policy",
+        )
+        return cls(
+            relative_rank_tolerance=mapping["relative_rank_tolerance"],
+            maximum_relative_trace_distortion=mapping[
+                "maximum_relative_trace_distortion"
+            ],
+            maximum_relative_frobenius_distortion=mapping[
+                "maximum_relative_frobenius_distortion"
+            ],
+            minimum_directional_variance_ratio=mapping[
+                "minimum_directional_variance_ratio"
+            ],
+            maximum_directional_variance_ratio=mapping[
+                "maximum_directional_variance_ratio"
+            ],
+            maximum_unsupported_trace_fraction=mapping[
+                "maximum_unsupported_trace_fraction"
+            ],
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class QueryCovarianceCandidateV1:
+    """One query-space covariance representation and optional cost evidence."""
+
+    candidate_id: str
+    representation: str
+    covariance: FloatArray
+    estimated_memory_bytes: int | None = None
+    estimated_runtime_seconds: float | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "candidate_id",
+            require_exact_string(self.candidate_id, name="candidate_id"),
+        )
+        object.__setattr__(
+            self,
+            "representation",
+            require_exact_string(self.representation, name="representation"),
+        )
+        object.__setattr__(
+            self,
+            "covariance",
+            _validated_covariance(self.covariance, name="candidate covariance"),
+        )
+        object.__setattr__(
+            self,
+            "estimated_memory_bytes",
+            _optional_nonnegative_integer(
+                self.estimated_memory_bytes,
+                name="estimated_memory_bytes",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "estimated_runtime_seconds",
+            _optional_nonnegative_number(
+                self.estimated_runtime_seconds,
+                name="estimated_runtime_seconds",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "metadata",
+            frozen_finite_json_mapping(self.metadata, name="candidate metadata"),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "candidate_id": self.candidate_id,
+            "representation": self.representation,
+            "covariance": self.covariance.tolist(),
+            "estimated_memory_bytes": self.estimated_memory_bytes,
+            "estimated_runtime_seconds": self.estimated_runtime_seconds,
+            "metadata": plain_json(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> QueryCovarianceCandidateV1:
+        mapping = require_mapping(value, name="query covariance candidate")
+        require_exact_fields(
+            mapping,
+            _CANDIDATE_FIELDS,
+            name="query covariance candidate",
+        )
+        return cls(
+            candidate_id=mapping["candidate_id"],
+            representation=mapping["representation"],
+            covariance=mapping["covariance"],
+            estimated_memory_bytes=mapping["estimated_memory_bytes"],
+            estimated_runtime_seconds=mapping["estimated_runtime_seconds"],
+            metadata=require_finite_json_mapping(
+                mapping["metadata"], name="candidate metadata"
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class QueryCovarianceApproximationResultV1:
+    """Derived directional and aggregate distortion for one candidate."""
+
+    candidate_id: str
+    representation: str
+    relative_trace_distortion: float
+    relative_frobenius_distortion: float
+    minimum_directional_variance_ratio: float
+    mean_directional_variance_ratio: float
+    maximum_directional_variance_ratio: float
+    maximum_directional_variance_ratio_error: float
+    unsupported_trace_fraction: float
+    preserved: bool
+    failure_reasons: tuple[str, ...]
+    estimated_memory_bytes: int | None
+    estimated_runtime_seconds: float | None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "candidate_id": self.candidate_id,
+            "representation": self.representation,
+            "relative_trace_distortion": self.relative_trace_distortion,
+            "relative_frobenius_distortion": self.relative_frobenius_distortion,
+            "minimum_directional_variance_ratio": (
+                self.minimum_directional_variance_ratio
+            ),
+            "mean_directional_variance_ratio": self.mean_directional_variance_ratio,
+            "maximum_directional_variance_ratio": (
+                self.maximum_directional_variance_ratio
+            ),
+            "maximum_directional_variance_ratio_error": (
+                self.maximum_directional_variance_ratio_error
+            ),
+            "unsupported_trace_fraction": self.unsupported_trace_fraction,
+            "preserved": self.preserved,
+            "failure_reasons": list(self.failure_reasons),
+            "estimated_memory_bytes": self.estimated_memory_bytes,
+            "estimated_runtime_seconds": self.estimated_runtime_seconds,
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> QueryCovarianceApproximationResultV1:
+        mapping = require_mapping(value, name="query covariance approximation result")
+        require_exact_fields(
+            mapping,
+            _RESULT_FIELDS,
+            name="query covariance approximation result",
+        )
+        reasons = mapping["failure_reasons"]
+        if not isinstance(reasons, list):
+            raise ValueError("failure_reasons must be a JSON array")
+        normalized_reasons = tuple(
+            require_exact_string(item, name=f"failure_reasons[{index}]")
+            for index, item in enumerate(reasons)
+        )
+        if normalized_reasons != tuple(sorted(set(normalized_reasons))):
+            raise ValueError("failure_reasons must be sorted and unique")
+        preserved = mapping["preserved"]
+        if type(preserved) is not bool:
+            raise ValueError("preserved must be a Boolean")
+        return cls(
+            candidate_id=require_exact_string(
+                mapping["candidate_id"], name="candidate_id"
+            ),
+            representation=require_exact_string(
+                mapping["representation"], name="representation"
+            ),
+            relative_trace_distortion=_nonnegative(
+                mapping["relative_trace_distortion"],
+                name="relative_trace_distortion",
+            ),
+            relative_frobenius_distortion=_nonnegative(
+                mapping["relative_frobenius_distortion"],
+                name="relative_frobenius_distortion",
+            ),
+            minimum_directional_variance_ratio=_nonnegative(
+                mapping["minimum_directional_variance_ratio"],
+                name="minimum_directional_variance_ratio",
+            ),
+            mean_directional_variance_ratio=_nonnegative(
+                mapping["mean_directional_variance_ratio"],
+                name="mean_directional_variance_ratio",
+            ),
+            maximum_directional_variance_ratio=_nonnegative(
+                mapping["maximum_directional_variance_ratio"],
+                name="maximum_directional_variance_ratio",
+            ),
+            maximum_directional_variance_ratio_error=_nonnegative(
+                mapping["maximum_directional_variance_ratio_error"],
+                name="maximum_directional_variance_ratio_error",
+            ),
+            unsupported_trace_fraction=_probability(
+                mapping["unsupported_trace_fraction"],
+                name="unsupported_trace_fraction",
+            ),
+            preserved=preserved,
+            failure_reasons=normalized_reasons,
+            estimated_memory_bytes=_optional_nonnegative_integer(
+                mapping["estimated_memory_bytes"],
+                name="estimated_memory_bytes",
+            ),
+            estimated_runtime_seconds=_optional_nonnegative_number(
+                mapping["estimated_runtime_seconds"],
+                name="estimated_runtime_seconds",
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class QueryCovariancePreservationCertificateV1:
+    """Replay-complete query-space covariance approximation certificate."""
+
+    query_definition_id: str
+    observation_artifact_id: str
+    reference_representation: str
+    reference_covariance: FloatArray
+    policy: QueryCovariancePreservationPolicyV1
+    candidates: tuple[QueryCovarianceCandidateV1, ...]
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    query_dimension: int = field(init=False)
+    reference_effective_rank: int = field(init=False)
+    results: tuple[QueryCovarianceApproximationResultV1, ...] = field(init=False)
+    preserved_candidate_ids: tuple[str, ...] = field(init=False)
+    any_preserved: bool = field(init=False)
+    all_preserved: bool = field(init=False)
+    query_covariance_preservation_id: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        query_id = require_sha256(self.query_definition_id, name="query_definition_id")
+        observation_id = require_sha256(
+            self.observation_artifact_id,
+            name="observation_artifact_id",
+        )
+        reference_representation = require_exact_string(
+            self.reference_representation,
+            name="reference_representation",
+        )
+        reference = _validated_covariance(
+            self.reference_covariance,
+            name="reference_covariance",
+            require_positive_trace=True,
+        )
+        if not isinstance(self.policy, QueryCovariancePreservationPolicyV1):
+            raise TypeError("policy must be QueryCovariancePreservationPolicyV1")
+        if type(self.candidates) is not tuple or not self.candidates:
+            raise ValueError("candidates must be a nonempty canonical tuple")
+        if any(not isinstance(item, QueryCovarianceCandidateV1) for item in self.candidates):
+            raise TypeError("candidates must contain QueryCovarianceCandidateV1 values")
+        candidates = tuple(sorted(self.candidates, key=lambda item: item.candidate_id))
+        candidate_ids = tuple(item.candidate_id for item in candidates)
+        if candidate_ids != tuple(sorted(set(candidate_ids))):
+            raise ValueError("candidate IDs must be unique")
+        dimension = int(reference.shape[0])
+        if any(item.covariance.shape != reference.shape for item in candidates):
+            raise ValueError("candidate covariance dimensions must match the reference")
+        metadata = frozen_finite_json_mapping(
+            self.metadata,
+            name="query preservation metadata",
+        )
+        eigenvalues = np.linalg.eigvalsh(reference)
+        maximum = float(np.max(eigenvalues, initial=0.0))
+        active_rank = int(
+            np.count_nonzero(
+                eigenvalues > self.policy.relative_rank_tolerance * maximum
+            )
+        )
+        if active_rank < 1:
+            raise ValueError("reference covariance has no numerically supported query rank")
+        results = tuple(self._evaluate_candidate(reference, item) for item in candidates)
+        preserved_ids = tuple(item.candidate_id for item in results if item.preserved)
+
+        object.__setattr__(self, "query_definition_id", query_id)
+        object.__setattr__(self, "observation_artifact_id", observation_id)
+        object.__setattr__(self, "reference_representation", reference_representation)
+        object.__setattr__(self, "reference_covariance", reference)
+        object.__setattr__(self, "candidates", candidates)
+        object.__setattr__(self, "metadata", metadata)
+        object.__setattr__(self, "query_dimension", dimension)
+        object.__setattr__(self, "reference_effective_rank", active_rank)
+        object.__setattr__(self, "results", results)
+        object.__setattr__(self, "preserved_candidate_ids", preserved_ids)
+        object.__setattr__(self, "any_preserved", bool(preserved_ids))
+        object.__setattr__(self, "all_preserved", len(preserved_ids) == len(candidates))
+        object.__setattr__(
+            self,
+            "query_covariance_preservation_id",
+            _sha256_json(self._content_dict()),
+        )
+
+    def _evaluate_candidate(
+        self,
+        reference: FloatArray,
+        candidate: QueryCovarianceCandidateV1,
+    ) -> QueryCovarianceApproximationResultV1:
+        candidate_covariance = candidate.covariance
+        reference_trace = float(np.trace(reference))
+        reference_norm = float(np.linalg.norm(reference, ord="fro"))
+        trace_distortion = abs(float(np.trace(candidate_covariance)) - reference_trace)
+        trace_distortion /= reference_trace
+        frobenius_distortion = float(
+            np.linalg.norm(candidate_covariance - reference, ord="fro")
+        ) / reference_norm
+
+        eigenvalues, eigenvectors = np.linalg.eigh(reference)
+        maximum = float(np.max(eigenvalues, initial=0.0))
+        active = eigenvalues > self.policy.relative_rank_tolerance * maximum
+        basis = eigenvectors[:, active]
+        active_values = eigenvalues[active]
+        candidate_active = basis.T @ candidate_covariance @ basis
+        inverse_root = 1.0 / np.sqrt(active_values)
+        whitened = inverse_root[:, None] * candidate_active * inverse_root[None, :]
+        whitened = 0.5 * (whitened + whitened.T)
+        ratios = np.linalg.eigvalsh(whitened)
+        scale = max(float(np.max(np.abs(ratios), initial=0.0)), 1.0)
+        if float(np.min(ratios, initial=0.0)) < -(1e-12 + 1e-10 * scale):
+            raise ValueError("candidate covariance became indefinite in query whitening")
+        ratios = np.maximum(ratios, 0.0)
+        minimum_ratio = float(np.min(ratios))
+        mean_ratio = float(np.mean(ratios))
+        maximum_ratio = float(np.max(ratios))
+        maximum_ratio_error = max(abs(minimum_ratio - 1.0), abs(maximum_ratio - 1.0))
+
+        candidate_trace = float(np.trace(candidate_covariance))
+        active_trace = float(np.trace(candidate_active))
+        unsupported_trace = max(candidate_trace - active_trace, 0.0)
+        unsupported_fraction = (
+            0.0
+            if candidate_trace <= np.finfo(np.float64).eps
+            else float(np.clip(unsupported_trace / candidate_trace, 0.0, 1.0))
+        )
+
+        reasons: list[str] = []
+        if trace_distortion > self.policy.maximum_relative_trace_distortion:
+            reasons.append("relative-trace-distortion-exceeded")
+        if frobenius_distortion > self.policy.maximum_relative_frobenius_distortion:
+            reasons.append("relative-frobenius-distortion-exceeded")
+        if minimum_ratio < self.policy.minimum_directional_variance_ratio:
+            reasons.append("directional-understatement-exceeded")
+        if maximum_ratio > self.policy.maximum_directional_variance_ratio:
+            reasons.append("directional-overstatement-exceeded")
+        if unsupported_fraction > self.policy.maximum_unsupported_trace_fraction:
+            reasons.append("unsupported-query-trace-exceeded")
+        return QueryCovarianceApproximationResultV1(
+            candidate_id=candidate.candidate_id,
+            representation=candidate.representation,
+            relative_trace_distortion=trace_distortion,
+            relative_frobenius_distortion=frobenius_distortion,
+            minimum_directional_variance_ratio=minimum_ratio,
+            mean_directional_variance_ratio=mean_ratio,
+            maximum_directional_variance_ratio=maximum_ratio,
+            maximum_directional_variance_ratio_error=maximum_ratio_error,
+            unsupported_trace_fraction=unsupported_fraction,
+            preserved=not reasons,
+            failure_reasons=tuple(sorted(reasons)),
+            estimated_memory_bytes=candidate.estimated_memory_bytes,
+            estimated_runtime_seconds=candidate.estimated_runtime_seconds,
+        )
+
+    @classmethod
+    def from_projections(
+        cls,
+        *,
+        query_definition_id: str,
+        observation_artifact_id: str,
+        reference_representation: str,
+        reference_projection: object,
+        candidate_projections: Mapping[str, object],
+        policy: QueryCovariancePreservationPolicyV1,
+        candidate_representations: Mapping[str, str] | None = None,
+        metadata: Mapping[str, Any] | None = None,
+    ) -> QueryCovariancePreservationCertificateV1:
+        """Build from QueryCovarianceProjectionV1-like objects."""
+
+        reference = getattr(reference_projection, "total_covariance", None)
+        representations = {} if candidate_representations is None else candidate_representations
+        candidates = tuple(
+            QueryCovarianceCandidateV1(
+                candidate_id=candidate_id,
+                representation=representations.get(candidate_id, candidate_id),
+                covariance=getattr(projection, "total_covariance", None),
+            )
+            for candidate_id, projection in sorted(candidate_projections.items())
+        )
+        return cls(
+            query_definition_id=query_definition_id,
+            observation_artifact_id=observation_artifact_id,
+            reference_representation=reference_representation,
+            reference_covariance=reference,
+            policy=policy,
+            candidates=candidates,
+            metadata={} if metadata is None else metadata,
+        )
+
+    def _content_dict(self) -> dict[str, object]:
+        return {
+            "schema": QUERY_COVARIANCE_PRESERVATION_SCHEMA,
+            "schema_version": QUERY_COVARIANCE_PRESERVATION_VERSION,
+            "query_definition_id": self.query_definition_id,
+            "observation_artifact_id": self.observation_artifact_id,
+            "reference_representation": self.reference_representation,
+            "reference_covariance": self.reference_covariance.tolist(),
+            "query_dimension": self.query_dimension,
+            "reference_effective_rank": self.reference_effective_rank,
+            "policy": self.policy.to_dict(),
+            "candidates": [item.to_dict() for item in self.candidates],
+            "results": [item.to_dict() for item in self.results],
+            "preserved_candidate_ids": list(self.preserved_candidate_ids),
+            "any_preserved": self.any_preserved,
+            "all_preserved": self.all_preserved,
+            "metadata": plain_json(self.metadata),
+            "claim_boundary": QUERY_COVARIANCE_PRESERVATION_CLAIM_BOUNDARY,
+        }
+
+    def to_dict(self) -> dict[str, object]:
+        result = self._content_dict()
+        result["query_covariance_preservation_id"] = (
+            self.query_covariance_preservation_id
+        )
+        return result
+
+    @classmethod
+    def from_dict(cls, value: object) -> QueryCovariancePreservationCertificateV1:
+        mapping = require_mapping(value, name="query covariance preservation certificate")
+        require_exact_fields(
+            mapping,
+            _CERTIFICATE_FIELDS,
+            name="query covariance preservation certificate",
+        )
+        if mapping["schema"] != QUERY_COVARIANCE_PRESERVATION_SCHEMA:
+            raise ValueError("query covariance preservation schema changed")
+        if mapping["schema_version"] != QUERY_COVARIANCE_PRESERVATION_VERSION:
+            raise ValueError("query covariance preservation version changed")
+        if mapping["claim_boundary"] != QUERY_COVARIANCE_PRESERVATION_CLAIM_BOUNDARY:
+            raise ValueError("query covariance preservation claim boundary changed")
+        raw_candidates = mapping["candidates"]
+        if not isinstance(raw_candidates, list):
+            raise ValueError("candidates must be a JSON array")
+        result = cls(
+            query_definition_id=mapping["query_definition_id"],
+            observation_artifact_id=mapping["observation_artifact_id"],
+            reference_representation=mapping["reference_representation"],
+            reference_covariance=mapping["reference_covariance"],
+            policy=QueryCovariancePreservationPolicyV1.from_dict(mapping["policy"]),
+            candidates=tuple(
+                QueryCovarianceCandidateV1.from_dict(item) for item in raw_candidates
+            ),
+            metadata=require_finite_json_mapping(
+                mapping["metadata"], name="query preservation metadata"
+            ),
+        )
+        raw_results = mapping["results"]
+        if not isinstance(raw_results, list):
+            raise ValueError("results must be a JSON array")
+        tuple(QueryCovarianceApproximationResultV1.from_dict(item) for item in raw_results)
+        if plain_json(result.to_dict()) != plain_json(mapping):
+            raise ValueError("query covariance preservation derived fields changed")
+        return result
+
+    def summary(self) -> dict[str, object]:
+        return {
+            "query_covariance_preservation_id": self.query_covariance_preservation_id,
+            "query_dimension": self.query_dimension,
+            "reference_effective_rank": self.reference_effective_rank,
+            "preserved_candidate_ids": list(self.preserved_candidate_ids),
+            "any_preserved": self.any_preserved,
+            "all_preserved": self.all_preserved,
+            "claim_boundary": QUERY_COVARIANCE_PRESERVATION_CLAIM_BOUNDARY,
+        }
+
+
+def write_query_covariance_preservation(
+    path: str | Path,
+    certificate: QueryCovariancePreservationCertificateV1,
+    *,
+    overwrite: bool = False,
+) -> None:
+    if not isinstance(certificate, QueryCovariancePreservationCertificateV1):
+        raise TypeError("certificate must be QueryCovariancePreservationCertificateV1")
+    _atomic_write_json(path, certificate.to_dict(), overwrite=overwrite)
+
+
+def load_query_covariance_preservation(
+    path: str | Path,
+) -> QueryCovariancePreservationCertificateV1:
+    return QueryCovariancePreservationCertificateV1.from_dict(
+        load_json_object(path, name="query covariance preservation certificate")
+    )
+
+
+__all__ = [
+    "QUERY_COVARIANCE_PRESERVATION_CLAIM_BOUNDARY",
+    "QUERY_COVARIANCE_PRESERVATION_SCHEMA",
+    "QUERY_COVARIANCE_PRESERVATION_VERSION",
+    "QueryCovarianceApproximationResultV1",
+    "QueryCovarianceCandidateV1",
+    "QueryCovariancePreservationCertificateV1",
+    "QueryCovariancePreservationPolicyV1",
+    "load_query_covariance_preservation",
+    "write_query_covariance_preservation",
+]

--- a/src/prob4d/source_provider_competence.py
+++ b/src/prob4d/source_provider_competence.py
@@ -1,0 +1,914 @@
+"""Source-only provider mean-quality and identity-competence evidence.
+
+The report in this module treats complete physical objects or acquisition sessions
+as the statistical units. It deliberately separates observation-mean competence
+from identity/reliability competence so downstream readiness logic cannot respond
+to an inaccurate mean by merely fitting a richer covariance model.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+import numpy as np
+
+from ._immutable_json import frozen_finite_json_mapping, plain_json
+from ._strict_json import (
+    load_json_object,
+    require_exact_fields,
+    require_exact_integer,
+    require_exact_string,
+    require_finite_json_mapping,
+    require_json_number,
+    require_mapping,
+    require_sha256,
+)
+
+SOURCE_PROVIDER_COMPETENCE_SCHEMA = "prob4d.source-provider-competence"
+SOURCE_PROVIDER_COMPETENCE_VERSION = 1
+SOURCE_PROVIDER_COMPETENCE_CLAIM_BOUNDARY = (
+    "This source-only report evaluates observation-mean and identity/reliability "
+    "competence on complete development or calibration objects/sessions. It does "
+    "not use target payloads or outcomes, prove target transfer, authorize a "
+    "BayesianPhysTwin update, establish Causal4D benefit, or establish state of the art."
+)
+
+GateStatus = Literal["pass", "fail", "technical-failure"]
+
+_POLICY_FIELDS = frozenset(
+    {
+        "minimum_evaluable_groups",
+        "maximum_technical_failures",
+        "permitted_technical_failure_codes",
+        "maximum_mean_proper_score_delta",
+        "maximum_mean_point_rmse_ratio",
+        "maximum_mean_endpoint_rmse_ratio",
+        "maximum_worst_group_point_rmse_ratio",
+        "maximum_mean_absolute_drift_slope_m_per_frame",
+        "maximum_mean_seam_rmse_m",
+        "minimum_mean_quality_group_pass_fraction",
+        "minimum_mean_association_precision",
+        "minimum_mean_identity_retention",
+        "minimum_mean_support_retention",
+        "minimum_identity_group_pass_fraction",
+    }
+)
+_GROUP_FIELDS = frozenset(
+    {
+        "group_id",
+        "candidate_proper_score",
+        "baseline_proper_score",
+        "candidate_point_rmse_m",
+        "baseline_point_rmse_m",
+        "candidate_endpoint_rmse_m",
+        "baseline_endpoint_rmse_m",
+        "absolute_drift_slope_m_per_frame",
+        "seam_rmse_m",
+        "association_precision",
+        "identity_retention",
+        "support_retention",
+        "technical_failure_code",
+        "metadata",
+    }
+)
+_REPORT_FIELDS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "provider_manifest_id",
+        "cohort_binding_id",
+        "group_definition",
+        "policy",
+        "groups",
+        "source_truth_used",
+        "target_payloads_opened",
+        "target_outcomes_opened",
+        "group_count",
+        "technical_failure_count",
+        "evaluable_group_count",
+        "technical_integrity_pass",
+        "mean_proper_score_delta",
+        "mean_point_rmse_ratio",
+        "mean_endpoint_rmse_ratio",
+        "worst_group_point_rmse_ratio",
+        "mean_absolute_drift_slope_m_per_frame",
+        "mean_seam_rmse_m",
+        "mean_association_precision",
+        "mean_identity_retention",
+        "mean_support_retention",
+        "mean_quality_group_pass_fraction",
+        "identity_group_pass_fraction",
+        "mean_quality_status",
+        "identity_reliability_status",
+        "mean_quality_reasons",
+        "identity_reliability_reasons",
+        "source_competence_pass",
+        "metadata",
+        "claim_boundary",
+        "source_provider_competence_id",
+    }
+)
+
+
+def _strict_bool(value: object, *, name: str) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be a Boolean")
+    return value
+
+
+def _probability(value: object, *, name: str) -> float:
+    result = require_json_number(value, name=name)
+    if not 0.0 <= result <= 1.0:
+        raise ValueError(f"{name} must lie in [0, 1]")
+    return result
+
+
+def _nonnegative(value: object, *, name: str) -> float:
+    result = require_json_number(value, name=name)
+    if result < 0.0:
+        raise ValueError(f"{name} must be non-negative")
+    return result
+
+
+def _positive(value: object, *, name: str) -> float:
+    result = require_json_number(value, name=name)
+    if result <= 0.0:
+        raise ValueError(f"{name} must be positive")
+    return result
+
+
+def _optional_string(value: object, *, name: str) -> str | None:
+    if value is None:
+        return None
+    return require_exact_string(value, name=name)
+
+
+def _sorted_unique_strings(
+    value: object,
+    *,
+    name: str,
+    allow_empty: bool,
+) -> tuple[str, ...]:
+    if type(value) is not tuple:
+        raise ValueError(f"{name} must be a canonical tuple")
+    result = tuple(
+        require_exact_string(item, name=f"{name}[{index}]")
+        for index, item in enumerate(value)
+    )
+    if not allow_empty and not result:
+        raise ValueError(f"{name} must not be empty")
+    if result != tuple(sorted(result)) or len(result) != len(set(result)):
+        raise ValueError(f"{name} must be sorted and unique")
+    return result
+
+
+def _strings_from_json(value: object, *, name: str, allow_empty: bool) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise ValueError(f"{name} must be a JSON array")
+    return _sorted_unique_strings(tuple(value), name=name, allow_empty=allow_empty)
+
+
+def _canonical_json_bytes(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        plain_json(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _sha256_json(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json_bytes(value)).hexdigest()
+
+
+def _atomic_write_json(
+    path: str | Path,
+    value: Mapping[str, Any],
+    *,
+    overwrite: bool,
+) -> None:
+    destination = Path(path)
+    if type(overwrite) is not bool:
+        raise ValueError("overwrite must be a Boolean")
+    if destination.exists() and not overwrite:
+        raise FileExistsError(destination)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(
+        plain_json(value),
+        sort_keys=True,
+        indent=2,
+        allow_nan=False,
+    ) + "\n"
+    temporary = destination.with_name(
+        f".{destination.name}.tmp-{os.getpid()}-"
+        f"{hashlib.sha256(payload.encode()).hexdigest()[:16]}"
+    )
+    try:
+        with temporary.open("x", encoding="utf-8") as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        if destination.exists() and not overwrite:
+            raise FileExistsError(destination)
+        os.replace(temporary, destination)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+@dataclass(frozen=True, slots=True)
+class SourceProviderCompetencePolicyV1:
+    """Frozen equal-group source-competence decision policy."""
+
+    minimum_evaluable_groups: int
+    maximum_technical_failures: int
+    permitted_technical_failure_codes: tuple[str, ...]
+    maximum_mean_proper_score_delta: float
+    maximum_mean_point_rmse_ratio: float
+    maximum_mean_endpoint_rmse_ratio: float
+    maximum_worst_group_point_rmse_ratio: float
+    maximum_mean_absolute_drift_slope_m_per_frame: float
+    maximum_mean_seam_rmse_m: float
+    minimum_mean_quality_group_pass_fraction: float
+    minimum_mean_association_precision: float
+    minimum_mean_identity_retention: float
+    minimum_mean_support_retention: float
+    minimum_identity_group_pass_fraction: float
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "minimum_evaluable_groups",
+            require_exact_integer(
+                self.minimum_evaluable_groups,
+                name="minimum_evaluable_groups",
+                minimum=1,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "maximum_technical_failures",
+            require_exact_integer(
+                self.maximum_technical_failures,
+                name="maximum_technical_failures",
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "permitted_technical_failure_codes",
+            _sorted_unique_strings(
+                self.permitted_technical_failure_codes,
+                name="permitted_technical_failure_codes",
+                allow_empty=True,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "maximum_mean_proper_score_delta",
+            require_json_number(
+                self.maximum_mean_proper_score_delta,
+                name="maximum_mean_proper_score_delta",
+            ),
+        )
+        for name in (
+            "maximum_mean_point_rmse_ratio",
+            "maximum_mean_endpoint_rmse_ratio",
+            "maximum_worst_group_point_rmse_ratio",
+        ):
+            object.__setattr__(self, name, _positive(getattr(self, name), name=name))
+        for name in (
+            "maximum_mean_absolute_drift_slope_m_per_frame",
+            "maximum_mean_seam_rmse_m",
+        ):
+            object.__setattr__(self, name, _nonnegative(getattr(self, name), name=name))
+        for name in (
+            "minimum_mean_quality_group_pass_fraction",
+            "minimum_mean_association_precision",
+            "minimum_mean_identity_retention",
+            "minimum_mean_support_retention",
+            "minimum_identity_group_pass_fraction",
+        ):
+            object.__setattr__(self, name, _probability(getattr(self, name), name=name))
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "minimum_evaluable_groups": self.minimum_evaluable_groups,
+            "maximum_technical_failures": self.maximum_technical_failures,
+            "permitted_technical_failure_codes": list(
+                self.permitted_technical_failure_codes
+            ),
+            "maximum_mean_proper_score_delta": self.maximum_mean_proper_score_delta,
+            "maximum_mean_point_rmse_ratio": self.maximum_mean_point_rmse_ratio,
+            "maximum_mean_endpoint_rmse_ratio": self.maximum_mean_endpoint_rmse_ratio,
+            "maximum_worst_group_point_rmse_ratio": (
+                self.maximum_worst_group_point_rmse_ratio
+            ),
+            "maximum_mean_absolute_drift_slope_m_per_frame": (
+                self.maximum_mean_absolute_drift_slope_m_per_frame
+            ),
+            "maximum_mean_seam_rmse_m": self.maximum_mean_seam_rmse_m,
+            "minimum_mean_quality_group_pass_fraction": (
+                self.minimum_mean_quality_group_pass_fraction
+            ),
+            "minimum_mean_association_precision": (
+                self.minimum_mean_association_precision
+            ),
+            "minimum_mean_identity_retention": self.minimum_mean_identity_retention,
+            "minimum_mean_support_retention": self.minimum_mean_support_retention,
+            "minimum_identity_group_pass_fraction": (
+                self.minimum_identity_group_pass_fraction
+            ),
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> SourceProviderCompetencePolicyV1:
+        mapping = require_mapping(value, name="source competence policy")
+        require_exact_fields(mapping, _POLICY_FIELDS, name="source competence policy")
+        return cls(
+            minimum_evaluable_groups=mapping["minimum_evaluable_groups"],
+            maximum_technical_failures=mapping["maximum_technical_failures"],
+            permitted_technical_failure_codes=_strings_from_json(
+                mapping["permitted_technical_failure_codes"],
+                name="permitted_technical_failure_codes",
+                allow_empty=True,
+            ),
+            maximum_mean_proper_score_delta=mapping[
+                "maximum_mean_proper_score_delta"
+            ],
+            maximum_mean_point_rmse_ratio=mapping[
+                "maximum_mean_point_rmse_ratio"
+            ],
+            maximum_mean_endpoint_rmse_ratio=mapping[
+                "maximum_mean_endpoint_rmse_ratio"
+            ],
+            maximum_worst_group_point_rmse_ratio=mapping[
+                "maximum_worst_group_point_rmse_ratio"
+            ],
+            maximum_mean_absolute_drift_slope_m_per_frame=mapping[
+                "maximum_mean_absolute_drift_slope_m_per_frame"
+            ],
+            maximum_mean_seam_rmse_m=mapping["maximum_mean_seam_rmse_m"],
+            minimum_mean_quality_group_pass_fraction=mapping[
+                "minimum_mean_quality_group_pass_fraction"
+            ],
+            minimum_mean_association_precision=mapping[
+                "minimum_mean_association_precision"
+            ],
+            minimum_mean_identity_retention=mapping[
+                "minimum_mean_identity_retention"
+            ],
+            minimum_mean_support_retention=mapping[
+                "minimum_mean_support_retention"
+            ],
+            minimum_identity_group_pass_fraction=mapping[
+                "minimum_identity_group_pass_fraction"
+            ],
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SourceProviderGroupResultV1:
+    """One complete object/session source result."""
+
+    group_id: str
+    candidate_proper_score: float | None
+    baseline_proper_score: float | None
+    candidate_point_rmse_m: float | None
+    baseline_point_rmse_m: float | None
+    candidate_endpoint_rmse_m: float | None
+    baseline_endpoint_rmse_m: float | None
+    absolute_drift_slope_m_per_frame: float | None
+    seam_rmse_m: float | None
+    association_precision: float | None
+    identity_retention: float | None
+    support_retention: float | None
+    technical_failure_code: str | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "group_id",
+            require_exact_string(self.group_id, name="group_id"),
+        )
+        failure = _optional_string(
+            self.technical_failure_code,
+            name="technical_failure_code",
+        )
+        metric_names = (
+            "candidate_proper_score",
+            "baseline_proper_score",
+            "candidate_point_rmse_m",
+            "baseline_point_rmse_m",
+            "candidate_endpoint_rmse_m",
+            "baseline_endpoint_rmse_m",
+            "absolute_drift_slope_m_per_frame",
+            "seam_rmse_m",
+            "association_precision",
+            "identity_retention",
+            "support_retention",
+        )
+        if failure is not None:
+            if any(getattr(self, name) is not None for name in metric_names):
+                raise ValueError("technical-failure groups must not contain scored metrics")
+        else:
+            if any(getattr(self, name) is None for name in metric_names):
+                raise ValueError("evaluable groups require every scored metric")
+            for name in ("candidate_proper_score", "baseline_proper_score"):
+                object.__setattr__(
+                    self,
+                    name,
+                    require_json_number(getattr(self, name), name=name),
+                )
+            for name in (
+                "candidate_point_rmse_m",
+                "candidate_endpoint_rmse_m",
+                "absolute_drift_slope_m_per_frame",
+                "seam_rmse_m",
+            ):
+                object.__setattr__(
+                    self,
+                    name,
+                    _nonnegative(getattr(self, name), name=name),
+                )
+            for name in ("baseline_point_rmse_m", "baseline_endpoint_rmse_m"):
+                object.__setattr__(
+                    self,
+                    name,
+                    _positive(getattr(self, name), name=name),
+                )
+            for name in (
+                "association_precision",
+                "identity_retention",
+                "support_retention",
+            ):
+                object.__setattr__(
+                    self,
+                    name,
+                    _probability(getattr(self, name), name=name),
+                )
+        object.__setattr__(self, "technical_failure_code", failure)
+        object.__setattr__(
+            self,
+            "metadata",
+            frozen_finite_json_mapping(self.metadata, name="group metadata"),
+        )
+
+    @property
+    def evaluable(self) -> bool:
+        return self.technical_failure_code is None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "group_id": self.group_id,
+            "candidate_proper_score": self.candidate_proper_score,
+            "baseline_proper_score": self.baseline_proper_score,
+            "candidate_point_rmse_m": self.candidate_point_rmse_m,
+            "baseline_point_rmse_m": self.baseline_point_rmse_m,
+            "candidate_endpoint_rmse_m": self.candidate_endpoint_rmse_m,
+            "baseline_endpoint_rmse_m": self.baseline_endpoint_rmse_m,
+            "absolute_drift_slope_m_per_frame": (
+                self.absolute_drift_slope_m_per_frame
+            ),
+            "seam_rmse_m": self.seam_rmse_m,
+            "association_precision": self.association_precision,
+            "identity_retention": self.identity_retention,
+            "support_retention": self.support_retention,
+            "technical_failure_code": self.technical_failure_code,
+            "metadata": plain_json(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> SourceProviderGroupResultV1:
+        mapping = require_mapping(value, name="source provider group")
+        require_exact_fields(mapping, _GROUP_FIELDS, name="source provider group")
+        return cls(
+            group_id=mapping["group_id"],
+            candidate_proper_score=mapping["candidate_proper_score"],
+            baseline_proper_score=mapping["baseline_proper_score"],
+            candidate_point_rmse_m=mapping["candidate_point_rmse_m"],
+            baseline_point_rmse_m=mapping["baseline_point_rmse_m"],
+            candidate_endpoint_rmse_m=mapping["candidate_endpoint_rmse_m"],
+            baseline_endpoint_rmse_m=mapping["baseline_endpoint_rmse_m"],
+            absolute_drift_slope_m_per_frame=mapping[
+                "absolute_drift_slope_m_per_frame"
+            ],
+            seam_rmse_m=mapping["seam_rmse_m"],
+            association_precision=mapping["association_precision"],
+            identity_retention=mapping["identity_retention"],
+            support_retention=mapping["support_retention"],
+            technical_failure_code=mapping["technical_failure_code"],
+            metadata=require_finite_json_mapping(
+                mapping["metadata"], name="group metadata"
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SourceProviderCompetenceReportV1:
+    """Replay-complete equal-group source competence decision."""
+
+    provider_manifest_id: str
+    cohort_binding_id: str
+    group_definition: str
+    policy: SourceProviderCompetencePolicyV1
+    groups: tuple[SourceProviderGroupResultV1, ...]
+    source_truth_used: bool = True
+    target_payloads_opened: bool = False
+    target_outcomes_opened: bool = False
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    group_count: int = field(init=False)
+    technical_failure_count: int = field(init=False)
+    evaluable_group_count: int = field(init=False)
+    technical_integrity_pass: bool = field(init=False)
+    mean_proper_score_delta: float | None = field(init=False)
+    mean_point_rmse_ratio: float | None = field(init=False)
+    mean_endpoint_rmse_ratio: float | None = field(init=False)
+    worst_group_point_rmse_ratio: float | None = field(init=False)
+    mean_absolute_drift_slope_m_per_frame: float | None = field(init=False)
+    mean_seam_rmse_m: float | None = field(init=False)
+    mean_association_precision: float | None = field(init=False)
+    mean_identity_retention: float | None = field(init=False)
+    mean_support_retention: float | None = field(init=False)
+    mean_quality_group_pass_fraction: float | None = field(init=False)
+    identity_group_pass_fraction: float | None = field(init=False)
+    mean_quality_status: GateStatus = field(init=False)
+    identity_reliability_status: GateStatus = field(init=False)
+    mean_quality_reasons: tuple[str, ...] = field(init=False)
+    identity_reliability_reasons: tuple[str, ...] = field(init=False)
+    source_competence_pass: bool = field(init=False)
+    source_provider_competence_id: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        provider_id = require_sha256(
+            self.provider_manifest_id,
+            name="provider_manifest_id",
+        )
+        cohort_id = require_sha256(self.cohort_binding_id, name="cohort_binding_id")
+        group_definition = require_exact_string(
+            self.group_definition,
+            name="group_definition",
+        )
+        if not isinstance(self.policy, SourceProviderCompetencePolicyV1):
+            raise TypeError("policy must be SourceProviderCompetencePolicyV1")
+        if type(self.groups) is not tuple or not self.groups:
+            raise ValueError("groups must be a nonempty canonical tuple")
+        if any(not isinstance(item, SourceProviderGroupResultV1) for item in self.groups):
+            raise TypeError("groups must contain SourceProviderGroupResultV1 values")
+        groups = tuple(sorted(self.groups, key=lambda item: item.group_id))
+        if tuple(item.group_id for item in groups) != tuple(
+            sorted({item.group_id for item in groups})
+        ):
+            raise ValueError("group IDs must be unique")
+        source_truth_used = _strict_bool(self.source_truth_used, name="source_truth_used")
+        target_payloads_opened = _strict_bool(
+            self.target_payloads_opened,
+            name="target_payloads_opened",
+        )
+        target_outcomes_opened = _strict_bool(
+            self.target_outcomes_opened,
+            name="target_outcomes_opened",
+        )
+        if not source_truth_used:
+            raise ValueError("source competence scoring requires declared source truth")
+        if target_payloads_opened or target_outcomes_opened:
+            raise ValueError("source competence evidence must remain target closed")
+        metadata = frozen_finite_json_mapping(self.metadata, name="report metadata")
+
+        technical = tuple(item for item in groups if not item.evaluable)
+        evaluable = tuple(item for item in groups if item.evaluable)
+        permitted = set(self.policy.permitted_technical_failure_codes)
+        unknown_failures = tuple(
+            item.technical_failure_code
+            for item in technical
+            if item.technical_failure_code not in permitted
+        )
+        technical_integrity = (
+            len(technical) <= self.policy.maximum_technical_failures
+            and not unknown_failures
+        )
+
+        metrics = self._aggregate(evaluable)
+        mean_reasons: list[str] = []
+        identity_reasons: list[str] = []
+        if not technical_integrity:
+            if len(technical) > self.policy.maximum_technical_failures:
+                mean_reasons.append("technical-failure-budget-exceeded")
+                identity_reasons.append("technical-failure-budget-exceeded")
+            if unknown_failures:
+                mean_reasons.append("unpermitted-technical-failure-code")
+                identity_reasons.append("unpermitted-technical-failure-code")
+        if len(evaluable) < self.policy.minimum_evaluable_groups:
+            mean_reasons.append("insufficient-evaluable-groups")
+            identity_reasons.append("insufficient-evaluable-groups")
+
+        if evaluable:
+            assert metrics["mean_proper_score_delta"] is not None
+            assert metrics["mean_point_rmse_ratio"] is not None
+            assert metrics["mean_endpoint_rmse_ratio"] is not None
+            assert metrics["worst_group_point_rmse_ratio"] is not None
+            assert metrics["mean_absolute_drift_slope_m_per_frame"] is not None
+            assert metrics["mean_seam_rmse_m"] is not None
+            assert metrics["mean_quality_group_pass_fraction"] is not None
+            assert metrics["mean_association_precision"] is not None
+            assert metrics["mean_identity_retention"] is not None
+            assert metrics["mean_support_retention"] is not None
+            assert metrics["identity_group_pass_fraction"] is not None
+            if (
+                metrics["mean_proper_score_delta"]
+                > self.policy.maximum_mean_proper_score_delta
+            ):
+                mean_reasons.append("mean-proper-score-regression")
+            if (
+                metrics["mean_point_rmse_ratio"]
+                > self.policy.maximum_mean_point_rmse_ratio
+            ):
+                mean_reasons.append("mean-point-rmse-regression")
+            if (
+                metrics["mean_endpoint_rmse_ratio"]
+                > self.policy.maximum_mean_endpoint_rmse_ratio
+            ):
+                mean_reasons.append("mean-endpoint-rmse-regression")
+            if (
+                metrics["worst_group_point_rmse_ratio"]
+                > self.policy.maximum_worst_group_point_rmse_ratio
+            ):
+                mean_reasons.append("worst-group-point-rmse-regression")
+            if (
+                metrics["mean_absolute_drift_slope_m_per_frame"]
+                > self.policy.maximum_mean_absolute_drift_slope_m_per_frame
+            ):
+                mean_reasons.append("drift-slope-exceeded")
+            if metrics["mean_seam_rmse_m"] > self.policy.maximum_mean_seam_rmse_m:
+                mean_reasons.append("seam-error-exceeded")
+            if (
+                metrics["mean_quality_group_pass_fraction"]
+                < self.policy.minimum_mean_quality_group_pass_fraction
+            ):
+                mean_reasons.append("mean-quality-group-pass-fraction-below-minimum")
+            if (
+                metrics["mean_association_precision"]
+                < self.policy.minimum_mean_association_precision
+            ):
+                identity_reasons.append("association-precision-below-minimum")
+            if (
+                metrics["mean_identity_retention"]
+                < self.policy.minimum_mean_identity_retention
+            ):
+                identity_reasons.append("identity-retention-below-minimum")
+            if (
+                metrics["mean_support_retention"]
+                < self.policy.minimum_mean_support_retention
+            ):
+                identity_reasons.append("support-retention-below-minimum")
+            if (
+                metrics["identity_group_pass_fraction"]
+                < self.policy.minimum_identity_group_pass_fraction
+            ):
+                identity_reasons.append("identity-group-pass-fraction-below-minimum")
+
+        mean_status: GateStatus
+        identity_status: GateStatus
+        if not technical_integrity:
+            mean_status = "technical-failure"
+            identity_status = "technical-failure"
+        else:
+            mean_status = "pass" if not mean_reasons else "fail"
+            identity_status = "pass" if not identity_reasons else "fail"
+
+        object.__setattr__(self, "provider_manifest_id", provider_id)
+        object.__setattr__(self, "cohort_binding_id", cohort_id)
+        object.__setattr__(self, "group_definition", group_definition)
+        object.__setattr__(self, "groups", groups)
+        object.__setattr__(self, "source_truth_used", source_truth_used)
+        object.__setattr__(self, "target_payloads_opened", target_payloads_opened)
+        object.__setattr__(self, "target_outcomes_opened", target_outcomes_opened)
+        object.__setattr__(self, "metadata", metadata)
+        object.__setattr__(self, "group_count", len(groups))
+        object.__setattr__(self, "technical_failure_count", len(technical))
+        object.__setattr__(self, "evaluable_group_count", len(evaluable))
+        object.__setattr__(self, "technical_integrity_pass", technical_integrity)
+        for name, value in metrics.items():
+            object.__setattr__(self, name, value)
+        object.__setattr__(self, "mean_quality_status", mean_status)
+        object.__setattr__(self, "identity_reliability_status", identity_status)
+        object.__setattr__(self, "mean_quality_reasons", tuple(sorted(mean_reasons)))
+        object.__setattr__(
+            self,
+            "identity_reliability_reasons",
+            tuple(sorted(identity_reasons)),
+        )
+        object.__setattr__(
+            self,
+            "source_competence_pass",
+            mean_status == "pass" and identity_status == "pass",
+        )
+        object.__setattr__(
+            self,
+            "source_provider_competence_id",
+            _sha256_json(self._content_dict()),
+        )
+
+    def _aggregate(
+        self,
+        groups: tuple[SourceProviderGroupResultV1, ...],
+    ) -> dict[str, float | None]:
+        names = {
+            "mean_proper_score_delta",
+            "mean_point_rmse_ratio",
+            "mean_endpoint_rmse_ratio",
+            "worst_group_point_rmse_ratio",
+            "mean_absolute_drift_slope_m_per_frame",
+            "mean_seam_rmse_m",
+            "mean_association_precision",
+            "mean_identity_retention",
+            "mean_support_retention",
+            "mean_quality_group_pass_fraction",
+            "identity_group_pass_fraction",
+        }
+        if not groups:
+            return {name: None for name in names}
+
+        proper_deltas = []
+        point_ratios = []
+        endpoint_ratios = []
+        mean_quality_pass = []
+        identity_pass = []
+        drifts = []
+        seams = []
+        associations = []
+        identities = []
+        supports = []
+        for group in groups:
+            assert group.candidate_proper_score is not None
+            assert group.baseline_proper_score is not None
+            assert group.candidate_point_rmse_m is not None
+            assert group.baseline_point_rmse_m is not None
+            assert group.candidate_endpoint_rmse_m is not None
+            assert group.baseline_endpoint_rmse_m is not None
+            assert group.absolute_drift_slope_m_per_frame is not None
+            assert group.seam_rmse_m is not None
+            assert group.association_precision is not None
+            assert group.identity_retention is not None
+            assert group.support_retention is not None
+            proper_delta = group.candidate_proper_score - group.baseline_proper_score
+            point_ratio = group.candidate_point_rmse_m / group.baseline_point_rmse_m
+            endpoint_ratio = (
+                group.candidate_endpoint_rmse_m / group.baseline_endpoint_rmse_m
+            )
+            proper_deltas.append(proper_delta)
+            point_ratios.append(point_ratio)
+            endpoint_ratios.append(endpoint_ratio)
+            drifts.append(group.absolute_drift_slope_m_per_frame)
+            seams.append(group.seam_rmse_m)
+            associations.append(group.association_precision)
+            identities.append(group.identity_retention)
+            supports.append(group.support_retention)
+            mean_quality_pass.append(
+                proper_delta <= self.policy.maximum_mean_proper_score_delta
+                and point_ratio <= self.policy.maximum_worst_group_point_rmse_ratio
+                and endpoint_ratio <= self.policy.maximum_mean_endpoint_rmse_ratio
+                and group.absolute_drift_slope_m_per_frame
+                <= self.policy.maximum_mean_absolute_drift_slope_m_per_frame
+                and group.seam_rmse_m <= self.policy.maximum_mean_seam_rmse_m
+            )
+            identity_pass.append(
+                group.association_precision
+                >= self.policy.minimum_mean_association_precision
+                and group.identity_retention
+                >= self.policy.minimum_mean_identity_retention
+                and group.support_retention
+                >= self.policy.minimum_mean_support_retention
+            )
+        return {
+            "mean_proper_score_delta": float(np.mean(proper_deltas)),
+            "mean_point_rmse_ratio": float(np.mean(point_ratios)),
+            "mean_endpoint_rmse_ratio": float(np.mean(endpoint_ratios)),
+            "worst_group_point_rmse_ratio": float(np.max(point_ratios)),
+            "mean_absolute_drift_slope_m_per_frame": float(np.mean(drifts)),
+            "mean_seam_rmse_m": float(np.mean(seams)),
+            "mean_association_precision": float(np.mean(associations)),
+            "mean_identity_retention": float(np.mean(identities)),
+            "mean_support_retention": float(np.mean(supports)),
+            "mean_quality_group_pass_fraction": float(np.mean(mean_quality_pass)),
+            "identity_group_pass_fraction": float(np.mean(identity_pass)),
+        }
+
+    def _content_dict(self) -> dict[str, object]:
+        return {
+            "schema": SOURCE_PROVIDER_COMPETENCE_SCHEMA,
+            "schema_version": SOURCE_PROVIDER_COMPETENCE_VERSION,
+            "provider_manifest_id": self.provider_manifest_id,
+            "cohort_binding_id": self.cohort_binding_id,
+            "group_definition": self.group_definition,
+            "policy": self.policy.to_dict(),
+            "groups": [item.to_dict() for item in self.groups],
+            "source_truth_used": self.source_truth_used,
+            "target_payloads_opened": self.target_payloads_opened,
+            "target_outcomes_opened": self.target_outcomes_opened,
+            "group_count": self.group_count,
+            "technical_failure_count": self.technical_failure_count,
+            "evaluable_group_count": self.evaluable_group_count,
+            "technical_integrity_pass": self.technical_integrity_pass,
+            "mean_proper_score_delta": self.mean_proper_score_delta,
+            "mean_point_rmse_ratio": self.mean_point_rmse_ratio,
+            "mean_endpoint_rmse_ratio": self.mean_endpoint_rmse_ratio,
+            "worst_group_point_rmse_ratio": self.worst_group_point_rmse_ratio,
+            "mean_absolute_drift_slope_m_per_frame": (
+                self.mean_absolute_drift_slope_m_per_frame
+            ),
+            "mean_seam_rmse_m": self.mean_seam_rmse_m,
+            "mean_association_precision": self.mean_association_precision,
+            "mean_identity_retention": self.mean_identity_retention,
+            "mean_support_retention": self.mean_support_retention,
+            "mean_quality_group_pass_fraction": (
+                self.mean_quality_group_pass_fraction
+            ),
+            "identity_group_pass_fraction": self.identity_group_pass_fraction,
+            "mean_quality_status": self.mean_quality_status,
+            "identity_reliability_status": self.identity_reliability_status,
+            "mean_quality_reasons": list(self.mean_quality_reasons),
+            "identity_reliability_reasons": list(
+                self.identity_reliability_reasons
+            ),
+            "source_competence_pass": self.source_competence_pass,
+            "metadata": plain_json(self.metadata),
+            "claim_boundary": SOURCE_PROVIDER_COMPETENCE_CLAIM_BOUNDARY,
+        }
+
+    def to_dict(self) -> dict[str, object]:
+        result = self._content_dict()
+        result["source_provider_competence_id"] = self.source_provider_competence_id
+        return result
+
+    @classmethod
+    def from_dict(cls, value: object) -> SourceProviderCompetenceReportV1:
+        mapping = require_mapping(value, name="source provider competence report")
+        require_exact_fields(
+            mapping,
+            _REPORT_FIELDS,
+            name="source provider competence report",
+        )
+        if mapping["schema"] != SOURCE_PROVIDER_COMPETENCE_SCHEMA:
+            raise ValueError("source provider competence schema changed")
+        if mapping["schema_version"] != SOURCE_PROVIDER_COMPETENCE_VERSION:
+            raise ValueError("source provider competence version changed")
+        if mapping["claim_boundary"] != SOURCE_PROVIDER_COMPETENCE_CLAIM_BOUNDARY:
+            raise ValueError("source provider competence claim boundary changed")
+        raw_groups = mapping["groups"]
+        if not isinstance(raw_groups, list):
+            raise ValueError("groups must be a JSON array")
+        result = cls(
+            provider_manifest_id=mapping["provider_manifest_id"],
+            cohort_binding_id=mapping["cohort_binding_id"],
+            group_definition=mapping["group_definition"],
+            policy=SourceProviderCompetencePolicyV1.from_dict(mapping["policy"]),
+            groups=tuple(SourceProviderGroupResultV1.from_dict(item) for item in raw_groups),
+            source_truth_used=mapping["source_truth_used"],
+            target_payloads_opened=mapping["target_payloads_opened"],
+            target_outcomes_opened=mapping["target_outcomes_opened"],
+            metadata=require_finite_json_mapping(
+                mapping["metadata"],
+                name="report metadata",
+            ),
+        )
+        if plain_json(result.to_dict()) != plain_json(mapping):
+            raise ValueError("source provider competence derived fields changed")
+        return result
+
+
+def write_source_provider_competence(
+    path: str | Path,
+    report: SourceProviderCompetenceReportV1,
+    *,
+    overwrite: bool = False,
+) -> None:
+    if not isinstance(report, SourceProviderCompetenceReportV1):
+        raise TypeError("report must be SourceProviderCompetenceReportV1")
+    _atomic_write_json(path, report.to_dict(), overwrite=overwrite)
+
+
+def load_source_provider_competence(
+    path: str | Path,
+) -> SourceProviderCompetenceReportV1:
+    return SourceProviderCompetenceReportV1.from_dict(
+        load_json_object(path, name="source provider competence report")
+    )
+
+
+__all__ = [
+    "SOURCE_PROVIDER_COMPETENCE_CLAIM_BOUNDARY",
+    "SOURCE_PROVIDER_COMPETENCE_SCHEMA",
+    "SOURCE_PROVIDER_COMPETENCE_VERSION",
+    "SourceProviderCompetencePolicyV1",
+    "SourceProviderCompetenceReportV1",
+    "SourceProviderGroupResultV1",
+    "load_source_provider_competence",
+    "write_source_provider_competence",
+]

--- a/tests/test_fresh_provider_readiness.py
+++ b/tests/test_fresh_provider_readiness.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+import pytest
+
+from prob4d.fresh_provider_readiness import (
+    FreshProviderCohortLockV1,
+    FreshProviderReadinessRequestV1,
+    ReadinessGateV1,
+    authorize_fresh_provider_target,
+    evaluate_fresh_provider_readiness,
+    load_fresh_provider_readiness_decision,
+    load_fresh_provider_readiness_request,
+    load_fresh_provider_target_authorization,
+    source_competence_gates,
+    unevaluated_gate,
+    write_fresh_provider_readiness_decision,
+    write_fresh_provider_readiness_request,
+    write_fresh_provider_target_authorization,
+)
+from prob4d.source_provider_competence import (
+    SourceProviderCompetencePolicyV1,
+    SourceProviderCompetenceReportV1,
+    SourceProviderGroupResultV1,
+)
+
+GATE_NAMES = (
+    "support-feasibility",
+    "source-mean",
+    "identity-reliability",
+    "gauge-dependence",
+    "point-covariance",
+    "query-relevance",
+    "exact-fallback",
+)
+
+
+def _lock() -> FreshProviderCohortLockV1:
+    return FreshProviderCohortLockV1(
+        protocol_id="fresh-provider-v1",
+        source_repository="IPS-Stuttgart/Prob4D",
+        source_revision="a" * 40,
+        provider_repository="example/provider",
+        provider_revision="b" * 40,
+        model_set_id="1" * 64,
+        loader_id="2" * 64,
+        cohort_binding_id="3" * 64,
+        promotion_lock_id="4" * 64,
+        query_definition_id="5" * 64,
+        fallback_identity_id="6" * 64,
+        development_group_ids=("dev-1", "dev-2"),
+        calibration_group_ids=("cal-1", "cal-2"),
+        target_group_ids=("target-1", "target-2"),
+        confirmation_group_ids=("confirm-1",),
+    )
+
+
+def _pass(name: str, digit: str) -> ReadinessGateV1:
+    return ReadinessGateV1(
+        gate_name=name,
+        status="pass",
+        evidence_id=digit * 64,
+    )
+
+
+def _request(gates: tuple[ReadinessGateV1, ...]) -> FreshProviderReadinessRequestV1:
+    return FreshProviderReadinessRequestV1(cohort_lock=_lock(), gates=gates)
+
+
+def _all_pass() -> tuple[ReadinessGateV1, ...]:
+    return tuple(_pass(name, str(index + 1)) for index, name in enumerate(GATE_NAMES))
+
+
+def _terminal_request(
+    index: int,
+    *,
+    status: str = "fail",
+) -> FreshProviderReadinessRequestV1:
+    gates = []
+    for position, name in enumerate(GATE_NAMES):
+        if position < index:
+            gates.append(_pass(name, str(position + 1)))
+        elif position == index:
+            gates.append(
+                ReadinessGateV1(
+                    gate_name=name,
+                    status=status,
+                    evidence_id="f" * 64,
+                    reason_codes=("registered-failure",),
+                )
+            )
+        else:
+            gates.append(unevaluated_gate(name))
+    return _request(tuple(gates))
+
+
+def test_all_pass_authorizes_exactly_one_target_evaluation() -> None:
+    decision = evaluate_fresh_provider_readiness(_request(_all_pass()))
+
+    assert decision.classification == "ready-for-one-target-evaluation"
+    assert decision.authorize_target_evaluation
+    assert not decision.authorize_point_uncertainty_development
+    assert decision.target_evaluation_budget == 1
+
+    authorization = authorize_fresh_provider_target(decision)
+    assert authorization.target_group_ids == ("target-1", "target-2")
+    assert authorization.target_evaluation_budget == 1
+
+
+@pytest.mark.parametrize(
+    ("index", "classification"),
+    (
+        (0, "support-negative"),
+        (1, "source-mean-negative"),
+        (2, "identity-or-association-negative"),
+        (3, "gauge-or-dependence-negative"),
+        (4, "point-covariance-localized"),
+        (5, "query-irrelevant-or-nonidentifiable"),
+        (6, "technical-failure"),
+    ),
+)
+def test_each_gate_has_one_terminal_classification(
+    index: int,
+    classification: str,
+) -> None:
+    decision = evaluate_fresh_provider_readiness(_terminal_request(index))
+
+    assert decision.classification == classification
+    assert decision.authorize_point_uncertainty_development == (
+        classification == "point-covariance-localized"
+    )
+    assert not decision.authorize_target_evaluation
+    assert decision.target_evaluation_budget == 0
+
+
+@pytest.mark.parametrize("index", range(len(GATE_NAMES)))
+def test_technical_failure_stops_at_exact_stage(index: int) -> None:
+    decision = evaluate_fresh_provider_readiness(
+        _terminal_request(index, status="technical-failure")
+    )
+
+    assert decision.classification == "technical-failure"
+    assert decision.terminal_gate == GATE_NAMES[index]
+
+
+def test_downstream_evidence_after_terminal_failure_is_rejected() -> None:
+    gates = list(_terminal_request(1).gates)
+    gates[2] = _pass("identity-reliability", "9")
+    with pytest.raises(ValueError, match="must remain not-evaluated"):
+        evaluate_fresh_provider_readiness(_request(tuple(gates)))
+
+
+def test_missing_gate_after_pass_is_not_silently_interpreted() -> None:
+    gates = list(_all_pass())
+    gates[3] = unevaluated_gate("gauge-dependence")
+    with pytest.raises(ValueError, match="unevaluated"):
+        evaluate_fresh_provider_readiness(_request(tuple(gates)))
+
+
+def test_rosters_must_be_disjoint() -> None:
+    with pytest.raises(ValueError, match="overlap"):
+        replace(_lock(), target_group_ids=("dev-1", "target-2"))
+
+
+def _source_report(*, point_rmse: float = 0.9, association: float = 0.95):
+    policy = SourceProviderCompetencePolicyV1(
+        minimum_evaluable_groups=2,
+        maximum_technical_failures=0,
+        permitted_technical_failure_codes=(),
+        maximum_mean_proper_score_delta=0.0,
+        maximum_mean_point_rmse_ratio=1.0,
+        maximum_mean_endpoint_rmse_ratio=1.0,
+        maximum_worst_group_point_rmse_ratio=1.1,
+        maximum_mean_absolute_drift_slope_m_per_frame=0.02,
+        maximum_mean_seam_rmse_m=0.03,
+        minimum_mean_quality_group_pass_fraction=0.5,
+        minimum_mean_association_precision=0.9,
+        minimum_mean_identity_retention=0.8,
+        minimum_mean_support_retention=0.85,
+        minimum_identity_group_pass_fraction=0.5,
+    )
+
+    def group(group_id: str) -> SourceProviderGroupResultV1:
+        return SourceProviderGroupResultV1(
+            group_id=group_id,
+            candidate_proper_score=9.0,
+            baseline_proper_score=10.0,
+            candidate_point_rmse_m=point_rmse,
+            baseline_point_rmse_m=1.0,
+            candidate_endpoint_rmse_m=0.8,
+            baseline_endpoint_rmse_m=1.0,
+            absolute_drift_slope_m_per_frame=0.01,
+            seam_rmse_m=0.02,
+            association_precision=association,
+            identity_retention=0.9,
+            support_retention=0.95,
+        )
+
+    return SourceProviderCompetenceReportV1(
+        provider_manifest_id="a" * 64,
+        cohort_binding_id="b" * 64,
+        group_definition="complete-object-v1",
+        policy=policy,
+        groups=(group("source-a"), group("source-b")),
+    )
+
+
+def test_source_report_adapter_does_not_evaluate_identity_after_mean_failure() -> None:
+    mean_gate, identity_gate = source_competence_gates(_source_report(point_rmse=1.4))
+
+    assert mean_gate.status == "fail"
+    assert identity_gate.status == "not-evaluated"
+
+
+def test_source_report_adapter_retains_identity_failure() -> None:
+    mean_gate, identity_gate = source_competence_gates(_source_report(association=0.5))
+
+    assert mean_gate.status == "pass"
+    assert identity_gate.status == "fail"
+
+
+def test_round_trip_replays_request_decision_and_authorization(tmp_path) -> None:
+    request = _request(_all_pass())
+    decision = evaluate_fresh_provider_readiness(request)
+    authorization = authorize_fresh_provider_target(decision)
+    request_path = tmp_path / "request.json"
+    decision_path = tmp_path / "decision.json"
+    authorization_path = tmp_path / "authorization.json"
+
+    write_fresh_provider_readiness_request(request_path, request)
+    write_fresh_provider_readiness_decision(decision_path, decision)
+    write_fresh_provider_target_authorization(authorization_path, authorization)
+
+    assert load_fresh_provider_readiness_request(request_path).to_dict() == request.to_dict()
+    assert load_fresh_provider_readiness_decision(decision_path).to_dict() == decision.to_dict()
+    assert (
+        load_fresh_provider_target_authorization(authorization_path).to_dict()
+        == authorization.to_dict()
+    )
+
+    payload = json.loads(decision_path.read_text(encoding="utf-8"))
+    payload["target_evaluation_budget"] = 0
+    decision_path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError, match="authorization changed"):
+        load_fresh_provider_readiness_decision(decision_path)

--- a/tests/test_query_covariance_preservation.py
+++ b/tests/test_query_covariance_preservation.py
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from prob4d.query_covariance_preservation import (
+    QueryCovarianceCandidateV1,
+    QueryCovariancePreservationCertificateV1,
+    QueryCovariancePreservationPolicyV1,
+    load_query_covariance_preservation,
+    write_query_covariance_preservation,
+)
+
+
+def _policy(**overrides: float) -> QueryCovariancePreservationPolicyV1:
+    values = {
+        "relative_rank_tolerance": 1e-10,
+        "maximum_relative_trace_distortion": 0.1,
+        "maximum_relative_frobenius_distortion": 0.1,
+        "minimum_directional_variance_ratio": 0.9,
+        "maximum_directional_variance_ratio": 1.1,
+        "maximum_unsupported_trace_fraction": 0.0,
+    }
+    values.update(overrides)
+    return QueryCovariancePreservationPolicyV1(**values)
+
+
+def _candidate(
+    candidate_id: str,
+    covariance: np.ndarray,
+) -> QueryCovarianceCandidateV1:
+    return QueryCovarianceCandidateV1(
+        candidate_id=candidate_id,
+        representation=candidate_id,
+        covariance=covariance,
+        estimated_memory_bytes=128,
+        estimated_runtime_seconds=0.01,
+    )
+
+
+def _certificate(
+    reference: np.ndarray,
+    candidates: tuple[QueryCovarianceCandidateV1, ...],
+    *,
+    policy: QueryCovariancePreservationPolicyV1 | None = None,
+) -> QueryCovariancePreservationCertificateV1:
+    return QueryCovariancePreservationCertificateV1(
+        query_definition_id="1" * 64,
+        observation_artifact_id="2" * 64,
+        reference_representation="full-joint",
+        reference_covariance=reference,
+        policy=_policy() if policy is None else policy,
+        candidates=candidates,
+    )
+
+
+def test_exact_and_small_perturbation_preserve_query_covariance() -> None:
+    reference = np.diag([2.0, 1.0])
+    certificate = _certificate(
+        reference,
+        (
+            _candidate("exact", reference),
+            _candidate("near", np.diag([1.9, 1.0])),
+        ),
+    )
+
+    assert certificate.all_preserved
+    assert certificate.preserved_candidate_ids == ("exact", "near")
+    exact = certificate.results[0]
+    assert exact.minimum_directional_variance_ratio == pytest.approx(1.0)
+    assert exact.maximum_directional_variance_ratio_error == pytest.approx(0.0)
+
+
+def test_directional_understatement_fails_even_when_average_trace_is_close() -> None:
+    reference = np.eye(2)
+    candidate = np.diag([0.5, 1.5])
+    certificate = _certificate(reference, (_candidate("anisotropic", candidate),))
+
+    result = certificate.results[0]
+    assert not result.preserved
+    assert "directional-understatement-exceeded" in result.failure_reasons
+    assert "directional-overstatement-exceeded" in result.failure_reasons
+    assert result.relative_trace_distortion == pytest.approx(0.0)
+
+
+def test_nullspace_leakage_is_reported_separately() -> None:
+    reference = np.diag([2.0, 0.0])
+    candidate = np.diag([2.0, 1.0])
+    certificate = _certificate(reference, (_candidate("leaky", candidate),))
+
+    result = certificate.results[0]
+    assert result.minimum_directional_variance_ratio == pytest.approx(1.0)
+    assert result.unsupported_trace_fraction == pytest.approx(1.0 / 3.0)
+    assert "unsupported-query-trace-exceeded" in result.failure_reasons
+
+
+def test_from_projections_uses_total_covariance_only() -> None:
+    reference = SimpleNamespace(total_covariance=np.diag([2.0, 1.0]))
+    candidate = SimpleNamespace(total_covariance=np.diag([2.0, 1.0]))
+
+    certificate = QueryCovariancePreservationCertificateV1.from_projections(
+        query_definition_id="1" * 64,
+        observation_artifact_id="2" * 64,
+        reference_representation="full-joint",
+        reference_projection=reference,
+        candidate_projections={"tree-sparse": candidate},
+        policy=_policy(),
+    )
+
+    assert certificate.preserved_candidate_ids == ("tree-sparse",)
+
+
+def test_invalid_covariance_fails_closed() -> None:
+    with pytest.raises(ValueError, match="positive semidefinite"):
+        _candidate("bad", np.diag([1.0, -1.0]))
+    with pytest.raises(ValueError, match="positive trace"):
+        _certificate(np.zeros((2, 2)), (_candidate("zero", np.zeros((2, 2))),))
+
+
+def test_round_trip_recomputes_every_result(tmp_path) -> None:
+    reference = np.diag([2.0, 1.0])
+    certificate = _certificate(reference, (_candidate("exact", reference),))
+    path = tmp_path / "certificate.json"
+    write_query_covariance_preservation(path, certificate)
+
+    loaded = load_query_covariance_preservation(path)
+    assert loaded.to_dict() == certificate.to_dict()
+    with pytest.raises(FileExistsError):
+        write_query_covariance_preservation(path, certificate)
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["results"][0]["relative_trace_distortion"] = 0.5
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError, match="derived fields changed"):
+        load_query_covariance_preservation(path)

--- a/tests/test_source_provider_competence.py
+++ b/tests/test_source_provider_competence.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from prob4d.source_provider_competence import (
+    SourceProviderCompetencePolicyV1,
+    SourceProviderCompetenceReportV1,
+    SourceProviderGroupResultV1,
+    load_source_provider_competence,
+    write_source_provider_competence,
+)
+
+
+def _policy(**overrides: object) -> SourceProviderCompetencePolicyV1:
+    values: dict[str, object] = {
+        "minimum_evaluable_groups": 2,
+        "maximum_technical_failures": 0,
+        "permitted_technical_failure_codes": (),
+        "maximum_mean_proper_score_delta": 0.0,
+        "maximum_mean_point_rmse_ratio": 1.0,
+        "maximum_mean_endpoint_rmse_ratio": 1.0,
+        "maximum_worst_group_point_rmse_ratio": 1.1,
+        "maximum_mean_absolute_drift_slope_m_per_frame": 0.02,
+        "maximum_mean_seam_rmse_m": 0.03,
+        "minimum_mean_quality_group_pass_fraction": 0.5,
+        "minimum_mean_association_precision": 0.9,
+        "minimum_mean_identity_retention": 0.8,
+        "minimum_mean_support_retention": 0.85,
+        "minimum_identity_group_pass_fraction": 0.5,
+    }
+    values.update(overrides)
+    return SourceProviderCompetencePolicyV1(**values)
+
+
+def _group(group_id: str, **overrides: object) -> SourceProviderGroupResultV1:
+    values: dict[str, object] = {
+        "group_id": group_id,
+        "candidate_proper_score": 9.0,
+        "baseline_proper_score": 10.0,
+        "candidate_point_rmse_m": 0.9,
+        "baseline_point_rmse_m": 1.0,
+        "candidate_endpoint_rmse_m": 0.8,
+        "baseline_endpoint_rmse_m": 1.0,
+        "absolute_drift_slope_m_per_frame": 0.01,
+        "seam_rmse_m": 0.02,
+        "association_precision": 0.95,
+        "identity_retention": 0.9,
+        "support_retention": 0.95,
+    }
+    values.update(overrides)
+    return SourceProviderGroupResultV1(**values)
+
+
+def _failure(group_id: str, code: str) -> SourceProviderGroupResultV1:
+    return SourceProviderGroupResultV1(
+        group_id=group_id,
+        candidate_proper_score=None,
+        baseline_proper_score=None,
+        candidate_point_rmse_m=None,
+        baseline_point_rmse_m=None,
+        candidate_endpoint_rmse_m=None,
+        baseline_endpoint_rmse_m=None,
+        absolute_drift_slope_m_per_frame=None,
+        seam_rmse_m=None,
+        association_precision=None,
+        identity_retention=None,
+        support_retention=None,
+        technical_failure_code=code,
+    )
+
+
+def _report(
+    groups: tuple[SourceProviderGroupResultV1, ...],
+    *,
+    policy: SourceProviderCompetencePolicyV1 | None = None,
+) -> SourceProviderCompetenceReportV1:
+    return SourceProviderCompetenceReportV1(
+        provider_manifest_id="1" * 64,
+        cohort_binding_id="2" * 64,
+        group_definition="complete-physical-object-v1",
+        policy=_policy() if policy is None else policy,
+        groups=groups,
+        metadata={"split": "source-only"},
+    )
+
+
+def test_passing_report_separates_mean_and_identity_gates() -> None:
+    report = _report((_group("object-b"), _group("object-a")))
+
+    assert tuple(group.group_id for group in report.groups) == ("object-a", "object-b")
+    assert report.mean_quality_status == "pass"
+    assert report.identity_reliability_status == "pass"
+    assert report.source_competence_pass
+    assert report.mean_point_rmse_ratio == pytest.approx(0.9)
+    assert report.mean_endpoint_rmse_ratio == pytest.approx(0.8)
+    assert report.mean_quality_group_pass_fraction == 1.0
+    assert report.identity_group_pass_fraction == 1.0
+    assert len(report.source_provider_competence_id) == 64
+
+
+def test_mean_failure_is_not_relabelled_as_covariance_failure() -> None:
+    report = _report(
+        (
+            _group("object-a", candidate_point_rmse_m=1.4),
+            _group("object-b", candidate_point_rmse_m=1.3),
+        )
+    )
+
+    assert report.mean_quality_status == "fail"
+    assert "mean-point-rmse-regression" in report.mean_quality_reasons
+    assert report.identity_reliability_status == "pass"
+    assert not report.source_competence_pass
+
+
+def test_identity_failure_remains_separate_from_mean_quality() -> None:
+    report = _report(
+        (
+            _group("object-a", association_precision=0.5),
+            _group("object-b", identity_retention=0.4),
+        )
+    )
+
+    assert report.mean_quality_status == "pass"
+    assert report.identity_reliability_status == "fail"
+    assert "association-precision-below-minimum" in report.identity_reliability_reasons
+    assert "identity-retention-below-minimum" in report.identity_reliability_reasons
+
+
+def test_permitted_technical_failure_is_retained_but_not_scored() -> None:
+    policy = _policy(
+        maximum_technical_failures=1,
+        permitted_technical_failure_codes=("gpu-oom",),
+    )
+    report = _report(
+        (_group("object-a"), _group("object-b"), _failure("object-c", "gpu-oom")),
+        policy=policy,
+    )
+
+    assert report.group_count == 3
+    assert report.technical_failure_count == 1
+    assert report.evaluable_group_count == 2
+    assert report.technical_integrity_pass
+    assert report.source_competence_pass
+
+
+def test_unpermitted_technical_failure_is_a_technical_terminal() -> None:
+    report = _report(
+        (_group("object-a"), _group("object-b"), _failure("object-c", "gpu-oom"))
+    )
+
+    assert report.mean_quality_status == "technical-failure"
+    assert report.identity_reliability_status == "technical-failure"
+    assert "unpermitted-technical-failure-code" in report.mean_quality_reasons
+    assert not report.source_competence_pass
+
+
+def test_target_opening_is_rejected() -> None:
+    with pytest.raises(ValueError, match="target closed"):
+        SourceProviderCompetenceReportV1(
+            provider_manifest_id="1" * 64,
+            cohort_binding_id="2" * 64,
+            group_definition="complete-physical-object-v1",
+            policy=_policy(),
+            groups=(_group("object-a"), _group("object-b")),
+            target_payloads_opened=True,
+        )
+
+
+def test_technical_failure_group_cannot_mix_metrics() -> None:
+    with pytest.raises(ValueError, match="must not contain scored metrics"):
+        _group("object-a", technical_failure_code="gpu-oom")
+
+
+def test_round_trip_replays_all_derived_fields(tmp_path) -> None:
+    report = _report((_group("object-a"), _group("object-b")))
+    path = tmp_path / "report.json"
+    write_source_provider_competence(path, report)
+
+    loaded = load_source_provider_competence(path)
+    assert loaded.to_dict() == report.to_dict()
+    with pytest.raises(FileExistsError):
+        write_source_provider_competence(path, report)
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["mean_point_rmse_ratio"] = 999.0
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError, match="derived fields changed"):
+        load_source_provider_competence(path)


### PR DESCRIPTION
## What changed

- add a source-only provider competence artifact that evaluates complete object/session units and separates observation-mean quality from identity/reliability quality;
- add a target-closed fresh-provider cohort lock, ordered readiness gates, deterministic failure localization, and a one-shot target authorization;
- add query-space covariance-preservation certificates comparing full and simplified covariance treatments with trace, Frobenius, directional, and reference-nullspace distortion diagnostics;
- add strict finite-JSON replay, immutable metadata/arrays, content identities, atomic no-clobber persistence, module CLI verification, focused adversarial tests, and documentation.

## Why

The existing support, calibration, covariance, identity, and held-out promotion machinery did not yet compose into one executable pre-target decision. A source-mean failure could therefore remain ambiguous with covariance failure, and a passing collection of upstream checks did not produce an explicit one-shot authorization tied to the exact unopened target roster.

This PR makes the information order and terminal decisions executable:

1. support feasibility;
2. source mean quality;
3. identity/reliability;
4. gauge/dependence;
5. point covariance;
6. physical-query relevance; and
7. exact fallback.

Only a point-covariance-localized result authorizes source-only point-uncertainty development. Only seven passing gates authorize exactly one evaluation of the bound target cohort. Downstream evidence cannot rescue an earlier negative result.

## Scientific boundary

These additions are prospective protocol and diagnostic infrastructure. They do not establish real-provider competence, calibrated target uncertainty, BayesianPhysTwin benefit, Causal4D benefit, deployment safety, or state of the art. The stable `prob4d.api.v1`, provider-v2, and held-out promotion contracts are unchanged.

## Validation

- focused new suite: 35 passed;
- complete suite: 1,262 passed and 1 optional-dependency skip on Python 3.12;
- complete suite passed on Python 3.10, 3.11, 3.12, 3.13, and 3.14;
- declared Python 3.10 / NumPy 1.24.0 runtime floor passed;
- authoritative Ruff and stable-interface mypy passed;
- repository, release, API, runtime-attestation, and provider-contract checks passed;
- Python and Actions CodeQL plus dependency audit passed;
- wheel and source distribution build, `twine` validation, and source-archive audit passed;
- isolated wheel and sdist installs, package-contract assertions, and grouped/legacy CLI smoke passed;
- uploaded branch blobs were verified byte-identical to the locally tested files.

Closes #202