### PR TITLE
Add provider readiness localization and prefix admission

### DIFF
--- a/docs/provider-readiness-localization.md
+++ b/docs/provider-readiness-localization.md
@@ -1,0 +1,154 @@
+# Provider readiness localization
+
+Prob4D already separates support feasibility, source mean/identity competence,
+gauge/dependence diagnostics, point covariance, query relevance, and exact
+fallback. This note documents three additive tools that close the remaining
+integration gaps without changing provider-v2 or fitting a new uncertainty model.
+
+## 1. Contiguous support envelopes before residuals
+
+`ProviderSupportFeasibilityV1` answers whether one frozen required-frame set is
+supported. `ProviderSupportEnvelopeV1` additionally summarizes **all contiguous
+frame intervals** that are supported by the same already-frozen camera/robot
+metadata.
+
+```bash
+python -m prob4d.provider_support_envelope derive \
+  --request support-request.json \
+  --output support-envelope.json
+
+python -m prob4d.provider_support_envelope verify \
+  --artifact support-envelope.json
+```
+
+For each stream the artifact records:
+
+- the frozen causal span;
+- all contiguous admissible intervals `[start, stop_exclusive)`;
+- earliest/latest admissible bounds and maximum contiguous length;
+- required-frame support fraction;
+- static intrinsics/extrinsics/metric-anchor completeness; and
+- the original feasibility result and reason codes.
+
+The envelope is derived without prediction payloads, residuals, or target
+outcomes. It **does not modify** its source request. If a different prefix is to
+be tried, freeze a new `ProviderSupportFeasibilityRequestV1` or a prospectively
+declared `ProviderSupportDesignRequestV1` from the envelope before opening later
+information. This is the safe route for avoiding another fixed-prefix support
+failure without deleting cameras after outcomes are known.
+
+## 2. Evidence-driven source covariance localization
+
+`SourceCovarianceLocalizationV1` binds two existing source-only evidence types:
+
+1. `SourceProviderCompetenceReportV1`, which separates observation-mean quality
+   from identity/reliability quality; and
+2. `prob4d.joint-covariance-diagnostics`, which separates shared/gauge-subspace
+   residual energy from conditional-subspace residual energy.
+
+A frozen policy declares acceptable bands and minimum independent-group pass
+fractions. Evaluation obeys this stop order:
+
+1. source-mean failure -> stop, no covariance development;
+2. identity/association failure -> stop, no covariance development;
+3. shared/gauge energy failure -> `gauge-or-dependence-negative`;
+4. shared/gauge pass **and** conditional failure ->
+   `point-covariance-localized`; and
+5. both subspaces plus joint NEES pass -> `covariance-adequate`.
+
+Only step 4 sets `authorize_point_uncertainty_development=true`. A joint-NEES
+failure that cannot be assigned to the conditional subspace is conservatively
+classified as gauge/dependence failure rather than being used to justify a more
+complex point model.
+
+The localizer also requires the joint diagnostic's factor-group IDs to match the
+exact evaluable source object/session IDs in the source-competence report. This
+prevents pixel-, frame-, or mismatched-cohort evidence from silently being used
+as independent calibration groups.
+
+Example policy:
+
+```json
+{
+  "minimum_group_count": 8,
+  "normalized_nees_lower": 0.7,
+  "normalized_nees_upper": 1.3,
+  "minimum_joint_pass_fraction": 0.8,
+  "shared_energy_lower": 0.7,
+  "shared_energy_upper": 1.3,
+  "minimum_shared_pass_fraction": 0.8,
+  "conditional_energy_lower": 0.7,
+  "conditional_energy_upper": 1.3,
+  "minimum_conditional_pass_fraction": 0.8,
+  "require_shared_subspace": true
+}
+```
+
+These numbers are examples only; a real study must freeze its policy from the
+source/calibration protocol rather than copy them.
+
+```bash
+python -m prob4d.source_covariance_localization evaluate \
+  --source-competence source-provider-competence.json \
+  --joint-diagnostic joint-covariance.json \
+  --policy covariance-localization-policy.json \
+  --output covariance-localization.json
+```
+
+`readiness_gates()` converts the result directly into the existing
+`gauge-dependence` and `point-covariance` `ReadinessGateV1` entries. No new
+readiness classification is introduced.
+
+## 3. Strict causal-prefix admission
+
+Calibration transport already detects whether a causal target prefix lies in the
+source-calibration feature regime. `ProviderPrefixAdmissionV1` makes the missing
+conjunction explicit:
+
+```text
+admitted = support_feasible AND calibration_transport_accepted
+```
+
+The calibration-transport evidence must include the following metadata binding:
+
+```json
+{
+  "provider_prefix_binding": {
+    "provider_manifest_id": "<sha256>",
+    "cohort_binding_id": "<sha256>",
+    "target_prefix_id": "<sha256>",
+    "causal_prefix_only": true,
+    "target_residuals_used": false,
+    "target_outcomes_used": false
+  }
+}
+```
+
+The builder rejects provider, cohort, or prefix mismatches as invalid evidence;
+they are not converted into scientific negatives. A valid negative support or
+transport result instead produces `admitted=false` and
+`exact_fallback_required=true`.
+
+```bash
+python -m prob4d.provider_prefix_admission build \
+  --support provider-support.json \
+  --transport-model calibration-transport-model.json \
+  --transport-evidence calibration-transport-evidence.json \
+  --provider-manifest-id <sha256> \
+  --target-prefix-id <sha256> \
+  --output provider-prefix-admission.json
+```
+
+This certificate remains upstream of BayesianPhysTwin. Passing it means only
+that Prob4D's provider prefix is geometrically feasible and inside the frozen
+source-calibration support region. BayesianPhysTwin still owns physical-query
+relevance, update admission, regret guards, and exact physical fallback;
+Causal4D still consumes only the resulting accepted physical belief.
+
+## Scientific stop rule
+
+These additions deliberately do **not** implement `PointUncertaintyCalibrationV2`.
+A richer point model is justified only after a real source/calibration execution
+produces `point-covariance-localized`. A support, mean, identity, gauge/dependence,
+transport, or query failure redirects the provider instead of increasing
+covariance-model complexity.

