### PR TITLE
Add joint multi-window material-identity posterior

### DIFF
--- a/.github/workflows/material-identity-marginalization.yml
+++ b/.github/workflows/material-identity-marginalization.yml
@@ -5,8 +5,17 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/material-identity-marginalization.yml"
+      - "docs/examples/joint-material-identity-posterior-config.json"
+      - "docs/joint-material-identity-posterior.md"
+      - "docs/material-identity-cli.md"
       - "docs/material-identity-marginalization.md"
+      - "src/prob4d/command_registry.py"
+      - "src/prob4d/_joint_material_identity_*.py"
+      - "src/prob4d/joint_material_identity.py"
+      - "src/prob4d/material_identity_cli.py"
       - "src/prob4d/material_identity_mixture.py"
+      - "tests/*joint_material_identity*.py"
+      - "tests/test_material_identity_cli.py"
       - "tests/test_material_identity_mixture.py"
   workflow_dispatch:
 
@@ -23,7 +32,7 @@ env:
 
 jobs:
   contract:
-    name: Local-ID mixture and marginalization contract
+    name: Local and joint material-identity contracts
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -45,14 +54,31 @@ jobs:
       - name: Check focused source quality
         run: |
           python -m ruff check \
+            src/prob4d/_joint_material_identity_*.py \
+            src/prob4d/joint_material_identity.py \
+            src/prob4d/material_identity_cli.py \
             src/prob4d/material_identity_mixture.py \
+            tests/test_joint_material_identity*.py \
+            tests/test_material_identity_cli.py \
             tests/test_material_identity_mixture.py
-          python -m mypy src/prob4d/material_identity_mixture.py
+          python -m mypy \
+            src/prob4d/_joint_material_identity_*.py \
+            src/prob4d/joint_material_identity.py \
+            src/prob4d/material_identity_mixture.py
       - name: Run focused regressions
-        run: python -m pytest -q tests/test_material_identity_mixture.py
-      - name: Verify installed public module
+        run: |
+          python -m pytest -q \
+            tests/test_joint_material_identity*.py \
+            tests/test_material_identity_cli.py \
+            tests/test_material_identity_mixture.py
+      - name: Verify installed public modules
         run: |
           python - <<'PY'
