### PR TITLE
Attest the trusted self-hosted validation boundary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,19 @@ release notes and scientific boundaries live under `docs/releases/`.
 
 ## Unreleased
 
-No changes yet.
+### Added
+
+- A content-addressed trusted-validation boundary attestation that keeps GitHub
+  environment policy, runner-host hardening, dataset isolation, and exact-head
+  positive and negative controls as separately evidenced external boundaries.
+  Unverified templates and repository-local files cannot claim readiness.
+
+### Scientific boundary
+
+This is operational evidence infrastructure. It does not configure or sandbox a
+runner, authorize protected target access, establish provider accuracy or
+calibration, establish BayesianPhysTwin or Causal4D benefit, approve deployment,
+or establish state of the art.
 
 ## 0.4.1 — 2026-08-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,19 +5,7 @@ release notes and scientific boundaries live under `docs/releases/`.
 
 ## Unreleased
 
-### Added
-
-- A content-addressed trusted-validation boundary attestation that keeps GitHub
-  environment policy, runner-host hardening, dataset isolation, and exact-head
-  positive and negative controls as separately evidenced external boundaries.
-  Unverified templates and repository-local files cannot claim readiness.
-
-### Scientific boundary
-
-This is operational evidence infrastructure. It does not configure or sandbox a
-runner, authorize protected target access, establish provider accuracy or
-calibration, establish BayesianPhysTwin or Causal4D benefit, approve deployment,
-or establish state of the art.
+No changes yet.
 
 ## 0.4.1 — 2026-08-12
 

--- a/docs/trusted-self-hosted-validation.md
+++ b/docs/trusted-self-hosted-validation.md
@@ -9,6 +9,13 @@ The only repository workflow allowed to execute reviewed pull-request source on
 manual, exact-revision validation path for work that genuinely needs local GPU,
 large-memory, or approved data access.
 
+The workflow and this repository document the intended controls, but repository
+files cannot prove current external settings or host state. Record those through
+the separately validated, machine-readable
+[trusted validation boundary attestation](trusted-validation-boundary-attestation.md).
+An unverified template or repository-local statement never counts as operational
+proof.
+
 ## Required repository environment
 
 Create an environment named exactly:
@@ -46,9 +53,8 @@ From the default branch, open **Actions → Trusted exact-head validation → Ru
 workflow** and provide:
 
 1. the open pull-request number;
-2. the exact reviewed 40-character head SHA;
-3. whether to run the complete pytest suite; and
-4. whether to run the optional full-resolution memory profile.
+2. the exact reviewed 40-character head SHA; and
+3. the fixed reviewed profile: `full-validation` or `production-memory`.
 
 The self-hosted job pauses at the protected environment. After approval, it
 checks out only the authorized SHA with persisted Git credentials disabled,
@@ -87,7 +93,10 @@ code from reading any resource available to the runner account.
 ## Evidence and claim boundary
 
 A successful run proves that one exact source revision passed the selected
-implementation checks in the recorded environment. It does not establish:
+implementation checks in the recorded environment. A ready boundary attestation
+additionally records independent evidence for the GitHub environment, runner
+host, dataset namespace, and registered positive and negative controls at one
+snapshot. Neither establishes:
 
 - observation accuracy or uncertainty calibration;
 - BayesianPhysTwin or Causal4D benefit;

--- a/docs/trusted-validation-boundary-attestation.md
+++ b/docs/trusted-validation-boundary-attestation.md
@@ -1,0 +1,98 @@
+# Trusted validation boundary attestation
+
+The protected `Trusted exact-head validation` workflow controls which reviewed
+pull-request revision may execute on `workstation2`. Repository code alone cannot
+prove the external boundary around that workflow. In particular, a checked box,
+Markdown statement, workflow file, or repository-local JSON document is not proof
+of the current GitHub environment settings, runner-host state, dataset namespace,
+or executed positive and negative controls.
+
+`prob4d.trusted_validation_attestation` provides a strict, content-addressed
+record for those four independently evidenced boundaries.
+
+## Four separate evidence sections
+
+A ready artifact requires all assertions in all four sections:
+
+1. **GitHub environment policy** — independent review, no environment secrets,
+   main-only workflow definition, self-approval handling, and read-only workflow
+   permissions.
+2. **Runner-host hardening** — a dedicated non-administrator account, absence of
+   personal or write credentials, restricted unrelated resources and network
+   destinations, and an incident rebuild or rotation procedure.
+3. **Dataset namespace isolation** — only approved datasets exposed, read-only
+   mounts where possible, unopened target cohorts outside the ordinary runner
+   namespace, and an independently checked namespace inventory.
+4. **Exact-head acceptance tests** — a successful exact-head run and observed
+   environment pause, plus stale-SHA and non-`main` controls rejected before any
+   self-hosted checkout. Retained evidence must bind the pull request, head, base,
+   runner, and selected profile.
+
+The sections are intentionally independent. A passing GitHub environment query
+cannot substitute for a runner-host audit, and a successful exact-head run cannot
+substitute for dataset isolation.
+
+## Create an explicitly unverified draft
+
+Bind the draft to the exact repository revision and workflow bytes under review:
+
+```bash
+python -m prob4d.trusted_validation_attestation template \
+  --source-revision "$(git rev-parse HEAD)" \
+  --workflow-sha256 "$(sha256sum \
+    .github/workflows/trusted-self-hosted-validation.yml | cut -d' ' -f1)" \
+  --output trusted-validation-attestation.draft.json
+```
+
+The generated draft is structurally valid but every section is `unverified`,
+every assertion is `null`, and it cannot authorize trusted execution. Complete
+one section only after an independent verifier has collected external evidence.
+A completed section records:
+
+- `verification_status`: `verified` or `failed`;
+- the independent verifier and UTC verification time;
+- an allowed external evidence method;
+- an external HTTPS locator or `urn:prob4d:external-audit:...` locator;
+- the SHA-256 digest of the retained external evidence snapshot; and
+- every section-specific assertion as an explicit Boolean.
+
+Repository-relative paths, GitHub repository blob/tree URLs, raw repository files,
+and the evidence method `repository-file` are rejected. A `verified` section may
+not contain a failed assertion. A completed audit with any failed assertion must
+use status `failed` and keeps the overall boundary closed.
+
+## Seal and verify
+
+After completing the independently evidenced draft:
+
+```bash
+python -m prob4d.trusted_validation_attestation seal \
+  --draft trusted-validation-attestation.draft.json \
+  --output trusted-validation-attestation.json
+
+python -m prob4d.trusted_validation_attestation verify \
+  --artifact trusted-validation-attestation.json \
+  --require-ready
+```
+
+Sealing recomputes the readiness decision, complete failure-reason set, and
+content identity. The command returns status `2` when `--require-ready` is used
+and any section remains unverified or failed. Loading a sealed artifact also
+recomputes all derived fields, rejects duplicate JSON keys and non-finite values,
+and detects content or identity tampering. Writers are atomic and no-clobber by
+default.
+
+## Operational use
+
+A ready attestation should be retained beside the corresponding environment
+settings snapshot, host audit, dataset-namespace inventory, and Actions-run
+records. The workflow revision and source revision in the artifact must match the
+revision whose trusted-execution boundary is being approved. A later environment,
+host, dataset, workflow, or runner change requires a new attestation rather than
+editing an old sealed artifact.
+
+This artifact records an independently evidenced operational boundary. It does
+not itself configure GitHub, sandbox the runner, grant protected target access,
+establish provider accuracy or uncertainty calibration, establish
+BayesianPhysTwin or Causal4D benefit, approve deployment, or constitute a
+scientific result.

