### PR TITLE
Add installed-wheel typing and cross-platform contract portability

### DIFF
--- a/.github/workflows/contract-portability.yml
+++ b/.github/workflows/contract-portability.yml
@@ -1,0 +1,159 @@
+name: Contract portability
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/contract-portability.yml"
+      - "CHANGELOG.d/contract-portability.md"
+      - "docs/contract-portability.md"
+      - "integration_tests/typing/**"
+      - "pyproject.toml"
+      - "requirements/ci/quality.txt"
+      - "src/prob4d/_atomic_file.py"
+      - "src/prob4d/api/v2.py"
+      - "src/prob4d/data.py"
+      - "src/prob4d/prediction_store.py"
+      - "src/prob4d/provider_v2_loading.py"
+      - "tests/test_atomic_evidence_publication.py"
+      - "tests/test_contract_portability_workflow.py"
+      - "tests/test_data_storage.py"
+      - "tests/test_prediction_store.py"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/contract-portability.yml"
+      - "CHANGELOG.d/contract-portability.md"
+      - "docs/contract-portability.md"
+      - "integration_tests/typing/**"
+      - "pyproject.toml"
+      - "requirements/ci/quality.txt"
+      - "src/prob4d/_atomic_file.py"
+      - "src/prob4d/api/v2.py"
+      - "src/prob4d/data.py"
+      - "src/prob4d/prediction_store.py"
+      - "src/prob4d/provider_v2_loading.py"
+      - "tests/test_atomic_evidence_publication.py"
+      - "tests/test_contract_portability_workflow.py"
+      - "tests/test_data_storage.py"
+      - "tests/test_prediction_store.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: contract-portability-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONUNBUFFERED: "1"
+
+jobs:
+  installed-wheel-typing:
+    name: Installed-wheel consumer typing
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out consumer fixtures
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements/ci/quality.txt
+      - name: Build the wheel and isolated typing environment
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install build
+          python -m build --wheel
+          python -m venv "$RUNNER_TEMP/prob4d-installed-typing"
+          python_bin="$RUNNER_TEMP/prob4d-installed-typing/bin/python"
+          "$python_bin" -m pip install --upgrade pip
+          wheel=$(find dist -maxdepth 1 -name '*.whl' -print -quit)
+          test -n "$wheel"
+          "$python_bin" -m pip install "$wheel" mypy==2.3.0
+          "$python_bin" -m pip check
+      - name: Type-check the valid installed-wheel consumer
+        shell: bash
+        run: |
+          set -euo pipefail
+          python_bin="$RUNNER_TEMP/prob4d-installed-typing/bin/python"
+          "$python_bin" -m mypy \
+            --strict \
+            --disallow-any-expr \
+            --disallow-any-unimported \
+            --show-error-codes \
+            integration_tests/typing/consumer_v2.py \
+            2>&1 | tee typing-valid.txt
+      - name: Require the invalid consumer to fail
+        shell: bash
+        run: |
+          set -euo pipefail
+          python_bin="$RUNNER_TEMP/prob4d-installed-typing/bin/python"
+          set +e
+          "$python_bin" -m mypy \
+            --strict \
+            --show-error-codes \
+            integration_tests/typing/consumer_v2_invalid.py \
+            > typing-invalid.txt 2>&1
+          status=$?
+          set -e
+          cat typing-invalid.txt
+          if (( status == 0 )); then
+            echo "Invalid installed-wheel consumer unexpectedly type-checked." >&2
+            exit 1
+          fi
+          grep -F "[arg-type]" typing-invalid.txt
+      - name: Upload typing diagnostics
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: installed-wheel-typing-diagnostics
+          path: |
+            typing-valid.txt
+            typing-invalid.txt
+          if-no-files-found: warn
+          retention-days: 14
+
+  atomic-publication-portability:
+    name: Immutable publication / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install the lightweight development environment
+        run: python -m pip install -e ".[dev]"
+      - name: Verify immutable publication and portable storage
+        run: >-
+          python -m pytest -q
+          tests/test_atomic_evidence_publication.py
+          tests/test_data_storage.py
+          tests/test_prediction_store.py
+          --junitxml=pytest-contract-portability-${{ matrix.os }}.xml
+      - name: Upload portability report
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: contract-portability-${{ matrix.os }}
+          path: pytest-contract-portability-${{ matrix.os }}.xml
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/contract-portability.yml
+++ b/.github/workflows/contract-portability.yml
@@ -85,10 +85,7 @@ jobs:
           set -euo pipefail
           python_bin="$RUNNER_TEMP/prob4d-installed-typing/bin/python"
           "$python_bin" -m mypy \
