### PR TITLE
Add gated point uncertainty calibration v2

### DIFF
--- a/docs/point-uncertainty-v2.md
+++ b/docs/point-uncertainty-v2.md
@@ -1,0 +1,200 @@
+# Point uncertainty calibration v2
+
+`PointUncertaintyCalibrationV2` is an **experimental, source/calibration-only**
+conditional point-covariance model. It is deliberately downstream of
+`SourceCovarianceLocalizationV1` and refuses to fit unless that artifact classifies
+the remaining source-side failure as `point-covariance-localized`.
+
+This preserves the provider stop rule:
+
+1. support failure redirects the provider;
+2. observation-mean failure redirects the provider;
+3. identity/association failure redirects the provider;
+4. gauge/dependence failure redirects the gauge or dependence model; and
+5. only a conditional point-covariance failure authorizes this model.
+
+The model is not enabled in provider v2 exports by this implementation.
+
+## Motivation
+
+The production point model uses one variance along the viewing ray and one
+shared lateral variance. That is intentionally compact, but a localized
+conditional failure may indicate that the two lateral directions have
+systematically different uncertainty.
+
+Version 2 uses the orthonormal basis
+
+\[
+(r,t_1,t_2),
+\]
+
+where:
+
+- `r` is the viewing ray;
+- `t1` is the prediction-only reference direction projected into the tangent
+  plane; and
+- `t2 = r x t1`.
+
+If the reference direction is degenerate, a deterministic camera-coordinate
+axis is projected into the tangent plane. Residuals or target outcomes must not
+be used to choose the reference direction.
+
+The conditional covariance is
+
+\[
+\Sigma_{\mathrm{point}} =
+\sigma_r^2 rr^\top +
+\sigma_{t_1}^2 t_1t_1^\top +
+\sigma_{t_2}^2 t_2t_2^\top.
+\]
+
+The **shared Sim(3) gauge covariance remains separate**. Version 2 must not absorb
+that low-rank nuisance into local point variances.
+
+## Heteroscedastic variance model
+
+For each of the three local axes, the log variance is a linear function of frozen
+source-side features:
+
+\[
+\log \sigma_k^2 = \beta_{k,0} + x^\top \beta_k.
+\]
+
+Features are standardized using equal-group weighted source statistics. Candidate
+features should be computable without residual or target access, for example:
+
+- predicted depth or inverse depth;
+- overlap disagreement computed out of fold;
+- temporal position inside the source window;
+- predicted flow magnitude and direction;
+- prediction-only occlusion or visibility scores;
+- association entropy or retained-track support; and
+- geometry-conditioning diagnostics.
+
+Do not use target residuals, future frames beyond the causal cutoff, manually
+selected error regions, or downstream physical innovations as features.
+
+## Fit objective
+
+Rows inside one physical object/session are not treated as independent
+calibration units. Each independent group receives equal total weight, and rows
+inside a group divide that weight equally.
+
+For projected residual `e` and predicted variance `v`, the data term is the
+Gaussian variance negative log likelihood
+
+\[
+\frac{1}{2}(\log v + e^2/v).
+\]
+
+This is optimized directly with damped Newton steps. It avoids the systematic
+variance bias that results from least-squares regression on `log(e^2)`.
+
+A ridge penalty regularizes feature coefficients. A separate coupling penalty
+
+\[
+\lambda_{\mathrm{lat}}\|\beta_{t_1}-\beta_{t_2}\|^2
+\]
+
+shrinks the two lateral models toward the existing isotropic-lateral model.
+Anisotropy therefore has to be supported by the source/calibration evidence
+rather than appearing merely because two unconstrained regressions were fitted.
+
+The artifact records the in-sample normalized residual energies only as a fit
+diagnostic. They are **not** calibration evidence and cannot replace a disjoint
+source-validation or fresh-target evaluation.
+
+## Authorization
+
+The Python API requires an actual `SourceCovarianceLocalizationV1` instance and
+checks both:
+
+```text
+classification == "point-covariance-localized"
+authorize_point_uncertainty_development == true
+```
+
+Any other source classification raises an error before training rows are used.
+
+The training group roster must exactly equal the localization's independent group
+roster. This prevents a richer covariance model from silently being fitted on a
+different or partial source cohort.
+
+## Training data
+
+The module can be used from Python or with the research-only module CLI.
+
+The CLI accepts one NPZ with exactly these arrays:
+
+- `residual_xyz`: shape `(N, 3)`, source/calibration point residuals;
+- `ray_directions`: shape `(N, 3)`;
+- `tangent_reference`: shape `(N, 3)`, prediction-only reference vectors;
+- `features`: shape `(N, F)`, prediction-only covariates;
+- `group_ids`: shape `(N,)`, physical object/session IDs; and
+- `feature_names`: shape `(F,)`.
+
+The complete NPZ bytes are SHA-256 bound into the output artifact.
+
+Example:
+
+```bash
+python -m prob4d.point_uncertainty_v2 fit \
+  --localization outputs/source-covariance-localization.json \
+  --training outputs/point-uncertainty-source-v2.npz \
+  --policy protocols/point-uncertainty-v2-policy.json \
+  --output outputs/point-uncertainty-v2.json
+
+python -m prob4d.point_uncertainty_v2 verify \
+  --artifact outputs/point-uncertainty-v2.json
+```
+
+The optional policy JSON freezes:
+
+- ridge strength;
+- lateral coupling strength;
+- minimum independent-group count;
+- minimum rows per group;
+- variance floor;
+- log-variance clipping bounds;
+- Newton tolerance; and
+- maximum iteration count.
+
+## Consumer API
+
+```python
+from prob4d.point_uncertainty_v2 import (
+    load_point_uncertainty_calibration_v2,
+)
+
+calibration = load_point_uncertainty_calibration_v2(
+    "outputs/point-uncertainty-v2.json"
+)
+
+variances = calibration.predict_variances(features)
+conditional_covariance = calibration.covariance_matrices(
+    ray_directions,
+    tangent_reference,
+    features,
+)
+```
+
+`conditional_covariance` contains only the local conditional point covariance.
+A downstream gauge-aware consumer must continue to carry the shared gauge
+Jacobian and gauge prior separately.
+
+## Promotion requirements
+
+Implementing and successfully fitting this model does not justify replacing the
+production uncertainty model. Promotion requires a separately frozen experiment
+that demonstrates, on disjoint source-validation or fresh object/session units:
+
+- improved proper score such as Gaussian NLL;
+- improved or non-worse object/session-level coverage;
+- acceptable interval/covariance width;
+- no degradation of point-mean or identity competence;
+- no evidence that the remaining error is actually shared gauge/common-mode
+  error; and
+- downstream BayesianPhysTwin benefit under the same regret guard and exact
+  fallback rule.
+
+A valid negative result leaves the production point model unchanged.

