### PR TITLE
Harden observation-belief descriptor loading

### DIFF
--- a/docs/strict-artifact-loading.md
+++ b/docs/strict-artifact-loading.md
@@ -1,9 +1,9 @@
 # Strict artifact loading
 
-Prob4D's current content-addressed calibration artifacts and schema-v4
-observation-factor manifests use portable JSON types as part of their contract.
-Loaders reject Python-style coercion aliases rather than normalizing them after
-parsing.
+Prob4D's current content-addressed calibration artifacts, portable
+observation-belief archives, and schema-v4 observation-factor manifests use
+portable JSON types as part of their contract. Loaders reject Python-style
+coercion aliases rather than normalizing them after parsing.
 
 The strict boundary requires:
 
@@ -14,12 +14,20 @@ The strict boundary requires:
 - revisions, identifiers, repository names, array keys, and SHA-256 digests to
   already be strings;
 - metadata object keys to be strings at every nesting level;
-- exact schema-v1 calibration and schema-v4 manifest field sets;
-- literal JSON Booleans for security- and covariance-semantics flags; and
+- exact schema-v1 calibration, observation-belief, and schema-v4 manifest field
+  sets;
+- literal JSON Booleans for security- and covariance-semantics flags;
+- scalar UTF-8 JSON descriptor members in portable NPZ archives; and
 - unique JSON object keys. Duplicate keys and non-finite `NaN`/`Infinity` tokens
   fail before any artifact is constructed.
 
-Valid existing calibration descriptors, canonical bytes, and artifact IDs are
-unchanged. Observation-factor schema v2 and v3 remain explicit compatibility
-inputs; their historical value upgrading is not promoted into the schema-v4
-contract.
+Observation-belief loading validates the raw descriptor before constructing the
+normalized Python value. A numeric `case_id`, Boolean `schema_version`, numeric
+view name, or similar value therefore cannot be accepted merely because a
+Python `str(...)` or `int(...)` conversion would produce a valid-looking
+artifact.
+
+Valid existing calibration and observation descriptors, canonical bytes,
+numeric arrays, and artifact IDs are unchanged. Observation-factor schema v2
+and v3 remain explicit compatibility inputs; their historical value upgrading
+is not promoted into the schema-v4 contract.

--- a/src/prob4d/_strict_json.py
+++ b/src/prob4d/_strict_json.py
@@ -128,8 +128,11 @@ def require_finite_json_mapping(value: Any, *, name: str) -> Mapping[str, Any]:
     return mapping
 
 
-def load_json_object(path: str | Path, *, name: str) -> dict[str, Any]:
-    """Load one finite JSON object while rejecting duplicate object keys."""
+def loads_json_object(content: str, *, name: str) -> dict[str, Any]:
+    """Parse one finite JSON object while rejecting duplicate object keys."""
+
+    if type(content) is not str:
+        raise ValueError(f"{name} must be UTF-8 text")
 
     def object_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
         result: dict[str, Any] = {}
@@ -144,7 +147,7 @@ def load_json_object(path: str | Path, *, name: str) -> dict[str, Any]:
 
     try:
         value = json.loads(
-            Path(path).read_text(encoding="utf-8"),
+            content,
             object_pairs_hook=object_pairs,
             parse_constant=reject_constant,
         )
@@ -157,8 +160,15 @@ def load_json_object(path: str | Path, *, name: str) -> dict[str, Any]:
     return value
 
 
