### PR TITLE
Add a Prob4D-owned ecosystem contract test

### DIFF
--- a/.github/workflows/ecosystem-release-capsule.yml
+++ b/.github/workflows/ecosystem-release-capsule.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - ".github/workflows/ecosystem-release-capsule.yml"
       - "MANIFEST.in"
+      - "integration_tests/**"
       - "pyproject.toml"
       - "scripts/ci/build_ecosystem_release_capsule.py"
       - "scripts/ci/check_sdist.py"
@@ -20,6 +21,7 @@ on:
     paths:
       - ".github/workflows/ecosystem-release-capsule.yml"
       - "MANIFEST.in"
+      - "integration_tests/**"
       - "pyproject.toml"
       - "scripts/ci/build_ecosystem_release_capsule.py"
       - "scripts/ci/check_sdist.py"

--- a/integration_tests/README.md
+++ b/integration_tests/README.md
@@ -1,0 +1,17 @@
+# Prob4D-Owned Ecosystem Integration Tests
+
+Files named `test_three_repository_*.py` in this directory are executed by the
+BayesianPhysTwin installed-wheel golden path after exact Prob4D,
+BayesianPhysTwin, and Causal4D source snapshots have been built into wheels and
+installed into a clean environment.
+
+These tests own producer-side assumptions. They must import only installed
+public package surfaces, must not reach into any source checkout, and must not
+open scientific data or generated evidence. Repository-local support modules
+and fixtures may live below this directory and are staged with the tests.
+
+The first owned test verifies that all three independently implemented packages
+validate and materialize the same content-locked `phys4d.observation_belief.v1`
+corpus. Passing establishes contract interoperability only; it does not
+establish provider accuracy, calibration, physical benefit, intervention
+benefit, deployment safety, or state of the art.

--- a/integration_tests/test_three_repository_prob4d_contract_corpus.py
+++ b/integration_tests/test_three_repository_prob4d_contract_corpus.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from importlib import import_module
 from types import ModuleType
-from typing import Any, Mapping
+from typing import Any
 
 import numpy as np
 import pytest

--- a/integration_tests/test_three_repository_prob4d_contract_corpus.py
+++ b/integration_tests/test_three_repository_prob4d_contract_corpus.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from importlib import import_module
+from types import ModuleType
+from typing import Any, Mapping
+
+import numpy as np
+import pytest
+
+EXPECTED_BUNDLE_SHA256 = "a62c693a14c227daa1f4c8db850e691a1d0081df0c853cf0174c33d0b8504ce9"
+MODULE_NAMES = (
+    "prob4d.observation_contract_bundle",
+    "bayesian_phystwin.observation_contract_bundle",
+    "causal4d.observation_contract_bundle",
+)
+
+
+def _modules() -> tuple[ModuleType, ...]:
+    return tuple(import_module(name) for name in MODULE_NAMES)
+
+
+def _assert_equal_arrays(
+    expected: Mapping[str, np.ndarray],
+    observed: Mapping[str, np.ndarray],
+) -> None:
+    assert tuple(sorted(observed)) == tuple(sorted(expected))
+    for name in sorted(expected):
+        expected_array = expected[name]
+        observed_array = observed[name]
+        assert observed_array.dtype == expected_array.dtype
+        assert observed_array.shape == expected_array.shape
+        assert observed_array.flags.writeable is False
+        np.testing.assert_array_equal(observed_array, expected_array)
+
+
+def test_all_installed_packages_validate_the_same_normative_bundle() -> None:
+    manifests = tuple(module.observation_contract_bundle_manifest() for module in _modules())
+
+    assert manifests[0]["bundle_sha256"] == EXPECTED_BUNDLE_SHA256
+    assert manifests[1:] == (manifests[0], manifests[0])
+    assert manifests[0]["bundle_name"] == "phys4d.observation_belief.v1"
+    assert manifests[0]["bundle_version"] == 1
+
+
+@pytest.mark.parametrize("vector_name", ("minimal", "zero_rank"))
+def test_valid_vector_payloads_and_hashes_match_across_installed_packages(
+    vector_name: str,
+) -> None:
+    modules = _modules()
+    vectors = tuple(module.observation_contract_vector(vector_name) for module in modules)
+    reference = vectors[0]
+
+    for module, vector in zip(modules, vectors, strict=True):
+        assert vector.name == reference.name
+        assert vector.descriptor == reference.descriptor
+        assert vector.expected_artifact_id == reference.expected_artifact_id
+        _assert_equal_arrays(reference.arrays, vector.arrays)
+        assert (
+            module.observation_contract_artifact_id(vector.descriptor, vector.arrays)
+            == reference.expected_artifact_id
+        )
+        for name, values in vector.arrays.items():
+            assert module.observation_contract_array_sha256(values) == modules[
+                0
+            ].observation_contract_array_sha256(reference.arrays[name])
+
+
+def _invalid_case_ids(module: ModuleType) -> tuple[str, ...]:
+    cases: tuple[Mapping[str, Any], ...] = module.observation_contract_invalid_cases()
+    return tuple(str(case["id"]) for case in cases)
+
+
+def test_invalid_case_rosters_match_across_installed_packages() -> None:
+    modules = _modules()
+    reference_ids = _invalid_case_ids(modules[0])
+
+    assert reference_ids
+    assert _invalid_case_ids(modules[1]) == reference_ids
+    assert _invalid_case_ids(modules[2]) == reference_ids
+
+
+@pytest.mark.parametrize(
+    "case_id",
+    _invalid_case_ids(import_module("prob4d.observation_contract_bundle")),
+)
+def test_invalid_vectors_materialize_identically_across_installed_packages(
+    case_id: str,
+) -> None:
+    vectors = tuple(
+        module.invalid_observation_contract_vector(case_id) for module in _modules()
+    )
+    reference = vectors[0]
+
+    for vector in vectors:
+        assert vector.case_id == reference.case_id
+        assert vector.mode == reference.mode
+        assert vector.descriptor == reference.descriptor
+        assert vector.original_artifact_id == reference.original_artifact_id
+        _assert_equal_arrays(reference.arrays, vector.arrays)