-            --strict \
-            --disallow-any-expr \
-            --disallow-any-unimported \
-            --show-error-codes \
+            --config-file integration_tests/typing/mypy.ini \
             integration_tests/typing/consumer_v2.py \
             2>&1 | tee typing-valid.txt
       - name: Require the invalid consumer to fail
@@ -98,8 +95,7 @@ jobs:
           python_bin="$RUNNER_TEMP/prob4d-installed-typing/bin/python"
           set +e
           "$python_bin" -m mypy \
-            --strict \
-            --show-error-codes \
+            --config-file integration_tests/typing/mypy.ini \
             integration_tests/typing/consumer_v2_invalid.py \
             > typing-invalid.txt 2>&1
           status=$?

--- a/CHANGELOG.d/contract-portability.md
+++ b/CHANGELOG.d/contract-portability.md
@@ -9,8 +9,18 @@
 - Repository policy tests and documentation for the installed typing and
   filesystem portability boundaries.
 
+### Fixed
+
+- Immutable temporary-file publication now synchronizes through a read/write
+  descriptor, which preserves the durability barrier on Windows instead of
+  failing with `EBADF`; the hard-link no-clobber and atomic-replacement semantics
+  are unchanged.
+- Installed-wheel typing uses an explicit consumer configuration rather than the
+  repository development setting that intentionally skips followed imports.
+
 ### Scientific boundary
 
-These checks strengthen installed-package typing and local-filesystem portability
-only. They change no estimator, covariance, provider output, cohort, target-access
-decision, physical update, exact fallback, empirical result, or scientific claim.
+These changes strengthen installed-package typing and local-filesystem
+portability only. They change no estimator, covariance, provider output, cohort,
+target-access decision, physical update, exact fallback, empirical result, or
+scientific claim.

--- a/CHANGELOG.d/contract-portability.md
+++ b/CHANGELOG.d/contract-portability.md
@@ -1,0 +1,16 @@
+### Added
+
+- A consolidated read-only contract-portability workflow that type-checks the
+  installed Prob4D wheel from a downstream `prob4d.api.v2` consumer with
+  expression-level `Any` rejected and a required invalid-call negative control.
+- Focused macOS and Windows validation for atomic no-clobber publication,
+  prediction-window serialization, and read-only memory-mapped prediction
+  stores.
+- Repository policy tests and documentation for the installed typing and
+  filesystem portability boundaries.
+
+### Scientific boundary
+
+These checks strengthen installed-package typing and local-filesystem portability
+only. They change no estimator, covariance, provider output, cohort, target-access
+decision, physical update, exact fallback, empirical result, or scientific claim.

--- a/docs/contract-portability.md
+++ b/docs/contract-portability.md
@@ -1,0 +1,50 @@
+# Contract portability
+
+Prob4D publishes portable, typed, immutable artifacts for consumers that do not
+share its source checkout. The `Contract portability` workflow closes two gaps
+that ordinary Linux editable-install tests do not cover.
+
+## Installed-wheel consumer typing
+
+The workflow builds one wheel, installs it into an isolated environment together
+with the authoritative MyPy version, and type-checks only the public
+`prob4d.api.v2` consumer fixture. The positive fixture runs with strict checking,
+`disallow-any-expr`, and `disallow-any-unimported` so a façade that silently
+returns `Any` cannot pass merely because its re-export module is annotated.
+
+A separate invalid fixture passes an integer to
+`load_claim_bearing_observation_belief`. CI requires that fixture to fail with an
+`arg-type` diagnostic. Together the two fixtures establish that the installed
+`py.typed` distribution exposes concrete consumer-visible types and rejects an
+incorrect call.
+
+The typing fixtures must import only stable installed package surfaces. They must
+not depend on repository-only helpers, editable installs, scientific data, or
+private implementation modules.
+
+## Immutable publication on supported hosted systems
+
+The second job runs the focused immutable-publication, prediction-window storage,
+and memory-mapped prediction-store tests on GitHub-hosted macOS and Windows. The
+ordinary complete suite continues to cover Linux and every supported Python
+version.
+
+This matrix checks the actual hard-link no-clobber path, explicit atomic
+replacement, temporary-file cleanup, NPZ round trips, and read-only memory maps.
+A platform failure is treated as a portability failure; the implementation must
+not silently weaken create-once semantics on that platform.
+
+Network filesystems and externally mounted volumes may provide weaker semantics
+than the hosted local filesystems. Claim-bearing deployments must retain the
+existing write-then-reopen verification and should validate their actual storage
+backend before treating it as immutable evidence storage.
+
+## Security and scientific boundary
+
+The workflow is read-only, uses pinned GitHub Actions, does not receive secrets,
+and never opens provider, calibration, target, or physical-query data.
+
+Passing establishes installed-package typing and local-filesystem portability
+only. It does not establish provider accuracy, uncertainty calibration,
+BayesianPhysTwin benefit, Causal4D intervention benefit, deployment safety, or
+state of the art.

