### PR TITLE
Type-check the stable API v2 façade authoritatively

### DIFF
--- a/.github/workflows/fail-closed-quality.yml
+++ b/.github/workflows/fail-closed-quality.yml
@@ -76,6 +76,7 @@ jobs:
           python -m mypy \
             src/prob4d/_version.py \
             src/prob4d/api/v1.py \
+            src/prob4d/api/v2.py \
             src/prob4d/cli.py \
             src/prob4d/calibration_compatibility.py \
             src/prob4d/composition_jacobian.py \

--- a/tests/test_fail_closed_quality_workflow.py
+++ b/tests/test_fail_closed_quality_workflow.py
@@ -64,6 +64,7 @@ def test_authoritative_quality_workflow_covers_current_stable_surfaces() -> None
     required = (
         "src/prob4d/_version.py",
         "src/prob4d/api/v1.py",
+        "src/prob4d/api/v2.py",
         "src/prob4d/provider_v2_factor_bundle.py",
         "src/prob4d/provider_v2_factors.py",
         "src/prob4d/sparse_observation_factors.py",


### PR DESCRIPTION
## Summary

- add `src/prob4d/api/v2.py` to the authoritative fail-closed MyPy invocation;
- extend the workflow-policy regression so the supported provider-v2 façade cannot silently fall out of the strict lane; and
- preserve the existing pinned quality environment, read-only permissions, pipefail diagnostics, and all provider semantics.

## Why

The compatibility guide declares `prob4d.api.v2` as the supported ecosystem-facing boundary for new BayesianPhysTwin, Causal4D, and independent provider integrations. Its implementation dependencies were already type-checked, but the façade itself was not named in the authoritative lane. This closes that gap directly without broadening the scientific or runtime surface.

## Validation

GitHub Actions on the exact pull-request head are authoritative for the MyPy lane, Ruff, complete test matrix, NumPy floor, distributions, installed-artifact smoke tests, provider contracts, and security scanning.

## Scientific boundary

This is static-analysis policy only. It changes no estimator, provider artifact, admission decision, target boundary, physical evidence, or scientific claim.