+          from prob4d.joint_material_identity import (
+              JOINT_ASSIGNMENT_SEMANTICS,
+              JOINT_LIKELIHOOD_SEMANTICS,
+              JOINT_MATERIAL_IDENTITY_POSTERIOR_SCHEMA,
+          )
           from prob4d.material_identity_mixture import (
               LIKELIHOOD_MARGINALIZATION_SEMANTICS,
               MATERIAL_IDENTITY_MIXTURE_SCHEMA,
@@ -64,4 +90,7 @@ jobs:
           assert LIKELIHOOD_MARGINALIZATION_SEMANTICS.startswith("logsumexp-")
           assert MOMENT_MATCH_SEMANTICS == "law-of-total-covariance-v1"
           assert NULL_HYPOTHESIS_SEMANTICS == "newest-window-local-reference-v1"
+          assert JOINT_MATERIAL_IDENTITY_POSTERIOR_SCHEMA.startswith("prob4d.")
+          assert JOINT_ASSIGNMENT_SEMANTICS.endswith("forest-v1")
+          assert JOINT_LIKELIHOOD_SEMANTICS.startswith("logsumexp-")
           PY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,19 @@ release notes and scientific boundaries live under `docs/releases/`.
 
 ## Unreleased
 
-No changes yet.
+### Added
+
+- A bounded exact joint multi-window material-identity posterior that conditions
+  source-calibrated local mixtures on a window-unique forest constraint, embeds
+  and replays every source mixture, preserves exact local null fallback, and
+  exposes grouped build, validation, and downstream marginalization commands.
+
+### Scientific boundary
+
+The joint posterior is source-side identity and consistency infrastructure. It
+requires separately calibrated local weights and does not establish association
+precision, real-provider competence, BayesianPhysTwin benefit, Causal4D benefit,
+physical-state identifiability, deployment safety, or state of the art.
 
 ## 0.5.0 — 2026-08-12
 

--- a/docs/examples/joint-material-identity-posterior-config.json
+++ b/docs/examples/joint-material-identity-posterior-config.json
@@ -1,0 +1,17 @@
+{
+  "window_order": [
+    "window-000",
+    "window-001",
+    "window-002"
+  ],
+  "mixture_paths": [
+    "mixtures/window-001-track-000.json",
+    "mixtures/window-002-track-000.json"
+  ],
+  "maximum_joint_assignments": 100000,
+  "metadata": {
+    "stage": "source-only",
+    "uses_target_truth": false,
+    "uses_downstream_physical_innovation": false
+  }
+}

--- a/docs/joint-material-identity-posterior.md
+++ b/docs/joint-material-identity-posterior.md
@@ -1,0 +1,145 @@
+# Joint multi-window material-identity posterior
+
+`prob4d.joint_material_identity` conditions several source-calibrated
+`MaterialIdentityMixtureV1` artifacts on one global consistency rule without
+creating global point IDs.
+
+A local mixture chooses exactly one candidate for one target-local track:
+
+- its mandatory null candidate, which preserves the newest-window reference; or
+- one linked predecessor identified by its original `(window_id, track_id)`.
+
+Evaluating those mixtures independently can assign the same earlier material
+track to two different tracks in one later window. Pairwise links can also become
+inconsistent only after several windows are connected. The joint posterior
+removes those assignments before any downstream physical likelihood is applied.
+
+## Constraint
+
+Every candidate selection forms a directed edge from an earlier source endpoint
+to one target endpoint. A complete assignment is admitted only when every
+connected component contains at most one endpoint from each prediction window.
+Together with one candidate per target mixture and the declared window order,
+this gives an acyclic window-local identity forest.
+
+The rule permits one material point to continue across several windows while
+preventing one inferred material component from splitting into two tracks in the
+same window. Endpoints remain local, and no connected-component label is exported
+as a provider-v2 point identity.
+
+For local calibrated log weights `w_ij`, the source-side joint prior is
+
+```text
+q(a) proportional to exp(sum_i w_i,a_i) * 1[a is globally feasible].
+```
+
+Conditioning therefore changes local candidate marginals when independent local
+choices are mutually incompatible. Additive constants in one local mixture
+cancel because every joint assignment selects exactly one candidate from that
+mixture.
+
+## Bounded exact enumeration
+
+Version 1 enumerates the exact Cartesian product only when its unconstrained size
+is no larger than `maximum_joint_assignments`. It fails closed before enumeration
+when the declared bound would be exceeded. There is no silent beam search,
+approximate truncation, or assignment dropping.
+
+The self-contained posterior embeds and revalidates every source mixture. Loading
+replays:
+
+- canonical mixture and target ordering;
+- common calibration, association-rule, and implementation identities;
+- the global window-prefix contract;
+- every feasible and rejected assignment;
+- normalized assignment probabilities;
+- target-aligned candidate marginals;
+- entropy and effective assignment count; and
+- the content-derived posterior identity.
+
+Changing a source mixture, selected candidate, probability, marginal, count, or
+claim boundary therefore fails exact replay even when the outer JSON is otherwise
+well formed.
+
+## Python API
+
+```python
+from prob4d.joint_material_identity import (
+    build_joint_material_identity_posterior,
+    marginalize_joint_assignment_log_likelihoods,
+)
+
+posterior = build_joint_material_identity_posterior(
+    local_mixtures,
+    window_order=("window-000", "window-001", "window-002"),
+    maximum_joint_assignments=100_000,
+    metadata={"stage": "source-only"},
+)
+
+result = marginalize_joint_assignment_log_likelihoods(
+    posterior,
+    posterior.assignment_ids,
+    downstream_log_likelihoods,
+)
+```
+
+`assignment_components` returns the selected components as tuples of original
+`LocalTrackEndpoint` values. `joint_candidate_marginals` projects either the
+source joint prior or a downstream assignment posterior back to the exact local
+candidate order.
+
+Candidate IDs and assignment IDs must align exactly. A likelihood power of zero
+returns the source-side joint prior without consulting impossible `-inf`
+likelihood entries.
+
+## Grouped command line
+
+Create a configuration whose mixture paths are confined relative to the
+configuration file:
+
+```json
+{
+  "window_order": ["window-000", "window-001", "window-002"],
+  "mixture_paths": [
+    "mixtures/window-001-track-000.json",
+    "mixtures/window-002-track-000.json"
+  ],
+  "maximum_joint_assignments": 100000,
+  "metadata": {"stage": "source-only"}
+}
+```
+
+Then run:
+
+```bash
+prob4d identity build-joint joint-config.json \
+  --output joint-material-identity.json
+
+prob4d identity validate-joint joint-material-identity.json
+```
+
+Marginalize a candidate-aligned downstream likelihood with:
+
+```bash
+prob4d identity marginalize-joint \
+  joint-material-identity.json \
+  joint-assignment-likelihoods.json
+```
+
+The likelihood file contains exactly `assignment_ids`, `log_likelihoods`, and
+`likelihood_power`.
+
+## Statistical and scientific boundary
+
+The local log weights must be calibrated using complete source/calibration
+objects or acquisition sessions. Exact global conditioning does not make those
+weights calibrated, independent, or correct. It also does not establish
+cross-window association precision, real-provider competence, physical-state
+identifiability, BayesianPhysTwin benefit, Causal4D benefit, or deployment
+safety.
+
+Promotion requires an object/session-held-out comparison of framewise identity,
+within-window persistence, pairwise hard links, independent local mixtures, the
+joint posterior, an identity oracle used only for headroom, and exact physical
+fallback. BayesianPhysTwin continues to own the downstream regret guard and
+complete-belief fallback.

--- a/docs/material-identity-cli.md
+++ b/docs/material-identity-cli.md
@@ -1,8 +1,8 @@
 # Material-identity command line
 
-`prob4d identity` exposes the existing append-only hypothesis stream and
-source-calibrated identity-mixture contracts without promoting global material
-IDs or changing provider-v2 observation identities.
+`prob4d identity` exposes append-only hypothesis streams, source-calibrated
+local mixtures, and bounded exact joint posteriors without promoting global
+material IDs or changing provider-v2 observation identities.
 
 The commands do not fit weights and do not accept BayesianPhysTwin updates.
 Calibration must be completed on declared source/calibration objects or sessions
@@ -29,6 +29,36 @@ Validate an append-only multi-window stream independently with:
 ```bash
 prob4d identity validate-stream material-identities.json
 ```
+
+## Joint multi-window consistency
+
+Several local mixtures can be conditioned on the exact window-unique forest
+constraint before a downstream physical likelihood is evaluated:
+
+```bash
+cp docs/examples/joint-material-identity-posterior-config.json joint-config.json
+prob4d identity build-joint joint-config.json \
+  --output joint-material-identity.json
+prob4d identity validate-joint joint-material-identity.json
+```
+
+The joint artifact embeds every source mixture, rejects assignments whose
+connected component would contain two endpoints from one prediction window, and
+fails before enumeration when the declared Cartesian-product bound is exceeded.
+It retains the mandatory null candidate for every target mixture.
+
+Evaluate assignment-aligned downstream likelihoods with:
+
+```bash
+prob4d identity marginalize-joint \
+  joint-material-identity.json \
+  joint-assignment-likelihoods.json
+```
+
+The output includes exact assignment probabilities and candidate-aligned local
+marginals after global conditioning. See the
+[joint material-identity posterior](joint-material-identity-posterior.md) for the
+constraint, replay, and claim boundaries.
 
 ## Likelihood marginalization
 

--- a/docs/material-identity-marginalization.md
+++ b/docs/material-identity-marginalization.md
@@ -56,6 +56,18 @@ cov  = sum_a q_a cov_a
 
 The second term is retained explicitly as between-hypothesis uncertainty.
 
+## Joint consistency across target tracks and windows
+
+Independent local mixtures can still be mutually inconsistent. For example, two
+target tracks in one window may both select the same source material endpoint,
+or a conflict may appear only after several pairwise links become transitive.
+`prob4d.joint_material_identity` conditions the local mixture product on one
+window-unique forest constraint and returns exact assignment and candidate
+marginals under a declared combinatorial bound. It preserves the same local null
+fallbacks and never emits a rewritten global point ID.
+
+See [joint multi-window material-identity posterior](joint-material-identity-posterior.md).
+
 ## Fallback behavior
 
 A mixture containing only the null hypothesis returns the null likelihood, mean,

--- a/src/prob4d/_joint_material_identity_common.py
+++ b/src/prob4d/_joint_material_identity_common.py
@@ -1,0 +1,231 @@
+"""Shared validation and graph helpers for joint local material identities."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from typing import Any, Literal, TypeAlias, cast
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ._immutable_json import plain_json
+from .material_identity_mixture import (
+    LocalTrackEndpoint,
+    MaterialIdentityMixtureV1,
+)
+
+FloatArray: TypeAlias = NDArray[np.floating[Any]]
+
+JOINT_MATERIAL_IDENTITY_POSTERIOR_SCHEMA = (
+    "prob4d.joint-material-identity-posterior"
+)
+JOINT_MATERIAL_IDENTITY_POSTERIOR_VERSION = 1
+JOINT_ASSIGNMENT_SEMANTICS: Literal[
+    "conditioned-local-mixtures-window-unique-forest-v1"
+] = "conditioned-local-mixtures-window-unique-forest-v1"
+JOINT_LIKELIHOOD_SEMANTICS: Literal[
+    "logsumexp-discrete-joint-identity-v1"
+] = "logsumexp-discrete-joint-identity-v1"
+CLAIM_BOUNDARY = (
+    "Source-calibrated material-identity mixtures conditioned on the declared "
+    "window-unique forest constraint. Endpoints remain window-local, every "
+    "local null candidate remains available, and no provider competence, "
+    "physical-state update, BayesianPhysTwin benefit, or Causal4D benefit is "
+    "established by this artifact."
+)
+
+
+def _canonical_json(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        plain_json(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _sha256_json(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json(value)).hexdigest()
+
+
+def _string(value: object, *, name: str) -> str:
+    if type(value) is not str or not value or value.strip() != value:
+        raise ValueError(f"{name} must be a non-empty canonical string")
+    return value
+
+
+def _integer(value: object, *, name: str, minimum: int = 0) -> int:
+    if type(value) is not int and not isinstance(value, np.integer):
+        raise ValueError(f"{name} must be an integer")
+    result = int(value)
+    if result < minimum:
+        raise ValueError(f"{name} must be at least {minimum}")
+    return result
+
+
+def _finite_real(value: object, *, name: str, minimum: float | None = None) -> float:
+    if type(value) not in {int, float} and not isinstance(
+        value, (np.integer, np.floating)
+    ):
+        raise ValueError(f"{name} must be a real number")
+    result = float(cast(Any, value))
+    if not np.isfinite(result):
+        raise ValueError(f"{name} must be finite")
+    if minimum is not None and result < minimum:
+        raise ValueError(f"{name} must be at least {minimum}")
+    return result
+
+
+def _sha256(value: object, *, name: str) -> str:
+    digest = _string(value, name=name)
+    if len(digest) != 64 or any(
+        character not in "0123456789abcdef" for character in digest
+    ):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return digest
+
+
+def _readonly(value: np.ndarray, *, dtype: Any) -> np.ndarray:
+    result = np.asarray(value, dtype=dtype).copy()
+    result.setflags(write=False)
+    return result
+
+
+def _logsumexp(values: FloatArray) -> float:
+    array = np.asarray(values, dtype=np.float64)
+    if array.ndim != 1 or array.size == 0:
+        raise ValueError("logsumexp values must be a non-empty vector")
+    if np.any(np.isnan(array)) or np.any(np.isposinf(array)):
+        raise ValueError("logsumexp values may not contain NaN or positive infinity")
+    maximum = float(np.max(array))
+    if np.isneginf(maximum):
+        return float("-inf")
+    return float(maximum + np.log(np.sum(np.exp(array - maximum))))
+
+
+def _endpoint_key(
+    endpoint: LocalTrackEndpoint,
+    *,
+    window_indices: Mapping[str, int],
+) -> tuple[int, int, str]:
+    return window_indices[endpoint.window_id], endpoint.track_id, endpoint.window_id
+
+
+def _canonical_mixtures(
+    mixtures: Sequence[MaterialIdentityMixtureV1],
+    *,
+    window_order: tuple[str, ...],
+) -> tuple[MaterialIdentityMixtureV1, ...]:
+    if type(window_order) is not tuple or not window_order:
+        raise ValueError("window_order must be a non-empty tuple")
+    order = tuple(
+        _string(window_id, name=f"window_order[{index}]")
+        for index, window_id in enumerate(window_order)
+    )
+    if len(set(order)) != len(order):
+        raise ValueError("window_order must contain unique window IDs")
+    values = tuple(mixtures)
+    if not values:
+        raise ValueError("at least one material-identity mixture is required")
+    if any(not isinstance(value, MaterialIdentityMixtureV1) for value in values):
+        raise ValueError("mixtures must contain MaterialIdentityMixtureV1 values")
+
+    indices = {window_id: index for index, window_id in enumerate(order)}
+    for mixture in values:
+        target_window = mixture.target_endpoint.window_id
+        if target_window not in indices:
+            raise ValueError("mixture target window is absent from window_order")
+        expected_prefix = order[: indices[target_window] + 1]
+        if mixture.window_order != expected_prefix:
+            raise ValueError(
+                "every mixture window_order must equal the global prefix ending "
+                "at its target window"
+            )
+
+    canonical = tuple(
+        sorted(
+            values,
+            key=lambda mixture: (
+                indices[mixture.target_endpoint.window_id],
+                mixture.target_endpoint.track_id,
+                cast(str, mixture.mixture_id),
+            ),
+        )
+    )
+    if len({mixture.target_endpoint for mixture in canonical}) != len(canonical):
+        raise ValueError("joint mixtures must have unique target endpoints")
+    if len({mixture.mixture_id for mixture in canonical}) != len(canonical):
+        raise ValueError("joint mixture IDs must be unique")
+    for field_name in (
+        "association_rule_id",
+        "calibration_id",
+        "tracklet_producer_revision",
+        "association_revision",
+        "weight_semantics",
+        "null_hypothesis_semantics",
+    ):
+        if len({getattr(mixture, field_name) for mixture in canonical}) != 1:
+            raise ValueError(f"joint mixtures disagree on {field_name}")
+    return canonical
+
+
+class _WindowUniqueForest:
+    """Union-find that rejects a second endpoint from an occupied window."""
+
+    def __init__(self) -> None:
+        self.parent: dict[LocalTrackEndpoint, LocalTrackEndpoint] = {}
+        self.rank: dict[LocalTrackEndpoint, int] = {}
+        self.windows: dict[LocalTrackEndpoint, frozenset[str]] = {}
+
+    def add(self, endpoint: LocalTrackEndpoint) -> None:
+        if endpoint in self.parent:
+            return
+        self.parent[endpoint] = endpoint
+        self.rank[endpoint] = 0
+        self.windows[endpoint] = frozenset({endpoint.window_id})
+
+    def find(self, endpoint: LocalTrackEndpoint) -> LocalTrackEndpoint:
+        parent = self.parent[endpoint]
+        if parent != endpoint:
+            self.parent[endpoint] = self.find(parent)
+        return self.parent[endpoint]
+
+    def union(self, first: LocalTrackEndpoint, second: LocalTrackEndpoint) -> bool:
+        self.add(first)
+        self.add(second)
+        first_root = self.find(first)
+        second_root = self.find(second)
+        if first_root == second_root:
+            return False
+        if self.windows[first_root] & self.windows[second_root]:
+            return False
+        if self.rank[first_root] < self.rank[second_root]:
+            first_root, second_root = second_root, first_root
+        self.parent[second_root] = first_root
+        self.windows[first_root] |= self.windows[second_root]
+        del self.windows[second_root]
+        if self.rank[first_root] == self.rank[second_root]:
+            self.rank[first_root] += 1
+        return True
+
+    def components(self) -> tuple[tuple[LocalTrackEndpoint, ...], ...]:
+        grouped: dict[LocalTrackEndpoint, list[LocalTrackEndpoint]] = {}
+        for endpoint in self.parent:
+            grouped.setdefault(self.find(endpoint), []).append(endpoint)
+        return tuple(tuple(values) for values in grouped.values())
+
+
+def _selection_is_feasible(
+    mixtures: tuple[MaterialIdentityMixtureV1, ...],
+    candidate_indices: tuple[int, ...],
+) -> bool:
+    forest = _WindowUniqueForest()
+    for mixture, candidate_index in zip(mixtures, candidate_indices, strict=True):
+        target = mixture.target_endpoint
+        forest.add(target)
+        source = mixture.candidates[candidate_index].source_endpoint
+        if source is not None and not forest.union(source, target):
+            return False
+    return True

--- a/src/prob4d/_joint_material_identity_compute.py
+++ b/src/prob4d/_joint_material_identity_compute.py
@@ -39,7 +39,7 @@ def _marginals_from_assignments(
 ) -> tuple[JointIdentityMarginalV1, ...]:
     results: list[JointIdentityMarginalV1] = []
     for mixture_index, mixture in enumerate(mixtures):
-        values = np.zeros(len(mixture.candidates), dtype=np.float64)
+        values: FloatArray = np.zeros(len(mixture.candidates), dtype=np.float64)
         index_by_id = {
             candidate_id: index for index, candidate_id in enumerate(mixture.candidate_ids)
         }

--- a/src/prob4d/_joint_material_identity_compute.py
+++ b/src/prob4d/_joint_material_identity_compute.py
@@ -11,7 +11,6 @@ import numpy as np
 
 from ._joint_material_identity_common import (
     FloatArray,
-    _WindowUniqueForest,
     _canonical_mixtures,
     _endpoint_key,
     _finite_real,
@@ -19,6 +18,7 @@ from ._joint_material_identity_common import (
     _logsumexp,
     _selection_is_feasible,
     _sha256,
+    _WindowUniqueForest,
 )
 from ._joint_material_identity_likelihood import MarginalizedJointIdentityLikelihood
 from ._joint_material_identity_model import JointMaterialIdentityPosteriorV1

--- a/src/prob4d/_joint_material_identity_compute.py
+++ b/src/prob4d/_joint_material_identity_compute.py
@@ -1,0 +1,239 @@
+"""Exact bounded enumeration and inference for joint material identities."""
+
+from __future__ import annotations
+
+import itertools
+import math
+from collections.abc import Mapping, Sequence
+from typing import Any, cast
+
+import numpy as np
+
+from ._joint_material_identity_common import (
+    FloatArray,
+    _WindowUniqueForest,
+    _canonical_mixtures,
+    _endpoint_key,
+    _finite_real,
+    _integer,
+    _logsumexp,
+    _selection_is_feasible,
+    _sha256,
+)
+from ._joint_material_identity_likelihood import MarginalizedJointIdentityLikelihood
+from ._joint_material_identity_model import JointMaterialIdentityPosteriorV1
+from ._joint_material_identity_records import (
+    JointIdentityAssignmentV1,
+    JointIdentityMarginalV1,
+)
+from .material_identity_mixture import (
+    LocalTrackEndpoint,
+    MaterialIdentityMixtureV1,
+)
+
+
+def _marginals_from_assignments(
+    mixtures: tuple[MaterialIdentityMixtureV1, ...],
+    assignments: tuple[JointIdentityAssignmentV1, ...],
+    probabilities: FloatArray,
+) -> tuple[JointIdentityMarginalV1, ...]:
+    results: list[JointIdentityMarginalV1] = []
+    for mixture_index, mixture in enumerate(mixtures):
+        values = np.zeros(len(mixture.candidates), dtype=np.float64)
+        index_by_id = {
+            candidate_id: index for index, candidate_id in enumerate(mixture.candidate_ids)
+        }
+        for assignment, probability in zip(assignments, probabilities, strict=True):
+            values[index_by_id[assignment.candidate_ids[mixture_index]]] += probability
+        results.append(
+            JointIdentityMarginalV1(
+                mixture_id=cast(str, mixture.mixture_id),
+                target_endpoint=mixture.target_endpoint,
+                candidate_ids=mixture.candidate_ids,
+                probabilities=values,
+            )
+        )
+    return tuple(results)
+
+
+def build_joint_material_identity_posterior(
+    mixtures: Sequence[MaterialIdentityMixtureV1],
+    *,
+    window_order: tuple[str, ...],
+    maximum_joint_assignments: int = 100_000,
+    metadata: Mapping[str, Any] | None = None,
+) -> JointMaterialIdentityPosteriorV1:
+    """Condition local mixtures on the exact window-unique forest rule."""
+
+    canonical = _canonical_mixtures(mixtures, window_order=window_order)
+    maximum = _integer(
+        maximum_joint_assignments,
+        name="maximum_joint_assignments",
+        minimum=1,
+    )
+    unconstrained = math.prod(len(mixture.candidates) for mixture in canonical)
+    if unconstrained > maximum:
+        raise ValueError(
+            "unconstrained assignment count "
+            f"{unconstrained} exceeds maximum_joint_assignments {maximum}"
+        )
+
+    raw: list[tuple[tuple[str, ...], float]] = []
+    candidate_ranges = tuple(range(len(mixture.candidates)) for mixture in canonical)
+    for indices in itertools.product(*candidate_ranges):
+        if not _selection_is_feasible(canonical, indices):
+            continue
+        candidate_ids = tuple(
+            mixture.candidate_ids[index]
+            for mixture, index in zip(canonical, indices, strict=True)
+        )
+        log_weight = float(
+            sum(
+                mixture.candidates[index].calibrated_log_weight
+                for mixture, index in zip(canonical, indices, strict=True)
+            )
+        )
+        raw.append((candidate_ids, log_weight))
+    if not raw:
+        raise ValueError("the joint identity constraint admitted no assignments")
+    log_weights = np.asarray([value[1] for value in raw], dtype=np.float64)
+    log_normalizer = _logsumexp(log_weights)
+    probabilities = np.exp(log_weights - log_normalizer)
+    mixture_ids = tuple(cast(str, mixture.mixture_id) for mixture in canonical)
+    assignments = tuple(
+        JointIdentityAssignmentV1(
+            mixture_ids=mixture_ids,
+            candidate_ids=candidate_ids,
+            log_weight=log_weight,
+            probability=float(probability),
+        )
+        for (candidate_ids, log_weight), probability in zip(
+            raw,
+            probabilities,
+            strict=True,
+        )
+    )
+    marginals = _marginals_from_assignments(canonical, assignments, probabilities)
+    return JointMaterialIdentityPosteriorV1(
+        window_order=window_order,
+        mixtures=canonical,
+        maximum_joint_assignments=maximum,
+        unconstrained_assignment_count=unconstrained,
+        assignments=assignments,
+        marginals=marginals,
+        log_normalizer=log_normalizer,
+        metadata={} if metadata is None else metadata,
+    )
+
+
+def marginalize_joint_assignment_log_likelihoods(
+    posterior: JointMaterialIdentityPosteriorV1,
+    assignment_ids: tuple[str, ...],
+    log_likelihoods: FloatArray,
+    *,
+    likelihood_power: float = 1.0,
+) -> MarginalizedJointIdentityLikelihood:
+    """Marginalize a downstream likelihood over feasible assignments."""
+
+    if not isinstance(posterior, JointMaterialIdentityPosteriorV1):
+        raise ValueError("posterior must be JointMaterialIdentityPosteriorV1")
+    if type(assignment_ids) is not tuple or assignment_ids != posterior.assignment_ids:
+        raise ValueError("assignment_ids must exactly match posterior.assignment_ids")
+    values = np.asarray(log_likelihoods, dtype=np.float64)
+    if values.shape != (len(assignment_ids),):
+        raise ValueError("log_likelihoods must match the assignment count")
+    if np.any(np.isnan(values)) or np.any(np.isposinf(values)):
+        raise ValueError("log_likelihoods may not contain NaN or positive infinity")
+    power = _finite_real(likelihood_power, name="likelihood_power", minimum=0.0)
+    prior_log = np.log(posterior.probabilities)
+    terms = prior_log if power == 0.0 else prior_log + power * values
+    log_marginal = _logsumexp(terms)
+    if np.isneginf(log_marginal):
+        raise ValueError("every joint assignment has impossible likelihood")
+    return MarginalizedJointIdentityLikelihood(
+        assignment_ids=assignment_ids,
+        log_marginal_likelihood=log_marginal,
+        posterior_probabilities=np.exp(terms - log_marginal),
+        likelihood_power=power,
+    )
+
+
+def joint_candidate_marginals(
+    posterior: JointMaterialIdentityPosteriorV1,
+    *,
+    assignment_probabilities: FloatArray | None = None,
+) -> tuple[JointIdentityMarginalV1, ...]:
+    """Project assignment probabilities to exact local candidate order."""
+
+    if not isinstance(posterior, JointMaterialIdentityPosteriorV1):
+        raise ValueError("posterior must be JointMaterialIdentityPosteriorV1")
+    if assignment_probabilities is None:
+        probabilities = posterior.probabilities
+    else:
+        probabilities = np.asarray(assignment_probabilities, dtype=np.float64)
+        if probabilities.shape != (posterior.feasible_assignment_count,):
+            raise ValueError("assignment_probabilities must match assignments")
+        if not np.all(np.isfinite(probabilities)) or np.any(probabilities < 0.0):
+            raise ValueError("assignment_probabilities must be finite and non-negative")
+        if not np.isclose(float(np.sum(probabilities)), 1.0, atol=1e-12, rtol=1e-12):
+            raise ValueError("assignment_probabilities must sum to one")
+    return _marginals_from_assignments(
+        posterior.mixtures,
+        posterior.assignments,
+        probabilities,
+    )
+
+
+def assignment_components(
+    posterior: JointMaterialIdentityPosteriorV1,
+    assignment_id: str,
+) -> tuple[tuple[LocalTrackEndpoint, ...], ...]:
+    """Return canonical local endpoint components for one assignment."""
+
+    expected = _sha256(assignment_id, name="assignment_id")
+    matches = [
+        assignment
+        for assignment in posterior.assignments
+        if assignment.assignment_id == expected
+    ]
+    if not matches:
+        raise ValueError("assignment_id is absent from the posterior")
+    assignment = matches[0]
+    lookup = {
+        cast(str, mixture.mixture_id): dict(
+            zip(mixture.candidate_ids, mixture.candidates, strict=True)
+        )
+        for mixture in posterior.mixtures
+    }
+    forest = _WindowUniqueForest()
+    for mixture, candidate_id in zip(
+        posterior.mixtures,
+        assignment.candidate_ids,
+        strict=True,
+    ):
+        forest.add(mixture.target_endpoint)
+        candidate = lookup[cast(str, mixture.mixture_id)][candidate_id]
+        if candidate.source_endpoint is not None and not forest.union(
+            candidate.source_endpoint,
+            mixture.target_endpoint,
+        ):
+            raise AssertionError("stored assignment violates the forest constraint")
+    indices = {value: index for index, value in enumerate(posterior.window_order)}
+    components = tuple(
+        tuple(
+            sorted(
+                component,
+                key=lambda endpoint: _endpoint_key(endpoint, window_indices=indices),
+            )
+        )
+        for component in forest.components()
+    )
+    return tuple(
+        sorted(
+            components,
+            key=lambda component: _endpoint_key(
+                component[0],
+                window_indices=indices,
+            ),
+        )
+    )

--- a/src/prob4d/_joint_material_identity_io.py
+++ b/src/prob4d/_joint_material_identity_io.py
@@ -85,35 +85,44 @@ def _replay(value: Mapping[str, Any]) -> JointMaterialIdentityPosteriorV1:
     assignments = _list(value["assignments"], name="assignments")
     if len(assignments) != len(posterior.assignments):
         raise ValueError("assignments differ from exact joint-posterior replay")
-    for index, (raw, expected) in enumerate(
+    for index, (raw, expected_assignment) in enumerate(
         zip(assignments, posterior.assignments, strict=True)
     ):
         record = _mapping(raw, name=f"assignments[{index}]")
         if (
-            record.get("assignment_id") != expected.assignment_id
-            or record.get("mixture_ids") != list(expected.mixture_ids)
-            or record.get("candidate_ids") != list(expected.candidate_ids)
+            record.get("assignment_id") != expected_assignment.assignment_id
+            or record.get("mixture_ids") != list(expected_assignment.mixture_ids)
+            or record.get("candidate_ids") != list(expected_assignment.candidate_ids)
         ):
             raise ValueError("assignments differ from exact joint-posterior replay")
-        _close(record.get("log_weight"), expected.log_weight, name="assignment.log_weight")
-        _close(record.get("probability"), expected.probability, name="assignment.probability")
+        _close(
+            record.get("log_weight"),
+            expected_assignment.log_weight,
+            name="assignment.log_weight",
+        )
+        _close(
+            record.get("probability"),
+            expected_assignment.probability,
+            name="assignment.probability",
+        )
     marginals = _list(value["marginals"], name="marginals")
     if len(marginals) != len(posterior.marginals):
         raise ValueError("marginals differ from exact joint-posterior replay")
-    for index, (raw, expected) in enumerate(
+    for index, (raw, expected_marginal) in enumerate(
         zip(marginals, posterior.marginals, strict=True)
     ):
         record = _mapping(raw, name=f"marginals[{index}]")
         if (
-            record.get("mixture_id") != expected.mixture_id
-            or record.get("candidate_ids") != list(expected.candidate_ids)
-            or record.get("target_endpoint") != expected.target_endpoint.to_dict()
+            record.get("mixture_id") != expected_marginal.mixture_id
+            or record.get("candidate_ids") != list(expected_marginal.candidate_ids)
+            or record.get("target_endpoint")
+            != expected_marginal.target_endpoint.to_dict()
         ):
             raise ValueError("marginals differ from exact joint-posterior replay")
         probabilities = np.asarray(record.get("probabilities"), dtype=np.float64)
         if not np.allclose(
             probabilities,
-            expected.probabilities,
+            expected_marginal.probabilities,
             atol=1e-12,
             rtol=1e-10,
         ):

--- a/src/prob4d/_joint_material_identity_io.py
+++ b/src/prob4d/_joint_material_identity_io.py
@@ -1,0 +1,154 @@
+"""Strict persistence and replay for joint material-identity posteriors."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, cast
+
+import numpy as np
+
+from ._atomic_file import atomic_write_bytes
+from ._joint_material_identity_common import (
+    CLAIM_BOUNDARY,
+    JOINT_ASSIGNMENT_SEMANTICS,
+    JOINT_MATERIAL_IDENTITY_POSTERIOR_SCHEMA,
+    JOINT_MATERIAL_IDENTITY_POSTERIOR_VERSION,
+    _canonical_json,
+)
+from ._joint_material_identity_compute import build_joint_material_identity_posterior
+from ._joint_material_identity_json import (
+    _POSTERIOR_FIELDS,
+    _fields,
+    _list,
+    _load,
+    _mapping,
+)
+from ._joint_material_identity_mixture_io import _mixture
+from ._joint_material_identity_model import JointMaterialIdentityPosteriorV1
+
+
+def _close(actual: object, expected: float, *, name: str) -> None:
+    try:
+        value = float(cast(Any, actual))
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"{name} must be a real number") from error
+    if not np.isfinite(value) or not np.isclose(
+        value,
+        expected,
+        atol=1e-12,
+        rtol=1e-10,
+    ):
+        raise ValueError(f"{name} differs from exact joint-posterior replay")
+
+
+def _replay(value: Mapping[str, Any]) -> JointMaterialIdentityPosteriorV1:
+    _fields(value, _POSTERIOR_FIELDS, name="posterior")
+    if value["schema"] != JOINT_MATERIAL_IDENTITY_POSTERIOR_SCHEMA:
+        raise ValueError("unsupported joint material-identity posterior schema")
+    if value["schema_version"] != JOINT_MATERIAL_IDENTITY_POSTERIOR_VERSION:
+        raise ValueError("unsupported joint material-identity posterior version")
+    if value["constraint_semantics"] != JOINT_ASSIGNMENT_SEMANTICS:
+        raise ValueError("unsupported joint assignment semantics")
+    if value["claim_boundary"] != CLAIM_BOUNDARY:
+        raise ValueError("joint material-identity claim boundary changed")
+    mixtures = tuple(
+        _mixture(raw, index=index)
+        for index, raw in enumerate(_list(value["mixtures"], name="mixtures"))
+    )
+    posterior = build_joint_material_identity_posterior(
+        mixtures,
+        window_order=tuple(_list(value["window_order"], name="window_order")),
+        maximum_joint_assignments=value["maximum_joint_assignments"],
+        metadata=_mapping(value["metadata"], name="metadata"),
+    )
+    if value["posterior_id"] != posterior.posterior_id:
+        raise ValueError("posterior_id differs from exact joint-posterior replay")
+    for name in (
+        "unconstrained_assignment_count",
+        "feasible_assignment_count",
+        "rejected_assignment_count",
+    ):
+        if value[name] != getattr(posterior, name):
+            raise ValueError(f"{name} differs from exact joint-posterior replay")
+    _close(value["log_normalizer"], posterior.log_normalizer, name="log_normalizer")
+    _close(
+        value["joint_entropy_nats"],
+        posterior.joint_entropy_nats,
+        name="joint_entropy_nats",
+    )
+    _close(
+        value["effective_assignment_count"],
+        posterior.effective_assignment_count,
+        name="effective_assignment_count",
+    )
+    assignments = _list(value["assignments"], name="assignments")
+    if len(assignments) != len(posterior.assignments):
+        raise ValueError("assignments differ from exact joint-posterior replay")
+    for index, (raw, expected) in enumerate(
+        zip(assignments, posterior.assignments, strict=True)
+    ):
+        record = _mapping(raw, name=f"assignments[{index}]")
+        if (
+            record.get("assignment_id") != expected.assignment_id
+            or record.get("mixture_ids") != list(expected.mixture_ids)
+            or record.get("candidate_ids") != list(expected.candidate_ids)
+        ):
+            raise ValueError("assignments differ from exact joint-posterior replay")
+        _close(record.get("log_weight"), expected.log_weight, name="assignment.log_weight")
+        _close(record.get("probability"), expected.probability, name="assignment.probability")
+    marginals = _list(value["marginals"], name="marginals")
+    if len(marginals) != len(posterior.marginals):
+        raise ValueError("marginals differ from exact joint-posterior replay")
+    for index, (raw, expected) in enumerate(
+        zip(marginals, posterior.marginals, strict=True)
+    ):
+        record = _mapping(raw, name=f"marginals[{index}]")
+        if (
+            record.get("mixture_id") != expected.mixture_id
+            or record.get("candidate_ids") != list(expected.candidate_ids)
+            or record.get("target_endpoint") != expected.target_endpoint.to_dict()
+        ):
+            raise ValueError("marginals differ from exact joint-posterior replay")
+        probabilities = np.asarray(record.get("probabilities"), dtype=np.float64)
+        if not np.allclose(
+            probabilities,
+            expected.probabilities,
+            atol=1e-12,
+            rtol=1e-10,
+        ):
+            raise ValueError("marginals differ from exact joint-posterior replay")
+    return posterior
+
+
+def write_joint_material_identity_posterior(
+    path: str | Path,
+    posterior: JointMaterialIdentityPosteriorV1,
+    *,
+    overwrite: bool = False,
+) -> None:
+    """Atomically write one replay-complete joint posterior."""
+
+    if not isinstance(posterior, JointMaterialIdentityPosteriorV1):
+        raise ValueError("posterior must be JointMaterialIdentityPosteriorV1")
+    if type(overwrite) is not bool:
+        raise ValueError("overwrite must be a Boolean")
+    atomic_write_bytes(
+        path,
+        _canonical_json(posterior.to_record()) + b"\n",
+        overwrite=overwrite,
+    )
+
+
+def load_joint_material_identity_posterior(
+    path: str | Path,
+) -> JointMaterialIdentityPosteriorV1:
+    """Load, independently reconstruct, and replay one joint posterior."""
+
+    return _replay(_load(Path(path)))
+
+
+__all__ = [
+    "load_joint_material_identity_posterior",
+    "write_joint_material_identity_posterior",
+]