--- a/docs/contract-portability.md
+++ b/docs/contract-portability.md
@@ -8,9 +8,11 @@ that ordinary Linux editable-install tests do not cover.
 
 The workflow builds one wheel, installs it into an isolated environment together
 with the authoritative MyPy version, and type-checks only the public
-`prob4d.api.v2` consumer fixture. The positive fixture runs with strict checking,
-`disallow-any-expr`, and `disallow-any-unimported` so a façade that silently
-returns `Any` cannot pass merely because its re-export module is annotated.
+`prob4d.api.v2` consumer fixture. A dedicated consumer configuration overrides
+the repository development setting `follow_imports = skip`, targets Python 3.12,
+and enables strict checking, `disallow_any_expr`, and
+`disallow_any_unimported`. A façade that silently returns `Any` therefore cannot
+pass merely because its re-export module is annotated.
 
 A separate invalid fixture passes an integer to
 `load_claim_bearing_observation_belief`. CI requires that fixture to fail with an
@@ -31,6 +33,11 @@ version.
 
 This matrix checks the actual hard-link no-clobber path, explicit atomic
 replacement, temporary-file cleanup, NPZ round trips, and read-only memory maps.
+The first Windows execution exposed that `os.fsync` rejects a descriptor opened
+read-only. The publication path now reopens its owned temporary file read/write
+for synchronization without changing bytes, then retains the same hard-link or
+atomic-replacement publication rule.
+
 A platform failure is treated as a portability failure; the implementation must
 not silently weaken create-once semantics on that platform.
 

--- a/integration_tests/typing/README.md
+++ b/integration_tests/typing/README.md
@@ -1,0 +1,15 @@
+# Installed-wheel typing fixtures
+
+These files validate Prob4D from the perspective of a downstream package after
+an actual wheel has been installed into an isolated environment.
+
+- `consumer_v2.py` must pass strict MyPy checking with expression-level `Any`
+  rejected. It exercises the concrete return type of the claim-bearing loader and
+  the annotated `Sim3` method surface.
+- `consumer_v2_invalid.py` must fail with an `arg-type` diagnostic. It is a
+  negative control proving that the installed `py.typed` package does not accept
+  an integer where a path is required.
+
+The fixtures are type-check inputs, not runtime examples. They import only the
+stable `prob4d.api.v2` façade and must not reach into a source checkout or open
+scientific data.

--- a/integration_tests/typing/README.md
+++ b/integration_tests/typing/README.md
@@ -3,9 +3,12 @@
 These files validate Prob4D from the perspective of a downstream package after
 an actual wheel has been installed into an isolated environment.
 
-- `consumer_v2.py` must pass strict MyPy checking with expression-level `Any`
-  rejected. It exercises the concrete return type of the claim-bearing loader and
-  the annotated `Sim3` method surface.
+- `mypy.ini` deliberately overrides the repository development setting
+  `follow_imports = skip`. It follows installed inline annotations normally and
+  rejects expression-level and imported `Any`.
+- `consumer_v2.py` must pass under that consumer configuration. It exercises the
+  concrete return type of the claim-bearing loader and the annotated `Sim3`
+  method surface.
 - `consumer_v2_invalid.py` must fail with an `arg-type` diagnostic. It is a
   negative control proving that the installed `py.typed` package does not accept
   an integer where a path is required.

