### PR TITLE
Superseded: causal provider batch preflight and terminal decisions

### DIFF
--- a/.github/workflows/provider-batch-preflight.yml
+++ b/.github/workflows/provider-batch-preflight.yml
@@ -1,0 +1,45 @@
+name: Provider batch preflight
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: provider-batch-preflight-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONUNBUFFERED: "1"
+
+jobs:
+  focused:
+    name: Causal batch and terminal contracts
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install package and test tools
+        run: python -m pip install -e ".[dev]"
+      - name: Run focused regressions
+        run: >-
+          python -m pytest -q
+          tests/test_prediction_batch_preflight.py
+          tests/test_provider_terminal_decision.py
+      - name: Exercise module command help
+        run: |
+          python -m prob4d.prediction_batch_preflight --help
+          python -m prob4d.provider_terminal_decision --help

--- a/docs/prediction-batch-preflight.md
+++ b/docs/prediction-batch-preflight.md
@@ -1,0 +1,59 @@
+# Causal prediction-batch preflight
+
+Individually valid provider archives can still be incompatible with one frozen
+scorer batch because frame counts, spatial grids, dtypes, or optional fields
+differ. `prob4d.prediction_batch_preflight` detects that boundary before a
+scorer calls `stack`.
+
+## Causal loading
+
+The manifest is parsed before any dense payload is opened. With an exclusive
+causal cutoff, only payloads admitted by their declared source-frame lineage are
+hashed and decoded. Excluded future payloads are never opened, and every result
+records `future_prediction_payloads_opened: 0`.
+
+A selected payload with a byte-count, SHA-256, schema, window-ID, frame-lineage,
+optional-field, or storage-dtype mismatch raises
+`PredictionBatchIntegrityError`. Integrity failure is not relabelled as a
+scientific negative.
+
+## Default policy
+
+`PredictionBatchPolicyV1` requires:
+
+- at least one admitted payload;
+- a common frame count;
+- a common spatial point-grid shape;
+- a common point dtype; and
+- a common scene-flow/ray presence signature.
+
+A prospectively defined ragged scorer can explicitly relax the relevant
+requirement. The preflight never pads, truncates, or rewrites payload bytes.
+
+## Commands
+
+```bash
+python -m prob4d.prediction_batch_preflight build \
+  outputs/provider/provider-neutral.json \
+  outputs/provider/prediction-batch-preflight.json \
+  --causal-frame-stop 134
+```
+
+Exit status `0` means compatibility. Exit status `2` is a valid persisted
+`batch-incompatible` result with stable violations such as
+`frame-count-mismatch`, `spatial-shape-mismatch`, `point-dtype-mismatch`, and
+`optional-field-mismatch`.
+
+```bash
+python -m prob4d.prediction_batch_preflight verify \
+  outputs/provider/prediction-batch-preflight.json
+```
+
+A stopped protocol can bind this artifact in a
+[`ProviderTerminalDecisionV1`](provider-terminal-decision.md).
+
+## Nonclaim
+
+Passing preflight establishes representation compatibility only. It does not
+establish provider accuracy, calibration, independence, BayesianPhysTwin
+benefit, Causal4D intervention benefit, deployment safety, or state of the art.

--- a/docs/provider-terminal-decision.md
+++ b/docs/provider-terminal-decision.md
@@ -1,0 +1,63 @@
+# Provider terminal decision artifact
+
+Provider experiments can stop at different information boundaries. Unsupported
+geometry, an incompatible prediction batch, a scorer crash, a valid scientific
+negative, and a completed target result must not share one generic `failed`
+flag.
+
+`ProviderTerminalDecisionV1` records the exact boundary, information access,
+evidence identities, and authorized and forbidden inferences.
+
+## Classifications
+
+| Classification | Boundary |
+| --- | --- |
+| `support-negative` | Frozen support feasibility failed before payload access. |
+| `batch-incompatible` | Valid admitted bytes violate the frozen scorer representation. |
+| `technical-failure` | Execution terminated before a valid scientific outcome. |
+| `scientific-negative` | A registered outcome gate produced a valid negative. |
+| `completed-positive` | A registered target gate produced a valid positive. |
+
+The four access flags separately record source payloads, source outcomes, target
+payloads, and target outcomes. Outcome access requires payload access. Once
+target outcomes have been opened, the same protocol cannot authorize a rerun.
+
+## Infrastructure nonclaims
+
+`batch-incompatible` and `technical-failure` authorize no scientific inference.
+They must explicitly forbid:
+
+```text
+provider-competence
+provider-calibration
+bayesian-phystwin-benefit
+causal4d-intervention-benefit
+deployment-safety
+state-of-the-art
+```
+
+A `support-negative` must precede all payload access and may authorize only
+`provider-support-negative`.
+
+## Commands
+
+Create a specification containing every field except `artifact_id`, then run:
+
+```bash
+python -m prob4d.provider_terminal_decision build \
+  provider-terminal-specification.json \
+  provider-terminal-decision.json
+
+python -m prob4d.provider_terminal_decision verify \
+  provider-terminal-decision.json
+```
+
+Writes are atomic and no-clobber. Repeating identical bytes is idempotent;
+replacing a sealed decision fails.
+
+## Repository boundary
+
+Prob4D owns provider-side execution evidence. BayesianPhysTwin continues to own
+physical-query admission, guards, selected beliefs, and exact fallback.
+Causal4D consumes only the selected BayesianPhysTwin belief and owns
+interventional inference. This artifact bypasses neither boundary.

