### PR TITLE
Make the package root lazy and prepare Prob4D 0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,55 @@ release notes and scientific boundaries live under `docs/releases/`.
 
 No changes yet.
 
+## 0.4.1 — 2026-08-12
+
+### Added
+
+- A source-fitted correlation-group robust likelihood with complete
+  object/session selection, one contamination state per declared dependence
+  group, and exact Gaussian fallback when source support is insufficient.
+- An additive analytic `Sim(3)` composition and inversion covariance path with
+  branch-cut rejection and factorized solves for declared full-rank alignment
+  systems.
+- Source-only calibration-transport certificates, source-provider competence
+  reports, and query-space covariance relevance and preservation diagnostics.
+- A target-closed fresh-provider cohort lock, ordered seven-gate readiness
+  decision, deterministic failure localization, one-shot target authorization,
+  and a conformance corpus covering every terminal classification.
+- A content-addressed public API manifest for the compatibility root and the
+  stable `prob4d.api.v1` and `prob4d.api.v2` façades.
+- A packaged root typing stub that preserves the historical typed import surface
+  under lazy runtime loading.
+
+### Changed
+
+- Importing the broad `prob4d` compatibility root no longer eagerly imports
+  calibration, fusion, gauge-graph, observation, storage, and reliability
+  implementations. Historical exports load on first access and retain exact
+  object identity.
+- Source-distribution and release checks now require and exercise the root typing
+  stub, public API manifest, current release note, and installed lazy-import
+  behavior.
+- Public API documentation now distinguishes the lazy compatibility root from the
+  supported versioned façades and provides a reproducible manifest workflow.
+
+### Fixed
+
+- Sampled Gaussian fusion and declared full-rank covariance operations use
+  validated factorized solves instead of explicit inverses or pseudoinverses.
+- Invalid Sintel truth coordinates are prevented from leaking through bilinear
+  resampling.
+- Fresh-provider readiness cannot conflate failed means, identities,
+  gauge/dependence, point covariance, query relevance, or technical fallback
+  failures, and target authorization is bound to exactly one unopened roster.
+
+### Scientific boundary
+
+This release adds implementation, interoperability, and prospective protocol
+infrastructure. It does not establish fresh real-provider competence, calibrated
+target uncertainty, unseen-object BayesianPhysTwin benefit, Causal4D
+intervention benefit, deployment safety, or state of the art.
+
 ## 0.4.0 — 2026-08-10
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,8 +8,8 @@ authors:
 repository-code: "https://github.com/IPS-Stuttgart/Prob4D"
 url: "https://github.com/IPS-Stuttgart/Prob4D"
 license: "MIT"
-version: "0.4.0"
-date-released: "2026-08-10"
+version: "0.4.1"
+date-released: "2026-08-12"
 abstract: >-
   Probabilistic recursive fusion for long-horizon 4D reconstruction from overlapping
   prediction windows, with uncertain Sim(3) gauges, calibrated conditional and shared

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,7 @@ include LICENSE
 include README.md
 include SECURITY.md
 include pyproject.toml
+include src/prob4d/__init__.pyi
 graft docs
 graft protocols
 prune .github

--- a/docs/compatibility.md
+++ b/docs/compatibility.md
@@ -30,6 +30,13 @@ the strict loaders and contracts through `prob4d.api.v2`. Direct imports from
 `prob4d.sim3` are implementation dependencies rather than the supported
 ecosystem boundary.
 
+The broad `prob4d` root remains a historical compatibility surface. Its export
+inventory is unchanged, but runtime attributes are now loaded lazily and its
+complete static typing surface is packaged in `prob4d/__init__.pyi`. The
+content-addressed public API manifest records the exact root, `api.v1`, and
+`api.v2` inventories for an installed distribution. See
+[public API manifest](public-api-manifest.md).
+
 The historical `prob4d.motioncrafter-model.v1` identifier covers the original
 common-seed behavior, whether the manifest omits `seed_policy` or explicitly
 uses `legacy-common`. A run using `derived-per-call` receives a
@@ -116,6 +123,6 @@ and output artifact digests inside the owning evidence record.
 - A repository transfer alone does not permit rewriting a frozen artifact's
   source-repository field.
 
-Passing compatibility tests is infrastructure evidence. It does not establish
-accuracy, calibration, transfer, intervention benefit, deployment safety, or
-state of the art.
+Passing compatibility tests or validating a public API manifest is
+infrastructure evidence. It does not establish accuracy, calibration, transfer,
+intervention benefit, deployment safety, or state of the art.

--- a/docs/distribution-boundaries.md
+++ b/docs/distribution-boundaries.md
@@ -9,9 +9,16 @@ data, project metadata, documentation, and frozen protocol descriptions. They do
 not contain GitHub workflows, generated evidence, CI environments, repository
 tests, or one-off maintenance scripts.
 
+The package includes both `py.typed` and the root `__init__.pyi` compatibility
+stub. Runtime root exports are lazy, while static type checkers retain the exact
+historical root inventory. The installed distribution can emit a
+content-addressed public API manifest covering the root and both versioned
+façades.
+
 The source-distribution audit installs the built archive into an isolated virtual
-environment and exercises the installed package, public API, contract data, and
-canonical CLI. It intentionally does not run tests copied into the archive.
+environment and exercises the installed package, lazy root behavior, versioned
+public APIs, public API manifest, contract data, and canonical CLI. It
+intentionally does not run tests copied into the archive.
 
 ## Evidence capsule
 
@@ -21,6 +28,10 @@ dependency locks, protocol identifiers, execution identity, and checksums needed
 to reproduce a declared result. They are produced by explicit evidence workflows
 and are not part of the package consumed by normal Python users.
 
+A public API manifest or green installed-wheel capsule is compatibility and
+provenance evidence. Neither is provider-accuracy, calibration, physical-query,
+Causal4D intervention, deployment-safety, or state-of-the-art evidence.
+
 This separation prevents repository-maintenance state from changing package
-installation semantics and prevents stale copied tests or workflows from blocking
-a valid source distribution.
+installation semantics and prevents stale copied tests or workflows from
+blocking a valid source distribution.

--- a/docs/public-api-manifest.md
+++ b/docs/public-api-manifest.md
@@ -1,0 +1,57 @@
+# Public API manifest
+
+Prob4D exposes a content-addressed, machine-readable inventory of the Python
+surfaces intended for downstream compatibility checks. The manifest records:
+
+- the installed Prob4D version and transfer-safe project identity;
+- the historical package-root export inventory and its lazy loading semantics;
+- every export from `prob4d.api.v1`;
+- every export from `prob4d.api.v2`; and
+- the provider and provider-factor API versions attached to those façades.
+
+Generate the manifest from the exact installed wheel or source distribution that
+will be used downstream:
+
+```bash
+python -m prob4d.public_api_manifest print
+
+python -m prob4d.public_api_manifest build \
+  --output public-api-manifest.json
+```
+
+Validate persisted bytes structurally:
+
+```bash
+python -m prob4d.public_api_manifest verify public-api-manifest.json
+```
+
+For release or integration checks, also require equality with the executing
+installation:
+
+```bash
+python -m prob4d.public_api_manifest verify \
+  public-api-manifest.json \
+  --require-current
+```
+
+The writer is no-clobber. Repeating an identical build is idempotent; an existing
+different or malformed artifact is rejected instead of being overwritten.
+
+## Compatibility interpretation
+
+The broad `prob4d` package root is a historical compatibility surface. Importing
+it is lightweight: implementation modules are loaded only when their exported
+attributes are accessed. Its complete typing surface is retained in
+`prob4d/__init__.pyi`.
+
+New integrations should still use `prob4d.api.v1` or `prob4d.api.v2`. The
+manifest makes accidental additions, removals, provider-version changes, and
+packaging drift visible without promoting the broad root into the preferred
+dependency boundary.
+
+## Claim boundary
+
+A valid manifest establishes exact installed Python export and version metadata.
+It does not establish provider accuracy, uncertainty calibration, physical-query
+improvement, BayesianPhysTwin admission, Causal4D intervention benefit,
+deployment safety, or state of the art.

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -25,6 +25,21 @@ new-integration dependency boundaries. A breaking change requires a new module
 such as `prob4d.api.v3`; it must not silently change `prob4d.api.v1` or
 `prob4d.api.v2`.
 
+## Lazy compatibility root
+
+Importing `prob4d` now records the complete historical root export inventory
+without importing calibration, fusion, gauge-graph, observation, prediction
+storage, or reliability implementations. Accessing an exported attribute loads
+its owning module once and caches the object in the package root.
+
+The export set and object identities are unchanged. `dir(prob4d)`,
+`from prob4d import Sim3`, and historical star imports continue to see the same
+inventory. The packaged `prob4d/__init__.pyi` retains the complete static typing
+surface even though runtime loading is lazy.
+
+This optimization does not promote the broad root into a stable dependency
+boundary. New integrations should still use a versioned façade.
+
 ## Version 1 boundary
 
 `prob4d.api.v1` is the frozen provider-v1 reproduction surface. It exposes the
@@ -47,6 +62,25 @@ provider-evaluation studies, and paper-specific evidence code are deliberately
 outside the façade. BayesianPhysTwin may independently revalidate producer
 artifacts and apply its own physical-update guards. Causal4D may continue to
 validate neutral wire artifacts without importing Prob4D.
+
+## Machine-readable inventory
+
+The exact executing surfaces can be emitted as a content-addressed JSON artifact:
+
+```bash
+python -m prob4d.public_api_manifest print
+
+python -m prob4d.public_api_manifest build \
+  --output public-api-manifest.json
+
+python -m prob4d.public_api_manifest verify \
+  public-api-manifest.json \
+  --require-current
+```
+
+The artifact records the package version, project identity, root loading mode,
+root exports, versioned façade exports, and provider API versions. See
+[public API manifest](public-api-manifest.md) for the schema and claim boundary.
 
 ## Ownership boundary
 

--- a/docs/releases/0.4.1.md
+++ b/docs/releases/0.4.1.md
@@ -1,0 +1,71 @@
+# Prob4D 0.4.1 release boundary
+
+Prob4D 0.4.1 is a compatibility-preserving maintenance and readiness release.
+It consolidates the provider-v2 interoperability surface, makes the historical
+package root lazy, and closes the implementation gaps needed to decide one fresh
+real-provider experiment without opening target outcomes prematurely.
+
+## Main additions
+
+- A source-fitted correlation-group robust likelihood with exact Gaussian
+  fallback when finite-source support is insufficient.
+- Analytic `Sim(3)` composition and inversion covariance propagation as an
+  additive experimental path, plus factorized numerical solves for declared
+  full-rank alignment systems.
+- Source-only calibration-transport certificates and query-space covariance
+  relevance and preservation diagnostics.
+- Source-provider competence reports that separate mean quality from identity and
+  reliability quality at complete object/session level.
+- A target-closed fresh-provider cohort lock, ordered seven-gate readiness
+  decision, deterministic failure localization, and one-shot target
+  authorization.
+- A deterministic readiness conformance corpus covering every terminal decision,
+  point-uncertainty authorization, and exact target-roster binding.
+- A content-addressed public API manifest covering the lazy compatibility root
+  and the stable `prob4d.api.v1` and `prob4d.api.v2` façades.
+
+## Compatibility
+
+The historical package-root export set is unchanged. Importing `prob4d` no longer
+loads its calibration, fusion, gauge-graph, observation, storage, and reliability
+implementation modules eagerly. A requested root attribute is imported from its
+owning module once and cached. The accompanying `prob4d/__init__.pyi` preserves
+the complete typed compatibility surface in wheels and source distributions.
+
+`prob4d.api.v1` remains the frozen provider-v1 reproduction boundary.
+`prob4d.api.v2` remains the supported provider-v2 and explicit-gauge boundary.
+No observation schema, provider manifest, content identity, covariance semantics,
+fallback decision, or legacy executable meaning changes in this release.
+
+## Release and integration evidence
+
+Release checks now require the root typing stub, public API manifest module and
+documentation, and this release note in the source distribution. Installed
+source-distribution smoke tests verify that the package root is lazy, every
+sampled historical export retains object identity, the typing stub is packaged,
+and a current public API manifest can be generated and verified.
+
+The public API manifest is content-addressed and can be archived beside the
+existing three-repository installed-wheel release capsule. It is compatibility
+and provenance evidence only.
+
+## Scientific claim boundary
+
+The controlled Prob4D-to-BayesianPhysTwin mechanism result remains positive, but
+this release does not add fresh physical evidence. The retrospective
+19-interaction MotionCrafter route remains negative, and the earlier official-Hub
+Deform360 route remains terminal at its complete-stream support boundary.
+
+Fresh-provider readiness, conformance fixtures, analytic propagation, robust
+likelihoods, covariance diagnostics, and public API manifests are implementation
+and protocol infrastructure. They do not establish real-provider competence,
+target uncertainty calibration, BayesianPhysTwin benefit on unseen
+objects/sessions, Causal4D intervention benefit, deployment safety, or state of
+the art.
+
+## Publication
+
+Merging the release-preparation change synchronizes package metadata, citation
+metadata, changelog, typed root surface, release documentation, and distribution
+checks. It does not create a Git tag or publish to a package registry. Those
+operations require a separate explicit action against the reviewed merge commit.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "prob4d"
-version = "0.4.0"
+version = "0.4.1"
 description = "Probabilistic recursive fusion for long-horizon 4D reconstruction"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -82,6 +82,7 @@ where = ["src"]
 
 [tool.setuptools.package-data]
 prob4d = [
+    "__init__.pyi",
     "py.typed",
     "contract_data/observation_belief_v1/*.json",
     "contract_data/observation_belief_v1/vectors/*.json",
@@ -109,3 +110,12 @@ ignore_missing_imports = true
 no_implicit_optional = true
 show_error_codes = true
 warn_unused_ignores = true
+
+[[tool.mypy.overrides]]
+module = [
+    "prob4d.api.v1",
+    "prob4d.api.v2",
+    "prob4d.public_api_manifest",
+]
+disallow_untyped_defs = true
+warn_return_any = true

--- a/scripts/ci/check_sdist.py
+++ b/scripts/ci/check_sdist.py
@@ -61,9 +61,7 @@ def _validated_members(archive: Path) -> tuple[str, tuple[tarfile.TarInfo, ...]]
             raise RuntimeError(f"unsafe source-distribution path: {member.name}")
         roots.add(path.parts[0])
         if member.issym() or member.islnk() or not (member.isdir() or member.isfile()):
-            raise RuntimeError(
-                f"source distribution contains a non-regular member: {member.name}"
-            )
+            raise RuntimeError(f"source distribution contains a non-regular member: {member.name}")
         if len(path.parts) > 1:
             relative_paths.add(PurePosixPath(*path.parts[1:]).as_posix())
 
@@ -78,14 +76,11 @@ def _validated_members(archive: Path) -> tuple[str, tuple[tarfile.TarInfo, ...]]
         path
         for path in relative_paths
         if any(
-            path == prefix.rstrip("/") or path.startswith(prefix)
-            for prefix in FORBIDDEN_PREFIXES
+            path == prefix.rstrip("/") or path.startswith(prefix) for prefix in FORBIDDEN_PREFIXES
         )
     )
     if forbidden:
-        raise RuntimeError(
-            f"source distribution contains repository-only assets: {forbidden[:20]}"
-        )
+        raise RuntimeError(f"source distribution contains repository-only assets: {forbidden[:20]}")
     return roots.pop(), members
 
 

--- a/scripts/ci/check_sdist.py
+++ b/scripts/ci/check_sdist.py
@@ -20,16 +20,20 @@ REQUIRED_PATHS = frozenset(
         "README.md",
         "SECURITY.md",
         "docs/distribution-boundaries.md",
+        "docs/public-api-manifest.md",
         "docs/public-api.md",
-        "docs/releases/0.4.0.md",
+        "docs/releases/0.4.1.md",
         "protocols/cycle-guard-normalization-v1.json",
         "pyproject.toml",
         "src/prob4d/__init__.py",
+        "src/prob4d/__init__.pyi",
         "src/prob4d/_version.py",
         "src/prob4d/api/__init__.py",
         "src/prob4d/api/v1.py",
+        "src/prob4d/api/v2.py",
         "src/prob4d/contract_data/observation_belief_v1/manifest.json",
         "src/prob4d/contract_data/observation_belief_v1/schema.json",
+        "src/prob4d/public_api_manifest.py",
         "src/prob4d/py.typed",
     }
 )
@@ -57,7 +61,9 @@ def _validated_members(archive: Path) -> tuple[str, tuple[tarfile.TarInfo, ...]]
             raise RuntimeError(f"unsafe source-distribution path: {member.name}")
         roots.add(path.parts[0])
         if member.issym() or member.islnk() or not (member.isdir() or member.isfile()):
-            raise RuntimeError(f"source distribution contains a non-regular member: {member.name}")
+            raise RuntimeError(
+                f"source distribution contains a non-regular member: {member.name}"
+            )
         if len(path.parts) > 1:
             relative_paths.add(PurePosixPath(*path.parts[1:]).as_posix())
 
@@ -72,11 +78,14 @@ def _validated_members(archive: Path) -> tuple[str, tuple[tarfile.TarInfo, ...]]
         path
         for path in relative_paths
         if any(
-            path == prefix.rstrip("/") or path.startswith(prefix) for prefix in FORBIDDEN_PREFIXES
+            path == prefix.rstrip("/") or path.startswith(prefix)
+            for prefix in FORBIDDEN_PREFIXES
         )
     )
     if forbidden:
-        raise RuntimeError(f"source distribution contains repository-only assets: {forbidden[:20]}")
+        raise RuntimeError(
+            f"source distribution contains repository-only assets: {forbidden[:20]}"
+        )
     return roots.pop(), members
 
 
@@ -133,26 +142,50 @@ def _smoke_installed_archive(archive: Path, destination: Path) -> None:
     smoke = """
 from importlib import resources
 from importlib.metadata import version
+import sys
 
 import prob4d
+
+assert "prob4d.sim3" not in sys.modules
+assert "Sim3" not in prob4d.__dict__
+
+from prob4d.sim3 import Sim3
+
+assert prob4d.Sim3 is Sim3
+assert prob4d.__dict__["Sim3"] is Sim3
+
 import prob4d.api.v1 as api_v1
+import prob4d.api.v2 as api_v2
 import prob4d.provider_v1 as provider_v1
 import prob4d.provider_v2 as provider_v2
+from prob4d.public_api_manifest import build_public_api_manifest
 
 installed = version("prob4d")
 assert prob4d.__version__ == installed
 assert api_v1.__version__ == installed
 assert api_v1.API_VERSION == 1
+assert api_v2.API_VERSION == 2
 assert api_v1.PROVIDER_API_VERSION == provider_v1.PROVIDER_API_VERSION == 1
 assert provider_v2.PROVIDER_API_VERSION == 2
 assert callable(api_v1.export_calibrated_observation_belief)
 assert callable(provider_v2.load_claim_bearing_observation_belief)
-assert resources.files("prob4d").joinpath("py.typed").is_file()
-assert resources.files("prob4d").joinpath(
+
+manifest = build_public_api_manifest()
+assert manifest["package"]["version"] == installed
+assert manifest["surfaces"]["compatibility_root"]["loading"] == (
+    "lazy-compatibility-shim-v1"
+)
+assert manifest["surfaces"]["compatibility_root"]["exports"] == sorted(prob4d.__all__)
+
+package = resources.files("prob4d")
+assert package.joinpath("__init__.pyi").is_file()
+assert package.joinpath("py.typed").is_file()
+assert package.joinpath(
     "contract_data/observation_belief_v1/manifest.json"
 ).is_file()
 """
     _run([python, "-c", smoke])
+    _run([python, "-m", "prob4d.public_api_manifest", "print"])
 
     cli = _venv_executable(environment, "prob4d")
     _run([cli, "--help"])

--- a/src/prob4d/__init__.py
+++ b/src/prob4d/__init__.py
@@ -364,6 +364,7 @@ if len(_LAZY_EXPORTS) != sum(len(names) for _, names in _LAZY_EXPORT_GROUPS):
 if set(__all__) != set(_LAZY_EXPORTS) | {"__version__"}:
     raise RuntimeError("Prob4D lazy exports and __all__ differ")
 
+
 def __getattr__(name: str) -> object:
     """Load one historical top-level export from its owning module."""
 
@@ -373,6 +374,7 @@ def __getattr__(name: str) -> object:
     value = getattr(import_module(module_name), name)
     globals()[name] = value
     return value
+
 
 def __dir__() -> list[str]:
     """Include lazy public exports in module introspection."""

--- a/src/prob4d/__init__.py
+++ b/src/prob4d/__init__.py
@@ -1,157 +1,244 @@
-"""Probabilistic long-horizon fusion for MotionCrafter predictions."""
+"""Public Prob4D exports with compatibility-preserving lazy loading.
+Importing the package root defines the historical export inventory without
+eagerly importing calibration, fusion, provider, or experiment modules. Each
+public attribute is loaded from its owning module on first access and then
+cached in this module. New downstream code should prefer ``prob4d.api.v1`` or
+``prob4d.api.v2`` for explicit compatibility promises.
+"""
+
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Final
 
 from ._version import __version__
