### PR TITLE
Bind Sim3 propagation adequacy to provider readiness

### DIFF
--- a/docs/gauge-propagation-readiness.md
+++ b/docs/gauge-propagation-readiness.md
@@ -161,6 +161,19 @@ allow the conditional point-covariance result to enter the final fresh-provider
 readiness request. A source gauge/dependence failure remains terminal and cannot
 be overridden by a separately adequate linearization certificate.
 
+## Point-uncertainty-v2 enforcement
+
+`fit_point_uncertainty_calibration_v2` requires this propagation artifact in
+addition to `SourceCovarianceLocalizationV1`. The fitter validates the provider,
+cohort, source-localization, source-group, and propagation identities before it
+reads any residual, feature, or basis array. The resulting calibration artifact
+binds `gauge_propagation_readiness_id` into its content identity.
+
+A propagation failure, technical failure, binding mismatch, or fallback-required
+result therefore cannot be bypassed by calling the point-v2 fitter directly. The
+research CLI likewise loads and validates `--localization` and `--propagation`
+before opening `--training`.
+
 ## Scientific boundary
 
 These artifacts are source-only readiness and failure-localization evidence. They

--- a/docs/gauge-propagation-readiness.md
+++ b/docs/gauge-propagation-readiness.md
@@ -1,0 +1,172 @@
+# Gauge-propagation readiness
+
+Prob4D distinguishes two valid ways to carry uncertain `Sim(3)` gauges into a
+physical query:
+
+1. retain the explicit gauge latent; or
+2. marginalize it through a frozen first-order approximation.
+
+The second route is an approximation and must not be admitted merely because the
+source covariance decomposition looks calibrated. A nonlinear gauge posterior can
+make a Jacobian-propagated covariance inaccurate even when the underlying shared
+and conditional covariance components are otherwise well specified.
+
+`prob4d.gauge_propagation_readiness` binds that missing prerequisite into the
+prospective fresh-provider information order.
+
+## Information order
+
+For a first-order-marginalized provider, use the following order before any
+protected target is opened:
+
+1. pass support feasibility and source mean/identity competence;
+2. run source covariance localization;
+3. require the source `gauge-dependence` result to pass;
+4. generate a source-only nonlinear-versus-linearized `Sim(3)` certificate for
+   the exact frozen query projection;
+5. bind the certificate to the provider, cohort, source covariance localization,
+   source group roster, and query definition; and
+6. compose the propagation result with the source covariance gates.
+
+If the propagation result fails or is technically incomplete, the
+`point-covariance` gate remains `not-evaluated`. This prevents nonlinear gauge
+error from being misclassified as evidence authorizing a richer conditional point
+model.
+
+An explicit-gauge-latent implementation does not need a linearization certificate.
+It still receives a content-addressed propagation record so the readiness request
+states explicitly that no first-order marginalization was used.
+
+## Strict certificate verification
+
+The original diagnostic emits a content-addressed JSON certificate. The strict
+loader replays all fields and its identity, rejects duplicate JSON keys, validates
+point and query diagnostic rosters, and detects tampering:
+
+```bash
+python -m prob4d.diagnostics.sim3_linearization_certificate \
+  source-linearization.json
+```
+
+Add `--fail-on-inadequate` when a valid but inadequate certificate should return
+status 2.
+
+## Required source-only binding
+
+A certificate used for fresh-provider readiness must include this exact nested
+metadata object:
+
+```json
+{
+  "fresh_provider_readiness_binding": {
+    "provider_manifest_id": "<sha256>",
+    "cohort_binding_id": "<sha256>",
+    "query_definition_id": "<sha256>",
+    "source_covariance_localization_id": "<sha256>",
+    "source_group_ids": ["object-or-session-a", "object-or-session-b"],
+    "causal_prefix_only": true,
+    "target_residuals_used": false,
+    "target_outcomes_used": false
+  }
+}
+```
+
+The builder rejects mismatched provider, cohort, query, localization, or source
+roster identities as invalid evidence. It also rejects noncausal bindings and any
+claim that target residuals or outcomes were used. Those are not scientific
+negative results.
+
+## First-order policy
+
+Freeze the policy before producing the certificate. For example:
+
+```json
+{
+  "propagation_mode": "first-order-marginalized",
+  "expected_perturbation_side": "left",
+  "expected_parameter_order": ["scale", "rotation", "translation"],
+  "minimum_sample_count": 4096,
+  "require_query_projection": true,
+  "require_supplied_jacobian_validation": true
+}
+```
+
+The policy verifies the exact perturbation convention and block order, minimum
+Monte Carlo sample count, presence of query-space diagnostics, and—when required—
+that a supplied analytic Jacobian passed the independent finite-difference check.
+
+Build and verify the propagation artifact:
+
+```bash
+python -m prob4d.gauge_propagation_readiness build \
+  --localization source-covariance-localization.json \
+  --policy gauge-propagation-policy.json \
+  --query-definition-id <sha256> \
+  --certificate source-linearization.json \
+  --output gauge-propagation-readiness.json
+
+python -m prob4d.gauge_propagation_readiness verify \
+  --artifact gauge-propagation-readiness.json
+```
+
+A first-order certificate can produce three terminal results:
+
+- `first-order-adequate`: permit only the declared first-order marginalization;
+- `first-order-inadequate`: retain the explicit gauge latent or exact fallback;
+- `technical-failure`: evidence is valid but incomplete for the frozen policy,
+  such as too few samples, a missing query projection, or an unvalidated supplied
+  Jacobian.
+
+Neither failure authorizes target-side covariance inflation.
+
+## Explicit-latent policy
+
+The explicit route uses this canonical policy:
+
+```json
+{
+  "propagation_mode": "explicit-gauge-latent",
+  "expected_perturbation_side": null,
+  "expected_parameter_order": [],
+  "minimum_sample_count": 0,
+  "require_query_projection": false,
+  "require_supplied_jacobian_validation": false
+}
+```
+
+No certificate is supplied. The resulting pass means only that the declared
+provider retains the gauge latent rather than relying on the tested approximation.
+It does not establish calibration or physical-query benefit.
+
+## Gate composition
+
+Use `compose_source_covariance_readiness_gates` with the exact
+`FreshProviderCohortLockV1`. It verifies the cohort and query bindings and applies
+the strict stage order:
+
+```python
+from prob4d.gauge_propagation_readiness import (
+    compose_source_covariance_readiness_gates,
+)
+
+gauge_gate, point_gate = compose_source_covariance_readiness_gates(
+    cohort_lock,
+    source_covariance_localization,
+    gauge_propagation_readiness,
+)
+```
+
+Only a passing source gauge/dependence result and a passing propagation result
+allow the conditional point-covariance result to enter the final fresh-provider
+readiness request. A source gauge/dependence failure remains terminal and cannot
+be overridden by a separately adequate linearization certificate.
+
+## Scientific boundary
+
+These artifacts are source-only readiness and failure-localization evidence. They
+do not establish real-provider competence, target calibration, BayesianPhysTwin
+benefit, Causal4D intervention benefit, deployment safety, or state of the art.
+They do not reopen the already-used MotionCrafter interactions or Deform360 source
+objects, and they do not authorize a new point-uncertainty model unless the
+remaining conditional point-covariance gate is localized after every earlier gate
+passes.

--- a/docs/point-uncertainty-v2.md
+++ b/docs/point-uncertainty-v2.md
@@ -1,17 +1,22 @@
 # Point uncertainty calibration v2
 
 `PointUncertaintyCalibrationV2` is an **experimental, source/calibration-only**
-conditional point-covariance model. It is deliberately downstream of
-`SourceCovarianceLocalizationV1` and refuses to fit unless that artifact classifies
-the remaining source-side failure as `point-covariance-localized`.
+conditional point-covariance model. It is deliberately downstream of both
+`SourceCovarianceLocalizationV1` and `GaugePropagationReadinessV1`. It refuses to
+fit unless the localization classifies the remaining source-side failure as
+`point-covariance-localized` and the declared gauge-propagation path passes for
+the same provider, cohort, source groups, and frozen physical query.
 
 This preserves the provider stop rule:
 
 1. support failure redirects the provider;
 2. observation-mean failure redirects the provider;
 3. identity/association failure redirects the provider;
-4. gauge/dependence failure redirects the gauge or dependence model; and
-5. only a conditional point-covariance failure authorizes this model.
+4. gauge/dependence failure redirects the gauge or dependence model;
+5. inadequate or incomplete first-order gauge propagation retains the explicit
+   gauge latent or exact fallback; and
+6. only a conditional point-covariance failure after propagation admission
+   authorizes this model.
 
 The model is not enabled in provider v2 exports by this implementation.
 
@@ -106,19 +111,29 @@ source-validation or fresh-target evaluation.
 
 ## Authorization
 
-The Python API requires an actual `SourceCovarianceLocalizationV1` instance and
-checks both:
+The Python API requires actual `SourceCovarianceLocalizationV1` and
+`GaugePropagationReadinessV1` instances. Before reading or validating any training
+array it checks:
 
 ```text
-classification == "point-covariance-localized"
-authorize_point_uncertainty_development == true
+localization.classification == "point-covariance-localized"
+localization.authorize_point_uncertainty_development == true
+propagation.gate_status == "pass"
+propagation.classification in {
+    "explicit-gauge-latent-retained",
+    "first-order-adequate",
+}
 ```
 
-Any other source classification raises an error before training rows are used.
+It also requires exact provider, cohort, source-localization, and independent-group
+identity agreement. A failed or technically incomplete propagation decision is
+terminal for this fitter even when conditional point covariance appears poor. This
+prevents nonlinear gauge-propagation error from being absorbed into local point
+variance.
 
-The training group roster must exactly equal the localization's independent group
-roster. This prevents a richer covariance model from silently being fitted on a
-different or partial source cohort.
+The training group roster must exactly equal both the localization and propagation
+source-group roster. This prevents a richer covariance model from silently being
+fitted on a different or partial source cohort.
 
 ## Training data
 
@@ -133,13 +148,16 @@ The CLI accepts one NPZ with exactly these arrays:
 - `group_ids`: shape `(N,)`, physical object/session IDs; and
 - `feature_names`: shape `(F,)`.
 