--- a/src/prob4d/_joint_material_identity_json.py
+++ b/src/prob4d/_joint_material_identity_json.py
@@ -1,0 +1,107 @@
+"""Strict JSON helpers for joint material-identity artifacts."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+_POSTERIOR_FIELDS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "posterior_id",
+        "window_order",
+        "maximum_joint_assignments",
+        "unconstrained_assignment_count",
+        "feasible_assignment_count",
+        "rejected_assignment_count",
+        "log_normalizer",
+        "joint_entropy_nats",
+        "effective_assignment_count",
+        "constraint_semantics",
+        "mixtures",
+        "assignments",
+        "marginals",
+        "metadata",
+        "claim_boundary",
+    }
+)
+_MIXTURE_FIELDS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "mixture_id",
+        "target_endpoint",
+        "window_order",
+        "causal_frame_stop",
+        "association_rule_id",
+        "calibration_id",
+        "tracklet_producer_revision",
+        "association_revision",
+        "weight_semantics",
+        "null_hypothesis_semantics",
+        "candidates",
+        "metadata",
+        "claim_boundary",
+    }
+)
+_CANDIDATE_FIELDS = frozenset(
+    {
+        "candidate_id",
+        "kind",
+        "source_endpoint",
+        "association_result_id",
+        "source_score",
+        "calibrated_log_weight",
+        "metadata",
+    }
+)
+
+
+def _pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON object key: {key}")
+        result[key] = value
+    return result
+
+
+def _constant(value: str) -> None:
+    raise ValueError(f"non-finite JSON constant is not permitted: {value}")
+
+
+def _load(path: Path) -> Mapping[str, Any]:
+    try:
+        value = json.loads(
+            path.read_text(encoding="utf-8"),
+            object_pairs_hook=_pairs,
+            parse_constant=_constant,
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot read joint material-identity posterior {path}") from error
+    if not isinstance(value, Mapping):
+        raise ValueError("joint posterior root must be a JSON object")
+    return value
+
+
+def _fields(value: Mapping[str, Any], expected: frozenset[str], *, name: str) -> None:
+    missing = sorted(expected - set(value))
+    extra = sorted(set(value) - expected)
+    if missing or extra:
+        raise ValueError(f"{name} fields changed: missing={missing}, extra={extra}")
+
+
+def _mapping(value: object, *, name: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{name} must be a JSON object")
+    return value
+
+
+def _list(value: object, *, name: str) -> list[Any]:
+    if type(value) is not list:
+        raise ValueError(f"{name} must be a JSON array")
+    return value
+

--- a/src/prob4d/_joint_material_identity_likelihood.py
+++ b/src/prob4d/_joint_material_identity_likelihood.py
@@ -1,0 +1,74 @@
+"""Downstream likelihood result for a joint identity posterior."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+
+from ._joint_material_identity_common import (
+    JOINT_LIKELIHOOD_SEMANTICS,
+    FloatArray,
+    _finite_real,
+    _readonly,
+    _sha256,
+)
+
+
+@dataclass(frozen=True)
+class MarginalizedJointIdentityLikelihood:
+    """Downstream likelihood marginalized over feasible joint assignments."""
+
+    assignment_ids: tuple[str, ...]
+    log_marginal_likelihood: float
+    posterior_probabilities: FloatArray
+    likelihood_power: float
+    semantics: Literal[
+        "logsumexp-discrete-joint-identity-v1"
+    ] = JOINT_LIKELIHOOD_SEMANTICS
+
+    def __post_init__(self) -> None:
+        assignment_ids = tuple(
+            _sha256(value, name=f"assignment_ids[{index}]")
+            for index, value in enumerate(self.assignment_ids)
+        )
+        probabilities = np.asarray(self.posterior_probabilities, dtype=np.float64)
+        if probabilities.shape != (len(assignment_ids),):
+            raise ValueError("posterior_probabilities must match assignment_ids")
+        if not np.all(np.isfinite(probabilities)) or np.any(probabilities < 0.0):
+            raise ValueError("posterior_probabilities must be finite and non-negative")
+        if not np.isclose(float(np.sum(probabilities)), 1.0, atol=1e-12, rtol=1e-12):
+            raise ValueError("posterior_probabilities must sum to one")
+        if self.semantics != JOINT_LIKELIHOOD_SEMANTICS:
+            raise ValueError("unsupported joint likelihood semantics")
+        object.__setattr__(self, "assignment_ids", assignment_ids)
+        object.__setattr__(
+            self,
+            "log_marginal_likelihood",
+            _finite_real(self.log_marginal_likelihood, name="log_marginal_likelihood"),
+        )
+        object.__setattr__(
+            self,
+            "posterior_probabilities",
+            _readonly(probabilities, dtype=np.float64),
+        )
+        object.__setattr__(
+            self,
+            "likelihood_power",
+            _finite_real(self.likelihood_power, name="likelihood_power", minimum=0.0),
+        )
+
+    @property
+    def joint_entropy_nats(self) -> float:
+        active = self.posterior_probabilities > 0.0
+        return float(
+            -np.sum(
+                self.posterior_probabilities[active]
+                * np.log(self.posterior_probabilities[active])
+            )
+        )
+
+    @property
+    def effective_assignment_count(self) -> float:
+        return float(np.exp(self.joint_entropy_nats))