-from .alignment_cycles import (
-    AlignmentCycleAudit,
-    AlignmentCycleResidual,
-    alignment_edge_id,
-    audit_alignment_cycles,
+
+_LAZY_EXPORT_GROUPS: Final = (
+    (
+        "prob4d.alignment_cycles",
+        (
+            "AlignmentCycleAudit",
+            "AlignmentCycleResidual",
+            "alignment_edge_id",
+            "audit_alignment_cycles",
+        ),
+    ),
+    (
+        "prob4d.calibration",
+        (
+            "GAUGE_COVARIANCE_CALIBRATION_SCHEMA",
+            "GAUGE_COVARIANCE_CALIBRATION_VERSION",
+            "GROUP_BALANCED_UPPER_WINSORIZED_RATIOS_V2",
+            "LEGACY_GROUP_BALANCED_TRIMMED_RATIOS_V1",
+            "POINT_UNCERTAINTY_CALIBRATION_SCHEMA",
+            "POINT_UNCERTAINTY_CALIBRATION_VERSION",
+            "UPPER_WINSORIZED_MEAN_V1",
+            "GaugeCovarianceCalibrationV1",
+            "PointUncertaintyCalibrationV1",
+            "fit_group_balanced_point_uncertainty_calibration",
+            "group_balanced_point_calibration_metadata",
+            "load_gauge_covariance_calibration",
+            "load_point_uncertainty_calibration",
+            "save_gauge_covariance_calibration",
+            "save_point_uncertainty_calibration",
+            "upper_winsorized_mean",
+        ),
+    ),
+    (
+        "prob4d.causal_gauge_graph",
+        (
+            "CAUSAL_GAUGE_GRAPH_DEPENDENCE",
+            "CAUSAL_GAUGE_GRAPH_MODE",
+            "CausalGaugeGraphReport",
+            "CausalGaugeGraphStep",
+            "estimate_causal_multi_edge_gauge_graph",
+        ),
+    ),
+    (
+        "prob4d.causal_tracklets",
+        (
+            "CausalTrackletReport",
+            "CausalTrackletSet",
+            "build_causal_scene_flow_tracklets",
+            "tracklets_to_observation_factors",
+        ),
+    ),
+    (
+        "prob4d.cross_fitted_disagreement",
+        (
+            "CrossFittedDisagreementReport",
+            "accumulate_cross_fitted_disagreement",
+        ),
+    ),
+    (
+        "prob4d.data",
+        ("PredictionWindow",),
+    ),
+    (
+        "prob4d.evaluation_modes",
+        (
+            "EvaluationModeResult",
+            "EvaluationModes",
+            "evaluate_sequence_modes",
+        ),
+    ),
+    (
+        "prob4d.finite_sample_threshold",
+        (
+            "FINITE_SAMPLE_UPPER_THRESHOLD_SEMANTICS",
+            "FiniteSampleUpperThreshold",
+            "fit_finite_sample_upper_threshold",
+        ),
+    ),
+    (
+        "prob4d.fusion",
+        ("FusedSequence",),
+    ),
+    (
+        "prob4d.gauge_tree_prior",
+        (
+            "GAUGE_TREE_PRIOR_SCHEMA",
+            "GAUGE_TREE_PRIOR_SEMANTICS",
+            "GAUGE_TREE_PRIOR_VERSION",
+            "GaugeTreeSquareRootPriorV1",
+        ),
+    ),
+    (
+        "prob4d.gauge_tree_prior_io",
+        (
+            "GAUGE_TREE_PRIOR_ARTIFACT_CLAIM_BOUNDARY",
+            "GAUGE_TREE_PRIOR_ARTIFACT_SCHEMA",
+            "GAUGE_TREE_PRIOR_ARTIFACT_VERSION",
+            "gauge_tree_prior_artifact_id",
+            "load_gauge_tree_prior",
+            "write_gauge_tree_prior",
+        ),
+    ),
+    (
+        "prob4d.guarded_causal_gauge_graph",
+        (
+            "GUARDED_CAUSAL_GAUGE_GRAPH_DEPENDENCE",
+            "GUARDED_CAUSAL_GAUGE_GRAPH_MODE",
+            "GuardedCausalGaugeGraphReport",
+            "estimate_guarded_causal_multi_edge_gauge_graph",
+        ),
+    ),
+    (
+        "prob4d.observation_contract",
+        (
+            "OBSERVATION_BELIEF_SCHEMA",
+            "OBSERVATION_BELIEF_VERSION",
+            "ObservationBeliefExportV1",
+            "save_observation_belief_export",
+        ),
+    ),
+    (
+        "prob4d.observation_export",
+        (
+            "JointGaugePosterior",
+            "MetricGaugeAnchor",
+            "build_prob4d_observation_belief",
+            "deterministic_covariance_root",
+            "estimate_joint_gauge_tree",
+            "load_metric_gauge_anchor",
+            "save_metric_gauge_anchor",
+        ),
+    ),
+    (
+        "prob4d.observation_factor_stream",
+        (
+            "OBSERVATION_FACTOR_STREAM_SCHEMA",
+            "OBSERVATION_FACTOR_STREAM_VERSION",
+            "ObservationFactorStreamUpdateV1",
+            "ObservationFactorStreamV1",
+            "append_observation_factor_bundle",
+            "load_observation_factor_stream",
+            "write_observation_factor_stream",
+        ),
+    ),
+    (
+        "prob4d.observation_factors",
+        (
+            "LinearizedObservationFactor",
+            "ObservationFactor",
+            "ObservationFactorBundle",
+            "StackedObservationFactors",
+            "load_observation_factor_bundle",
+            "stack_observation_factors",
+            "write_observation_factor_bundle",
+        ),
+    ),
+    (
+        "prob4d.observation_validation",
+        ("load_observation_belief_export",),
+    ),
+    (
+        "prob4d.prediction_store",
+        (
+            "PREDICTION_BUNDLE_STORE_SCHEMA",
+            "PREDICTION_BUNDLE_STORE_VERSION",
+            "PREDICTION_WINDOW_STORE_SCHEMA",
+            "PREDICTION_WINDOW_STORE_VERSION",
+            "MMapPredictionWindow",
+            "load_prediction_bundle_store",
+            "load_prediction_window_store",
+            "materialize_prediction_bundle_store",
+            "prediction_bundle_store_summary",
+            "write_prediction_window_store",
+        ),
+    ),
+    (
+        "prob4d.project_identity",
+        (
+            "PROB4D_CANONICAL_REPOSITORY",
+            "PROB4D_FROZEN_ARTIFACT_REPOSITORY",
+            "PROB4D_GITHUB_REPOSITORY_ID",
+            "PROB4D_PROJECT_ID",
+            "PROB4D_REPOSITORY_ALIASES",
+            "canonical_prob4d_repository",
+            "is_prob4d_repository",
+            "prob4d_project_identity",
+            "validate_prob4d_project_identity",
+        ),
+    ),
+    (
+        "prob4d.sim3",
+        ("Sim3",),
+    ),
+    (
+        "prob4d.source_diagnostics",
+        (
+            "CommonModeFailureAudit",
+            "SourceOnlyDiagnosticGrid",
+            "audit_common_mode_failures",
+            "augment_source_reliability_features",
+            "build_common_gauge_seed_dispersion_diagnostic",
+            "build_flow_point_consistency_diagnostic",
+        ),
+    ),
+    (
+        "prob4d.source_reliability",
+        (
+            "SOURCE_RELIABILITY_SCHEMA",
+            "SOURCE_RELIABILITY_VERSION",
+            "SourceReliabilityCalibrationReport",
+            "SourceReliabilityFeatures",
+            "SourceReliabilityModelV1",
+            "build_source_reliability_features",
+            "fit_group_balanced_source_reliability",
+            "load_source_reliability_model",
+            "save_source_reliability_model",
+        ),
+    ),
+    (
+        "prob4d.uncertainty",
+        ("GroupBalancedCalibrationReport",),
+    ),
 )
-from .calibration import (
-    GAUGE_COVARIANCE_CALIBRATION_SCHEMA,
-    GAUGE_COVARIANCE_CALIBRATION_VERSION,
-    GROUP_BALANCED_UPPER_WINSORIZED_RATIOS_V2,
-    LEGACY_GROUP_BALANCED_TRIMMED_RATIOS_V1,
-    POINT_UNCERTAINTY_CALIBRATION_SCHEMA,
-    POINT_UNCERTAINTY_CALIBRATION_VERSION,
-    UPPER_WINSORIZED_MEAN_V1,
-    GaugeCovarianceCalibrationV1,
-    PointUncertaintyCalibrationV1,
-    fit_group_balanced_point_uncertainty_calibration,
-    group_balanced_point_calibration_metadata,
-    load_gauge_covariance_calibration,
-    load_point_uncertainty_calibration,
-    save_gauge_covariance_calibration,
-    save_point_uncertainty_calibration,
-    upper_winsorized_mean,
-)
-from .causal_gauge_graph import (
-    CAUSAL_GAUGE_GRAPH_DEPENDENCE,
-    CAUSAL_GAUGE_GRAPH_MODE,
-    CausalGaugeGraphReport,
-    CausalGaugeGraphStep,
-    estimate_causal_multi_edge_gauge_graph,
-)
-from .causal_tracklets import (
-    CausalTrackletReport,
-    CausalTrackletSet,
-    build_causal_scene_flow_tracklets,
-    tracklets_to_observation_factors,
-)
-from .cross_fitted_disagreement import (
-    CrossFittedDisagreementReport,
-    accumulate_cross_fitted_disagreement,
-)
-from .data import PredictionWindow
-from .evaluation_modes import (
-    EvaluationModeResult,
-    EvaluationModes,
-    evaluate_sequence_modes,
-)
-from .finite_sample_threshold import (
-    FINITE_SAMPLE_UPPER_THRESHOLD_SEMANTICS,
-    FiniteSampleUpperThreshold,
-    fit_finite_sample_upper_threshold,
-)
-from .fusion import FusedSequence
-from .gauge_tree_prior import (
-    GAUGE_TREE_PRIOR_SCHEMA,
-    GAUGE_TREE_PRIOR_SEMANTICS,
-    GAUGE_TREE_PRIOR_VERSION,
-    GaugeTreeSquareRootPriorV1,
-)
-from .gauge_tree_prior_io import (
-    GAUGE_TREE_PRIOR_ARTIFACT_CLAIM_BOUNDARY,
-    GAUGE_TREE_PRIOR_ARTIFACT_SCHEMA,
-    GAUGE_TREE_PRIOR_ARTIFACT_VERSION,
-    gauge_tree_prior_artifact_id,
-    load_gauge_tree_prior,
-    write_gauge_tree_prior,
-)
-from .guarded_causal_gauge_graph import (
-    GUARDED_CAUSAL_GAUGE_GRAPH_DEPENDENCE,
-    GUARDED_CAUSAL_GAUGE_GRAPH_MODE,
-    GuardedCausalGaugeGraphReport,
-    estimate_guarded_causal_multi_edge_gauge_graph,
-)
-from .observation_contract import (
-    OBSERVATION_BELIEF_SCHEMA,
-    OBSERVATION_BELIEF_VERSION,
-    ObservationBeliefExportV1,
-    save_observation_belief_export,
-)
-from .observation_export import (
-    JointGaugePosterior,
-    MetricGaugeAnchor,
-    build_prob4d_observation_belief,
-    deterministic_covariance_root,
-    estimate_joint_gauge_tree,
-    load_metric_gauge_anchor,
-    save_metric_gauge_anchor,
-)
-from .observation_factor_stream import (
-    OBSERVATION_FACTOR_STREAM_SCHEMA,
-    OBSERVATION_FACTOR_STREAM_VERSION,
-    ObservationFactorStreamUpdateV1,
-    ObservationFactorStreamV1,
-    append_observation_factor_bundle,
-    load_observation_factor_stream,
-    write_observation_factor_stream,
-)
-from .observation_factors import (
-    LinearizedObservationFactor,
-    ObservationFactor,
-    ObservationFactorBundle,
-    StackedObservationFactors,
-    load_observation_factor_bundle,
-    stack_observation_factors,
-    write_observation_factor_bundle,
-)
-from .observation_validation import load_observation_belief_export
-from .prediction_store import (
-    PREDICTION_BUNDLE_STORE_SCHEMA,
-    PREDICTION_BUNDLE_STORE_VERSION,
-    PREDICTION_WINDOW_STORE_SCHEMA,
-    PREDICTION_WINDOW_STORE_VERSION,
-    MMapPredictionWindow,
-    load_prediction_bundle_store,
-    load_prediction_window_store,
-    materialize_prediction_bundle_store,
-    prediction_bundle_store_summary,
-    write_prediction_window_store,
-)
-from .project_identity import (
-    PROB4D_CANONICAL_REPOSITORY,
-    PROB4D_FROZEN_ARTIFACT_REPOSITORY,
-    PROB4D_GITHUB_REPOSITORY_ID,
-    PROB4D_PROJECT_ID,
-    PROB4D_REPOSITORY_ALIASES,
-    canonical_prob4d_repository,
-    is_prob4d_repository,
-    prob4d_project_identity,
-    validate_prob4d_project_identity,
-)
-from .sim3 import Sim3
-from .source_diagnostics import (
-    CommonModeFailureAudit,
-    SourceOnlyDiagnosticGrid,
-    audit_common_mode_failures,
-    augment_source_reliability_features,
-    build_common_gauge_seed_dispersion_diagnostic,
-    build_flow_point_consistency_diagnostic,
-)
-from .source_reliability import (
-    SOURCE_RELIABILITY_SCHEMA,
-    SOURCE_RELIABILITY_VERSION,
-    SourceReliabilityCalibrationReport,
-    SourceReliabilityFeatures,
-    SourceReliabilityModelV1,
-    build_source_reliability_features,
-    fit_group_balanced_source_reliability,
-    load_source_reliability_model,
-    save_source_reliability_model,
-)
-from .uncertainty import GroupBalancedCalibrationReport
+
+_LAZY_EXPORTS: Final = {
+    name: module_name for module_name, names in _LAZY_EXPORT_GROUPS for name in names
+}
 
 __all__ = [
     "CAUSAL_GAUGE_GRAPH_DEPENDENCE",
@@ -271,3 +358,23 @@ __all__ = [
     "write_observation_factor_stream",
     "write_prediction_window_store",
 ]
+
+if len(_LAZY_EXPORTS) != sum(len(names) for _, names in _LAZY_EXPORT_GROUPS):
+    raise RuntimeError("duplicate Prob4D lazy export")
+if set(__all__) != set(_LAZY_EXPORTS) | {"__version__"}:
+    raise RuntimeError("Prob4D lazy exports and __all__ differ")
+
+def __getattr__(name: str) -> object:
+    """Load one historical top-level export from its owning module."""
+
+    module_name = _LAZY_EXPORTS.get(name)
+    if module_name is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    value = getattr(import_module(module_name), name)
+    globals()[name] = value
+    return value
+
+def __dir__() -> list[str]:
+    """Include lazy public exports in module introspection."""
+
+    return sorted(set(globals()) | set(__all__))

--- a/src/prob4d/__init__.pyi
+++ b/src/prob4d/__init__.pyi
@@ -1,0 +1,167 @@
+"""Typing surface for the compatibility-preserving package-root exports."""
+
+from prob4d.alignment_cycles import (
+    AlignmentCycleAudit as AlignmentCycleAudit,
+    AlignmentCycleResidual as AlignmentCycleResidual,
+    alignment_edge_id as alignment_edge_id,
+    audit_alignment_cycles as audit_alignment_cycles,
+)
+from prob4d.calibration import (
+    GAUGE_COVARIANCE_CALIBRATION_SCHEMA as GAUGE_COVARIANCE_CALIBRATION_SCHEMA,
+    GAUGE_COVARIANCE_CALIBRATION_VERSION as GAUGE_COVARIANCE_CALIBRATION_VERSION,
+    GROUP_BALANCED_UPPER_WINSORIZED_RATIOS_V2 as GROUP_BALANCED_UPPER_WINSORIZED_RATIOS_V2,
+    LEGACY_GROUP_BALANCED_TRIMMED_RATIOS_V1 as LEGACY_GROUP_BALANCED_TRIMMED_RATIOS_V1,
+    POINT_UNCERTAINTY_CALIBRATION_SCHEMA as POINT_UNCERTAINTY_CALIBRATION_SCHEMA,
+    POINT_UNCERTAINTY_CALIBRATION_VERSION as POINT_UNCERTAINTY_CALIBRATION_VERSION,
+    UPPER_WINSORIZED_MEAN_V1 as UPPER_WINSORIZED_MEAN_V1,
+    GaugeCovarianceCalibrationV1 as GaugeCovarianceCalibrationV1,
+    PointUncertaintyCalibrationV1 as PointUncertaintyCalibrationV1,
+    fit_group_balanced_point_uncertainty_calibration as
+    fit_group_balanced_point_uncertainty_calibration,
+    group_balanced_point_calibration_metadata as group_balanced_point_calibration_metadata,
+    load_gauge_covariance_calibration as load_gauge_covariance_calibration,
+    load_point_uncertainty_calibration as load_point_uncertainty_calibration,
+    save_gauge_covariance_calibration as save_gauge_covariance_calibration,
+    save_point_uncertainty_calibration as save_point_uncertainty_calibration,
+    upper_winsorized_mean as upper_winsorized_mean,
+)
+from prob4d.causal_gauge_graph import (
+    CAUSAL_GAUGE_GRAPH_DEPENDENCE as CAUSAL_GAUGE_GRAPH_DEPENDENCE,
+    CAUSAL_GAUGE_GRAPH_MODE as CAUSAL_GAUGE_GRAPH_MODE,
+    CausalGaugeGraphReport as CausalGaugeGraphReport,
+    CausalGaugeGraphStep as CausalGaugeGraphStep,
+    estimate_causal_multi_edge_gauge_graph as estimate_causal_multi_edge_gauge_graph,
+)
+from prob4d.causal_tracklets import (
+    CausalTrackletReport as CausalTrackletReport,
+    CausalTrackletSet as CausalTrackletSet,
+    build_causal_scene_flow_tracklets as build_causal_scene_flow_tracklets,
+    tracklets_to_observation_factors as tracklets_to_observation_factors,
+)
+from prob4d.cross_fitted_disagreement import (
+    CrossFittedDisagreementReport as CrossFittedDisagreementReport,
+    accumulate_cross_fitted_disagreement as accumulate_cross_fitted_disagreement,
+)
+from prob4d.data import (
+    PredictionWindow as PredictionWindow,
+)
+from prob4d.evaluation_modes import (
+    EvaluationModeResult as EvaluationModeResult,
+    EvaluationModes as EvaluationModes,
+    evaluate_sequence_modes as evaluate_sequence_modes,
+)
+from prob4d.finite_sample_threshold import (
+    FINITE_SAMPLE_UPPER_THRESHOLD_SEMANTICS as FINITE_SAMPLE_UPPER_THRESHOLD_SEMANTICS,
+    FiniteSampleUpperThreshold as FiniteSampleUpperThreshold,
+    fit_finite_sample_upper_threshold as fit_finite_sample_upper_threshold,
+)
+from prob4d.fusion import (
+    FusedSequence as FusedSequence,
+)
+from prob4d.gauge_tree_prior import (
+    GAUGE_TREE_PRIOR_SCHEMA as GAUGE_TREE_PRIOR_SCHEMA,
+    GAUGE_TREE_PRIOR_SEMANTICS as GAUGE_TREE_PRIOR_SEMANTICS,
+    GAUGE_TREE_PRIOR_VERSION as GAUGE_TREE_PRIOR_VERSION,
+    GaugeTreeSquareRootPriorV1 as GaugeTreeSquareRootPriorV1,
+)
+from prob4d.gauge_tree_prior_io import (
+    GAUGE_TREE_PRIOR_ARTIFACT_CLAIM_BOUNDARY as GAUGE_TREE_PRIOR_ARTIFACT_CLAIM_BOUNDARY,
+    GAUGE_TREE_PRIOR_ARTIFACT_SCHEMA as GAUGE_TREE_PRIOR_ARTIFACT_SCHEMA,
+    GAUGE_TREE_PRIOR_ARTIFACT_VERSION as GAUGE_TREE_PRIOR_ARTIFACT_VERSION,
+    gauge_tree_prior_artifact_id as gauge_tree_prior_artifact_id,
+    load_gauge_tree_prior as load_gauge_tree_prior,
+    write_gauge_tree_prior as write_gauge_tree_prior,
+)
+from prob4d.guarded_causal_gauge_graph import (
+    GUARDED_CAUSAL_GAUGE_GRAPH_DEPENDENCE as GUARDED_CAUSAL_GAUGE_GRAPH_DEPENDENCE,
+    GUARDED_CAUSAL_GAUGE_GRAPH_MODE as GUARDED_CAUSAL_GAUGE_GRAPH_MODE,
+    GuardedCausalGaugeGraphReport as GuardedCausalGaugeGraphReport,
+    estimate_guarded_causal_multi_edge_gauge_graph as
+    estimate_guarded_causal_multi_edge_gauge_graph,
+)
+from prob4d.observation_contract import (
+    OBSERVATION_BELIEF_SCHEMA as OBSERVATION_BELIEF_SCHEMA,
+    OBSERVATION_BELIEF_VERSION as OBSERVATION_BELIEF_VERSION,
+    ObservationBeliefExportV1 as ObservationBeliefExportV1,
+    save_observation_belief_export as save_observation_belief_export,
+)
+from prob4d.observation_export import (
+    JointGaugePosterior as JointGaugePosterior,
+    MetricGaugeAnchor as MetricGaugeAnchor,
+    build_prob4d_observation_belief as build_prob4d_observation_belief,
+    deterministic_covariance_root as deterministic_covariance_root,
+    estimate_joint_gauge_tree as estimate_joint_gauge_tree,
+    load_metric_gauge_anchor as load_metric_gauge_anchor,
+    save_metric_gauge_anchor as save_metric_gauge_anchor,
+)
+from prob4d.observation_factor_stream import (
+    OBSERVATION_FACTOR_STREAM_SCHEMA as OBSERVATION_FACTOR_STREAM_SCHEMA,
+    OBSERVATION_FACTOR_STREAM_VERSION as OBSERVATION_FACTOR_STREAM_VERSION,
+    ObservationFactorStreamUpdateV1 as ObservationFactorStreamUpdateV1,
+    ObservationFactorStreamV1 as ObservationFactorStreamV1,
+    append_observation_factor_bundle as append_observation_factor_bundle,
+    load_observation_factor_stream as load_observation_factor_stream,
+    write_observation_factor_stream as write_observation_factor_stream,
+)
+from prob4d.observation_factors import (
+    LinearizedObservationFactor as LinearizedObservationFactor,
+    ObservationFactor as ObservationFactor,
+    ObservationFactorBundle as ObservationFactorBundle,
+    StackedObservationFactors as StackedObservationFactors,
+    load_observation_factor_bundle as load_observation_factor_bundle,
+    stack_observation_factors as stack_observation_factors,
+    write_observation_factor_bundle as write_observation_factor_bundle,
+)
+from prob4d.observation_validation import (
+    load_observation_belief_export as load_observation_belief_export,
+)
+from prob4d.prediction_store import (
+    PREDICTION_BUNDLE_STORE_SCHEMA as PREDICTION_BUNDLE_STORE_SCHEMA,
+    PREDICTION_BUNDLE_STORE_VERSION as PREDICTION_BUNDLE_STORE_VERSION,
+    PREDICTION_WINDOW_STORE_SCHEMA as PREDICTION_WINDOW_STORE_SCHEMA,
+    PREDICTION_WINDOW_STORE_VERSION as PREDICTION_WINDOW_STORE_VERSION,
+    MMapPredictionWindow as MMapPredictionWindow,
+    load_prediction_bundle_store as load_prediction_bundle_store,
+    load_prediction_window_store as load_prediction_window_store,
+    materialize_prediction_bundle_store as materialize_prediction_bundle_store,
+    prediction_bundle_store_summary as prediction_bundle_store_summary,
+    write_prediction_window_store as write_prediction_window_store,
+)
+from prob4d.project_identity import (
+    PROB4D_CANONICAL_REPOSITORY as PROB4D_CANONICAL_REPOSITORY,
+    PROB4D_FROZEN_ARTIFACT_REPOSITORY as PROB4D_FROZEN_ARTIFACT_REPOSITORY,
+    PROB4D_GITHUB_REPOSITORY_ID as PROB4D_GITHUB_REPOSITORY_ID,
+    PROB4D_PROJECT_ID as PROB4D_PROJECT_ID,
+    PROB4D_REPOSITORY_ALIASES as PROB4D_REPOSITORY_ALIASES,
+    canonical_prob4d_repository as canonical_prob4d_repository,
+    is_prob4d_repository as is_prob4d_repository,
+    prob4d_project_identity as prob4d_project_identity,
+    validate_prob4d_project_identity as validate_prob4d_project_identity,
+)
+from prob4d.sim3 import (
+    Sim3 as Sim3,
+)
+from prob4d.source_diagnostics import (
+    CommonModeFailureAudit as CommonModeFailureAudit,
+    SourceOnlyDiagnosticGrid as SourceOnlyDiagnosticGrid,
+    audit_common_mode_failures as audit_common_mode_failures,
+    augment_source_reliability_features as augment_source_reliability_features,
+    build_common_gauge_seed_dispersion_diagnostic as build_common_gauge_seed_dispersion_diagnostic,
+    build_flow_point_consistency_diagnostic as build_flow_point_consistency_diagnostic,
+)
+from prob4d.source_reliability import (
+    SOURCE_RELIABILITY_SCHEMA as SOURCE_RELIABILITY_SCHEMA,
+    SOURCE_RELIABILITY_VERSION as SOURCE_RELIABILITY_VERSION,
+    SourceReliabilityCalibrationReport as SourceReliabilityCalibrationReport,
+    SourceReliabilityFeatures as SourceReliabilityFeatures,
+    SourceReliabilityModelV1 as SourceReliabilityModelV1,
+    build_source_reliability_features as build_source_reliability_features,
+    fit_group_balanced_source_reliability as fit_group_balanced_source_reliability,
+    load_source_reliability_model as load_source_reliability_model,
+    save_source_reliability_model as save_source_reliability_model,
+)
+from prob4d.uncertainty import (
+    GroupBalancedCalibrationReport as GroupBalancedCalibrationReport,
+)
+
+__version__: str

--- a/src/prob4d/_atomic_file.py
+++ b/src/prob4d/_atomic_file.py
@@ -1,0 +1,100 @@
+"""Durable same-directory publication primitives for immutable artifacts."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+
+
+def _fsync_directory(path: Path) -> None:
+    """Best-effort directory synchronization after changing one directory entry."""
+
+    flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
+    try:
+        descriptor = os.open(path, flags)
+    except OSError:
+        return
+    try:
+        os.fsync(descriptor)
+    except OSError:
+        pass
+    finally:
+        os.close(descriptor)
+
+
+def publish_temporary_file(
+    temporary: str | Path,
+    destination: str | Path,
+    *,
+    overwrite: bool,
+) -> None:
+    """Publish one complete same-directory temporary file atomically.
+
+    With ``overwrite=False``, hard-link creation is the decisive no-clobber
+    operation. Concurrent writers therefore cannot both publish successfully.
+    The caller retains ownership of the temporary file when publication fails.
+    """
+
+    if type(overwrite) is not bool:
+        raise ValueError("overwrite must be a Boolean")
+    temporary_path = Path(temporary)
+    destination_path = Path(destination)
+    if temporary_path.parent.resolve() != destination_path.parent.resolve():
+        raise ValueError("temporary and destination must share one directory")
+
+    with temporary_path.open("rb") as stream:
+        os.fsync(stream.fileno())
+    if overwrite:
+        os.replace(temporary_path, destination_path)
+    else:
+        try:
+            os.link(temporary_path, destination_path)
+        except FileExistsError:
+            raise FileExistsError(destination_path) from None
+        temporary_path.unlink()
+    _fsync_directory(destination_path.parent)
+
+
+def atomic_write_bytes(
+    path: str | Path,
+    content: bytes,
+    *,
+    overwrite: bool,
+) -> None:
+    """Publish complete bytes atomically with an optional no-clobber guarantee."""
+
+    if type(content) is not bytes:
+        raise TypeError("content must be bytes")
+    if type(overwrite) is not bool:
+        raise ValueError("overwrite must be a Boolean")
+
+    destination = Path(path)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{destination.name}.",
+        suffix=".tmp",
+        dir=destination.parent,
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(content)
+            stream.flush()
+            os.fsync(stream.fileno())
+        publish_temporary_file(temporary, destination, overwrite=overwrite)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def atomic_write_text(
+    path: str | Path,
+    content: str,
+    *,
+    overwrite: bool,
+) -> None:
+    """UTF-8 text wrapper around :func:`atomic_write_bytes`."""
+
+    if type(content) is not str:
+        raise TypeError("content must be a string")
+    atomic_write_bytes(path, content.encode("utf-8"), overwrite=overwrite)

--- a/src/prob4d/_heldout_promotion_common.py
+++ b/src/prob4d/_heldout_promotion_common.py
@@ -2,15 +2,14 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
-import os
 import re
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal, cast
 
+from ._atomic_file import atomic_write_text
 from ._immutable_json import frozen_finite_json_mapping, plain_json
 from ._provider_evaluation_manifest import validate_finite_json
 from ._selection_evidence_common import (
@@ -122,9 +121,6 @@ def _atomic_write_json(
 ) -> None:
     if type(overwrite) is not bool:
         raise ValueError("overwrite must be a Boolean")
-    if path.exists() and not overwrite:
-        raise FileExistsError(path)
-    path.parent.mkdir(parents=True, exist_ok=True)
     payload = (
         json.dumps(
             plain_json(value),
@@ -134,19 +130,7 @@ def _atomic_write_json(
         )
         + "\n"
     )
-    temporary = path.with_name(
-        f".{path.name}.tmp-{os.getpid()}-{hashlib.sha256(payload.encode()).hexdigest()[:16]}"
-    )
-    try:
-        with temporary.open("x", encoding="utf-8") as stream:
-            stream.write(payload)
-            stream.flush()
-            os.fsync(stream.fileno())
-        if path.exists() and not overwrite:
-            raise FileExistsError(path)
-        os.replace(temporary, path)
-    finally:
-        temporary.unlink(missing_ok=True)
+    atomic_write_text(path, payload, overwrite=overwrite)
 
 
 def _repository(value: Any, *, name: str) -> str:

--- a/src/prob4d/common_mode_stress.py
+++ b/src/prob4d/common_mode_stress.py
@@ -12,8 +12,6 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-import os
-import tempfile
 from collections.abc import Mapping, Sequence
 from dataclasses import asdict, dataclass
 from pathlib import Path
@@ -21,6 +19,7 @@ from typing import Any, Final
 
 import numpy as np
 
+from ._atomic_file import atomic_write_text
 from ._immutable_json import plain_json
 from ._strict_json import load_json_object
 from .source_diagnostics import audit_common_mode_failures
@@ -68,37 +67,9 @@ def _positive_real(value: object, *, name: str, allow_zero: bool = False) -> flo
     return result
 
 
-def _fsync_directory(path: Path) -> None:
-    try:
-        descriptor = os.open(path, os.O_RDONLY)
-    except OSError:
-        return
-    try:
-        os.fsync(descriptor)
-    except OSError:
-        pass
-    finally:
-        os.close(descriptor)
-
-
 def _atomic_write_json(path: Path, record: Mapping[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    descriptor, temporary_name = tempfile.mkstemp(
-        prefix=f".{path.name}.",
-        suffix=".tmp",
-        dir=path.parent,
-    )
-    try:
-        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
-            json.dump(record, stream, indent=2, sort_keys=True, allow_nan=False)
-            stream.write("\n")
-            stream.flush()
-            os.fsync(stream.fileno())
-        os.replace(temporary_name, path)
-        _fsync_directory(path.parent)
-    finally:
-        if os.path.exists(temporary_name):
-            os.unlink(temporary_name)
+    payload = json.dumps(record, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    atomic_write_text(path, payload, overwrite=False)
 
 
 @dataclass(frozen=True)
@@ -538,12 +509,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     report = run_common_mode_stress(config)
     destination = Path(arguments.output)
-    if destination.exists():
+    record = report.to_record()
+    try:
+        _atomic_write_json(destination, record)
+    except FileExistsError:
         existing = load_json_object(destination, name="common-mode stress report")
-        if existing != report.to_record():
-            raise ValueError("refusing to replace a different common-mode stress report")
-    else:
-        _atomic_write_json(destination, report.to_record())
+        if existing != record:
+            raise ValueError(
+                "refusing to replace a different common-mode stress report"
+            ) from None
     print(json.dumps(report.to_record(), indent=2, sort_keys=True))
     return 0 if report.decision == "pass-controlled-common-mode-mechanism" else 3
 

--- a/src/prob4d/fresh_provider_readiness.py
+++ b/src/prob4d/fresh_provider_readiness.py
@@ -11,12 +11,12 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-import os
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Literal, cast
 
+from ._atomic_file import atomic_write_text
 from ._immutable_json import frozen_finite_json_mapping, plain_json
 from ._strict_json import (
     load_json_object,
@@ -231,32 +231,15 @@ def _atomic_write_json(
     *,
     overwrite: bool,
 ) -> None:
-    destination = Path(path)
     if type(overwrite) is not bool:
         raise ValueError("overwrite must be a Boolean")
-    if destination.exists() and not overwrite:
-        raise FileExistsError(destination)
-    destination.parent.mkdir(parents=True, exist_ok=True)
     payload = json.dumps(
         plain_json(value),
         sort_keys=True,
         indent=2,
         allow_nan=False,
     ) + "\n"
-    temporary = destination.with_name(
-        f".{destination.name}.tmp-{os.getpid()}-"
-        f"{hashlib.sha256(payload.encode()).hexdigest()[:16]}"
-    )
-    try:
-        with temporary.open("x", encoding="utf-8") as stream:
-            stream.write(payload)
-            stream.flush()
-            os.fsync(stream.fileno())
-        if destination.exists() and not overwrite:
-            raise FileExistsError(destination)
-        os.replace(temporary, destination)
-    finally:
-        temporary.unlink(missing_ok=True)
+    atomic_write_text(path, payload, overwrite=overwrite)
 
 
 def _gate_name(value: object) -> GateName:

--- a/src/prob4d/material_identity_mixture.py
+++ b/src/prob4d/material_identity_mixture.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -25,6 +24,7 @@ from typing import Any, Literal, TypeAlias, cast
 import numpy as np
 from numpy.typing import NDArray
 
+from ._atomic_file import atomic_write_bytes
 from ._immutable_json import frozen_finite_json_mapping, plain_json
 
 FloatArray: TypeAlias = NDArray[np.floating[Any]]
@@ -794,27 +794,8 @@ def write_material_identity_mixture(
 
     if type(overwrite) is not bool:
         raise ValueError("overwrite must be a Boolean")
-    destination = Path(path)
-    if destination.exists() and not overwrite:
-        raise FileExistsError(destination)
-    destination.parent.mkdir(parents=True, exist_ok=True)
     payload = _canonical_json(mixture.to_record()) + b"\n"
-    temporary = destination.with_name(
-        f".{destination.name}.tmp-{os.getpid()}-{hashlib.sha256(payload).hexdigest()[:16]}"
-    )
-    try:
-        with temporary.open("xb") as stream:
-            stream.write(payload)
-            stream.flush()
-            os.fsync(stream.fileno())
-        if destination.exists() and not overwrite:
-            raise FileExistsError(destination)
-        os.replace(temporary, destination)
-    finally:
-        try:
-            temporary.unlink()
-        except FileNotFoundError:
-            pass
+    atomic_write_bytes(path, payload, overwrite=overwrite)
 
 
 def load_material_identity_mixture(path: str | Path) -> MaterialIdentityMixtureV1:

--- a/src/prob4d/prediction_provider_manifest.py
+++ b/src/prob4d/prediction_provider_manifest.py
@@ -12,13 +12,12 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-import os
-import tempfile
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path, PurePosixPath
 from typing import Any, Final
 
+from ._atomic_file import atomic_write_text
 from ._immutable_json import frozen_finite_json_mapping, plain_json
 from ._strict_json import (
     load_json_object,
@@ -185,36 +184,8 @@ def _relative_member(path: Path, *, root: Path, name: str) -> str:
     return _safe_relative_path(relative.as_posix(), name=name)
 
 
-def _fsync_directory(path: Path) -> None:
-    try:
-        descriptor = os.open(path, os.O_RDONLY)
-    except OSError:
-        return
-    try:
-        os.fsync(descriptor)
-    except OSError:
-        pass
-    finally:
-        os.close(descriptor)
-
-
 def _atomic_write_text(path: Path, content: str) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    descriptor, temporary_name = tempfile.mkstemp(
-        prefix=f".{path.name}.",
-        suffix=".tmp",
-        dir=path.parent,
-    )
-    try:
-        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
-            stream.write(content)
-            stream.flush()
-            os.fsync(stream.fileno())
-        os.replace(temporary_name, path)
-        _fsync_directory(path.parent)
-    finally:
-        if os.path.exists(temporary_name):
-            os.unlink(temporary_name)
+    atomic_write_text(path, content, overwrite=False)
 
 
 @dataclass(frozen=True)
@@ -713,12 +684,14 @@ def save_prediction_provider_manifest(
     destination = Path(path)
     record = manifest.to_record()
     content = json.dumps(record, indent=2, sort_keys=True, allow_nan=False) + "\n"
-    if destination.exists():
+    try:
+        _atomic_write_text(destination, content)
+    except FileExistsError:
         existing = load_prediction_provider_manifest(destination)
         if existing.to_record() != record:
-            raise ValueError("refusing to replace a different prediction-provider manifest")
-        return destination
-    _atomic_write_text(destination, content)
+            raise ValueError(
+                "refusing to replace a different prediction-provider manifest"
+            ) from None
     return destination
 
 

--- a/src/prob4d/public_api_manifest.py
+++ b/src/prob4d/public_api_manifest.py
@@ -257,7 +257,7 @@ def validate_public_api_manifest(value: Any) -> dict[str, Any]:
     unsigned.pop("manifest_id")
     if manifest_id != _manifest_id(unsigned):
         raise ValueError("manifest_id does not match the canonical manifest content")
-    canonical: dict[str, Any] = json.loads(_canonical_json(payload))
+    canonical = cast(dict[str, Any], json.loads(_canonical_json(payload)))
     return canonical
 
 

--- a/src/prob4d/public_api_manifest.py
+++ b/src/prob4d/public_api_manifest.py
@@ -86,7 +86,7 @@ def build_public_api_manifest() -> dict[str, Any]:
                 "exports": _surface_exports(api_v2.__all__, name="api_v2"),
             },
         },
-        "claim_boundary": PUBLIC_API_MANIFST_CLAIM_BOUNDARY,
+        "claim_boundary": PUBLIC_API_MANIFEST_CLAIM_BOUNDARY,
     }
     payload["manifest_id"] = _manifest_id(payload)
     return validate_public_api_manifest(payload)
@@ -155,7 +155,7 @@ def validate_public_api_manifest(value: Any) -> dict[str, Any]:
         raise ValueError("unsupported public-API manifest schema version")
     if (
         _strict_string(payload["claim_boundary"], name="claim_boundary")
-        != PUBLIC_API_MANIFST_CLAIM_BOUNDARY
+        != PUBLIC_API_MANIFEST_CLAIM_BOUNDARY
     ):
         raise ValueError("public-API manifest claim boundary is not canonical")
 
@@ -256,7 +256,7 @@ def validate_public_api_manifest(value: Any) -> dict[str, Any]:
     unsigned = dict(payload)
     unsigned.pop("manifest_id")
     if manifest_id != _manifest_id(unsigned):
-        raise ValueEError("manifest_id does not match the canonical manifest content")
+        raise ValueError("manifest_id does not match the canonical manifest content")
     canonical: dict[str, Any] = json.loads(_canonical_json(payload))
     return canonical
 
@@ -265,7 +265,7 @@ def load_public_api_manifest(path: str | Path) -> dict[str, Any]:
     """Load strict JSON and validate a public-API manifest."""
 
     def reject_constant(value: str) -> None:
-        raise ValueEError(f"non-finite JSON constant is forbidden: {value}")
+        raise ValueError(f"non-finite JSON constant is forbidden: {value}")
 
     def unique_object(pairs: Sequence[tuple[str, Any]]) -> dict[str, Any]:
         result: dict[str, Any] = {}

--- a/src/prob4d/public_api_manifest.py
+++ b/src/prob4d/public_api_manifest.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
-import os
 from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any, Final, cast
 
 from . import __all__ as ROOT_PUBLIC_EXPORTS
+from ._atomic_file import atomic_write_bytes
 from ._version import __version__
 from .api import v1 as api_v1
 from .api import v2 as api_v2
@@ -297,19 +297,16 @@ def write_public_api_manifest(
     destination = Path(path)
     if destination.is_symlink():
         raise ValueError("public-API manifest destination must not be a symbolic link")
-    destination.parent.mkdir(parents=True, exist_ok=True)
     encoded = _canonical_json(payload)
-    if destination.exists():
+    try:
+        atomic_write_bytes(destination, encoded, overwrite=False)
+    except FileExistsError:
         existing = load_public_api_manifest(destination)
         if existing != payload:
             raise FileExistsError(
                 f"refusing to replace a different public-API manifest: {destination}"
-            )
+            ) from None
         return existing
-    with destination.open("xb") as stream:
-        stream.write(encoded)
-        stream.flush()
-        os.fsync(stream.fileno())
     return payload
 
 

--- a/src/prob4d/public_api_manifest.py
+++ b/src/prob4d/public_api_manifest.py
@@ -1,0 +1,379 @@
+"""Build and verify a content-addressed inventory of supported Python surfaces."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final, cast
+
+from . import __all__ as ROOT_PUBLIC_EXPORTS
+from ._version import __version__
+from .api import v1 as api_v1
+from .api import v2 as api_v2
+from .project_identity import PROB4D_PROJECT_ID
+
+PUBLIC_API_MANIFEST_SCHEMA: Final = "prob4d.public-api-manifest"
+PUBLIC_API_MANIFEST_VERSION: Final = 1
+ROOT_COMPATIBILITY_SURFACE_VERSION: Final = 1
+PUBLIC_API_MANIFEST_CLAIM_BOUNDARY: Final = (
+    "This manifest records installed Python compatibility surfaces and their exact "
+    "export inventories. It is interoperability evidence only; it does not establish "
+    "provider accuracy, uncertainty calibration, physical-query improvement, "
+    "Causal4D intervention benefit, deployment safety, or state of the art."
+)
+
+
+def _canonical_json(value: Mapping[str, Any]) -> bytes:
+    serialized = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+    return (serialized + "\n").encode("utf-8")
+
+
+def _manifest_id(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json(value)).hexdigest()
+
+
+def _surface_exports(value: Sequence[str], *, name: str) -> list[str]:
+    exports = list(value)
+    if any(type(item) is not str or not item for item in exports):
+        raise ValueError(f"{name} exports must be nonempty exact strings")
+    if len(exports) != len(set(exports)):
+        raise ValueError(f"{name} exports must be unique")
+    return sorted(exports)
+
+
+def build_public_api_manifest() -> dict[str, Any]:
+    """Return the canonical manifest for the executing Prob4D installation."""
+
+    payload: dict[str, Any] = {
+        "schema": PUBLIC_API_MANIFEST_SCHEMA,
+        "schema_version": PUBLIC_API_MANIFEST_VERSION,
+        "package": {
+            "name": "prob4d",
+            "version": __version__,
+            "project_id": PROB4D_PROJECT_ID,
+        },
+        "surfaces": {
+            "compatibility_root": {
+                "module": "prob4d",
+                "surface_version": ROOT_COMPATIBILITY_SURFACE_VERSION,
+                "loading": "lazy-compatibility-shim-v1",
+                "exports": _surface_exports(
+                    ROOT_PUBLIC_EXPORTS,
+                    name="compatibility_root",
+                ),
+            },
+            "api_v1": {
+                "module": "prob4d.api.v1",
+                "api_version": api_v1.API_VERSION,
+                "provider_api_version": api_v1.PROVIDER_API_VERSION,
+                "exports": _surface_exports(api_v1.__all__, name="api_v1"),
+            },
+            "api_v2": {
+                "module": "prob4d.api.v2",
+                "api_version": api_v2.API_VERSION,
+                "provider_api_version": api_v2.PROVIDER_API_VERSION,
+                "provider_factor_api_version": api_v2.PROVIDER_FACTOR_API_VERSION,
+                "exports": _surface_exports(api_v2.__all__, name="api_v2"),
+            },
+        },
+        "claim_boundary": PUBLIC_API_MANIFST_CLAIM_BOUNDARY,
+    }
+    payload["manifest_id"] = _manifest_id(payload)
+    return validate_public_api_manifest(payload)
+
+
+def _strict_mapping(value: Any, *, name: str) -> Mapping[str, Any]:
+    if type(value) is not dict or any(type(key) is not str for key in value):
+        raise ValueError(f"{name} must be a JSON object with exact string keys")
+    return cast(Mapping[str, Any], value)
+
+
+def _exact_keys(value: Mapping[str, Any], expected: set[str], *, name: str) -> None:
+    keys = set(value)
+    if keys != expected:
+        missing = sorted(expected - keys)
+        extra = sorted(keys - expected)
+        raise ValueError(f"{name} has noncanonical keys; missing={missing}, extra={extra}")
+
+
+def _strict_string(value: Any, *, name: str) -> str:
+    if type(value) is not str or not value or value != value.strip():
+        raise ValueError(f"{name} must be a nonempty exact string without surrounding whitespace")
+    return cast(str, value)
+
+
+def _strict_integer(value: Any, *, name: str, minimum: int = 1) -> int:
+    if type(value) is not int or value < minimum:
+        raise ValueError(f"{name} must be an integer >= {minimum}")
+    return cast(int, value)
+
+
+def _validate_exports(value: Any, *, name: str) -> list[str]:
+    if type(value) is not list:
+        raise ValueError(f"{name} must be a JSON array")
+    exports = _surface_exports(value, name=name)
+    if list(value) != exports:
+        raise ValueError(f"{name} must be sorted canonically")
+    for export in exports:
+        if export.startswith("_") and export != "__version__":
+            raise ValueError(f"{name} contains a private export: {export}")
+    return exports
+
+
+def validate_public_api_manifest(value: Any) -> dict[str, Any]:
+    """Deeply validate a public-API manifest and return canonical plain data."""
+
+    payload = _strict_mapping(value, name="manifest")
+    _exact_keys(
+        payload,
+        {
+            "schema",
+            "schema_version",
+            "package",
+            "surfaces",
+            "claim_boundary",
+            "manifest_id",
+        },
+        name="manifest",
+    )
+    if _strict_string(payload["schema"], name="schema") != PUBLIC_API_MANIFEST_SCHEMA:
+        raise ValueError("unsupported public-API manifest schema")
+    if (
+        _strict_integer(payload["schema_version"], name="schema_version")
+        != PUBLIC_API_MANIFEST_VERSION
+    ):
+        raise ValueError("unsupported public-API manifest schema version")
+    if (
+        _strict_string(payload["claim_boundary"], name="claim_boundary")
+        != PUBLIC_API_MANIFST_CLAIM_BOUNDARY
+    ):
+        raise ValueError("public-API manifest claim boundary is not canonical")
+
+    package = _strict_mapping(payload["package"], name="package")
+    _exact_keys(package, {"name", "version", "project_id"}, name="package")
+    if _strict_string(package["name"], name="package.name") != "prob4d":
+        raise ValueError("public-API manifest package name must be 'prob4d'")
+    _strict_string(package["version"], name="package.version")
+    if (
+        _strict_string(package["project_id"], name="package.project_id")
+        != PROB4D_PROJECT_ID
+    ):
+        raise ValueError("public-API manifest project identity is not canonical")
+
+    surfaces = _strict_mapping(payload["surfaces"], name="surfaces")
+    _exact_keys(
+        surfaces,
+        {"compatibility_root", "api_v1", "api_v2"},
+        name="surfaces",
+    )
+
+    root = _strict_mapping(surfaces["compatibility_root"], name="compatibility_root")
+    _exact_keys(
+        root,
+        {"module", "surface_version", "loading", "exports"},
+        name="compatibility_root",
+    )
+    if _strict_string(root["module"], name="compatibility_root.module") != "prob4d":
+        raise ValueError("compatibility-root module is not canonical")
+    if (
+        _strict_integer(
+            root["surface_version"],
+            name="compatibility_root.surface_version",
+        )
+        != ROOT_COMPATIBILITY_SURFACE_VERSION
+    ):
+        raise ValueError("compatibility-root surface version is not supported")
+    if (
+        _strict_string(root["loading"], name="compatibility_root.loading")
+        != "lazy-compatibility-shim-v1"
+    ):
+        raise ValueError("compatibility-root loading mode is not canonical")
+    _validate_exports(root["exports"], name="compatibility_root.exports")
+
+    api1 = _strict_mapping(surfaces["api_v1"], name="api_v1")
+    _exact_keys(
+        api1,
+        {"module", "api_version", "provider_api_version", "exports"},
+        name="api_v1",
+    )
+    if _strict_string(api1["module"], name="api_v1.module") != "prob4d.api.v1":
+        raise ValueError("api_v1 module is not canonical")
+    if _strict_integer(api1["api_version"], name="api_v1.api_version") != 1:
+        raise ValueError("api_v1 API version is not canonical")
+    if (
+        _strict_integer(api1["provider_api_version"], name="api_v1.provider_api_version")
+        != 1
+    ):
+        raise ValueError("api_v1 provider API version is not canonical")
+    _validate_exports(api1["exports"], name="api_v1.exports")
+
+    api2 = _strict_mapping(surfaces["api_v2"], name="api_v2")
+    _exact_keys(
+        api2,
+        {
+            "module",
+            "api_version",
+            "provider_api_version",
+            "provider_factor_api_version",
+            "exports",
+        },
+        name="api_v2",
+    )
+    if _strict_string(api2["module"], name="api_v2.module") != "prob4d.api.v2":
+        raise ValueError("api_v2 module is not canonical")
+    if _strict_integer(api2["api_version"], name="api_v2.api_version") != 2:
+        raise ValueError("api_v2 API version is not canonical")
+    if (
+        _strict_integer(api2["provider_api_version"], name="api_v2.provider_api_version")
+        != 2
+    ):
+        raise ValueError("api_v2 provider API version is not canonical")
+    if (
+        _strict_integer(
+            api2["provider_factor_api_version"],
+            name="api_v2.provider_factor_api_version",
+        )
+        != 2
+    ):
+        raise ValueError("api_v2 provider-factor API version is not canonical")
+    _validate_exports(api2["exports"], name="api_v2.exports")
+
+    manifest_id = _strict_string(payload["manifest_id"], name="manifest_id")
+    if len(manifest_id) != 64 or any(
+        character not in "0123456789abcdef" for character in manifest_id
+    ):
+        raise ValueError("manifest_id must be a lowercase SHA-256 digest")
+    unsigned = dict(payload)
+    unsigned.pop("manifest_id")
+    if manifest_id != _manifest_id(unsigned):
+        raise ValueEError("manifest_id does not match the canonical manifest content")
+    canonical: dict[str, Any] = json.loads(_canonical_json(payload))
+    return canonical
+
+
+def load_public_api_manifest(path: str | Path) -> dict[str, Any]:
+    """Load strict JSON and validate a public-API manifest."""
+
+    def reject_constant(value: str) -> None:
+        raise ValueEError(f"non-finite JSON constant is forbidden: {value}")
+
+    def unique_object(pairs: Sequence[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, item in pairs:
+            if key in result:
+                raise ValueError(f"duplicate JSON key: {key}")
+            result[key] = item
+        return result
+
+    payload = json.loads(
+        Path(path).read_text(encoding="utf-8"),
+        parse_constant=reject_constant,
+        object_pairs_hook=unique_object,
+    )
+    return validate_public_api_manifest(payload)
+
+
+def write_public_api_manifest(
+    path: str | Path,
+    manifest: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Write one manifest without replacing different existing bytes."""
+
+    payload = (
+        build_public_api_manifest()
+        if manifest is None
+        else validate_public_api_manifest(manifest)
+    )
+    destination = Path(path)
+    if destination.is_symlink():
+        raise ValueError("public-API manifest destination must not be a symbolic link")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    encoded = _canonical_json(payload)
+    if destination.exists():
+        existing = load_public_api_manifest(destination)
+        if existing != payload:
+            raise FileExistsError(
+                f"refusing to replace a different public-API manifest: {destination}"
+            )
+        return existing
+    with destination.open("xb") as stream:
+        stream.write(encoded)
+        stream.flush()
+        os.fsync(stream.fileno())
+    return payload
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    show = subparsers.add_parser("print", help="print the executing installation's manifest")
+    show.set_defaults(handler=_print_command)
+
+    build = subparsers.add_parser("build", help="write the executing installation's manifest")
+    build.add_argument("--output", required=True)
+    build.set_defaults(handler=_build_command)
+
+    verify = subparsers.add_parser("verify", help="verify a persisted manifest")
+    verify.add_argument("manifest")
+    verify.add_argument(
+        "--require-current",
+        action="store_true",
+        help="also require equality with the executing installation",
+    )
+    verify.set_defaults(handler=_verify_command)
+    return parser
+
+
+def _print_command(arguments: argparse.Namespace) -> int:
+    del arguments
+    print(_canonical_json(build_public_api_manifest()).decode("utf-8"), end="")
+    return 0
+
+
+def _build_command(arguments: argparse.Namespace) -> int:
+    manifest = write_public_api_manifest(arguments.output)
+    print(manifest["manifest_id"])
+    return 0
+
+
+def _verify_command(arguments: argparse.Namespace) -> int:
+    manifest = load_public_api_manifest(arguments.manifest)
+    if arguments.require_current and manifest != build_public_api_manifest():
+        raise ValueError("persisted public-API manifest does not match this installation")
+    print(manifest["manifest_id"])
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the public-API manifest command."""
+
+    arguments = _parser().parse_args(argv)
+    return int(arguments.handler(arguments))
+
+
+__all__ = [
+    "PUBLIC_API_MANIFEST_CLAIM_BOUNDARY",
+    "PUBLIC_API_MANIFEST_SCHEMA",
+    "PUBLIC_API_MANIFEST_VERSION",
+    "ROOT_COMPATIBILITY_SURFACE_VERSION",
+    "build_public_api_manifest",
+    "load_public_api_manifest",
+    "main",
+    "validate_public_api_manifest",
+    "write_public_api_manifest",
+]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/prob4d/query_covariance_preservation.py
+++ b/src/prob4d/query_covariance_preservation.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -20,6 +19,7 @@ from typing import Any, TypeAlias
 import numpy as np
 from numpy.typing import NDArray
 
+from ._atomic_file import atomic_write_text
 from ._immutable_json import frozen_finite_json_mapping, plain_json
 from ._strict_json import (
     load_json_object,
@@ -193,32 +193,15 @@ def _atomic_write_json(
     *,
     overwrite: bool,
 ) -> None:
-    destination = Path(path)
     if type(overwrite) is not bool:
         raise ValueError("overwrite must be a Boolean")
-    if destination.exists() and not overwrite:
-        raise FileExistsError(destination)
-    destination.parent.mkdir(parents=True, exist_ok=True)
     payload = json.dumps(
         plain_json(value),
         sort_keys=True,
         indent=2,
         allow_nan=False,
     ) + "\n"
-    temporary = destination.with_name(
-        f".{destination.name}.tmp-{os.getpid()}-"
-        f"{hashlib.sha256(payload.encode()).hexdigest()[:16]}"
-    )
-    try:
-        with temporary.open("x", encoding="utf-8") as stream:
-            stream.write(payload)
-            stream.flush()
-            os.fsync(stream.fileno())
-        if destination.exists() and not overwrite:
-            raise FileExistsError(destination)
-        os.replace(temporary, destination)
-    finally:
-        temporary.unlink(missing_ok=True)
+    atomic_write_text(path, payload, overwrite=overwrite)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/prob4d/source_provider_competence.py
+++ b/src/prob4d/source_provider_competence.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -18,6 +17,7 @@ from typing import Any, Literal
 
 import numpy as np
 
+from ._atomic_file import atomic_write_text
 from ._immutable_json import frozen_finite_json_mapping, plain_json
 from ._strict_json import (
     load_json_object,
@@ -193,32 +193,15 @@ def _atomic_write_json(
     *,
     overwrite: bool,
 ) -> None:
-    destination = Path(path)
     if type(overwrite) is not bool:
         raise ValueError("overwrite must be a Boolean")
-    if destination.exists() and not overwrite:
-        raise FileExistsError(destination)
-    destination.parent.mkdir(parents=True, exist_ok=True)
     payload = json.dumps(
         plain_json(value),
         sort_keys=True,
         indent=2,
         allow_nan=False,
     ) + "\n"
-    temporary = destination.with_name(
-        f".{destination.name}.tmp-{os.getpid()}-"
-        f"{hashlib.sha256(payload.encode()).hexdigest()[:16]}"
-    )
-    try:
-        with temporary.open("x", encoding="utf-8") as stream:
-            stream.write(payload)
-            stream.flush()
-            os.fsync(stream.fileno())
-        if destination.exists() and not overwrite:
-            raise FileExistsError(destination)
-        os.replace(temporary, destination)
-    finally:
-        temporary.unlink(missing_ok=True)
+    atomic_write_text(path, payload, overwrite=overwrite)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/prob4d/vggt_baseline.py
+++ b/src/prob4d/vggt_baseline.py
@@ -16,6 +16,7 @@ from typing import Any
 
 import numpy as np
 
+from ._atomic_file import publish_temporary_file
 from .vggt_integrity import (
     VGGT_REPRESENTATIONS,
     build_run_record,
@@ -272,14 +273,13 @@ def write_prediction_archive(
             camera_extrinsics=np.asarray(camera_extrinsics, dtype=np.float32),
             camera_intrinsics=np.asarray(camera_intrinsics, dtype=np.float32),
         )
-        if path.exists():
+        try:
+            publish_temporary_file(temporary, path, overwrite=False)
+        except FileExistsError:
             if not _archives_equal(path, temporary):
-                raise ValueError(f"refusing to replace different VGGT prediction {path}")
-            return
-        os.replace(temporary, path)
+                raise ValueError(f"refusing to replace different VGGT prediction {path}") from None
     finally:
-        if temporary.exists():
-            temporary.unlink()
+        temporary.unlink(missing_ok=True)
 
 
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:

--- a/src/prob4d/vggt_integrity.py
+++ b/src/prob4d/vggt_integrity.py
@@ -11,14 +11,13 @@ from __future__ import annotations
 import hashlib
 import json
 import math
-import os
-import tempfile
 from collections.abc import Mapping, Sequence
 from pathlib import Path, PurePosixPath
 from typing import Any, Final
 
 import numpy as np
 
+from ._atomic_file import atomic_write_text
 from ._strict_json import (
     load_json_object,
     require_exact_fields,
@@ -687,19 +686,6 @@ def load_vggt_run_metadata(path: str | Path) -> dict[str, Any]:
     return validate_run_record(record)
 
 
-def _fsync_directory(path: Path) -> None:
-    try:
-        descriptor = os.open(path, os.O_RDONLY)
-    except OSError:
-        return
-    try:
-        os.fsync(descriptor)
-    except OSError:
-        pass
-    finally:
-        os.close(descriptor)
-
-
 def save_vggt_run_metadata(
     path: str | Path,
     record: Mapping[str, Any],
@@ -709,27 +695,12 @@ def save_vggt_run_metadata(
     destination = Path(path)
     normalized = validate_run_record(record)
     content = json.dumps(normalized, indent=2, sort_keys=True, allow_nan=False) + "\n"
-    if destination.exists():
+    try:
+        atomic_write_text(destination, content, overwrite=False)
+    except FileExistsError:
         existing = load_vggt_run_metadata(destination)
         if existing["run_id"] != normalized["run_id"]:
-            raise ValueError("refusing to replace different VGGT run metadata")
-        return destination
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    descriptor, temporary_name = tempfile.mkstemp(
-        prefix=f".{destination.name}.",
-        suffix=".tmp",
-        dir=destination.parent,
-    )
-    try:
-        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
-            stream.write(content)
-            stream.flush()
-            os.fsync(stream.fileno())
-        os.replace(temporary_name, destination)
-        _fsync_directory(destination.parent)
-    finally:
-        if os.path.exists(temporary_name):
-            os.unlink(temporary_name)
+            raise ValueError("refusing to replace different VGGT run metadata") from None
     return destination
 
 

--- a/src/prob4d/vggt_provider_adapter.py
+++ b/src/prob4d/vggt_provider_adapter.py
@@ -13,6 +13,7 @@ from typing import Any
 
 import numpy as np
 
+from ._atomic_file import publish_temporary_file
 from .data import DENSE_STORAGE_DTYPES, PredictionWindow
 from .prediction_provider_manifest import (
     PredictionFrameLineageV1,
@@ -93,26 +94,28 @@ def _windows_equal(first: PredictionWindow, second: PredictionWindow) -> bool:
 
 def _write_window_atomically(path: Path, window: PredictionWindow) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
-    if path.exists():
-        existing = PredictionWindow.from_npz(
-            path,
-            dense_storage_dtype=window.dense_storage_dtype,
-        )
-        if not _windows_equal(existing, window):
-            raise ValueError(f"refusing to replace different canonical VGGT payload {path.name!r}")
-        return
     descriptor, temporary_name = tempfile.mkstemp(
         prefix=f".{path.stem}.",
         suffix=".npz",
         dir=path.parent,
     )
     os.close(descriptor)
+    temporary = Path(temporary_name)
     try:
-        window.to_npz(temporary_name)
-        os.replace(temporary_name, path)
+        window.to_npz(temporary)
+        try:
+            publish_temporary_file(temporary, path, overwrite=False)
+        except FileExistsError:
+            existing = PredictionWindow.from_npz(
+                path,
+                dense_storage_dtype=window.dense_storage_dtype,
+            )
+            if not _windows_equal(existing, window):
+                raise ValueError(
+                    f"refusing to replace different canonical VGGT payload {path.name!r}"
+                ) from None
     finally:
-        if os.path.exists(temporary_name):
-            os.unlink(temporary_name)
+        temporary.unlink(missing_ok=True)
 
 
 def _adapter_id() -> str:

--- a/tests/test_atomic_evidence_publication.py
+++ b/tests/test_atomic_evidence_publication.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from prob4d import (
+    _atomic_file,
+    _heldout_promotion_common,
+    common_mode_stress,
+    fresh_provider_readiness,
+    material_identity_mixture,
+    prediction_provider_manifest,
+    query_covariance_preservation,
+    source_provider_competence,
+    vggt_provider_adapter,
+)
+from prob4d._atomic_file import atomic_write_bytes
+from prob4d.data import PredictionWindow
+from prob4d.vggt_baseline import write_prediction_archive
+
+
+def test_no_clobber_publication_has_exactly_one_concurrent_winner(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    destination = tmp_path / "evidence.json"
+    barrier = threading.Barrier(2)
+    original_link = _atomic_file.os.link
+
+    def synchronized_link(source: object, target: object) -> None:
+        barrier.wait(timeout=5.0)
+        original_link(source, target)
+
+    monkeypatch.setattr(_atomic_file.os, "link", synchronized_link)
+
+    def write(payload: bytes) -> Exception | None:
+        try:
+            atomic_write_bytes(destination, payload, overwrite=False)
+        except Exception as error:  # pragma: no branch - asserted below
+            return error
+        return None
+
+    payloads = (b'{"writer": 1}\n', b'{"writer": 2}\n')
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        outcomes = tuple(executor.map(write, payloads))
+
+    assert sum(outcome is None for outcome in outcomes) == 1
+    errors = [outcome for outcome in outcomes if outcome is not None]
+    assert len(errors) == 1
+    assert isinstance(errors[0], FileExistsError)
+    assert destination.read_bytes() in payloads
+    assert list(tmp_path.glob(f".{destination.name}.*.tmp")) == []
+
+
+def test_explicit_overwrite_replaces_complete_bytes(tmp_path: Path) -> None:
+    destination = tmp_path / "artifact.bin"
+    atomic_write_bytes(destination, b"first", overwrite=False)
+    atomic_write_bytes(destination, b"second", overwrite=True)
+    assert destination.read_bytes() == b"second"
+
+
+def test_atomic_writer_rejects_non_boolean_overwrite(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="overwrite must be a Boolean"):
+        atomic_write_bytes(
+            tmp_path / "artifact.bin",
+            b"payload",
+            overwrite=1,  # type: ignore[arg-type]
+        )
+
+
+@pytest.mark.parametrize(
+    "writer",
+    [
+        fresh_provider_readiness._atomic_write_json,
+        source_provider_competence._atomic_write_json,
+        query_covariance_preservation._atomic_write_json,
+        _heldout_promotion_common._atomic_write_json,
+    ],
+)
+def test_claim_bearing_json_writers_preserve_no_clobber(
+    tmp_path: Path,
+    writer: Any,
+) -> None:
+    destination = tmp_path / "report.json"
+    writer(destination, {"value": 1}, overwrite=False)
+    with pytest.raises(FileExistsError):
+        writer(destination, {"value": 2}, overwrite=False)
+    writer(destination, {"value": 2}, overwrite=True)
+    assert destination.read_text(encoding="utf-8") == '{\n  "value": 2\n}\n'
+
+
+def test_other_claim_bearing_writers_use_shared_no_clobber(tmp_path: Path) -> None:
+    report = tmp_path / "common-mode.json"
+    common_mode_stress._atomic_write_json(report, {"value": 1})
+    with pytest.raises(FileExistsError):
+        common_mode_stress._atomic_write_json(report, {"value": 2})
+
+    manifest = tmp_path / "provider.json"
+    prediction_provider_manifest._atomic_write_text(manifest, "first\n")
+    with pytest.raises(FileExistsError):
+        prediction_provider_manifest._atomic_write_text(manifest, "second\n")
+
+
+class _MixtureRecord:
+    def __init__(self, value: int) -> None:
+        self.value = value
+
+    def to_record(self) -> dict[str, int]:
+        return {"value": self.value}
+
+
+def test_material_identity_writer_is_race_safe_and_overwritable(tmp_path: Path) -> None:
+    destination = tmp_path / "mixture.json"
+    material_identity_mixture.write_material_identity_mixture(
+        destination,
+        _MixtureRecord(1),  # type: ignore[arg-type]
+    )
+    with pytest.raises(FileExistsError):
+        material_identity_mixture.write_material_identity_mixture(
+            destination,
+            _MixtureRecord(2),  # type: ignore[arg-type]
+        )
+    material_identity_mixture.write_material_identity_mixture(
+        destination,
+        _MixtureRecord(2),  # type: ignore[arg-type]
+        overwrite=True,
+    )
+    assert destination.read_text(encoding="utf-8") == '{"value":2}\n'
+
+
+def _window(value: float) -> PredictionWindow:
+    return PredictionWindow(
+        window_id="window-0",
+        frame_indices=np.array([0], dtype=np.int64),
+        point_map=np.full((1, 1, 1, 3), value, dtype=np.float32),
+        valid_mask=np.ones((1, 1, 1), dtype=bool),
+        dense_storage_dtype="float32",
+    )
+
+
+def test_vggt_window_publication_is_idempotent_and_rejects_conflicts(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "window.npz"
+    vggt_provider_adapter._write_window_atomically(destination, _window(1.0))
+    vggt_provider_adapter._write_window_atomically(destination, _window(1.0))
+    with pytest.raises(ValueError, match="different canonical VGGT payload"):
+        vggt_provider_adapter._write_window_atomically(destination, _window(2.0))
+
+
+def test_vggt_prediction_archive_publication_is_idempotent_and_rejects_conflicts(
+    tmp_path: Path,
+) -> None:
+    destination = tmp_path / "prediction.npz"
+    points = np.ones((1, 1, 1, 3), dtype=np.float32)
+    extrinsics = np.eye(4, dtype=np.float32)[None, ...]
+    intrinsics = np.eye(3, dtype=np.float32)[None, ...]
+
+    write_prediction_archive(
+        destination,
+        point_map=points,
+        camera_extrinsics=extrinsics,
+        camera_intrinsics=intrinsics,
+    )
+    write_prediction_archive(
+        destination,
+        point_map=points.copy(),
+        camera_extrinsics=extrinsics.copy(),
+        camera_intrinsics=intrinsics.copy(),
+    )
+    with pytest.raises(ValueError, match="different VGGT prediction"):
+        write_prediction_archive(
+            destination,
+            point_map=points * 2.0,
+            camera_extrinsics=extrinsics,
+            camera_intrinsics=intrinsics,
+        )

--- a/tests/test_lazy_package_imports.py
+++ b/tests/test_lazy_package_imports.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+import textwrap
+from importlib import import_module
+from pathlib import Path
+
+import prob4d
+import pytest
+
+
+def _run_probe(source: str) -> None:
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(source)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr
+
+
+def test_root_import_does_not_eagerly_load_public_implementation_modules() -> None:
+    _run_probe(
+        """
+        import sys
+        import prob4d
+
+        forbidden = {
+            "prob4d.alignment_cycles",
+            "prob4d.calibration",
+            "prob4d.causal_gauge_graph",
+            "prob4d.fusion",
+            "prob4d.observation_export",
+            "prob4d.prediction_store",
+            "prob4d.sim3",
+            "prob4d.source_reliability",
+        }
+        loaded = forbidden.intersection(sys.modules)
+        if loaded:
+            raise SystemExit(f"eager Prob4D imports: {sorted(loaded)}")
+        if "Sim3" in prob4d.__dict__:
+            raise SystemExit("lazy export was populated before first access")
+        if "Sim3" not in prob4d.__all__:
+            raise SystemExit("Sim3 is absent from the historical public inventory")
+        if "Sim3" not in dir(prob4d):
+            raise SystemExit("lazy export is absent from module introspection")
+        """
+    )
+
+
+def test_lazy_root_export_is_loaded_once_and_cached() -> None:
+    _run_probe(
+        """
+        import prob4d
+        from prob4d.sim3 import Sim3
+
+        if "Sim3" in prob4d.__dict__:
+            raise SystemExit("root export was populated by the submodule import")
+        if prob4d.Sim3 is not Sim3:
+            raise SystemExit("lazy export differs from the owning module object")
+        if prob4d.__dict__["Sim3"] is not Sim3:
+            raise SystemExit("lazy export was not cached in the package root")
+        if prob4d.Sim3 is not Sim3:
+            raise SystemExit("cached export identity changed on repeated access")
+        """
+    )
+
+
+def test_lazy_export_inventory_is_complete_unique_and_resolvable() -> None:
+    assert len(prob4d.__all__) == len(set(prob4d.__all__))
+    assert set(prob4d.__all__) == set(prob4d._LAZY_EXPORTS) | {"__version__"}
+
+    for name, module_name in prob4d._LAZY_EXPORTS.items():
+        owner = import_module(module_name)
+        assert getattr(prob4d, name) is getattr(owner, name)
+
+
+def test_package_root_typing_stub_covers_every_lazy_export() -> None:
+    stub_path = Path(prob4d.__file__).with_suffix(".pyi")
+    assert stub_path.is_file()
+    tree = ast.parse(stub_path.read_text(encoding="utf-8"))
+    stub_exports: set[str] = set()
+    has_version_annotation = False
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                assert alias.asname == alias.name
+                stub_exports.add(alias.name)
+        elif (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Name)
+            and node.target.id == "__version__"
+        ):
+            has_version_annotation = True
+    assert stub_exports == set(prob4d.__all__) - {"__version__"}
+    assert has_version_annotation
+
+
+def test_unknown_root_attribute_raises_standard_attribute_error() -> None:
+    with pytest.raises(
+        AttributeError,
+        match="module 'prob4d' has no attribute 'definitely_not_an_export'",
+    ):
+        getattr(prob4d, "definitely_not_an_export")

--- a/tests/test_lazy_package_imports.py
+++ b/tests/test_lazy_package_imports.py
@@ -8,7 +8,6 @@ from importlib import import_module
 from pathlib import Path
 
 import pytest
-
 import prob4d
 
 

--- a/tests/test_lazy_package_imports.py
+++ b/tests/test_lazy_package_imports.py
@@ -7,8 +7,9 @@ import textwrap
 from importlib import import_module
 from pathlib import Path
 
-import prob4d
 import pytest
+
+import prob4d
 
 
 def _run_probe(source: str) -> None:
@@ -103,4 +104,4 @@ def test_unknown_root_attribute_raises_standard_attribute_error() -> None:
         AttributeError,
         match="module 'prob4d' has no attribute 'definitely_not_an_export'",
     ):
-        getattr(prob4d, "definitely_not_an_export")
+        prob4d.definitely_not_an_export

--- a/tests/test_lazy_package_imports.py
+++ b/tests/test_lazy_package_imports.py
@@ -8,6 +8,7 @@ from importlib import import_module
 from pathlib import Path
 
 import pytest
+
 import prob4d
 
 
@@ -103,4 +104,4 @@ def test_unknown_root_attribute_raises_standard_attribute_error() -> None:
         AttributeError,
         match="module 'prob4d' has no attribute 'definitely_not_an_export'",
     ):
-        prob4d.definitely_not_an_export
+        _ = prob4d.definitely_not_an_export

--- a/tests/test_public_api_manifest.py
+++ b/tests/test_public_api_manifest.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+
+import prob4d
+import pytest
+from prob4d.api import v1 as api_v1
+from prob4d.api import v2 as api_v2
+from prob4d.public_api_manifest import (
+    PUBLIC_API_MANIFEST_CLAIM_BOUNDARY,
+    PUBLIC_API_MANIFEST_SCHEMA,
+    PUBLIC_API_MANIFEST_VERSION,
+    build_public_api_manifest,
+    load_public_api_manifest,
+    main,
+    validate_public_api_manifest,
+    write_public_api_manifest,
+)
+
+
+def test_public_api_manifest_is_deterministic_and_complete() -> None:
+    first = build_public_api_manifest()
+    second = build_public_api_manifest()
+
+    assert first == second
+    assert first["schema"] == PUBLIC_API_MANIFEST_SCHEMA
+    assert first["schema_version"] == PUBLIC_API_MANIFST_VERSION
+    assert first["package"]["version"] == prob4d.__version__
+    assert first["claim_boundary"] == PUBLIC_API_MANIFST_CLAIM_BOUNDARY
+
+    surfaces = first["surfaces"]
+    assert surfaces["compatibility_root"]["loading"] == "lazy-compatibility-shim-v1"
+    assert surfaces["compatibility_root"]["exports"] == sorted(prob4d.__all__)
+    assert surfaces["api_v1"]["api_version"] == api_v1.API_VERSION == 1
+    assert surfaces["api_v1"]["exports"] == sorted(api_v1.__all__)
+    assert surfaces["api_v2"]["api_version"] == api_v2.API_VERSION == 2
+    assert surfaces["api_v2"]["exports"] == sorted(api_v2.__all__)
+    assert validate_public_api_manifest(first) == first
+
+
+def test_public_api_manifest_rejects_tampering() -> None:
+    manifest = build_public_api_manifest()
+    tampered = deepcopy(manifest)
+    tampered["package"]["version"] = "999.0.0"
+    with pytest.raises(ValueError, match="manifest_id does not match"):
+        validate_public_api_manifest(tampered)
+
+    unsorted = deepcopy(manifest)
+    unsorted["surfaces"]["api_v1"]["exports"] = list(
+        reversed(unsorted["surfaces"]["api_v1"]["exports"])
+    )
+    with pytest.raises(ValueError, match="sorted canonically"):
+        validate_public_api_manifest(unsorted)
+
+
+def test_public_api_manifest_round_trip_is_no_clobber(tmp_path) -> None:
+    output = tmp_path / "public-api.json"
+    expected = build_public_api_manifest()
+
+    assert write_public_api_manifest(output) == expected
+    assert load_public_api_manifest(output) == expected
+    assert write_public_api_manifest(output) == expected
+
+    changed = deepcopy(expected)
+    changed["package"]["version"] = "999.0.0"
+    changed["manifest_id"] = "0" * 64
+    output.write_text(json.dumps(changed), encoding="utf-8")
+    with pytest.raises(ValueError):
+        write_public_api_manifest(output)
+
+
+def test_public_api_manifest_cli_print_build_and_verify(tmp_path, capsys) -> None:
+    assert main(["print"]) == 0
+    printed = json.loads(capsys.readouterr().out)
+    assert printed == build_public_api_manifest()
+
+    output = tmp_path / "public-api.json"
+    assert main(["build", "--output", str(output)]) == 0
+    build_output = capsys.readouterr().out.strip()
+    assert build_output == build_public_api_manifest()["manifest_id"]
+
+    assert main(["verify", str(output), "--require-current"]) == 0
+    verify_output = capsys.readouterr().out.strip()
+    assert verify_output == build_output
+
+
+def test_public_api_manifest_loader_rejects_duplicate_json_keys(tmp_path) -> None:
+    path = tmp_path / "duplicate.json"
+    path.write_text('{"schema":"a","schema":"b"}', encoding="utf-8")
+    with pytest.raises(ValueError, match="duplicate JSON key"):
+        load_public_api_manifest(path)

--- a/tests/test_public_api_manifest.py
+++ b/tests/test_public_api_manifest.py
@@ -4,6 +4,7 @@ import json
 from copy import deepcopy
 
 import pytest
+
 import prob4d
 from prob4d.api import v1 as api_v1
 from prob4d.api import v2 as api_v2

--- a/tests/test_public_api_manifest.py
+++ b/tests/test_public_api_manifest.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import json
 from copy import deepcopy
 
-import prob4d
 import pytest
+
+import prob4d
 from prob4d.api import v1 as api_v1
 from prob4d.api import v2 as api_v2
 from prob4d.public_api_manifest import (
@@ -25,9 +26,9 @@ def test_public_api_manifest_is_deterministic_and_complete() -> None:
 
     assert first == second
     assert first["schema"] == PUBLIC_API_MANIFEST_SCHEMA
-    assert first["schema_version"] == PUBLIC_API_MANIFST_VERSION
+    assert first["schema_version"] == PUBLIC_API_MANIFEST_VERSION
     assert first["package"]["version"] == prob4d.__version__
-    assert first["claim_boundary"] == PUBLIC_API_MANIFST_CLAIM_BOUNDARY
+    assert first["claim_boundary"] == PUBLIC_API_MANIFEST_CLAIM_BOUNDARY
 
     surfaces = first["surfaces"]
     assert surfaces["compatibility_root"]["loading"] == "lazy-compatibility-shim-v1"

--- a/tests/test_public_api_manifest.py
+++ b/tests/test_public_api_manifest.py
@@ -4,7 +4,6 @@ import json
 from copy import deepcopy
 
 import pytest
-
 import prob4d
 from prob4d.api import v1 as api_v1
 from prob4d.api import v2 as api_v2

--- a/tests/test_release_040_boundary.py
+++ b/tests/test_release_040_boundary.py
@@ -1,3 +1,5 @@
+"""Current 0.4.x release checks; the historical filename is retained for CI stability."""
+
 from __future__ import annotations
 
 import re
@@ -13,7 +15,7 @@ from prob4d.provider_v2_tree_sparse_manifest import (
 )
 
 ROOT = Path(__file__).resolve().parents[1]
-EXPECTED_VERSION = "0.4.0"
+EXPECTED_VERSION = "0.4.1"
 
 
 def _declared_version(path: Path, pattern: str) -> str:
@@ -54,29 +56,25 @@ def test_all_source_release_version_declarations_are_synchronized() -> None:
 def test_release_changelog_and_claim_boundary_are_published() -> None:
     changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
     assert "## Unreleased\n\nNo changes yet." in changelog
-    assert "## 0.4.0 — 2026-08-10" in changelog
+    assert "## 0.4.1 — 2026-08-12" in changelog
     lower_changelog = changelog.lower()
-    assert "claim-bearing tree-sparse observation artifacts" in lower_changelog
-    assert "outcome-blind provider support feasibility" in lower_changelog
-    assert "replay-complete held-out provider evidence" in lower_changelog
-    assert "canonical grouped `prob4d` registry" in lower_changelog
-    assert "compatibility wrappers" in lower_changelog
-    assert "versioned `prob4d.api.v1`" in lower_changelog
-    assert "installed source distribution" in lower_changelog
+    assert "correlation-group robust likelihood" in lower_changelog
+    assert "analytic `sim(3)`" in lower_changelog
+    assert "fresh-provider cohort lock" in lower_changelog
+    assert "content-addressed public api manifest" in lower_changelog
+    assert "historical exports load on first access" in lower_changelog
 
-    boundary = (ROOT / "docs" / "releases" / "0.4.0.md").read_text(
+    boundary = (ROOT / "docs" / "releases" / "0.4.1.md").read_text(
         encoding="utf-8"
     )
     normalized_boundary = " ".join(boundary.split())
-    assert (
-        "does not publish to a package registry or create a Git tag"
-        in normalized_boundary
-    )
-    assert "does not establish real-provider competence" in normalized_boundary
-    assert "313/324" in normalized_boundary
+    assert "does not create a Git tag or publish to a package registry" in normalized_boundary
+    assert "does not add fresh physical evidence" in normalized_boundary
+    assert "lazy compatibility root" in normalized_boundary
+    assert "one-shot target authorization" in normalized_boundary
 
 
-def test_compatibility_guide_matches_the_040_surface() -> None:
+def test_compatibility_guide_matches_the_04x_surface() -> None:
     compatibility = (ROOT / "docs" / "compatibility.md").read_text(
         encoding="utf-8"
     )
@@ -118,15 +116,16 @@ def test_v1_v2_and_tree_sparse_manifest_boundaries_remain_distinct() -> None:
 
 
 def test_release_boundary_contains_no_self_mutating_workflow() -> None:
-    assert not (ROOT / ".github" / "workflows" / "prepare-release-040.yml").exists()
-    assert not (ROOT / "scripts" / "ci" / "prepare_release_040.py").exists()
+    assert not (ROOT / ".github" / "workflows" / "prepare-release-041.yml").exists()
+    assert not (ROOT / "scripts" / "ci" / "prepare_release_041.py").exists()
 
 
-def test_ci_and_release_tests_do_not_retain_the_previous_version() -> None:
+def test_current_ci_and_release_checks_do_not_retain_the_previous_version() -> None:
     checked = (
         ROOT / ".github" / "workflows" / "tests.yml",
+        ROOT / "scripts" / "ci" / "check_sdist.py",
         ROOT / "tests" / "test_release_metadata.py",
         ROOT / "tests" / "test_provider_manifest.py",
     )
     for path in checked:
-        assert "0.3.1" not in path.read_text(encoding="utf-8"), path
+        assert "0.4.0" not in path.read_text(encoding="utf-8"), path

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -74,6 +74,12 @@ def test_license_and_typing_metadata_are_explicit() -> None:
     assert isinstance(classifiers, list)
     assert "Typing :: Typed" in classifiers
 
+    package_data = tomllib.loads(
+        (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )["tool"]["setuptools"]["package-data"]["prob4d"]
+    assert "__init__.pyi" in package_data
+    assert "py.typed" in package_data
+
     license_text = (ROOT / "LICENSE").read_text(encoding="utf-8")
     assert license_text.startswith("MIT License\n")
     assert "Copyright (c) 2026 Florian Pfaff" in license_text
@@ -81,10 +87,17 @@ def test_license_and_typing_metadata_are_explicit() -> None:
 
 
 def test_observation_export_documentation_uses_an_explicit_route() -> None:
-    documentation = (ROOT / "docs" / "observation-belief-export.md").read_text(encoding="utf-8")
+    documentation = (ROOT / "docs" / "observation-belief-export.md").read_text(
+        encoding="utf-8"
+    )
     assert "prob4d observation export-calibrated \\" in documentation
     assert "prob4d observation export \\" not in documentation
     assert "prob4d observation export-v1" in documentation
+
+
+def test_current_release_note_exists() -> None:
+    release_note = ROOT / "docs" / "releases" / f"{_expected_version()}.md"
+    assert release_note.is_file()
 
 
 def test_release_governance_files_exist() -> None:
@@ -101,10 +114,12 @@ def test_release_governance_files_exist() -> None:
         "SECURITY.md",
         "docs/distribution-boundaries.md",
         "docs/ecosystem-release-capsule.md",
+        "docs/public-api-manifest.md",
         "docs/public-api.md",
-        "docs/releases/0.4.0.md",
         "docs/trusted-self-hosted-validation.md",
         "scripts/ci/build_ecosystem_release_capsule.py",
         "scripts/ci/check_sdist.py",
+        "src/prob4d/__init__.pyi",
+        "src/prob4d/public_api_manifest.py",
     ):
         assert (ROOT / name).is_file(), name

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -90,8 +90,10 @@ def test_observation_export_documentation_uses_an_explicit_route() -> None:
     documentation = (ROOT / "docs" / "observation-belief-export.md").read_text(
         encoding="utf-8"
     )
-    assert "prob4d observation export-calibrated \\" in documentation
-    assert "prob4d observation export \\" not in documentation
+    calibrated_command = "prob4d observation export-calibrated \\"
+    ambiguous_command = "prob4d observation export \\"
+    assert calibrated_command in documentation
+    assert ambiguous_command not in documentation
     assert "prob4d observation export-v1" in documentation
 
 


### PR DESCRIPTION
## What changed

- replace the eager historical `prob4d` package root with a compatibility-preserving lazy export map;
- preserve the complete historical root typing surface in a packaged `prob4d/__init__.pyi` stub;
- add a strict, content-addressed `prob4d.public-api-manifest` artifact covering the root, `prob4d.api.v1`, and `prob4d.api.v2` export inventories and provider API versions;
- add build, print, verify, duplicate-key rejection, tamper detection, and idempotent no-clobber persistence for that manifest;
- publish the manifest through Prob4D's shared atomic, race-safe artifact writer rather than a weaker module-local file-creation path;
- update package, citation, changelog, compatibility, distribution, and release metadata for Prob4D 0.4.1;
- strengthen release and source-distribution checks so isolated installs verify lazy loading, root export identity, the typing stub, the API manifest, and current release documentation.

## Why

Prob4D already has narrow versioned downstream façades, but importing the broad compatibility root still eagerly imported calibration, fusion, gauge-graph, observation, storage, and reliability implementation modules. That made lightweight metadata and integration inspection unnecessarily expensive and allowed the exact supported export inventory to drift without a standalone content identity.

This PR keeps the broad root for historical compatibility while making `prob4d.api.v1` and `prob4d.api.v2` visibly preferable for new integrations. The new manifest gives installed-wheel compatibility capsules a deterministic artifact that detects accidental export additions, removals, provider-version changes, packaging drift, and changed persisted bytes.

## Compatibility boundary

- all 115 historical root exports remain present;
- `prob4d.__all__` retains its exact pre-change order and adds no new compatibility-root export;
- first access returns the exact object from the owning implementation module and caches it in the package root;
- `dir(prob4d)`, explicit imports, and historical star imports retain the same inventory;
- `prob4d.api.v1`, `prob4d.api.v2`, provider manifests, schemas, artifact identities, legacy executable meanings, and estimator behavior are unchanged;
- same-content public-API manifest publication remains idempotent, while different existing bytes and symbolic-link destinations fail closed;
- the historical `tests/test_release_040_boundary.py` path is retained because the current workflow invokes it explicitly; its assertions now cover the current 0.4.x maintenance release.

## Authoritative validation on exact head

Exact head: `175e6b4d9b4e5804e1d8100edd36df70d97cc9b5`.

- complete suite passed on Python 3.10, 3.11, 3.12, 3.13, and 3.14;
- Python 3.12 reported `1,346 passed`, `1` optional-dependency skip;
- declared Python 3.10 / NumPy 1.24.0 runtime floor passed;
- authoritative Ruff and stable-façade MyPy checks passed;
- repository, release, API, clean-checkout runtime-attestation, and provider-contract checks passed;
- wheel and source distribution build and validation passed;
- isolated wheel and sdist installation plus grouped/legacy CLI smoke passed;
- generic-provider import and exact-head target-provider admission workflows passed;
- three-repository installed-wheel ecosystem capsule passed;
- security scanning passed;
- the unchanged frozen fresh-seed finite-sample calibration study and decision verification passed.

## Scientific and data-access boundary

This is release, compatibility, typing, and distribution infrastructure only.

- target or confirmation outcomes accessed: **none**;
- physical data, experiment rosters, thresholds, estimators, calibration methods, fallback decisions, and evidence counts changed: **none**;
- new provider competence, target calibration, BayesianPhysTwin benefit, Causal4D benefit, deployment safety, or state-of-the-art claim: **none**;
- statistical units affected: **none**;
- exact fallback semantics: **unchanged**.

The release note retains the controlled-mechanism/real-provider evidence separation and explicitly states that a valid public API manifest is interoperability evidence, not scientific evidence.