### PR TITLE
Prevent temporary workflows from returning to main

### DIFF
--- a/tests/test_workflow_hygiene_policy.py
+++ b/tests/test_workflow_hygiene_policy.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from pathlib import Path
 
-
 WORKFLOW_DIR = Path(__file__).resolve().parents[1] / ".github" / "workflows"
 DISALLOWED_PREFIXES = (
     "_one_shot",

--- a/tests/test_workflow_hygiene_policy.py
+++ b/tests/test_workflow_hygiene_policy.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+WORKFLOW_DIR = Path(__file__).resolve().parents[1] / ".github" / "workflows"
+DISALLOWED_PREFIXES = (
+    "_one_shot",
+    "_temporary",
+    "agent-",
+    "temporary-",
+)
+DISALLOWED_SUFFIXES = (
+    "-once.yml",
+    "-once.yaml",
+)
+
+
+def test_default_branch_ships_no_temporary_or_one_shot_workflows() -> None:
+    offenders = sorted(
+        path.name
+        for path in WORKFLOW_DIR.iterdir()
+        if path.is_file()
+        and path.suffix in {".yml", ".yaml"}
+        and (
+            path.name.startswith(DISALLOWED_PREFIXES)
+            or path.name.endswith(DISALLOWED_SUFFIXES)
+        )
+    )
+
+    assert offenders == []
+
+
+def test_workflow_hygiene_policy_covers_historical_agent_patterns() -> None:
+    assert "agent-" in DISALLOWED_PREFIXES
+    assert "_temporary" in DISALLOWED_PREFIXES
+    assert "_one_shot" in DISALLOWED_PREFIXES
+    assert "-once.yml" in DISALLOWED_SUFFIXES


### PR DESCRIPTION
## Summary

- add a default-branch workflow-hygiene regression
- reject temporary, one-shot, and agent-specific workflow filenames
- preserve permanent scientific, provider, release, and security workflows unchanged

## Why

The repository has accumulated many historical GitHub Actions workflow records from one-shot repair and agent-execution files. Those files are no longer present on the current default branch, but without a policy regression the same maintenance and security surface can silently return.

## Validation

- full test workflow passes
- fail-closed Ruff, MyPy, and documentation-surface checks pass
- provider batch preflight passes
- security scanning passes

## Scope

This is CI policy only. It changes no estimator, artifact contract, provider implementation, protocol, evidence decision, or scientific claim.