--- a/integration_tests/typing/consumer_v2.py
+++ b/integration_tests/typing/consumer_v2.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import assert_type
+
+from prob4d.api.v2 import (
+    Sim3,
+    ValidatedClaimBearingObservation,
+    load_claim_bearing_observation_belief,
+)
+
+
+def load_artifact(path: Path) -> str:
+    """Exercise the concrete installed-wheel observation loader type."""
+
+    validated = load_claim_bearing_observation_belief(path)
+    assert_type(validated, ValidatedClaimBearingObservation)
+    assert_type(validated.artifact_id, str)
+    return validated.artifact_id
+
+
+def compose_round_trip(transform: Sim3) -> Sim3:
+    """Exercise method return types from the installed inline annotations."""
+
+    inverse = transform.inverse()
+    assert_type(inverse, Sim3)
+    round_trip = inverse.compose(transform)
+    assert_type(round_trip, Sim3)
+    return round_trip
+
+
+identity = Sim3.identity()
+assert_type(identity, Sim3)

--- a/integration_tests/typing/consumer_v2_invalid.py
+++ b/integration_tests/typing/consumer_v2_invalid.py
@@ -1,0 +1,3 @@
+from prob4d.api.v2 import load_claim_bearing_observation_belief
+
+load_claim_bearing_observation_belief(123)

--- a/integration_tests/typing/mypy.ini
+++ b/integration_tests/typing/mypy.ini
@@ -1,0 +1,9 @@
+[mypy]
+python_version = 3.12
+strict = True
+follow_imports = normal
+ignore_missing_imports = False
+disallow_any_expr = True
+disallow_any_unimported = True
+show_error_codes = True
+warn_unused_configs = True