--- a/src/prob4d/_joint_material_identity_mixture_io.py
+++ b/src/prob4d/_joint_material_identity_mixture_io.py
@@ -12,6 +12,8 @@ from ._joint_material_identity_json import (
 )
 from .material_identity_mixture import (
     CLAIM_BOUNDARY as LOCAL_CLAIM_BOUNDARY,
+)
+from .material_identity_mixture import (
     MATERIAL_IDENTITY_MIXTURE_SCHEMA,
     MATERIAL_IDENTITY_MIXTURE_VERSION,
     LocalTrackEndpoint,

--- a/src/prob4d/_joint_material_identity_mixture_io.py
+++ b/src/prob4d/_joint_material_identity_mixture_io.py
@@ -1,0 +1,84 @@
+"""Independent reconstruction of embedded local identity mixtures."""
+
+from __future__ import annotations
+
+from ._joint_material_identity_common import _sha256
+from ._joint_material_identity_json import (
+    _CANDIDATE_FIELDS,
+    _MIXTURE_FIELDS,
+    _fields,
+    _list,
+    _mapping,
+)
+from .material_identity_mixture import (
+    CLAIM_BOUNDARY as LOCAL_CLAIM_BOUNDARY,
+    MATERIAL_IDENTITY_MIXTURE_SCHEMA,
+    MATERIAL_IDENTITY_MIXTURE_VERSION,
+    LocalTrackEndpoint,
+    MaterialIdentityCandidateV1,
+    MaterialIdentityMixtureV1,
+)
+
+
+def _mixture(value: object, *, index: int) -> MaterialIdentityMixtureV1:
+    record = _mapping(value, name=f"mixtures[{index}]")
+    _fields(record, _MIXTURE_FIELDS, name=f"mixtures[{index}]")
+    if record["schema"] != MATERIAL_IDENTITY_MIXTURE_SCHEMA:
+        raise ValueError("embedded mixture schema changed")
+    if record["schema_version"] != MATERIAL_IDENTITY_MIXTURE_VERSION:
+        raise ValueError("embedded mixture version changed")
+    if record["claim_boundary"] != LOCAL_CLAIM_BOUNDARY:
+        raise ValueError("embedded mixture claim boundary changed")
+    target = LocalTrackEndpoint.from_mapping(
+        record["target_endpoint"],
+        name=f"mixtures[{index}].target_endpoint",
+    )
+    candidates: list[MaterialIdentityCandidateV1] = []
+    supplied_ids: list[str] = []
+    for candidate_index, raw in enumerate(
+        _list(record["candidates"], name=f"mixtures[{index}].candidates")
+    ):
+        name = f"mixtures[{index}].candidates[{candidate_index}]"
+        candidate_record = _mapping(raw, name=name)
+        _fields(candidate_record, _CANDIDATE_FIELDS, name=name)
+        source_raw = candidate_record["source_endpoint"]
+        source = (
+            None
+            if source_raw is None
+            else LocalTrackEndpoint.from_mapping(
+                source_raw,
+                name=f"{name}.source_endpoint",
+            )
+        )
+        kind = candidate_record["kind"]
+        if kind not in {"null", "linked"} or (kind == "null") != (source is None):
+            raise ValueError(f"{name}.kind does not match source_endpoint")
+        candidates.append(
+            MaterialIdentityCandidateV1(
+                source_endpoint=source,
+                association_result_id=candidate_record["association_result_id"],
+                source_score=candidate_record["source_score"],
+                calibrated_log_weight=candidate_record["calibrated_log_weight"],
+                metadata=_mapping(candidate_record["metadata"], name=f"{name}.metadata"),
+            )
+        )
+        supplied_ids.append(
+            _sha256(candidate_record["candidate_id"], name=f"{name}.candidate_id")
+        )
+    mixture = MaterialIdentityMixtureV1(
+        target_endpoint=target,
+        window_order=tuple(_list(record["window_order"], name="window_order")),
+        causal_frame_stop=record["causal_frame_stop"],
+        association_rule_id=record["association_rule_id"],
+        calibration_id=record["calibration_id"],
+        tracklet_producer_revision=record["tracklet_producer_revision"],
+        association_revision=record["association_revision"],
+        candidates=tuple(candidates),
+        metadata=_mapping(record["metadata"], name=f"mixtures[{index}].metadata"),
+        weight_semantics=record["weight_semantics"],
+        null_hypothesis_semantics=record["null_hypothesis_semantics"],
+        mixture_id=record["mixture_id"],
+    )
+    if tuple(supplied_ids) != mixture.candidate_ids:
+        raise ValueError("embedded material-identity candidate ID mismatch")
+    return mixture

--- a/src/prob4d/_joint_material_identity_model.py
+++ b/src/prob4d/_joint_material_identity_model.py
@@ -1,0 +1,172 @@
+"""Immutable bounded joint material-identity posterior record."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any, Literal, cast
+
+import numpy as np
+
+from ._immutable_json import frozen_finite_json_mapping, plain_json
+from ._joint_material_identity_common import (
+    CLAIM_BOUNDARY,
+    JOINT_ASSIGNMENT_SEMANTICS,
+    JOINT_MATERIAL_IDENTITY_POSTERIOR_SCHEMA,
+    JOINT_MATERIAL_IDENTITY_POSTERIOR_VERSION,
+    FloatArray,
+    _canonical_mixtures,
+    _finite_real,
+    _integer,
+    _readonly,
+    _sha256,
+    _sha256_json,
+    _string,
+)
+from ._joint_material_identity_records import (
+    JointIdentityAssignmentV1,
+    JointIdentityMarginalV1,
+)
+from .material_identity_mixture import MaterialIdentityMixtureV1
+
+
+@dataclass(frozen=True, eq=False)
+class JointMaterialIdentityPosteriorV1:
+    """Self-contained posterior over exact globally feasible assignments."""
+
+    window_order: tuple[str, ...]
+    mixtures: tuple[MaterialIdentityMixtureV1, ...]
+    maximum_joint_assignments: int
+    unconstrained_assignment_count: int
+    assignments: tuple[JointIdentityAssignmentV1, ...]
+    marginals: tuple[JointIdentityMarginalV1, ...]
+    log_normalizer: float
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+    constraint_semantics: Literal[
+        "conditioned-local-mixtures-window-unique-forest-v1"
+    ] = JOINT_ASSIGNMENT_SEMANTICS
+    posterior_id: str | None = None
+
+    def __post_init__(self) -> None:
+        order = tuple(
+            _string(value, name=f"window_order[{index}]")
+            for index, value in enumerate(self.window_order)
+        )
+        canonical = _canonical_mixtures(self.mixtures, window_order=order)
+        if canonical != self.mixtures:
+            raise ValueError("mixtures must use canonical target-endpoint order")
+        maximum = _integer(
+            self.maximum_joint_assignments,
+            name="maximum_joint_assignments",
+            minimum=1,
+        )
+        unconstrained = _integer(
+            self.unconstrained_assignment_count,
+            name="unconstrained_assignment_count",
+            minimum=1,
+        )
+        if type(self.assignments) is not tuple or not self.assignments:
+            raise ValueError("assignments must be a non-empty tuple")
+        if type(self.marginals) is not tuple or len(self.marginals) != len(canonical):
+            raise ValueError("marginals must align with mixtures")
+        probabilities = np.asarray(
+            [assignment.probability for assignment in self.assignments],
+            dtype=np.float64,
+        )
+        if not np.isclose(float(np.sum(probabilities)), 1.0, atol=1e-12, rtol=1e-12):
+            raise ValueError("assignment probabilities must sum to one")
+        if self.constraint_semantics != JOINT_ASSIGNMENT_SEMANTICS:
+            raise ValueError("unsupported joint assignment semantics")
+        metadata = frozen_finite_json_mapping(
+            self.metadata,
+            name="joint material-identity posterior metadata",
+        )
+        log_normalizer = _finite_real(self.log_normalizer, name="log_normalizer")
+        object.__setattr__(self, "window_order", order)
+        object.__setattr__(self, "maximum_joint_assignments", maximum)
+        object.__setattr__(self, "unconstrained_assignment_count", unconstrained)
+        object.__setattr__(self, "log_normalizer", log_normalizer)
+        object.__setattr__(self, "metadata", metadata)
+        expected = _sha256_json(self.identity_record())
+        if self.posterior_id is not None and _sha256(
+            self.posterior_id,
+            name="posterior_id",
+        ) != expected:
+            raise ValueError("joint material-identity posterior ID mismatch")
+        object.__setattr__(self, "posterior_id", expected)
+
+    @property
+    def mixture_ids(self) -> tuple[str, ...]:
+        return tuple(cast(str, mixture.mixture_id) for mixture in self.mixtures)
+
+    @property
+    def assignment_ids(self) -> tuple[str, ...]:
+        return tuple(cast(str, assignment.assignment_id) for assignment in self.assignments)
+
+    @property
+    def probabilities(self) -> FloatArray:
+        return _readonly(
+            np.asarray(
+                [assignment.probability for assignment in self.assignments],
+                dtype=np.float64,
+            ),
+            dtype=np.float64,
+        )
+
+    @property
+    def feasible_assignment_count(self) -> int:
+        return len(self.assignments)
+
+    @property
+    def rejected_assignment_count(self) -> int:
+        return self.unconstrained_assignment_count - self.feasible_assignment_count
+
+    @property
+    def constraint_rejection_fraction(self) -> float:
+        return self.rejected_assignment_count / self.unconstrained_assignment_count
+
+    @property
+    def joint_entropy_nats(self) -> float:
+        probabilities = self.probabilities
+        active = probabilities > 0.0
+        return float(-np.sum(probabilities[active] * np.log(probabilities[active])))
+
+    @property
+    def effective_assignment_count(self) -> float:
+        return float(np.exp(self.joint_entropy_nats))
+
+    def identity_record(self) -> dict[str, object]:
+        return {
+            "schema": JOINT_MATERIAL_IDENTITY_POSTERIOR_SCHEMA,
+            "schema_version": JOINT_MATERIAL_IDENTITY_POSTERIOR_VERSION,
+            "window_order": list(self.window_order),
+            "maximum_joint_assignments": self.maximum_joint_assignments,
+            "unconstrained_assignment_count": self.unconstrained_assignment_count,
+            "feasible_assignment_count": self.feasible_assignment_count,
+            "rejected_assignment_count": self.rejected_assignment_count,
+            "log_normalizer": self.log_normalizer,
+            "joint_entropy_nats": self.joint_entropy_nats,
+            "effective_assignment_count": self.effective_assignment_count,
+            "constraint_semantics": self.constraint_semantics,
+            "mixtures": [mixture.to_record() for mixture in self.mixtures],
+            "assignments": [assignment.to_record() for assignment in self.assignments],
+            "marginals": [marginal.to_record() for marginal in self.marginals],
+            "metadata": plain_json(self.metadata),
+            "claim_boundary": CLAIM_BOUNDARY,
+        }
+
+    def to_record(self) -> dict[str, object]:
+        return {**self.identity_record(), "posterior_id": self.posterior_id}
+
+    def __eq__(self, other: object) -> bool:
+        return bool(
+            isinstance(other, JointMaterialIdentityPosteriorV1)
+            and self.posterior_id == other.posterior_id
+            and self.window_order == other.window_order
+            and self.mixture_ids == other.mixture_ids
+            and self.assignment_ids == other.assignment_ids
+            and np.allclose(self.probabilities, other.probabilities)
+            and self.marginals == other.marginals
+            and plain_json(self.metadata) == plain_json(other.metadata)
+        )
+

--- a/src/prob4d/_joint_material_identity_records.py
+++ b/src/prob4d/_joint_material_identity_records.py
@@ -1,0 +1,149 @@
+"""Immutable assignment and marginal records for joint material identity."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+from ._joint_material_identity_common import (
+    FloatArray,
+    _finite_real,
+    _readonly,
+    _sha256,
+    _sha256_json,
+)
+from .material_identity_mixture import LocalTrackEndpoint
+
+
+@dataclass(frozen=True)
+class JointIdentityAssignmentV1:
+    """One globally feasible choice of one candidate per local mixture."""
+
+    mixture_ids: tuple[str, ...]
+    candidate_ids: tuple[str, ...]
+    log_weight: float
+    probability: float
+    assignment_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if type(self.mixture_ids) is not tuple or not self.mixture_ids:
+            raise ValueError("mixture_ids must be a non-empty tuple")
+        if type(self.candidate_ids) is not tuple:
+            raise ValueError("candidate_ids must be a tuple")
+        mixture_ids = tuple(
+            _sha256(value, name=f"mixture_ids[{index}]")
+            for index, value in enumerate(self.mixture_ids)
+        )
+        candidate_ids = tuple(
+            _sha256(value, name=f"candidate_ids[{index}]")
+            for index, value in enumerate(self.candidate_ids)
+        )
+        if len(candidate_ids) != len(mixture_ids):
+            raise ValueError("candidate_ids must align with mixture_ids")
+        log_weight = _finite_real(self.log_weight, name="log_weight")
+        probability = _finite_real(
+            self.probability,
+            name="probability",
+            minimum=0.0,
+        )
+        if probability > 1.0:
+            raise ValueError("probability must be at most one")
+        identity = {
+            "mixture_ids": list(mixture_ids),
+            "candidate_ids": list(candidate_ids),
+        }
+        expected = _sha256_json(identity)
+        if self.assignment_id is not None and _sha256(
+            self.assignment_id,
+            name="assignment_id",
+        ) != expected:
+            raise ValueError("joint assignment ID mismatch")
+        object.__setattr__(self, "mixture_ids", mixture_ids)
+        object.__setattr__(self, "candidate_ids", candidate_ids)
+        object.__setattr__(self, "log_weight", log_weight)
+        object.__setattr__(self, "probability", probability)
+        object.__setattr__(self, "assignment_id", expected)
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "assignment_id": self.assignment_id,
+            "mixture_ids": list(self.mixture_ids),
+            "candidate_ids": list(self.candidate_ids),
+            "log_weight": self.log_weight,
+            "probability": self.probability,
+        }
+
+
+@dataclass(frozen=True, eq=False)
+class JointIdentityMarginalV1:
+    """Candidate-aligned marginal for one local mixture after conditioning."""
+
+    mixture_id: str
+    target_endpoint: LocalTrackEndpoint
+    candidate_ids: tuple[str, ...]
+    probabilities: FloatArray
+
+    def __post_init__(self) -> None:
+        mixture_id = _sha256(self.mixture_id, name="mixture_id")
+        if not isinstance(self.target_endpoint, LocalTrackEndpoint):
+            raise ValueError("target_endpoint must be LocalTrackEndpoint")
+        candidate_ids = tuple(
+            _sha256(value, name=f"candidate_ids[{index}]")
+            for index, value in enumerate(self.candidate_ids)
+        )
+        probabilities = np.asarray(self.probabilities, dtype=np.float64)
+        if probabilities.shape != (len(candidate_ids),):
+            raise ValueError("probabilities must align with candidate_ids")
+        if not np.all(np.isfinite(probabilities)) or np.any(probabilities < 0.0):
+            raise ValueError("probabilities must be finite and non-negative")
+        if not np.isclose(float(np.sum(probabilities)), 1.0, atol=1e-12, rtol=1e-12):
+            raise ValueError("probabilities must sum to one")
+        object.__setattr__(self, "mixture_id", mixture_id)
+        object.__setattr__(self, "candidate_ids", candidate_ids)
+        object.__setattr__(
+            self,
+            "probabilities",
+            _readonly(probabilities, dtype=np.float64),
+        )
+
+    @property
+    def null_probability(self) -> float:
+        return float(self.probabilities[0])
+
+    @property
+    def identity_entropy_nats(self) -> float:
+        active = self.probabilities > 0.0
+        return float(
+            -np.sum(self.probabilities[active] * np.log(self.probabilities[active]))
+        )
+
+    @property
+    def effective_hypothesis_count(self) -> float:
+        return float(np.exp(self.identity_entropy_nats))
+
+    def __eq__(self, other: object) -> bool:
+        return bool(
+            isinstance(other, JointIdentityMarginalV1)
+            and self.mixture_id == other.mixture_id
+            and self.target_endpoint == other.target_endpoint
+            and self.candidate_ids == other.candidate_ids
+            and np.allclose(
+                self.probabilities,
+                other.probabilities,
+                atol=1e-12,
+                rtol=1e-10,
+            )
+        )
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "mixture_id": self.mixture_id,
+            "target_endpoint": self.target_endpoint.to_dict(),
+            "candidate_ids": list(self.candidate_ids),
+            "probabilities": self.probabilities.tolist(),
+            "null_probability": self.null_probability,
+            "identity_entropy_nats": self.identity_entropy_nats,
+            "effective_hypothesis_count": self.effective_hypothesis_count,
+        }
+

