### PR TITLE
Pin ecosystem capsule companion revisions

### DIFF
--- a/.github/workflows/ecosystem-release-capsule.yml
+++ b/.github/workflows/ecosystem-release-capsule.yml
@@ -42,11 +42,11 @@ on:
       bayesian_phystwin_ref:
         description: BayesianPhysTwin branch, tag, or commit to validate
         required: false
-        default: main
+        default: 322458dfc23f1db9419ed1eb0f4728dcde9135b0
       causal4d_ref:
         description: Causal4D branch, tag, or commit to validate
         required: false
-        default: main
+        default: e6a7047ed479879810a9c6b4aba1bcdc41566a4d
   schedule:
     - cron: "23 5 * * 1"
 
@@ -56,13 +56,17 @@ permissions:
 concurrency:
   group: >-
     ecosystem-release-capsule-${{ github.workflow }}-${{ github.ref }}-
-    ${{ inputs.bayesian_phystwin_ref || 'main' }}-
-    ${{ inputs.causal4d_ref || 'main' }}
+    ${{ inputs.bayesian_phystwin_ref || '322458dfc23f1db9419ed1eb0f4728dcde9135b0' }}-
+    ${{ inputs.causal4d_ref || 'e6a7047ed479879810a9c6b4aba1bcdc41566a4d' }}
   cancel-in-progress: true
 
 env:
-  BAYESIAN_PHYSTWIN_REF: ${{ inputs.bayesian_phystwin_ref || 'main' }}
-  CAUSAL4D_REF: ${{ inputs.causal4d_ref || 'main' }}
+  # Normal PR, push, and scheduled runs use exact release-compatible revisions.
+  # workflow_dispatch remains the explicit escape hatch for testing another pair.
+  BAYESIAN_PHYSTWIN_REF: >-
+    ${{ inputs.bayesian_phystwin_ref || '322458dfc23f1db9419ed1eb0f4728dcde9135b0' }}
+  CAUSAL4D_REF: >-
+    ${{ inputs.causal4d_ref || 'e6a7047ed479879810a9c6b4aba1bcdc41566a4d' }}
 
 jobs:
   capsule:

--- a/docs/ecosystem-release-capsule.md
+++ b/docs/ecosystem-release-capsule.md
@@ -85,10 +85,18 @@ produces a different capsule.
 
 ## Running the workflow
 
-Use the workflow's manual dispatch and select the BayesianPhysTwin and Causal4D
-branch, tag, or commit to validate. The selected refs are resolved to exact commit
+Normal pull-request, push, and scheduled executions use the exact
+release-compatible BayesianPhysTwin and Causal4D commit SHAs declared in the
+workflow. A rerun of the same Prob4D revision therefore cannot silently switch to
+new companion repository contents merely because either `main` branch moved.
+Updating either pinned companion revision is a reviewed Prob4D change and reruns
+the complete installed-wheel path.
+
+Use the workflow's manual dispatch to test another BayesianPhysTwin or Causal4D
+branch, tag, or commit explicitly. The selected refs are resolved to exact commit
 SHAs before the capsule is written. Prob4D is always the exact reviewed workflow
 revision: a pull-request head on pull-request events and `github.sha` otherwise.
+The resulting capsule records the actual resolved revisions in either mode.
 
 The workflow also runs weekly and whenever the release-capsule implementation,
 Prob4D-owned integration tests, public API manifest, or stable provider/observation

--- a/tests/test_ecosystem_capsule_workflow.py
+++ b/tests/test_ecosystem_capsule_workflow.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "ecosystem-release-capsule.yml"
+BAYESIAN_PHYSTWIN_PIN = "322458dfc23f1db9419ed1eb0f4728dcde9135b0"
+CAUSAL4D_PIN = "e6a7047ed479879810a9c6b4aba1bcdc41566a4d"
 
 
 def test_repository_owned_integration_tests_trigger_ecosystem_capsule() -> None:
@@ -50,3 +52,21 @@ def test_workflow_keeps_external_actions_and_checkouts_fail_closed() -> None:
     assert "actions/upload-artifact@v" not in text
     assert text.count("persist-credentials: false") == 3
     assert "permissions:\n  contents: read" in text
+
+
+def test_automatic_capsule_runs_pin_exact_companion_revisions() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert text.count(BAYESIAN_PHYSTWIN_PIN) == 3
+    assert text.count(CAUSAL4D_PIN) == 3
+    assert "BAYESIAN_PHYSTWIN_REF: ${{ inputs.bayesian_phystwin_ref || 'main' }}" not in text
+    assert "CAUSAL4D_REF: ${{ inputs.causal4d_ref || 'main' }}" not in text
+
+
+def test_manual_dispatch_retains_explicit_companion_overrides() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "bayesian_phystwin_ref:" in text
+    assert "causal4d_ref:" in text
+    assert "ref: ${{ env.BAYESIAN_PHYSTWIN_REF }}" in text
+    assert "ref: ${{ env.CAUSAL4D_REF }}" in text


### PR DESCRIPTION
## Summary

- pin automatic PR, push, and scheduled capsule runs to exact release-compatible BayesianPhysTwin and Causal4D commits;
- retain workflow-dispatch inputs as explicit branch, tag, or commit overrides;
- add workflow regression tests preventing moving-`main` defaults from returning; and
- document the reproducibility and override boundaries.

## Motivation

The capsule already records resolved SHAs, but a rerun of an unchanged Prob4D revision could previously test different companion contents after either `main` branch moved. This makes normal capsule execution deterministic while preserving deliberate compatibility probes.

Pinned companion revisions:

- BayesianPhysTwin: `322458dfc23f1db9419ed1eb0f4728dcde9135b0`
- Causal4D: `e6a7047ed479879810a9c6b4aba1bcdc41566a4d`

## Validation

All pull-request workflows passed on exact head `5e349fbaa4244d07f15917dde0963126b669e07a`:

- complete suites on Python 3.10, 3.11, 3.12, 3.13, and 3.14;
- the declared Python 3.10 / NumPy 1.24 runtime floor;
- repository, release, API, and distribution policy checks;
- wheel and source-distribution construction;
- isolated installed-wheel and installed-sdist CLI smoke tests;
- fail-closed Ruff and mypy quality checks;
- dependency and CodeQL security scanning; and
- the evidence-bound Prob4D → BayesianPhysTwin → Causal4D installed-wheel capsule using the pinned companion revisions.

The branch contains one commit and changes exactly three files. No estimator, artifact, fallback, target-access, or scientific-result semantics changed.

## Scientific boundary

This is CI and provenance hardening only. It does not establish provider accuracy, uncertainty calibration, BayesianPhysTwin benefit, Causal4D intervention benefit, deployment safety, or state of the art.