### PR TITLE
Harden immutable artifact publication

### DIFF
--- a/src/prob4d/_metric_gauge_anchor.py
+++ b/src/prob4d/_metric_gauge_anchor.py
@@ -3,15 +3,24 @@
 from __future__ import annotations
 
 import json
-import os
-import tempfile
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 import numpy as np
 
+from ._atomic_file import atomic_write_text
+from ._immutable_json import frozen_finite_json_mapping, plain_json
+from ._strict_json import (
+    load_json_object,
+    require_exact_fields,
+    require_exact_integer,
+    require_exact_string,
+    require_json_number,
+    require_mapping,
+    require_sha256,
+)
 from .observation_contract import canonical_json_sha256
 from .sim3 import Sim3
 
@@ -21,40 +30,55 @@ CALIBRATION_ARTIFACT_SHA256_KEY = "calibration_artifact_sha256"
 FIXED_EXTERNAL_CALIBRATION = "fixed_external_calibration"
 PROPAGATED_EXTERNAL_PRIOR = "propagated_external_prior"
 
+_ANCHOR_DESCRIPTOR_FIELDS = frozenset(
+    {
+        "schema_name",
+        "schema_version",
+        "window_id",
+        "global_from_local",
+        "covariance",
+        "coordinate_frame",
+        "metric_units",
+        "source_kind",
+        "source_artifact_sha256",
+        "metadata",
+    }
+)
+_ANCHOR_SERIALIZED_FIELDS = _ANCHOR_DESCRIPTOR_FIELDS | {"artifact_id"}
 
-def _require_sha256(value: str, *, name: str) -> None:
-    if len(value) != 64 or any(
-        character not in "0123456789abcdef" for character in value
-    ):
-        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
 
-
-def _finite_json_copy(value: Mapping[str, Any], *, name: str) -> dict[str, Any]:
+def _require_numeric_array(
+    value: object,
+    *,
+    shape: tuple[int, ...],
+    name: str,
+) -> np.ndarray:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise ValueError(f"{name} must have shape {shape}")
     try:
-        return json.loads(json.dumps(dict(value), sort_keys=True, allow_nan=False))
+        object_array = np.asarray(value, dtype=object)
     except (TypeError, ValueError) as error:
-        raise ValueError(f"{name} must be finite JSON data") from error
+        raise ValueError(f"{name} must have shape {shape}") from error
+    if object_array.shape != shape:
+        raise ValueError(f"{name} must have shape {shape}")
+    normalized = np.empty(shape, dtype=np.float64)
+    for index in np.ndindex(shape):
+        normalized[index] = require_json_number(
+            object_array[index],
+            name=f"{name}{index}",
+        )
+    return normalized
 
 
-def _atomic_write_text(path: Path, content: str) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    handle = tempfile.NamedTemporaryFile(
-        mode="w",
-        encoding="utf-8",
-        dir=path.parent,
-        prefix=f".{path.name}.",
-        suffix=".tmp",
-        delete=False,
+def _require_anchor_fields(payload: Mapping[str, Any]) -> None:
+    actual = frozenset(payload)
+    if actual in {_ANCHOR_DESCRIPTOR_FIELDS, _ANCHOR_SERIALIZED_FIELDS}:
+        return
+    require_exact_fields(
+        payload,
+        _ANCHOR_SERIALIZED_FIELDS,
+        name="metric gauge-anchor artifact",
     )
-    temporary = Path(handle.name)
-    try:
-        with handle:
-            handle.write(content)
-            handle.flush()
-            os.fsync(handle.fileno())
-        os.replace(temporary, path)
-    finally:
-        temporary.unlink(missing_ok=True)
 
 
 @dataclass(frozen=True)
@@ -76,12 +100,25 @@ class MetricGaugeAnchor:
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        if not self.window_id or not self.coordinate_frame or not self.source_kind:
-            raise ValueError("metric gauge-anchor identities must be nonempty")
-        _require_sha256(
+        window_id = require_exact_string(
+            self.window_id,
+            name="metric gauge-anchor window_id",
+        )
+        coordinate_frame = require_exact_string(
+            self.coordinate_frame,
+            name="metric gauge-anchor coordinate_frame",
+        )
+        source_kind = require_exact_string(
+            self.source_kind,
+            name="metric gauge-anchor source_kind",
+        )
+        source_artifact_sha256 = require_sha256(
             self.source_artifact_sha256,
             name="metric gauge-anchor source_artifact_sha256",
         )
+        if not isinstance(self.global_from_local, Sim3):
+            raise TypeError("metric gauge-anchor global_from_local must be a Sim3")
+
         covariance = np.asarray(self.covariance, dtype=np.float64).copy()
         if covariance.shape != (7, 7) or not np.all(np.isfinite(covariance)):
             raise ValueError(
@@ -95,17 +132,26 @@ class MetricGaugeAnchor:
                 "metric gauge-anchor covariance must be positive semidefinite"
             )
         symmetric.setflags(write=False)
-        metadata = _finite_json_copy(
+
+        metadata = frozen_finite_json_mapping(
             self.metadata,
             name="metric gauge-anchor metadata",
         )
         calibration_digest = metadata.get(CALIBRATION_ARTIFACT_SHA256_KEY)
         if calibration_digest is not None:
-            _require_sha256(
-                str(calibration_digest),
+            require_sha256(
+                calibration_digest,
                 name="metric gauge-anchor calibration_artifact_sha256",
             )
-            metadata[CALIBRATION_ARTIFACT_SHA256_KEY] = str(calibration_digest)
+
+        object.__setattr__(self, "window_id", window_id)
+        object.__setattr__(self, "coordinate_frame", coordinate_frame)
+        object.__setattr__(self, "source_kind", source_kind)
+        object.__setattr__(
+            self,
+            "source_artifact_sha256",
+            source_artifact_sha256,
+        )
         object.__setattr__(self, "covariance", symmetric)
         object.__setattr__(self, "metadata", metadata)
 
@@ -135,7 +181,7 @@ class MetricGaugeAnchor:
             "metric_units": "m",
             "source_kind": self.source_kind,
             "source_artifact_sha256": self.source_artifact_sha256,
-            "metadata": self.metadata,
+            "metadata": plain_json(self.metadata),
         }
 
     def contract_metadata(self, *, case_id: str) -> dict[str, Any]:
@@ -147,13 +193,15 @@ class MetricGaugeAnchor:
                 "strict causal-stream export requires metric-anchor metadata "
                 "with calibration_artifact_sha256"
             )
-        if not case_id:
-            raise ValueError("metric gauge-anchor case_id must be nonempty")
+        validated_case_id = require_exact_string(
+            case_id,
+            name="metric gauge-anchor case_id",
+        )
         return {
             "schema_name": METRIC_GAUGE_ANCHOR_SCHEMA,
             "schema_version": METRIC_GAUGE_ANCHOR_VERSION,
             "artifact_id": self.artifact_id,
-            "case_id": case_id,
+            "case_id": validated_case_id,
             "window_id": self.window_id,
             "coordinate_frame": self.coordinate_frame,
             "world_frame_id": self.coordinate_frame,
@@ -162,7 +210,7 @@ class MetricGaugeAnchor:
             "source_artifact_sha256": self.source_artifact_sha256,
             "calibration_artifact_sha256": calibration_digest,
             "covariance_treatment": self.covariance_treatment,
-            "metadata": dict(self.metadata),
+            "metadata": plain_json(self.metadata),
         }
 
     @property
@@ -173,40 +221,96 @@ class MetricGaugeAnchor:
 def load_metric_gauge_anchor(path: str | Path) -> MetricGaugeAnchor:
     """Load and content-validate a metric first-window gauge prior."""
 
-    source = Path(path)
-    payload = json.loads(source.read_text(encoding="utf-8"))
-    if payload.get("schema_name") != METRIC_GAUGE_ANCHOR_SCHEMA:
+    payload = load_json_object(path, name="metric gauge anchor")
+    _require_anchor_fields(payload)
+
+    schema_name = require_exact_string(
+        payload["schema_name"],
+        name="metric gauge-anchor schema_name",
+    )
+    if schema_name != METRIC_GAUGE_ANCHOR_SCHEMA:
         raise ValueError("unsupported metric gauge-anchor schema")
-    if int(payload.get("schema_version", -1)) != METRIC_GAUGE_ANCHOR_VERSION:
+    schema_version = require_exact_integer(
+        payload["schema_version"],
+        name="metric gauge-anchor schema_version",
+        minimum=1,
+    )
+    if schema_version != METRIC_GAUGE_ANCHOR_VERSION:
         raise ValueError("unsupported metric gauge-anchor version")
-    if payload.get("metric_units") != "m":
+    metric_units = require_exact_string(
+        payload["metric_units"],
+        name="metric gauge-anchor metric_units",
+    )
+    if metric_units != "m":
         raise ValueError("metric gauge anchor must declare metric_units='m'")
-    expected_artifact_id = payload.pop("artifact_id", None)
+
+    expected_artifact_id = (
+        None
+        if "artifact_id" not in payload
+        else require_sha256(
+            payload["artifact_id"],
+            name="metric gauge-anchor artifact_id",
+        )
+    )
+    metadata = require_mapping(
+        payload["metadata"],
+        name="metric gauge-anchor metadata",
+    )
     anchor = MetricGaugeAnchor(
-        window_id=str(payload["window_id"]),
-        global_from_local=Sim3.from_vector(
-            np.asarray(payload["global_from_local"], dtype=np.float64)
+        window_id=require_exact_string(
+            payload["window_id"],
+            name="metric gauge-anchor window_id",
         ),
-        covariance=np.asarray(payload["covariance"], dtype=np.float64),
-        coordinate_frame=str(payload["coordinate_frame"]),
-        source_kind=str(payload["source_kind"]),
-        source_artifact_sha256=str(payload["source_artifact_sha256"]),
-        metadata=payload.get("metadata", {}),
+        global_from_local=Sim3.from_vector(
+            _require_numeric_array(
+                payload["global_from_local"],
+                shape=(7,),
+                name="metric gauge-anchor global_from_local",
+            )
+        ),
+        covariance=_require_numeric_array(
+            payload["covariance"],
+            shape=(7, 7),
+            name="metric gauge-anchor covariance",
+        ),
+        coordinate_frame=require_exact_string(
+            payload["coordinate_frame"],
+            name="metric gauge-anchor coordinate_frame",
+        ),
+        source_kind=require_exact_string(
+            payload["source_kind"],
+            name="metric gauge-anchor source_kind",
+        ),
+        source_artifact_sha256=require_sha256(
+            payload["source_artifact_sha256"],
+            name="metric gauge-anchor source_artifact_sha256",
+        ),
+        metadata=metadata,
     )
     if expected_artifact_id is not None and expected_artifact_id != anchor.artifact_id:
         raise ValueError("metric gauge-anchor artifact_id does not match its content")
     return anchor
 
 
-def save_metric_gauge_anchor(path: str | Path, anchor: MetricGaugeAnchor) -> None:
-    """Atomically write a canonical metric gauge-anchor JSON document."""
+def save_metric_gauge_anchor(
+    path: str | Path,
+    anchor: MetricGaugeAnchor,
+    *,
+    overwrite: bool = False,
+) -> None:
+    """Atomically publish and verify a canonical metric gauge-anchor artifact."""
 
+    destination = Path(path)
     payload = anchor.descriptor()
     payload["artifact_id"] = anchor.artifact_id
-    _atomic_write_text(
-        Path(path),
+    atomic_write_text(
+        destination,
         json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        overwrite=overwrite,
     )
+    restored = load_metric_gauge_anchor(destination)
+    if restored.descriptor() != anchor.descriptor():
+        raise RuntimeError("published metric gauge-anchor differs from its source")
 
 
 __all__ = [

--- a/src/prob4d/_strict_calibration.py
+++ b/src/prob4d/_strict_calibration.py
@@ -2,17 +2,17 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, cast
 
+from ._atomic_file import atomic_write_text
 from ._gauge_calibration import (
     GaugeCovarianceCalibrationV1 as _GaugeCovarianceCalibrationV1,
-    save_gauge_covariance_calibration,
 )
 from ._point_calibration import (
     PointUncertaintyCalibrationV1 as _PointUncertaintyCalibrationV1,
-    save_point_uncertainty_calibration,
 )
 from ._strict_calibration_artifact import (
     validate_gauge_calibration_payload,
@@ -61,6 +61,56 @@ def load_point_uncertainty_calibration(
 ) -> PointUncertaintyCalibrationV1:
     payload = load_json_object(path, name="point uncertainty calibration")
     return PointUncertaintyCalibrationV1.from_dict(payload)
+
+
+def save_gauge_covariance_calibration(
+    artifact: GaugeCovarianceCalibrationV1,
+    path: str | Path,
+    *,
+    overwrite: bool = False,
+) -> None:
+    """Atomically publish and verify a strict gauge calibration artifact."""
+
+    destination = Path(path)
+    atomic_write_text(
+        destination,
+        json.dumps(
+            artifact.to_dict(),
+            sort_keys=True,
+            indent=2,
+            allow_nan=False,
+        )
+        + "\n",
+        overwrite=overwrite,
+    )
+    restored = load_gauge_covariance_calibration(destination)
+    if restored.to_dict() != artifact.to_dict():
+        raise RuntimeError("published gauge covariance calibration differs from its source")
+
+
+def save_point_uncertainty_calibration(
+    artifact: PointUncertaintyCalibrationV1,
+    path: str | Path,
+    *,
+    overwrite: bool = False,
+) -> None:
+    """Atomically publish and verify a strict point calibration artifact."""
+
+    destination = Path(path)
+    atomic_write_text(
+        destination,
+        json.dumps(
+            artifact.to_dict(),
+            sort_keys=True,
+            indent=2,
+            allow_nan=False,
+        )
+        + "\n",
+        overwrite=overwrite,
+    )
+    restored = load_point_uncertainty_calibration(destination)
+    if restored.to_dict() != artifact.to_dict():
+        raise RuntimeError("published point uncertainty calibration differs from its source")
 
 
 __all__ = [

--- a/tests/test_immutable_artifact_publication.py
+++ b/tests/test_immutable_artifact_publication.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from prob4d.calibration import (
+    GaugeCovarianceCalibrationV1,
+    PointUncertaintyCalibrationV1,
+    load_gauge_covariance_calibration,
+    load_point_uncertainty_calibration,
+    save_gauge_covariance_calibration,
+    save_point_uncertainty_calibration,
+)
+from prob4d.observation_export import (
+    MetricGaugeAnchor,
+    load_metric_gauge_anchor,
+    save_metric_gauge_anchor,
+)
+from prob4d.sim3 import Sim3
+
+
+def _anchor(
+    *,
+    source_artifact_sha256: str = "a" * 64,
+    metadata: dict[str, Any] | None = None,
+) -> MetricGaugeAnchor:
+    return MetricGaugeAnchor(
+        window_id="window_0000",
+        global_from_local=Sim3.identity(),
+        covariance=np.eye(7) * 1e-6,
+        coordinate_frame="phystwin-world",
+        source_kind="prefix_registration",
+        source_artifact_sha256=source_artifact_sha256,
+        metadata=(
+            {
+                "calibration_artifact_sha256": "b" * 64,
+                "nested": {"values": [1, 2]},
+            }
+            if metadata is None
+            else metadata
+        ),
+    )
+
+
+def _common_provenance() -> dict[str, Any]:
+    return {
+        "calibration_case_ids": ("case-a",),
+        "source_repository": "IPS-Stuttgart/Prob4D",
+        "source_revision": "1" * 40,
+        "motioncrafter_revision": "2" * 40,
+        "model_identifier": "unit-test-model",
+        "covariance_method": "unit-test-covariance",
+        "image_resolution": (2, 2),
+        "window_size": 4,
+        "window_overlap": 2,
+        "covariance_cluster_size": 1,
+        "input_artifact_sha256": ("3" * 64,),
+        "metadata": {"nested": {"values": [1, 2]}},
+    }
+
+
+def _gauge_calibration() -> GaugeCovarianceCalibrationV1:
+    return GaugeCovarianceCalibrationV1(
+        scale=1.0,
+        rotation=1.0,
+        translation=1.0,
+        count=1,
+        trim_quantile=0.99,
+        **_common_provenance(),
+    )
+
+
+def _point_calibration() -> PointUncertaintyCalibrationV1:
+    return PointUncertaintyCalibrationV1(
+        parallel_floor=0.0,
+        parallel_depth_coefficient=0.0,
+        lateral_floor=0.0,
+        lateral_depth_coefficient=0.0,
+        disagreement_gain=0.0,
+        parallel_scale=1.0,
+        lateral_scale=1.0,
+        count=1,
+        trim_quantile=0.99,
+        parallel_scale_update=1.0,
+        lateral_scale_update=1.0,
+        parallel_normalized_mse=1.0,
+        lateral_normalized_mse=1.0,
+        **_common_provenance(),
+    )
+
+
+def _anchor_payload(anchor: MetricGaugeAnchor) -> dict[str, Any]:
+    return {"artifact_id": anchor.artifact_id, **anchor.descriptor()}
+
+
+def test_metric_anchor_metadata_is_recursively_immutable() -> None:
+    metadata = {
+        "calibration_artifact_sha256": "b" * 64,
+        "nested": {"values": [1, 2]},
+    }
+    anchor = _anchor(metadata=metadata)
+    artifact_id = anchor.artifact_id
+
+    metadata["calibration_artifact_sha256"] = "c" * 64
+    metadata["nested"]["values"].append(3)
+
+    assert anchor.artifact_id == artifact_id
+    assert anchor.descriptor()["metadata"]["nested"]["values"] == [1, 2]
+    json.dumps(anchor.descriptor(), sort_keys=True, allow_nan=False)
+
+    with pytest.raises(TypeError, match="immutable"):
+        anchor.metadata["nested"]["values"].append(3)
+    with pytest.raises(TypeError, match="immutable"):
+        anchor.metadata["new"] = "value"
+
+
+def test_metric_anchor_loader_rejects_duplicate_and_extra_fields(
+    tmp_path: Path,
+) -> None:
+    anchor = _anchor()
+    payload = _anchor_payload(anchor)
+
+    duplicate = tmp_path / "duplicate.json"
+    serialized = json.dumps(payload, sort_keys=True)
+    duplicate.write_text(
+        serialized.replace("{", '{"schema_name":"duplicate",', 1),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="duplicate JSON object key"):
+        load_metric_gauge_anchor(duplicate)
+
+    extra = tmp_path / "extra.json"
+    payload["unexpected"] = True
+    extra.write_text(json.dumps(payload), encoding="utf-8")
+    with pytest.raises(ValueError, match="fields changed"):
+        load_metric_gauge_anchor(extra)
+
+
+def test_metric_anchor_loader_rejects_scalar_coercion(tmp_path: Path) -> None:
+    anchor = _anchor()
+    payload = _anchor_payload(anchor)
+    payload["schema_version"] = True
+    path = tmp_path / "coercive.json"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="schema_version must be an integer"):
+        load_metric_gauge_anchor(path)
+
+
+def test_metric_anchor_loader_preserves_legacy_missing_artifact_id(
+    tmp_path: Path,
+) -> None:
+    anchor = _anchor()
+    path = tmp_path / "legacy.json"
+    path.write_text(json.dumps(anchor.descriptor()), encoding="utf-8")
+
+    restored = load_metric_gauge_anchor(path)
+    assert restored.artifact_id == anchor.artifact_id
+
+
+def test_metric_anchor_publication_is_no_clobber_by_default(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "anchor.json"
+    first = _anchor()
+    replacement = _anchor(source_artifact_sha256="c" * 64)
+
+    save_metric_gauge_anchor(path, first)
+    original = path.read_bytes()
+    with pytest.raises(FileExistsError):
+        save_metric_gauge_anchor(path, replacement)
+    assert path.read_bytes() == original
+
+    save_metric_gauge_anchor(path, replacement, overwrite=True)
+    assert load_metric_gauge_anchor(path).artifact_id == replacement.artifact_id
+
+
+@pytest.mark.parametrize(
+    ("artifact", "save", "load", "filename"),
+    [
+        pytest.param(
+            _gauge_calibration(),
+            save_gauge_covariance_calibration,
+            load_gauge_covariance_calibration,
+            "gauge.json",
+            id="gauge",
+        ),
+        pytest.param(
+            _point_calibration(),
+            save_point_uncertainty_calibration,
+            load_point_uncertainty_calibration,
+            "point.json",
+            id="point",
+        ),
+    ],
+)
+def test_calibration_publication_is_atomic_no_clobber_and_verified(
+    tmp_path: Path,
+    artifact: GaugeCovarianceCalibrationV1 | PointUncertaintyCalibrationV1,
+    save: Any,
+    load: Any,
+    filename: str,
+) -> None:
+    path = tmp_path / filename
+    save(artifact, path)
+    original = path.read_bytes()
+    assert load(path).artifact_id == artifact.artifact_id
+
+    with pytest.raises(FileExistsError):
+        save(artifact, path)
+    assert path.read_bytes() == original
+
+    save(artifact, path, overwrite=True)
+    assert load(path).to_dict() == artifact.to_dict()


### PR DESCRIPTION
## Summary

Harden the claim-bearing metric-anchor and public covariance-calibration publication boundaries.

- recursively freeze `MetricGaugeAnchor.metadata` so caller-side or nested mutation cannot change a validated artifact's content identity;
- load metric anchors through duplicate-key-rejecting strict JSON validation;
- reject unknown fields, Boolean/coercive schema values, malformed numeric arrays, and noncanonical identity strings;
- preserve loading of historical metric-anchor descriptors that omit `artifact_id`;
- publish metric anchors, gauge calibrations, and point calibrations atomically with no-clobber semantics by default;
- require deliberate replacement through keyword-only `overwrite=True`;
- reload and verify every successfully published artifact; and
- add focused adversarial coverage for immutability, strict loading, compatibility, no-clobber behavior, and explicit overwrite.

## Compatibility

Existing two-argument save calls remain syntactically valid. A second publication to an existing path now fails closed with `FileExistsError`; callers that intentionally replace a non-claim-bearing development artifact must opt in with `overwrite=True`.

Historical metric-anchor JSON without an `artifact_id` remains loadable. Canonical valid artifacts retain their descriptor and content identity.

## Change classification

- [x] Stable contract or supported public interface hardening
- [x] Artifact integrity and provenance
- [x] Tests
- [ ] Estimator or covariance-model change
- [ ] Dataset, protocol, split, target-access, or fallback change
- [ ] Scientific result or claim change

## Validation

Prepared before publication:

- Python syntax parsing passed for all three changed files;
- no changed line exceeds the repository's 100-character limit;
- the branch contains one commit and exactly three intended files.

GitHub Actions on exact PR head `b58b2a0ad4662ec8541a93e96ea9a126ab8ac6fa` are the authoritative Ruff, MyPy, full-suite, minimum-dependency, build, installed-artifact, ecosystem, provider-gate, and security validation.

## Scientific boundary

This changes invalid-input and artifact-publication behavior only. It does not change a gauge estimate, point mean, covariance equation, provider selection, physical update, exact fallback, cohort, target-access rule, empirical result, or scientific claim.