+def load_json_object(path: str | Path, *, name: str) -> dict[str, Any]:
+    """Load one finite JSON object while rejecting duplicate object keys."""
+
+    return loads_json_object(Path(path).read_text(encoding="utf-8"), name=name)
+
+
 __all__ = [
     "load_json_object",
+    "loads_json_object",
     "require_exact_fields",
     "require_exact_integer",
     "require_exact_string",

--- a/src/prob4d/observation_validation.py
+++ b/src/prob4d/observation_validation.py
@@ -9,6 +9,15 @@ from typing import Any
 
 import numpy as np
 
+from ._strict_json import (
+    loads_json_object,
+    require_exact_integer,
+    require_exact_string,
+    require_mapping,
+    require_nonempty_string,
+    require_sha256,
+    require_string_sequence,
+)
 from .observation_contract import (
     OBSERVATION_BELIEF_SCHEMA,
     OBSERVATION_BELIEF_VERSION,
@@ -25,11 +34,25 @@ _ARRAY_DTYPES = {
 }
 
 
-def _require_sha256(value: str, *, name: str) -> None:
-    if len(value) != 64 or any(
-        character not in "0123456789abcdef" for character in value
-    ):
-        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+def _descriptor_text(value: np.ndarray) -> str:
+    array = np.asarray(value)
+    if array.shape != () or array.dtype.kind not in {"U", "S"}:
+        raise ValueError(
+            "observation artifact descriptor_json must be one scalar UTF-8 string"
+        )
+    item = array.item()
+    if isinstance(item, bytes):
+        try:
+            return item.decode("utf-8")
+        except UnicodeDecodeError as error:
+            raise ValueError(
+                "observation artifact descriptor_json must contain UTF-8 text"
+            ) from error
+    if type(item) is not str:
+        raise ValueError(
+            "observation artifact descriptor_json must be one scalar UTF-8 string"
+        )
+    return item
 
 
 def load_observation_belief_export(
@@ -42,35 +65,46 @@ def load_observation_belief_export(
         with np.load(source, allow_pickle=False) as archive:
             if "descriptor_json" not in archive:
                 raise ValueError("observation artifact has no descriptor_json")
-            try:
-                descriptor = json.loads(str(archive["descriptor_json"]))
-            except (TypeError, ValueError) as error:
-                raise ValueError(
-                    "observation artifact descriptor is not valid JSON"
-                ) from error
+            descriptor = loads_json_object(
+                _descriptor_text(archive["descriptor_json"]),
+                name="observation artifact descriptor",
+            )
             arrays = {
                 name: np.asarray(archive[name])
                 for name in archive.files
                 if name != "descriptor_json"
             }
     except (OSError, ValueError) as error:
-        if isinstance(error, ValueError) and str(error).startswith("observation artifact"):
+        if isinstance(error, ValueError) and str(error).startswith(
+            "observation artifact"
+        ):
             raise
-        raise ValueError("observation artifact is not a valid non-pickled NPZ") from error
+        raise ValueError(
+            "observation artifact is not a valid non-pickled NPZ"
+        ) from error
 
-    if not isinstance(descriptor, dict):
-        raise ValueError("observation artifact descriptor must be a JSON object")
     descriptor_fields = set(descriptor)
     missing_descriptor = _REQUIRED_DESCRIPTOR_FIELDS - descriptor_fields
     extra_descriptor = descriptor_fields - _REQUIRED_DESCRIPTOR_FIELDS
     if missing_descriptor or extra_descriptor:
         raise ValueError(
             "observation artifact descriptor changed; "
-            f"missing={sorted(missing_descriptor)}, extra={sorted(extra_descriptor)}"
+            f"missing={sorted(missing_descriptor)}, "
+            f"extra={sorted(extra_descriptor)}"
         )
-    if descriptor["schema_name"] != OBSERVATION_BELIEF_SCHEMA:
+
+    schema_name = require_exact_string(
+        descriptor["schema_name"],
+        name="observation artifact schema_name",
+    )
+    if schema_name != OBSERVATION_BELIEF_SCHEMA:
         raise ValueError("unsupported observation-belief schema")
-    if int(descriptor["schema_version"]) != OBSERVATION_BELIEF_VERSION:
+    schema_version = require_exact_integer(
+        descriptor["schema_version"],
+        name="observation artifact schema_version",
+        minimum=1,
+    )
+    if schema_version != OBSERVATION_BELIEF_VERSION:
         raise ValueError("unsupported observation-belief version")
 
     missing_arrays = _REQUIRED_ARRAYS - arrays.keys()
@@ -87,19 +121,53 @@ def load_observation_belief_export(
                 f"{arrays[name].dtype}, expected {expected_dtype}"
             )
 
-    expected_artifact_id = str(descriptor["artifact_id"])
-    _require_sha256(expected_artifact_id, name="artifact_id")
+    expected_artifact_id = require_sha256(
+        descriptor["artifact_id"],
+        name="observation artifact artifact_id",
+    )
     artifact = ObservationBeliefExportV1(
-        case_id=str(descriptor["case_id"]),
-        stream_id=str(descriptor["stream_id"]),
-        causal_frame_stop=int(descriptor["causal_frame_stop"]),
-        view_names=tuple(map(str, descriptor["view_names"])),
-        window_names=tuple(map(str, descriptor["window_names"])),
-        factor_names=tuple(map(str, descriptor["factor_names"])),
-        source_repository=str(descriptor["source_repository"]),
-        source_revision=str(descriptor["source_revision"]),
-        source_artifact_sha256=str(descriptor["source_artifact_sha256"]),
-        metadata=descriptor["metadata"],
+        case_id=require_nonempty_string(
+            descriptor["case_id"],
+            name="observation artifact case_id",
+        ),
+        stream_id=require_nonempty_string(
+            descriptor["stream_id"],
+            name="observation artifact stream_id",
+        ),
+        causal_frame_stop=require_exact_integer(
+            descriptor["causal_frame_stop"],
+            name="observation artifact causal_frame_stop",
+            minimum=1,
+        ),
+        view_names=require_string_sequence(
+            descriptor["view_names"],
+            name="observation artifact view_names",
+        ),
+        window_names=require_string_sequence(
+            descriptor["window_names"],
+            name="observation artifact window_names",
+        ),
+        factor_names=require_string_sequence(
+            descriptor["factor_names"],
+            name="observation artifact factor_names",
+            allow_empty=True,
+        ),
+        source_repository=require_nonempty_string(
+            descriptor["source_repository"],
+            name="observation artifact source_repository",
+        ),
+        source_revision=require_nonempty_string(
+            descriptor["source_revision"],
+            name="observation artifact source_revision",
+        ),
+        source_artifact_sha256=require_sha256(
+            descriptor["source_artifact_sha256"],
+            name="observation artifact source_artifact_sha256",
+        ),
+        metadata=require_mapping(
+            descriptor["metadata"],
+            name="observation artifact metadata",
+        ),
         **arrays,
     )
     if artifact.artifact_id != expected_artifact_id:

--- a/tests/test_observation_contract.py
+++ b/tests/test_observation_contract.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import numpy as np
@@ -7,10 +8,8 @@ from prob4d.observation_contract import (
     ObservationBeliefExportV1,
     save_observation_belief_export,
 )
-from prob4d.observation_validation import (
-    load_observation_belief_export,
-    main as validate_main,
-)
+from prob4d.observation_validation import load_observation_belief_export
+from prob4d.observation_validation import main as validate_main
 
 GOLDEN_ARTIFACT_ID = (
     "9c02e638f60424cca7738d347d1258acd208eb562f422efacd077db4edb2fe80"
@@ -55,6 +54,39 @@ def _artifact() -> ObservationBeliefExportV1:
         group_prior_nominal_probability=np.asarray([0.85, 0.65]),
         group_composite_weight=np.asarray([0.5, 0.5]),
         metadata={"causal_source": "prefix only"},
+    )
+
+
+def _descriptor(artifact: ObservationBeliefExportV1) -> dict[str, object]:
+    return {"artifact_id": artifact.artifact_id, **artifact.descriptor()}
+
+
+def _write_raw_descriptor(
+    path: Path,
+    artifact: ObservationBeliefExportV1,
+    descriptor_text: str,
+) -> None:
+    np.savez_compressed(
+        path,
+        descriptor_json=np.asarray(descriptor_text),
+        **artifact.arrays(),
+    )
+
+
+def _write_descriptor(
+    path: Path,
+    artifact: ObservationBeliefExportV1,
+    descriptor: dict[str, object],
+) -> None:
+    _write_raw_descriptor(
+        path,
+        artifact,
+        json.dumps(
+            descriptor,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ),
     )
 
 
@@ -109,6 +141,75 @@ def test_contract_loader_rejects_extra_array(tmp_path: Path) -> None:
     np.savez_compressed(path, **payload, unexpected=np.asarray([1]))
 
     with pytest.raises(ValueError, match="arrays changed"):
+        load_observation_belief_export(path)
+
+
+def test_contract_loader_rejects_duplicate_descriptor_keys(
+    tmp_path: Path,
+) -> None:
+    artifact = _artifact()
+    descriptor_text = json.dumps(
+        _descriptor(artifact),
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+    descriptor_text = descriptor_text.replace(
+        '"case_id":"case-1"',
+        '"case_id":"ignored","case_id":"case-1"',
+        1,
+    )
+    path = tmp_path / "duplicate-descriptor.npz"
+    _write_raw_descriptor(path, artifact, descriptor_text)
+
+    with pytest.raises(
+        ValueError,
+        match="duplicate JSON object key 'case_id'",
+    ):
+        load_observation_belief_export(path)
+
+
+def test_contract_loader_rejects_boolean_schema_version_alias(
+    tmp_path: Path,
+) -> None:
+    artifact = _artifact()
+    descriptor = _descriptor(artifact)
+    descriptor["schema_version"] = True
+    path = tmp_path / "boolean-version.npz"
+    _write_descriptor(path, artifact, descriptor)
+
+    with pytest.raises(ValueError, match="schema_version must be an integer"):
+        load_observation_belief_export(path)
+
+
+def test_contract_loader_rejects_numeric_case_id_alias(tmp_path: Path) -> None:
+    base = _artifact()
+    artifact = ObservationBeliefExportV1(
+        **{**base.__dict__, "case_id": "7"}
+    )
+    descriptor = _descriptor(artifact)
+    descriptor["case_id"] = 7
+    path = tmp_path / "numeric-case-id.npz"
+    _write_descriptor(path, artifact, descriptor)
+
+    with pytest.raises(ValueError, match="case_id must be a nonempty string"):
+        load_observation_belief_export(path)
+
+
+def test_contract_loader_rejects_numeric_name_alias(tmp_path: Path) -> None:
+    base = _artifact()
+    artifact = ObservationBeliefExportV1(
+        **{**base.__dict__, "view_names": ("7",)}
+    )
+    descriptor = _descriptor(artifact)
+    descriptor["view_names"] = [7]
+    path = tmp_path / "numeric-view-name.npz"
+    _write_descriptor(path, artifact, descriptor)
+
+    with pytest.raises(
+        ValueError,
+        match="view_names must contain nonempty strings",
+    ):
         load_observation_belief_export(path)
 
 


### PR DESCRIPTION
## Summary

Harden the raw JSON boundary of the portable `phys4d.observation_belief` loader before normalized Python values are constructed.

- add a reusable in-memory strict JSON-object parser that rejects duplicate keys and non-finite constants;
- require `descriptor_json` to be one scalar UTF-8 string member;
- reject Boolean schema-version aliases, numeric identifier aliases, non-string name entries, malformed digests, and non-object metadata before artifact reconstruction;
- remove permissive `str(...)`, `int(...)`, and `map(str, ...)` normalization from the observation-belief loading path;
- preserve the complete valid schema-v1 descriptor, array roster, canonical serialization, and golden artifact identity; and
- add focused adversarial regression coverage and update the strict-loading documentation.

## Root cause

The loader previously parsed the descriptor with ordinary `json.loads` and then normalized several raw fields while constructing `ObservationBeliefExportV1`. Invalid raw JSON could therefore be accepted when its supplied `artifact_id` matched the normalized value. Examples included `schema_version: true`, numeric `case_id`, numeric view names, and duplicate object keys whose final value won during parsing.

Content-address verification after normalization is not sufficient for a closed portable schema: the serialized input itself must conform before any normalization can occur.

## Compatibility

Valid existing observation-belief archives are unchanged. The cross-repository golden artifact ID remains:

```text
9c02e638f60424cca7738d347d1258acd208eb562f422efacd077db4edb2fe80
```

No descriptor field, array name, dtype, shape, byte representation, content-address rule, or valid artifact identity changes. Only previously malformed or coercive raw descriptors fail earlier and with field-level diagnostics.

## Validation

The branch was rebased and squashed to one commit on exact current base:

```text
base  911ef571641dafc980134c3bc415a6fedce9a411
head  49df0aa56950be77ab14bf9972a359a5ab343dad
```

All pull-request workflows passed on that exact head:

- complete suites on Python 3.10, 3.11, 3.12, 3.13, and 3.14;
- the declared Python 3.10 / minimum-dependency runtime floor;
- repository, release, API, and provider-contract validation;
- focused strict-JSON, project-identity, and source-diagnostic regressions;
- fail-closed Ruff, Ruff formatting, MyPy, and documentation-surface checks;
- provider batch preflight;
- wheel and source-distribution construction;
- isolated installed-wheel and installed-sdist grouped-CLI smoke tests; and
- dependency audit plus Python and Actions CodeQL security scanning.

The one-commit branch changes exactly four intended files.

## Scientific boundary

This is portable-contract input hardening only. It does not change an estimator, covariance, mean, low-rank factor, gauge result, provider selection, dataset, causal cutoff, fallback, empirical result, or scientific claim.