--- a/src/prob4d/command_registry.py
+++ b/src/prob4d/command_registry.py
@@ -286,7 +286,7 @@ _COMMAND_ROWS: Final[tuple[CommandRow, ...]] = (
         "material-identity",
         "identity",
         "prob4d.material_identity_cli:main",
-        "build, validate, and marginalize material-identity artifacts",
+        "build, validate, and marginalize local or joint material-identity artifacts",
         S,
         "material-identity",
         (),

--- a/src/prob4d/joint_material_identity.py
+++ b/src/prob4d/joint_material_identity.py
@@ -1,0 +1,49 @@
+"""Exact bounded posterior over globally consistent local material identities.
+
+Each input :class:`MaterialIdentityMixtureV1` selects one null or linked
+predecessor for one target-local track. The posterior conditions several such
+source-calibrated mixtures on a window-unique forest constraint while preserving
+all local ``(window_id, track_id)`` identities and mandatory null fallbacks.
+"""
+
+from ._joint_material_identity_common import (
+    CLAIM_BOUNDARY,
+    JOINT_ASSIGNMENT_SEMANTICS,
+    JOINT_LIKELIHOOD_SEMANTICS,
+    JOINT_MATERIAL_IDENTITY_POSTERIOR_SCHEMA,
+    JOINT_MATERIAL_IDENTITY_POSTERIOR_VERSION,
+)
+from ._joint_material_identity_compute import (
+    assignment_components,
+    build_joint_material_identity_posterior,
+    joint_candidate_marginals,
+    marginalize_joint_assignment_log_likelihoods,
+)
+from ._joint_material_identity_io import (
+    load_joint_material_identity_posterior,
+    write_joint_material_identity_posterior,
+)
+from ._joint_material_identity_likelihood import MarginalizedJointIdentityLikelihood
+from ._joint_material_identity_model import JointMaterialIdentityPosteriorV1
+from ._joint_material_identity_records import (
+    JointIdentityAssignmentV1,
+    JointIdentityMarginalV1,
+)
+
+__all__ = [
+    "CLAIM_BOUNDARY",
+    "JOINT_ASSIGNMENT_SEMANTICS",
+    "JOINT_LIKELIHOOD_SEMANTICS",
+    "JOINT_MATERIAL_IDENTITY_POSTERIOR_SCHEMA",
+    "JOINT_MATERIAL_IDENTITY_POSTERIOR_VERSION",
+    "JointIdentityAssignmentV1",
+    "JointIdentityMarginalV1",
+    "JointMaterialIdentityPosteriorV1",
+    "MarginalizedJointIdentityLikelihood",
+    "assignment_components",
+    "build_joint_material_identity_posterior",
+    "joint_candidate_marginals",
+    "load_joint_material_identity_posterior",
+    "marginalize_joint_assignment_log_likelihoods",
+    "write_joint_material_identity_posterior",
+]

--- a/src/prob4d/material_identity_cli.py
+++ b/src/prob4d/material_identity_cli.py
@@ -183,17 +183,13 @@ def _confined_config_path(config: Path, value: Any, *, index: int) -> Path:
         raise ValueError(f"mixture_paths[{index}] must be a canonical string")
     relative = Path(value)
     if relative.is_absolute() or ".." in relative.parts:
-        raise ValueError(
-            f"mixture_paths[{index}] must be a confined relative path"
-        )
+        raise ValueError(f"mixture_paths[{index}] must be a confined relative path")
     root = config.parent.resolve()
     resolved = (config.parent / relative).resolve()
     try:
         resolved.relative_to(root)
     except ValueError as error:
-        raise ValueError(
-            f"mixture_paths[{index}] escapes the configuration directory"
-        ) from error
+        raise ValueError(f"mixture_paths[{index}] escapes the configuration directory") from error
     return resolved
 
 
@@ -291,15 +287,11 @@ def _build_joint(arguments: Sequence[str]) -> int:
 def _validate_joint(arguments: Sequence[str]) -> int:
     parser = argparse.ArgumentParser(
         prog="prob4d identity validate-joint",
-        description=(
-            "strictly validate and exactly replay one joint identity posterior"
-        ),
+        description=("strictly validate and exactly replay one joint identity posterior"),
     )
     parser.add_argument("posterior", type=Path)
     parsed = parser.parse_args(arguments)
-    _print_json(
-        _joint_summary(load_joint_material_identity_posterior(parsed.posterior))
-    )
+    _print_json(_joint_summary(load_joint_material_identity_posterior(parsed.posterior)))
     return 0
 
 
@@ -369,8 +361,7 @@ def _marginalize_joint(arguments: Sequence[str]) -> int:
     parser = argparse.ArgumentParser(
         prog="prob4d identity marginalize-joint",
         description=(
-            "marginalize downstream log likelihoods over feasible joint "
-            "identity assignments"
+            "marginalize downstream log likelihoods over feasible joint identity assignments"
         ),
     )
     parser.add_argument("posterior", type=Path)
@@ -383,9 +374,7 @@ def _marginalize_joint(arguments: Sequence[str]) -> int:
         {"assignment_ids", "log_likelihoods", "likelihood_power"},
         name="joint identity likelihood input",
     )