--- a/tests/test_ecosystem_capsule_workflow.py
+++ b/tests/test_ecosystem_capsule_workflow.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "ecosystem-release-capsule.yml"
+
+
+def test_repository_owned_integration_tests_trigger_ecosystem_capsule() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    pull_request, remainder = text.split("  push:\n", maxsplit=1)
+    push, _ = remainder.split("  workflow_dispatch:\n", maxsplit=1)
+
+    path_filter = '      - "integration_tests/**"'
+    assert path_filter in pull_request
+    assert path_filter in push
+    assert text.count(path_filter) == 2


### PR DESCRIPTION
## Summary

Add the first Prob4D-owned test for the isolated installed-wheel `Prob4D -> BayesianPhysTwin -> Causal4D` golden path.

- compare the independently packaged `phys4d.observation_belief.v1` manifests across all three installed wheels;
- verify complete valid-vector payloads, artifact IDs, array hashes, dtypes, shapes, values, and read-only flags;
- verify that all three packages expose the same invalid-case roster;
- materialize every invalid vector independently and require exact descriptor, mode, identity, and array parity;
- trigger the ecosystem capsule whenever `integration_tests/**` changes on a pull request or push;
- lock those workflow triggers with a repository policy test; and
- document that Prob4D owns producer/provider assertions and that these tests use only installed public package surfaces.

## Dependency

BayesianPhysTwin PR #602 is merged. Its three-repository runner now discovers owner-namespaced integration tests from all three exact source snapshots and executes each explicit test file in Python isolated mode.

## Fixes made during validation

- move `Mapping` to `collections.abc` to satisfy the authoritative Ruff boundary;
- add the missing `integration_tests/**` workflow paths so the producer-owned test cannot be introduced without actually running the three-wheel capsule; and
- add a regression test that requires the pull-request and push triggers to remain present.

## Authoritative validation

Exact head: `9053e896473daaf7cf8814ee8382ceab5db4170e`.

- complete Tests workflow: passed;
- authoritative Ruff and stable-interface MyPy: passed;
- security scanning: passed; and
- installed-wheel ecosystem capsule: passed, including the Prob4D-owned contract-corpus test across Prob4D, BayesianPhysTwin, and Causal4D.

## Scientific boundary

This is interoperability and CI evidence only. It changes no estimator, provider schema, artifact identity, data boundary, fallback decision, metric, or scientific claim, and it does not establish provider competence, calibration, physical benefit, intervention benefit, deployment safety, or state of the art.