--- a/src/prob4d/trusted_validation_attestation.py
+++ b/src/prob4d/trusted_validation_attestation.py
@@ -1,0 +1,748 @@
+"""External attestation for the trusted self-hosted validation boundary.
+
+The repository workflow can prove exact-head execution semantics, but repository files
+cannot prove GitHub environment settings, runner-host hardening, dataset namespace
+isolation, or that the registered positive and negative controls were actually run.
+This module records those four externally verified boundaries without treating a
+checked box or repository-local document as evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Final, Literal, cast
+from urllib.parse import urlparse
+
+from ._atomic_file import atomic_write_text
+from ._immutable_json import frozen_finite_json_mapping, plain_json
+from ._strict_json import (
+    load_json_object,
+    require_exact_fields,
+    require_exact_string,
+    require_finite_json_mapping,
+    require_mapping,
+    require_sha256,
+)
+
+TRUSTED_VALIDATION_ATTESTATION_DRAFT_SCHEMA: Final = (
+    "prob4d.trusted-validation-boundary-attestation-draft"
+)
+TRUSTED_VALIDATION_ATTESTATION_SCHEMA: Final = (
+    "prob4d.trusted-validation-boundary-attestation"
+)
+TRUSTED_VALIDATION_ATTESTATION_VERSION: Final = 1
+TRUSTED_VALIDATION_ENVIRONMENT: Final = "trusted-self-hosted-validation"
+TRUSTED_VALIDATION_WORKFLOW_PATH: Final = (
+    ".github/workflows/trusted-self-hosted-validation.yml"
+)
+TRUSTED_VALIDATION_ATTESTATION_CLAIM_BOUNDARY: Final = (
+    "A ready attestation records independent external evidence for the GitHub "
+    "environment policy, runner-host hardening, dataset namespace isolation, and "
+    "exact-head positive and negative controls at one evidence snapshot. It does not "
+    "make repository assertions proof of external state, guarantee that the boundary "
+    "remains unchanged, authorize protected target access, establish provider accuracy "
+    "or calibration, establish BayesianPhysTwin or Causal4D benefit, approve deployment, "
+    "or establish state of the art."
+)
+
+SectionName = Literal[
+    "github-environment",
+    "runner-host",
+    "dataset-namespace",
+    "exact-head-acceptance",
+]
+VerificationStatus = Literal["unverified", "verified", "failed"]
+
+_SECTION_ORDER: Final[tuple[SectionName, ...]] = (
+    "github-environment",
+    "runner-host",
+    "dataset-namespace",
+    "exact-head-acceptance",
+)
+_SECTION_ASSERTIONS: Final[dict[SectionName, tuple[str, ...]]] = {
+    "github-environment": (
+        "independent_reviewer_required",
+        "no_environment_secrets",
+        "workflow_definition_restricted_to_main",
+        "self_approval_prevented_or_documented_unavailable",
+        "read_only_permissions_confirmed",
+    ),
+    "runner-host": (
+        "dedicated_non_administrator_account",
+        "no_ssh_cloud_registry_or_personal_credentials",
+        "unrelated_homes_repositories_caches_and_services_restricted",
+        "network_destinations_restricted_or_documented",
+        "incident_rebuild_or_rotation_procedure_defined",
+    ),
+    "dataset-namespace": (
+        "only_approved_datasets_exposed",
+        "approved_datasets_read_only_where_possible",
+        "unopened_target_cohorts_outside_ordinary_namespace",
+        "dataset_namespace_inventory_independently_verified",
+    ),
+    "exact-head-acceptance": (
+        "exact_head_positive_control_passed",
+        "environment_approval_pause_observed",
+        "stale_sha_rejected_before_self_hosted_checkout",
+        "non_main_ref_rejected_before_self_hosted_checkout",
+        "retained_evidence_bound_pr_head_base_runner_and_profile",
+    ),
+}
+_ALLOWED_EVIDENCE_METHODS: Final[dict[SectionName, tuple[str, ...]]] = {
+    "github-environment": (
+        "github-api-query",
+        "signed-administrative-attestation",
+    ),
+    "runner-host": (
+        "independent-host-audit",
+        "signed-administrative-attestation",
+    ),
+    "dataset-namespace": (
+        "independent-dataset-namespace-audit",
+        "signed-administrative-attestation",
+    ),
+    "exact-head-acceptance": (
+        "github-actions-api-query",
+        "signed-administrative-attestation",
+    ),
+}
+_SECTION_FIELDS = frozenset(
+    {
+        "section_name",
+        "verification_status",
+        "verified_by",
+        "verified_at",
+        "evidence_method",
+        "evidence_locator",
+        "evidence_sha256",
+        "assertions",
+        "notes",
+    }
+)
+_DRAFT_FIELDS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "repository",
+        "environment_name",
+        "workflow_path",
+        "source_revision",
+        "workflow_sha256",
+        "github_environment",
+        "runner_host",
+        "dataset_namespace",
+        "exact_head_acceptance",
+        "metadata",
+        "claim_boundary",
+    }
+)
+_ATTESTATION_FIELDS = frozenset(
+    set(_DRAFT_FIELDS)
+    | {
+        "ready",
+        "failure_reasons",
+        "trusted_validation_boundary_attestation_id",
+    }
+)
+
+
+def _canonical_json_bytes(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        plain_json(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _sha256_json(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json_bytes(value)).hexdigest()
+
+
+def _strict_optional_string(value: object, *, name: str) -> str | None:
+    if value is None:
+        return None
+    return require_exact_string(value, name=name)
+
+
+def _exact_source_revision(value: object) -> str:
+    revision = require_exact_string(value, name="source_revision")
+    if re.fullmatch(r"[0-9a-f]{40}", revision) is None:
+        raise ValueError("source_revision must be a full lowercase 40-character Git SHA")
+    return revision
+
+
+def _repository(value: object) -> str:
+    repository = require_exact_string(value, name="repository")
+    if repository.count("/") != 1 or repository.startswith("/") or repository.endswith("/"):
+        raise ValueError("repository must use canonical owner/name form")
+    return repository
+
+
+def _verified_at(value: object) -> str | None:
+    timestamp = _strict_optional_string(value, name="verified_at")
+    if timestamp is None:
+        return None
+    if re.fullmatch(r"[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z", timestamp) is None:
+        raise ValueError("verified_at must use UTC YYYY-MM-DDTHH:MM:SSZ form")
+    try:
+        datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError as error:
+        raise ValueError("verified_at must be a valid UTC timestamp") from error
+    return timestamp
+
+
+def _external_evidence_locator(value: object) -> str:
+    locator = require_exact_string(value, name="evidence_locator")
+    parsed = urlparse(locator)
+    if parsed.scheme == "https" and parsed.netloc:
+        hostname = parsed.netloc.lower()
+        path = parsed.path.lower()
+        repository_file = (
+            hostname == "raw.githubusercontent.com"
+            or (hostname == "github.com" and ("/blob/" in path or "/tree/" in path))
+            or (hostname == "api.github.com" and "/contents/" in path)
+        )
+        if repository_file:
+            raise ValueError("repository files cannot serve as external evidence")
+        return locator
+    if locator.startswith("urn:prob4d:external-audit:") and len(locator) > len(
+        "urn:prob4d:external-audit:"
+    ):
+        return locator
+    raise ValueError(
+        "evidence_locator must be an external HTTPS URL or prob4d external-audit URN"
+    )
+
+
+def _section_name(value: object) -> SectionName:
+    name = require_exact_string(value, name="section_name")
+    if name not in _SECTION_ORDER:
+        raise ValueError(f"section_name must be one of {list(_SECTION_ORDER)}")
+    return cast(SectionName, name)
+
+
+def _verification_status(value: object) -> VerificationStatus:
+    status = require_exact_string(value, name="verification_status")
+    if status not in {"unverified", "verified", "failed"}:
+        raise ValueError("verification_status is not supported")
+    return cast(VerificationStatus, status)
+
+
+def _notes(value: object) -> tuple[str, ...]:
+    if type(value) is not tuple:
+        raise ValueError("notes must be a canonical tuple")
+    notes = tuple(
+        require_exact_string(item, name=f"notes[{index}]")
+        for index, item in enumerate(value)
+    )
+    if notes != tuple(sorted(notes)) or len(notes) != len(set(notes)):
+        raise ValueError("notes must be sorted and unique")
+    return notes
+
+
+def _notes_from_json(value: object) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise ValueError("notes must be a JSON array")
+    return _notes(tuple(value))
+
+
+def _assertions(
+    value: object,
+    *,
+    section_name: SectionName,
+) -> Mapping[str, bool | None]:
+    mapping = require_mapping(value, name=f"{section_name} assertions")
+    expected = frozenset(_SECTION_ASSERTIONS[section_name])
+    require_exact_fields(mapping, expected, name=f"{section_name} assertions")
+    normalized: dict[str, bool | None] = {}
+    for key in _SECTION_ASSERTIONS[section_name]:
+        item = mapping[key]
+        if item is not None and type(item) is not bool:
+            raise ValueError(f"{section_name} assertion {key!r} must be Boolean or null")
+        normalized[key] = item
+    return frozen_finite_json_mapping(normalized, name=f"{section_name} assertions")
+
+
+@dataclass(frozen=True, slots=True)
+class TrustedValidationBoundarySectionV1:
+    """One independently evidenced administrative or host boundary."""
+
+    section_name: SectionName
+    verification_status: VerificationStatus
+    verified_by: str | None
+    verified_at: str | None
+    evidence_method: str | None
+    evidence_locator: str | None
+    evidence_sha256: str | None
+    assertions: Mapping[str, bool | None]
+    notes: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        name = _section_name(self.section_name)
+        status = _verification_status(self.verification_status)
+        verifier = _strict_optional_string(self.verified_by, name="verified_by")
+        timestamp = _verified_at(self.verified_at)
+        method = _strict_optional_string(self.evidence_method, name="evidence_method")
+        locator = (
+            None
+            if self.evidence_locator is None
+            else _external_evidence_locator(self.evidence_locator)
+        )
+        digest = (
+            None
+            if self.evidence_sha256 is None
+            else require_sha256(self.evidence_sha256, name="evidence_sha256")
+        )
+        assertions = _assertions(self.assertions, section_name=name)
+        notes = _notes(self.notes)
+
+        evidence_values = (verifier, timestamp, method, locator, digest)
+        assertion_values = tuple(assertions[key] for key in _SECTION_ASSERTIONS[name])
+        if status == "unverified":
+            if any(value is not None for value in evidence_values):
+                raise ValueError("unverified sections must not claim external evidence")
+            if any(value is not None for value in assertion_values):
+                raise ValueError("unverified sections must leave every assertion null")
+        else:
+            if any(value is None for value in evidence_values):
+                raise ValueError(
+                    "completed sections require verifier, time, method, locator, and digest"
+                )
+            assert method is not None
+            if method not in _ALLOWED_EVIDENCE_METHODS[name]:
+                raise ValueError(
+                    f"{name} evidence_method must be one of "
+                    f"{list(_ALLOWED_EVIDENCE_METHODS[name])}"
+                )
+            if any(type(value) is not bool for value in assertion_values):
+                raise ValueError("completed sections require every assertion to be Boolean")
+            if status == "verified" and not all(cast(bool, value) for value in assertion_values):
+                raise ValueError("verified sections require every assertion to pass")
+            if status == "failed" and all(cast(bool, value) for value in assertion_values):
+                raise ValueError("failed sections require at least one failed assertion")
+
+        object.__setattr__(self, "section_name", name)
+        object.__setattr__(self, "verification_status", status)
+        object.__setattr__(self, "verified_by", verifier)
+        object.__setattr__(self, "verified_at", timestamp)
+        object.__setattr__(self, "evidence_method", method)
+        object.__setattr__(self, "evidence_locator", locator)
+        object.__setattr__(self, "evidence_sha256", digest)
+        object.__setattr__(self, "assertions", assertions)
+        object.__setattr__(self, "notes", notes)
+
+    @classmethod
+    def unverified(cls, section_name: SectionName) -> TrustedValidationBoundarySectionV1:
+        return cls(
+            section_name=section_name,
+            verification_status="unverified",
+            verified_by=None,
+            verified_at=None,
+            evidence_method=None,
+            evidence_locator=None,
+            evidence_sha256=None,
+            assertions={key: None for key in _SECTION_ASSERTIONS[section_name]},
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "section_name": self.section_name,
+            "verification_status": self.verification_status,
+            "verified_by": self.verified_by,
+            "verified_at": self.verified_at,
+            "evidence_method": self.evidence_method,
+            "evidence_locator": self.evidence_locator,
+            "evidence_sha256": self.evidence_sha256,
+            "assertions": plain_json(self.assertions),
+            "notes": list(self.notes),
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> TrustedValidationBoundarySectionV1:
+        mapping = require_mapping(value, name="trusted validation boundary section")
+        require_exact_fields(
+            mapping,
+            _SECTION_FIELDS,
+            name="trusted validation boundary section",
+        )
+        return cls(
+            section_name=mapping["section_name"],
+            verification_status=mapping["verification_status"],
+            verified_by=mapping["verified_by"],
+            verified_at=mapping["verified_at"],
+            evidence_method=mapping["evidence_method"],
+            evidence_locator=mapping["evidence_locator"],
+            evidence_sha256=mapping["evidence_sha256"],
+            assertions=mapping["assertions"],
+            notes=_notes_from_json(mapping["notes"]),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class TrustedValidationBoundaryAttestationV1:
+    """Content-addressed readiness record for all four external boundaries."""
+
+    repository: str
+    environment_name: str
+    workflow_path: str
+    source_revision: str
+    workflow_sha256: str
+    github_environment: TrustedValidationBoundarySectionV1
+    runner_host: TrustedValidationBoundarySectionV1
+    dataset_namespace: TrustedValidationBoundarySectionV1
+    exact_head_acceptance: TrustedValidationBoundarySectionV1
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    ready: bool = field(init=False)
+    failure_reasons: tuple[str, ...] = field(init=False)
+    trusted_validation_boundary_attestation_id: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        repository = _repository(self.repository)
+        environment_name = require_exact_string(
+            self.environment_name,
+            name="environment_name",
+        )
+        if environment_name != TRUSTED_VALIDATION_ENVIRONMENT:
+            raise ValueError("environment_name changed from the protected environment")
+        workflow_path = require_exact_string(self.workflow_path, name="workflow_path")
+        if workflow_path != TRUSTED_VALIDATION_WORKFLOW_PATH:
+            raise ValueError("workflow_path changed from the trusted workflow")
+        revision = _exact_source_revision(self.source_revision)
+        workflow_digest = require_sha256(self.workflow_sha256, name="workflow_sha256")
+
+        sections = {
+            "github-environment": self.github_environment,
+            "runner-host": self.runner_host,
+            "dataset-namespace": self.dataset_namespace,
+            "exact-head-acceptance": self.exact_head_acceptance,
+        }
+        for expected_name, section in sections.items():
+            if not isinstance(section, TrustedValidationBoundarySectionV1):
+                raise TypeError(f"{expected_name} section has the wrong type")
+            if section.section_name != expected_name:
+                raise ValueError(f"{expected_name} section name changed")
+
+        reasons: list[str] = []
+        for section_name in _SECTION_ORDER:
+            section = sections[section_name]
+            if section.verification_status == "unverified":
+                reasons.append(f"{section_name}:unverified")
+            elif section.verification_status == "failed":
+                reasons.extend(
+                    f"{section_name}:{key}"
+                    for key in _SECTION_ASSERTIONS[section_name]
+                    if section.assertions[key] is False
+                )
+        failure_reasons = tuple(sorted(reasons))
+        ready = not failure_reasons
+        metadata = frozen_finite_json_mapping(
+            self.metadata,
+            name="trusted validation attestation metadata",
+        )
+
+        object.__setattr__(self, "repository", repository)
+        object.__setattr__(self, "environment_name", environment_name)
+        object.__setattr__(self, "workflow_path", workflow_path)
+        object.__setattr__(self, "source_revision", revision)
+        object.__setattr__(self, "workflow_sha256", workflow_digest)
+        object.__setattr__(self, "metadata", metadata)
+        object.__setattr__(self, "ready", ready)
+        object.__setattr__(self, "failure_reasons", failure_reasons)
+        object.__setattr__(
+            self,
+            "trusted_validation_boundary_attestation_id",
+            _sha256_json(self._content_dict()),
+        )
+
+    def _content_dict(self) -> dict[str, object]:
+        return {
+            "schema": TRUSTED_VALIDATION_ATTESTATION_SCHEMA,
+            "schema_version": TRUSTED_VALIDATION_ATTESTATION_VERSION,
+            "repository": self.repository,
+            "environment_name": self.environment_name,
+            "workflow_path": self.workflow_path,
+            "source_revision": self.source_revision,
+            "workflow_sha256": self.workflow_sha256,
+            "github_environment": self.github_environment.to_dict(),
+            "runner_host": self.runner_host.to_dict(),
+            "dataset_namespace": self.dataset_namespace.to_dict(),
+            "exact_head_acceptance": self.exact_head_acceptance.to_dict(),
+            "metadata": plain_json(self.metadata),
+            "ready": self.ready,
+            "failure_reasons": list(self.failure_reasons),
+            "claim_boundary": TRUSTED_VALIDATION_ATTESTATION_CLAIM_BOUNDARY,
+        }
+
+    def to_dict(self) -> dict[str, object]:
+        result = self._content_dict()
+        result["trusted_validation_boundary_attestation_id"] = (
+            self.trusted_validation_boundary_attestation_id
+        )
+        return result
+
+    @classmethod
+    def from_dict(cls, value: object) -> TrustedValidationBoundaryAttestationV1:
+        mapping = require_mapping(value, name="trusted validation boundary attestation")
+        require_exact_fields(
+            mapping,
+            _ATTESTATION_FIELDS,
+            name="trusted validation boundary attestation",
+        )
+        if mapping["schema"] != TRUSTED_VALIDATION_ATTESTATION_SCHEMA:
+            raise ValueError("trusted validation attestation schema changed")
+        if mapping["schema_version"] != TRUSTED_VALIDATION_ATTESTATION_VERSION:
+            raise ValueError("trusted validation attestation version changed")
+        if mapping["claim_boundary"] != TRUSTED_VALIDATION_ATTESTATION_CLAIM_BOUNDARY:
+            raise ValueError("trusted validation attestation claim boundary changed")
+        result = cls(
+            repository=mapping["repository"],
+            environment_name=mapping["environment_name"],
+            workflow_path=mapping["workflow_path"],
+            source_revision=mapping["source_revision"],
+            workflow_sha256=mapping["workflow_sha256"],
+            github_environment=TrustedValidationBoundarySectionV1.from_dict(
+                mapping["github_environment"]
+            ),
+            runner_host=TrustedValidationBoundarySectionV1.from_dict(
+                mapping["runner_host"]
+            ),
+            dataset_namespace=TrustedValidationBoundarySectionV1.from_dict(
+                mapping["dataset_namespace"]
+            ),
+            exact_head_acceptance=TrustedValidationBoundarySectionV1.from_dict(
+                mapping["exact_head_acceptance"]
+            ),
+            metadata=require_finite_json_mapping(
+                mapping["metadata"],
+                name="trusted validation attestation metadata",
+            ),
+        )
+        if plain_json(result.to_dict()) != plain_json(mapping):
+            raise ValueError("trusted validation attestation derived fields changed")
+        return result
+
+
+def build_trusted_validation_attestation_draft(
+    *,
+    source_revision: str,
+    workflow_sha256: str,
+    repository: str = "IPS-Stuttgart/Prob4D",
+    metadata: Mapping[str, Any] | None = None,
+) -> dict[str, object]:
+    """Return an explicitly unverified draft that cannot claim operational readiness."""
+
+    return {
+        "schema": TRUSTED_VALIDATION_ATTESTATION_DRAFT_SCHEMA,
+        "schema_version": TRUSTED_VALIDATION_ATTESTATION_VERSION,
+        "repository": _repository(repository),
+        "environment_name": TRUSTED_VALIDATION_ENVIRONMENT,
+        "workflow_path": TRUSTED_VALIDATION_WORKFLOW_PATH,
+        "source_revision": _exact_source_revision(source_revision),
+        "workflow_sha256": require_sha256(workflow_sha256, name="workflow_sha256"),
+        "github_environment": TrustedValidationBoundarySectionV1.unverified(
+            "github-environment"
+        ).to_dict(),
+        "runner_host": TrustedValidationBoundarySectionV1.unverified(
+            "runner-host"
+        ).to_dict(),
+        "dataset_namespace": TrustedValidationBoundarySectionV1.unverified(
+            "dataset-namespace"
+        ).to_dict(),
+        "exact_head_acceptance": TrustedValidationBoundarySectionV1.unverified(
+            "exact-head-acceptance"
+        ).to_dict(),
+        "metadata": plain_json(
+            frozen_finite_json_mapping(
+                {} if metadata is None else metadata,
+                name="trusted validation draft metadata",
+            )
+        ),
+        "claim_boundary": TRUSTED_VALIDATION_ATTESTATION_CLAIM_BOUNDARY,
+    }
+
+
+def seal_trusted_validation_attestation_draft(
+    value: object,
+) -> TrustedValidationBoundaryAttestationV1:
+    """Validate a completed draft and derive readiness, reasons, and content identity."""
+
+    mapping = require_mapping(value, name="trusted validation attestation draft")
+    require_exact_fields(mapping, _DRAFT_FIELDS, name="trusted validation attestation draft")
+    if mapping["schema"] != TRUSTED_VALIDATION_ATTESTATION_DRAFT_SCHEMA:
+        raise ValueError("trusted validation attestation draft schema changed")
+    if mapping["schema_version"] != TRUSTED_VALIDATION_ATTESTATION_VERSION:
+        raise ValueError("trusted validation attestation draft version changed")
+    if mapping["claim_boundary"] != TRUSTED_VALIDATION_ATTESTATION_CLAIM_BOUNDARY:
+        raise ValueError("trusted validation attestation draft claim boundary changed")
+    return TrustedValidationBoundaryAttestationV1(
+        repository=mapping["repository"],
+        environment_name=mapping["environment_name"],
+        workflow_path=mapping["workflow_path"],
+        source_revision=mapping["source_revision"],
+        workflow_sha256=mapping["workflow_sha256"],
+        github_environment=TrustedValidationBoundarySectionV1.from_dict(
+            mapping["github_environment"]
+        ),
+        runner_host=TrustedValidationBoundarySectionV1.from_dict(mapping["runner_host"]),
+        dataset_namespace=TrustedValidationBoundarySectionV1.from_dict(
+            mapping["dataset_namespace"]
+        ),
+        exact_head_acceptance=TrustedValidationBoundarySectionV1.from_dict(
+            mapping["exact_head_acceptance"]
+        ),
+        metadata=require_finite_json_mapping(
+            mapping["metadata"],
+            name="trusted validation draft metadata",
+        ),
+    )
+
+
+def _write_json(
+    path: str | Path,
+    value: Mapping[str, Any],
+    *,
+    overwrite: bool,
+) -> None:
+    if type(overwrite) is not bool:
+        raise ValueError("overwrite must be a Boolean")
+    payload = json.dumps(
+        plain_json(value),
+        sort_keys=True,
+        indent=2,
+        allow_nan=False,
+    ) + "\n"
+    atomic_write_text(path, payload, overwrite=overwrite)
+
+
+def write_trusted_validation_attestation_draft(
+    path: str | Path,
+    draft: Mapping[str, Any],
+    *,
+    overwrite: bool = False,
+) -> None:
+    seal_trusted_validation_attestation_draft(draft)
+    _write_json(path, draft, overwrite=overwrite)
+
+
+def load_trusted_validation_attestation_draft(path: str | Path) -> dict[str, Any]:
+    draft = load_json_object(path, name="trusted validation attestation draft")
+    seal_trusted_validation_attestation_draft(draft)
+    return draft
+
+
+def write_trusted_validation_attestation(
+    path: str | Path,
+    attestation: TrustedValidationBoundaryAttestationV1,
+    *,
+    overwrite: bool = False,
+) -> None:
+    if not isinstance(attestation, TrustedValidationBoundaryAttestationV1):
+        raise TypeError("attestation must be TrustedValidationBoundaryAttestationV1")
+    _write_json(path, attestation.to_dict(), overwrite=overwrite)
+
+
+def load_trusted_validation_attestation(
+    path: str | Path,
+) -> TrustedValidationBoundaryAttestationV1:
+    return TrustedValidationBoundaryAttestationV1.from_dict(
+        load_json_object(path, name="trusted validation boundary attestation")
+    )
+
+
+def _summary(value: Mapping[str, Any]) -> None:
+    print(json.dumps(plain_json(value), sort_keys=True, allow_nan=False))
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    template = subparsers.add_parser("template")
+    template.add_argument("--source-revision", required=True)
+    template.add_argument("--workflow-sha256", required=True)
+    template.add_argument("--repository", default="IPS-Stuttgart/Prob4D")
+    template.add_argument("--output", type=Path, required=True)
+    template.add_argument("--overwrite", action="store_true")
+
+    seal = subparsers.add_parser("seal")
+    seal.add_argument("--draft", type=Path, required=True)
+    seal.add_argument("--output", type=Path, required=True)
+    seal.add_argument("--overwrite", action="store_true")
+
+    verify = subparsers.add_parser("verify")
+    verify.add_argument("--artifact", type=Path, required=True)
+    verify.add_argument("--require-ready", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _parser().parse_args(argv)
+    if arguments.command == "template":
+        draft = build_trusted_validation_attestation_draft(
+            source_revision=arguments.source_revision,
+            workflow_sha256=arguments.workflow_sha256,
+            repository=arguments.repository,
+        )
+        _write_json(arguments.output, draft, overwrite=arguments.overwrite)
+        _summary({"draft": str(arguments.output), "ready": False})
+        return 0
+    if arguments.command == "seal":
+        draft = load_json_object(
+            arguments.draft,
+            name="trusted validation attestation draft",
+        )
+        attestation = seal_trusted_validation_attestation_draft(draft)
+        write_trusted_validation_attestation(
+            arguments.output,
+            attestation,
+            overwrite=arguments.overwrite,
+        )
+        _summary(
+            {
+                "attestation_id": attestation.trusted_validation_boundary_attestation_id,
+                "failure_reasons": list(attestation.failure_reasons),
+                "ready": attestation.ready,
+            }
+        )
+        return 0
+    attestation = load_trusted_validation_attestation(arguments.artifact)
+    _summary(
+        {
+            "attestation_id": attestation.trusted_validation_boundary_attestation_id,
+            "failure_reasons": list(attestation.failure_reasons),
+            "ready": attestation.ready,
+        }
+    )
+    if arguments.require_ready and not attestation.ready:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+
+
+__all__ = [
+    "TRUSTED_VALIDATION_ATTESTATION_CLAIM_BOUNDARY",
+    "TRUSTED_VALIDATION_ATTESTATION_DRAFT_SCHEMA",
+    "TRUSTED_VALIDATION_ATTESTATION_SCHEMA",
+    "TRUSTED_VALIDATION_ATTESTATION_VERSION",
+    "TRUSTED_VALIDATION_ENVIRONMENT",
+    "TRUSTED_VALIDATION_WORKFLOW_PATH",
+    "TrustedValidationBoundaryAttestationV1",
+    "TrustedValidationBoundarySectionV1",
+    "build_trusted_validation_attestation_draft",
+    "load_trusted_validation_attestation",
+    "load_trusted_validation_attestation_draft",
+    "seal_trusted_validation_attestation_draft",
+    "write_trusted_validation_attestation",
+    "write_trusted_validation_attestation_draft",
+]

--- a/tests/test_trusted_validation_attestation.py
+++ b/tests/test_trusted_validation_attestation.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from prob4d.trusted_validation_attestation import (
+    TRUSTED_VALIDATION_ATTESTATION_CLAIM_BOUNDARY,
+    TRUSTED_VALIDATION_ATTESTATION_DRAFT_SCHEMA,
+    TrustedValidationBoundaryAttestationV1,
+    build_trusted_validation_attestation_draft,
+    load_trusted_validation_attestation,
+    main,
+    seal_trusted_validation_attestation_draft,
+    write_trusted_validation_attestation,
+)
+
+SOURCE_REVISION = "1" * 40
+WORKFLOW_SHA256 = "2" * 64
+EVIDENCE_SHA256 = "3" * 64
+
+
+def _verified_section(draft: dict[str, object], field: str, method: str) -> None:
+    section = draft[field]
+    assert isinstance(section, dict)
+    section["verification_status"] = "verified"
+    section["verified_by"] = "independent-verifier"
+    section["verified_at"] = "2026-08-12T08:30:00Z"
+    section["evidence_method"] = method
+    section["evidence_locator"] = f"urn:prob4d:external-audit:{field}"
+    section["evidence_sha256"] = EVIDENCE_SHA256
+    assertions = section["assertions"]
+    assert isinstance(assertions, dict)
+    for key in assertions:
+        assertions[key] = True
+
+
+def _ready_draft() -> dict[str, object]:
+    draft = build_trusted_validation_attestation_draft(
+        source_revision=SOURCE_REVISION,
+        workflow_sha256=WORKFLOW_SHA256,
+    )
+    _verified_section(draft, "github_environment", "github-api-query")
+    _verified_section(draft, "runner_host", "independent-host-audit")
+    _verified_section(
+        draft,
+        "dataset_namespace",
+        "independent-dataset-namespace-audit",
+    )
+    _verified_section(draft, "exact_head_acceptance", "github-actions-api-query")
+    return draft
+
+
+def test_template_is_explicitly_unverified_and_not_ready() -> None:
+    draft = build_trusted_validation_attestation_draft(
+        source_revision=SOURCE_REVISION,
+        workflow_sha256=WORKFLOW_SHA256,
+    )
+
+    assert draft["schema"] == TRUSTED_VALIDATION_ATTESTATION_DRAFT_SCHEMA
+    attestation = seal_trusted_validation_attestation_draft(draft)
+
+    assert not attestation.ready
+    assert attestation.failure_reasons == (
+        "dataset-namespace:unverified",
+        "exact-head-acceptance:unverified",
+        "github-environment:unverified",
+        "runner-host:unverified",
+    )
+
+
+def test_complete_independent_evidence_seals_ready_attestation() -> None:
+    attestation = seal_trusted_validation_attestation_draft(_ready_draft())
+
+    assert attestation.ready
+    assert attestation.failure_reasons == ()
+    assert len(attestation.trusted_validation_boundary_attestation_id) == 64
+    assert attestation.to_dict()["claim_boundary"] == (
+        TRUSTED_VALIDATION_ATTESTATION_CLAIM_BOUNDARY
+    )
+
+
+def test_failed_negative_control_keeps_boundary_closed() -> None:
+    draft = _ready_draft()
+    section = draft["exact_head_acceptance"]
+    assert isinstance(section, dict)
+    section["verification_status"] = "failed"
+    assertions = section["assertions"]
+    assert isinstance(assertions, dict)
+    assertions["stale_sha_rejected_before_self_hosted_checkout"] = False
+
+    attestation = seal_trusted_validation_attestation_draft(draft)
+
+    assert not attestation.ready
+    assert attestation.failure_reasons == (
+        "exact-head-acceptance:stale_sha_rejected_before_self_hosted_checkout",
+    )
+
+
+def test_verified_section_cannot_hide_failed_assertion() -> None:
+    draft = _ready_draft()
+    section = draft["runner_host"]
+    assert isinstance(section, dict)
+    assertions = section["assertions"]
+    assert isinstance(assertions, dict)
+    assertions["dedicated_non_administrator_account"] = False
+
+    with pytest.raises(ValueError, match="every assertion to pass"):
+        seal_trusted_validation_attestation_draft(draft)
+
+
+def test_unverified_section_cannot_claim_external_evidence() -> None:
+    draft = build_trusted_validation_attestation_draft(
+        source_revision=SOURCE_REVISION,
+        workflow_sha256=WORKFLOW_SHA256,
+    )
+    section = draft["runner_host"]
+    assert isinstance(section, dict)
+    section["evidence_locator"] = "urn:prob4d:external-audit:forged"
+
+    with pytest.raises(ValueError, match="must not claim external evidence"):
+        seal_trusted_validation_attestation_draft(draft)
+
+
+def test_repository_relative_evidence_is_rejected() -> None:
+    draft = _ready_draft()
+    section = draft["runner_host"]
+    assert isinstance(section, dict)
+    section["evidence_locator"] = "docs/runner-audit.md"
+
+    with pytest.raises(ValueError, match="external HTTPS URL"):
+        seal_trusted_validation_attestation_draft(draft)
+
+
+def test_repository_blob_url_is_rejected_as_external_evidence() -> None:
+    draft = _ready_draft()
+    section = draft["github_environment"]
+    assert isinstance(section, dict)
+    section["evidence_locator"] = (
+        "https://github.com/IPS-Stuttgart/Prob4D/blob/main/docs/runner-audit.md"
+    )
+
+    with pytest.raises(ValueError, match="repository files cannot serve"):
+        seal_trusted_validation_attestation_draft(draft)
+
+
+def test_repository_file_is_not_an_evidence_method() -> None:
+    draft = _ready_draft()
+    section = draft["github_environment"]
+    assert isinstance(section, dict)
+    section["evidence_method"] = "repository-file"
+
+    with pytest.raises(ValueError, match="evidence_method"):
+        seal_trusted_validation_attestation_draft(draft)
+
+
+def test_round_trip_recomputes_derived_fields_and_rejects_tampering(
+    tmp_path: Path,
+) -> None:
+    attestation = seal_trusted_validation_attestation_draft(_ready_draft())
+    path = tmp_path / "attestation.json"
+    write_trusted_validation_attestation(path, attestation)
+
+    loaded = load_trusted_validation_attestation(path)
+    assert loaded.trusted_validation_boundary_attestation_id == (
+        attestation.trusted_validation_boundary_attestation_id
+    )
+
+    tampered = deepcopy(attestation.to_dict())
+    tampered["ready"] = False
+    path.write_text(json.dumps(tampered), encoding="utf-8")
+    with pytest.raises(ValueError, match="derived fields changed"):
+        load_trusted_validation_attestation(path)
+
+
+def test_duplicate_json_keys_fail_closed(tmp_path: Path) -> None:
+    path = tmp_path / "duplicate.json"
+    path.write_text('{"schema": 1, "schema": 2}', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="duplicate JSON object key"):
+        load_trusted_validation_attestation(path)
+
+
+def test_writer_is_no_clobber(tmp_path: Path) -> None:
+    attestation = seal_trusted_validation_attestation_draft(_ready_draft())
+    path = tmp_path / "attestation.json"
+    write_trusted_validation_attestation(path, attestation)
+
+    with pytest.raises(FileExistsError):
+        write_trusted_validation_attestation(path, attestation)
+
+
+def test_cli_template_seal_and_require_ready(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    draft_path = tmp_path / "draft.json"
+    artifact_path = tmp_path / "attestation.json"
+    assert (
+        main(
+            [
+                "template",
+                "--source-revision",
+                SOURCE_REVISION,
+                "--workflow-sha256",
+                WORKFLOW_SHA256,
+                "--output",
+                str(draft_path),
+            ]
+        )
+        == 0
+    )
+    assert main(["seal", "--draft", str(draft_path), "--output", str(artifact_path)]) == 0
+    assert main(["verify", "--artifact", str(artifact_path)]) == 0
+    assert main(["verify", "--artifact", str(artifact_path), "--require-ready"]) == 2
+    assert '"ready": false' in capsys.readouterr().out
+
+
+def test_direct_constructor_requires_canonical_section_placement() -> None:
+    attestation = seal_trusted_validation_attestation_draft(_ready_draft())
+
+    with pytest.raises(ValueError, match="section name changed"):
+        TrustedValidationBoundaryAttestationV1(
+            repository=attestation.repository,
+            environment_name=attestation.environment_name,
+            workflow_path=attestation.workflow_path,
+            source_revision=attestation.source_revision,
+            workflow_sha256=attestation.workflow_sha256,
+            github_environment=attestation.runner_host,
+            runner_host=attestation.github_environment,
+            dataset_namespace=attestation.dataset_namespace,
+            exact_head_acceptance=attestation.exact_head_acceptance,
+        )


### PR DESCRIPTION
## What changed

- add `prob4d.trusted_validation_attestation`, a strict machine-readable record for the four externally controlled parts of trusted self-hosted validation:
  - GitHub environment policy;
  - runner-host hardening;
  - dataset namespace isolation; and
  - exact-head positive and negative acceptance controls;
- add explicit `template`, `seal`, and `verify` module commands;
- make an initial template structurally valid but unverified and ineligible for readiness;
- require completed sections to bind an independent verifier, UTC timestamp, allowed external evidence method, external evidence locator, evidence SHA-256, and every section-specific assertion;
- reject repository-relative paths, repository blob/tree/raw/contents URLs, and `repository-file` as external proof;
- derive readiness, precise failure reasons, and a content identity during sealing and recompute them during loading;
- publish through the shared atomic no-clobber writer;
- add adversarial tests and link the operational guide from the existing trusted-runner documentation.

## Why

The protected workflow can enforce exact pull-request-head checkout semantics, but repository files cannot prove current GitHub environment settings, runner-account hardening, the mounted dataset namespace, or whether stale-SHA and non-`main` controls were actually executed. Issue #203 requires those boundaries to remain distinct and independently attestable rather than being represented by unchecked repository assertions.

This PR implements the repository-side artifact and verifier. It intentionally does **not** close #203: completion still requires external evidence for all four sections and successful execution of the registered positive, stale-SHA, and non-`main` controls.

## Validation performed before publication

- focused attestation suite: 13 tests passed in an isolated harness using the repository's strict JSON, immutable JSON, and atomic publication helpers;
- Python byte compilation passed;
- all new Python and test lines satisfy the repository's 100-character limit;
- cases cover unverified templates, ready attestations, failed negative controls, hidden failed assertions, forged evidence, repository-local evidence rejection, tampering, duplicate JSON keys, no-clobber persistence, CLI exit semantics, and canonical section placement.

GitHub Actions on the exact pull-request head remain authoritative for Ruff, the complete supported-Python suite, the NumPy floor, packaging, installed-module execution, repository policy, and security scanning.

## Operational and scientific boundary

A ready artifact records independently supplied evidence at one snapshot. It does not configure GitHub, sandbox a persistent runner, guarantee unchanged future state, authorize a held-out or confirmatory cohort, establish provider accuracy or uncertainty calibration, establish BayesianPhysTwin or Causal4D benefit, approve deployment, or establish state of the art.

Addresses the repository-side implementation required by #203.