-    assignment_ids = tuple(
-        _list(value["assignment_ids"], name="assignment_ids")
-    )
+    assignment_ids = tuple(_list(value["assignment_ids"], name="assignment_ids"))
     result = marginalize_joint_assignment_log_likelihoods(
         posterior,
         assignment_ids,

--- a/src/prob4d/material_identity_cli.py
+++ b/src/prob4d/material_identity_cli.py
@@ -1,9 +1,9 @@
-"""Grouped CLI for portable material-identity streams and mixtures.
+"""Grouped CLI for local and joint material-identity artifacts.
 
 The commands in this module do not fit calibration parameters or decide whether a
 BayesianPhysTwin update is accepted. They seal externally source-calibrated
-mixtures, validate stream/mixture artifacts, and exercise exact downstream
-likelihood marginalization or Gaussian moment matching with candidate-ID checks.
+mixtures, condition bounded sets of mixtures on global consistency, validate
+portable artifacts, and exercise candidate-aligned downstream marginalization.
 """
 
 from __future__ import annotations
@@ -17,6 +17,14 @@ from typing import Any
 
 import numpy as np
 
+from .joint_material_identity import (
+    JointMaterialIdentityPosteriorV1,
+    build_joint_material_identity_posterior,
+    joint_candidate_marginals,
+    load_joint_material_identity_posterior,
+    marginalize_joint_assignment_log_likelihoods,
+    write_joint_material_identity_posterior,
+)
 from .material_identity_mixture import (
     LocalTrackEndpoint,
     MaterialIdentityCandidateV1,
@@ -152,6 +160,43 @@ def _mixture_summary(mixture: MaterialIdentityMixtureV1) -> dict[str, object]:
     }
 
 
+def _joint_summary(
+    posterior: JointMaterialIdentityPosteriorV1,
+) -> dict[str, object]:
+    return {
+        "posterior_id": posterior.posterior_id,
+        "window_order": list(posterior.window_order),
+        "mixture_ids": list(posterior.mixture_ids),
+        "assignment_ids": list(posterior.assignment_ids),
+        "unconstrained_assignment_count": posterior.unconstrained_assignment_count,
+        "feasible_assignment_count": posterior.feasible_assignment_count,
+        "rejected_assignment_count": posterior.rejected_assignment_count,
+        "constraint_rejection_fraction": posterior.constraint_rejection_fraction,
+        "joint_entropy_nats": posterior.joint_entropy_nats,
+        "effective_assignment_count": posterior.effective_assignment_count,
+        "marginals": [marginal.to_record() for marginal in posterior.marginals],
+    }
+
+
+def _confined_config_path(config: Path, value: Any, *, index: int) -> Path:
+    if type(value) is not str or not value or value.strip() != value:
+        raise ValueError(f"mixture_paths[{index}] must be a canonical string")
+    relative = Path(value)
+    if relative.is_absolute() or ".." in relative.parts:
+        raise ValueError(
+            f"mixture_paths[{index}] must be a confined relative path"
+        )
+    root = config.parent.resolve()
+    resolved = (config.parent / relative).resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as error:
+        raise ValueError(
+            f"mixture_paths[{index}] escapes the configuration directory"
+        ) from error
+    return resolved
+
+
 def _stream_summary(path: Path) -> dict[str, object]:
     stream = load_material_identity_stream(path)
     return {
@@ -193,6 +238,68 @@ def _build(arguments: Sequence[str]) -> int:
         overwrite=parsed.overwrite,
     )
     _print_json(_mixture_summary(mixture))
+    return 0
+
+
+def _build_joint(arguments: Sequence[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="prob4d identity build-joint",
+        description=(
+            "condition source-calibrated local identity mixtures on one exact "
+            "window-unique forest constraint"
+        ),
+    )
+    parser.add_argument("config", type=Path)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--overwrite", action="store_true")
+    parsed = parser.parse_args(arguments)
+    value = _load_json(parsed.config, name="joint identity configuration")
+    _exact_fields(
+        value,
+        {
+            "window_order",
+            "mixture_paths",
+            "maximum_joint_assignments",
+            "metadata",
+        },
+        name="joint identity configuration",
+    )
+    raw_paths = _list(value["mixture_paths"], name="mixture_paths")
+    if not raw_paths:
+        raise ValueError("mixture_paths must not be empty")
+    paths = tuple(
+        _confined_config_path(parsed.config, item, index=index)
+        for index, item in enumerate(raw_paths)
+    )
+    if len(set(paths)) != len(paths):
+        raise ValueError("mixture_paths must be unique")
+    posterior = build_joint_material_identity_posterior(
+        [load_material_identity_mixture(path) for path in paths],
+        window_order=tuple(_list(value["window_order"], name="window_order")),
+        maximum_joint_assignments=value["maximum_joint_assignments"],
+        metadata=_mapping(value["metadata"], name="metadata"),
+    )
+    write_joint_material_identity_posterior(
+        parsed.output,
+        posterior,
+        overwrite=parsed.overwrite,
+    )
+    _print_json(_joint_summary(posterior))
+    return 0
+
+
+def _validate_joint(arguments: Sequence[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="prob4d identity validate-joint",
+        description=(
+            "strictly validate and exactly replay one joint identity posterior"
+        ),
+    )
+    parser.add_argument("posterior", type=Path)
+    parsed = parser.parse_args(arguments)
+    _print_json(
+        _joint_summary(load_joint_material_identity_posterior(parsed.posterior))
+    )
     return 0
 
 
@@ -258,6 +365,55 @@ def _marginalize(arguments: Sequence[str]) -> int:
     return 0
 
 
+def _marginalize_joint(arguments: Sequence[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="prob4d identity marginalize-joint",
+        description=(
+            "marginalize downstream log likelihoods over feasible joint "
+            "identity assignments"
+        ),
+    )
+    parser.add_argument("posterior", type=Path)
+    parser.add_argument("likelihoods", type=Path)
+    parsed = parser.parse_args(arguments)
+    posterior = load_joint_material_identity_posterior(parsed.posterior)
+    value = _load_json(parsed.likelihoods, name="joint identity likelihood input")
+    _exact_fields(
+        value,
+        {"assignment_ids", "log_likelihoods", "likelihood_power"},
+        name="joint identity likelihood input",
+    )
+    assignment_ids = tuple(
+        _list(value["assignment_ids"], name="assignment_ids")
+    )
+    result = marginalize_joint_assignment_log_likelihoods(
+        posterior,
+        assignment_ids,
+        np.asarray(
+            _list(value["log_likelihoods"], name="log_likelihoods"),
+            dtype=np.float64,
+        ),
+        likelihood_power=value["likelihood_power"],
+    )
+    marginals = joint_candidate_marginals(
+        posterior,
+        assignment_probabilities=result.posterior_probabilities,
+    )
+    _print_json(
+        {
+            "assignment_ids": list(result.assignment_ids),
+            "log_marginal_likelihood": result.log_marginal_likelihood,
+            "posterior_probabilities": result.posterior_probabilities.tolist(),
+            "joint_entropy_nats": result.joint_entropy_nats,
+            "effective_assignment_count": result.effective_assignment_count,
+            "likelihood_power": result.likelihood_power,
+            "semantics": result.semantics,
+            "marginals": [marginal.to_record() for marginal in marginals],
+        }
+    )
+    return 0
+
+
 def _moment_match(arguments: Sequence[str]) -> int:
     parser = argparse.ArgumentParser(
         prog="prob4d identity moment-match",
@@ -314,10 +470,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument(
         "command",
         choices=(
+            "build-joint",
             "build-mixture",
+            "validate-joint",
             "validate-mixture",
             "validate-stream",
             "marginalize",
+            "marginalize-joint",
             "moment-match",
         ),
         help=(
@@ -329,14 +488,20 @@ def main(argv: Sequence[str] | None = None) -> int:
         parser.print_help()
         return 0
     parsed, remaining = parser.parse_known_args(arguments)
+    if parsed.command == "build-joint":
+        return _build_joint(remaining)
     if parsed.command == "build-mixture":
         return _build(remaining)
+    if parsed.command == "validate-joint":
+        return _validate_joint(remaining)
     if parsed.command == "validate-mixture":
         return _validate_mixture(remaining)
     if parsed.command == "validate-stream":
         return _validate_stream(remaining)
     if parsed.command == "marginalize":
         return _marginalize(remaining)
+    if parsed.command == "marginalize-joint":
+        return _marginalize_joint(remaining)
     if parsed.command == "moment-match":
         return _moment_match(remaining)
     raise AssertionError("unreachable material-identity command")

--- a/tests/test_joint_material_identity.py
+++ b/tests/test_joint_material_identity.py
@@ -1,0 +1,244 @@
+import numpy as np
+import pytest
+
+from prob4d.joint_material_identity import (
+    assignment_components,
+    build_joint_material_identity_posterior,
+    joint_candidate_marginals,
+    marginalize_joint_assignment_log_likelihoods,
+)
+from prob4d.material_identity_mixture import (
+    LocalTrackEndpoint,
+    MaterialIdentityCandidateV1,
+    MaterialIdentityMixtureV1,
+)
+
+RULE_ID = "a" * 64
+CALIBRATION_ID = "b" * 64
+TRACKLET_REVISION = "c" * 40
+ASSOCIATION_REVISION = "d" * 40
+RESULT_ID = "e" * 64
+
+
+def mixture(
+    *,
+    target_window: str,
+    target_track: int,
+    window_order: tuple[str, ...],
+    source_endpoint: LocalTrackEndpoint | None,
+    linked_weight: float = 9.0,
+    null_weight: float = 1.0,
+    result_id: str = RESULT_ID,
+) -> MaterialIdentityMixtureV1:
+    candidates = [
+        MaterialIdentityCandidateV1(
+            source_endpoint=None,
+            association_result_id=None,
+            source_score=None,
+            calibrated_log_weight=np.log(null_weight),
+            metadata={"role": "exact-local-fallback"},
+        )
+    ]
+    if source_endpoint is not None:
+        candidates.append(
+            MaterialIdentityCandidateV1(
+                source_endpoint=source_endpoint,
+                association_result_id=result_id,
+                source_score=0.9,
+                calibrated_log_weight=np.log(linked_weight),
+                metadata={"source": "calibration-only"},
+            )
+        )
+    return MaterialIdentityMixtureV1(
+        target_endpoint=LocalTrackEndpoint(target_window, target_track),
+        window_order=window_order,
+        causal_frame_stop=20 + window_order.index(target_window),
+        association_rule_id=RULE_ID,
+        calibration_id=CALIBRATION_ID,
+        tracklet_producer_revision=TRACKLET_REVISION,
+        association_revision=ASSOCIATION_REVISION,
+        candidates=tuple(candidates),
+        metadata={"stage": "source-only"},
+    )
+
+
+def conflicting_pair() -> tuple[MaterialIdentityMixtureV1, ...]:
+    source = LocalTrackEndpoint("window-0", 0)
+    return (
+        mixture(
+            target_window="window-1",
+            target_track=0,
+            window_order=("window-0", "window-1"),
+            source_endpoint=source,
+        ),
+        mixture(
+            target_window="window-1",
+            target_track=1,
+            window_order=("window-0", "window-1"),
+            source_endpoint=source,
+        ),
+    )
+
+
+def test_global_constraint_removes_one_source_splitting_into_two_target_tracks() -> None:
+    posterior = build_joint_material_identity_posterior(
+        conflicting_pair(),
+        window_order=("window-0", "window-1"),
+    )
+
+    assert posterior.unconstrained_assignment_count == 4
+    assert posterior.feasible_assignment_count == 3
+    assert posterior.rejected_assignment_count == 1
+    assert posterior.constraint_rejection_fraction == pytest.approx(0.25)
+    np.testing.assert_allclose(
+        posterior.probabilities,
+        [1.0 / 19.0, 9.0 / 19.0, 9.0 / 19.0],
+    )
+    for marginal in posterior.marginals:
+        np.testing.assert_allclose(
+            marginal.probabilities,
+            [10.0 / 19.0, 9.0 / 19.0],
+        )
+        assert marginal.null_probability == pytest.approx(10.0 / 19.0)
+
+
+def test_transitive_component_cannot_contain_two_endpoints_from_one_window() -> None:
+    source = LocalTrackEndpoint("window-0", 0)
+    middle = LocalTrackEndpoint("window-1", 0)
+    mixtures = (
+        mixture(
+            target_window="window-1",
+            target_track=0,
+            window_order=("window-0", "window-1"),
+            source_endpoint=source,
+        ),
+        mixture(
+            target_window="window-2",
+            target_track=0,
+            window_order=("window-0", "window-1", "window-2"),
+            source_endpoint=middle,
+        ),
+        mixture(
+            target_window="window-2",
+            target_track=1,
+            window_order=("window-0", "window-1", "window-2"),
+            source_endpoint=source,
+            result_id="f" * 64,
+        ),
+    )
+
+    posterior = build_joint_material_identity_posterior(
+        mixtures,
+        window_order=("window-0", "window-1", "window-2"),
+    )
+
+    assert posterior.unconstrained_assignment_count == 8
+    assert posterior.feasible_assignment_count == 7
+    all_linked = tuple(value.candidate_ids[1] for value in posterior.mixtures)
+    assert all_linked not in {assignment.candidate_ids for assignment in posterior.assignments}
+
+
+def test_input_order_is_canonical_and_content_identity_is_stable() -> None:
+    mixtures = conflicting_pair()
+    first = build_joint_material_identity_posterior(
+        mixtures,
+        window_order=("window-0", "window-1"),
+        metadata={"experiment": "joint-source-prior"},
+    )
+    second = build_joint_material_identity_posterior(
+        tuple(reversed(mixtures)),
+        window_order=("window-0", "window-1"),
+        metadata={"experiment": "joint-source-prior"},
+    )
+
+    assert first.posterior_id == second.posterior_id
+    assert first.mixture_ids == second.mixture_ids
+    assert first.assignment_ids == second.assignment_ids
+
+
+def test_assignment_bound_fails_closed_before_combinatorial_growth() -> None:
+    mixtures = tuple(
+        mixture(
+            target_window="window-1",
+            target_track=index,
+            window_order=("window-0", "window-1"),
+            source_endpoint=LocalTrackEndpoint("window-0", index),
+        )
+        for index in range(8)
+    )
+    with pytest.raises(ValueError, match="exceeds maximum_joint_assignments"):
+        build_joint_material_identity_posterior(
+            mixtures,
+            window_order=("window-0", "window-1"),
+            maximum_joint_assignments=100,
+        )
+
+
+def test_joint_likelihood_marginalization_and_candidate_projection() -> None:
+    posterior = build_joint_material_identity_posterior(
+        conflicting_pair(),
+        window_order=("window-0", "window-1"),
+    )
+    log_likelihoods = np.array([-5.0, -1.0, -3.0])
+    result = marginalize_joint_assignment_log_likelihoods(
+        posterior,
+        posterior.assignment_ids,
+        log_likelihoods,
+    )
+
+    expected_terms = posterior.probabilities * np.exp(
+        log_likelihoods - np.max(log_likelihoods)
+    )
+    expected_probabilities = expected_terms / np.sum(expected_terms)
+    np.testing.assert_allclose(
+        result.posterior_probabilities,
+        expected_probabilities,
+    )
+    marginals = joint_candidate_marginals(
+        posterior,
+        assignment_probabilities=result.posterior_probabilities,
+    )
+    assert len(marginals) == 2
+    np.testing.assert_allclose(
+        marginals[0].probabilities,
+        [expected_probabilities[0] + expected_probabilities[1], expected_probabilities[2]],
+    )
+
+    prior_only = marginalize_joint_assignment_log_likelihoods(
+        posterior,
+        posterior.assignment_ids,
+        np.array([-np.inf, -3.0, -np.inf]),
+        likelihood_power=0.0,
+    )
+    assert prior_only.log_marginal_likelihood == pytest.approx(0.0)
+    np.testing.assert_allclose(
+        prior_only.posterior_probabilities,
+        posterior.probabilities,
+    )
+
+
+def test_assignment_components_keep_local_endpoints_without_global_id_rewrite() -> None:
+    posterior = build_joint_material_identity_posterior(
+        conflicting_pair(),
+        window_order=("window-0", "window-1"),
+    )
+    linked_assignment = next(
+        assignment
+        for assignment in posterior.assignments
+        if assignment.candidate_ids[0] == posterior.mixtures[0].candidate_ids[1]
+    )
+    components = assignment_components(posterior, linked_assignment.assignment_id)
+
+    assert any(
+        component
+        == (
+            LocalTrackEndpoint("window-0", 0),
+            LocalTrackEndpoint("window-1", 0),
+        )
+        for component in components
+    )
+    assert any(
+        component == (LocalTrackEndpoint("window-1", 1),)
+        for component in components
+    )
+

--- a/tests/test_joint_material_identity_cli.py
+++ b/tests/test_joint_material_identity_cli.py
@@ -1,0 +1,120 @@
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from prob4d.joint_material_identity import load_joint_material_identity_posterior
+from prob4d.material_identity_cli import main
+from prob4d.material_identity_mixture import (
+    LocalTrackEndpoint,
+    MaterialIdentityCandidateV1,
+    MaterialIdentityMixtureV1,
+    write_material_identity_mixture,
+)
+
+RULE_ID = "a" * 64
+CALIBRATION_ID = "b" * 64
+TRACKLET_REVISION = "c" * 40
+ASSOCIATION_REVISION = "d" * 40
+RESULT_ID = "e" * 64
+
+
+def write_mixture(path: Path, *, target_track: int) -> None:
+    mixture = MaterialIdentityMixtureV1(
+        target_endpoint=LocalTrackEndpoint("window-1", target_track),
+        window_order=("window-0", "window-1"),
+        causal_frame_stop=22,
+        association_rule_id=RULE_ID,
+        calibration_id=CALIBRATION_ID,
+        tracklet_producer_revision=TRACKLET_REVISION,
+        association_revision=ASSOCIATION_REVISION,
+        candidates=(
+            MaterialIdentityCandidateV1(
+                source_endpoint=None,
+                association_result_id=None,
+                source_score=None,
+                calibrated_log_weight=0.0,
+            ),
+            MaterialIdentityCandidateV1(
+                source_endpoint=LocalTrackEndpoint("window-0", 0),
+                association_result_id=RESULT_ID,
+                source_score=0.9,
+                calibrated_log_weight=np.log(9.0),
+            ),
+        ),
+    )
+    write_material_identity_mixture(path, mixture)
+
+
+def test_build_validate_and_marginalize_joint_cli(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    write_mixture(tmp_path / "first.json", target_track=0)
+    write_mixture(tmp_path / "second.json", target_track=1)
+    config = {
+        "window_order": ["window-0", "window-1"],
+        "mixture_paths": ["first.json", "second.json"],
+        "maximum_joint_assignments": 100,
+        "metadata": {"purpose": "source-only"},
+    }
+    config_path = tmp_path / "joint-config.json"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    output = tmp_path / "joint.json"
+
+    assert main(["build-joint", str(config_path), "--output", str(output)]) == 0
+    build_summary = json.loads(capsys.readouterr().out)
+    assert build_summary["feasible_assignment_count"] == 3
+    assert build_summary["rejected_assignment_count"] == 1
+    posterior = load_joint_material_identity_posterior(output)
+
+    assert main(["validate-joint", str(output)]) == 0
+    validation = json.loads(capsys.readouterr().out)
+    assert validation["posterior_id"] == posterior.posterior_id
+
+    likelihoods = {
+        "assignment_ids": list(posterior.assignment_ids),
+        "log_likelihoods": [-5.0, -1.0, -3.0],
+        "likelihood_power": 1.0,
+    }
+    likelihood_path = tmp_path / "likelihoods.json"
+    likelihood_path.write_text(json.dumps(likelihoods), encoding="utf-8")
+    assert main(["marginalize-joint", str(output), str(likelihood_path)]) == 0
+    marginal = json.loads(capsys.readouterr().out)
+    assert marginal["assignment_ids"] == list(posterior.assignment_ids)
+    assert len(marginal["marginals"]) == 2
+    assert sum(marginal["posterior_probabilities"]) == pytest.approx(1.0)
+
+
+def test_joint_cli_rejects_unconfined_and_duplicate_paths(tmp_path: Path) -> None:
+    write_mixture(tmp_path / "first.json", target_track=0)
+    config_path = tmp_path / "joint-config.json"
+    config = {
+        "window_order": ["window-0", "window-1"],
+        "mixture_paths": ["../outside.json"],
+        "maximum_joint_assignments": 100,
+        "metadata": {},
+    }
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    with pytest.raises(ValueError, match="confined relative path"):
+        main(
+            [
+                "build-joint",
+                str(config_path),
+                "--output",
+                str(tmp_path / "joint.json"),
+            ]
+        )
+
+    config["mixture_paths"] = ["first.json", "first.json"]
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+    with pytest.raises(ValueError, match="must be unique"):
+        main(
+            [
+                "build-joint",
+                str(config_path),
+                "--output",
+                str(tmp_path / "joint.json"),
+            ]
+        )

--- a/tests/test_joint_material_identity_io.py
+++ b/tests/test_joint_material_identity_io.py
@@ -1,0 +1,170 @@
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from prob4d.joint_material_identity import (
+    build_joint_material_identity_posterior,
+    load_joint_material_identity_posterior,
+    write_joint_material_identity_posterior,
+)
+from prob4d.material_identity_mixture import (
+    LocalTrackEndpoint,
+    MaterialIdentityCandidateV1,
+    MaterialIdentityMixtureV1,
+)
+
+RULE_ID = "a" * 64
+CALIBRATION_ID = "b" * 64
+TRACKLET_REVISION = "c" * 40
+ASSOCIATION_REVISION = "d" * 40
+RESULT_ID = "e" * 64
+
+
+def mixture(
+    *,
+    target_window: str,
+    target_track: int,
+    window_order: tuple[str, ...],
+    source_endpoint: LocalTrackEndpoint | None,
+    linked_weight: float = 9.0,
+    null_weight: float = 1.0,
+    result_id: str = RESULT_ID,
+) -> MaterialIdentityMixtureV1:
+    candidates = [
+        MaterialIdentityCandidateV1(
+            source_endpoint=None,
+            association_result_id=None,
+            source_score=None,
+            calibrated_log_weight=np.log(null_weight),
+            metadata={"role": "exact-local-fallback"},
+        )
+    ]
+    if source_endpoint is not None:
+        candidates.append(
+            MaterialIdentityCandidateV1(
+                source_endpoint=source_endpoint,
+                association_result_id=result_id,
+                source_score=0.9,
+                calibrated_log_weight=np.log(linked_weight),
+                metadata={"source": "calibration-only"},
+            )
+        )
+    return MaterialIdentityMixtureV1(
+        target_endpoint=LocalTrackEndpoint(target_window, target_track),
+        window_order=window_order,
+        causal_frame_stop=20 + window_order.index(target_window),
+        association_rule_id=RULE_ID,
+        calibration_id=CALIBRATION_ID,
+        tracklet_producer_revision=TRACKLET_REVISION,
+        association_revision=ASSOCIATION_REVISION,
+        candidates=tuple(candidates),
+        metadata={"stage": "source-only"},
+    )
+
+
+def conflicting_pair() -> tuple[MaterialIdentityMixtureV1, ...]:
+    source = LocalTrackEndpoint("window-0", 0)
+    return (
+        mixture(
+            target_window="window-1",
+            target_track=0,
+            window_order=("window-0", "window-1"),
+            source_endpoint=source,
+        ),
+        mixture(
+            target_window="window-1",
+            target_track=1,
+            window_order=("window-0", "window-1"),
+            source_endpoint=source,
+        ),
+    )
+
+
+def test_self_contained_round_trip_and_derived_tamper_rejection(tmp_path: Path) -> None:
+    posterior = build_joint_material_identity_posterior(
+        conflicting_pair(),
+        window_order=("window-0", "window-1"),
+        metadata={"nested": {"source_only": True}},
+    )
+    path = tmp_path / "joint.json"
+    write_joint_material_identity_posterior(path, posterior)
+    loaded = load_joint_material_identity_posterior(path)
+
+    assert loaded == posterior
+    assert path.read_bytes().endswith(b"\n")
+    with pytest.raises(FileExistsError):
+        write_joint_material_identity_posterior(path, posterior)
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["assignments"][0]["probability"] += 0.01
+    payload["posterior_id"] = "0" * 64
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError, match="exact joint-posterior replay"):
+        load_joint_material_identity_posterior(path)
+
+
+def test_duplicate_json_keys_and_embedded_mixture_tampering_fail_closed(
+    tmp_path: Path,
+) -> None:
+    posterior = build_joint_material_identity_posterior(
+        conflicting_pair(),
+        window_order=("window-0", "window-1"),
+    )
+    path = tmp_path / "joint.json"
+    write_joint_material_identity_posterior(path, posterior)
+    duplicate = path.read_text(encoding="utf-8").replace(
+        '"schema_version":1',
+        '"schema_version":1,"schema_version":1',
+        1,
+    )
+    path.write_text(duplicate, encoding="utf-8")
+    with pytest.raises(ValueError, match="duplicate JSON object key"):
+        load_joint_material_identity_posterior(path)
+
+    write_joint_material_identity_posterior(path, posterior, overwrite=True)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["mixtures"][0]["candidates"][0]["candidate_id"] = "1" * 64
+    payload["posterior_id"] = "2" * 64
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError, match="candidate ID mismatch"):
+        load_joint_material_identity_posterior(path)
+
+
+def test_window_prefix_and_calibration_mismatches_are_rejected() -> None:
+    first, second = conflicting_pair()
+    with pytest.raises(ValueError, match="global prefix"):
+        build_joint_material_identity_posterior(
+            (first,),
+            window_order=("window-extra", "window-0", "window-1"),
+        )
+
+    changed = MaterialIdentityMixtureV1(
+        target_endpoint=second.target_endpoint,
+        window_order=second.window_order,
+        causal_frame_stop=second.causal_frame_stop,
+        association_rule_id=second.association_rule_id,
+        calibration_id="9" * 64,
+        tracklet_producer_revision=second.tracklet_producer_revision,
+        association_revision=second.association_revision,
+        candidates=second.candidates,
+        metadata=second.metadata,
+    )
+    with pytest.raises(ValueError, match="calibration_id"):
+        build_joint_material_identity_posterior(
+            (first, changed),
+            window_order=("window-0", "window-1"),
+        )
+
+
+def test_metadata_and_probability_arrays_are_immutable() -> None:
+    posterior = build_joint_material_identity_posterior(
+        conflicting_pair(),
+        window_order=("window-0", "window-1"),
+        metadata={"nested": {"source_only": True}},
+    )
+    with pytest.raises(TypeError, match="immutable"):
+        posterior.metadata["changed"] = True  # type: ignore[index]
+    with pytest.raises(ValueError, match="read-only"):
+        posterior.marginals[0].probabilities[0] = 0.0

--- a/tests/test_release_050_boundary.py
+++ b/tests/test_release_050_boundary.py
@@ -58,8 +58,11 @@ def test_all_release_version_declarations_are_synchronized() -> None:
 
 def test_cleanup_release_changelog_and_boundary_are_published() -> None:
     changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
-    assert "## Unreleased\n\nNo changes yet." in changelog
-    assert "## 0.5.0 — 2026-08-12" in changelog
+    unreleased_heading = "## Unreleased"
+    release_heading = "## 0.5.0 — 2026-08-12"
+    assert unreleased_heading in changelog
+    assert release_heading in changelog
+    assert changelog.index(unreleased_heading) < changelog.index(release_heading)
     lower_changelog = changelog.lower()
     assert "standalone `prob4d-*`" in lower_changelog
     assert "package-root export inventory" in lower_changelog


### PR DESCRIPTION
## Summary

- condition source-calibrated `MaterialIdentityMixtureV1` artifacts on exact window-unique forest consistency;
- retain window-local endpoint IDs and mandatory null fallback;
- fail closed before exact enumeration exceeds a declared bound;
- persist a self-contained content-addressed posterior with replayed assignments and marginals;
- add exact downstream assignment-likelihood marginalization and local candidate projection;
- add grouped CLI build, validation, and marginalization commands; and
- expand focused material-identity CI and documentation.

## Why

Independent local identity mixtures can be mutually inconsistent: one source track can split into several target tracks, and multi-window conflicts can appear only transitively. The new posterior removes those assignments without inventing global point IDs.

## Validation

At exact head `4ec0f572e53724f2775610ea852cb8990fe12949`, all ten triggered workflows succeeded:

- `Material identity marginalization`;
- `Tests`;
- `Fail-closed quality`;
- `Held-out provider promotion`;
- `Target provider admission`;
- `Finite-sample capability`;
- `Sparse gauge-tree prior`;
- `Portable sparse gauge-tree prior artifact`;
- `Source-only visual-bias calibration`; and
- `Security scanning`.

The focused source and isolated-wheel suites, package construction, installed import/CLI smoke tests, strict replay, Ruff, MyPy, supported Python matrix, and distribution-content checks therefore all pass on the exact PR head.

## Promotion gate

This remains an experimental draft until a fresh provider diagnostic reaches all of the following without opening protected target outcomes:

1. support feasibility passes;
2. source mean competence passes; and
3. identity/reliability is the first terminal failing stage.

A failure at support or source mean should lead to a successor provider/support protocol instead of promoting this posterior. A later first failure should select the corresponding gauge, point-covariance, query-relevance, or fallback work rather than identity machinery. Before promotion, this branch must also be rebased onto current `main` and its complete exact-head checks rerun.

## Scientific boundary

No target or confirmation data were accessed. The change does not rewrite provider-v2 identities, change BayesianPhysTwin guard or exact fallback semantics, alter Causal4D, or establish provider competence, calibration, physical benefit, intervention benefit, deployment safety, or state of the art. It is source-side consistency infrastructure with a declared exact-enumeration bound and mandatory null fallback.