--- a/src/prob4d/provider_prefix_admission.py
+++ b/src/prob4d/provider_prefix_admission.py
@@ -1,0 +1,413 @@
+"""Fail-closed admission binding support feasibility to calibration transport.
+
+Provider support and calibration-transport evidence intentionally answer separate
+questions.  This module creates one small content-addressed certificate that
+requires both to pass for the same provider, cohort, and causal target prefix.
+It remains upstream of BayesianPhysTwin's independent physical-update guard.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from ._atomic_file import atomic_write_text
+from ._immutable_json import frozen_finite_json_mapping, plain_json
+from ._strict_json import (
+    load_json_object,
+    require_exact_fields,
+    require_exact_string,
+    require_finite_json_mapping,
+    require_mapping,
+    require_sha256,
+)
+from .calibration_transport import (
+    CalibrationTransportEvidenceV1,
+    load_calibration_transport_evidence,
+    load_calibration_transport_model,
+)
+from .provider_support_feasibility import (
+    ProviderSupportFeasibilityV1,
+    load_provider_support_feasibility,
+)
+
+PROVIDER_PREFIX_ADMISSION_SCHEMA = "prob4d.provider-prefix-admission"
+PROVIDER_PREFIX_ADMISSION_VERSION = 1
+PROVIDER_PREFIX_BINDING_METADATA_KEY = "provider_prefix_binding"
+PROVIDER_PREFIX_ADMISSION_CLAIM_BOUNDARY = (
+    "This artifact verifies that an exact causal provider prefix passes both a "
+    "pre-residual support-feasibility gate and a source-only calibration-transport "
+    "gate with matching provider/cohort/prefix bindings. It does not establish "
+    "point accuracy, covariance coverage, authorize a BayesianPhysTwin state update, "
+    "establish physical-query or Causal4D benefit, deployment safety, or state of the art."
+)
+
+_BINDING_FIELDS = frozenset(
+    {
+        "provider_manifest_id",
+        "cohort_binding_id",
+        "target_prefix_id",
+        "causal_prefix_only",
+        "target_residuals_used",
+        "target_outcomes_used",
+    }
+)
+_ARTIFACT_FIELDS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "provider_manifest_id",
+        "cohort_binding_id",
+        "target_prefix_id",
+        "provider_support_feasibility_id",
+        "calibration_transport_model_id",
+        "calibration_transport_evidence_id",
+        "calibration_transport_feature_contract_id",
+        "support_feasible",
+        "calibration_transport_accepted",
+        "admitted",
+        "exact_fallback_required",
+        "decision_reasons",
+        "metadata",
+        "claim_boundary",
+        "provider_prefix_admission_id",
+    }
+)
+
+
+def _canonical_json_bytes(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        plain_json(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _sha256_json(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json_bytes(value)).hexdigest()
+
+
+def _strict_bool(value: object, *, name: str) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be a Boolean")
+    return value
+
+
+def _sorted_unique_strings(value: object, *, name: str) -> tuple[str, ...]:
+    if type(value) is not tuple:
+        raise ValueError(f"{name} must be a canonical tuple")
+    result = tuple(
+        require_exact_string(item, name=f"{name}[{index}]")
+        for index, item in enumerate(value)
+    )
+    if result != tuple(sorted(set(result))):
+        raise ValueError(f"{name} must be sorted and unique")
+    return result
+
+
+def _strings_from_json(value: object, *, name: str) -> tuple[str, ...]:
+    if type(value) is not list:
+        raise ValueError(f"{name} must be a JSON array")
+    return _sorted_unique_strings(tuple(value), name=name)
+
+
+def _binding(evidence: CalibrationTransportEvidenceV1) -> Mapping[str, Any]:
+    raw = evidence.metadata.get(PROVIDER_PREFIX_BINDING_METADATA_KEY)
+    mapping = require_mapping(raw, name=PROVIDER_PREFIX_BINDING_METADATA_KEY)
+    require_exact_fields(
+        mapping,
+        _BINDING_FIELDS,
+        name=PROVIDER_PREFIX_BINDING_METADATA_KEY,
+    )
+    provider_manifest_id = require_sha256(
+        mapping["provider_manifest_id"],
+        name="provider_prefix_binding.provider_manifest_id",
+    )
+    cohort_binding_id = require_sha256(
+        mapping["cohort_binding_id"],
+        name="provider_prefix_binding.cohort_binding_id",
+    )
+    target_prefix_id = require_sha256(
+        mapping["target_prefix_id"],
+        name="provider_prefix_binding.target_prefix_id",
+    )
+    causal_prefix_only = _strict_bool(
+        mapping["causal_prefix_only"],
+        name="provider_prefix_binding.causal_prefix_only",
+    )
+    residuals_used = _strict_bool(
+        mapping["target_residuals_used"],
+        name="provider_prefix_binding.target_residuals_used",
+    )
+    outcomes_used = _strict_bool(
+        mapping["target_outcomes_used"],
+        name="provider_prefix_binding.target_outcomes_used",
+    )
+    if not causal_prefix_only:
+        raise ValueError("calibration transport is not bound to a causal prefix")
+    if residuals_used or outcomes_used:
+        raise ValueError("calibration transport admission must not use target residuals/outcomes")
+    return {
+        "provider_manifest_id": provider_manifest_id,
+        "cohort_binding_id": cohort_binding_id,
+        "target_prefix_id": target_prefix_id,
+        "causal_prefix_only": True,
+        "target_residuals_used": False,
+        "target_outcomes_used": False,
+    }
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderPrefixAdmissionV1:
+    """Conjunctive provider-prefix admission and exact-fallback certificate."""
+
+    provider_manifest_id: str
+    cohort_binding_id: str
+    target_prefix_id: str
+    provider_support_feasibility_id: str
+    calibration_transport_model_id: str
+    calibration_transport_evidence_id: str
+    calibration_transport_feature_contract_id: str
+    support_feasible: bool
+    calibration_transport_accepted: bool
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    admitted: bool = field(init=False)
+    exact_fallback_required: bool = field(init=False)
+    decision_reasons: tuple[str, ...] = field(init=False)
+    provider_prefix_admission_id: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        for name in (
+            "provider_manifest_id",
+            "cohort_binding_id",
+            "target_prefix_id",
+            "provider_support_feasibility_id",
+            "calibration_transport_model_id",
+            "calibration_transport_evidence_id",
+            "calibration_transport_feature_contract_id",
+        ):
+            object.__setattr__(self, name, require_sha256(getattr(self, name), name=name))
+        support = _strict_bool(self.support_feasible, name="support_feasible")
+        transport = _strict_bool(
+            self.calibration_transport_accepted,
+            name="calibration_transport_accepted",
+        )
+        metadata = frozen_finite_json_mapping(
+            require_finite_json_mapping(self.metadata, name="metadata"),
+            name="metadata",
+        )
+        reasons: list[str] = []
+        if not support:
+            reasons.append("support-feasibility-negative")
+        if not transport:
+            reasons.append("calibration-transport-negative")
+        admitted = support and transport
+        object.__setattr__(self, "support_feasible", support)
+        object.__setattr__(self, "calibration_transport_accepted", transport)
+        object.__setattr__(self, "metadata", metadata)
+        object.__setattr__(self, "admitted", admitted)
+        object.__setattr__(self, "exact_fallback_required", not admitted)
+        object.__setattr__(self, "decision_reasons", tuple(reasons))
+        object.__setattr__(
+            self,
+            "provider_prefix_admission_id",
+            _sha256_json(self._content_dict()),
+        )
+
+    def _content_dict(self) -> dict[str, object]:
+        return {
+            "schema": PROVIDER_PREFIX_ADMISSION_SCHEMA,
+            "schema_version": PROVIDER_PREFIX_ADMISSION_VERSION,
+            "provider_manifest_id": self.provider_manifest_id,
+            "cohort_binding_id": self.cohort_binding_id,
+            "target_prefix_id": self.target_prefix_id,
+            "provider_support_feasibility_id": self.provider_support_feasibility_id,
+            "calibration_transport_model_id": self.calibration_transport_model_id,
+            "calibration_transport_evidence_id": self.calibration_transport_evidence_id,
+            "calibration_transport_feature_contract_id": (
+                self.calibration_transport_feature_contract_id
+            ),
+            "support_feasible": self.support_feasible,
+            "calibration_transport_accepted": self.calibration_transport_accepted,
+            "admitted": self.admitted,
+            "exact_fallback_required": self.exact_fallback_required,
+            "decision_reasons": list(self.decision_reasons),
+            "metadata": plain_json(self.metadata),
+            "claim_boundary": PROVIDER_PREFIX_ADMISSION_CLAIM_BOUNDARY,
+        }
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            **self._content_dict(),
+            "provider_prefix_admission_id": self.provider_prefix_admission_id,
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> ProviderPrefixAdmissionV1:
+        mapping = require_mapping(value, name="provider prefix admission")
+        require_exact_fields(mapping, _ARTIFACT_FIELDS, name="provider prefix admission")
+        if mapping["schema"] != PROVIDER_PREFIX_ADMISSION_SCHEMA:
+            raise ValueError("provider prefix admission schema changed")
+        if mapping["schema_version"] != PROVIDER_PREFIX_ADMISSION_VERSION:
+            raise ValueError("provider prefix admission version changed")
+        if mapping["claim_boundary"] != PROVIDER_PREFIX_ADMISSION_CLAIM_BOUNDARY:
+            raise ValueError("provider prefix admission claim boundary changed")
+        result = cls(
+            provider_manifest_id=mapping["provider_manifest_id"],
+            cohort_binding_id=mapping["cohort_binding_id"],
+            target_prefix_id=mapping["target_prefix_id"],
+            provider_support_feasibility_id=mapping[
+                "provider_support_feasibility_id"
+            ],
+            calibration_transport_model_id=mapping["calibration_transport_model_id"],
+            calibration_transport_evidence_id=mapping[
+                "calibration_transport_evidence_id"
+            ],
+            calibration_transport_feature_contract_id=mapping[
+                "calibration_transport_feature_contract_id"
+            ],
+            support_feasible=mapping["support_feasible"],
+            calibration_transport_accepted=mapping[
+                "calibration_transport_accepted"
+            ],
+            metadata=require_finite_json_mapping(mapping["metadata"], name="metadata"),
+        )
+        supplied_id = require_sha256(
+            mapping["provider_prefix_admission_id"],
+            name="provider_prefix_admission_id",
+        )
+        if supplied_id != result.provider_prefix_admission_id:
+            raise ValueError("provider prefix admission identity mismatch")
+        if plain_json(mapping) != result.to_dict():
+            raise ValueError("provider prefix admission derived fields changed")
+        return result
+
+
+def build_provider_prefix_admission(
+    support: ProviderSupportFeasibilityV1,
+    transport: CalibrationTransportEvidenceV1,
+    *,
+    provider_manifest_id: str,
+    target_prefix_id: str,
+    metadata: Mapping[str, Any] | None = None,
+) -> ProviderPrefixAdmissionV1:
+    """Bind two validated upstream gates to the same exact causal provider prefix."""
+
+    if not isinstance(support, ProviderSupportFeasibilityV1):
+        raise TypeError("support must be ProviderSupportFeasibilityV1")
+    if not isinstance(transport, CalibrationTransportEvidenceV1):
+        raise TypeError("transport must be CalibrationTransportEvidenceV1")
+    manifest_id = require_sha256(provider_manifest_id, name="provider_manifest_id")
+    prefix_id = require_sha256(target_prefix_id, name="target_prefix_id")
+    binding = _binding(transport)
+    if binding["provider_manifest_id"] != manifest_id:
+        raise ValueError("calibration transport provider_manifest_id binding changed")
+    if binding["target_prefix_id"] != prefix_id:
+        raise ValueError("calibration transport target_prefix_id binding changed")
+    cohort_id = support.request.cohort_binding_id
+    if binding["cohort_binding_id"] != cohort_id:
+        raise ValueError("support and calibration transport cohort bindings differ")
+    return ProviderPrefixAdmissionV1(
+        provider_manifest_id=manifest_id,
+        cohort_binding_id=cohort_id,
+        target_prefix_id=prefix_id,
+        provider_support_feasibility_id=support.provider_support_feasibility_id,
+        calibration_transport_model_id=transport.model.model_id,
+        calibration_transport_evidence_id=transport.evidence_id,
+        calibration_transport_feature_contract_id=transport.model.feature_contract_id,
+        support_feasible=support.support_feasible,
+        calibration_transport_accepted=transport.accepted,
+        metadata={} if metadata is None else metadata,
+    )
+
+
+def write_provider_prefix_admission(
+    path: str | Path,
+    admission: ProviderPrefixAdmissionV1,
+    *,
+    overwrite: bool = False,
+) -> None:
+    if not isinstance(admission, ProviderPrefixAdmissionV1):
+        raise TypeError("admission must be ProviderPrefixAdmissionV1")
+    payload = json.dumps(admission.to_dict(), sort_keys=True, indent=2, allow_nan=False) + "\n"
+    atomic_write_text(path, payload, overwrite=overwrite)
+
+
+def load_provider_prefix_admission(path: str | Path) -> ProviderPrefixAdmissionV1:
+    return ProviderPrefixAdmissionV1.from_dict(
+        load_json_object(path, name="provider prefix admission")
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    build = subparsers.add_parser("build")
+    build.add_argument("--support", type=Path, required=True)
+    build.add_argument("--transport-model", type=Path, required=True)
+    build.add_argument("--transport-evidence", type=Path, required=True)
+    build.add_argument("--provider-manifest-id", required=True)
+    build.add_argument("--target-prefix-id", required=True)
+    build.add_argument("--output", type=Path, required=True)
+    build.add_argument("--overwrite", action="store_true")
+    verify = subparsers.add_parser("verify")
+    verify.add_argument("--artifact", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _parser().parse_args(argv)
+    if arguments.command == "build":
+        support = load_provider_support_feasibility(arguments.support)
+        model = load_calibration_transport_model(arguments.transport_model)
+        evidence = load_calibration_transport_evidence(
+            arguments.transport_evidence,
+            model=model,
+        )
+        admission = build_provider_prefix_admission(
+            support,
+            evidence,
+            provider_manifest_id=arguments.provider_manifest_id,
+            target_prefix_id=arguments.target_prefix_id,
+        )
+        write_provider_prefix_admission(
+            arguments.output,
+            admission,
+            overwrite=arguments.overwrite,
+        )
+    else:
+        admission = load_provider_prefix_admission(arguments.artifact)
+    print(
+        json.dumps(
+            {
+                "provider_prefix_admission_id": admission.provider_prefix_admission_id,
+                "admitted": admission.admitted,
+                "exact_fallback_required": admission.exact_fallback_required,
+                "decision_reasons": list(admission.decision_reasons),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0 if admission.admitted else 2
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+
+
+__all__ = [
+    "PROVIDER_PREFIX_ADMISSION_CLAIM_BOUNDARY",
+    "PROVIDER_PREFIX_ADMISSION_SCHEMA",
+    "PROVIDER_PREFIX_ADMISSION_VERSION",
+    "PROVIDER_PREFIX_BINDING_METADATA_KEY",
+    "ProviderPrefixAdmissionV1",
+    "build_provider_prefix_admission",
+    "load_provider_prefix_admission",
+    "write_provider_prefix_admission",
+]

--- a/src/prob4d/provider_support_envelope.py
+++ b/src/prob4d/provider_support_envelope.py
@@ -1,0 +1,567 @@
+"""Outcome-blind contiguous support envelopes for frozen provider streams.
+
+The existing provider-support feasibility contract answers whether one exact set
+of required frames is supported.  This module derives a reusable per-stream
+frame envelope from the same pre-residual metadata.  The envelope can be used to
+freeze a *new* support request or support-design candidate before prediction
+payloads or residuals are opened; it never mutates the request it was derived
+from.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from ._atomic_file import atomic_write_text
+from ._immutable_json import frozen_finite_json_mapping, plain_json
+from ._strict_json import (
+    load_json_object,
+    require_exact_fields,
+    require_exact_integer,
+    require_exact_string,
+    require_finite_json_mapping,
+    require_mapping,
+    require_sha256,
+)
+from .provider_support_feasibility import (
+    ProviderSupportFeasibilityRequestV1,
+    evaluate_provider_support_feasibility,
+    load_provider_support_feasibility_request,
+)
+
+PROVIDER_SUPPORT_ENVELOPE_SCHEMA = "prob4d.provider-support-envelope"
+PROVIDER_SUPPORT_ENVELOPE_VERSION = 1
+PROVIDER_SUPPORT_ENVELOPE_CLAIM_BOUNDARY = (
+    "This artifact derives contiguous frame-support envelopes only from an exact "
+    "outcome-blind ProviderSupportFeasibilityRequestV1. It does not change that "
+    "request, select a causal prefix after seeing provider residuals, establish "
+    "provider competence or calibration, authorize a BayesianPhysTwin update, "
+    "establish Causal4D benefit, deployment safety, or state of the art."
+)
+
+_STREAM_FIELDS = frozenset(
+    {
+        "group_id",
+        "stream_id",
+        "causal_frame_start",
+        "causal_frame_stop_exclusive",
+        "admissible_intervals",
+        "admissible_frame_count",
+        "earliest_admissible_frame",
+        "latest_admissible_frame_exclusive",
+        "maximum_contiguous_frame_count",
+        "required_frame_count",
+        "required_admissible_frame_count",
+        "required_support_fraction",
+        "static_support_complete",
+        "technical_failure_code",
+        "feasibility_supported",
+        "excluded_from_admission",
+        "feasibility_reason_codes",
+    }
+)
+_ARTIFACT_FIELDS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "request",
+        "streams",
+        "stream_count",
+        "stream_with_nonempty_envelope_count",
+        "total_admissible_frame_count",
+        "metadata",
+        "claim_boundary",
+        "provider_support_envelope_id",
+    }
+)
+
+
+def _canonical_json_bytes(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        plain_json(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _sha256_json(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json_bytes(value)).hexdigest()
+
+
+def _strict_bool(value: object, *, name: str) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be a Boolean")
+    return value
+
+
+def _optional_integer(value: object, *, name: str) -> int | None:
+    if value is None:
+        return None
+    return require_exact_integer(value, name=name, minimum=0)
+
+
+def _string_tuple(value: object, *, name: str) -> tuple[str, ...]:
+    if type(value) is not tuple:
+        raise ValueError(f"{name} must be a canonical tuple")
+    result = tuple(
+        require_exact_string(item, name=f"{name}[{index}]")
+        for index, item in enumerate(value)
+    )
+    if result != tuple(sorted(set(result))):
+        raise ValueError(f"{name} must be sorted and unique")
+    return result
+
+
+def _string_tuple_from_json(value: object, *, name: str) -> tuple[str, ...]:
+    if type(value) is not list:
+        raise ValueError(f"{name} must be a JSON array")
+    return _string_tuple(tuple(value), name=name)
+
+
+def _intervals(frames: Sequence[int]) -> tuple[tuple[int, int], ...]:
+    ordered = tuple(sorted(set(int(frame) for frame in frames)))
+    if not ordered:
+        return ()
+    result: list[tuple[int, int]] = []
+    start = ordered[0]
+    previous = start
+    for frame in ordered[1:]:
+        if frame != previous + 1:
+            result.append((start, previous + 1))
+            start = frame
+        previous = frame
+    result.append((start, previous + 1))
+    return tuple(result)
+
+
+def _interval_tuple(value: object, *, name: str) -> tuple[tuple[int, int], ...]:
+    if type(value) is not tuple:
+        raise ValueError(f"{name} must be a canonical tuple")
+    result: list[tuple[int, int]] = []
+    previous_stop: int | None = None
+    for index, interval in enumerate(value):
+        if type(interval) is not tuple or len(interval) != 2:
+            raise ValueError(f"{name}[{index}] must be a (start, stop) tuple")
+        start = require_exact_integer(interval[0], name=f"{name}[{index}][0]", minimum=0)
+        stop = require_exact_integer(interval[1], name=f"{name}[{index}][1]", minimum=1)
+        if stop <= start:
+            raise ValueError(f"{name}[{index}] stop must exceed start")
+        if previous_stop is not None and start <= previous_stop:
+            raise ValueError(f"{name} intervals must be strictly separated")
+        result.append((start, stop))
+        previous_stop = stop
+    return tuple(result)
+
+
+def _interval_tuple_from_json(value: object, *, name: str) -> tuple[tuple[int, int], ...]:
+    if type(value) is not list:
+        raise ValueError(f"{name} must be a JSON array")
+    tuples: list[tuple[int, int]] = []
+    for index, interval in enumerate(value):
+        if type(interval) is not list or len(interval) != 2:
+            raise ValueError(f"{name}[{index}] must be a two-element JSON array")
+        tuples.append((interval[0], interval[1]))  # type: ignore[arg-type]
+    return _interval_tuple(tuple(tuples), name=name)
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderSupportStreamEnvelopeV1:
+    """Derived contiguous support summary for one frozen stream."""
+
+    group_id: str
+    stream_id: str
+    causal_frame_start: int
+    causal_frame_stop_exclusive: int
+    admissible_intervals: tuple[tuple[int, int], ...]
+    admissible_frame_count: int
+    earliest_admissible_frame: int | None
+    latest_admissible_frame_exclusive: int | None
+    maximum_contiguous_frame_count: int
+    required_frame_count: int
+    required_admissible_frame_count: int
+    required_support_fraction: float
+    static_support_complete: bool
+    technical_failure_code: str | None
+    feasibility_supported: bool
+    excluded_from_admission: bool
+    feasibility_reason_codes: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        group_id = require_exact_string(self.group_id, name="group_id")
+        stream_id = require_exact_string(self.stream_id, name="stream_id")
+        start = require_exact_integer(
+            self.causal_frame_start,
+            name="causal_frame_start",
+            minimum=0,
+        )
+        stop = require_exact_integer(
+            self.causal_frame_stop_exclusive,
+            name="causal_frame_stop_exclusive",
+            minimum=1,
+        )
+        if stop <= start:
+            raise ValueError("causal_frame_stop_exclusive must exceed causal_frame_start")
+        intervals = _interval_tuple(self.admissible_intervals, name="admissible_intervals")
+        if any(
+            interval_start < start or interval_stop > stop
+            for interval_start, interval_stop in intervals
+        ):
+            raise ValueError("admissible_intervals cross the frozen causal span")
+        frame_count = require_exact_integer(
+            self.admissible_frame_count,
+            name="admissible_frame_count",
+            minimum=0,
+        )
+        expected_count = sum(
+            interval_stop - interval_start
+            for interval_start, interval_stop in intervals
+        )
+        if frame_count != expected_count:
+            raise ValueError("admissible_frame_count is inconsistent")
+        earliest = _optional_integer(
+            self.earliest_admissible_frame,
+            name="earliest_admissible_frame",
+        )
+        latest = _optional_integer(
+            self.latest_admissible_frame_exclusive,
+            name="latest_admissible_frame_exclusive",
+        )
+        if intervals:
+            if earliest != intervals[0][0] or latest != intervals[-1][1]:
+                raise ValueError("admissible frame bounds are inconsistent")
+        elif earliest is not None or latest is not None:
+            raise ValueError("empty envelopes require null admissible frame bounds")
+        maximum = require_exact_integer(
+            self.maximum_contiguous_frame_count,
+            name="maximum_contiguous_frame_count",
+            minimum=0,
+        )
+        expected_maximum = max(
+            (interval_stop - interval_start for interval_start, interval_stop in intervals),
+            default=0,
+        )
+        if maximum != expected_maximum:
+            raise ValueError("maximum_contiguous_frame_count is inconsistent")
+        required = require_exact_integer(
+            self.required_frame_count,
+            name="required_frame_count",
+            minimum=1,
+        )
+        required_admissible = require_exact_integer(
+            self.required_admissible_frame_count,
+            name="required_admissible_frame_count",
+            minimum=0,
+        )
+        if required_admissible > required:
+            raise ValueError("required_admissible_frame_count exceeds required_frame_count")
+        fraction = float(self.required_support_fraction)
+        if not 0.0 <= fraction <= 1.0 or abs(fraction - required_admissible / required) > 1.0e-15:
+            raise ValueError("required_support_fraction is inconsistent")
+        static_complete = _strict_bool(self.static_support_complete, name="static_support_complete")
+        technical_failure = self.technical_failure_code
+        if technical_failure is not None:
+            technical_failure = require_exact_string(
+                technical_failure,
+                name="technical_failure_code",
+            )
+        feasibility_supported = _strict_bool(
+            self.feasibility_supported,
+            name="feasibility_supported",
+        )
+        excluded = _strict_bool(self.excluded_from_admission, name="excluded_from_admission")
+        reasons = _string_tuple(self.feasibility_reason_codes, name="feasibility_reason_codes")
+
+        object.__setattr__(self, "group_id", group_id)
+        object.__setattr__(self, "stream_id", stream_id)
+        object.__setattr__(self, "causal_frame_start", start)
+        object.__setattr__(self, "causal_frame_stop_exclusive", stop)
+        object.__setattr__(self, "admissible_intervals", intervals)
+        object.__setattr__(self, "admissible_frame_count", frame_count)
+        object.__setattr__(self, "earliest_admissible_frame", earliest)
+        object.__setattr__(self, "latest_admissible_frame_exclusive", latest)
+        object.__setattr__(self, "maximum_contiguous_frame_count", maximum)
+        object.__setattr__(self, "required_frame_count", required)
+        object.__setattr__(self, "required_admissible_frame_count", required_admissible)
+        object.__setattr__(self, "required_support_fraction", fraction)
+        object.__setattr__(self, "static_support_complete", static_complete)
+        object.__setattr__(self, "technical_failure_code", technical_failure)
+        object.__setattr__(self, "feasibility_supported", feasibility_supported)
+        object.__setattr__(self, "excluded_from_admission", excluded)
+        object.__setattr__(self, "feasibility_reason_codes", reasons)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "group_id": self.group_id,
+            "stream_id": self.stream_id,
+            "causal_frame_start": self.causal_frame_start,
+            "causal_frame_stop_exclusive": self.causal_frame_stop_exclusive,
+            "admissible_intervals": [list(interval) for interval in self.admissible_intervals],
+            "admissible_frame_count": self.admissible_frame_count,
+            "earliest_admissible_frame": self.earliest_admissible_frame,
+            "latest_admissible_frame_exclusive": self.latest_admissible_frame_exclusive,
+            "maximum_contiguous_frame_count": self.maximum_contiguous_frame_count,
+            "required_frame_count": self.required_frame_count,
+            "required_admissible_frame_count": self.required_admissible_frame_count,
+            "required_support_fraction": self.required_support_fraction,
+            "static_support_complete": self.static_support_complete,
+            "technical_failure_code": self.technical_failure_code,
+            "feasibility_supported": self.feasibility_supported,
+            "excluded_from_admission": self.excluded_from_admission,
+            "feasibility_reason_codes": list(self.feasibility_reason_codes),
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> ProviderSupportStreamEnvelopeV1:
+        mapping = require_mapping(value, name="provider support stream envelope")
+        require_exact_fields(mapping, _STREAM_FIELDS, name="provider support stream envelope")
+        return cls(
+            group_id=mapping["group_id"],
+            stream_id=mapping["stream_id"],
+            causal_frame_start=mapping["causal_frame_start"],
+            causal_frame_stop_exclusive=mapping["causal_frame_stop_exclusive"],
+            admissible_intervals=_interval_tuple_from_json(
+                mapping["admissible_intervals"],
+                name="admissible_intervals",
+            ),
+            admissible_frame_count=mapping["admissible_frame_count"],
+            earliest_admissible_frame=mapping["earliest_admissible_frame"],
+            latest_admissible_frame_exclusive=mapping[
+                "latest_admissible_frame_exclusive"
+            ],
+            maximum_contiguous_frame_count=mapping["maximum_contiguous_frame_count"],
+            required_frame_count=mapping["required_frame_count"],
+            required_admissible_frame_count=mapping["required_admissible_frame_count"],
+            required_support_fraction=mapping["required_support_fraction"],
+            static_support_complete=mapping["static_support_complete"],
+            technical_failure_code=mapping["technical_failure_code"],
+            feasibility_supported=mapping["feasibility_supported"],
+            excluded_from_admission=mapping["excluded_from_admission"],
+            feasibility_reason_codes=_string_tuple_from_json(
+                mapping["feasibility_reason_codes"],
+                name="feasibility_reason_codes",
+            ),
+        )
+
+
+def _derive_streams(
+    request: ProviderSupportFeasibilityRequestV1,
+) -> tuple[ProviderSupportStreamEnvelopeV1, ...]:
+    feasibility = evaluate_provider_support_feasibility(request)
+    evaluation_by_key = {
+        (item.group_id, item.stream_id): item for item in feasibility.stream_results
+    }
+    result: list[ProviderSupportStreamEnvelopeV1] = []
+    for stream in request.streams:
+        evaluation = evaluation_by_key[stream.key]
+        static_complete = (
+            (not stream.intrinsics_required or stream.intrinsics_id is not None)
+            and (not stream.extrinsics_required or stream.extrinsics_id is not None)
+            and (not stream.metric_anchor_required or stream.metric_anchor_id is not None)
+        )
+        admissible = set(stream.available_frame_ids).intersection(
+            stream.geometry_supported_frame_ids
+        )
+        if not static_complete or stream.technical_failure_code is not None:
+            admissible.clear()
+        intervals = _intervals(tuple(admissible))
+        required_admissible = len(set(stream.required_frame_ids).intersection(admissible))
+        result.append(
+            ProviderSupportStreamEnvelopeV1(
+                group_id=stream.group_id,
+                stream_id=stream.stream_id,
+                causal_frame_start=stream.causal_frame_start,
+                causal_frame_stop_exclusive=stream.causal_frame_stop_exclusive,
+                admissible_intervals=intervals,
+                admissible_frame_count=len(admissible),
+                earliest_admissible_frame=None if not intervals else intervals[0][0],
+                latest_admissible_frame_exclusive=None if not intervals else intervals[-1][1],
+                maximum_contiguous_frame_count=max(
+                    (interval_stop - interval_start for interval_start, interval_stop in intervals),
+                    default=0,
+                ),
+                required_frame_count=len(stream.required_frame_ids),
+                required_admissible_frame_count=required_admissible,
+                required_support_fraction=required_admissible / len(stream.required_frame_ids),
+                static_support_complete=static_complete,
+                technical_failure_code=stream.technical_failure_code,
+                feasibility_supported=evaluation.supported,
+                excluded_from_admission=evaluation.excluded_from_admission,
+                feasibility_reason_codes=evaluation.reason_codes,
+            )
+        )
+    return tuple(result)
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderSupportEnvelopeV1:
+    """Replayable support envelope derived from one exact feasibility request."""
+
+    request: ProviderSupportFeasibilityRequestV1
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    streams: tuple[ProviderSupportStreamEnvelopeV1, ...] = field(init=False)
+    stream_count: int = field(init=False)
+    stream_with_nonempty_envelope_count: int = field(init=False)
+    total_admissible_frame_count: int = field(init=False)
+    provider_support_envelope_id: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.request, ProviderSupportFeasibilityRequestV1):
+            raise TypeError("request must be ProviderSupportFeasibilityRequestV1")
+        metadata = frozen_finite_json_mapping(
+            require_finite_json_mapping(self.metadata, name="metadata"),
+            name="metadata",
+        )
+        streams = _derive_streams(self.request)
+        object.__setattr__(self, "metadata", metadata)
+        object.__setattr__(self, "streams", streams)
+        object.__setattr__(self, "stream_count", len(streams))
+        object.__setattr__(
+            self,
+            "stream_with_nonempty_envelope_count",
+            sum(item.admissible_frame_count > 0 for item in streams),
+        )
+        object.__setattr__(
+            self,
+            "total_admissible_frame_count",
+            sum(item.admissible_frame_count for item in streams),
+        )
+        object.__setattr__(
+            self,
+            "provider_support_envelope_id",
+            _sha256_json(self._content_dict()),
+        )
+
+    def _content_dict(self) -> dict[str, object]:
+        return {
+            "schema": PROVIDER_SUPPORT_ENVELOPE_SCHEMA,
+            "schema_version": PROVIDER_SUPPORT_ENVELOPE_VERSION,
+            "request": self.request.to_dict(),
+            "streams": [item.to_dict() for item in self.streams],
+            "stream_count": self.stream_count,
+            "stream_with_nonempty_envelope_count": self.stream_with_nonempty_envelope_count,
+            "total_admissible_frame_count": self.total_admissible_frame_count,
+            "metadata": plain_json(self.metadata),
+            "claim_boundary": PROVIDER_SUPPORT_ENVELOPE_CLAIM_BOUNDARY,
+        }
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            **self._content_dict(),
+            "provider_support_envelope_id": self.provider_support_envelope_id,
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> ProviderSupportEnvelopeV1:
+        mapping = require_mapping(value, name="provider support envelope")
+        require_exact_fields(mapping, _ARTIFACT_FIELDS, name="provider support envelope")
+        if mapping["schema"] != PROVIDER_SUPPORT_ENVELOPE_SCHEMA:
+            raise ValueError("provider support envelope schema changed")
+        if mapping["schema_version"] != PROVIDER_SUPPORT_ENVELOPE_VERSION:
+            raise ValueError("provider support envelope version changed")
+        if mapping["claim_boundary"] != PROVIDER_SUPPORT_ENVELOPE_CLAIM_BOUNDARY:
+            raise ValueError("provider support envelope claim boundary changed")
+        result = cls(
+            request=ProviderSupportFeasibilityRequestV1.from_dict(mapping["request"]),
+            metadata=require_finite_json_mapping(mapping["metadata"], name="metadata"),
+        )
+        supplied_id = require_sha256(
+            mapping["provider_support_envelope_id"],
+            name="provider_support_envelope_id",
+        )
+        if supplied_id != result.provider_support_envelope_id:
+            raise ValueError("provider support envelope identity mismatch")
+        if plain_json(mapping) != result.to_dict():
+            raise ValueError("provider support envelope derived fields changed")
+        return result
+
+
+def derive_provider_support_envelope(
+    request: ProviderSupportFeasibilityRequestV1,
+    *,
+    metadata: Mapping[str, Any] | None = None,
+) -> ProviderSupportEnvelopeV1:
+    return ProviderSupportEnvelopeV1(
+        request=request,
+        metadata={} if metadata is None else metadata,
+    )
+
+
+def write_provider_support_envelope(
+    path: str | Path,
+    envelope: ProviderSupportEnvelopeV1,
+    *,
+    overwrite: bool = False,
+) -> None:
+    if not isinstance(envelope, ProviderSupportEnvelopeV1):
+        raise TypeError("envelope must be ProviderSupportEnvelopeV1")
+    payload = json.dumps(envelope.to_dict(), sort_keys=True, indent=2, allow_nan=False) + "\n"
+    atomic_write_text(path, payload, overwrite=overwrite)
+
+
+def load_provider_support_envelope(path: str | Path) -> ProviderSupportEnvelopeV1:
+    return ProviderSupportEnvelopeV1.from_dict(
+        load_json_object(path, name="provider support envelope")
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    derive = subparsers.add_parser("derive")
+    derive.add_argument("--request", type=Path, required=True)
+    derive.add_argument("--output", type=Path, required=True)
+    derive.add_argument("--overwrite", action="store_true")
+    verify = subparsers.add_parser("verify")
+    verify.add_argument("--artifact", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _parser().parse_args(argv)
+    if arguments.command == "derive":
+        request = load_provider_support_feasibility_request(arguments.request)
+        envelope = derive_provider_support_envelope(request)
+        write_provider_support_envelope(
+            arguments.output,
+            envelope,
+            overwrite=arguments.overwrite,
+        )
+    else:
+        envelope = load_provider_support_envelope(arguments.artifact)
+    print(
+        json.dumps(
+            {
+                "provider_support_envelope_id": envelope.provider_support_envelope_id,
+                "stream_count": envelope.stream_count,
+                "stream_with_nonempty_envelope_count": (
+                    envelope.stream_with_nonempty_envelope_count
+                ),
+                "total_admissible_frame_count": envelope.total_admissible_frame_count,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+
+
+__all__ = [
+    "PROVIDER_SUPPORT_ENVELOPE_CLAIM_BOUNDARY",
+    "PROVIDER_SUPPORT_ENVELOPE_SCHEMA",
+    "PROVIDER_SUPPORT_ENVELOPE_VERSION",
+    "ProviderSupportEnvelopeV1",
+    "ProviderSupportStreamEnvelopeV1",
+    "derive_provider_support_envelope",
+    "load_provider_support_envelope",
+    "write_provider_support_envelope",
+]

--- a/src/prob4d/source_covariance_localization.py
+++ b/src/prob4d/source_covariance_localization.py
@@ -1,0 +1,868 @@
+"""Localize source-side covariance failure before point-model development.
+
+This module connects already-existing source mean/identity evidence and joint
+covariance diagnostics to the covariance stages of ``fresh_provider_readiness``.
+It deliberately does not fit a new covariance model.  Point-uncertainty
+improvement is authorized only when source mean and identity gates pass, shared
+(gauge/dependence) residual energy is adequately calibrated, and the remaining
+conditional subspace is miscalibrated under a policy frozen on source data.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal, cast
+
+from ._atomic_file import atomic_write_text
+from ._immutable_json import frozen_finite_json_mapping, plain_json
+from ._strict_json import (
+    load_json_object,
+    require_exact_fields,
+    require_exact_integer,
+    require_exact_string,
+    require_finite_json_mapping,
+    require_json_number,
+    require_mapping,
+    require_sha256,
+)
+from .fresh_provider_readiness import ReadinessGateV1, unevaluated_gate
+from .joint_covariance_metrics import (
+    JOINT_COVARIANCE_CLAIM_BOUNDARY,
+    JOINT_COVARIANCE_DIAGNOSTIC_SCHEMA,
+    JOINT_COVARIANCE_DIAGNOSTIC_VERSION,
+)
+from .source_provider_competence import (
+    SourceProviderCompetenceReportV1,
+    load_source_provider_competence,
+)
+
+SOURCE_COVARIANCE_LOCALIZATION_SCHEMA = "prob4d.source-covariance-localization"
+SOURCE_COVARIANCE_LOCALIZATION_VERSION = 1
+SOURCE_COVARIANCE_LOCALIZATION_CLAIM_BOUNDARY = (
+    "This artifact localizes already-open source/calibration covariance evidence. "
+    "It does not fit or select a richer covariance model, use protected target "
+    "outcomes, authorize a BayesianPhysTwin update, establish provider transfer, "
+    "Causal4D intervention benefit, deployment safety, or state of the art. Point "
+    "uncertainty development is authorized only for the explicit "
+    "point-covariance-localized classification."
+)
+
+LocalizationClassification = Literal[
+    "source-mean-negative",
+    "identity-or-association-negative",
+    "gauge-or-dependence-negative",
+    "point-covariance-localized",
+    "covariance-adequate",
+    "technical-failure",
+]
+
+_POLICY_FIELDS = frozenset(
+    {
+        "minimum_group_count",
+        "normalized_nees_lower",
+        "normalized_nees_upper",
+        "minimum_joint_pass_fraction",
+        "shared_energy_lower",
+        "shared_energy_upper",
+        "minimum_shared_pass_fraction",
+        "conditional_energy_lower",
+        "conditional_energy_upper",
+        "minimum_conditional_pass_fraction",
+        "require_shared_subspace",
+    }
+)
+_GROUP_FIELDS = frozenset(
+    {
+        "group_id",
+        "normalized_nees",
+        "shared_subspace_normalized_energy",
+        "conditional_subspace_normalized_energy",
+        "joint_in_band",
+        "shared_in_band",
+        "conditional_in_band",
+    }
+)
+_ARTIFACT_FIELDS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "provider_manifest_id",
+        "cohort_binding_id",
+        "source_provider_competence_id",
+        "joint_diagnostic_sha256",
+        "joint_residual_source_sha256",
+        "policy",
+        "groups",
+        "group_count",
+        "joint_pass_fraction",
+        "shared_pass_fraction",
+        "conditional_pass_fraction",
+        "classification",
+        "reason_codes",
+        "authorize_point_uncertainty_development",
+        "metadata",
+        "claim_boundary",
+        "source_covariance_localization_id",
+    }
+)
+
+
+def _canonical_json_bytes(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        plain_json(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _sha256_json(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json_bytes(value)).hexdigest()
+
+
+def _strict_bool(value: object, *, name: str) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be a Boolean")
+    return value
+
+
+def _probability(value: object, *, name: str) -> float:
+    result = require_json_number(value, name=name)
+    if not 0.0 <= result <= 1.0:
+        raise ValueError(f"{name} must lie in [0, 1]")
+    return result
+
+
+def _nonnegative(value: object, *, name: str) -> float:
+    result = require_json_number(value, name=name)
+    if result < 0.0:
+        raise ValueError(f"{name} must be non-negative")
+    return result
+
+
+def _optional_nonnegative(value: object, *, name: str) -> float | None:
+    if value is None:
+        return None
+    return _nonnegative(value, name=name)
+
+
+def _sorted_unique_strings(value: object, *, name: str) -> tuple[str, ...]:
+    if type(value) is not tuple:
+        raise ValueError(f"{name} must be a canonical tuple")
+    result = tuple(
+        require_exact_string(item, name=f"{name}[{index}]")
+        for index, item in enumerate(value)
+    )
+    if result != tuple(sorted(set(result))):
+        raise ValueError(f"{name} must be sorted and unique")
+    return result
+
+
+def _strings_from_json(value: object, *, name: str) -> tuple[str, ...]:
+    if type(value) is not list:
+        raise ValueError(f"{name} must be a JSON array")
+    return _sorted_unique_strings(tuple(value), name=name)
+
+
+def _classification(value: object) -> LocalizationClassification:
+    result = require_exact_string(value, name="classification")
+    allowed = {
+        "source-mean-negative",
+        "identity-or-association-negative",
+        "gauge-or-dependence-negative",
+        "point-covariance-localized",
+        "covariance-adequate",
+        "technical-failure",
+    }
+    if result not in allowed:
+        raise ValueError("unsupported source covariance localization classification")
+    return cast(LocalizationClassification, result)
+
+
+def _json_bytes_object(payload: bytes, *, name: str) -> dict[str, Any]:
+    class DuplicateKey(ValueError):
+        pass
+
+    def pairs(items: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, item in items:
+            if key in result:
+                raise DuplicateKey(f"{name} contains duplicate JSON object key {key!r}")
+            result[key] = item
+        return result
+
+    def reject_constant(token: str) -> Any:
+        raise DuplicateKey(f"{name} contains non-finite JSON number {token!r}")
+
+    try:
+        value = json.loads(
+            payload.decode("utf-8"),
+            object_pairs_hook=pairs,
+            parse_constant=reject_constant,
+        )
+    except UnicodeDecodeError as error:
+        raise ValueError(f"{name} must be UTF-8 JSON") from error
+    except json.JSONDecodeError as error:
+        raise ValueError(f"{name} must contain valid JSON") from error
+    if not isinstance(value, dict):
+        raise ValueError(f"{name} must contain one JSON object")
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class SourceCovarianceLocalizationPolicyV1:
+    """Frozen source-only thresholds for assigning the covariance failure stage."""
+
+    minimum_group_count: int
+    normalized_nees_lower: float
+    normalized_nees_upper: float
+    minimum_joint_pass_fraction: float
+    shared_energy_lower: float
+    shared_energy_upper: float
+    minimum_shared_pass_fraction: float
+    conditional_energy_lower: float
+    conditional_energy_upper: float
+    minimum_conditional_pass_fraction: float
+    require_shared_subspace: bool = True
+
+    def __post_init__(self) -> None:
+        count = require_exact_integer(
+            self.minimum_group_count,
+            name="minimum_group_count",
+            minimum=1,
+        )
+        bands: dict[str, tuple[float, float]] = {}
+        for prefix in ("normalized_nees", "shared_energy", "conditional_energy"):
+            lower = _nonnegative(getattr(self, f"{prefix}_lower"), name=f"{prefix}_lower")
+            upper = _nonnegative(getattr(self, f"{prefix}_upper"), name=f"{prefix}_upper")
+            if upper < lower:
+                raise ValueError(f"{prefix}_upper must not be below {prefix}_lower")
+            bands[prefix] = (lower, upper)
+        for name in (
+            "minimum_joint_pass_fraction",
+            "minimum_shared_pass_fraction",
+            "minimum_conditional_pass_fraction",
+        ):
+            object.__setattr__(self, name, _probability(getattr(self, name), name=name))
+        object.__setattr__(self, "minimum_group_count", count)
+        for prefix, (lower, upper) in bands.items():
+            object.__setattr__(self, f"{prefix}_lower", lower)
+            object.__setattr__(self, f"{prefix}_upper", upper)
+        object.__setattr__(
+            self,
+            "require_shared_subspace",
+            _strict_bool(self.require_shared_subspace, name="require_shared_subspace"),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "minimum_group_count": self.minimum_group_count,
+            "normalized_nees_lower": self.normalized_nees_lower,
+            "normalized_nees_upper": self.normalized_nees_upper,
+            "minimum_joint_pass_fraction": self.minimum_joint_pass_fraction,
+            "shared_energy_lower": self.shared_energy_lower,
+            "shared_energy_upper": self.shared_energy_upper,
+            "minimum_shared_pass_fraction": self.minimum_shared_pass_fraction,
+            "conditional_energy_lower": self.conditional_energy_lower,
+            "conditional_energy_upper": self.conditional_energy_upper,
+            "minimum_conditional_pass_fraction": (
+                self.minimum_conditional_pass_fraction
+            ),
+            "require_shared_subspace": self.require_shared_subspace,
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> SourceCovarianceLocalizationPolicyV1:
+        mapping = require_mapping(value, name="source covariance localization policy")
+        require_exact_fields(
+            mapping,
+            _POLICY_FIELDS,
+            name="source covariance localization policy",
+        )
+        return cls(**mapping)  # type: ignore[arg-type]
+
+
+@dataclass(frozen=True, slots=True)
+class SourceCovarianceLocalizationGroupV1:
+    """Per-independent-group subspace calibration classification."""
+
+    group_id: str
+    normalized_nees: float
+    shared_subspace_normalized_energy: float | None
+    conditional_subspace_normalized_energy: float | None
+    joint_in_band: bool
+    shared_in_band: bool
+    conditional_in_band: bool
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "group_id", require_exact_string(self.group_id, name="group_id"))
+        object.__setattr__(
+            self,
+            "normalized_nees",
+            _nonnegative(self.normalized_nees, name="normalized_nees"),
+        )
+        object.__setattr__(
+            self,
+            "shared_subspace_normalized_energy",
+            _optional_nonnegative(
+                self.shared_subspace_normalized_energy,
+                name="shared_subspace_normalized_energy",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "conditional_subspace_normalized_energy",
+            _optional_nonnegative(
+                self.conditional_subspace_normalized_energy,
+                name="conditional_subspace_normalized_energy",
+            ),
+        )
+        for name in ("joint_in_band", "shared_in_band", "conditional_in_band"):
+            object.__setattr__(self, name, _strict_bool(getattr(self, name), name=name))
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "group_id": self.group_id,
+            "normalized_nees": self.normalized_nees,
+            "shared_subspace_normalized_energy": self.shared_subspace_normalized_energy,
+            "conditional_subspace_normalized_energy": (
+                self.conditional_subspace_normalized_energy
+            ),
+            "joint_in_band": self.joint_in_band,
+            "shared_in_band": self.shared_in_band,
+            "conditional_in_band": self.conditional_in_band,
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> SourceCovarianceLocalizationGroupV1:
+        mapping = require_mapping(value, name="source covariance localization group")
+        require_exact_fields(
+            mapping,
+            _GROUP_FIELDS,
+            name="source covariance localization group",
+        )
+        return cls(**mapping)  # type: ignore[arg-type]
+
+
+def _in_band(value: float | None, lower: float, upper: float) -> bool:
+    return value is not None and lower <= value <= upper
+
+
+def _normalize_joint_groups(
+    report: Mapping[str, Any],
+    *,
+    policy: SourceCovarianceLocalizationPolicyV1,
+) -> tuple[SourceCovarianceLocalizationGroupV1, ...]:
+    if report.get("schema_name") != JOINT_COVARIANCE_DIAGNOSTIC_SCHEMA:
+        raise ValueError("joint covariance diagnostic schema changed")
+    if report.get("schema_version") != JOINT_COVARIANCE_DIAGNOSTIC_VERSION:
+        raise ValueError("joint covariance diagnostic version changed")
+    if report.get("claim_boundary") != JOINT_COVARIANCE_CLAIM_BOUNDARY:
+        raise ValueError("joint covariance diagnostic claim boundary changed")
+    evaluation = require_mapping(report.get("evaluation"), name="joint covariance evaluation")
+    raw_groups = evaluation.get("groups")
+    if type(raw_groups) is not list or not raw_groups:
+        raise ValueError("joint covariance diagnostic groups must be a nonempty JSON array")
+    result: list[SourceCovarianceLocalizationGroupV1] = []
+    for index, raw in enumerate(raw_groups):
+        group = require_mapping(raw, name=f"joint covariance groups[{index}]")
+        group_id = require_exact_string(
+            group.get("factor_group_id"),
+            name=f"joint covariance groups[{index}].factor_group_id",
+        )
+        nees = _nonnegative(
+            group.get("normalized_nees"),
+            name=f"joint covariance groups[{index}].normalized_nees",
+        )
+        shared = _optional_nonnegative(
+            group.get("shared_subspace_normalized_energy"),
+            name=(
+                f"joint covariance groups[{index}].shared_subspace_normalized_energy"
+            ),
+        )
+        conditional = _optional_nonnegative(
+            group.get("conditional_subspace_normalized_energy"),
+            name=(
+                f"joint covariance groups[{index}].conditional_subspace_normalized_energy"
+            ),
+        )
+        result.append(
+            SourceCovarianceLocalizationGroupV1(
+                group_id=group_id,
+                normalized_nees=nees,
+                shared_subspace_normalized_energy=shared,
+                conditional_subspace_normalized_energy=conditional,
+                joint_in_band=_in_band(
+                    nees,
+                    policy.normalized_nees_lower,
+                    policy.normalized_nees_upper,
+                ),
+                shared_in_band=(
+                    not policy.require_shared_subspace
+                    if shared is None
+                    else _in_band(
+                        shared,
+                        policy.shared_energy_lower,
+                        policy.shared_energy_upper,
+                    )
+                ),
+                conditional_in_band=_in_band(
+                    conditional,
+                    policy.conditional_energy_lower,
+                    policy.conditional_energy_upper,
+                ),
+            )
+        )
+    ordered = tuple(sorted(result, key=lambda item: item.group_id))
+    if len({item.group_id for item in ordered}) != len(ordered):
+        raise ValueError("joint covariance factor_group_id values must be unique")
+    return ordered
+
+
+def _fraction(groups: tuple[SourceCovarianceLocalizationGroupV1, ...], field: str) -> float:
+    return sum(bool(getattr(group, field)) for group in groups) / len(groups)
+
+
+@dataclass(frozen=True, slots=True)
+class SourceCovarianceLocalizationV1:
+    """Content-addressed source-only covariance failure localization."""
+
+    provider_manifest_id: str
+    cohort_binding_id: str
+    source_provider_competence_id: str
+    joint_diagnostic_sha256: str
+    joint_residual_source_sha256: str
+    policy: SourceCovarianceLocalizationPolicyV1
+    groups: tuple[SourceCovarianceLocalizationGroupV1, ...]
+    source_mean_status: str = field(repr=False)
+    identity_reliability_status: str = field(repr=False)
+    source_mean_reasons: tuple[str, ...] = field(default=(), repr=False)
+    identity_reliability_reasons: tuple[str, ...] = field(default=(), repr=False)
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    group_count: int = field(init=False)
+    joint_pass_fraction: float = field(init=False)
+    shared_pass_fraction: float = field(init=False)
+    conditional_pass_fraction: float = field(init=False)
+    classification: LocalizationClassification = field(init=False)
+    reason_codes: tuple[str, ...] = field(init=False)
+    authorize_point_uncertainty_development: bool = field(init=False)
+    source_covariance_localization_id: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        for name in (
+            "provider_manifest_id",
+            "cohort_binding_id",
+            "source_provider_competence_id",
+            "joint_diagnostic_sha256",
+            "joint_residual_source_sha256",
+        ):
+            object.__setattr__(self, name, require_sha256(getattr(self, name), name=name))
+        if not isinstance(self.policy, SourceCovarianceLocalizationPolicyV1):
+            raise TypeError("policy must be SourceCovarianceLocalizationPolicyV1")
+        if type(self.groups) is not tuple or not all(
+            isinstance(item, SourceCovarianceLocalizationGroupV1) for item in self.groups
+        ):
+            raise TypeError("groups must contain SourceCovarianceLocalizationGroupV1 values")
+        groups = tuple(sorted(self.groups, key=lambda item: item.group_id))
+        if len({item.group_id for item in groups}) != len(groups):
+            raise ValueError("groups must have unique group_id values")
+        for group in groups:
+            expected_joint = _in_band(
+                group.normalized_nees,
+                self.policy.normalized_nees_lower,
+                self.policy.normalized_nees_upper,
+            )
+            expected_shared = (
+                not self.policy.require_shared_subspace
+                if group.shared_subspace_normalized_energy is None
+                else _in_band(
+                    group.shared_subspace_normalized_energy,
+                    self.policy.shared_energy_lower,
+                    self.policy.shared_energy_upper,
+                )
+            )
+            expected_conditional = _in_band(
+                group.conditional_subspace_normalized_energy,
+                self.policy.conditional_energy_lower,
+                self.policy.conditional_energy_upper,
+            )
+            if (
+                group.joint_in_band != expected_joint
+                or group.shared_in_band != expected_shared
+                or group.conditional_in_band != expected_conditional
+            ):
+                raise ValueError("group band classifications do not match the frozen policy")
+        mean_status = require_exact_string(self.source_mean_status, name="source_mean_status")
+        identity_status = require_exact_string(
+            self.identity_reliability_status,
+            name="identity_reliability_status",
+        )
+        if mean_status not in {"pass", "fail", "technical-failure"}:
+            raise ValueError("unsupported source_mean_status")
+        if identity_status not in {"pass", "fail", "technical-failure"}:
+            raise ValueError("unsupported identity_reliability_status")
+        mean_reasons = _sorted_unique_strings(self.source_mean_reasons, name="source_mean_reasons")
+        identity_reasons = _sorted_unique_strings(
+            self.identity_reliability_reasons,
+            name="identity_reliability_reasons",
+        )
+        reserved_metadata = {
+            "source_mean_status",
+            "identity_reliability_status",
+            "source_mean_reasons",
+            "identity_reliability_reasons",
+        }
+        if reserved_metadata & self.metadata.keys():
+            raise ValueError("metadata uses reserved source-status keys")
+        metadata = frozen_finite_json_mapping(
+            require_finite_json_mapping(self.metadata, name="metadata"),
+            name="metadata",
+        )
+        count = len(groups)
+        joint_fraction = 0.0 if not groups else _fraction(groups, "joint_in_band")
+        shared_fraction = 0.0 if not groups else _fraction(groups, "shared_in_band")
+        conditional_fraction = 0.0 if not groups else _fraction(groups, "conditional_in_band")
+
+        reasons: list[str] = []
+        if mean_status == "technical-failure" or identity_status == "technical-failure":
+            classification: LocalizationClassification = "technical-failure"
+            reasons.extend(
+                mean_reasons
+                or identity_reasons
+                or ("source-competence-technical-failure",)
+            )
+        elif mean_status != "pass":
+            classification = "source-mean-negative"
+            reasons.extend(mean_reasons or ("source-mean-negative",))
+        elif identity_status != "pass":
+            classification = "identity-or-association-negative"
+            reasons.extend(identity_reasons or ("identity-or-association-negative",))
+        elif count < self.policy.minimum_group_count:
+            classification = "technical-failure"
+            reasons.append("insufficient-joint-covariance-groups")
+        elif self.policy.require_shared_subspace and any(
+            group.shared_subspace_normalized_energy is None for group in groups
+        ):
+            classification = "technical-failure"
+            reasons.append("missing-required-shared-subspace-energy")
+        elif any(group.conditional_subspace_normalized_energy is None for group in groups):
+            classification = "technical-failure"
+            reasons.append("missing-conditional-subspace-energy")
+        elif shared_fraction < self.policy.minimum_shared_pass_fraction:
+            classification = "gauge-or-dependence-negative"
+            reasons.append("shared-subspace-energy-outside-frozen-band")
+        elif conditional_fraction < self.policy.minimum_conditional_pass_fraction:
+            classification = "point-covariance-localized"
+            reasons.append("conditional-subspace-energy-outside-frozen-band")
+        elif joint_fraction < self.policy.minimum_joint_pass_fraction:
+            classification = "gauge-or-dependence-negative"
+            reasons.append("joint-nees-outside-band-with-subspaces-adequate")
+        else:
+            classification = "covariance-adequate"
+            reasons.append("covariance-diagnostics-within-frozen-bands")
+
+        object.__setattr__(self, "groups", groups)
+        object.__setattr__(self, "source_mean_status", mean_status)
+        object.__setattr__(self, "identity_reliability_status", identity_status)
+        object.__setattr__(self, "source_mean_reasons", mean_reasons)
+        object.__setattr__(self, "identity_reliability_reasons", identity_reasons)
+        object.__setattr__(self, "metadata", metadata)
+        object.__setattr__(self, "group_count", count)
+        object.__setattr__(self, "joint_pass_fraction", joint_fraction)
+        object.__setattr__(self, "shared_pass_fraction", shared_fraction)
+        object.__setattr__(self, "conditional_pass_fraction", conditional_fraction)
+        object.__setattr__(self, "classification", classification)
+        object.__setattr__(self, "reason_codes", tuple(sorted(set(reasons))))
+        object.__setattr__(
+            self,
+            "authorize_point_uncertainty_development",
+            classification == "point-covariance-localized",
+        )
+        object.__setattr__(
+            self,
+            "source_covariance_localization_id",
+            _sha256_json(self._content_dict()),
+        )
+
+    def _content_dict(self) -> dict[str, object]:
+        return {
+            "schema": SOURCE_COVARIANCE_LOCALIZATION_SCHEMA,
+            "schema_version": SOURCE_COVARIANCE_LOCALIZATION_VERSION,
+            "provider_manifest_id": self.provider_manifest_id,
+            "cohort_binding_id": self.cohort_binding_id,
+            "source_provider_competence_id": self.source_provider_competence_id,
+            "joint_diagnostic_sha256": self.joint_diagnostic_sha256,
+            "joint_residual_source_sha256": self.joint_residual_source_sha256,
+            "policy": self.policy.to_dict(),
+            "groups": [item.to_dict() for item in self.groups],
+            "group_count": self.group_count,
+            "joint_pass_fraction": self.joint_pass_fraction,
+            "shared_pass_fraction": self.shared_pass_fraction,
+            "conditional_pass_fraction": self.conditional_pass_fraction,
+            "classification": self.classification,
+            "reason_codes": list(self.reason_codes),
+            "authorize_point_uncertainty_development": (
+                self.authorize_point_uncertainty_development
+            ),
+            "metadata": {
+                **plain_json(self.metadata),
+                "source_mean_status": self.source_mean_status,
+                "identity_reliability_status": self.identity_reliability_status,
+                "source_mean_reasons": list(self.source_mean_reasons),
+                "identity_reliability_reasons": list(self.identity_reliability_reasons),
+            },
+            "claim_boundary": SOURCE_COVARIANCE_LOCALIZATION_CLAIM_BOUNDARY,
+        }
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            **self._content_dict(),
+            "source_covariance_localization_id": self.source_covariance_localization_id,
+        }
+
+    def readiness_gates(self) -> tuple[ReadinessGateV1, ReadinessGateV1]:
+        """Return the gauge/dependence and point-covariance gates in readiness order."""
+
+        evidence_id = self.source_covariance_localization_id
+        if self.source_mean_status != "pass" or self.identity_reliability_status != "pass":
+            return (
+                unevaluated_gate("gauge-dependence"),
+                unevaluated_gate("point-covariance"),
+            )
+        if self.classification == "technical-failure":
+            return (
+                ReadinessGateV1(
+                    gate_name="gauge-dependence",
+                    status="technical-failure",
+                    evidence_id=evidence_id,
+                    reason_codes=self.reason_codes,
+                ),
+                unevaluated_gate("point-covariance"),
+            )
+        if self.classification == "gauge-or-dependence-negative":
+            return (
+                ReadinessGateV1(
+                    gate_name="gauge-dependence",
+                    status="fail",
+                    evidence_id=evidence_id,
+                    reason_codes=self.reason_codes,
+                ),
+                unevaluated_gate("point-covariance"),
+            )
+        gauge_gate = ReadinessGateV1(
+            gate_name="gauge-dependence",
+            status="pass",
+            evidence_id=evidence_id,
+        )
+        if self.classification == "point-covariance-localized":
+            point_gate = ReadinessGateV1(
+                gate_name="point-covariance",
+                status="fail",
+                evidence_id=evidence_id,
+                reason_codes=self.reason_codes,
+            )
+        else:
+            point_gate = ReadinessGateV1(
+                gate_name="point-covariance",
+                status="pass",
+                evidence_id=evidence_id,
+            )
+        return gauge_gate, point_gate
+
+    @classmethod
+    def from_dict(cls, value: object) -> SourceCovarianceLocalizationV1:
+        mapping = require_mapping(value, name="source covariance localization")
+        require_exact_fields(mapping, _ARTIFACT_FIELDS, name="source covariance localization")
+        if mapping["schema"] != SOURCE_COVARIANCE_LOCALIZATION_SCHEMA:
+            raise ValueError("source covariance localization schema changed")
+        if mapping["schema_version"] != SOURCE_COVARIANCE_LOCALIZATION_VERSION:
+            raise ValueError("source covariance localization version changed")
+        if mapping["claim_boundary"] != SOURCE_COVARIANCE_LOCALIZATION_CLAIM_BOUNDARY:
+            raise ValueError("source covariance localization claim boundary changed")
+        metadata = require_mapping(mapping["metadata"], name="metadata")
+        required_metadata = {
+            "source_mean_status",
+            "identity_reliability_status",
+            "source_mean_reasons",
+            "identity_reliability_reasons",
+        }
+        if not required_metadata <= metadata.keys():
+            raise ValueError("source covariance localization status metadata is incomplete")
+        user_metadata = {
+            key: item for key, item in metadata.items() if key not in required_metadata
+        }
+        raw_groups = mapping["groups"]
+        if type(raw_groups) is not list:
+            raise ValueError("groups must be a JSON array")
+        result = cls(
+            provider_manifest_id=mapping["provider_manifest_id"],
+            cohort_binding_id=mapping["cohort_binding_id"],
+            source_provider_competence_id=mapping["source_provider_competence_id"],
+            joint_diagnostic_sha256=mapping["joint_diagnostic_sha256"],
+            joint_residual_source_sha256=mapping["joint_residual_source_sha256"],
+            policy=SourceCovarianceLocalizationPolicyV1.from_dict(mapping["policy"]),
+            groups=tuple(
+                SourceCovarianceLocalizationGroupV1.from_dict(item)
+                for item in raw_groups
+            ),
+            source_mean_status=metadata["source_mean_status"],
+            identity_reliability_status=metadata["identity_reliability_status"],
+            source_mean_reasons=_strings_from_json(
+                metadata["source_mean_reasons"],
+                name="source_mean_reasons",
+            ),
+            identity_reliability_reasons=_strings_from_json(
+                metadata["identity_reliability_reasons"],
+                name="identity_reliability_reasons",
+            ),
+            metadata=require_finite_json_mapping(user_metadata, name="metadata"),
+        )
+        supplied_id = require_sha256(
+            mapping["source_covariance_localization_id"],
+            name="source_covariance_localization_id",
+        )
+        if supplied_id != result.source_covariance_localization_id:
+            raise ValueError("source covariance localization identity mismatch")
+        if plain_json(mapping) != result.to_dict():
+            raise ValueError("source covariance localization derived fields changed")
+        return result
+
+
+def localize_source_covariance(
+    source_report: SourceProviderCompetenceReportV1,
+    joint_diagnostic: Mapping[str, Any],
+    *,
+    joint_diagnostic_sha256: str,
+    policy: SourceCovarianceLocalizationPolicyV1,
+    metadata: Mapping[str, Any] | None = None,
+) -> SourceCovarianceLocalizationV1:
+    """Build one localization from exact source competence and covariance evidence."""
+
+    if not isinstance(source_report, SourceProviderCompetenceReportV1):
+        raise TypeError("source_report must be SourceProviderCompetenceReportV1")
+    if not isinstance(policy, SourceCovarianceLocalizationPolicyV1):
+        raise TypeError("policy must be SourceCovarianceLocalizationPolicyV1")
+    digest = require_sha256(joint_diagnostic_sha256, name="joint_diagnostic_sha256")
+    groups = _normalize_joint_groups(joint_diagnostic, policy=policy)
+    evaluable_source_groups = tuple(
+        group.group_id for group in source_report.groups if group.evaluable
+    )
+    diagnostic_group_ids = tuple(group.group_id for group in groups)
+    if diagnostic_group_ids != evaluable_source_groups:
+        raise ValueError(
+            "joint covariance factor groups do not match evaluable source competence groups"
+        )
+    residual_source_sha256 = require_sha256(
+        joint_diagnostic.get("source_sha256"),
+        name="joint diagnostic source_sha256",
+    )
+    return SourceCovarianceLocalizationV1(
+        provider_manifest_id=source_report.provider_manifest_id,
+        cohort_binding_id=source_report.cohort_binding_id,
+        source_provider_competence_id=source_report.source_provider_competence_id,
+        joint_diagnostic_sha256=digest,
+        joint_residual_source_sha256=residual_source_sha256,
+        policy=policy,
+        groups=groups,
+        source_mean_status=source_report.mean_quality_status,
+        identity_reliability_status=source_report.identity_reliability_status,
+        source_mean_reasons=source_report.mean_quality_reasons,
+        identity_reliability_reasons=source_report.identity_reliability_reasons,
+        metadata={} if metadata is None else metadata,
+    )
+
+
+def write_source_covariance_localization(
+    path: str | Path,
+    result: SourceCovarianceLocalizationV1,
+    *,
+    overwrite: bool = False,
+) -> None:
+    if not isinstance(result, SourceCovarianceLocalizationV1):
+        raise TypeError("result must be SourceCovarianceLocalizationV1")
+    payload = json.dumps(result.to_dict(), sort_keys=True, indent=2, allow_nan=False) + "\n"
+    atomic_write_text(path, payload, overwrite=overwrite)
+
+
+def load_source_covariance_localization(
+    path: str | Path,
+) -> SourceCovarianceLocalizationV1:
+    return SourceCovarianceLocalizationV1.from_dict(
+        load_json_object(path, name="source covariance localization")
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    evaluate = subparsers.add_parser("evaluate")
+    evaluate.add_argument("--source-competence", type=Path, required=True)
+    evaluate.add_argument("--joint-diagnostic", type=Path, required=True)
+    evaluate.add_argument("--policy", type=Path, required=True)
+    evaluate.add_argument("--output", type=Path, required=True)
+    evaluate.add_argument("--overwrite", action="store_true")
+    verify = subparsers.add_parser("verify")
+    verify.add_argument("--artifact", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _parser().parse_args(argv)
+    if arguments.command == "evaluate":
+        source = load_source_provider_competence(arguments.source_competence)
+        joint_bytes = arguments.joint_diagnostic.read_bytes()
+        joint = _json_bytes_object(joint_bytes, name="joint covariance diagnostic")
+        policy = SourceCovarianceLocalizationPolicyV1.from_dict(
+            load_json_object(arguments.policy, name="source covariance localization policy")
+        )
+        result = localize_source_covariance(
+            source,
+            joint,
+            joint_diagnostic_sha256=hashlib.sha256(joint_bytes).hexdigest(),
+            policy=policy,
+        )
+        write_source_covariance_localization(
+            arguments.output,
+            result,
+            overwrite=arguments.overwrite,
+        )
+    else:
+        result = load_source_covariance_localization(arguments.artifact)
+    print(
+        json.dumps(
+            {
+                "source_covariance_localization_id": result.source_covariance_localization_id,
+                "classification": result.classification,
+                "authorize_point_uncertainty_development": (
+                    result.authorize_point_uncertainty_development
+                ),
+                "joint_pass_fraction": result.joint_pass_fraction,
+                "shared_pass_fraction": result.shared_pass_fraction,
+                "conditional_pass_fraction": result.conditional_pass_fraction,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0 if result.classification == "covariance-adequate" else 2
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+
+
+__all__ = [
+    "SOURCE_COVARIANCE_LOCALIZATION_CLAIM_BOUNDARY",
+    "SOURCE_COVARIANCE_LOCALIZATION_SCHEMA",
+    "SOURCE_COVARIANCE_LOCALIZATION_VERSION",
+    "SourceCovarianceLocalizationGroupV1",
+    "SourceCovarianceLocalizationPolicyV1",
+    "SourceCovarianceLocalizationV1",
+    "load_source_covariance_localization",
+    "localize_source_covariance",
+    "write_source_covariance_localization",
+]

--- a/tests/test_provider_prefix_admission.py
+++ b/tests/test_provider_prefix_admission.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from prob4d.calibration_transport import (
+    CalibrationTransportPolicyV1,
+    CalibrationTransportUnitV1,
+    calibration_transport_feature_contract_id,
+    evaluate_calibration_transport,
+    fit_calibration_transport_model,
+)
+from prob4d.provider_prefix_admission import (
+    PROVIDER_PREFIX_BINDING_METADATA_KEY,
+    build_provider_prefix_admission,
+    load_provider_prefix_admission,
+    write_provider_prefix_admission,
+)
+from prob4d.provider_support_feasibility import (
+    ProviderSupportFeasibilityRequestV1,
+    ProviderSupportStreamV1,
+    evaluate_provider_support_feasibility,
+)
+
+MANIFEST_ID = "1" * 64
+COHORT_ID = "2" * 64
+PREFIX_ID = "3" * 64
+FEATURE_NAMES = ("overlap", "relative_variance")
+FEATURE_CONTRACT = calibration_transport_feature_contract_id(
+    FEATURE_NAMES,
+    semantics="provider-prefix-admission-test-v1",
+    configuration={"causal_prefix_only": True},
+)
+
+
+def _support(*, supported: bool = True):
+    stream = ProviderSupportStreamV1(
+        group_id="target-object",
+        stream_id="camera-0",
+        causal_frame_start=0,
+        causal_frame_stop_exclusive=4,
+        required_frame_ids=(0, 1, 2, 3),
+        available_frame_ids=(0, 1, 2, 3),
+        geometry_supported_frame_ids=(0, 1, 2, 3) if supported else (0,),
+        minimum_geometry_support_fraction=1.0,
+        intrinsics_required=False,
+        intrinsics_id=None,
+        extrinsics_required=False,
+        extrinsics_id=None,
+        metric_anchor_required=False,
+        metric_anchor_id=None,
+    )
+    request = ProviderSupportFeasibilityRequestV1(
+        protocol_id="prefix-admission-test-v1",
+        source_repository="IPS-Stuttgart/Prob4D",
+        source_revision="a" * 40,
+        provider_family="test-provider",
+        provider_repository="example/provider",
+        provider_revision="b" * 40,
+        model_set_id="4" * 64,
+        loader_id="5" * 64,
+        cohort_binding_id=COHORT_ID,
+        promotion_lock_id="6" * 64,
+        coordinate_semantics="metric-world-frame",
+        admission_rule="all-streams",
+        minimum_supported_fraction=1.0,
+        permitted_technical_exclusion_codes=(),
+        maximum_technical_exclusions=0,
+        prediction_payloads_opened=False,
+        residuals_used=False,
+        target_outcomes_used=False,
+        streams=(stream,),
+    )
+    return evaluate_provider_support_feasibility(request)
+
+
+def _transport(*, shifted: bool = False, manifest_id: str = MANIFEST_ID):
+    policy = CalibrationTransportPolicyV1(
+        quantile_levels=(0.1, 0.5, 0.9),
+        miscoverage_rate=0.2,
+        minimum_source_units=6,
+        neighbor_count=1,
+        maximum_unsupported_group_fraction=0.0,
+        maximum_unsupported_row_fraction=0.0,
+        absolute_scale_floor=1e-6,
+        relative_scale_floor=1e-6,
+    )
+    sources = tuple(
+        CalibrationTransportUnitV1(
+            unit_id=f"source-{index}",
+            feature_contract_id=FEATURE_CONTRACT,
+            feature_names=FEATURE_NAMES,
+            feature_values=np.column_stack(
+                (
+                    np.linspace(-0.2, 0.2, 40) + 0.01 * index,
+                    np.linspace(0.1, -0.1, 40) - 0.01 * index,
+                )
+            ),
+        )
+        for index in range(6)
+    )
+    model = fit_calibration_transport_model(sources, policy=policy)
+    offset = 5.0 if shifted else 0.0
+    target = CalibrationTransportUnitV1(
+        unit_id="target-object",
+        feature_contract_id=FEATURE_CONTRACT,
+        feature_names=FEATURE_NAMES,
+        feature_values=np.column_stack(
+            (
+                np.linspace(-0.2, 0.2, 40) + offset,
+                np.linspace(0.1, -0.1, 40),
+            )
+        ),
+    )
+    evidence = evaluate_calibration_transport(
+        model,
+        [target],
+        metadata={
+            PROVIDER_PREFIX_BINDING_METADATA_KEY: {
+                "provider_manifest_id": manifest_id,
+                "cohort_binding_id": COHORT_ID,
+                "target_prefix_id": PREFIX_ID,
+                "causal_prefix_only": True,
+                "target_residuals_used": False,
+                "target_outcomes_used": False,
+            }
+        },
+    )
+    return evidence
+
+
+def test_both_upstream_gates_must_pass() -> None:
+    admitted = build_provider_prefix_admission(
+        _support(),
+        _transport(),
+        provider_manifest_id=MANIFEST_ID,
+        target_prefix_id=PREFIX_ID,
+    )
+    assert admitted.admitted
+    assert not admitted.exact_fallback_required
+    assert admitted.decision_reasons == ()
+
+    transport_negative = build_provider_prefix_admission(
+        _support(),
+        _transport(shifted=True),
+        provider_manifest_id=MANIFEST_ID,
+        target_prefix_id=PREFIX_ID,
+    )
+    assert not transport_negative.admitted
+    assert transport_negative.exact_fallback_required
+    assert transport_negative.decision_reasons == ("calibration-transport-negative",)
+
+    support_negative = build_provider_prefix_admission(
+        _support(supported=False),
+        _transport(),
+        provider_manifest_id=MANIFEST_ID,
+        target_prefix_id=PREFIX_ID,
+    )
+    assert not support_negative.admitted
+    assert support_negative.decision_reasons == ("support-feasibility-negative",)
+
+
+def test_binding_mismatch_is_invalid_not_a_scientific_negative() -> None:
+    with pytest.raises(ValueError, match="provider_manifest_id binding changed"):
+        build_provider_prefix_admission(
+            _support(),
+            _transport(manifest_id="9" * 64),
+            provider_manifest_id=MANIFEST_ID,
+            target_prefix_id=PREFIX_ID,
+        )
+
+
+def test_admission_round_trip_replays_fallback_decision(tmp_path: Path) -> None:
+    admission = build_provider_prefix_admission(
+        _support(),
+        _transport(shifted=True),
+        provider_manifest_id=MANIFEST_ID,
+        target_prefix_id=PREFIX_ID,
+    )
+    path = tmp_path / "admission.json"
+    write_provider_prefix_admission(path, admission)
+    assert load_provider_prefix_admission(path).to_dict() == admission.to_dict()
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["admitted"] = True
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError, match="identity mismatch|derived fields changed"):
+        load_provider_prefix_admission(path)

--- a/tests/test_provider_support_envelope.py
+++ b/tests/test_provider_support_envelope.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from prob4d.provider_support_envelope import (
+    PROVIDER_SUPPORT_ENVELOPE_CLAIM_BOUNDARY,
+    derive_provider_support_envelope,
+    load_provider_support_envelope,
+    write_provider_support_envelope,
+)
+from prob4d.provider_support_feasibility import (
+    ProviderSupportFeasibilityRequestV1,
+    ProviderSupportStreamV1,
+)
+
+DIGESTS = {
+    name: character * 64
+    for name, character in {
+        "model": "1",
+        "loader": "2",
+        "cohort": "3",
+        "lock": "4",
+        "intrinsics": "5",
+        "extrinsics": "6",
+        "anchor": "7",
+    }.items()
+}
+
+
+def _stream(**changes: object) -> ProviderSupportStreamV1:
+    values: dict[str, object] = {
+        "group_id": "object-a",
+        "stream_id": "camera-0",
+        "causal_frame_start": 0,
+        "causal_frame_stop_exclusive": 6,
+        "required_frame_ids": (0, 1, 2, 3, 4, 5),
+        "available_frame_ids": (0, 1, 2, 3, 4, 5),
+        "geometry_supported_frame_ids": (0, 1, 2, 3, 4, 5),
+        "minimum_geometry_support_fraction": 1.0,
+        "intrinsics_required": True,
+        "intrinsics_id": DIGESTS["intrinsics"],
+        "extrinsics_required": True,
+        "extrinsics_id": DIGESTS["extrinsics"],
+        "metric_anchor_required": True,
+        "metric_anchor_id": DIGESTS["anchor"],
+        "technical_failure_code": None,
+        "metadata": {},
+    }
+    values.update(changes)
+    return ProviderSupportStreamV1(**values)  # type: ignore[arg-type]
+
+
+def _request(stream: ProviderSupportStreamV1) -> ProviderSupportFeasibilityRequestV1:
+    return ProviderSupportFeasibilityRequestV1(
+        protocol_id="support-envelope-test-v1",
+        source_repository="IPS-Stuttgart/Prob4D",
+        source_revision="a" * 40,
+        provider_family="external-provider",
+        provider_repository="example/provider",
+        provider_revision="b" * 40,
+        model_set_id=DIGESTS["model"],
+        loader_id=DIGESTS["loader"],
+        cohort_binding_id=DIGESTS["cohort"],
+        promotion_lock_id=DIGESTS["lock"],
+        coordinate_semantics="metric-world-frame",
+        admission_rule="all-streams",
+        minimum_supported_fraction=1.0,
+        permitted_technical_exclusion_codes=(),
+        maximum_technical_exclusions=0,
+        prediction_payloads_opened=False,
+        residuals_used=False,
+        target_outcomes_used=False,
+        streams=(stream,),
+    )
+
+
+def test_envelope_reports_all_contiguous_supported_intervals() -> None:
+    request = _request(
+        _stream(
+            available_frame_ids=(0, 1, 2, 4, 5),
+            geometry_supported_frame_ids=(0, 1, 4, 5),
+        )
+    )
+
+    envelope = derive_provider_support_envelope(request)
+    stream = envelope.streams[0]
+
+    assert stream.admissible_intervals == ((0, 2), (4, 6))
+    assert stream.admissible_frame_count == 4
+    assert stream.earliest_admissible_frame == 0
+    assert stream.latest_admissible_frame_exclusive == 6
+    assert stream.maximum_contiguous_frame_count == 2
+    assert stream.required_admissible_frame_count == 4
+    assert stream.required_support_fraction == pytest.approx(4 / 6)
+    assert not stream.feasibility_supported
+    assert envelope.total_admissible_frame_count == 4
+
+
+def test_missing_static_support_or_technical_failure_empties_envelope() -> None:
+    missing_anchor = derive_provider_support_envelope(
+        _request(_stream(metric_anchor_id=None))
+    ).streams[0]
+    assert not missing_anchor.static_support_complete
+    assert missing_anchor.admissible_intervals == ()
+
+    technical = derive_provider_support_envelope(
+        _request(_stream(technical_failure_code="camera-unreadable"))
+    ).streams[0]
+    assert technical.technical_failure_code == "camera-unreadable"
+    assert technical.admissible_frame_count == 0
+
+
+def test_envelope_is_replayable_and_does_not_mutate_request(tmp_path: Path) -> None:
+    request = _request(_stream())
+    before = request.to_dict()
+    envelope = derive_provider_support_envelope(
+        request,
+        metadata={"stage": "pre-residual"},
+    )
+    path = tmp_path / "envelope.json"
+    write_provider_support_envelope(path, envelope)
+
+    loaded = load_provider_support_envelope(path)
+    assert loaded.to_dict() == envelope.to_dict()
+    assert request.to_dict() == before
+    assert loaded.to_dict()["claim_boundary"] == PROVIDER_SUPPORT_ENVELOPE_CLAIM_BOUNDARY
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["total_admissible_frame_count"] += 1
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError, match="identity mismatch|derived fields changed"):
+        load_provider_support_envelope(path)

--- a/tests/test_source_covariance_localization.py
+++ b/tests/test_source_covariance_localization.py
@@ -1,0 +1,199 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from prob4d.joint_covariance_metrics import (
+    JOINT_COVARIANCE_CLAIM_BOUNDARY,
+    JOINT_COVARIANCE_DIAGNOSTIC_SCHEMA,
+    JOINT_COVARIANCE_DIAGNOSTIC_VERSION,
+)
+from prob4d.source_covariance_localization import (
+    SourceCovarianceLocalizationPolicyV1,
+    load_source_covariance_localization,
+    localize_source_covariance,
+    write_source_covariance_localization,
+)
+from prob4d.source_provider_competence import (
+    SourceProviderCompetencePolicyV1,
+    SourceProviderCompetenceReportV1,
+    SourceProviderGroupResultV1,
+)
+
+
+def _source_policy() -> SourceProviderCompetencePolicyV1:
+    return SourceProviderCompetencePolicyV1(
+        minimum_evaluable_groups=2,
+        maximum_technical_failures=0,
+        permitted_technical_failure_codes=(),
+        maximum_mean_proper_score_delta=0.0,
+        maximum_mean_point_rmse_ratio=1.0,
+        maximum_mean_endpoint_rmse_ratio=1.0,
+        maximum_worst_group_point_rmse_ratio=1.1,
+        maximum_mean_absolute_drift_slope_m_per_frame=0.02,
+        maximum_mean_seam_rmse_m=0.03,
+        minimum_mean_quality_group_pass_fraction=0.5,
+        minimum_mean_association_precision=0.9,
+        minimum_mean_identity_retention=0.8,
+        minimum_mean_support_retention=0.85,
+        minimum_identity_group_pass_fraction=0.5,
+    )
+
+
+def _source_group(group_id: str, **changes: object) -> SourceProviderGroupResultV1:
+    values: dict[str, object] = {
+        "group_id": group_id,
+        "candidate_proper_score": 9.0,
+        "baseline_proper_score": 10.0,
+        "candidate_point_rmse_m": 0.9,
+        "baseline_point_rmse_m": 1.0,
+        "candidate_endpoint_rmse_m": 0.8,
+        "baseline_endpoint_rmse_m": 1.0,
+        "absolute_drift_slope_m_per_frame": 0.01,
+        "seam_rmse_m": 0.02,
+        "association_precision": 0.95,
+        "identity_retention": 0.9,
+        "support_retention": 0.95,
+    }
+    values.update(changes)
+    return SourceProviderGroupResultV1(**values)  # type: ignore[arg-type]
+
+
+def _source_report(**group_a_changes: object) -> SourceProviderCompetenceReportV1:
+    return SourceProviderCompetenceReportV1(
+        provider_manifest_id="1" * 64,
+        cohort_binding_id="2" * 64,
+        group_definition="complete-object-v1",
+        policy=_source_policy(),
+        groups=(
+            _source_group("object-a", **group_a_changes),
+            _source_group("object-b"),
+        ),
+    )
+
+
+def _policy() -> SourceCovarianceLocalizationPolicyV1:
+    return SourceCovarianceLocalizationPolicyV1(
+        minimum_group_count=2,
+        normalized_nees_lower=0.5,
+        normalized_nees_upper=1.5,
+        minimum_joint_pass_fraction=1.0,
+        shared_energy_lower=0.5,
+        shared_energy_upper=1.5,
+        minimum_shared_pass_fraction=1.0,
+        conditional_energy_lower=0.5,
+        conditional_energy_upper=1.5,
+        minimum_conditional_pass_fraction=1.0,
+    )
+
+
+def _joint(
+    *,
+    shared_a: float = 1.0,
+    shared_b: float = 1.0,
+    conditional_a: float = 1.0,
+    conditional_b: float = 1.0,
+    nees_a: float = 1.0,
+    nees_b: float = 1.0,
+) -> dict[str, object]:
+    return {
+        "schema_name": JOINT_COVARIANCE_DIAGNOSTIC_SCHEMA,
+        "schema_version": JOINT_COVARIANCE_DIAGNOSTIC_VERSION,
+        "source_path": "/sealed/source.npz",
+        "source_sha256": "3" * 64,
+        "evaluation": {
+            "groups": [
+                {
+                    "factor_group_id": "object-a",
+                    "normalized_nees": nees_a,
+                    "shared_subspace_normalized_energy": shared_a,
+                    "conditional_subspace_normalized_energy": conditional_a,
+                },
+                {
+                    "factor_group_id": "object-b",
+                    "normalized_nees": nees_b,
+                    "shared_subspace_normalized_energy": shared_b,
+                    "conditional_subspace_normalized_energy": conditional_b,
+                },
+            ]
+        },
+        "claim_boundary": JOINT_COVARIANCE_CLAIM_BOUNDARY,
+    }
+
+
+def _localize(report: SourceProviderCompetenceReportV1, joint: dict[str, object]):
+    return localize_source_covariance(
+        report,
+        joint,
+        joint_diagnostic_sha256="4" * 64,
+        policy=_policy(),
+    )
+
+
+def test_shared_failure_redirects_without_authorizing_point_model() -> None:
+    result = _localize(_source_report(), _joint(shared_a=3.0))
+
+    assert result.classification == "gauge-or-dependence-negative"
+    assert not result.authorize_point_uncertainty_development
+    gauge, point = result.readiness_gates()
+    assert gauge.status == "fail"
+    assert point.status == "not-evaluated"
+
+
+def test_conditional_failure_is_the_only_point_model_authorization() -> None:
+    result = _localize(_source_report(), _joint(conditional_b=3.0))
+
+    assert result.classification == "point-covariance-localized"
+    assert result.authorize_point_uncertainty_development
+    gauge, point = result.readiness_gates()
+    assert gauge.status == "pass"
+    assert point.status == "fail"
+    assert point.evidence_id == result.source_covariance_localization_id
+
+
+def test_adequate_subspaces_pass_both_covariance_gates() -> None:
+    result = _localize(_source_report(), _joint())
+
+    assert result.classification == "covariance-adequate"
+    assert not result.authorize_point_uncertainty_development
+    gauge, point = result.readiness_gates()
+    assert gauge.status == point.status == "pass"
+
+
+def test_mean_or_identity_failure_stops_before_covariance_gates() -> None:
+    mean_negative = _localize(
+        _source_report(candidate_point_rmse_m=2.0),
+        _joint(),
+    )
+    assert mean_negative.classification == "source-mean-negative"
+    assert all(gate.status == "not-evaluated" for gate in mean_negative.readiness_gates())
+
+    identity_negative = _localize(
+        _source_report(association_precision=0.1),
+        _joint(),
+    )
+    assert identity_negative.classification == "identity-or-association-negative"
+    assert all(gate.status == "not-evaluated" for gate in identity_negative.readiness_gates())
+
+
+def test_joint_groups_must_match_exact_evaluable_source_units() -> None:
+    joint = _joint()
+    groups = joint["evaluation"]["groups"]  # type: ignore[index]
+    groups[1]["factor_group_id"] = "object-c"  # type: ignore[index]
+    with pytest.raises(ValueError, match="do not match evaluable source"):
+        _localize(_source_report(), joint)
+
+
+def test_localization_round_trip_replays_derived_decision(tmp_path: Path) -> None:
+    result = _localize(_source_report(), _joint(conditional_a=2.0))
+    path = tmp_path / "localization.json"
+    write_source_covariance_localization(path, result)
+    assert load_source_covariance_localization(path).to_dict() == result.to_dict()
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["authorize_point_uncertainty_development"] = False
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError, match="identity mismatch|derived fields changed"):
+        load_source_covariance_localization(path)


### PR DESCRIPTION
## Summary

Close the missing integration gaps around the fresh real-provider gate without changing frozen provider-v2 semantics or fitting a richer uncertainty model.

- add `ProviderSupportEnvelopeV1`, derived only from an outcome-blind `ProviderSupportFeasibilityRequestV1`, to expose all contiguous admissible frame intervals before residuals are opened;
- add `SourceCovarianceLocalizationV1`, binding source mean/identity competence to the existing joint covariance diagnostic and emitting the existing `gauge-dependence` / `point-covariance` readiness gates;
- authorize point-uncertainty development **only** for `point-covariance-localized` after mean, identity, and shared/gauge diagnostics pass;
- add `ProviderPrefixAdmissionV1`, requiring both support feasibility and source-only calibration transport for the same provider/cohort/causal-prefix binding, with exact fallback required on either valid negative;
- add focused tamper/replay/stop-rule tests and documentation.

## Scientific boundary

This PR intentionally does **not** implement `PointUncertaintyCalibrationV2`, does not consume protected targets, and does not retune the opened MotionCrafter or Deform360 cohorts. Binding mismatches are invalid evidence rather than scientific negatives. BayesianPhysTwin continues to own query relevance, physical update admission/regret guards, and exact physical fallback; Causal4D remains downstream.

This is intended to provide the executable source-evidence path needed by #204 while preserving the stop rule that only a localized conditional point-covariance failure can authorize richer point uncertainty.

## Validation

All PR-triggered validation is green on head `43f867150a1377b6b91cf659f797560241934ff6`:

- `Fail-closed quality` run 31579500512: authoritative changed-file Ruff and mypy passed;
- `Security scanning` run 31579500519: CodeQL and resolved-runtime dependency audit passed;
- `Tests` run 31579500588: complete suites passed on Python 3.10, 3.11, 3.12, 3.13, and 3.14, including the declared Python 3.10 runtime floor and repository/provider-contract checks;
- wheel and sdist build/validation passed; and
- isolated installed-wheel and installed-sdist CLI smoke tests passed.