--- a/src/prob4d/prediction_batch_preflight.py
+++ b/src/prob4d/prediction_batch_preflight.py
@@ -1,0 +1,783 @@
+"""Causal, content-addressed preflight for provider prediction batches.
+
+Only manifest entries admitted by the exclusive causal cutoff are opened.  Batch
+shape differences become structured infrastructure evidence before a scorer
+attempts to stack arrays; malformed or changed selected bytes remain integrity
+errors rather than scientific negatives.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import tempfile
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Final
+
+import numpy as np
+
+from .data import PredictionWindow
+from .prediction_provider_manifest import load_prediction_provider_manifest
+
+PREDICTION_BATCH_PREFLIGHT_SCHEMA: Final = "prob4d.prediction-batch-preflight"
+PREDICTION_BATCH_PREFLIGHT_VERSION: Final = 1
+PREDICTION_BATCH_POLICY_SCHEMA: Final = "prob4d.prediction-batch-policy"
+PREDICTION_BATCH_POLICY_VERSION: Final = 1
+
+
+class PredictionBatchIntegrityError(ValueError):
+    """Selected provider bytes are missing, changed, or malformed."""
+
+
+def _canonical_bytes(record: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        record,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _sha256(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _artifact_id(record: Mapping[str, object]) -> str:
+    identity_record = dict(record)
+    identity_record.pop("artifact_id", None)
+    return _sha256(_canonical_bytes(identity_record))
+
+
+def _string(value: object, *, name: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{name} must be a nonempty string")
+    return value
+
+
+def _boolean(value: object, *, name: str) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{name} must be a boolean")
+    return value
+
+
+def _integer(value: object, *, name: str, minimum: int = 0) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+        raise ValueError(f"{name} must be an integer >= {minimum}")
+    return value
+
+
+def _mapping(value: object, *, name: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{name} must be an object")
+    return value
+
+
+def _exact_fields(
+    record: Mapping[str, object], expected: frozenset[str], *, name: str
+) -> None:
+    actual = frozenset(record)
+    if actual != expected:
+        raise ValueError(
+            f"{name} fields differ: missing={sorted(expected - actual)}, "
+            f"extra={sorted(actual - expected)}"
+        )
+
+
+def _string_tuple(value: object, *, name: str) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise ValueError(f"{name} must be an array")
+    result = tuple(_string(item, name=f"{name} item") for item in value)
+    if len(set(result)) != len(result):
+        raise ValueError(f"{name} must not contain duplicates")
+    return result
+
+
+def _integer_tuple(value: object, *, name: str) -> tuple[int, ...]:
+    if not isinstance(value, list):
+        raise ValueError(f"{name} must be an array")
+    return tuple(_integer(item, name=f"{name} item") for item in value)
+
+
+def _strict_json(path: Path, *, name: str) -> dict[str, Any]:
+    def pairs(items: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in items:
+            if key in result:
+                raise ValueError(f"{name} contains duplicate key {key!r}")
+            result[key] = value
+        return result
+
+    def reject_constant(token: str) -> Any:
+        raise ValueError(f"{name} contains non-finite number {token!r}")
+
+    if path.is_symlink():
+        raise ValueError(f"{name} is a symbolic link")
+    try:
+        payload = path.read_bytes()
+    except OSError as error:
+        raise ValueError(f"cannot read {name}") from error
+    try:
+        value = json.loads(
+            payload.decode("utf-8"),
+            object_pairs_hook=pairs,
+            parse_constant=reject_constant,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"{name} must contain UTF-8 JSON") from error
+    if not isinstance(value, dict):
+        raise ValueError(f"{name} must contain one JSON object")
+    return value
+
+
+@dataclass(frozen=True)
+class PredictionBatchPolicyV1:
+    """Frozen scorer compatibility requirements."""
+
+    require_nonempty: bool = True
+    require_common_frame_count: bool = True
+    require_common_spatial_shape: bool = True
+    require_common_point_dtype: bool = True
+    require_common_optional_fields: bool = True
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "schema": PREDICTION_BATCH_POLICY_SCHEMA,
+            "schema_version": PREDICTION_BATCH_POLICY_VERSION,
+            "require_nonempty": self.require_nonempty,
+            "require_common_frame_count": self.require_common_frame_count,
+            "require_common_spatial_shape": self.require_common_spatial_shape,
+            "require_common_point_dtype": self.require_common_point_dtype,
+            "require_common_optional_fields": self.require_common_optional_fields,
+        }
+
+    @classmethod
+    def from_record(cls, value: object) -> PredictionBatchPolicyV1:
+        record = _mapping(value, name="prediction batch policy")
+        expected = frozenset(
+            {
+                "schema",
+                "schema_version",
+                "require_nonempty",
+                "require_common_frame_count",
+                "require_common_spatial_shape",
+                "require_common_point_dtype",
+                "require_common_optional_fields",
+            }
+        )
+        _exact_fields(record, expected, name="prediction batch policy")
+        if record["schema"] != PREDICTION_BATCH_POLICY_SCHEMA:
+            raise ValueError("unsupported prediction batch policy schema")
+        if record["schema_version"] != PREDICTION_BATCH_POLICY_VERSION:
+            raise ValueError("unsupported prediction batch policy version")
+        return cls(
+            require_nonempty=_boolean(record["require_nonempty"], name="require_nonempty"),
+            require_common_frame_count=_boolean(
+                record["require_common_frame_count"],
+                name="require_common_frame_count",
+            ),
+            require_common_spatial_shape=_boolean(
+                record["require_common_spatial_shape"],
+                name="require_common_spatial_shape",
+            ),
+            require_common_point_dtype=_boolean(
+                record["require_common_point_dtype"],
+                name="require_common_point_dtype",
+            ),
+            require_common_optional_fields=_boolean(
+                record["require_common_optional_fields"],
+                name="require_common_optional_fields",
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class PredictionBatchEntryV1:
+    payload_id: str
+    window_id: str
+    relative_path: str
+    output_frame_ids: tuple[int, ...]
+    point_shape: tuple[int, ...]
+    point_dtype: str
+    scene_flow_shape: tuple[int, ...] | None
+    ray_shape: tuple[int, ...] | None
+    dense_storage_dtype: str
+    payload_sha256: str
+    payload_byte_count: int
+
+    def __post_init__(self) -> None:
+        if len(self.point_shape) < 2 or self.point_shape[-1] != 3:
+            raise ValueError("point_shape must end in coordinate dimension 3")
+        if len(self.output_frame_ids) != self.point_shape[0]:
+            raise ValueError("output frame count differs from point tensor")
+        if self.scene_flow_shape is not None and self.scene_flow_shape != self.point_shape:
+            raise ValueError("scene-flow shape must equal point shape")
+        if self.ray_shape is not None and self.ray_shape != self.point_shape:
+            raise ValueError("ray shape must equal point shape")
+        if len(self.payload_sha256) != 64:
+            raise ValueError("payload_sha256 must contain 64 hexadecimal characters")
+        try:
+            int(self.payload_sha256, 16)
+        except ValueError as error:
+            raise ValueError("payload_sha256 must be hexadecimal") from error
+
+    @property
+    def frame_count(self) -> int:
+        return self.point_shape[0]
+
+    @property
+    def spatial_shape(self) -> tuple[int, ...]:
+        return self.point_shape[1:-1]
+
+    @property
+    def optional_signature(self) -> tuple[bool, bool]:
+        return self.scene_flow_shape is not None, self.ray_shape is not None
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "payload_id": self.payload_id,
+            "window_id": self.window_id,
+            "relative_path": self.relative_path,
+            "output_frame_ids": list(self.output_frame_ids),
+            "point_shape": list(self.point_shape),
+            "point_dtype": self.point_dtype,
+            "scene_flow_shape": (
+                None if self.scene_flow_shape is None else list(self.scene_flow_shape)
+            ),
+            "ray_shape": None if self.ray_shape is None else list(self.ray_shape),
+            "dense_storage_dtype": self.dense_storage_dtype,
+            "payload_sha256": self.payload_sha256,
+            "payload_byte_count": self.payload_byte_count,
+        }
+
+    @classmethod
+    def from_record(cls, value: object) -> PredictionBatchEntryV1:
+        record = _mapping(value, name="prediction batch entry")
+        expected = frozenset(
+            {
+                "payload_id",
+                "window_id",
+                "relative_path",
+                "output_frame_ids",
+                "point_shape",
+                "point_dtype",
+                "scene_flow_shape",
+                "ray_shape",
+                "dense_storage_dtype",
+                "payload_sha256",
+                "payload_byte_count",
+            }
+        )
+        _exact_fields(record, expected, name="prediction batch entry")
+        scene = record["scene_flow_shape"]
+        rays = record["ray_shape"]
+        return cls(
+            payload_id=_string(record["payload_id"], name="payload_id"),
+            window_id=_string(record["window_id"], name="window_id"),
+            relative_path=_string(record["relative_path"], name="relative_path"),
+            output_frame_ids=_integer_tuple(
+                record["output_frame_ids"], name="output_frame_ids"
+            ),
+            point_shape=_integer_tuple(record["point_shape"], name="point_shape"),
+            point_dtype=_string(record["point_dtype"], name="point_dtype"),
+            scene_flow_shape=(
+                None if scene is None else _integer_tuple(scene, name="scene_flow_shape")
+            ),
+            ray_shape=None if rays is None else _integer_tuple(rays, name="ray_shape"),
+            dense_storage_dtype=_string(
+                record["dense_storage_dtype"], name="dense_storage_dtype"
+            ),
+            payload_sha256=_string(record["payload_sha256"], name="payload_sha256"),
+            payload_byte_count=_integer(
+                record["payload_byte_count"], name="payload_byte_count"
+            ),
+        )
+
+
+@dataclass(frozen=True)
+class PredictionBatchViolationV1:
+    code: str
+    field_name: str
+    reference_payload_id: str | None
+    payload_id: str | None
+    expected: object
+    observed: object
+    message: str
+
+    def to_record(self) -> dict[str, object]:
+        return {
+            "code": self.code,
+            "field_name": self.field_name,
+            "reference_payload_id": self.reference_payload_id,
+            "payload_id": self.payload_id,
+            "expected": self.expected,
+            "observed": self.observed,
+            "message": self.message,
+        }
+
+    @classmethod
+    def from_record(cls, value: object) -> PredictionBatchViolationV1:
+        record = _mapping(value, name="prediction batch violation")
+        expected_fields = frozenset(
+            {
+                "code",
+                "field_name",
+                "reference_payload_id",
+                "payload_id",
+                "expected",
+                "observed",
+                "message",
+            }
+        )
+        _exact_fields(record, expected_fields, name="prediction batch violation")
+        reference = record["reference_payload_id"]
+        payload = record["payload_id"]
+        return cls(
+            code=_string(record["code"], name="code"),
+            field_name=_string(record["field_name"], name="field_name"),
+            reference_payload_id=(
+                None if reference is None else _string(reference, name="reference_payload_id")
+            ),
+            payload_id=None if payload is None else _string(payload, name="payload_id"),
+            expected=record["expected"],
+            observed=record["observed"],
+            message=_string(record["message"], name="message"),
+        )
+
+
+@dataclass(frozen=True)
+class PredictionBatchPreflightV1:
+    manifest_artifact_id: str
+    causal_frame_stop: int | None
+    policy: PredictionBatchPolicyV1
+    selected_payload_ids: tuple[str, ...]
+    excluded_future_payload_ids: tuple[str, ...]
+    entries: tuple[PredictionBatchEntryV1, ...]
+    violations: tuple[PredictionBatchViolationV1, ...]
+    status: str
+    future_prediction_payloads_opened: int = 0
+    metadata: Mapping[str, object] = field(default_factory=dict)
+    artifact_id: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.status not in {"pass", "batch-incompatible"}:
+            raise ValueError("unsupported prediction batch status")
+        if self.future_prediction_payloads_opened != 0:
+            raise ValueError("causal preflight must not open future payloads")
+        if tuple(entry.payload_id for entry in self.entries) != self.selected_payload_ids:
+            raise ValueError("entry order differs from selected payload order")
+        if set(self.selected_payload_ids) & set(self.excluded_future_payload_ids):
+            raise ValueError("selected and excluded payload rosters overlap")
+        if self.status == "pass" and self.violations:
+            raise ValueError("passing preflight cannot retain violations")
+        if self.status == "batch-incompatible" and not self.violations:
+            raise ValueError("incompatible preflight requires a violation")
+        _canonical_bytes(dict(self.metadata))
+        expected = _artifact_id(self.to_record(include_artifact_id=False))
+        if self.artifact_id is None:
+            object.__setattr__(self, "artifact_id", expected)
+        elif self.artifact_id != expected:
+            raise ValueError("prediction batch preflight artifact ID mismatch")
+
+    @property
+    def compatible(self) -> bool:
+        return self.status == "pass"
+
+    def to_record(self, *, include_artifact_id: bool = True) -> dict[str, object]:
+        record: dict[str, object] = {
+            "schema": PREDICTION_BATCH_PREFLIGHT_SCHEMA,
+            "schema_version": PREDICTION_BATCH_PREFLIGHT_VERSION,
+            "manifest_artifact_id": self.manifest_artifact_id,
+            "causal_frame_stop": self.causal_frame_stop,
+            "policy": self.policy.to_record(),
+            "selected_payload_ids": list(self.selected_payload_ids),
+            "excluded_future_payload_ids": list(self.excluded_future_payload_ids),
+            "entries": [entry.to_record() for entry in self.entries],
+            "violations": [violation.to_record() for violation in self.violations],
+            "status": self.status,
+            "future_prediction_payloads_opened": self.future_prediction_payloads_opened,
+            "metadata": dict(self.metadata),
+        }
+        if include_artifact_id:
+            record["artifact_id"] = self.artifact_id
+        return record
+
+    @classmethod
+    def from_record(cls, value: object) -> PredictionBatchPreflightV1:
+        record = _mapping(value, name="prediction batch preflight")
+        expected = frozenset(
+            {
+                "schema",
+                "schema_version",
+                "manifest_artifact_id",
+                "causal_frame_stop",
+                "policy",
+                "selected_payload_ids",
+                "excluded_future_payload_ids",
+                "entries",
+                "violations",
+                "status",
+                "future_prediction_payloads_opened",
+                "metadata",
+                "artifact_id",
+            }
+        )
+        _exact_fields(record, expected, name="prediction batch preflight")
+        if record["schema"] != PREDICTION_BATCH_PREFLIGHT_SCHEMA:
+            raise ValueError("unsupported prediction batch preflight schema")
+        if record["schema_version"] != PREDICTION_BATCH_PREFLIGHT_VERSION:
+            raise ValueError("unsupported prediction batch preflight version")
+        raw_entries = record["entries"]
+        raw_violations = record["violations"]
+        if not isinstance(raw_entries, list) or not isinstance(raw_violations, list):
+            raise ValueError("entries and violations must be arrays")
+        cutoff_value = record["causal_frame_stop"]
+        cutoff = None if cutoff_value is None else _integer(cutoff_value, name="cutoff")
+        return cls(
+            manifest_artifact_id=_string(
+                record["manifest_artifact_id"], name="manifest_artifact_id"
+            ),
+            causal_frame_stop=cutoff,
+            policy=PredictionBatchPolicyV1.from_record(record["policy"]),
+            selected_payload_ids=_string_tuple(
+                record["selected_payload_ids"], name="selected_payload_ids"
+            ),
+            excluded_future_payload_ids=_string_tuple(
+                record["excluded_future_payload_ids"],
+                name="excluded_future_payload_ids",
+            ),
+            entries=tuple(PredictionBatchEntryV1.from_record(item) for item in raw_entries),
+            violations=tuple(
+                PredictionBatchViolationV1.from_record(item) for item in raw_violations
+            ),
+            status=_string(record["status"], name="status"),
+            future_prediction_payloads_opened=_integer(
+                record["future_prediction_payloads_opened"],
+                name="future_prediction_payloads_opened",
+            ),
+            metadata=dict(_mapping(record["metadata"], name="metadata")),
+            artifact_id=_string(record["artifact_id"], name="artifact_id"),
+        )
+
+
+def _payload_path(manifest_path: Path, relative_path: str) -> Path:
+    relative = Path(relative_path)
+    if relative.is_absolute() or ".." in relative.parts:
+        raise PredictionBatchIntegrityError("payload path escapes the manifest root")
+    root = manifest_path.parent.resolve()
+    candidate = manifest_path.parent / relative
+    if candidate.is_symlink():
+        raise PredictionBatchIntegrityError("payload path is a symbolic link")
+    resolved = candidate.resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError as error:
+        raise PredictionBatchIntegrityError("payload path escapes the manifest root") from error
+    return resolved
+
+
+def _load_selected_window(manifest_path: Path, descriptor: Any) -> PredictionBatchEntryV1:
+    path = _payload_path(manifest_path, descriptor.path)
+    try:
+        payload = path.read_bytes()
+    except OSError as error:
+        raise PredictionBatchIntegrityError("cannot read selected prediction payload") from error
+    if len(payload) != descriptor.byte_count:
+        raise PredictionBatchIntegrityError("selected prediction payload byte count mismatch")
+    if _sha256(payload) != descriptor.sha256:
+        raise PredictionBatchIntegrityError("selected prediction payload SHA-256 mismatch")
+    with tempfile.TemporaryDirectory(prefix="prob4d-batch-preflight-") as directory:
+        snapshot = Path(directory) / "window.npz"
+        snapshot.write_bytes(payload)
+        try:
+            window = PredictionWindow.from_npz(snapshot)
+        except (OSError, KeyError, ValueError) as error:
+            raise PredictionBatchIntegrityError(
+                "selected payload is not a canonical PredictionWindow"
+            ) from error
+    if path.read_bytes() != payload:
+        raise PredictionBatchIntegrityError("selected prediction payload changed during read")
+    if window.window_id != descriptor.window_id:
+        raise PredictionBatchIntegrityError("descriptor and payload window IDs differ")
+    frame_ids = tuple(int(value) for value in window.frame_indices)
+    if frame_ids != tuple(descriptor.output_frame_ids):
+        raise PredictionBatchIntegrityError("descriptor and payload frame identities differ")
+    if (window.scene_flow is not None) != bool(descriptor.has_scene_flow):
+        raise PredictionBatchIntegrityError("scene-flow declaration differs from payload")
+    if (window.ray_directions is not None) != bool(descriptor.has_ray_directions):
+        raise PredictionBatchIntegrityError("ray declaration differs from payload")
+    if window.dense_storage_dtype != descriptor.dense_storage_dtype:
+        raise PredictionBatchIntegrityError("storage dtype declaration differs from payload")
+    point_shape = tuple(int(value) for value in window.point_map.shape)
+    scene_shape = (
+        None
+        if window.scene_flow is None
+        else tuple(int(value) for value in window.scene_flow.shape)
+    )
+    ray_shape = (
+        None
+        if window.ray_directions is None
+        else tuple(int(value) for value in window.ray_directions.shape)
+    )
+    return PredictionBatchEntryV1(
+        payload_id=descriptor.payload_id,
+        window_id=descriptor.window_id,
+        relative_path=descriptor.path,
+        output_frame_ids=frame_ids,
+        point_shape=point_shape,
+        point_dtype=np.dtype(window.point_map.dtype).str,
+        scene_flow_shape=scene_shape,
+        ray_shape=ray_shape,
+        dense_storage_dtype=window.dense_storage_dtype,
+        payload_sha256=_sha256(payload),
+        payload_byte_count=len(payload),
+    )
+
+
+def _mismatch(
+    code: str,
+    field_name: str,
+    reference: PredictionBatchEntryV1,
+    entry: PredictionBatchEntryV1,
+    expected: object,
+    observed: object,
+) -> PredictionBatchViolationV1:
+    return PredictionBatchViolationV1(
+        code=code,
+        field_name=field_name,
+        reference_payload_id=reference.payload_id,
+        payload_id=entry.payload_id,
+        expected=expected,
+        observed=observed,
+        message=(
+            f"payload {entry.payload_id!r} has incompatible {field_name}; "
+            f"reference payload is {reference.payload_id!r}"
+        ),
+    )
+
+
+def _violations(
+    entries: tuple[PredictionBatchEntryV1, ...], policy: PredictionBatchPolicyV1
+) -> tuple[PredictionBatchViolationV1, ...]:
+    if not entries:
+        if not policy.require_nonempty:
+            return ()
+        return (
+            PredictionBatchViolationV1(
+                code="no-causally-admitted-payloads",
+                field_name="payload_roster",
+                reference_payload_id=None,
+                payload_id=None,
+                expected="at least one causally admitted payload",
+                observed=0,
+                message="no payload is admitted by the causal cutoff",
+            ),
+        )
+    reference = entries[0]
+    result: list[PredictionBatchViolationV1] = []
+    for entry in entries[1:]:
+        if policy.require_common_frame_count and entry.frame_count != reference.frame_count:
+            result.append(
+                _mismatch(
+                    "frame-count-mismatch",
+                    "frame_count",
+                    reference,
+                    entry,
+                    reference.frame_count,
+                    entry.frame_count,
+                )
+            )
+        if (
+            policy.require_common_spatial_shape
+            and entry.spatial_shape != reference.spatial_shape
+        ):
+            result.append(
+                _mismatch(
+                    "spatial-shape-mismatch",
+                    "spatial_shape",
+                    reference,
+                    entry,
+                    list(reference.spatial_shape),
+                    list(entry.spatial_shape),
+                )
+            )
+        if policy.require_common_point_dtype and entry.point_dtype != reference.point_dtype:
+            result.append(
+                _mismatch(
+                    "point-dtype-mismatch",
+                    "point_dtype",
+                    reference,
+                    entry,
+                    reference.point_dtype,
+                    entry.point_dtype,
+                )
+            )
+        if (
+            policy.require_common_optional_fields
+            and entry.optional_signature != reference.optional_signature
+        ):
+            result.append(
+                _mismatch(
+                    "optional-field-mismatch",
+                    "optional_signature",
+                    reference,
+                    entry,
+                    list(reference.optional_signature),
+                    list(entry.optional_signature),
+                )
+            )
+    return tuple(result)
+
+
+def preflight_prediction_batch(
+    manifest_path: str | Path,
+    *,
+    causal_frame_stop: int | None = None,
+    policy: PredictionBatchPolicyV1 | None = None,
+    metadata: Mapping[str, object] | None = None,
+) -> PredictionBatchPreflightV1:
+    """Inspect the causally admitted payloads and classify scorer compatibility."""
+
+    path_input = Path(manifest_path)
+    if path_input.is_symlink():
+        raise PredictionBatchIntegrityError("provider manifest is a symbolic link")
+    path = path_input.resolve()
+    if causal_frame_stop is not None:
+        _integer(causal_frame_stop, name="causal_frame_stop")
+    manifest = load_prediction_provider_manifest(path)
+    selected = tuple(
+        descriptor
+        for descriptor in manifest.payloads
+        if causal_frame_stop is None
+        or descriptor.is_causally_admitted(causal_frame_stop)
+    )
+    selected_ids = {descriptor.payload_id for descriptor in selected}
+    excluded = tuple(
+        descriptor for descriptor in manifest.payloads if descriptor.payload_id not in selected_ids
+    )
+    entries = tuple(_load_selected_window(path, descriptor) for descriptor in selected)
+    active_policy = policy or PredictionBatchPolicyV1()
+    violations = _violations(entries, active_policy)
+    return PredictionBatchPreflightV1(
+        manifest_artifact_id=manifest.artifact_id,
+        causal_frame_stop=causal_frame_stop,
+        policy=active_policy,
+        selected_payload_ids=tuple(entry.payload_id for entry in entries),
+        excluded_future_payload_ids=tuple(item.payload_id for item in excluded),
+        entries=entries,
+        violations=violations,
+        status="pass" if not violations else "batch-incompatible",
+        metadata={} if metadata is None else dict(metadata),
+    )
+
+
+def write_prediction_batch_preflight(
+    path: str | Path, artifact: PredictionBatchPreflightV1
+) -> Path:
+    """Write atomically and refuse to replace a different artifact."""
+
+    destination_input = Path(path)
+    if destination_input.is_symlink():
+        raise ValueError("preflight output is a symbolic link")
+    destination = destination_input.resolve()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    content = json.dumps(artifact.to_record(), indent=2, sort_keys=True, allow_nan=False) + "\n"
+    if destination.exists():
+        if destination.read_text(encoding="utf-8") == content:
+            return destination
+        raise FileExistsError("refusing to replace a different preflight artifact")
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{destination.name}.", suffix=".tmp", dir=destination.parent
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            stream.write(content)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, destination)
+    finally:
+        temporary.unlink(missing_ok=True)
+    return destination
+
+
+def load_prediction_batch_preflight(path: str | Path) -> PredictionBatchPreflightV1:
+    return PredictionBatchPreflightV1.from_record(
+        _strict_json(Path(path), name="prediction batch preflight artifact")
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build or verify prediction-batch preflight")
+    actions = parser.add_subparsers(dest="action", required=True)
+    build = actions.add_parser("build")
+    build.add_argument("manifest")
+    build.add_argument("output")
+    build.add_argument("--causal-frame-stop", type=int)
+    build.add_argument("--allow-empty", action="store_true")
+    build.add_argument("--allow-ragged-frames", action="store_true")
+    build.add_argument("--allow-ragged-spatial", action="store_true")
+    build.add_argument("--allow-mixed-dtypes", action="store_true")
+    build.add_argument("--allow-mixed-optional-fields", action="store_true")
+    verify = actions.add_parser("verify")
+    verify.add_argument("artifact")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _parser().parse_args(list(argv) if argv is not None else None)
+    if arguments.action == "verify":
+        artifact = load_prediction_batch_preflight(arguments.artifact)
+    else:
+        policy = PredictionBatchPolicyV1(
+            require_nonempty=not arguments.allow_empty,
+            require_common_frame_count=not arguments.allow_ragged_frames,
+            require_common_spatial_shape=not arguments.allow_ragged_spatial,
+            require_common_point_dtype=not arguments.allow_mixed_dtypes,
+            require_common_optional_fields=not arguments.allow_mixed_optional_fields,
+        )
+        artifact = preflight_prediction_batch(
+            arguments.manifest,
+            causal_frame_stop=arguments.causal_frame_stop,
+            policy=policy,
+        )
+        write_prediction_batch_preflight(arguments.output, artifact)
+    print(
+        json.dumps(
+            {
+                "artifact_id": artifact.artifact_id,
+                "status": artifact.status,
+                "selected_payload_count": len(artifact.entries),
+                "violation_count": len(artifact.violations),
+                "future_prediction_payloads_opened": 0,
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0 if arguments.action == "verify" or artifact.compatible else 2
+
+
+__all__ = [
+    "PREDICTION_BATCH_POLICY_SCHEMA",
+    "PREDICTION_BATCH_POLICY_VERSION",
+    "PREDICTION_BATCH_PREFLIGHT_SCHEMA",
+    "PREDICTION_BATCH_PREFLIGHT_VERSION",
+    "PredictionBatchEntryV1",
+    "PredictionBatchIntegrityError",
+    "PredictionBatchPolicyV1",
+    "PredictionBatchPreflightV1",
+    "PredictionBatchViolationV1",
+    "load_prediction_batch_preflight",
+    "main",
+    "preflight_prediction_batch",
+    "write_prediction_batch_preflight",
+]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/prob4d/provider_terminal_decision.py
+++ b/src/prob4d/provider_terminal_decision.py
@@ -1,0 +1,440 @@
+"""Content-addressed provider terminal decisions and scientific stop rules."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import tempfile
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Final
+
+PROVIDER_TERMINAL_DECISION_SCHEMA: Final = "prob4d.provider-terminal-decision"
+PROVIDER_TERMINAL_DECISION_VERSION: Final = 1
+
+CLASSIFICATION_SUPPORT_NEGATIVE: Final = "support-negative"
+CLASSIFICATION_BATCH_INCOMPATIBLE: Final = "batch-incompatible"
+CLASSIFICATION_SCIENTIFIC_NEGATIVE: Final = "scientific-negative"
+CLASSIFICATION_TECHNICAL_FAILURE: Final = "technical-failure"
+CLASSIFICATION_COMPLETED_POSITIVE: Final = "completed-positive"
+
+_VALID_CLASSIFICATIONS: Final = frozenset(
+    {
+        CLASSIFICATION_SUPPORT_NEGATIVE,
+        CLASSIFICATION_BATCH_INCOMPATIBLE,
+        CLASSIFICATION_SCIENTIFIC_NEGATIVE,
+        CLASSIFICATION_TECHNICAL_FAILURE,
+        CLASSIFICATION_COMPLETED_POSITIVE,
+    }
+)
+_INFRASTRUCTURE_CLASSIFICATIONS: Final = frozenset(
+    {CLASSIFICATION_BATCH_INCOMPATIBLE, CLASSIFICATION_TECHNICAL_FAILURE}
+)
+REQUIRED_INFRASTRUCTURE_NONCLAIMS: Final = frozenset(
+    {
+        "provider-competence",
+        "provider-calibration",
+        "bayesian-phystwin-benefit",
+        "causal4d-intervention-benefit",
+        "deployment-safety",
+        "state-of-the-art",
+    }
+)
+
+
+def _canonical_bytes(record: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        record,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _artifact_id(record: Mapping[str, object]) -> str:
+    identity_record = dict(record)
+    identity_record.pop("artifact_id", None)
+    return hashlib.sha256(_canonical_bytes(identity_record)).hexdigest()
+
+
+def _string(value: object, *, name: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{name} must be a nonempty string")
+    return value
+
+
+def _optional_string(value: object, *, name: str) -> str | None:
+    return None if value is None else _string(value, name=name)
+
+
+def _boolean(value: object, *, name: str) -> bool:
+    if not isinstance(value, bool):
+        raise ValueError(f"{name} must be a boolean")
+    return value
+
+
+def _string_tuple(value: object, *, name: str) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise ValueError(f"{name} must be an array")
+    result = tuple(_string(item, name=f"{name} item") for item in value)
+    if len(set(result)) != len(result):
+        raise ValueError(f"{name} must not contain duplicates")
+    return result
+
+
+def _mapping(value: object, *, name: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{name} must be an object")
+    return value
+
+
+def _exact_fields(
+    record: Mapping[str, object], expected: frozenset[str], *, name: str
+) -> None:
+    actual = frozenset(record)
+    if actual != expected:
+        raise ValueError(
+            f"{name} fields differ: missing={sorted(expected - actual)}, "
+            f"extra={sorted(actual - expected)}"
+        )
+
+
+def _strict_json(path: Path, *, name: str) -> dict[str, Any]:
+    def pairs(items: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in items:
+            if key in result:
+                raise ValueError(f"{name} contains duplicate key {key!r}")
+            result[key] = value
+        return result
+
+    def reject_constant(token: str) -> Any:
+        raise ValueError(f"{name} contains non-finite number {token!r}")
+
+    if path.is_symlink():
+        raise ValueError(f"{name} is a symbolic link")
+    try:
+        payload = path.read_bytes()
+    except OSError as error:
+        raise ValueError(f"cannot read {name}") from error
+    try:
+        value = json.loads(
+            payload.decode("utf-8"),
+            object_pairs_hook=pairs,
+            parse_constant=reject_constant,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"{name} must contain UTF-8 JSON") from error
+    if not isinstance(value, dict):
+        raise ValueError(f"{name} must contain one JSON object")
+    return value
+
+
+@dataclass(frozen=True)
+class ProviderTerminalDecisionV1:
+    """Classification of one completed provider information boundary."""
+
+    protocol_id: str
+    provider_manifest_id: str
+    classification: str
+    failed_stage: str | None
+    source_payloads_accessed: bool
+    source_outcomes_accessed: bool
+    target_payloads_accessed: bool
+    target_outcomes_accessed: bool
+    rerun_authorized: bool
+    successor_protocol_required: bool
+    evidence_ids: tuple[str, ...]
+    authorized_inferences: tuple[str, ...]
+    forbidden_inferences: tuple[str, ...]
+    summary: str
+    metadata: Mapping[str, object] = field(default_factory=dict)
+    artifact_id: str | None = None
+
+    def __post_init__(self) -> None:
+        _string(self.protocol_id, name="protocol_id")
+        _string(self.provider_manifest_id, name="provider_manifest_id")
+        _string(self.summary, name="summary")
+        if self.classification not in _VALID_CLASSIFICATIONS:
+            raise ValueError("unsupported provider terminal classification")
+        if self.failed_stage is not None:
+            _string(self.failed_stage, name="failed_stage")
+        for name, roster in (
+            ("evidence_ids", self.evidence_ids),
+            ("authorized_inferences", self.authorized_inferences),
+            ("forbidden_inferences", self.forbidden_inferences),
+        ):
+            if len(set(roster)) != len(roster):
+                raise ValueError(f"{name} must not contain duplicates")
+            for item in roster:
+                _string(item, name=f"{name} item")
+
+        # Report the scientifically important infrastructure rule before generic
+        # overlap diagnostics, even when a malformed specification both
+        # authorizes and forbids the same claim.
+        if self.classification in _INFRASTRUCTURE_CLASSIFICATIONS:
+            if self.authorized_inferences:
+                raise ValueError(
+                    "infrastructure terminal decisions authorize no scientific inference"
+                )
+            missing = REQUIRED_INFRASTRUCTURE_NONCLAIMS - set(
+                self.forbidden_inferences
+            )
+            if missing:
+                raise ValueError(
+                    "infrastructure terminal decision omits forbidden claims: "
+                    + ", ".join(sorted(missing))
+                )
+            if self.target_outcomes_accessed:
+                raise ValueError(
+                    "batch or technical failure must precede target outcomes"
+                )
+
+        if set(self.authorized_inferences) & set(self.forbidden_inferences):
+            raise ValueError("an inference cannot be both authorized and forbidden")
+        if self.source_outcomes_accessed and not self.source_payloads_accessed:
+            raise ValueError("source outcomes require source payload access")
+        if self.target_outcomes_accessed and not self.target_payloads_accessed:
+            raise ValueError("target outcomes require target payload access")
+        if self.target_payloads_accessed and not self.source_payloads_accessed:
+            raise ValueError("target payload access requires source payload access")
+
+        if self.classification == CLASSIFICATION_SUPPORT_NEGATIVE:
+            if self.source_payloads_accessed or self.target_payloads_accessed:
+                raise ValueError("support-negative decision must precede payload access")
+            if self.authorized_inferences != ("provider-support-negative",):
+                raise ValueError(
+                    "support-negative authorizes only provider-support-negative"
+                )
+        if self.classification == CLASSIFICATION_SCIENTIFIC_NEGATIVE:
+            if not (self.source_outcomes_accessed or self.target_outcomes_accessed):
+                raise ValueError("scientific-negative requires opened outcome evidence")
+            if not self.authorized_inferences:
+                raise ValueError("scientific-negative requires a declared inference")
+        if self.classification == CLASSIFICATION_COMPLETED_POSITIVE:
+            if not self.target_outcomes_accessed:
+                raise ValueError("completed-positive requires target outcome access")
+            if not self.authorized_inferences:
+                raise ValueError("completed-positive requires a declared inference")
+        if self.target_outcomes_accessed and self.rerun_authorized:
+            raise ValueError("opened target outcomes cannot authorize a rerun")
+        if (
+            self.classification
+            in {
+                CLASSIFICATION_SUPPORT_NEGATIVE,
+                CLASSIFICATION_BATCH_INCOMPATIBLE,
+                CLASSIFICATION_TECHNICAL_FAILURE,
+            }
+            and not self.successor_protocol_required
+        ):
+            raise ValueError("terminal infrastructure boundary requires a successor protocol")
+
+        _canonical_bytes(dict(self.metadata))
+        expected = _artifact_id(self.to_record(include_artifact_id=False))
+        if self.artifact_id is None:
+            object.__setattr__(self, "artifact_id", expected)
+        elif self.artifact_id != expected:
+            raise ValueError("provider terminal decision artifact ID mismatch")
+
+    @property
+    def scientific_result(self) -> bool:
+        return self.classification in {
+            CLASSIFICATION_SCIENTIFIC_NEGATIVE,
+            CLASSIFICATION_COMPLETED_POSITIVE,
+        }
+
+    def to_record(self, *, include_artifact_id: bool = True) -> dict[str, object]:
+        record: dict[str, object] = {
+            "schema": PROVIDER_TERMINAL_DECISION_SCHEMA,
+            "schema_version": PROVIDER_TERMINAL_DECISION_VERSION,
+            "protocol_id": self.protocol_id,
+            "provider_manifest_id": self.provider_manifest_id,
+            "classification": self.classification,
+            "failed_stage": self.failed_stage,
+            "source_payloads_accessed": self.source_payloads_accessed,
+            "source_outcomes_accessed": self.source_outcomes_accessed,
+            "target_payloads_accessed": self.target_payloads_accessed,
+            "target_outcomes_accessed": self.target_outcomes_accessed,
+            "rerun_authorized": self.rerun_authorized,
+            "successor_protocol_required": self.successor_protocol_required,
+            "evidence_ids": list(self.evidence_ids),
+            "authorized_inferences": list(self.authorized_inferences),
+            "forbidden_inferences": list(self.forbidden_inferences),
+            "summary": self.summary,
+            "metadata": dict(self.metadata),
+        }
+        if include_artifact_id:
+            record["artifact_id"] = self.artifact_id
+        return record
+
+    @classmethod
+    def from_record(cls, value: object) -> ProviderTerminalDecisionV1:
+        record = _mapping(value, name="provider terminal decision")
+        expected = frozenset(
+            {
+                "schema",
+                "schema_version",
+                "protocol_id",
+                "provider_manifest_id",
+                "classification",
+                "failed_stage",
+                "source_payloads_accessed",
+                "source_outcomes_accessed",
+                "target_payloads_accessed",
+                "target_outcomes_accessed",
+                "rerun_authorized",
+                "successor_protocol_required",
+                "evidence_ids",
+                "authorized_inferences",
+                "forbidden_inferences",
+                "summary",
+                "metadata",
+                "artifact_id",
+            }
+        )
+        _exact_fields(record, expected, name="provider terminal decision")
+        if record["schema"] != PROVIDER_TERMINAL_DECISION_SCHEMA:
+            raise ValueError("unsupported provider terminal decision schema")
+        if record["schema_version"] != PROVIDER_TERMINAL_DECISION_VERSION:
+            raise ValueError("unsupported provider terminal decision version")
+        return cls(
+            protocol_id=_string(record["protocol_id"], name="protocol_id"),
+            provider_manifest_id=_string(
+                record["provider_manifest_id"], name="provider_manifest_id"
+            ),
+            classification=_string(record["classification"], name="classification"),
+            failed_stage=_optional_string(record["failed_stage"], name="failed_stage"),
+            source_payloads_accessed=_boolean(
+                record["source_payloads_accessed"], name="source_payloads_accessed"
+            ),
+            source_outcomes_accessed=_boolean(
+                record["source_outcomes_accessed"], name="source_outcomes_accessed"
+            ),
+            target_payloads_accessed=_boolean(
+                record["target_payloads_accessed"], name="target_payloads_accessed"
+            ),
+            target_outcomes_accessed=_boolean(
+                record["target_outcomes_accessed"], name="target_outcomes_accessed"
+            ),
+            rerun_authorized=_boolean(
+                record["rerun_authorized"], name="rerun_authorized"
+            ),
+            successor_protocol_required=_boolean(
+                record["successor_protocol_required"],
+                name="successor_protocol_required",
+            ),
+            evidence_ids=_string_tuple(record["evidence_ids"], name="evidence_ids"),
+            authorized_inferences=_string_tuple(
+                record["authorized_inferences"], name="authorized_inferences"
+            ),
+            forbidden_inferences=_string_tuple(
+                record["forbidden_inferences"], name="forbidden_inferences"
+            ),
+            summary=_string(record["summary"], name="summary"),
+            metadata=dict(_mapping(record["metadata"], name="metadata")),
+            artifact_id=_string(record["artifact_id"], name="artifact_id"),
+        )
+
+
+def write_provider_terminal_decision(
+    path: str | Path, decision: ProviderTerminalDecisionV1
+) -> Path:
+    destination_input = Path(path)
+    if destination_input.is_symlink():
+        raise ValueError("terminal decision output is a symbolic link")
+    destination = destination_input.resolve()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    content = json.dumps(decision.to_record(), indent=2, sort_keys=True, allow_nan=False) + "\n"
+    if destination.exists():
+        if destination.read_text(encoding="utf-8") == content:
+            return destination
+        raise FileExistsError("refusing to replace a different terminal decision")
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{destination.name}.", suffix=".tmp", dir=destination.parent
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            stream.write(content)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, destination)
+    finally:
+        temporary.unlink(missing_ok=True)
+    return destination
+
+
+def load_provider_terminal_decision(path: str | Path) -> ProviderTerminalDecisionV1:
+    return ProviderTerminalDecisionV1.from_record(
+        _strict_json(Path(path), name="provider terminal decision artifact")
+    )
+
+
+def build_provider_terminal_decision(
+    specification_path: str | Path,
+) -> ProviderTerminalDecisionV1:
+    specification = _strict_json(
+        Path(specification_path), name="provider terminal decision specification"
+    )
+    record = dict(specification)
+    record["artifact_id"] = _artifact_id(record)
+    return ProviderTerminalDecisionV1.from_record(record)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Build or verify provider terminal decision")
+    actions = parser.add_subparsers(dest="action", required=True)
+    build = actions.add_parser("build")
+    build.add_argument("specification")
+    build.add_argument("output")
+    verify = actions.add_parser("verify")
+    verify.add_argument("artifact")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _parser().parse_args(list(argv) if argv is not None else None)
+    if arguments.action == "verify":
+        decision = load_provider_terminal_decision(arguments.artifact)
+    else:
+        decision = build_provider_terminal_decision(arguments.specification)
+        write_provider_terminal_decision(arguments.output, decision)
+    print(
+        json.dumps(
+            {
+                "artifact_id": decision.artifact_id,
+                "classification": decision.classification,
+                "scientific_result": decision.scientific_result,
+                "target_outcomes_accessed": decision.target_outcomes_accessed,
+                "authorized_inferences": list(decision.authorized_inferences),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+__all__ = [
+    "CLASSIFICATION_BATCH_INCOMPATIBLE",
+    "CLASSIFICATION_COMPLETED_POSITIVE",
+    "CLASSIFICATION_SCIENTIFIC_NEGATIVE",
+    "CLASSIFICATION_SUPPORT_NEGATIVE",
+    "CLASSIFICATION_TECHNICAL_FAILURE",
+    "PROVIDER_TERMINAL_DECISION_SCHEMA",
+    "PROVIDER_TERMINAL_DECISION_VERSION",
+    "REQUIRED_INFRASTRUCTURE_NONCLAIMS",
+    "ProviderTerminalDecisionV1",
+    "build_provider_terminal_decision",
+    "load_provider_terminal_decision",
+    "main",
+    "write_provider_terminal_decision",
+]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_prediction_batch_preflight.py
+++ b/tests/test_prediction_batch_preflight.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from prob4d.data import PredictionWindow
+from prob4d.prediction_batch_preflight import (
+    PredictionBatchIntegrityError,
+    PredictionBatchPolicyV1,
+    load_prediction_batch_preflight,
+    main,
+    preflight_prediction_batch,
+    write_prediction_batch_preflight,
+)
+from prob4d.prediction_provider_manifest import (
+    PredictionFrameLineageV1,
+    PredictionPayloadDescriptorV1,
+    PredictionProviderManifestV1,
+    save_prediction_provider_manifest,
+)
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _window(
+    path: Path,
+    *,
+    window_id: str,
+    frames: tuple[int, ...] = (0, 1),
+    height: int = 2,
+    width: int = 3,
+) -> PredictionWindow:
+    point_map = np.zeros((len(frames), height, width, 3), dtype=np.float32)
+    point_map[..., 2] = 1.0
+    valid = np.ones(point_map.shape[:-1], dtype=bool)
+    window = PredictionWindow(
+        window_id=window_id,
+        frame_indices=np.asarray(frames, dtype=np.int64),
+        point_map=point_map,
+        valid_mask=valid,
+        scene_flow=np.zeros_like(point_map),
+        deform_mask=valid,
+        dense_storage_dtype="float32",
+    )
+    window.to_npz(path)
+    return window
+
+
+def _descriptor(
+    path: Path,
+    window: PredictionWindow,
+    *,
+    relative_path: str,
+    source_stop: int,
+    member: str,
+) -> PredictionPayloadDescriptorV1:
+    frame_ids = tuple(int(value) for value in window.frame_indices)
+    return PredictionPayloadDescriptorV1(
+        product_role="independent-window",
+        window_id=window.window_id,
+        path=relative_path,
+        sha256=_sha256(path),
+        byte_count=path.stat().st_size,
+        view_id="camera-0",
+        stochastic_member_id=member,
+        dependence_group_ids=("model:shared", f"member:{member}"),
+        dense_storage_dtype=window.dense_storage_dtype,
+        has_scene_flow=True,
+        has_ray_directions=False,
+        frame_lineage=tuple(
+            PredictionFrameLineageV1(
+                output_frame_id=frame_id,
+                source_frame_start=0,
+                source_frame_stop_exclusive=source_stop,
+                contributor_ids=(window.window_id,),
+            )
+            for frame_id in frame_ids
+        ),
+    )
+
+
+def _future_descriptor() -> PredictionPayloadDescriptorV1:
+    return PredictionPayloadDescriptorV1(
+        product_role="independent-window",
+        window_id="future",
+        path="future-missing.npz",
+        sha256="f" * 64,
+        byte_count=1,
+        view_id="camera-0",
+        stochastic_member_id="future-member",
+        dependence_group_ids=("model:shared", "member:future"),
+        dense_storage_dtype="float32",
+        has_scene_flow=True,
+        has_ray_directions=False,
+        frame_lineage=tuple(
+            PredictionFrameLineageV1(
+                output_frame_id=frame_id,
+                source_frame_start=0,
+                source_frame_stop_exclusive=20,
+                contributor_ids=("future",),
+            )
+            for frame_id in (0, 1)
+        ),
+    )
+
+
+def _manifest(
+    path: Path, descriptors: tuple[PredictionPayloadDescriptorV1, ...]
+) -> Path:
+    manifest = PredictionProviderManifestV1(
+        sequence_id="case-a",
+        provider_family="Example4D",
+        provider_repository="example/provider",
+        provider_revision="a" * 40,
+        provider_run_id="b" * 64,
+        model_set_id="c" * 64,
+        loader_id="d" * 64,
+        coordinate_semantics="window-local-sim3",
+        point_semantics="dense-point-map",
+        flow_semantics="forward-point-displacement",
+        ray_semantics="absent",
+        payloads=descriptors,
+        metadata={
+            "uses_truth": False,
+            "uses_downstream_physical_innovation": False,
+        },
+    )
+    save_prediction_provider_manifest(path, manifest)
+    return path
+
+
+def _two_payload_manifest(
+    tmp_path: Path, *, first_height: int = 2, second_height: int = 2
+) -> Path:
+    first_path = tmp_path / "first.npz"
+    second_path = tmp_path / "second.npz"
+    first = _window(first_path, window_id="first", height=first_height)
+    second = _window(second_path, window_id="second", height=second_height)
+    return _manifest(
+        tmp_path / "provider.json",
+        (
+            _descriptor(
+                first_path,
+                first,
+                relative_path="first.npz",
+                source_stop=2,
+                member="one",
+            ),
+            _descriptor(
+                second_path,
+                second,
+                relative_path="second.npz",
+                source_stop=2,
+                member="two",
+            ),
+        ),
+    )
+
+
+def test_compatible_batch_passes_and_roundtrips(tmp_path: Path) -> None:
+    manifest_path = _two_payload_manifest(tmp_path)
+
+    result = preflight_prediction_batch(manifest_path, causal_frame_stop=2)
+
+    assert result.compatible is True
+    assert result.status == "pass"
+    assert len(result.entries) == 2
+    assert result.violations == ()
+    assert result.future_prediction_payloads_opened == 0
+
+    output = tmp_path / "preflight.json"
+    write_prediction_batch_preflight(output, result)
+    write_prediction_batch_preflight(output, result)
+    assert load_prediction_batch_preflight(output) == result
+
+
+def test_spatial_mismatch_is_a_structured_negative(tmp_path: Path) -> None:
+    manifest_path = _two_payload_manifest(tmp_path, second_height=4)
+
+    result = preflight_prediction_batch(manifest_path, causal_frame_stop=2)
+
+    assert result.compatible is False
+    assert result.status == "batch-incompatible"
+    assert [item.code for item in result.violations] == ["spatial-shape-mismatch"]
+    assert result.violations[0].expected == [2, 3]
+    assert result.violations[0].observed == [4, 3]
+
+
+def test_policy_can_admit_a_prospectively_declared_ragged_grid(
+    tmp_path: Path,
+) -> None:
+    manifest_path = _two_payload_manifest(tmp_path, second_height=4)
+
+    result = preflight_prediction_batch(
+        manifest_path,
+        causal_frame_stop=2,
+        policy=PredictionBatchPolicyV1(require_common_spatial_shape=False),
+    )
+
+    assert result.compatible is True
+    assert result.violations == ()
+
+
+def test_missing_future_payload_is_not_opened(tmp_path: Path) -> None:
+    current_path = tmp_path / "current.npz"
+    current = _window(current_path, window_id="current")
+    manifest_path = _manifest(
+        tmp_path / "provider.json",
+        (
+            _descriptor(
+                current_path,
+                current,
+                relative_path="current.npz",
+                source_stop=2,
+                member="current",
+            ),
+            _future_descriptor(),
+        ),
+    )
+
+    result = preflight_prediction_batch(manifest_path, causal_frame_stop=2)
+
+    assert result.compatible is True
+    assert len(result.entries) == 1
+    assert result.excluded_future_payload_ids
+    assert result.future_prediction_payloads_opened == 0
+    assert not (tmp_path / "future-missing.npz").exists()
+
+
+def test_selected_payload_tamper_is_an_integrity_failure(tmp_path: Path) -> None:
+    payload_path = tmp_path / "current.npz"
+    window = _window(payload_path, window_id="current")
+    manifest_path = _manifest(
+        tmp_path / "provider.json",
+        (
+            _descriptor(
+                payload_path,
+                window,
+                relative_path="current.npz",
+                source_stop=2,
+                member="current",
+            ),
+        ),
+    )
+    payload_path.write_bytes(payload_path.read_bytes() + b"tamper")
+
+    with pytest.raises(PredictionBatchIntegrityError, match="byte count mismatch"):
+        preflight_prediction_batch(manifest_path, causal_frame_stop=2)
+
+
+def test_cli_writes_negative_artifact_and_returns_two(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    manifest_path = _two_payload_manifest(tmp_path, second_height=4)
+    output = tmp_path / "preflight.json"
+
+    assert (
+        main(
+            [
+                "build",
+                str(manifest_path),
+                str(output),
+                "--causal-frame-stop",
+                "2",
+            ]
+        )
+        == 2
+    )
+    assert output.is_file()
+    assert '"status": "batch-incompatible"' in capsys.readouterr().out
+    assert load_prediction_batch_preflight(output).compatible is False

--- a/tests/test_provider_terminal_decision.py
+++ b/tests/test_provider_terminal_decision.py
@@ -1,0 +1,191 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from prob4d.provider_terminal_decision import (
+    CLASSIFICATION_BATCH_INCOMPATIBLE,
+    CLASSIFICATION_COMPLETED_POSITIVE,
+    CLASSIFICATION_SCIENTIFIC_NEGATIVE,
+    CLASSIFICATION_SUPPORT_NEGATIVE,
+    CLASSIFICATION_TECHNICAL_FAILURE,
+    REQUIRED_INFRASTRUCTURE_NONCLAIMS,
+    ProviderTerminalDecisionV1,
+    build_provider_terminal_decision,
+    load_provider_terminal_decision,
+    main,
+    write_provider_terminal_decision,
+)
+
+INFRASTRUCTURE_FORBIDDEN = tuple(sorted(REQUIRED_INFRASTRUCTURE_NONCLAIMS))
+
+
+def _batch_negative() -> ProviderTerminalDecisionV1:
+    return ProviderTerminalDecisionV1(
+        protocol_id="provider-v7-source",
+        provider_manifest_id="a" * 64,
+        classification=CLASSIFICATION_BATCH_INCOMPATIBLE,
+        failed_stage="source-batch-preflight",
+        source_payloads_accessed=True,
+        source_outcomes_accessed=False,
+        target_payloads_accessed=False,
+        target_outcomes_accessed=False,
+        rerun_authorized=False,
+        successor_protocol_required=True,
+        evidence_ids=("b" * 64,),
+        authorized_inferences=(),
+        forbidden_inferences=INFRASTRUCTURE_FORBIDDEN,
+        summary="The admitted source payloads cannot form the frozen scorer batch.",
+        metadata={"future_prediction_payloads_opened": 0},
+    )
+
+
+def test_infrastructure_negative_roundtrips_and_is_idempotent(tmp_path: Path) -> None:
+    decision = _batch_negative()
+    path = tmp_path / "terminal.json"
+
+    write_provider_terminal_decision(path, decision)
+    write_provider_terminal_decision(path, decision)
+    loaded = load_provider_terminal_decision(path)
+
+    assert loaded == decision
+    assert loaded.scientific_result is False
+    assert loaded.authorized_inferences == ()
+    assert loaded.target_outcomes_accessed is False
+
+
+def test_infrastructure_negative_cannot_authorize_scientific_claim() -> None:
+    with pytest.raises(ValueError, match="authorize no scientific inference"):
+        ProviderTerminalDecisionV1(
+            protocol_id="provider-v7-source",
+            provider_manifest_id="a" * 64,
+            classification=CLASSIFICATION_TECHNICAL_FAILURE,
+            failed_stage="source-scorer",
+            source_payloads_accessed=True,
+            source_outcomes_accessed=False,
+            target_payloads_accessed=False,
+            target_outcomes_accessed=False,
+            rerun_authorized=False,
+            successor_protocol_required=True,
+            evidence_ids=("b" * 64,),
+            authorized_inferences=("provider-competence",),
+            forbidden_inferences=INFRASTRUCTURE_FORBIDDEN,
+            summary="The scorer terminated before an outcome was computed.",
+        )
+
+
+def test_infrastructure_negative_requires_complete_nonclaim_boundary() -> None:
+    with pytest.raises(ValueError, match="omits forbidden claims"):
+        ProviderTerminalDecisionV1(
+            protocol_id="provider-v7-source",
+            provider_manifest_id="a" * 64,
+            classification=CLASSIFICATION_BATCH_INCOMPATIBLE,
+            failed_stage="source-batch-preflight",
+            source_payloads_accessed=True,
+            source_outcomes_accessed=False,
+            target_payloads_accessed=False,
+            target_outcomes_accessed=False,
+            rerun_authorized=False,
+            successor_protocol_required=True,
+            evidence_ids=("b" * 64,),
+            authorized_inferences=(),
+            forbidden_inferences=("provider-competence",),
+            summary="The admitted payloads are incompatible.",
+        )
+
+
+def test_support_negative_must_precede_payload_access() -> None:
+    with pytest.raises(ValueError, match="precede payload access"):
+        ProviderTerminalDecisionV1(
+            protocol_id="provider-v7-support",
+            provider_manifest_id="a" * 64,
+            classification=CLASSIFICATION_SUPPORT_NEGATIVE,
+            failed_stage="support-feasibility",
+            source_payloads_accessed=True,
+            source_outcomes_accessed=False,
+            target_payloads_accessed=False,
+            target_outcomes_accessed=False,
+            rerun_authorized=False,
+            successor_protocol_required=True,
+            evidence_ids=("b" * 64,),
+            authorized_inferences=("provider-support-negative",),
+            forbidden_inferences=INFRASTRUCTURE_FORBIDDEN,
+            summary="The frozen stream roster is not geometrically supported.",
+        )
+
+
+def test_scientific_negative_requires_outcome_evidence() -> None:
+    with pytest.raises(ValueError, match="requires opened outcome evidence"):
+        ProviderTerminalDecisionV1(
+            protocol_id="provider-v7-source",
+            provider_manifest_id="a" * 64,
+            classification=CLASSIFICATION_SCIENTIFIC_NEGATIVE,
+            failed_stage="source-competence",
+            source_payloads_accessed=True,
+            source_outcomes_accessed=False,
+            target_payloads_accessed=False,
+            target_outcomes_accessed=False,
+            rerun_authorized=False,
+            successor_protocol_required=False,
+            evidence_ids=("b" * 64,),
+            authorized_inferences=("provider-source-negative",),
+            forbidden_inferences=("provider-target-competence",),
+            summary="No outcome evidence was actually opened.",
+        )
+
+
+def test_opened_target_result_cannot_authorize_rerun() -> None:
+    with pytest.raises(ValueError, match="cannot authorize a rerun"):
+        ProviderTerminalDecisionV1(
+            protocol_id="provider-v7-target",
+            provider_manifest_id="a" * 64,
+            classification=CLASSIFICATION_COMPLETED_POSITIVE,
+            failed_stage=None,
+            source_payloads_accessed=True,
+            source_outcomes_accessed=True,
+            target_payloads_accessed=True,
+            target_outcomes_accessed=True,
+            rerun_authorized=True,
+            successor_protocol_required=False,
+            evidence_ids=("b" * 64,),
+            authorized_inferences=("provider-target-competence",),
+            forbidden_inferences=("deployment-safety", "state-of-the-art"),
+            summary="The frozen target gate passed.",
+        )
+
+
+def test_build_from_spec_and_cli_verify(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    decision = _batch_negative()
+    specification_path = tmp_path / "specification.json"
+    specification_path.write_text(
+        json.dumps(decision.to_record(include_artifact_id=False), indent=2),
+        encoding="utf-8",
+    )
+
+    rebuilt = build_provider_terminal_decision(specification_path)
+    assert rebuilt.artifact_id == decision.artifact_id
+
+    output = tmp_path / "terminal.json"
+    assert main(["build", str(specification_path), str(output)]) == 0
+    build_summary = json.loads(capsys.readouterr().out)
+    assert build_summary["scientific_result"] is False
+    assert build_summary["authorized_inferences"] == []
+
+    assert main(["verify", str(output)]) == 0
+    verify_summary = json.loads(capsys.readouterr().out)
+    assert verify_summary["artifact_id"] == decision.artifact_id
+
+
+def test_tampered_decision_fails_content_identity(tmp_path: Path) -> None:
+    path = tmp_path / "terminal.json"
+    write_provider_terminal_decision(path, _batch_negative())
+    record = json.loads(path.read_text(encoding="utf-8"))
+    record["summary"] = "changed after sealing"
+    path.write_text(json.dumps(record), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="artifact ID mismatch"):
+        load_provider_terminal_decision(path)


### PR DESCRIPTION
Superseded by #231, which has been merged into `main` as `1918ad8f585590f03640161c9877901a9506169b`.

The merged implementation covers the same causal/content-addressed batch-preflight and terminal-decision boundary, while additionally retaining reproducible examples, a changelog entry, optional-field compatibility coverage, stricter artifact round-trip checks, the corrected infrastructure-nonclaim diagnostic precedence, and exact-head validation against PRs #229, #228, and #230.

This draft is closed to avoid maintaining two divergent implementations of the same contract. No scientific result or target-data decision is affected.