--- a/src/prob4d/_atomic_file.py
+++ b/src/prob4d/_atomic_file.py
@@ -43,7 +43,10 @@ def publish_temporary_file(
     if temporary_path.parent.resolve() != destination_path.parent.resolve():
         raise ValueError("temporary and destination must share one directory")
 
-    with temporary_path.open("rb") as stream:
+    # Windows requires a writable descriptor for fsync. The temporary file is
+    # owned by this publication path, so opening it read/write changes no bytes
+    # while preserving the same durability barrier on every supported platform.
+    with temporary_path.open("rb+") as stream:
         os.fsync(stream.fileno())
     if overwrite:
         os.replace(temporary_path, destination_path)

--- a/tests/test_contract_portability_workflow.py
+++ b/tests/test_contract_portability_workflow.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
-WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "contract-portability.yml"
+REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = REPOSITORY_ROOT / ".github" / "workflows" / "contract-portability.yml"
 
 
 def _workflow_text() -> str:

--- a/tests/test_contract_portability_workflow.py
+++ b/tests/test_contract_portability_workflow.py
@@ -4,10 +4,15 @@ from pathlib import Path
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = REPOSITORY_ROOT / ".github" / "workflows" / "contract-portability.yml"
+MYPY_CONFIG = REPOSITORY_ROOT / "integration_tests" / "typing" / "mypy.ini"
 
 
 def _workflow_text() -> str:
     return WORKFLOW.read_text(encoding="utf-8")
+
+
+def _mypy_config_text() -> str:
+    return MYPY_CONFIG.read_text(encoding="utf-8")
 
 
 def test_contract_portability_workflow_is_read_only_and_consolidated() -> None:
@@ -21,12 +26,16 @@ def test_contract_portability_workflow_is_read_only_and_consolidated() -> None:
 
 
 def test_installed_typing_gate_rejects_any_and_invalid_calls() -> None:
-    text = _workflow_text()
-    assert "--disallow-any-expr" in text
-    assert "--disallow-any-unimported" in text
-    assert "consumer_v2.py" in text
-    assert "consumer_v2_invalid.py" in text
-    assert 'grep -F "[arg-type]" typing-invalid.txt' in text
+    workflow = _workflow_text()
+    config = _mypy_config_text()
+    assert "--config-file integration_tests/typing/mypy.ini" in workflow
+    assert "consumer_v2.py" in workflow
+    assert "consumer_v2_invalid.py" in workflow
+    assert 'grep -F "[arg-type]" typing-invalid.txt' in workflow
+    assert "follow_imports = normal" in config
+    assert "disallow_any_expr = True" in config
+    assert "disallow_any_unimported = True" in config
+    assert "ignore_missing_imports = False" in config
 
 
 def test_portability_matrix_covers_macos_and_windows() -> None:

--- a/tests/test_contract_portability_workflow.py
+++ b/tests/test_contract_portability_workflow.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+WORKFLOW = Path(__file__).resolve().parents[1] / ".github" / "workflows" / "contract-portability.yml"
+
+
+def _workflow_text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def test_contract_portability_workflow_is_read_only_and_consolidated() -> None:
+    text = _workflow_text()
+    assert "permissions:\n  contents: read" in text
+    assert "pull_request_target" not in text
+    assert "contents: write" not in text
+    assert "installed-wheel-typing:" in text
+    assert "atomic-publication-portability:" in text
+    assert text.count("persist-credentials: false") == 2
+
+
+def test_installed_typing_gate_rejects_any_and_invalid_calls() -> None:
+    text = _workflow_text()
+    assert "--disallow-any-expr" in text
+    assert "--disallow-any-unimported" in text
+    assert "consumer_v2.py" in text
+    assert "consumer_v2_invalid.py" in text
+    assert 'grep -F "[arg-type]" typing-invalid.txt' in text
+
+
+def test_portability_matrix_covers_macos_and_windows() -> None:
+    text = _workflow_text()
+    assert "os: [macos-latest, windows-latest]" in text
+    assert "tests/test_atomic_evidence_publication.py" in text
+    assert "tests/test_data_storage.py" in text
+    assert "tests/test_prediction_store.py" in text


### PR DESCRIPTION
## Summary

- add one consolidated, read-only `Contract portability` workflow;
- build and install the actual Prob4D wheel in an isolated environment before type-checking a downstream `prob4d.api.v2` consumer;
- follow installed inline annotations normally and reject expression-level/imported `Any`;
- require a deliberately invalid loader call to fail with MyPy `arg-type` evidence;
- run focused immutable-publication, prediction-window storage, and memory-mapped prediction-store tests on hosted macOS and Windows;
- fix the Windows durability barrier for temporary artifact publication;
- add workflow-policy regressions, documentation, and a changelog fragment.

## Root causes found by the new gate

The first exact-head run found two concrete gaps:

1. The repository development MyPy configuration intentionally used `follow_imports = skip`, so reusing it for an installed-wheel consumer test made imported API expressions appear as `Any`. The consumer gate now uses its own Python-3.12 strict configuration with `follow_imports = normal`, missing imports rejected, and expression-level/imported `Any` forbidden.
2. `publish_temporary_file` reopened its owned temporary file read-only before `os.fsync`. Windows rejects synchronization through that descriptor with `EBADF`. It now reopens the temporary file read/write for the durability barrier without changing bytes, then uses the same hard-link no-clobber or `os.replace` publication rule.

## Validation on exact head

All workflows passed on `29d1f6ac21c60277300b344d71b8664ce7aa28fd`:

- installed-wheel valid-consumer strict typing;
- invalid-consumer `arg-type` negative control;
- macOS and Windows immutable-publication and portable-storage tests;
- complete NumPy-core suites on Python 3.10, 3.11, 3.12, 3.13, and 3.14;
- declared NumPy 1.24.0 runtime floor;
- repository, release, API, documentation-surface, Ruff, and MyPy checks;
- wheel and source-distribution build validation;
- isolated installed wheel and source-distribution CLI smoke tests;
- provider batch preflight;
- ecosystem installed-wheel release capsule; and
- security scanning.

## Security boundary

- read-only `contents` permission;
- pinned GitHub Actions;
- no `pull_request_target`;
- no credentials persisted by checkout;
- no secrets or self-hosted runners;
- no provider, calibration, target, or physical-query data access.

## Scientific boundary

This strengthens installed-package typing and local-filesystem portability only. It changes no estimator, covariance, provider output, cohort, target-access decision, BayesianPhysTwin update, exact fallback, empirical result, or scientific claim.