-The complete NPZ bytes are SHA-256 bound into the output artifact.
+The complete NPZ bytes are SHA-256 bound into the output artifact. The artifact
+also binds the exact `gauge_propagation_readiness_id`; a calibration cannot be
+replayed under a different explicit-latent or first-order propagation decision.
 
 Example:
 
 ```bash
 python -m prob4d.point_uncertainty_v2 fit \
   --localization outputs/source-covariance-localization.json \
+  --propagation outputs/gauge-propagation-readiness.json \
   --training outputs/point-uncertainty-source-v2.npz \
   --policy protocols/point-uncertainty-v2-policy.json \
   --output outputs/point-uncertainty-v2.json
@@ -193,7 +211,8 @@ that demonstrates, on disjoint source-validation or fresh object/session units:
 - acceptable interval/covariance width;
 - no degradation of point-mean or identity competence;
 - no evidence that the remaining error is actually shared gauge/common-mode
-  error; and
+  error or first-order propagation distortion;
+- the same passing gauge-propagation readiness artifact used for fitting; and
 - downstream BayesianPhysTwin benefit under the same regret guard and exact
   fallback rule.
 

--- a/src/prob4d/_point_uncertainty_v2_fit.py
+++ b/src/prob4d/_point_uncertainty_v2_fit.py
@@ -14,6 +14,7 @@ from ._point_uncertainty_v2_common import (
 )
 from ._point_uncertainty_v2_model import PointUncertaintyCalibrationV2
 from ._strict_json import require_exact_string, require_sha256
+from .gauge_propagation_readiness import GaugePropagationReadinessV1
 from .source_covariance_localization import SourceCovarianceLocalizationV1
 
 
@@ -203,8 +204,51 @@ def _fit_lateral(
     return first, second, policy.maximum_iterations, False
 
 
+def validate_point_uncertainty_v2_eligibility(
+    localization: SourceCovarianceLocalizationV1,
+    propagation: GaugePropagationReadinessV1,
+) -> tuple[str, ...]:
+    """Validate source localization and gauge propagation before residual access."""
+
+    if not isinstance(localization, SourceCovarianceLocalizationV1):
+        raise TypeError("localization must be SourceCovarianceLocalizationV1")
+    if (
+        localization.classification != "point-covariance-localized"
+        or not localization.authorize_point_uncertainty_development
+    ):
+        raise ValueError(
+            "PointUncertaintyCalibrationV2 requires point-covariance-localized authorization"
+        )
+    if not isinstance(propagation, GaugePropagationReadinessV1):
+        raise TypeError("propagation must be GaugePropagationReadinessV1")
+    if propagation.provider_manifest_id != localization.provider_manifest_id:
+        raise ValueError("propagation and localization provider IDs differ")
+    if propagation.cohort_binding_id != localization.cohort_binding_id:
+        raise ValueError("propagation and localization cohort IDs differ")
+    if propagation.source_covariance_localization_id != (
+        localization.source_covariance_localization_id
+    ):
+        raise ValueError("propagation references a different covariance localization")
+    required_groups = tuple(group.group_id for group in localization.groups)
+    if propagation.source_group_ids != required_groups:
+        raise ValueError("propagation and localization source groups differ")
+    if propagation.gate_status != "pass":
+        raise ValueError(
+            "PointUncertaintyCalibrationV2 requires passing gauge propagation readiness"
+        )
+    if propagation.explicit_latent_or_exact_fallback_required:
+        raise ValueError("gauge propagation requires the explicit latent or exact fallback")
+    if propagation.classification not in {
+        "explicit-gauge-latent-retained",
+        "first-order-adequate",
+    }:
+        raise ValueError("gauge propagation classification does not authorize fitting")
+    return required_groups
+
+
 def fit_point_uncertainty_calibration_v2(
     localization: SourceCovarianceLocalizationV1,
+    propagation: GaugePropagationReadinessV1,
     *,
     residual_xyz: object,
     ray_directions: object,
@@ -218,15 +262,10 @@ def fit_point_uncertainty_calibration_v2(
 ) -> PointUncertaintyCalibrationV2:
     """Fit the gated equal-group Gaussian variance model."""
 
-    if not isinstance(localization, SourceCovarianceLocalizationV1):
-        raise TypeError("localization must be SourceCovarianceLocalizationV1")
-    if (
-        localization.classification != "point-covariance-localized"
-        or not localization.authorize_point_uncertainty_development
-    ):
-        raise ValueError(
-            "PointUncertaintyCalibrationV2 requires point-covariance-localized authorization"
-        )
+    required_groups = validate_point_uncertainty_v2_eligibility(
+        localization,
+        propagation,
+    )
     fit_policy = PointUncertaintyCalibrationPolicyV2() if policy is None else policy
     if not isinstance(fit_policy, PointUncertaintyCalibrationPolicyV2):
         raise TypeError("policy must be PointUncertaintyCalibrationPolicyV2")
@@ -244,7 +283,6 @@ def fit_point_uncertainty_calibration_v2(
     if len(group_ids) != residuals.shape[0]:
         raise ValueError("group_ids and residual_xyz must have matching rows")
 
-    required_groups = tuple(group.group_id for group in localization.groups)
     weights, group_counts = _group_weights(
         group_ids,
         required_groups=required_groups,
@@ -299,6 +337,7 @@ def fit_point_uncertainty_calibration_v2(
         provider_manifest_id=localization.provider_manifest_id,
         cohort_binding_id=localization.cohort_binding_id,
         source_covariance_localization_id=localization.source_covariance_localization_id,
+        gauge_propagation_readiness_id=propagation.gauge_propagation_readiness_id,
         source_training_sha256=require_sha256(
             source_training_sha256,
             name="source_training_sha256",
@@ -319,4 +358,7 @@ def fit_point_uncertainty_calibration_v2(
     )
 
 
-__all__ = ["fit_point_uncertainty_calibration_v2"]
+__all__ = [
+    "fit_point_uncertainty_calibration_v2",
+    "validate_point_uncertainty_v2_eligibility",
+]

--- a/src/prob4d/_point_uncertainty_v2_model.py
+++ b/src/prob4d/_point_uncertainty_v2_model.py
@@ -32,10 +32,12 @@ POINT_UNCERTAINTY_CALIBRATION_SCHEMA = "prob4d.point-uncertainty-calibration"
 POINT_UNCERTAINTY_CALIBRATION_VERSION = 2
 POINT_UNCERTAINTY_CALIBRATION_CLAIM_BOUNDARY = (
     "This source/calibration-only artifact is an experimental conditional point-covariance "
-    "model authorized by an explicit point-covariance-localized source diagnostic. It does "
-    "not absorb shared Sim(3) gauge uncertainty, use protected target outcomes, establish "
-    "provider competence or transfer, authorize a BayesianPhysTwin update, establish "
-    "Causal4D intervention benefit, deployment safety, or state of the art."
+    "model authorized by an explicit point-covariance-localized source diagnostic and a "
+    "passing gauge-propagation readiness decision for the same provider, cohort, source "
+    "groups, and physical query. It does not absorb shared Sim(3) gauge uncertainty, use "
+    "protected target outcomes, establish provider competence or transfer, authorize a "
+    "BayesianPhysTwin update, establish Causal4D intervention benefit, deployment safety, "
+    "or state of the art."
 )
 
 _ARTIFACT_FIELDS = frozenset(
@@ -45,6 +47,7 @@ _ARTIFACT_FIELDS = frozenset(
         "provider_manifest_id",
         "cohort_binding_id",
         "source_covariance_localization_id",
+        "gauge_propagation_readiness_id",
         "source_training_sha256",
         "feature_names",
         "feature_mean",
@@ -82,6 +85,7 @@ class PointUncertaintyCalibrationV2:
     provider_manifest_id: str
     cohort_binding_id: str
     source_covariance_localization_id: str
+    gauge_propagation_readiness_id: str
     source_training_sha256: str
     feature_names: tuple[str, ...]
     feature_mean: tuple[float, ...]
@@ -103,6 +107,7 @@ class PointUncertaintyCalibrationV2:
             "provider_manifest_id",
             "cohort_binding_id",
             "source_covariance_localization_id",
+            "gauge_propagation_readiness_id",
             "source_training_sha256",
         ):
             object.__setattr__(self, name, require_sha256(getattr(self, name), name=name))
@@ -191,6 +196,7 @@ class PointUncertaintyCalibrationV2:
             "provider_manifest_id": self.provider_manifest_id,
             "cohort_binding_id": self.cohort_binding_id,
             "source_covariance_localization_id": self.source_covariance_localization_id,
+            "gauge_propagation_readiness_id": self.gauge_propagation_readiness_id,
             "source_training_sha256": self.source_training_sha256,
             "feature_names": list(self.feature_names),
             "feature_mean": list(self.feature_mean),
@@ -234,6 +240,9 @@ class PointUncertaintyCalibrationV2:
             cohort_binding_id=mapping["cohort_binding_id"],
             source_covariance_localization_id=mapping[
                 "source_covariance_localization_id"
+            ],
+            gauge_propagation_readiness_id=mapping[
+                "gauge_propagation_readiness_id"
             ],
             source_training_sha256=mapping["source_training_sha256"],
             feature_names=tuple(cast(list[Any], mapping["feature_names"])),

--- a/src/prob4d/diagnostics/sim3_linearization_certificate.py
+++ b/src/prob4d/diagnostics/sim3_linearization_certificate.py
@@ -1,0 +1,479 @@
+"""Strict loading and verification for Sim(3) linearization certificates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from .._immutable_json import plain_json
+from .._strict_json import (
+    load_json_object,
+    require_exact_fields,
+    require_exact_integer,
+    require_exact_string,
+    require_finite_json_mapping,
+    require_json_number,
+    require_mapping,
+    require_sha256,
+)
+from .sim3_linearization import (
+    SIM3_LINEARIZATION_CLAIM_BOUNDARY,
+    SIM3_LINEARIZATION_SCHEMA,
+    SIM3_LINEARIZATION_VERSION,
+    GaussianLinearizationAdequacyV1,
+    LinearizationAdequacyThresholdsV1,
+)
+
+_CERTIFICATE_FIELDS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "parameterization",
+        "parameter_order",
+        "parameter_dimension",
+        "output_shape",
+        "sample_count",
+        "batch_size",
+        "seed",
+        "finite_difference_step",
+        "jacobian_validated",
+        "thresholds",
+        "point_diagnostics",
+        "query_diagnostics",
+        "adequate",
+        "failure_reasons",
+        "metadata",
+        "claim_boundary",
+        "gaussian_linearization_adequacy_id",
+    }
+)
+_THRESHOLD_FIELDS = frozenset(
+    {
+        "maximum_relative_trace_error",
+        "maximum_relative_frobenius_error",
+        "maximum_mean_shift_standard_deviations",
+        "maximum_principal_axis_angle_degrees",
+        "minimum_principal_axis_anisotropy",
+        "maximum_query_relative_trace_error",
+        "maximum_query_relative_frobenius_error",
+        "maximum_query_mean_shift_standard_deviations",
+    }
+)
+_POINT_FIELDS = frozenset(
+    {
+        "item_index",
+        "relative_trace_error",
+        "relative_frobenius_error",
+        "mean_shift_standard_deviations",
+        "nonlinear_trace",
+        "linearized_trace",
+        "principal_axis_anisotropy",
+        "principal_axis_angle_degrees",
+    }
+)
+_QUERY_FIELDS = frozenset(
+    {
+        "query_dimension",
+        "relative_trace_error",
+        "relative_frobenius_error",
+        "mean_shift_standard_deviations",
+        "nonlinear_trace",
+        "linearized_trace",
+    }
+)
+
+
+def _strict_bool(value: object, *, name: str) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be a Boolean")
+    return value
+
+
+def _finite_number(value: object, *, name: str) -> float:
+    return require_json_number(value, name=name)
+
+
+def _nonnegative_number(value: object, *, name: str) -> float:
+    result = _finite_number(value, name=name)
+    if result < 0.0:
+        raise ValueError(f"{name} must be non-negative")
+    return result
+
+
+def _optional_nonnegative_number(value: object, *, name: str) -> float | None:
+    if value is None:
+        return None
+    return _nonnegative_number(value, name=name)
+
+
+def _string_tuple(
+    value: object,
+    *,
+    name: str,
+    allow_empty: bool,
+    require_unique: bool,
+) -> tuple[str, ...]:
+    if type(value) is not list:
+        raise ValueError(f"{name} must be a JSON array")
+    result = tuple(
+        require_exact_string(item, name=f"{name}[{index}]")
+        for index, item in enumerate(value)
+    )
+    if not allow_empty and not result:
+        raise ValueError(f"{name} must not be empty")
+    if require_unique and len(result) != len(set(result)):
+        raise ValueError(f"{name} must not contain duplicates")
+    return result
+
+
+def _output_shape(value: object) -> tuple[int, int]:
+    if type(value) is not list or len(value) != 2:
+        raise ValueError("output_shape must be a two-element JSON array")
+    return (
+        require_exact_integer(value[0], name="output_shape[0]", minimum=1),
+        require_exact_integer(value[1], name="output_shape[1]", minimum=1),
+    )
+
+
+def _thresholds(value: object) -> LinearizationAdequacyThresholdsV1:
+    mapping = require_mapping(value, name="linearization thresholds")
+    require_exact_fields(mapping, _THRESHOLD_FIELDS, name="linearization thresholds")
+    return LinearizationAdequacyThresholdsV1(
+        maximum_relative_trace_error=_nonnegative_number(
+            mapping["maximum_relative_trace_error"],
+            name="maximum_relative_trace_error",
+        ),
+        maximum_relative_frobenius_error=_nonnegative_number(
+            mapping["maximum_relative_frobenius_error"],
+            name="maximum_relative_frobenius_error",
+        ),
+        maximum_mean_shift_standard_deviations=_nonnegative_number(
+            mapping["maximum_mean_shift_standard_deviations"],
+            name="maximum_mean_shift_standard_deviations",
+        ),
+        maximum_principal_axis_angle_degrees=_nonnegative_number(
+            mapping["maximum_principal_axis_angle_degrees"],
+            name="maximum_principal_axis_angle_degrees",
+        ),
+        minimum_principal_axis_anisotropy=_nonnegative_number(
+            mapping["minimum_principal_axis_anisotropy"],
+            name="minimum_principal_axis_anisotropy",
+        ),
+        maximum_query_relative_trace_error=_nonnegative_number(
+            mapping["maximum_query_relative_trace_error"],
+            name="maximum_query_relative_trace_error",
+        ),
+        maximum_query_relative_frobenius_error=_nonnegative_number(
+            mapping["maximum_query_relative_frobenius_error"],
+            name="maximum_query_relative_frobenius_error",
+        ),
+        maximum_query_mean_shift_standard_deviations=_nonnegative_number(
+            mapping["maximum_query_mean_shift_standard_deviations"],
+            name="maximum_query_mean_shift_standard_deviations",
+        ),
+    )
+
+
+def _point_diagnostic(value: object, *, index: int) -> Mapping[str, Any]:
+    mapping = require_mapping(value, name=f"point_diagnostics[{index}]")
+    require_exact_fields(mapping, _POINT_FIELDS, name=f"point_diagnostics[{index}]")
+    item_index = require_exact_integer(
+        mapping["item_index"],
+        name=f"point_diagnostics[{index}].item_index",
+        minimum=0,
+    )
+    if item_index != index:
+        raise ValueError("point_diagnostics item_index values must be contiguous and ordered")
+    normalized: dict[str, Any] = {
+        "item_index": item_index,
+        "relative_trace_error": _nonnegative_number(
+            mapping["relative_trace_error"],
+            name=f"point_diagnostics[{index}].relative_trace_error",
+        ),
+        "relative_frobenius_error": _nonnegative_number(
+            mapping["relative_frobenius_error"],
+            name=f"point_diagnostics[{index}].relative_frobenius_error",
+        ),
+        "mean_shift_standard_deviations": _nonnegative_number(
+            mapping["mean_shift_standard_deviations"],
+            name=f"point_diagnostics[{index}].mean_shift_standard_deviations",
+        ),
+        "nonlinear_trace": _nonnegative_number(
+            mapping["nonlinear_trace"],
+            name=f"point_diagnostics[{index}].nonlinear_trace",
+        ),
+        "linearized_trace": _nonnegative_number(
+            mapping["linearized_trace"],
+            name=f"point_diagnostics[{index}].linearized_trace",
+        ),
+        "principal_axis_anisotropy": _nonnegative_number(
+            mapping["principal_axis_anisotropy"],
+            name=f"point_diagnostics[{index}].principal_axis_anisotropy",
+        ),
+        "principal_axis_angle_degrees": _optional_nonnegative_number(
+            mapping["principal_axis_angle_degrees"],
+            name=f"point_diagnostics[{index}].principal_axis_angle_degrees",
+        ),
+    }
+    return require_finite_json_mapping(
+        normalized,
+        name=f"point_diagnostics[{index}]",
+    )
+
+
+def _query_diagnostic(value: object) -> Mapping[str, Any] | None:
+    if value is None:
+        return None
+    mapping = require_mapping(value, name="query_diagnostics")
+    require_exact_fields(mapping, _QUERY_FIELDS, name="query_diagnostics")
+    normalized = {
+        "query_dimension": require_exact_integer(
+            mapping["query_dimension"],
+            name="query_diagnostics.query_dimension",
+            minimum=1,
+        ),
+        "relative_trace_error": _nonnegative_number(
+            mapping["relative_trace_error"],
+            name="query_diagnostics.relative_trace_error",
+        ),
+        "relative_frobenius_error": _nonnegative_number(
+            mapping["relative_frobenius_error"],
+            name="query_diagnostics.relative_frobenius_error",
+        ),
+        "mean_shift_standard_deviations": _nonnegative_number(
+            mapping["mean_shift_standard_deviations"],
+            name="query_diagnostics.mean_shift_standard_deviations",
+        ),
+        "nonlinear_trace": _nonnegative_number(
+            mapping["nonlinear_trace"],
+            name="query_diagnostics.nonlinear_trace",
+        ),
+        "linearized_trace": _nonnegative_number(
+            mapping["linearized_trace"],
+            name="query_diagnostics.linearized_trace",
+        ),
+    }
+    return require_finite_json_mapping(normalized, name="query_diagnostics")
+
+
+def _replayed_failure_reasons(
+    points: tuple[Mapping[str, Any], ...],
+    query: Mapping[str, Any] | None,
+    thresholds: LinearizationAdequacyThresholdsV1,
+    *,
+    output_dimension: int,
+) -> tuple[str, ...]:
+    """Replay the diagnostic decision from persisted metrics and frozen thresholds."""
+
+    maximum_trace_error = max(
+        float(point["relative_trace_error"]) for point in points
+    )
+    maximum_frobenius_error = max(
+        float(point["relative_frobenius_error"]) for point in points
+    )
+    maximum_mean_shift = max(
+        float(point["mean_shift_standard_deviations"]) for point in points
+    )
+    axis_angles: list[float] = []
+    for index, point in enumerate(points):
+        anisotropy = float(point["principal_axis_anisotropy"])
+        raw_angle = point["principal_axis_angle_degrees"]
+        angle = None if raw_angle is None else float(raw_angle)
+        should_have_angle = (
+            output_dimension >= 2
+            and anisotropy >= thresholds.minimum_principal_axis_anisotropy
+        )
+        if should_have_angle != (angle is not None):
+            raise ValueError(
+                "point diagnostic principal-axis angle presence changed at "
+                f"item {index}"
+            )
+        if angle is not None:
+            if angle > 90.0:
+                raise ValueError(
+                    "point diagnostic principal-axis angle must not exceed 90 degrees"
+                )
+            axis_angles.append(angle)
+
+    reasons: list[str] = []
+    if maximum_trace_error > thresholds.maximum_relative_trace_error:
+        reasons.append("point-trace-distortion")
+    if maximum_frobenius_error > thresholds.maximum_relative_frobenius_error:
+        reasons.append("point-frobenius-distortion")
+    if maximum_mean_shift > thresholds.maximum_mean_shift_standard_deviations:
+        reasons.append("point-mean-shift")
+    if axis_angles and max(axis_angles) > thresholds.maximum_principal_axis_angle_degrees:
+        reasons.append("point-principal-axis-rotation")
+    if query is not None:
+        if float(query["relative_trace_error"]) > (
+            thresholds.maximum_query_relative_trace_error
+        ):
+            reasons.append("query-trace-distortion")
+        if float(query["relative_frobenius_error"]) > (
+            thresholds.maximum_query_relative_frobenius_error
+        ):
+            reasons.append("query-frobenius-distortion")
+        if float(query["mean_shift_standard_deviations"]) > (
+            thresholds.maximum_query_mean_shift_standard_deviations
+        ):
+            reasons.append("query-mean-shift")
+    return tuple(reasons)
+
+
+def gaussian_linearization_adequacy_from_dict(
+    value: object,
+) -> GaussianLinearizationAdequacyV1:
+    """Reconstruct one certificate and replay every derived field and identity."""
+
+    mapping = require_mapping(value, name="Gaussian linearization certificate")
+    require_exact_fields(
+        mapping,
+        _CERTIFICATE_FIELDS,
+        name="Gaussian linearization certificate",
+    )
+    if mapping["schema"] != SIM3_LINEARIZATION_SCHEMA:
+        raise ValueError("Gaussian linearization certificate schema changed")
+    if mapping["schema_version"] != SIM3_LINEARIZATION_VERSION:
+        raise ValueError("Gaussian linearization certificate version changed")
+    if mapping["claim_boundary"] != SIM3_LINEARIZATION_CLAIM_BOUNDARY:
+        raise ValueError("Gaussian linearization certificate claim boundary changed")
+
+    shape = _output_shape(mapping["output_shape"])
+    raw_points = mapping["point_diagnostics"]
+    if type(raw_points) is not list:
+        raise ValueError("point_diagnostics must be a JSON array")
+    if len(raw_points) != shape[0]:
+        raise ValueError("point_diagnostics count must match output_shape[0]")
+    points = tuple(
+        _point_diagnostic(item, index=index)
+        for index, item in enumerate(raw_points)
+    )
+    failure_reasons = _string_tuple(
+        mapping["failure_reasons"],
+        name="failure_reasons",
+        allow_empty=True,
+        require_unique=True,
+    )
+    threshold_set = _thresholds(mapping["thresholds"])
+    query = _query_diagnostic(mapping["query_diagnostics"])
+    replayed_reasons = _replayed_failure_reasons(
+        points,
+        query,
+        threshold_set,
+        output_dimension=shape[1],
+    )
+    if failure_reasons != replayed_reasons:
+        raise ValueError(
+            "Gaussian linearization certificate decision does not match diagnostics"
+        )
+    adequate = _strict_bool(mapping["adequate"], name="adequate")
+    if adequate != (not replayed_reasons):
+        raise ValueError(
+            "Gaussian linearization certificate adequacy does not match diagnostics"
+        )
+    result = GaussianLinearizationAdequacyV1(
+        parameterization=require_exact_string(
+            mapping["parameterization"],
+            name="parameterization",
+        ),
+        parameter_order=_string_tuple(
+            mapping["parameter_order"],
+            name="parameter_order",
+            allow_empty=True,
+            require_unique=True,
+        ),
+        parameter_dimension=require_exact_integer(
+            mapping["parameter_dimension"],
+            name="parameter_dimension",
+            minimum=1,
+        ),
+        output_shape=shape,
+        sample_count=require_exact_integer(
+            mapping["sample_count"],
+            name="sample_count",
+            minimum=2,
+        ),
+        batch_size=require_exact_integer(
+            mapping["batch_size"],
+            name="batch_size",
+            minimum=1,
+        ),
+        seed=require_exact_integer(mapping["seed"], name="seed", minimum=0),
+        finite_difference_step=_nonnegative_number(
+            mapping["finite_difference_step"],
+            name="finite_difference_step",
+        ),
+        jacobian_validated=_strict_bool(
+            mapping["jacobian_validated"],
+            name="jacobian_validated",
+        ),
+        thresholds=threshold_set,
+        point_diagnostics=points,
+        query_diagnostics=query,
+        adequate=adequate,
+        failure_reasons=failure_reasons,
+        metadata=require_finite_json_mapping(mapping["metadata"], name="metadata"),
+    )
+    supplied_id = require_sha256(
+        mapping["gaussian_linearization_adequacy_id"],
+        name="gaussian_linearization_adequacy_id",
+    )
+    if supplied_id != result.gaussian_linearization_adequacy_id:
+        raise ValueError("Gaussian linearization certificate identity mismatch")
+    if plain_json(mapping) != plain_json(result.to_dict()):
+        raise ValueError("Gaussian linearization certificate derived fields changed")
+    return result
+
+
+def load_gaussian_linearization_adequacy(
+    path: str | Path,
+) -> GaussianLinearizationAdequacyV1:
+    """Load one strict certificate while rejecting duplicate keys and tampering."""
+
+    return gaussian_linearization_adequacy_from_dict(
+        load_json_object(path, name="Gaussian linearization certificate")
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("artifact", type=Path)
+    parser.add_argument("--fail-on-inadequate", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _parser().parse_args(argv)
+    certificate = load_gaussian_linearization_adequacy(arguments.artifact)
+    print(
+        json.dumps(
+            {
+                "gaussian_linearization_adequacy_id": (
+                    certificate.gaussian_linearization_adequacy_id
+                ),
+                "adequate": certificate.adequate,
+                "parameterization": certificate.parameterization,
+                "sample_count": certificate.sample_count,
+                "query_projection_evaluated": certificate.query_diagnostics is not None,
+            },
+            sort_keys=True,
+        )
+    )
+    if arguments.fail_on_inadequate and not certificate.adequate:
+        return 2
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+
+
+__all__ = [
+    "gaussian_linearization_adequacy_from_dict",
+    "load_gaussian_linearization_adequacy",
+]

--- a/src/prob4d/diagnostics/sim3_linearization_certificate.py
+++ b/src/prob4d/diagnostics/sim3_linearization_certificate.py
@@ -8,8 +8,6 @@ from collections.abc import Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
-import numpy as np
-
 from .._immutable_json import plain_json
 from .._strict_json import (
     load_json_object,

--- a/src/prob4d/gauge_propagation_readiness.py
+++ b/src/prob4d/gauge_propagation_readiness.py
@@ -1,0 +1,769 @@
+"""Bind Sim(3) propagation adequacy into prospective provider readiness.
+
+Source covariance localization can establish that shared gauge/dependence energy is
+well behaved before conditional point covariance is inspected.  A provider that then
+marginalizes the gauge through a first-order approximation also needs evidence that
+that approximation is adequate for the exact source cohort and frozen physical query.
+This module makes that prerequisite content-addressed and fail closed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal, cast
+
+import numpy as np
+
+from ._atomic_file import atomic_write_text
+from ._immutable_json import frozen_finite_json_mapping, plain_json
+from ._strict_json import (
+    load_json_object,
+    require_exact_fields,
+    require_exact_integer,
+    require_exact_string,
+    require_finite_json_mapping,
+    require_mapping,
+    require_sha256,
+)
+from .diagnostics.sim3_linearization import GaussianLinearizationAdequacyV1
+from .diagnostics.sim3_linearization_certificate import (
+    gaussian_linearization_adequacy_from_dict,
+    load_gaussian_linearization_adequacy,
+)
+from .fresh_provider_readiness import (
+    FreshProviderCohortLockV1,
+    ReadinessGateV1,
+    unevaluated_gate,
+)
+from .source_covariance_localization import (
+    SourceCovarianceLocalizationV1,
+    load_source_covariance_localization,
+)
+
+GAUGE_PROPAGATION_READINESS_SCHEMA = "prob4d.gauge-propagation-readiness"
+GAUGE_PROPAGATION_READINESS_VERSION = 1
+GAUGE_PROPAGATION_BINDING_METADATA_KEY = "fresh_provider_readiness_binding"
+GAUGE_PROPAGATION_READINESS_CLAIM_BOUNDARY = (
+    "This artifact binds one declared gauge-propagation mode to an exact source "
+    "covariance localization, provider/cohort identity, and frozen physical query. "
+    "It authorizes first-order gauge marginalization only when a strict source-only "
+    "Sim(3) certificate is adequate under the frozen policy. It does not establish "
+    "provider competence, target calibration, BayesianPhysTwin or Causal4D benefit, "
+    "deployment safety, or state of the art. A rejected approximation requires the "
+    "explicit gauge latent or an already-declared exact fallback; it does not authorize "
+    "target-side covariance inflation."
+)
+
+PropagationMode = Literal["explicit-gauge-latent", "first-order-marginalized"]
+PropagationClassification = Literal[
+    "explicit-gauge-latent-retained",
+    "first-order-adequate",
+    "first-order-inadequate",
+    "technical-failure",
+]
+GateStatus = Literal["pass", "fail", "technical-failure"]
+PerturbationSide = Literal["left", "right"]
+
+_PARAMETER_BLOCKS = ("scale", "rotation", "translation")
+_POLICY_FIELDS = frozenset(
+    {
+        "propagation_mode",
+        "expected_perturbation_side",
+        "expected_parameter_order",
+        "minimum_sample_count",
+        "require_query_projection",
+        "require_supplied_jacobian_validation",
+    }
+)
+_BINDING_FIELDS = frozenset(
+    {
+        "provider_manifest_id",
+        "cohort_binding_id",
+        "query_definition_id",
+        "source_covariance_localization_id",
+        "source_group_ids",
+        "causal_prefix_only",
+        "target_residuals_used",
+        "target_outcomes_used",
+    }
+)
+_ARTIFACT_FIELDS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "provider_manifest_id",
+        "cohort_binding_id",
+        "query_definition_id",
+        "source_covariance_localization_id",
+        "source_group_ids",
+        "policy",
+        "certificate",
+        "gaussian_linearization_adequacy_id",
+        "classification",
+        "gate_status",
+        "reason_codes",
+        "linearized_marginalization_authorized",
+        "explicit_latent_or_exact_fallback_required",
+        "next_action",
+        "metadata",
+        "claim_boundary",
+        "gauge_propagation_readiness_id",
+    }
+)
+
+
+def _canonical_json_bytes(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        plain_json(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _sha256_json(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json_bytes(value)).hexdigest()
+
+
+def _strict_bool(value: object, *, name: str) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be a Boolean")
+    return value
+
+
+def _optional_string(value: object, *, name: str) -> str | None:
+    if value is None:
+        return None
+    return require_exact_string(value, name=name)
+
+
+def _mode(value: object) -> PropagationMode:
+    result = require_exact_string(value, name="propagation_mode")
+    if result not in {"explicit-gauge-latent", "first-order-marginalized"}:
+        raise ValueError("propagation_mode is not supported")
+    return cast(PropagationMode, result)
+
+
+def _side(value: object) -> PerturbationSide | None:
+    result = _optional_string(value, name="expected_perturbation_side")
+    if result is not None and result not in {"left", "right"}:
+        raise ValueError("expected_perturbation_side must be left, right, or null")
+    return cast(PerturbationSide | None, result)
+
+
+def _parameter_order(value: object, *, allow_empty: bool) -> tuple[str, ...]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise ValueError("expected_parameter_order must be a sequence")
+    result = tuple(
+        require_exact_string(item, name=f"expected_parameter_order[{index}]")
+        for index, item in enumerate(value)
+    )
+    if not result and allow_empty:
+        return ()
+    if len(result) != 3 or set(result) != set(_PARAMETER_BLOCKS):
+        raise ValueError("expected_parameter_order must permute scale, rotation, translation")
+    return result
+
+
+def _sorted_unique_strings(
+    value: object,
+    *,
+    name: str,
+    allow_empty: bool = False,
+) -> tuple[str, ...]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise ValueError(f"{name} must be a sequence")
+    result = tuple(
+        require_exact_string(item, name=f"{name}[{index}]")
+        for index, item in enumerate(value)
+    )
+    if not allow_empty and not result:
+        raise ValueError(f"{name} must not be empty")
+    if result != tuple(sorted(result)) or len(result) != len(set(result)):
+        raise ValueError(f"{name} must be sorted and unique")
+    return result
+
+
+def _mean_transform_vector(certificate: GaussianLinearizationAdequacyV1) -> tuple[float, ...]:
+    value = certificate.metadata.get("mean_transform_vector")
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence) or len(value) != 7:
+        raise ValueError("certificate metadata mean_transform_vector must contain 7 values")
+    result = tuple(float(item) for item in value)
+    if not np.all(np.isfinite(result)):
+        raise ValueError("certificate metadata mean_transform_vector must be finite")
+    return result
+
+
+def _certificate_binding(
+    certificate: GaussianLinearizationAdequacyV1,
+) -> Mapping[str, Any]:
+    raw = certificate.metadata.get(GAUGE_PROPAGATION_BINDING_METADATA_KEY)
+    mapping = require_mapping(raw, name=GAUGE_PROPAGATION_BINDING_METADATA_KEY)
+    require_exact_fields(
+        mapping,
+        _BINDING_FIELDS,
+        name=GAUGE_PROPAGATION_BINDING_METADATA_KEY,
+    )
+    source_groups = _sorted_unique_strings(
+        mapping["source_group_ids"],
+        name="source_group_ids",
+    )
+    causal_prefix_only = _strict_bool(
+        mapping["causal_prefix_only"],
+        name="causal_prefix_only",
+    )
+    residuals_used = _strict_bool(
+        mapping["target_residuals_used"],
+        name="target_residuals_used",
+    )
+    outcomes_used = _strict_bool(
+        mapping["target_outcomes_used"],
+        name="target_outcomes_used",
+    )
+    if not causal_prefix_only:
+        raise ValueError("linearization certificate is not bound to a causal prefix")
+    if residuals_used or outcomes_used:
+        raise ValueError("linearization readiness must not use target residuals or outcomes")
+    return {
+        "provider_manifest_id": require_sha256(
+            mapping["provider_manifest_id"],
+            name="provider_manifest_id",
+        ),
+        "cohort_binding_id": require_sha256(
+            mapping["cohort_binding_id"],
+            name="cohort_binding_id",
+        ),
+        "query_definition_id": require_sha256(
+            mapping["query_definition_id"],
+            name="query_definition_id",
+        ),
+        "source_covariance_localization_id": require_sha256(
+            mapping["source_covariance_localization_id"],
+            name="source_covariance_localization_id",
+        ),
+        "source_group_ids": source_groups,
+        "causal_prefix_only": True,
+        "target_residuals_used": False,
+        "target_outcomes_used": False,
+    }
+
+
+@dataclass(frozen=True, slots=True)
+class GaugePropagationReadinessPolicyV1:
+    """Frozen decision policy for one declared gauge-propagation implementation."""
+
+    propagation_mode: PropagationMode
+    expected_perturbation_side: PerturbationSide | None
+    expected_parameter_order: tuple[str, ...]
+    minimum_sample_count: int
+    require_query_projection: bool
+    require_supplied_jacobian_validation: bool
+
+    def __post_init__(self) -> None:
+        mode = _mode(self.propagation_mode)
+        side = _side(self.expected_perturbation_side)
+        order = _parameter_order(
+            self.expected_parameter_order,
+            allow_empty=mode == "explicit-gauge-latent",
+        )
+        minimum = require_exact_integer(
+            self.minimum_sample_count,
+            name="minimum_sample_count",
+            minimum=0,
+        )
+        require_query = _strict_bool(
+            self.require_query_projection,
+            name="require_query_projection",
+        )
+        require_jacobian = _strict_bool(
+            self.require_supplied_jacobian_validation,
+            name="require_supplied_jacobian_validation",
+        )
+        if mode == "explicit-gauge-latent":
+            if side is not None or order or minimum != 0 or require_query or require_jacobian:
+                raise ValueError(
+                    "explicit-gauge-latent policy must not declare linearization requirements"
+                )
+        else:
+            if side is None or not order or minimum < 2:
+                raise ValueError(
+                    "first-order-marginalized policy requires side, order, and samples"
+                )
+        object.__setattr__(self, "propagation_mode", mode)
+        object.__setattr__(self, "expected_perturbation_side", side)
+        object.__setattr__(self, "expected_parameter_order", order)
+        object.__setattr__(self, "minimum_sample_count", minimum)
+        object.__setattr__(self, "require_query_projection", require_query)
+        object.__setattr__(
+            self,
+            "require_supplied_jacobian_validation",
+            require_jacobian,
+        )
+
+    @classmethod
+    def explicit_latent(cls) -> GaugePropagationReadinessPolicyV1:
+        return cls(
+            propagation_mode="explicit-gauge-latent",
+            expected_perturbation_side=None,
+            expected_parameter_order=(),
+            minimum_sample_count=0,
+            require_query_projection=False,
+            require_supplied_jacobian_validation=False,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "propagation_mode": self.propagation_mode,
+            "expected_perturbation_side": self.expected_perturbation_side,
+            "expected_parameter_order": list(self.expected_parameter_order),
+            "minimum_sample_count": self.minimum_sample_count,
+            "require_query_projection": self.require_query_projection,
+            "require_supplied_jacobian_validation": (
+                self.require_supplied_jacobian_validation
+            ),
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> GaugePropagationReadinessPolicyV1:
+        mapping = require_mapping(value, name="gauge propagation readiness policy")
+        require_exact_fields(
+            mapping,
+            _POLICY_FIELDS,
+            name="gauge propagation readiness policy",
+        )
+        return cls(
+            propagation_mode=mapping["propagation_mode"],
+            expected_perturbation_side=mapping["expected_perturbation_side"],
+            expected_parameter_order=_parameter_order(
+                mapping["expected_parameter_order"],
+                allow_empty=mapping["propagation_mode"] == "explicit-gauge-latent",
+            ),
+            minimum_sample_count=mapping["minimum_sample_count"],
+            require_query_projection=mapping["require_query_projection"],
+            require_supplied_jacobian_validation=mapping[
+                "require_supplied_jacobian_validation"
+            ],
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class GaugePropagationReadinessV1:
+    """Content-addressed propagation decision bound to exact source evidence."""
+
+    provider_manifest_id: str
+    cohort_binding_id: str
+    query_definition_id: str
+    source_covariance_localization_id: str
+    source_group_ids: tuple[str, ...]
+    policy: GaugePropagationReadinessPolicyV1
+    certificate: GaussianLinearizationAdequacyV1 | None = None
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    gaussian_linearization_adequacy_id: str | None = field(init=False)
+    classification: PropagationClassification = field(init=False)
+    gate_status: GateStatus = field(init=False)
+    reason_codes: tuple[str, ...] = field(init=False)
+    linearized_marginalization_authorized: bool = field(init=False)
+    explicit_latent_or_exact_fallback_required: bool = field(init=False)
+    next_action: str = field(init=False)
+    gauge_propagation_readiness_id: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        provider_id = require_sha256(
+            self.provider_manifest_id,
+            name="provider_manifest_id",
+        )
+        cohort_id = require_sha256(self.cohort_binding_id, name="cohort_binding_id")
+        query_id = require_sha256(self.query_definition_id, name="query_definition_id")
+        localization_id = require_sha256(
+            self.source_covariance_localization_id,
+            name="source_covariance_localization_id",
+        )
+        groups = _sorted_unique_strings(self.source_group_ids, name="source_group_ids")
+        if not isinstance(self.policy, GaugePropagationReadinessPolicyV1):
+            raise TypeError("policy must be GaugePropagationReadinessPolicyV1")
+        metadata = frozen_finite_json_mapping(
+            require_finite_json_mapping(self.metadata, name="metadata"),
+            name="metadata",
+        )
+
+        reasons: list[str] = []
+        certificate_id: str | None = None
+        if self.policy.propagation_mode == "explicit-gauge-latent":
+            if self.certificate is not None:
+                raise ValueError("explicit-gauge-latent mode must not carry a certificate")
+            classification: PropagationClassification = "explicit-gauge-latent-retained"
+            gate_status: GateStatus = "pass"
+            authorized = False
+            fallback_required = False
+            next_action = "retain-explicit-gauge-latent"
+        else:
+            if not isinstance(self.certificate, GaussianLinearizationAdequacyV1):
+                raise TypeError(
+                    "first-order-marginalized mode requires a strict linearization certificate"
+                )
+            certificate = self.certificate
+            certificate_id = certificate.gaussian_linearization_adequacy_id
+            binding = _certificate_binding(certificate)
+            expected_binding = {
+                "provider_manifest_id": provider_id,
+                "cohort_binding_id": cohort_id,
+                "query_definition_id": query_id,
+                "source_covariance_localization_id": localization_id,
+                "source_group_ids": groups,
+                "causal_prefix_only": True,
+                "target_residuals_used": False,
+                "target_outcomes_used": False,
+            }
+            if plain_json(binding) != plain_json(expected_binding):
+                raise ValueError("linearization certificate readiness binding changed")
+            expected_side = self.policy.expected_perturbation_side
+            assert expected_side is not None
+            if certificate.parameterization != f"sim3-{expected_side}-perturbation":
+                raise ValueError("linearization certificate parameterization changed")
+            if certificate.parameter_dimension != 7:
+                raise ValueError("Sim(3) linearization certificate dimension must be seven")
+            if certificate.output_shape[1] != 3:
+                raise ValueError("Sim(3) linearization output must contain 3-D points")
+            if tuple(certificate.parameter_order) != self.policy.expected_parameter_order:
+                raise ValueError("linearization certificate parameter order changed")
+            if certificate.metadata.get("perturbation_side") != expected_side:
+                raise ValueError("linearization certificate perturbation-side metadata changed")
+            point_count = certificate.metadata.get("point_count")
+            if type(point_count) is not int or point_count != certificate.output_shape[0]:
+                raise ValueError("linearization certificate point_count metadata changed")
+            _mean_transform_vector(certificate)
+
+            if certificate.sample_count < self.policy.minimum_sample_count:
+                reasons.append("insufficient-linearization-sample-count")
+            if self.policy.require_query_projection and certificate.query_diagnostics is None:
+                reasons.append("missing-required-query-projection")
+            if (
+                self.policy.require_supplied_jacobian_validation
+                and not certificate.jacobian_validated
+            ):
+                reasons.append("supplied-jacobian-not-validated")
+
+            if reasons:
+                classification = "technical-failure"
+                gate_status = "technical-failure"
+                authorized = False
+                fallback_required = True
+                next_action = "retain-explicit-gauge-latent-or-exact-fallback"
+            elif not certificate.adequate:
+                classification = "first-order-inadequate"
+                gate_status = "fail"
+                reasons.extend(
+                    f"linearization:{reason}" for reason in certificate.failure_reasons
+                )
+                authorized = False
+                fallback_required = True
+                next_action = "retain-explicit-gauge-latent-or-exact-fallback"
+            else:
+                classification = "first-order-adequate"
+                gate_status = "pass"
+                authorized = True
+                fallback_required = False
+                next_action = "permit-declared-first-order-marginalization"
+
+        object.__setattr__(self, "provider_manifest_id", provider_id)
+        object.__setattr__(self, "cohort_binding_id", cohort_id)
+        object.__setattr__(self, "query_definition_id", query_id)
+        object.__setattr__(self, "source_covariance_localization_id", localization_id)
+        object.__setattr__(self, "source_group_ids", groups)
+        object.__setattr__(self, "metadata", metadata)
+        object.__setattr__(self, "gaussian_linearization_adequacy_id", certificate_id)
+        object.__setattr__(self, "classification", classification)
+        object.__setattr__(self, "gate_status", gate_status)
+        object.__setattr__(self, "reason_codes", tuple(sorted(set(reasons))))
+        object.__setattr__(self, "linearized_marginalization_authorized", authorized)
+        object.__setattr__(
+            self,
+            "explicit_latent_or_exact_fallback_required",
+            fallback_required,
+        )
+        object.__setattr__(self, "next_action", next_action)
+        object.__setattr__(
+            self,
+            "gauge_propagation_readiness_id",
+            _sha256_json(self._content_dict()),
+        )
+
+    def _content_dict(self) -> dict[str, object]:
+        return {
+            "schema": GAUGE_PROPAGATION_READINESS_SCHEMA,
+            "schema_version": GAUGE_PROPAGATION_READINESS_VERSION,
+            "provider_manifest_id": self.provider_manifest_id,
+            "cohort_binding_id": self.cohort_binding_id,
+            "query_definition_id": self.query_definition_id,
+            "source_covariance_localization_id": (
+                self.source_covariance_localization_id
+            ),
+            "source_group_ids": list(self.source_group_ids),
+            "policy": self.policy.to_dict(),
+            "certificate": None if self.certificate is None else self.certificate.to_dict(),
+            "gaussian_linearization_adequacy_id": (
+                self.gaussian_linearization_adequacy_id
+            ),
+            "classification": self.classification,
+            "gate_status": self.gate_status,
+            "reason_codes": list(self.reason_codes),
+            "linearized_marginalization_authorized": (
+                self.linearized_marginalization_authorized
+            ),
+            "explicit_latent_or_exact_fallback_required": (
+                self.explicit_latent_or_exact_fallback_required
+            ),
+            "next_action": self.next_action,
+            "metadata": plain_json(self.metadata),
+            "claim_boundary": GAUGE_PROPAGATION_READINESS_CLAIM_BOUNDARY,
+        }
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            **self._content_dict(),
+            "gauge_propagation_readiness_id": self.gauge_propagation_readiness_id,
+        }
+
+    def readiness_gate(self) -> ReadinessGateV1:
+        metadata = {
+            "propagation_mode": self.policy.propagation_mode,
+            "classification": self.classification,
+            "query_definition_id": self.query_definition_id,
+            "source_covariance_localization_id": (
+                self.source_covariance_localization_id
+            ),
+            "linearized_marginalization_authorized": (
+                self.linearized_marginalization_authorized
+            ),
+        }
+        return ReadinessGateV1(
+            gate_name="gauge-dependence",
+            status=self.gate_status,
+            evidence_id=self.gauge_propagation_readiness_id,
+            reason_codes=() if self.gate_status == "pass" else self.reason_codes,
+            metadata=metadata,
+        )
+
+    @classmethod
+    def from_dict(cls, value: object) -> GaugePropagationReadinessV1:
+        mapping = require_mapping(value, name="gauge propagation readiness")
+        require_exact_fields(mapping, _ARTIFACT_FIELDS, name="gauge propagation readiness")
+        if mapping["schema"] != GAUGE_PROPAGATION_READINESS_SCHEMA:
+            raise ValueError("gauge propagation readiness schema changed")
+        if mapping["schema_version"] != GAUGE_PROPAGATION_READINESS_VERSION:
+            raise ValueError("gauge propagation readiness version changed")
+        if mapping["claim_boundary"] != GAUGE_PROPAGATION_READINESS_CLAIM_BOUNDARY:
+            raise ValueError("gauge propagation readiness claim boundary changed")
+        raw_certificate = mapping["certificate"]
+        certificate = (
+            None
+            if raw_certificate is None
+            else gaussian_linearization_adequacy_from_dict(raw_certificate)
+        )
+        result = cls(
+            provider_manifest_id=mapping["provider_manifest_id"],
+            cohort_binding_id=mapping["cohort_binding_id"],
+            query_definition_id=mapping["query_definition_id"],
+            source_covariance_localization_id=mapping[
+                "source_covariance_localization_id"
+            ],
+            source_group_ids=_sorted_unique_strings(
+                mapping["source_group_ids"],
+                name="source_group_ids",
+            ),
+            policy=GaugePropagationReadinessPolicyV1.from_dict(mapping["policy"]),
+            certificate=certificate,
+            metadata=require_finite_json_mapping(mapping["metadata"], name="metadata"),
+        )
+        supplied_id = require_sha256(
+            mapping["gauge_propagation_readiness_id"],
+            name="gauge_propagation_readiness_id",
+        )
+        if supplied_id != result.gauge_propagation_readiness_id:
+            raise ValueError("gauge propagation readiness identity mismatch")
+        if plain_json(mapping) != plain_json(result.to_dict()):
+            raise ValueError("gauge propagation readiness derived fields changed")
+        return result
+
+
+def build_gauge_propagation_readiness(
+    localization: SourceCovarianceLocalizationV1,
+    policy: GaugePropagationReadinessPolicyV1,
+    *,
+    query_definition_id: str,
+    certificate: GaussianLinearizationAdequacyV1 | None = None,
+    metadata: Mapping[str, Any] | None = None,
+) -> GaugePropagationReadinessV1:
+    """Build one propagation decision from exact source-localization evidence."""
+
+    if not isinstance(localization, SourceCovarianceLocalizationV1):
+        raise TypeError("localization must be SourceCovarianceLocalizationV1")
+    if not isinstance(policy, GaugePropagationReadinessPolicyV1):
+        raise TypeError("policy must be GaugePropagationReadinessPolicyV1")
+    return GaugePropagationReadinessV1(
+        provider_manifest_id=localization.provider_manifest_id,
+        cohort_binding_id=localization.cohort_binding_id,
+        query_definition_id=query_definition_id,
+        source_covariance_localization_id=(
+            localization.source_covariance_localization_id
+        ),
+        source_group_ids=tuple(group.group_id for group in localization.groups),
+        policy=policy,
+        certificate=certificate,
+        metadata={} if metadata is None else metadata,
+    )
+
+
+def compose_source_covariance_readiness_gates(
+    cohort_lock: FreshProviderCohortLockV1,
+    localization: SourceCovarianceLocalizationV1,
+    propagation: GaugePropagationReadinessV1 | None,
+) -> tuple[ReadinessGateV1, ReadinessGateV1]:
+    """Compose source covariance and propagation evidence in strict stage order."""
+
+    if not isinstance(cohort_lock, FreshProviderCohortLockV1):
+        raise TypeError("cohort_lock must be FreshProviderCohortLockV1")
+    if not isinstance(localization, SourceCovarianceLocalizationV1):
+        raise TypeError("localization must be SourceCovarianceLocalizationV1")
+    if cohort_lock.cohort_binding_id != localization.cohort_binding_id:
+        raise ValueError("cohort lock and source covariance localization differ")
+    source_gauge, source_point = localization.readiness_gates()
+    if source_gauge.status != "pass":
+        if propagation is not None:
+            _validate_composition_bindings(cohort_lock, localization, propagation)
+        return source_gauge, source_point
+    if propagation is None:
+        raise ValueError(
+            "a passing gauge/dependence localization requires propagation readiness"
+        )
+    _validate_composition_bindings(cohort_lock, localization, propagation)
+    propagation_gate = propagation.readiness_gate()
+    if propagation_gate.status != "pass":
+        return propagation_gate, unevaluated_gate("point-covariance")
+    return propagation_gate, source_point
+
+
+def _validate_composition_bindings(
+    cohort_lock: FreshProviderCohortLockV1,
+    localization: SourceCovarianceLocalizationV1,
+    propagation: GaugePropagationReadinessV1,
+) -> None:
+    if not isinstance(propagation, GaugePropagationReadinessV1):
+        raise TypeError("propagation must be GaugePropagationReadinessV1")
+    if propagation.provider_manifest_id != localization.provider_manifest_id:
+        raise ValueError("propagation and covariance localization provider IDs differ")
+    if propagation.cohort_binding_id != localization.cohort_binding_id:
+        raise ValueError("propagation and covariance localization cohort IDs differ")
+    if propagation.cohort_binding_id != cohort_lock.cohort_binding_id:
+        raise ValueError("propagation and cohort lock bindings differ")
+    if propagation.query_definition_id != cohort_lock.query_definition_id:
+        raise ValueError("propagation and cohort lock query definitions differ")
+    if propagation.source_covariance_localization_id != (
+        localization.source_covariance_localization_id
+    ):
+        raise ValueError("propagation references a different covariance localization")
+    localization_groups = tuple(group.group_id for group in localization.groups)
+    if propagation.source_group_ids != localization_groups:
+        raise ValueError("propagation and covariance localization source groups differ")
+
+
+def write_gauge_propagation_readiness(
+    path: str | Path,
+    readiness: GaugePropagationReadinessV1,
+    *,
+    overwrite: bool = False,
+) -> None:
+    if not isinstance(readiness, GaugePropagationReadinessV1):
+        raise TypeError("readiness must be GaugePropagationReadinessV1")
+    payload = json.dumps(readiness.to_dict(), sort_keys=True, indent=2, allow_nan=False) + "\n"
+    atomic_write_text(path, payload, overwrite=overwrite)
+
+
+def load_gauge_propagation_readiness(
+    path: str | Path,
+) -> GaugePropagationReadinessV1:
+    return GaugePropagationReadinessV1.from_dict(
+        load_json_object(path, name="gauge propagation readiness")
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    build = subparsers.add_parser("build")
+    build.add_argument("--localization", type=Path, required=True)
+    build.add_argument("--policy", type=Path, required=True)
+    build.add_argument("--query-definition-id", required=True)
+    build.add_argument("--certificate", type=Path)
+    build.add_argument("--output", type=Path, required=True)
+    build.add_argument("--overwrite", action="store_true")
+    verify = subparsers.add_parser("verify")
+    verify.add_argument("--artifact", type=Path, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _parser().parse_args(argv)
+    if arguments.command == "build":
+        localization = load_source_covariance_localization(arguments.localization)
+        policy = GaugePropagationReadinessPolicyV1.from_dict(
+            load_json_object(arguments.policy, name="gauge propagation readiness policy")
+        )
+        certificate = (
+            None
+            if arguments.certificate is None
+            else load_gaussian_linearization_adequacy(arguments.certificate)
+        )
+        readiness = build_gauge_propagation_readiness(
+            localization,
+            policy,
+            query_definition_id=arguments.query_definition_id,
+            certificate=certificate,
+        )
+        write_gauge_propagation_readiness(
+            arguments.output,
+            readiness,
+            overwrite=arguments.overwrite,
+        )
+    else:
+        readiness = load_gauge_propagation_readiness(arguments.artifact)
+    print(
+        json.dumps(
+            {
+                "gauge_propagation_readiness_id": (
+                    readiness.gauge_propagation_readiness_id
+                ),
+                "classification": readiness.classification,
+                "gate_status": readiness.gate_status,
+                "linearized_marginalization_authorized": (
+                    readiness.linearized_marginalization_authorized
+                ),
+                "next_action": readiness.next_action,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0 if readiness.gate_status == "pass" else 2
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())
+
+
+__all__ = [
+    "GAUGE_PROPAGATION_BINDING_METADATA_KEY",
+    "GAUGE_PROPAGATION_READINESS_CLAIM_BOUNDARY",
+    "GAUGE_PROPAGATION_READINESS_SCHEMA",
+    "GAUGE_PROPAGATION_READINESS_VERSION",
+    "GaugePropagationReadinessPolicyV1",
+    "GaugePropagationReadinessV1",
+    "build_gauge_propagation_readiness",
+    "compose_source_covariance_readiness_gates",
+    "load_gauge_propagation_readiness",
+    "write_gauge_propagation_readiness",
+]

--- a/src/prob4d/point_uncertainty_v2.py
+++ b/src/prob4d/point_uncertainty_v2.py
@@ -3,7 +3,8 @@
 Version 2 models conditional point covariance in a local orthonormal basis:
 the viewing ray, a prediction-only reference tangent, and the orthogonal tangent.
 It can be fitted only after SourceCovarianceLocalizationV1 has explicitly
-localized the remaining failure to conditional point covariance.
+localized the remaining failure to conditional point covariance and a matching
+GaugePropagationReadinessV1 has admitted the declared gauge-propagation path.
 
 The shared Sim(3) gauge covariance remains outside this model.
 """
@@ -22,7 +23,10 @@ from ._point_uncertainty_v2_common import (
     PointUncertaintyCalibrationPolicyV2,
     local_point_basis,
 )
-from ._point_uncertainty_v2_fit import fit_point_uncertainty_calibration_v2
+from ._point_uncertainty_v2_fit import (
+    fit_point_uncertainty_calibration_v2,
+    validate_point_uncertainty_v2_eligibility,
+)
 from ._point_uncertainty_v2_model import (
     POINT_UNCERTAINTY_CALIBRATION_CLAIM_BOUNDARY,
     POINT_UNCERTAINTY_CALIBRATION_SCHEMA,
@@ -32,6 +36,7 @@ from ._point_uncertainty_v2_model import (
     write_point_uncertainty_calibration_v2,
 )
 from ._strict_json import load_json_object
+from .gauge_propagation_readiness import load_gauge_propagation_readiness
 from .source_covariance_localization import load_source_covariance_localization
 
 
@@ -40,6 +45,7 @@ def _parser() -> argparse.ArgumentParser:
     subparsers = parser.add_subparsers(dest="command", required=True)
     fit = subparsers.add_parser("fit")
     fit.add_argument("--localization", type=Path, required=True)
+    fit.add_argument("--propagation", type=Path, required=True)
     fit.add_argument("--training", type=Path, required=True)
     fit.add_argument("--policy", type=Path)
     fit.add_argument("--output", type=Path, required=True)
@@ -52,6 +58,9 @@ def _parser() -> argparse.ArgumentParser:
 def main(argv: Sequence[str] | None = None) -> int:
     arguments = _parser().parse_args(argv)
     if arguments.command == "fit":
+        localization = load_source_covariance_localization(arguments.localization)
+        propagation = load_gauge_propagation_readiness(arguments.propagation)
+        validate_point_uncertainty_v2_eligibility(localization, propagation)
         training_bytes = arguments.training.read_bytes()
         with np.load(arguments.training, allow_pickle=False) as archive:
             expected = {
@@ -73,7 +82,8 @@ def main(argv: Sequence[str] | None = None) -> int:
             )
         )
         calibration = fit_point_uncertainty_calibration_v2(
-            load_source_covariance_localization(arguments.localization),
+            localization,
+            propagation,
             residual_xyz=arrays["residual_xyz"],
             ray_directions=arrays["ray_directions"],
             tangent_reference=arrays["tangent_reference"],

--- a/tests/test_gauge_propagation_readiness.py
+++ b/tests/test_gauge_propagation_readiness.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from prob4d.diagnostics.sim3_linearization import (
+    GaussianLinearizationAdequacyV1,
+    LinearizationAdequacyThresholdsV1,
+)
+from prob4d.fresh_provider_readiness import FreshProviderCohortLockV1
+from prob4d.gauge_propagation_readiness import (
+    GAUGE_PROPAGATION_BINDING_METADATA_KEY,
+    GaugePropagationReadinessPolicyV1,
+    build_gauge_propagation_readiness,
+    compose_source_covariance_readiness_gates,
+    load_gauge_propagation_readiness,
+    write_gauge_propagation_readiness,
+)
+from prob4d.source_covariance_localization import (
+    SourceCovarianceLocalizationGroupV1,
+    SourceCovarianceLocalizationPolicyV1,
+    SourceCovarianceLocalizationV1,
+)
+
+PROVIDER_ID = "1" * 64
+COHORT_ID = "2" * 64
+QUERY_ID = "3" * 64
+SOURCE_COMPETENCE_ID = "4" * 64
+JOINT_DIAGNOSTIC_ID = "5" * 64
+RESIDUAL_SOURCE_ID = "6" * 64
+
+
+def _localization(
+    *,
+    shared: float = 1.0,
+    conditional: float = 1.0,
+) -> SourceCovarianceLocalizationV1:
+    policy = SourceCovarianceLocalizationPolicyV1(
+        minimum_group_count=1,
+        normalized_nees_lower=0.8,
+        normalized_nees_upper=1.2,
+        minimum_joint_pass_fraction=1.0,
+        shared_energy_lower=0.8,
+        shared_energy_upper=1.2,
+        minimum_shared_pass_fraction=1.0,
+        conditional_energy_lower=0.8,
+        conditional_energy_upper=1.2,
+        minimum_conditional_pass_fraction=1.0,
+        require_shared_subspace=True,
+    )
+    normalized_nees = max(shared, conditional)
+    return SourceCovarianceLocalizationV1(
+        provider_manifest_id=PROVIDER_ID,
+        cohort_binding_id=COHORT_ID,
+        source_provider_competence_id=SOURCE_COMPETENCE_ID,
+        joint_diagnostic_sha256=JOINT_DIAGNOSTIC_ID,
+        joint_residual_source_sha256=RESIDUAL_SOURCE_ID,
+        policy=policy,
+        groups=(
+            SourceCovarianceLocalizationGroupV1(
+                group_id="group-a",
+                normalized_nees=normalized_nees,
+                shared_subspace_normalized_energy=shared,
+                conditional_subspace_normalized_energy=conditional,
+                joint_in_band=0.8 <= normalized_nees <= 1.2,
+                shared_in_band=0.8 <= shared <= 1.2,
+                conditional_in_band=0.8 <= conditional <= 1.2,
+            ),
+        ),
+        source_mean_status="pass",
+        identity_reliability_status="pass",
+    )
+
+
+def _cohort_lock() -> FreshProviderCohortLockV1:
+    return FreshProviderCohortLockV1(
+        protocol_id="fresh-provider-test-v1",
+        source_repository="IPS-Stuttgart/Prob4D",
+        source_revision="a" * 40,
+        provider_repository="IPS-Stuttgart/Prob4D",
+        provider_revision="b" * 40,
+        model_set_id="7" * 64,
+        loader_id="8" * 64,
+        cohort_binding_id=COHORT_ID,
+        promotion_lock_id="9" * 64,
+        query_definition_id=QUERY_ID,
+        fallback_identity_id="a" * 64,
+        development_group_ids=("group-a",),
+        calibration_group_ids=("group-b",),
+        target_group_ids=("group-c",),
+    )
+
+
+def _binding(localization: SourceCovarianceLocalizationV1) -> dict[str, object]:
+    return {
+        "provider_manifest_id": PROVIDER_ID,
+        "cohort_binding_id": COHORT_ID,
+        "query_definition_id": QUERY_ID,
+        "source_covariance_localization_id": (
+            localization.source_covariance_localization_id
+        ),
+        "source_group_ids": ["group-a"],
+        "causal_prefix_only": True,
+        "target_residuals_used": False,
+        "target_outcomes_used": False,
+    }
+
+
+def _certificate(
+    localization: SourceCovarianceLocalizationV1,
+    *,
+    adequate: bool = True,
+    query: bool = True,
+    jacobian_validated: bool = True,
+    sample_count: int = 4096,
+    binding_updates: dict[str, object] | None = None,
+) -> GaussianLinearizationAdequacyV1:
+    binding = _binding(localization)
+    binding.update(binding_updates or {})
+    return GaussianLinearizationAdequacyV1(
+        parameterization="sim3-left-perturbation",
+        parameter_order=("scale", "rotation", "translation"),
+        parameter_dimension=7,
+        output_shape=(1, 3),
+        sample_count=sample_count,
+        batch_size=256,
+        seed=23,
+        finite_difference_step=1.0e-6,
+        jacobian_validated=jacobian_validated,
+        thresholds=LinearizationAdequacyThresholdsV1(),
+        point_diagnostics=(
+            {
+                "item_index": 0,
+                "relative_trace_error": 0.01,
+                "relative_frobenius_error": 0.02,
+                "mean_shift_standard_deviations": 0.03,
+                "nonlinear_trace": 1.0,
+                "linearized_trace": 1.01,
+                "principal_axis_anisotropy": 1.1,
+                "principal_axis_angle_degrees": None,
+            },
+        ),
+        query_diagnostics=(
+            {
+                "query_dimension": 1,
+                "relative_trace_error": 0.01,
+                "relative_frobenius_error": 0.02,
+                "mean_shift_standard_deviations": 0.03,
+                "nonlinear_trace": 1.0,
+                "linearized_trace": 1.01,
+            }
+            if query
+            else None
+        ),
+        adequate=adequate,
+        failure_reasons=() if adequate else ("point-trace-distortion",),
+        metadata={
+            "mean_transform_vector": [0.0] * 7,
+            "point_count": 1,
+            "perturbation_side": "left",
+            GAUGE_PROPAGATION_BINDING_METADATA_KEY: binding,
+        },
+    )
+
+
+def _first_order_policy() -> GaugePropagationReadinessPolicyV1:
+    return GaugePropagationReadinessPolicyV1(
+        propagation_mode="first-order-marginalized",
+        expected_perturbation_side="left",
+        expected_parameter_order=("scale", "rotation", "translation"),
+        minimum_sample_count=4096,
+        require_query_projection=True,
+        require_supplied_jacobian_validation=True,
+    )
+
+
+def test_adequate_first_order_readiness_round_trips(tmp_path: Path) -> None:
+    localization = _localization()
+    readiness = build_gauge_propagation_readiness(
+        localization,
+        _first_order_policy(),
+        query_definition_id=QUERY_ID,
+        certificate=_certificate(localization),
+    )
+    path = tmp_path / "readiness.json"
+    write_gauge_propagation_readiness(path, readiness)
+
+    loaded = load_gauge_propagation_readiness(path)
+    gauge_gate, point_gate = compose_source_covariance_readiness_gates(
+        _cohort_lock(),
+        localization,
+        loaded,
+    )
+
+    assert loaded.classification == "first-order-adequate"
+    assert loaded.linearized_marginalization_authorized
+    assert gauge_gate.status == "pass"
+    assert point_gate.status == "pass"
+    assert loaded.to_dict() == readiness.to_dict()
+
+
+def test_inadequate_linearization_blocks_point_model_authorization() -> None:
+    localization = _localization(conditional=2.0)
+    readiness = build_gauge_propagation_readiness(
+        localization,
+        _first_order_policy(),
+        query_definition_id=QUERY_ID,
+        certificate=_certificate(localization, adequate=False),
+    )
+
+    gauge_gate, point_gate = compose_source_covariance_readiness_gates(
+        _cohort_lock(),
+        localization,
+        readiness,
+    )
+
+    assert readiness.classification == "first-order-inadequate"
+    assert gauge_gate.status == "fail"
+    assert "linearization:point-trace-distortion" in gauge_gate.reason_codes
+    assert point_gate.status == "not-evaluated"
+
+
+def test_explicit_gauge_latent_preserves_conditional_covariance_localization() -> None:
+    localization = _localization(conditional=2.0)
+    readiness = build_gauge_propagation_readiness(
+        localization,
+        GaugePropagationReadinessPolicyV1.explicit_latent(),
+        query_definition_id=QUERY_ID,
+    )
+
+    gauge_gate, point_gate = compose_source_covariance_readiness_gates(
+        _cohort_lock(),
+        localization,
+        readiness,
+    )
+
+    assert readiness.classification == "explicit-gauge-latent-retained"
+    assert gauge_gate.status == "pass"
+    assert point_gate.status == "fail"
+    assert point_gate.reason_codes == (
+        "conditional-subspace-energy-outside-frozen-band",
+    )
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "reason"),
+    [
+        ({"query": False}, "missing-required-query-projection"),
+        ({"jacobian_validated": False}, "supplied-jacobian-not-validated"),
+        ({"sample_count": 1024}, "insufficient-linearization-sample-count"),
+    ],
+)
+def test_incomplete_first_order_evidence_is_technical_failure(
+    kwargs: dict[str, object],
+    reason: str,
+) -> None:
+    localization = _localization(conditional=2.0)
+    readiness = build_gauge_propagation_readiness(
+        localization,
+        _first_order_policy(),
+        query_definition_id=QUERY_ID,
+        certificate=_certificate(localization, **kwargs),  # type: ignore[arg-type]
+    )
+    gauge_gate, point_gate = compose_source_covariance_readiness_gates(
+        _cohort_lock(),
+        localization,
+        readiness,
+    )
+
+    assert readiness.classification == "technical-failure"
+    assert reason in readiness.reason_codes
+    assert gauge_gate.status == "technical-failure"
+    assert point_gate.status == "not-evaluated"
+
+
+def test_certificate_binding_mismatch_is_invalid_evidence() -> None:
+    localization = _localization()
+    certificate = _certificate(
+        localization,
+        binding_updates={"query_definition_id": "f" * 64},
+    )
+
+    with pytest.raises(ValueError, match="binding changed"):
+        build_gauge_propagation_readiness(
+            localization,
+            _first_order_policy(),
+            query_definition_id=QUERY_ID,
+            certificate=certificate,
+        )
+
+
+def test_target_outcome_use_is_rejected() -> None:
+    localization = _localization()
+    certificate = _certificate(
+        localization,
+        binding_updates={"target_outcomes_used": True},
+    )
+
+    with pytest.raises(ValueError, match="must not use target residuals or outcomes"):
+        build_gauge_propagation_readiness(
+            localization,
+            _first_order_policy(),
+            query_definition_id=QUERY_ID,
+            certificate=certificate,
+        )
+
+
+def test_passing_source_gauge_requires_propagation_evidence() -> None:
+    with pytest.raises(ValueError, match="requires propagation readiness"):
+        compose_source_covariance_readiness_gates(
+            _cohort_lock(),
+            _localization(),
+            None,
+        )
+
+
+def test_source_gauge_failure_has_priority() -> None:
+    localization = _localization(shared=2.0)
+
+    gauge_gate, point_gate = compose_source_covariance_readiness_gates(
+        _cohort_lock(),
+        localization,
+        None,
+    )
+
+    assert gauge_gate.status == "fail"
+    assert gauge_gate.reason_codes == (
+        "shared-subspace-energy-outside-frozen-band",
+    )
+    assert point_gate.status == "not-evaluated"
+
+
+def test_readiness_loader_rejects_tampered_derived_status(tmp_path: Path) -> None:
+    localization = _localization()
+    readiness = build_gauge_propagation_readiness(
+        localization,
+        _first_order_policy(),
+        query_definition_id=QUERY_ID,
+        certificate=_certificate(localization),
+    )
+    payload = readiness.to_dict()
+    payload["gate_status"] = "fail"
+    path = tmp_path / "tampered.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="derived fields changed"):
+        load_gauge_propagation_readiness(path)

--- a/tests/test_gauge_propagation_readiness.py
+++ b/tests/test_gauge_propagation_readiness.py
@@ -18,6 +18,7 @@ from prob4d.gauge_propagation_readiness import (
     load_gauge_propagation_readiness,
     write_gauge_propagation_readiness,
 )
+from prob4d.point_uncertainty_v2 import fit_point_uncertainty_calibration_v2
 from prob4d.source_covariance_localization import (
     SourceCovarianceLocalizationGroupV1,
     SourceCovarianceLocalizationPolicyV1,
@@ -347,3 +348,26 @@ def test_readiness_loader_rejects_tampered_derived_status(tmp_path: Path) -> Non
 
     with pytest.raises(ValueError, match="derived fields changed"):
         load_gauge_propagation_readiness(path)
+
+
+def test_point_v2_fitter_rejects_inadequate_propagation_before_arrays() -> None:
+    localization = _localization(conditional=2.0)
+    readiness = build_gauge_propagation_readiness(
+        localization,
+        _first_order_policy(),
+        query_definition_id=QUERY_ID,
+        certificate=_certificate(localization, adequate=False),
+    )
+
+    with pytest.raises(ValueError, match="passing gauge propagation readiness"):
+        fit_point_uncertainty_calibration_v2(
+            localization,
+            readiness,
+            residual_xyz=object(),
+            ray_directions=object(),
+            tangent_reference=object(),
+            features=object(),
+            feature_names=(),
+            group_ids=(),
+            source_training_sha256="7" * 64,
+        )

--- a/tests/test_point_uncertainty_v2.py
+++ b/tests/test_point_uncertainty_v2.py
@@ -5,6 +5,10 @@ import copy
 import numpy as np
 import pytest
 
+from prob4d.gauge_propagation_readiness import (
+    GaugePropagationReadinessPolicyV1,
+    build_gauge_propagation_readiness,
+)
 from prob4d.point_uncertainty_v2 import (
     PointUncertaintyCalibrationPolicyV2,
     PointUncertaintyCalibrationV2,
@@ -54,6 +58,14 @@ def _localization(*, conditional_energy: float) -> SourceCovarianceLocalizationV
         groups=groups,
         source_mean_status="pass",
         identity_reliability_status="pass",
+    )
+
+
+def _propagation(localization: SourceCovarianceLocalizationV1):
+    return build_gauge_propagation_readiness(
+        localization,
+        GaugePropagationReadinessPolicyV1.explicit_latent(),
+        query_definition_id="7" * 64,
     )
 
 
@@ -123,6 +135,7 @@ def test_fit_requires_explicit_point_covariance_localization() -> None:
     with pytest.raises(ValueError, match="point-covariance-localized"):
         fit_point_uncertainty_calibration_v2(
             localization,
+            _propagation(localization),
             residual_xyz=residuals,
             ray_directions=rays,
             tangent_reference=references,
@@ -139,11 +152,13 @@ def test_fit_requires_explicit_point_covariance_localization() -> None:
 
 def test_fit_is_group_balanced_anisotropic_and_roundtrips() -> None:
     localization = _localization(conditional_energy=2.0)
+    propagation = _propagation(localization)
     residuals, rays, references, features, group_ids = _synthetic_training(
         localization
     )
     calibration = fit_point_uncertainty_calibration_v2(
         localization,
+        propagation,
         residual_xyz=residuals,
         ray_directions=rays,
         tangent_reference=references,
@@ -158,6 +173,9 @@ def test_fit_is_group_balanced_anisotropic_and_roundtrips() -> None:
     )
 
     assert calibration.fit_converged
+    assert calibration.gauge_propagation_readiness_id == (
+        propagation.gauge_propagation_readiness_id
+    )
     assert calibration.group_counts == (96, 96, 96, 96)
     np.testing.assert_allclose(
         calibration.training_normalized_energy,
@@ -186,6 +204,9 @@ def test_fit_is_group_balanced_anisotropic_and_roundtrips() -> None:
         restored.point_uncertainty_calibration_id
         == calibration.point_uncertainty_calibration_id
     )
+    assert restored.gauge_propagation_readiness_id == (
+        propagation.gauge_propagation_readiness_id
+    )
 
 
 def test_fit_rejects_group_roster_mismatch() -> None:
@@ -198,6 +219,7 @@ def test_fit_rejects_group_roster_mismatch() -> None:
     with pytest.raises(ValueError, match="exactly match"):
         fit_point_uncertainty_calibration_v2(
             localization,
+            _propagation(localization),
             residual_xyz=residuals,
             ray_directions=rays,
             tangent_reference=references,
@@ -219,6 +241,7 @@ def test_calibration_content_address_detects_tampering() -> None:
     )
     calibration = fit_point_uncertainty_calibration_v2(
         localization,
+        _propagation(localization),
         residual_xyz=residuals,
         ray_directions=rays,
         tangent_reference=references,
@@ -236,3 +259,21 @@ def test_calibration_content_address_detects_tampering() -> None:
 
     with pytest.raises(ValueError, match="identity mismatch"):
         PointUncertaintyCalibrationV2.from_dict(tampered)
+
+
+def test_fit_rejects_mismatched_propagation_before_training_access() -> None:
+    localization = _localization(conditional_energy=2.0)
+    propagation = _propagation(_localization(conditional_energy=1.0))
+
+    with pytest.raises(ValueError, match="different covariance localization"):
+        fit_point_uncertainty_calibration_v2(
+            localization,
+            propagation,
+            residual_xyz=object(),
+            ray_directions=object(),
+            tangent_reference=object(),
+            features=object(),
+            feature_names=(),
+            group_ids=(),
+            source_training_sha256="6" * 64,
+        )

--- a/tests/test_sim3_linearization_certificate.py
+++ b/tests/test_sim3_linearization_certificate.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from prob4d.diagnostics.sim3_linearization import (
+    GaussianLinearizationAdequacyV1,
+    LinearizationAdequacyThresholdsV1,
+    write_linearization_certificate,
+)
+from prob4d.diagnostics.sim3_linearization_certificate import (
+    gaussian_linearization_adequacy_from_dict,
+    load_gaussian_linearization_adequacy,
+    main,
+)
+
+
+def _certificate() -> GaussianLinearizationAdequacyV1:
+    return GaussianLinearizationAdequacyV1(
+        parameterization="sim3-left-perturbation",
+        parameter_order=("scale", "rotation", "translation"),
+        parameter_dimension=7,
+        output_shape=(1, 3),
+        sample_count=4096,
+        batch_size=256,
+        seed=17,
+        finite_difference_step=1.0e-6,
+        jacobian_validated=True,
+        thresholds=LinearizationAdequacyThresholdsV1(),
+        point_diagnostics=(
+            {
+                "item_index": 0,
+                "relative_trace_error": 0.01,
+                "relative_frobenius_error": 0.02,
+                "mean_shift_standard_deviations": 0.03,
+                "nonlinear_trace": 1.0,
+                "linearized_trace": 1.01,
+                "principal_axis_anisotropy": 1.1,
+                "principal_axis_angle_degrees": None,
+            },
+        ),
+        query_diagnostics={
+            "query_dimension": 1,
+            "relative_trace_error": 0.01,
+            "relative_frobenius_error": 0.02,
+            "mean_shift_standard_deviations": 0.03,
+            "nonlinear_trace": 1.0,
+            "linearized_trace": 1.01,
+        },
+        adequate=True,
+        failure_reasons=(),
+        metadata={
+            "mean_transform_vector": [0.0] * 7,
+            "point_count": 1,
+            "perturbation_side": "left",
+        },
+    )
+
+
+def test_strict_certificate_round_trip(tmp_path: Path) -> None:
+    certificate = _certificate()
+    path = tmp_path / "certificate.json"
+    write_linearization_certificate(path, certificate)
+
+    loaded = load_gaussian_linearization_adequacy(path)
+
+    assert loaded.gaussian_linearization_adequacy_id == (
+        certificate.gaussian_linearization_adequacy_id
+    )
+    assert loaded.to_dict() == certificate.to_dict()
+    assert main([str(path)]) == 0
+
+
+def test_strict_certificate_rejects_identity_tampering() -> None:
+    payload = _certificate().to_dict()
+    payload["gaussian_linearization_adequacy_id"] = "0" * 64
+
+    with pytest.raises(ValueError, match="identity mismatch"):
+        gaussian_linearization_adequacy_from_dict(payload)
+
+
+def test_strict_certificate_rejects_point_roster_tampering() -> None:
+    payload = _certificate().to_dict()
+    payload["point_diagnostics"] = []
+
+    with pytest.raises(ValueError, match="count must match"):
+        gaussian_linearization_adequacy_from_dict(payload)
+
+
+def test_strict_certificate_rejects_duplicate_json_keys(tmp_path: Path) -> None:
+    path = tmp_path / "duplicate.json"
+    payload = json.dumps(_certificate().to_dict(), sort_keys=True)
+    path.write_text(payload[:-1] + ', "adequate": true}', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="duplicate JSON object key"):
+        load_gaussian_linearization_adequacy(path)
+
+
+def test_strict_certificate_replays_decision_from_metrics() -> None:
+    certificate = _certificate()
+    payload = certificate.to_dict()
+    point = dict(payload["point_diagnostics"][0])
+    point["relative_trace_error"] = 0.5
+    payload["point_diagnostics"] = [point]
+    forged = GaussianLinearizationAdequacyV1(
+        parameterization=payload["parameterization"],
+        parameter_order=tuple(payload["parameter_order"]),
+        parameter_dimension=payload["parameter_dimension"],
+        output_shape=tuple(payload["output_shape"]),
+        sample_count=payload["sample_count"],
+        batch_size=payload["batch_size"],
+        seed=payload["seed"],
+        finite_difference_step=payload["finite_difference_step"],
+        jacobian_validated=payload["jacobian_validated"],
+        thresholds=certificate.thresholds,
+        point_diagnostics=(point,),
+        query_diagnostics=payload["query_diagnostics"],
+        adequate=True,
+        failure_reasons=(),
+        metadata=payload["metadata"],
+    )
+
+    with pytest.raises(ValueError, match="decision does not match diagnostics"):
+        gaussian_linearization_adequacy_from_dict(forged.to_dict())
+
+
+def test_strict_certificate_rejects_hidden_principal_axis_angle() -> None:
+    certificate = _certificate()
+    payload = certificate.to_dict()
+    point = dict(payload["point_diagnostics"][0])
+    point["principal_axis_anisotropy"] = 2.0
+    point["principal_axis_angle_degrees"] = None
+    forged = GaussianLinearizationAdequacyV1(
+        parameterization=payload["parameterization"],
+        parameter_order=tuple(payload["parameter_order"]),
+        parameter_dimension=payload["parameter_dimension"],
+        output_shape=tuple(payload["output_shape"]),
+        sample_count=payload["sample_count"],
+        batch_size=payload["batch_size"],
+        seed=payload["seed"],
+        finite_difference_step=payload["finite_difference_step"],
+        jacobian_validated=payload["jacobian_validated"],
+        thresholds=certificate.thresholds,
+        point_diagnostics=(point,),
+        query_diagnostics=payload["query_diagnostics"],
+        adequate=True,
+        failure_reasons=(),
+        metadata=payload["metadata"],
+    )
+
+    with pytest.raises(ValueError, match="angle presence changed"):
+        gaussian_linearization_adequacy_from_dict(forged.to_dict())


### PR DESCRIPTION
## Summary

Bind the source-only `Sim(3)` linearization diagnostic into the prospective fresh-provider information order and make the newly merged experimental point-uncertainty-v2 fitter consume that decision explicitly.

- add a strict loader/verifier for `GaussianLinearizationAdequacyV1` artifacts;
- replay point-space, principal-axis, and optional query-space threshold decisions from persisted metrics rather than trusting stored status fields;
- reject duplicate JSON keys, changed schemas/claim boundaries, malformed diagnostic rosters, hidden principal-axis angles, content-identity tampering, and self-consistent but scientifically forged decisions;
- add `GaugePropagationReadinessPolicyV1` for the two declared propagation modes:
  - retain the explicit gauge latent; or
  - use a frozen first-order marginalized path with exact perturbation convention, parameter order, sample floor, query-projection, and Jacobian-validation requirements;
- bind first-order certificates to the exact provider manifest, cohort, source covariance localization, independent source-group roster, causal prefix, and physical-query definition;
- reject target-residual/outcome use and all binding mismatches as invalid evidence;
- compose propagation readiness with `SourceCovarianceLocalizationV1` so a propagation failure keeps `point-covariance` unevaluated instead of incorrectly authorizing point-model growth;
- require a matching, passing propagation artifact before the point-v2 API or CLI reads any residual, feature, basis, or training-NPZ data;
- bind `gauge_propagation_readiness_id` into every point-v2 calibration artifact and its content identity; and
- document the complete source-only information order and stop rules.

## Why

PR #219 separates shared gauge/dependence failure from conditional point-covariance failure. PR #220 added a gated point-covariance-v2 fitter, but localization alone is insufficient when the provider marginalizes an uncertain gauge through a first-order approximation: nonlinear propagation error could otherwise be misclassified as conditional point-covariance error and absorbed into local variance.

A richer point-uncertainty model is now reachable only when:

1. source means and identities pass;
2. shared gauge/dependence covariance passes;
3. the declared gauge-propagation path is admissible; and
4. the remaining conditional covariance is specifically localized as inadequate.

An inadequate or incomplete first-order certificate requires the explicit gauge latent or an already-declared exact fallback. It does not authorize covariance inflation.

## Validation performed before publication

Validation used the installed Prob4D 0.4.1 wheel built by the green PR #220 distribution workflow, with the proposed files overlaid:

- combined certificate, propagation-readiness, and point-v2 suite: `24 passed`;
- Python byte compilation passed;
- all changed Python and test lines satisfy the repository's 100-character limit;
- the point-v2 fitter was exercised with invalid array objects to verify that mismatched or inadequate propagation evidence is rejected before training-data access;
- cases cover exact round trips, metric-to-decision replay, forged adequate decisions, hidden principal-axis angles, content tampering, duplicate keys, adequate and inadequate first-order paths, explicit-latent mode, missing query projection, insufficient samples, unvalidated Jacobians, binding mismatches, target-outcome rejection, source-stage priority, point-gate suppression, point-v2 content binding, and direct-fitter bypass attempts.

GitHub Actions on the exact PR head remain authoritative for Ruff, MyPy, the complete supported-Python matrix, the NumPy floor, packaging, installed-wheel/sdist execution, repository policy, and security scanning.

## Scientific and data-access boundary

- protected target or confirmation payloads accessed: **none**;
- target residuals or outcomes used: **none**;
- opened MotionCrafter or Deform360 cohorts retuned: **none**;
- provider-v2 production exporter, association, physical guard, or exact-fallback defaults changed: **none**;
- the experimental point-v2 fit/artifact contract is intentionally strengthened to require propagation readiness;
- new provider competence, target calibration, BayesianPhysTwin benefit, Causal4D benefit, deployment safety, or state-of-the-art claim: **none**.

This is prospective source-only readiness and failure-localization infrastructure.