--- a/src/prob4d/_point_uncertainty_v2_common.py
+++ b/src/prob4d/_point_uncertainty_v2_common.py
@@ -1,0 +1,200 @@
+"""Shared validation and basis helpers for point uncertainty calibration v2."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, cast
+
+import numpy as np
+
+from ._scientific_scalars import require_finite_real, require_genuine_integer
+from ._strict_json import require_exact_fields, require_exact_string, require_mapping
+
+_POLICY_FIELDS = frozenset(
+    {
+        "ridge_strength",
+        "lateral_coupling_strength",
+        "minimum_group_count",
+        "minimum_rows_per_group",
+        "variance_floor",
+        "log_variance_lower",
+        "log_variance_upper",
+        "newton_tolerance",
+        "maximum_iterations",
+    }
+)
+
+
+def positive(value: object, *, name: str) -> float:
+    return require_finite_real(
+        value,
+        name=name,
+        minimum=0.0,
+        minimum_inclusive=False,
+    )
+
+
+def float_tuple(
+    value: object,
+    *,
+    name: str,
+    length: int,
+    positive_only: bool = False,
+) -> tuple[float, ...]:
+    if type(value) not in {tuple, list}:
+        raise TypeError(f"{name} must be a sequence")
+    items = tuple(
+        (
+            positive(item, name=f"{name}[{index}]")
+            if positive_only
+            else require_finite_real(item, name=f"{name}[{index}]")
+        )
+        for index, item in enumerate(value)
+    )
+    if len(items) != length:
+        raise ValueError(f"{name} must contain exactly {length} values")
+    return items
+
+
+def string_tuple(
+    value: object,
+    *,
+    name: str,
+    sorted_unique: bool = False,
+) -> tuple[str, ...]:
+    if type(value) not in {tuple, list}:
+        raise TypeError(f"{name} must be a sequence")
+    result = tuple(
+        require_exact_string(item, name=f"{name}[{index}]")
+        for index, item in enumerate(value)
+    )
+    if not result:
+        raise ValueError(f"{name} must be non-empty")
+    if len(set(result)) != len(result):
+        raise ValueError(f"{name} must be unique")
+    if sorted_unique and result != tuple(sorted(result)):
+        raise ValueError(f"{name} must use canonical sorted order")
+    return result
+
+
+def float_matrix(value: object, *, name: str, columns: int | None = None) -> np.ndarray:
+    result = np.asarray(value, dtype=np.float64)
+    if result.ndim != 2:
+        raise ValueError(f"{name} must be a rank-2 array")
+    if columns is not None and result.shape[1] != columns:
+        raise ValueError(f"{name} must have shape (N, {columns})")
+    if not np.all(np.isfinite(result)):
+        raise ValueError(f"{name} must be finite")
+    return result
+
+
+def _normalize_rows(value: np.ndarray, *, name: str) -> np.ndarray:
+    norms = np.linalg.norm(value, axis=1)
+    if np.any(norms <= 1e-12):
+        raise ValueError(f"{name} contains a zero vector")
+    return value / norms[:, None]
+
+
+def local_point_basis(
+    ray_directions: object,
+    tangent_reference: object,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return ray, prediction-reference tangent, and orthogonal tangent axes."""
+
+    rays = _normalize_rows(
+        float_matrix(ray_directions, name="ray_directions", columns=3),
+        name="ray_directions",
+    )
+    reference = float_matrix(
+        tangent_reference,
+        name="tangent_reference",
+        columns=3,
+    )
+    if reference.shape[0] != rays.shape[0]:
+        raise ValueError("tangent_reference and ray_directions must have matching rows")
+
+    tangent = reference - np.sum(reference * rays, axis=1)[:, None] * rays
+    fallback = np.linalg.norm(tangent, axis=1) <= 1e-10
+    if np.any(fallback):
+        indices = np.argmin(np.abs(rays[fallback]), axis=1)
+        canonical = np.eye(3, dtype=np.float64)[indices]
+        tangent[fallback] = (
+            canonical
+            - np.sum(canonical * rays[fallback], axis=1)[:, None] * rays[fallback]
+        )
+    tangent_one = _normalize_rows(tangent, name="projected tangent_reference")
+    tangent_two = _normalize_rows(np.cross(rays, tangent_one), name="orthogonal tangent")
+    return rays, tangent_one, tangent_two
+
+
+@dataclass(frozen=True, slots=True)
+class PointUncertaintyCalibrationPolicyV2:
+    """Frozen source-only fit and numerical-stability policy."""
+
+    ridge_strength: float = 1e-3
+    lateral_coupling_strength: float = 1e-2
+    minimum_group_count: int = 8
+    minimum_rows_per_group: int = 64
+    variance_floor: float = 1e-10
+    log_variance_lower: float = -30.0
+    log_variance_upper: float = 10.0
+    newton_tolerance: float = 1e-8
+    maximum_iterations: int = 80
+
+    def __post_init__(self) -> None:
+        for name in ("ridge_strength", "lateral_coupling_strength"):
+            object.__setattr__(
+                self,
+                name,
+                require_finite_real(getattr(self, name), name=name, minimum=0.0),
+            )
+        for name in ("minimum_group_count", "minimum_rows_per_group", "maximum_iterations"):
+            object.__setattr__(
+                self,
+                name,
+                require_genuine_integer(getattr(self, name), name=name, minimum=1),
+            )
+        object.__setattr__(
+            self,
+            "variance_floor",
+            positive(self.variance_floor, name="variance_floor"),
+        )
+        lower = require_finite_real(self.log_variance_lower, name="log_variance_lower")
+        upper = require_finite_real(self.log_variance_upper, name="log_variance_upper")
+        if upper <= lower:
+            raise ValueError("log_variance_upper must exceed log_variance_lower")
+        object.__setattr__(self, "log_variance_lower", lower)
+        object.__setattr__(self, "log_variance_upper", upper)
+        object.__setattr__(
+            self,
+            "newton_tolerance",
+            positive(self.newton_tolerance, name="newton_tolerance"),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "ridge_strength": self.ridge_strength,
+            "lateral_coupling_strength": self.lateral_coupling_strength,
+            "minimum_group_count": self.minimum_group_count,
+            "minimum_rows_per_group": self.minimum_rows_per_group,
+            "variance_floor": self.variance_floor,
+            "log_variance_lower": self.log_variance_lower,
+            "log_variance_upper": self.log_variance_upper,
+            "newton_tolerance": self.newton_tolerance,
+            "maximum_iterations": self.maximum_iterations,
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> PointUncertaintyCalibrationPolicyV2:
+        mapping = require_mapping(value, name="point uncertainty v2 policy")
+        require_exact_fields(mapping, _POLICY_FIELDS, name="point uncertainty v2 policy")
+        return cls(**cast(dict[str, Any], dict(mapping)))
+
+
+__all__ = [
+    "PointUncertaintyCalibrationPolicyV2",
+    "float_matrix",
+    "float_tuple",
+    "local_point_basis",
+    "string_tuple",
+]

--- a/src/prob4d/_point_uncertainty_v2_fit.py
+++ b/src/prob4d/_point_uncertainty_v2_fit.py
@@ -1,0 +1,322 @@
+"""Equal-group Gaussian-NLL fitting for point uncertainty calibration v2."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import numpy as np
+
+from ._point_uncertainty_v2_common import (
+    PointUncertaintyCalibrationPolicyV2,
+    float_matrix,
+    local_point_basis,
+)
+from ._point_uncertainty_v2_model import PointUncertaintyCalibrationV2
+from ._strict_json import require_exact_string, require_sha256
+from .source_covariance_localization import SourceCovarianceLocalizationV1
+
+
+def _group_weights(
+    group_ids: Sequence[str],
+    *,
+    required_groups: tuple[str, ...],
+    policy: PointUncertaintyCalibrationPolicyV2,
+) -> tuple[np.ndarray, tuple[int, ...]]:
+    values = tuple(require_exact_string(item, name="group_id") for item in group_ids)
+    actual_groups = tuple(sorted(set(values)))
+    if actual_groups != required_groups:
+        raise ValueError("training group IDs must exactly match localization groups")
+    if len(actual_groups) < policy.minimum_group_count:
+        raise ValueError("too few independent groups for point uncertainty calibration")
+    counts = tuple(values.count(group_id) for group_id in actual_groups)
+    if any(count < policy.minimum_rows_per_group for count in counts):
+        raise ValueError("one or more groups have too few calibration rows")
+    count_by_group = dict(zip(actual_groups, counts, strict=True))
+    weights = np.asarray(
+        [
+            1.0 / (len(actual_groups) * count_by_group[group_id])
+            for group_id in values
+        ],
+        dtype=np.float64,
+    )
+    return weights, counts
+
+
+def _weighted_design(
+    features: np.ndarray,
+    weights: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    mean = np.sum(weights[:, None] * features, axis=0)
+    centered = features - mean[None, :]
+    scale = np.sqrt(
+        np.maximum(np.sum(weights[:, None] * centered * centered, axis=0), 1e-12)
+    )
+    return np.column_stack((np.ones(features.shape[0]), centered / scale)), mean, scale
+
+
+def _axis_terms(
+    design: np.ndarray,
+    residual_squared: np.ndarray,
+    weights: np.ndarray,
+    coefficients: np.ndarray,
+    *,
+    policy: PointUncertaintyCalibrationPolicyV2,
+) -> tuple[float, np.ndarray, np.ndarray]:
+    eta = np.clip(
+        design @ coefficients,
+        policy.log_variance_lower,
+        policy.log_variance_upper,
+    )
+    variance = np.maximum(np.exp(eta), policy.variance_floor)
+    ratio = residual_squared / variance
+    penalty = coefficients.copy()
+    penalty[0] = 0.0
+    objective = 0.5 * float(
+        np.sum(weights * (np.log(variance) + ratio))
+        + policy.ridge_strength * penalty @ penalty
+    )
+    regularizer = np.eye(design.shape[1], dtype=np.float64)
+    regularizer[0, 0] = 0.0
+    gradient = (
+        0.5 * design.T @ (weights * (1.0 - ratio))
+        + policy.ridge_strength * regularizer @ coefficients
+    )
+    hessian = (
+        0.5 * design.T @ ((weights * ratio)[:, None] * design)
+        + policy.ridge_strength * regularizer
+    )
+    return objective, gradient, hessian
+
+
+def _fit_axis(
+    design: np.ndarray,
+    residual_squared: np.ndarray,
+    weights: np.ndarray,
+    *,
+    policy: PointUncertaintyCalibrationPolicyV2,
+) -> tuple[np.ndarray, int, bool]:
+    coefficients = np.zeros(design.shape[1], dtype=np.float64)
+    coefficients[0] = np.log(
+        max(float(np.sum(weights * residual_squared)), policy.variance_floor)
+    )
+    for iteration in range(1, policy.maximum_iterations + 1):
+        objective, gradient, hessian = _axis_terms(
+            design,
+            residual_squared,
+            weights,
+            coefficients,
+            policy=policy,
+        )
+        step = np.linalg.solve(
+            hessian + 1e-12 * np.eye(design.shape[1]),
+            gradient,
+        )
+        if np.linalg.norm(step, ord=np.inf) <= policy.newton_tolerance:
+            return coefficients, iteration, True
+        damping = 1.0
+        while damping >= 2.0**-20:
+            candidate = coefficients - damping * step
+            candidate_objective, _, _ = _axis_terms(
+                design,
+                residual_squared,
+                weights,
+                candidate,
+                policy=policy,
+            )
+            if candidate_objective <= objective:
+                coefficients = candidate
+                break
+            damping *= 0.5
+        else:
+            return coefficients, iteration, False
+    return coefficients, policy.maximum_iterations, False
+
+
+def _fit_lateral(
+    design: np.ndarray,
+    residual_one: np.ndarray,
+    residual_two: np.ndarray,
+    weights: np.ndarray,
+    *,
+    policy: PointUncertaintyCalibrationPolicyV2,
+) -> tuple[np.ndarray, np.ndarray, int, bool]:
+    first, _, _ = _fit_axis(design, residual_one, weights, policy=policy)
+    second, _, _ = _fit_axis(design, residual_two, weights, policy=policy)
+    size = design.shape[1]
+    coupling = policy.lateral_coupling_strength * np.eye(size, dtype=np.float64)
+
+    for iteration in range(1, policy.maximum_iterations + 1):
+        obj_one, grad_one, hess_one = _axis_terms(
+            design, residual_one, weights, first, policy=policy
+        )
+        obj_two, grad_two, hess_two = _axis_terms(
+            design, residual_two, weights, second, policy=policy
+        )
+        difference = first - second
+        objective = (
+            obj_one
+            + obj_two
+            + 0.5 * policy.lateral_coupling_strength * difference @ difference
+        )
+        gradient = np.concatenate(
+            (grad_one + coupling @ difference, grad_two - coupling @ difference)
+        )
+        hessian = np.block(
+            [
+                [hess_one + coupling, -coupling],
+                [-coupling, hess_two + coupling],
+            ]
+        )
+        step = np.linalg.solve(
+            hessian + 1e-12 * np.eye(2 * size),
+            gradient,
+        )
+        if np.linalg.norm(step, ord=np.inf) <= policy.newton_tolerance:
+            return first, second, iteration, True
+
+        damping = 1.0
+        while damping >= 2.0**-20:
+            candidate_one = first - damping * step[:size]
+            candidate_two = second - damping * step[size:]
+            cand_obj_one, _, _ = _axis_terms(
+                design, residual_one, weights, candidate_one, policy=policy
+            )
+            cand_obj_two, _, _ = _axis_terms(
+                design, residual_two, weights, candidate_two, policy=policy
+            )
+            cand_difference = candidate_one - candidate_two
+            candidate_objective = (
+                cand_obj_one
+                + cand_obj_two
+                + 0.5
+                * policy.lateral_coupling_strength
+                * cand_difference
+                @ cand_difference
+            )
+            if candidate_objective <= objective:
+                first, second = candidate_one, candidate_two
+                break
+            damping *= 0.5
+        else:
+            return first, second, iteration, False
+    return first, second, policy.maximum_iterations, False
+
+
+def fit_point_uncertainty_calibration_v2(
+    localization: SourceCovarianceLocalizationV1,
+    *,
+    residual_xyz: object,
+    ray_directions: object,
+    tangent_reference: object,
+    features: object,
+    feature_names: Sequence[str],
+    group_ids: Sequence[str],
+    source_training_sha256: str,
+    policy: PointUncertaintyCalibrationPolicyV2 | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> PointUncertaintyCalibrationV2:
+    """Fit the gated equal-group Gaussian variance model."""
+
+    if not isinstance(localization, SourceCovarianceLocalizationV1):
+        raise TypeError("localization must be SourceCovarianceLocalizationV1")
+    if (
+        localization.classification != "point-covariance-localized"
+        or not localization.authorize_point_uncertainty_development
+    ):
+        raise ValueError(
+            "PointUncertaintyCalibrationV2 requires point-covariance-localized authorization"
+        )
+    fit_policy = PointUncertaintyCalibrationPolicyV2() if policy is None else policy
+    if not isinstance(fit_policy, PointUncertaintyCalibrationPolicyV2):
+        raise TypeError("policy must be PointUncertaintyCalibrationPolicyV2")
+
+    residuals = float_matrix(residual_xyz, name="residual_xyz", columns=3)
+    feature_matrix = float_matrix(features, name="features")
+    if feature_matrix.shape[0] != residuals.shape[0]:
+        raise ValueError("features and residual_xyz must have matching rows")
+    names = tuple(
+        require_exact_string(item, name=f"feature_names[{index}]")
+        for index, item in enumerate(feature_names)
+    )
+    if len(names) != feature_matrix.shape[1] or len(set(names)) != len(names):
+        raise ValueError("feature_names must be unique and match feature columns")
+    if len(group_ids) != residuals.shape[0]:
+        raise ValueError("group_ids and residual_xyz must have matching rows")
+
+    required_groups = tuple(group.group_id for group in localization.groups)
+    weights, group_counts = _group_weights(
+        group_ids,
+        required_groups=required_groups,
+        policy=fit_policy,
+    )
+    rays, tangent_one, tangent_two = local_point_basis(
+        ray_directions,
+        tangent_reference,
+    )
+    if rays.shape[0] != residuals.shape[0]:
+        raise ValueError("basis inputs and residual_xyz must have matching rows")
+    projected = np.column_stack(
+        (
+            np.sum(residuals * rays, axis=1),
+            np.sum(residuals * tangent_one, axis=1),
+            np.sum(residuals * tangent_two, axis=1),
+        )
+    )
+    residual_squared = projected * projected
+    design, feature_mean, feature_scale = _weighted_design(feature_matrix, weights)
+
+    parallel, parallel_iterations, parallel_converged = _fit_axis(
+        design,
+        residual_squared[:, 0],
+        weights,
+        policy=fit_policy,
+    )
+    lateral_one, lateral_two, lateral_iterations, lateral_converged = _fit_lateral(
+        design,
+        residual_squared[:, 1],
+        residual_squared[:, 2],
+        weights,
+        policy=fit_policy,
+    )
+    coefficients = np.vstack((parallel, lateral_one, lateral_two))
+    predicted = np.maximum(
+        np.exp(
+            np.clip(
+                design @ coefficients.T,
+                fit_policy.log_variance_lower,
+                fit_policy.log_variance_upper,
+            )
+        ),
+        fit_policy.variance_floor,
+    )
+    normalized_energy = np.sum(
+        weights[:, None] * residual_squared / predicted,
+        axis=0,
+    )
+
+    return PointUncertaintyCalibrationV2(
+        provider_manifest_id=localization.provider_manifest_id,
+        cohort_binding_id=localization.cohort_binding_id,
+        source_covariance_localization_id=localization.source_covariance_localization_id,
+        source_training_sha256=require_sha256(
+            source_training_sha256,
+            name="source_training_sha256",
+        ),
+        feature_names=names,
+        feature_mean=tuple(float(item) for item in feature_mean),
+        feature_scale=tuple(float(item) for item in feature_scale),
+        parallel_coefficients=tuple(float(item) for item in parallel),
+        lateral_reference_coefficients=tuple(float(item) for item in lateral_one),
+        lateral_orthogonal_coefficients=tuple(float(item) for item in lateral_two),
+        group_ids=required_groups,
+        group_counts=group_counts,
+        policy=fit_policy,
+        training_normalized_energy=tuple(float(item) for item in normalized_energy),
+        fit_iterations=max(parallel_iterations, lateral_iterations),
+        fit_converged=parallel_converged and lateral_converged,
+        metadata={} if metadata is None else metadata,
+    )
+
+
+__all__ = ["fit_point_uncertainty_calibration_v2"]

--- a/src/prob4d/_point_uncertainty_v2_model.py
+++ b/src/prob4d/_point_uncertainty_v2_model.py
@@ -13,19 +13,19 @@ import numpy as np
 
 from ._atomic_file import atomic_write_text
 from ._immutable_json import frozen_finite_json_mapping, plain_json
-from ._scientific_scalars import require_genuine_integer
-from ._strict_json import (
-    load_json_object,
-    require_exact_fields,
-    require_mapping,
-    require_sha256,
-)
 from ._point_uncertainty_v2_common import (
     PointUncertaintyCalibrationPolicyV2,
     float_matrix,
     float_tuple,
     local_point_basis,
     string_tuple,
+)
+from ._scientific_scalars import require_genuine_integer
+from ._strict_json import (
+    load_json_object,
+    require_exact_fields,
+    require_mapping,
+    require_sha256,
 )
 
 POINT_UNCERTAINTY_CALIBRATION_SCHEMA = "prob4d.point-uncertainty-calibration"

--- a/src/prob4d/_point_uncertainty_v2_model.py
+++ b/src/prob4d/_point_uncertainty_v2_model.py
@@ -1,0 +1,355 @@
+"""Artifact model and prediction path for point uncertainty calibration v2."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, cast
+
+import numpy as np
+
+from ._atomic_file import atomic_write_text
+from ._immutable_json import frozen_finite_json_mapping, plain_json
+from ._scientific_scalars import require_genuine_integer
+from ._strict_json import (
+    load_json_object,
+    require_exact_fields,
+    require_mapping,
+    require_sha256,
+)
+from ._point_uncertainty_v2_common import (
+    PointUncertaintyCalibrationPolicyV2,
+    float_matrix,
+    float_tuple,
+    local_point_basis,
+    string_tuple,
+)
+
+POINT_UNCERTAINTY_CALIBRATION_SCHEMA = "prob4d.point-uncertainty-calibration"
+POINT_UNCERTAINTY_CALIBRATION_VERSION = 2
+POINT_UNCERTAINTY_CALIBRATION_CLAIM_BOUNDARY = (
+    "This source/calibration-only artifact is an experimental conditional point-covariance "
+    "model authorized by an explicit point-covariance-localized source diagnostic. It does "
+    "not absorb shared Sim(3) gauge uncertainty, use protected target outcomes, establish "
+    "provider competence or transfer, authorize a BayesianPhysTwin update, establish "
+    "Causal4D intervention benefit, deployment safety, or state of the art."
+)
+
+_ARTIFACT_FIELDS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "provider_manifest_id",
+        "cohort_binding_id",
+        "source_covariance_localization_id",
+        "source_training_sha256",
+        "feature_names",
+        "feature_mean",
+        "feature_scale",
+        "parallel_coefficients",
+        "lateral_reference_coefficients",
+        "lateral_orthogonal_coefficients",
+        "group_ids",
+        "group_counts",
+        "policy",
+        "training_normalized_energy",
+        "fit_iterations",
+        "fit_converged",
+        "metadata",
+        "claim_boundary",
+        "point_uncertainty_calibration_id",
+    }
+)
+
+
+def _sha256_json(value: Mapping[str, Any]) -> str:
+    payload = json.dumps(
+        plain_json(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class PointUncertaintyCalibrationV2:
+    """Content-addressed three-axis conditional point-covariance calibration."""
+
+    provider_manifest_id: str
+    cohort_binding_id: str
+    source_covariance_localization_id: str
+    source_training_sha256: str
+    feature_names: tuple[str, ...]
+    feature_mean: tuple[float, ...]
+    feature_scale: tuple[float, ...]
+    parallel_coefficients: tuple[float, ...]
+    lateral_reference_coefficients: tuple[float, ...]
+    lateral_orthogonal_coefficients: tuple[float, ...]
+    group_ids: tuple[str, ...]
+    group_counts: tuple[int, ...]
+    policy: PointUncertaintyCalibrationPolicyV2
+    training_normalized_energy: tuple[float, float, float]
+    fit_iterations: int
+    fit_converged: bool
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    point_uncertainty_calibration_id: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        for name in (
+            "provider_manifest_id",
+            "cohort_binding_id",
+            "source_covariance_localization_id",
+            "source_training_sha256",
+        ):
+            object.__setattr__(self, name, require_sha256(getattr(self, name), name=name))
+
+        names = string_tuple(self.feature_names, name="feature_names")
+        object.__setattr__(self, "feature_names", names)
+        object.__setattr__(
+            self,
+            "feature_mean",
+            float_tuple(self.feature_mean, name="feature_mean", length=len(names)),
+        )
+        object.__setattr__(
+            self,
+            "feature_scale",
+            float_tuple(
+                self.feature_scale,
+                name="feature_scale",
+                length=len(names),
+                positive_only=True,
+            ),
+        )
+        for name in (
+            "parallel_coefficients",
+            "lateral_reference_coefficients",
+            "lateral_orthogonal_coefficients",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                float_tuple(
+                    getattr(self, name),
+                    name=name,
+                    length=len(names) + 1,
+                ),
+            )
+
+        group_ids = string_tuple(
+            self.group_ids,
+            name="group_ids",
+            sorted_unique=True,
+        )
+        if type(self.group_counts) not in {tuple, list}:
+            raise TypeError("group_counts must be a sequence")
+        group_counts = tuple(
+            require_genuine_integer(item, name=f"group_counts[{index}]", minimum=1)
+            for index, item in enumerate(self.group_counts)
+        )
+        if len(group_ids) != len(group_counts):
+            raise ValueError("group_ids and group_counts must have matching lengths")
+        object.__setattr__(self, "group_ids", group_ids)
+        object.__setattr__(self, "group_counts", group_counts)
+
+        if not isinstance(self.policy, PointUncertaintyCalibrationPolicyV2):
+            raise TypeError("policy must be PointUncertaintyCalibrationPolicyV2")
+        object.__setattr__(
+            self,
+            "training_normalized_energy",
+            float_tuple(
+                self.training_normalized_energy,
+                name="training_normalized_energy",
+                length=3,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "fit_iterations",
+            require_genuine_integer(self.fit_iterations, name="fit_iterations", minimum=1),
+        )
+        if type(self.fit_converged) is not bool:
+            raise TypeError("fit_converged must be a Boolean")
+        object.__setattr__(
+            self,
+            "metadata",
+            frozen_finite_json_mapping(dict(self.metadata), name="metadata"),
+        )
+        object.__setattr__(
+            self,
+            "point_uncertainty_calibration_id",
+            _sha256_json(self._content_dict()),
+        )
+
+    def _content_dict(self) -> dict[str, object]:
+        return {
+            "schema": POINT_UNCERTAINTY_CALIBRATION_SCHEMA,
+            "schema_version": POINT_UNCERTAINTY_CALIBRATION_VERSION,
+            "provider_manifest_id": self.provider_manifest_id,
+            "cohort_binding_id": self.cohort_binding_id,
+            "source_covariance_localization_id": self.source_covariance_localization_id,
+            "source_training_sha256": self.source_training_sha256,
+            "feature_names": list(self.feature_names),
+            "feature_mean": list(self.feature_mean),
+            "feature_scale": list(self.feature_scale),
+            "parallel_coefficients": list(self.parallel_coefficients),
+            "lateral_reference_coefficients": list(self.lateral_reference_coefficients),
+            "lateral_orthogonal_coefficients": list(self.lateral_orthogonal_coefficients),
+            "group_ids": list(self.group_ids),
+            "group_counts": list(self.group_counts),
+            "policy": self.policy.to_dict(),
+            "training_normalized_energy": list(self.training_normalized_energy),
+            "fit_iterations": self.fit_iterations,
+            "fit_converged": self.fit_converged,
+            "metadata": plain_json(self.metadata),
+            "claim_boundary": POINT_UNCERTAINTY_CALIBRATION_CLAIM_BOUNDARY,
+        }
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            **self._content_dict(),
+            "point_uncertainty_calibration_id": self.point_uncertainty_calibration_id,
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> PointUncertaintyCalibrationV2:
+        mapping = require_mapping(value, name="point uncertainty v2 calibration")
+        require_exact_fields(
+            mapping,
+            _ARTIFACT_FIELDS,
+            name="point uncertainty v2 calibration",
+        )
+        if mapping["schema"] != POINT_UNCERTAINTY_CALIBRATION_SCHEMA:
+            raise ValueError("point uncertainty calibration schema changed")
+        if mapping["schema_version"] != POINT_UNCERTAINTY_CALIBRATION_VERSION:
+            raise ValueError("point uncertainty calibration version changed")
+        if mapping["claim_boundary"] != POINT_UNCERTAINTY_CALIBRATION_CLAIM_BOUNDARY:
+            raise ValueError("point uncertainty calibration claim boundary changed")
+
+        result = cls(
+            provider_manifest_id=mapping["provider_manifest_id"],
+            cohort_binding_id=mapping["cohort_binding_id"],
+            source_covariance_localization_id=mapping[
+                "source_covariance_localization_id"
+            ],
+            source_training_sha256=mapping["source_training_sha256"],
+            feature_names=tuple(cast(list[Any], mapping["feature_names"])),
+            feature_mean=tuple(cast(list[Any], mapping["feature_mean"])),
+            feature_scale=tuple(cast(list[Any], mapping["feature_scale"])),
+            parallel_coefficients=tuple(
+                cast(list[Any], mapping["parallel_coefficients"])
+            ),
+            lateral_reference_coefficients=tuple(
+                cast(list[Any], mapping["lateral_reference_coefficients"])
+            ),
+            lateral_orthogonal_coefficients=tuple(
+                cast(list[Any], mapping["lateral_orthogonal_coefficients"])
+            ),
+            group_ids=tuple(cast(list[Any], mapping["group_ids"])),
+            group_counts=tuple(cast(list[Any], mapping["group_counts"])),
+            policy=PointUncertaintyCalibrationPolicyV2.from_dict(mapping["policy"]),
+            training_normalized_energy=tuple(
+                cast(list[Any], mapping["training_normalized_energy"])
+            ),
+            fit_iterations=mapping["fit_iterations"],
+            fit_converged=mapping["fit_converged"],
+            metadata=cast(Mapping[str, Any], mapping["metadata"]),
+        )
+        supplied_id = require_sha256(
+            mapping["point_uncertainty_calibration_id"],
+            name="point_uncertainty_calibration_id",
+        )
+        if supplied_id != result.point_uncertainty_calibration_id:
+            raise ValueError("point uncertainty calibration identity mismatch")
+        if plain_json(mapping) != result.to_dict():
+            raise ValueError("point uncertainty calibration derived fields changed")
+        return result
+
+    def _design(self, features: object) -> np.ndarray:
+        matrix = float_matrix(features, name="features")
+        if matrix.shape[1] != len(self.feature_names):
+            raise ValueError("features have the wrong number of columns")
+        standardized = (
+            matrix - np.asarray(self.feature_mean, dtype=np.float64)[None, :]
+        ) / np.asarray(self.feature_scale, dtype=np.float64)[None, :]
+        return np.column_stack((np.ones(matrix.shape[0]), standardized))
+
+    def predict_variances(self, features: object) -> np.ndarray:
+        """Predict ray, reference-tangent, and orthogonal-tangent variances."""
+
+        design = self._design(features)
+        coefficients = np.asarray(
+            [
+                self.parallel_coefficients,
+                self.lateral_reference_coefficients,
+                self.lateral_orthogonal_coefficients,
+            ],
+            dtype=np.float64,
+        )
+        log_variance = np.clip(
+            design @ coefficients.T,
+            self.policy.log_variance_lower,
+            self.policy.log_variance_upper,
+        )
+        return np.maximum(np.exp(log_variance), self.policy.variance_floor)
+
+    def covariance_matrices(
+        self,
+        ray_directions: object,
+        tangent_reference: object,
+        features: object,
+    ) -> np.ndarray:
+        """Construct conditional 3x3 covariances without shared gauge terms."""
+
+        rays, tangent_one, tangent_two = local_point_basis(
+            ray_directions,
+            tangent_reference,
+        )
+        variances = self.predict_variances(features)
+        if variances.shape[0] != rays.shape[0]:
+            raise ValueError("features and basis inputs must have matching rows")
+        return (
+            variances[:, 0, None, None] * np.einsum("ni,nj->nij", rays, rays)
+            + variances[:, 1, None, None]
+            * np.einsum("ni,nj->nij", tangent_one, tangent_one)
+            + variances[:, 2, None, None]
+            * np.einsum("ni,nj->nij", tangent_two, tangent_two)
+        )
+
+
+def write_point_uncertainty_calibration_v2(
+    path: str | Path,
+    calibration: PointUncertaintyCalibrationV2,
+    *,
+    overwrite: bool = False,
+) -> None:
+    if not isinstance(calibration, PointUncertaintyCalibrationV2):
+        raise TypeError("calibration must be PointUncertaintyCalibrationV2")
+    payload = json.dumps(
+        calibration.to_dict(),
+        sort_keys=True,
+        indent=2,
+        allow_nan=False,
+    ) + "\n"
+    atomic_write_text(path, payload, overwrite=overwrite)
+
+
+def load_point_uncertainty_calibration_v2(
+    path: str | Path,
+) -> PointUncertaintyCalibrationV2:
+    return PointUncertaintyCalibrationV2.from_dict(
+        load_json_object(path, name="point uncertainty v2 calibration")
+    )
+
+
+__all__ = [
+    "POINT_UNCERTAINTY_CALIBRATION_CLAIM_BOUNDARY",
+    "POINT_UNCERTAINTY_CALIBRATION_SCHEMA",
+    "POINT_UNCERTAINTY_CALIBRATION_VERSION",
+    "PointUncertaintyCalibrationV2",
+    "load_point_uncertainty_calibration_v2",
+    "write_point_uncertainty_calibration_v2",
+]

--- a/src/prob4d/point_uncertainty_v2.py
+++ b/src/prob4d/point_uncertainty_v2.py
@@ -1,0 +1,125 @@
+"""Experimental source-only three-axis point-uncertainty calibration.
+
+Version 2 models conditional point covariance in a local orthonormal basis:
+the viewing ray, a prediction-only reference tangent, and the orthogonal tangent.
+It can be fitted only after SourceCovarianceLocalizationV1 has explicitly
+localized the remaining failure to conditional point covariance.
+
+The shared Sim(3) gauge covariance remains outside this model.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections.abc import Sequence
+from pathlib import Path
+
+import numpy as np
+
+from ._point_uncertainty_v2_common import (
+    PointUncertaintyCalibrationPolicyV2,
+    local_point_basis,
+)
+from ._point_uncertainty_v2_fit import fit_point_uncertainty_calibration_v2
+from ._point_uncertainty_v2_model import (
+    POINT_UNCERTAINTY_CALIBRATION_CLAIM_BOUNDARY,
+    POINT_UNCERTAINTY_CALIBRATION_SCHEMA,
+    POINT_UNCERTAINTY_CALIBRATION_VERSION,
+    PointUncertaintyCalibrationV2,
+    load_point_uncertainty_calibration_v2,
+    write_point_uncertainty_calibration_v2,
+)
+from ._strict_json import load_json_object
+from .source_covariance_localization import load_source_covariance_localization
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    fit = subparsers.add_parser("fit")
+    fit.add_argument("--localization", type=Path, required=True)
+    fit.add_argument("--training", type=Path, required=True)
+    fit.add_argument("--policy", type=Path)
+    fit.add_argument("--output", type=Path, required=True)
+    fit.add_argument("--overwrite", action="store_true")
+    verify = subparsers.add_parser("verify")
+    verify.add_argument("--artifact", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _parser().parse_args(argv)
+    if arguments.command == "fit":
+        training_bytes = arguments.training.read_bytes()
+        with np.load(arguments.training, allow_pickle=False) as archive:
+            expected = {
+                "residual_xyz",
+                "ray_directions",
+                "tangent_reference",
+                "features",
+                "group_ids",
+                "feature_names",
+            }
+            if set(archive.files) != expected:
+                raise ValueError("training NPZ fields changed")
+            arrays = {name: np.asarray(archive[name]) for name in archive.files}
+        policy = (
+            None
+            if arguments.policy is None
+            else PointUncertaintyCalibrationPolicyV2.from_dict(
+                load_json_object(arguments.policy, name="point uncertainty v2 policy")
+            )
+        )
+        calibration = fit_point_uncertainty_calibration_v2(
+            load_source_covariance_localization(arguments.localization),
+            residual_xyz=arrays["residual_xyz"],
+            ray_directions=arrays["ray_directions"],
+            tangent_reference=arrays["tangent_reference"],
+            features=arrays["features"],
+            feature_names=tuple(str(item) for item in arrays["feature_names"].tolist()),
+            group_ids=tuple(str(item) for item in arrays["group_ids"].tolist()),
+            source_training_sha256=hashlib.sha256(training_bytes).hexdigest(),
+            policy=policy,
+        )
+        write_point_uncertainty_calibration_v2(
+            arguments.output,
+            calibration,
+            overwrite=arguments.overwrite,
+        )
+    else:
+        calibration = load_point_uncertainty_calibration_v2(arguments.artifact)
+
+    print(
+        json.dumps(
+            {
+                "point_uncertainty_calibration_id": (
+                    calibration.point_uncertainty_calibration_id
+                ),
+                "fit_converged": calibration.fit_converged,
+                "training_normalized_energy": list(
+                    calibration.training_normalized_energy
+                ),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0 if calibration.fit_converged else 2
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+
+
+__all__ = [
+    "POINT_UNCERTAINTY_CALIBRATION_CLAIM_BOUNDARY",
+    "POINT_UNCERTAINTY_CALIBRATION_SCHEMA",
+    "POINT_UNCERTAINTY_CALIBRATION_VERSION",
+    "PointUncertaintyCalibrationPolicyV2",
+    "PointUncertaintyCalibrationV2",
+    "fit_point_uncertainty_calibration_v2",
+    "load_point_uncertainty_calibration_v2",
+    "local_point_basis",
+    "write_point_uncertainty_calibration_v2",
+]

--- a/tests/test_point_uncertainty_v2.py
+++ b/tests/test_point_uncertainty_v2.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import copy
+
+import numpy as np
+import pytest
+
+from prob4d.point_uncertainty_v2 import (
+    PointUncertaintyCalibrationPolicyV2,
+    PointUncertaintyCalibrationV2,
+    fit_point_uncertainty_calibration_v2,
+    local_point_basis,
+)
+from prob4d.source_covariance_localization import (
+    SourceCovarianceLocalizationGroupV1,
+    SourceCovarianceLocalizationPolicyV1,
+    SourceCovarianceLocalizationV1,
+)
+
+
+def _localization(*, conditional_energy: float) -> SourceCovarianceLocalizationV1:
+    policy = SourceCovarianceLocalizationPolicyV1(
+        minimum_group_count=4,
+        normalized_nees_lower=0.5,
+        normalized_nees_upper=1.5,
+        minimum_joint_pass_fraction=0.75,
+        shared_energy_lower=0.5,
+        shared_energy_upper=1.5,
+        minimum_shared_pass_fraction=0.75,
+        conditional_energy_lower=0.8,
+        conditional_energy_upper=1.2,
+        minimum_conditional_pass_fraction=0.75,
+        require_shared_subspace=True,
+    )
+    groups = tuple(
+        SourceCovarianceLocalizationGroupV1(
+            group_id=f"group-{index}",
+            normalized_nees=1.0 if conditional_energy == 1.0 else 2.0,
+            shared_subspace_normalized_energy=1.0,
+            conditional_subspace_normalized_energy=conditional_energy,
+            joint_in_band=conditional_energy == 1.0,
+            shared_in_band=True,
+            conditional_in_band=conditional_energy == 1.0,
+        )
+        for index in range(4)
+    )
+    return SourceCovarianceLocalizationV1(
+        provider_manifest_id="1" * 64,
+        cohort_binding_id="2" * 64,
+        source_provider_competence_id="3" * 64,
+        joint_diagnostic_sha256="4" * 64,
+        joint_residual_source_sha256="5" * 64,
+        policy=policy,
+        groups=groups,
+        source_mean_status="pass",
+        identity_reliability_status="pass",
+    )
+
+
+def _synthetic_training(
+    localization: SourceCovarianceLocalizationV1,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, list[str]]:
+    rng = np.random.default_rng(19)
+    rows_per_group = 96
+    group_ids = [
+        group.group_id
+        for group in localization.groups
+        for _ in range(rows_per_group)
+    ]
+    row_count = len(group_ids)
+    features = rng.normal(size=(row_count, 3))
+    rays = rng.normal(size=(row_count, 3))
+    rays /= np.linalg.norm(rays, axis=1, keepdims=True)
+    tangent_reference = rng.normal(size=(row_count, 3))
+    rays, tangent_one, tangent_two = local_point_basis(
+        rays,
+        tangent_reference,
+    )
+
+    design = np.column_stack((np.ones(row_count), features))
+    coefficients = np.asarray(
+        [
+            [-5.0, 0.25, -0.10, 0.05],
+            [-5.4, 0.10, 0.20, -0.08],
+            [-6.2, -0.05, 0.12, 0.10],
+        ],
+        dtype=np.float64,
+    )
+    variances = np.exp(design @ coefficients.T)
+    local_residuals = rng.normal(size=(row_count, 3)) * np.sqrt(variances)
+    residual_xyz = (
+        local_residuals[:, 0, None] * rays
+        + local_residuals[:, 1, None] * tangent_one
+        + local_residuals[:, 2, None] * tangent_two
+    )
+    return residual_xyz, rays, tangent_reference, features, group_ids
+
+
+def test_local_point_basis_is_orthonormal_with_zero_reference() -> None:
+    rays = np.asarray([[0.0, 0.0, 1.0], [1.0, 1.0, 1.0]])
+    references = np.zeros_like(rays)
+    ray, tangent_one, tangent_two = local_point_basis(rays, references)
+
+    for basis in (ray, tangent_one, tangent_two):
+        np.testing.assert_allclose(np.linalg.norm(basis, axis=1), 1.0)
+    np.testing.assert_allclose(np.sum(ray * tangent_one, axis=1), 0.0, atol=1e-12)
+    np.testing.assert_allclose(np.sum(ray * tangent_two, axis=1), 0.0, atol=1e-12)
+    np.testing.assert_allclose(
+        np.sum(tangent_one * tangent_two, axis=1),
+        0.0,
+        atol=1e-12,
+    )
+
+
+def test_fit_requires_explicit_point_covariance_localization() -> None:
+    localization = _localization(conditional_energy=1.0)
+    residuals, rays, references, features, group_ids = _synthetic_training(
+        localization
+    )
+    assert localization.classification == "covariance-adequate"
+    assert not localization.authorize_point_uncertainty_development
+
+    with pytest.raises(ValueError, match="point-covariance-localized"):
+        fit_point_uncertainty_calibration_v2(
+            localization,
+            residual_xyz=residuals,
+            ray_directions=rays,
+            tangent_reference=references,
+            features=features,
+            feature_names=("depth", "flow", "disagreement"),
+            group_ids=group_ids,
+            source_training_sha256="6" * 64,
+            policy=PointUncertaintyCalibrationPolicyV2(
+                minimum_group_count=4,
+                minimum_rows_per_group=64,
+            ),
+        )
+
+
+def test_fit_is_group_balanced_anisotropic_and_roundtrips() -> None:
+    localization = _localization(conditional_energy=2.0)
+    residuals, rays, references, features, group_ids = _synthetic_training(
+        localization
+    )
+    calibration = fit_point_uncertainty_calibration_v2(
+        localization,
+        residual_xyz=residuals,
+        ray_directions=rays,
+        tangent_reference=references,
+        features=features,
+        feature_names=("depth", "flow", "disagreement"),
+        group_ids=group_ids,
+        source_training_sha256="6" * 64,
+        policy=PointUncertaintyCalibrationPolicyV2(
+            minimum_group_count=4,
+            minimum_rows_per_group=64,
+        ),
+    )
+
+    assert calibration.fit_converged
+    assert calibration.group_counts == (96, 96, 96, 96)
+    np.testing.assert_allclose(
+        calibration.training_normalized_energy,
+        np.ones(3),
+        atol=0.04,
+    )
+    predicted = calibration.predict_variances(features)
+    assert predicted.shape == (features.shape[0], 3)
+    assert np.all(predicted > 0.0)
+    assert np.mean(predicted[:, 1]) > 1.4 * np.mean(predicted[:, 2])
+
+    covariance = calibration.covariance_matrices(
+        rays[:32],
+        references[:32],
+        features[:32],
+    )
+    np.testing.assert_allclose(
+        covariance,
+        np.transpose(covariance, (0, 2, 1)),
+        atol=1e-12,
+    )
+    assert np.all(np.linalg.eigvalsh(covariance) > 0.0)
+
+    restored = PointUncertaintyCalibrationV2.from_dict(calibration.to_dict())
+    assert (
+        restored.point_uncertainty_calibration_id
+        == calibration.point_uncertainty_calibration_id
+    )
+
+
+def test_fit_rejects_group_roster_mismatch() -> None:
+    localization = _localization(conditional_energy=2.0)
+    residuals, rays, references, features, group_ids = _synthetic_training(
+        localization
+    )
+    group_ids[-1] = "unexpected-group"
+
+    with pytest.raises(ValueError, match="exactly match"):
+        fit_point_uncertainty_calibration_v2(
+            localization,
+            residual_xyz=residuals,
+            ray_directions=rays,
+            tangent_reference=references,
+            features=features,
+            feature_names=("depth", "flow", "disagreement"),
+            group_ids=group_ids,
+            source_training_sha256="6" * 64,
+            policy=PointUncertaintyCalibrationPolicyV2(
+                minimum_group_count=4,
+                minimum_rows_per_group=64,
+            ),
+        )
+
+
+def test_calibration_content_address_detects_tampering() -> None:
+    localization = _localization(conditional_energy=2.0)
+    residuals, rays, references, features, group_ids = _synthetic_training(
+        localization
+    )
+    calibration = fit_point_uncertainty_calibration_v2(
+        localization,
+        residual_xyz=residuals,
+        ray_directions=rays,
+        tangent_reference=references,
+        features=features,
+        feature_names=("depth", "flow", "disagreement"),
+        group_ids=group_ids,
+        source_training_sha256="6" * 64,
+        policy=PointUncertaintyCalibrationPolicyV2(
+            minimum_group_count=4,
+            minimum_rows_per_group=64,
+        ),
+    )
+    tampered = copy.deepcopy(calibration.to_dict())
+    tampered["parallel_coefficients"][0] += 0.1
+
+    with pytest.raises(ValueError, match="identity mismatch"):
+        PointUncertaintyCalibrationV2.from_dict(tampered)


### PR DESCRIPTION
## Summary

Add an experimental three-axis conditional point-covariance calibrator that is available only after `SourceCovarianceLocalizationV1` explicitly classifies the source-side failure as `point-covariance-localized`.

- model covariance in the local `(ray, prediction-reference tangent, orthogonal tangent)` basis;
- fit log variances by equal-group weighted Gaussian NLL with damped Newton steps;
- shrink the two lateral models toward the existing isotropic-lateral model with an explicit coupling penalty;
- keep shared `Sim(3)` gauge uncertainty outside the local covariance;
- bind the exact source training NPZ and localization artifact into a content-addressed calibration artifact;
- reject changed/partial group rosters and unauthorized covariance development;
- add synthetic anisotropy, SPD, round-trip, tamper, and stop-rule tests; and
- document the scientific promotion boundary.

## Scientific boundary

This PR does **not** change provider-v2 export defaults and does not promote the richer model. A successful fit is not provider-competence or calibration evidence. Promotion still requires a separately frozen disjoint source-validation or fresh object/session result with proper-score, coverage/width, and downstream BayesianPhysTwin gates.

## Validation

Local syntax checks and a standalone synthetic numerical exercise converged in 5 Newton iterations with normalized training energies approximately `(1.0000, 1.0068, 0.9932)`, positive-definite predicted covariances, and content-address round-trip parity. GitHub Actions is the authoritative repository integration check.