### PR TITLE
Improve provider-import CI diagnostics

### DIFF
--- a/.github/workflows/generic-provider-import.yml
+++ b/.github/workflows/generic-provider-import.yml
@@ -57,7 +57,7 @@ jobs:
           python -m pip install -e ".[dev]" "numpy>=1.24,<2.3"
           python -m pip check
 
-      - name: Validate source and focused contracts
+      - name: Lint focused provider-import sources
         run: |
           python -m ruff check \
             scripts/ci/check_sdist.py \
@@ -73,7 +73,10 @@ jobs:
             tests/test_cut3r_provider_adapter.py \
             tests/test_prediction_provider_import.py \
             tests/test_prediction_provider_scaffold.py
-          python -m ruff format --check \
+
+      - name: Check focused provider-import formatting
+        run: |
+          python -m ruff format --check --diff \
             scripts/ci/check_sdist.py \
             src/prob4d/_cut3r_cli.py \
             src/prob4d/_cut3r_limits.py \
@@ -87,6 +90,9 @@ jobs:
             tests/test_cut3r_provider_adapter.py \
             tests/test_prediction_provider_import.py \
             tests/test_prediction_provider_scaffold.py
+
+      - name: Type-check focused provider-import sources
+        run: |
           python -m mypy \
             src/prob4d/_cut3r_cli.py \
             src/prob4d/_cut3r_limits.py \
@@ -95,6 +101,9 @@ jobs:
             src/prob4d/cut3r_provider_adapter.py \
             src/prob4d/prediction_provider_import.py \
             src/prob4d/prediction_provider_scaffold.py
+
+      - name: Run focused provider-import contracts
+        run: |
           python -m pytest -q \
             tests/test_cli.py \
             tests/test_cut3r_provider_adapter.py \
@@ -103,6 +112,9 @@ jobs:
             tests/test_prediction_provider_scaffold.py \
             tests/test_data.py \
             tests/test_data_storage.py
+
+      - name: Compile focused provider-import sources
+        run: |
           python -m compileall -q src/prob4d
           python -m py_compile scripts/ci/check_sdist.py
 

--- a/.github/workflows/generic-provider-import.yml
+++ b/.github/workflows/generic-provider-import.yml
@@ -9,6 +9,10 @@ on:
       - "docs/examples/provider-neutral-import-spec.json"
       - "docs/generic-provider-import.md"
       - "scripts/ci/check_sdist.py"
+      - "src/prob4d/_cut3r_cli.py"
+      - "src/prob4d/_cut3r_limits.py"
+      - "src/prob4d/_cut3r_source.py"
+      - "src/prob4d/_cut3r_window.py"
       - "src/prob4d/cut3r_provider_adapter.py"
       - "src/prob4d/prediction_cli.py"
       - "src/prob4d/prediction_provider_import.py"
@@ -57,6 +61,10 @@ jobs:
         run: |
           python -m ruff check \
             scripts/ci/check_sdist.py \
+            src/prob4d/_cut3r_cli.py \
+            src/prob4d/_cut3r_limits.py \
+            src/prob4d/_cut3r_source.py \
+            src/prob4d/_cut3r_window.py \
             src/prob4d/cut3r_provider_adapter.py \
             src/prob4d/prediction_cli.py \
             src/prob4d/prediction_provider_import.py \
@@ -67,6 +75,10 @@ jobs:
             tests/test_prediction_provider_scaffold.py
           python -m ruff format --check \
             scripts/ci/check_sdist.py \
+            src/prob4d/_cut3r_cli.py \
+            src/prob4d/_cut3r_limits.py \
+            src/prob4d/_cut3r_source.py \
+            src/prob4d/_cut3r_window.py \
             src/prob4d/cut3r_provider_adapter.py \
             src/prob4d/prediction_cli.py \
             src/prob4d/prediction_provider_import.py \
@@ -76,6 +88,10 @@ jobs:
             tests/test_prediction_provider_import.py \
             tests/test_prediction_provider_scaffold.py
           python -m mypy \
+            src/prob4d/_cut3r_cli.py \
+            src/prob4d/_cut3r_limits.py \
+            src/prob4d/_cut3r_source.py \
+            src/prob4d/_cut3r_window.py \
             src/prob4d/cut3r_provider_adapter.py \
             src/prob4d/prediction_provider_import.py \
             src/prob4d/prediction_provider_scaffold.py

--- a/CHANGELOG.d/cut3r-bounded-import.md
+++ b/CHANGELOG.d/cut3r-bounded-import.md
@@ -1,0 +1,16 @@
+### Changed
+
+- The recurrent-online CUT3R adapter now canonicalizes frames through temporary
+  NPY memory maps instead of retaining and stacking the complete reconstructed
+  sequence in memory.
+- CUT3R imports fail closed on configurable frame-count, spatial-size,
+  source-byte, and uncompressed dense-array budgets, and reject singular camera
+  intrinsics with a contextual validation error. The loader identity now binds
+  every implementation module introduced by the bounded-memory split.
+
+### Scientific boundary
+
+The change preserves the portable prediction-window schema, provider-manifest
+semantics, causal lineage, confidence support rule, and all downstream readiness
+and promotion gates. It is an ingestion scalability and hardening change, not new
+provider-competence or physical-twin evidence.

--- a/docs/cut3r-online-provider.md
+++ b/docs/cut3r-online-provider.md
@@ -66,20 +66,47 @@ prob4d prediction import-cut3r-online \
 The importer:
 
 1. rejects symlinks, missing or mismatched frames, malformed arrays, non-rigid
-   poses, invalid intrinsics, and empty selected support;
+   poses, singular or invalid intrinsics, and empty selected support;
 2. hashes every depth, confidence, and camera member while checking that it does
    not change during reading;
 3. rechecks the complete source tree after canonical loading;
 4. writes one immutable versioned `PredictionWindow` payload;
 5. records frame `i` as depending on the complete source prefix ending at
    `i + 1` exclusively;
-6. binds the CUT3R code revision, checkpoint, input video, source bundle, adapter,
-   threshold, and output payload into content identities; and
+6. binds the CUT3R code revision, checkpoint, input video, source bundle, the
+   complete adapter implementation-set digest, threshold, and output payload into
+   content identities; and
 7. immediately reopens and verifies the published provider manifest.
 
 The canonical coordinate declaration is `sequence-local-sim3`. Even when an
 upstream model describes its output as metric-scale, Prob4D does not promote that
 claim without an independently calibrated metric anchor.
+
+## Bounded-memory canonicalization
+
+The adapter reads depth and confidence members through read-only NumPy memory
+maps, reconstructs one frame at a time, and writes the canonical point map and
+support mask into temporary NPY memory maps. It no longer retains a Python list
+of every reconstructed frame, performs a sequence-wide dense `stack`, or asks the
+ordinary `PredictionWindow` constructor to copy the complete sequence before NPZ
+publication. The portable NPZ schema and provider-manifest semantics are
+unchanged.
+
+Imports fail closed before large allocations when any configured budget is
+exceeded. The defaults are:
+
+- `--max-frames 4096`;
+- `--max-height 4096`;
+- `--max-width 4096`;
+- `--max-source-bytes 137438953472` (128 GiB); and
+- `--max-dense-bytes 137438953472` (128 GiB of uncompressed frame indices,
+  point-map values, and support-mask values).
+
+Use smaller values in automated ingestion environments. Raising a limit only
+permits a larger import; it does not alter the reconstructed values, confidence
+threshold, causal lineage, statistical dependence declarations, or scientific
+readiness decision. The manifest records the actual source-member and dense-array
+byte counts together with `canonicalization_backend="frame-streamed-npy-memmap-v1"`.
 
 ## Scientific progression
 

--- a/src/prob4d/_cut3r_cli.py
+++ b/src/prob4d/_cut3r_cli.py
@@ -1,0 +1,102 @@
+"""Command-line interface for recurrent-online CUT3R imports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+from typing import Any, cast
+
+from ._cut3r_limits import Cut3RImportLimits, DEFAULT_CUT3R_IMPORT_LIMITS
+from .data import DENSE_STORAGE_DTYPES, DenseStorageDType
+from .prediction_provider_manifest import verify_prediction_provider_manifest
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="prob4d prediction import-cut3r-online",
+        description=(
+            "convert official recurrent-online CUT3R depth/conf/camera outputs "
+            "into a provider-neutral prediction manifest"
+        ),
+    )
+    parser.add_argument("source_root")
+    parser.add_argument("output")
+    parser.add_argument("--sequence-id", required=True)
+    parser.add_argument("--cut3r-revision", required=True)
+    parser.add_argument("--checkpoint-sha256", required=True)
+    parser.add_argument("--input-video-sha256", required=True)
+    parser.add_argument("--input-video-byte-count", type=int, required=True)
+    parser.add_argument("--frame-start", type=int, default=0)
+    parser.add_argument("--view-id", default="camera-0")
+    parser.add_argument("--window-id", default="cut3r-online")
+    parser.add_argument("--confidence-threshold", type=float, default=1.5)
+    parser.add_argument(
+        "--storage-dtype",
+        choices=DENSE_STORAGE_DTYPES,
+        default="float32",
+    )
+    parser.add_argument(
+        "--max-frames",
+        type=int,
+        default=DEFAULT_CUT3R_IMPORT_LIMITS.max_frames,
+    )
+    parser.add_argument(
+        "--max-height",
+        type=int,
+        default=DEFAULT_CUT3R_IMPORT_LIMITS.max_height,
+    )
+    parser.add_argument(
+        "--max-width",
+        type=int,
+        default=DEFAULT_CUT3R_IMPORT_LIMITS.max_width,
+    )
+    parser.add_argument(
+        "--max-source-bytes",
+        type=int,
+        default=DEFAULT_CUT3R_IMPORT_LIMITS.max_source_bytes,
+    )
+    parser.add_argument(
+        "--max-dense-bytes",
+        type=int,
+        default=DEFAULT_CUT3R_IMPORT_LIMITS.max_dense_bytes,
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    from .cut3r_provider_adapter import import_cut3r_online_prediction_manifest
+
+    arguments = _build_parser().parse_args(list(argv) if argv is not None else None)
+    limits = Cut3RImportLimits(
+        max_frames=arguments.max_frames,
+        max_height=arguments.max_height,
+        max_width=arguments.max_width,
+        max_source_bytes=arguments.max_source_bytes,
+        max_dense_bytes=arguments.max_dense_bytes,
+    )
+    manifest = import_cut3r_online_prediction_manifest(
+        arguments.source_root,
+        arguments.output,
+        sequence_id=arguments.sequence_id,
+        cut3r_revision=arguments.cut3r_revision,
+        checkpoint_sha256=arguments.checkpoint_sha256,
+        input_video_sha256=arguments.input_video_sha256,
+        input_video_byte_count=arguments.input_video_byte_count,
+        frame_start=arguments.frame_start,
+        view_id=arguments.view_id,
+        window_id=arguments.window_id,
+        confidence_threshold=arguments.confidence_threshold,
+        storage_dtype=cast(DenseStorageDType, arguments.storage_dtype),
+        limits=limits,
+    )
+    _, report = verify_prediction_provider_manifest(arguments.output)
+    output: dict[str, Any] = {
+        **manifest.summary(),
+        "verified_payload_count": report["verified_payload_count"],
+        "execution_mode": "recurrent-online",
+        "online_prefix_only": True,
+        "global_alignment": False,
+    }
+    print(json.dumps(output, indent=2, sort_keys=True))
+    return 0

--- a/src/prob4d/_cut3r_cli.py
+++ b/src/prob4d/_cut3r_cli.py
@@ -7,7 +7,7 @@ import json
 from collections.abc import Sequence
 from typing import Any, cast
 
-from ._cut3r_limits import Cut3RImportLimits, DEFAULT_CUT3R_IMPORT_LIMITS
+from ._cut3r_limits import DEFAULT_CUT3R_IMPORT_LIMITS, Cut3RImportLimits
 from .data import DENSE_STORAGE_DTYPES, DenseStorageDType
 from .prediction_provider_manifest import verify_prediction_provider_manifest
 

--- a/src/prob4d/_cut3r_limits.py
+++ b/src/prob4d/_cut3r_limits.py
@@ -1,0 +1,145 @@
+"""Resource limits and per-frame geometry for CUT3R imports."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final, cast
+
+import numpy as np
+
+from ._strict_json import require_exact_integer
+from .data import DenseStorageDType
+
+_GIB: Final = 1024**3
+
+
+@dataclass(frozen=True)
+class Cut3RImportLimits:
+    """Fail-closed resource limits for one CUT3R source-tree import."""
+
+    max_frames: int = 4096
+    max_height: int = 4096
+    max_width: int = 4096
+    max_source_bytes: int = 128 * _GIB
+    max_dense_bytes: int = 128 * _GIB
+
+    def __post_init__(self) -> None:
+        for name in (
+            "max_frames",
+            "max_height",
+            "max_width",
+            "max_source_bytes",
+            "max_dense_bytes",
+        ):
+            require_exact_integer(getattr(self, name), name=name, minimum=1)
+
+
+DEFAULT_CUT3R_IMPORT_LIMITS: Final = Cut3RImportLimits()
+
+
+def _validate_camera(pose: np.ndarray, intrinsics: np.ndarray) -> None:
+    if pose.shape != (4, 4):
+        raise ValueError("CUT3R camera pose must have shape (4, 4)")
+    if intrinsics.shape != (3, 3):
+        raise ValueError("CUT3R camera intrinsics must have shape (3, 3)")
+    if not np.all(np.isfinite(pose)) or not np.all(np.isfinite(intrinsics)):
+        raise ValueError("CUT3R camera pose and intrinsics must be finite")
+    if not np.allclose(pose[3], np.asarray([0.0, 0.0, 0.0, 1.0]), atol=1e-7):
+        raise ValueError("CUT3R camera pose must be a homogeneous rigid transform")
+    rotation = pose[:3, :3]
+    if not np.allclose(rotation.T @ rotation, np.eye(3), atol=1e-6, rtol=1e-6):
+        raise ValueError("CUT3R camera rotation must be orthonormal")
+    if not np.isclose(np.linalg.det(rotation), 1.0, atol=1e-6, rtol=1e-6):
+        raise ValueError("CUT3R camera rotation must be proper")
+    if not np.allclose(intrinsics[2], np.asarray([0.0, 0.0, 1.0]), atol=1e-7):
+        raise ValueError("CUT3R camera intrinsics must use the standard final row")
+    if intrinsics[0, 0] <= 0.0 or intrinsics[1, 1] <= 0.0:
+        raise ValueError("CUT3R focal lengths must be strictly positive")
+
+
+def _validated_grid_shape(
+    depth: np.ndarray,
+    confidence: np.ndarray,
+    *,
+    limits: Cut3RImportLimits,
+    expected_shape: tuple[int, int] | None,
+) -> tuple[int, int]:
+    if depth.ndim != 2:
+        raise ValueError("CUT3R depth members must have shape (H, W)")
+    if confidence.shape != depth.shape:
+        raise ValueError("CUT3R confidence must match the depth grid")
+    if depth.dtype.kind not in {"f", "i", "u"} or confidence.dtype.kind not in {
+        "f",
+        "i",
+        "u",
+    }:
+        raise ValueError("CUT3R depth and confidence must be real numeric arrays")
+    height, width = cast(tuple[int, int], depth.shape)
+    if height > limits.max_height:
+        raise ValueError(
+            f"CUT3R frame height {height} exceeds max_height={limits.max_height}"
+        )
+    if width > limits.max_width:
+        raise ValueError(f"CUT3R frame width {width} exceeds max_width={limits.max_width}")
+    shape = (height, width)
+    if expected_shape is not None and shape != expected_shape:
+        raise ValueError("CUT3R frames must share one spatial prediction grid")
+    return shape
+
+
+def _unproject_world_points(
+    depth: np.ndarray,
+    confidence: np.ndarray,
+    pose: np.ndarray,
+    intrinsics: np.ndarray,
+    *,
+    confidence_threshold: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    _validate_camera(pose, intrinsics)
+
+    depth64 = np.asarray(depth, dtype=np.float64)
+    confidence64 = np.asarray(confidence, dtype=np.float64)
+    valid = (
+        np.isfinite(depth64)
+        & np.isfinite(confidence64)
+        & (depth64 > 0.0)
+        & (confidence64 >= confidence_threshold)
+    )
+
+    height, width = depth64.shape
+    rows, columns = np.indices((height, width), dtype=np.float64)
+    homogeneous_pixels = np.stack(
+        (columns, rows, np.ones((height, width), dtype=np.float64)),
+        axis=-1,
+    )
+    try:
+        camera_rays = np.linalg.solve(
+            intrinsics,
+            homogeneous_pixels.reshape(-1, 3).T,
+        ).T.reshape(height, width, 3)
+    except np.linalg.LinAlgError as error:
+        raise ValueError("CUT3R camera intrinsics must be nonsingular") from error
+    camera_points = camera_rays * depth64[..., None]
+    world = np.einsum("ij,hwj->hwi", pose[:3, :3], camera_points) + pose[:3, 3]
+    valid &= np.all(np.isfinite(world), axis=-1)
+    world[~valid] = 0.0
+    return world, valid
+
+
+def _dense_array_byte_count(
+    frame_count: int,
+    height: int,
+    width: int,
+    storage_dtype: DenseStorageDType,
+) -> int:
+    dense_itemsize = np.dtype(np.float32 if storage_dtype == "float32" else np.float64).itemsize
+    point_bytes = frame_count * height * width * 3 * dense_itemsize
+    mask_bytes = frame_count * height * width * np.dtype(bool).itemsize
+    frame_index_bytes = frame_count * np.dtype(np.int64).itemsize
+    return point_bytes + mask_bytes + frame_index_bytes
+
+
+__all__ = [
+    "Cut3RImportLimits",
+    "DEFAULT_CUT3R_IMPORT_LIMITS",
+]

--- a/src/prob4d/_cut3r_limits.py
+++ b/src/prob4d/_cut3r_limits.py
@@ -76,9 +76,7 @@ def _validated_grid_shape(
         raise ValueError("CUT3R depth and confidence must be real numeric arrays")
     height, width = cast(tuple[int, int], depth.shape)
     if height > limits.max_height:
-        raise ValueError(
-            f"CUT3R frame height {height} exceeds max_height={limits.max_height}"
-        )
+        raise ValueError(f"CUT3R frame height {height} exceeds max_height={limits.max_height}")
     if width > limits.max_width:
         raise ValueError(f"CUT3R frame width {width} exceeds max_width={limits.max_width}")
     shape = (height, width)

--- a/src/prob4d/_cut3r_source.py
+++ b/src/prob4d/_cut3r_source.py
@@ -1,0 +1,182 @@
+"""Strict source-tree loading and identities for CUT3R imports."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path, PurePosixPath
+from typing import Any, Final, TypedDict
+
+import numpy as np
+
+_MIB: Final = 1024**2
+_ADAPTER_IMPLEMENTATION_MEMBERS: Final = (
+    "_cut3r_cli.py",
+    "_cut3r_limits.py",
+    "_cut3r_source.py",
+    "_cut3r_window.py",
+    "cut3r_provider_adapter.py",
+)
+
+
+class _SourceMemberDescriptor(TypedDict):
+    """Content descriptor for one exact CUT3R output member."""
+
+    path: str
+    sha256: str
+    byte_count: int
+
+
+def _canonical_json_bytes(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _record_id(domain: str, value: Mapping[str, Any]) -> str:
+    digest = hashlib.sha256()
+    digest.update(domain.encode("utf-8"))
+    digest.update(b"\0")
+    digest.update(_canonical_json_bytes(value))
+    return digest.hexdigest()
+
+
+def _file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as stream:
+            for block in iter(lambda: stream.read(_MIB), b""):
+                digest.update(block)
+    except OSError as error:
+        raise ValueError(f"cannot read CUT3R source member {path.name!r}") from error
+    return digest.hexdigest()
+
+
+def _file_descriptor(path: Path, *, root: Path) -> _SourceMemberDescriptor:
+    if path.is_symlink() or not path.is_file():
+        raise ValueError(f"CUT3R source member {path.name!r} must be an ordinary file")
+    try:
+        relative = path.resolve().relative_to(root.resolve())
+    except ValueError as error:
+        raise ValueError("CUT3R source member escapes the declared output root") from error
+    return {
+        "path": PurePosixPath(*relative.parts).as_posix(),
+        "sha256": _file_sha256(path),
+        "byte_count": int(path.stat().st_size),
+    }
+
+
+def _validated_source_directory(root: Path, name: str, suffix: str) -> dict[int, Path]:
+    directory = root / name
+    if directory.is_symlink() or not directory.is_dir():
+        raise ValueError(f"CUT3R output requires an ordinary {name!r} directory")
+    indexed: dict[int, Path] = {}
+    for member in sorted(directory.iterdir()):
+        if member.is_symlink() or not member.is_file():
+            raise ValueError(f"CUT3R {name!r} directory contains a non-regular member")
+        if member.suffix != suffix or len(member.stem) != 6 or not member.stem.isdigit():
+            raise ValueError(f"CUT3R {name!r} members must use six-digit {suffix} filenames")
+        index = int(member.stem)
+        if index in indexed:
+            raise ValueError(f"duplicate CUT3R frame index {index} in {name!r}")
+        indexed[index] = member
+    if not indexed:
+        raise ValueError(f"CUT3R {name!r} directory is empty")
+    if set(indexed) != set(range(len(indexed))):
+        raise ValueError(f"CUT3R {name!r} frame indices must be contiguous from zero")
+    return indexed
+
+
+def _validated_source_members(
+    root: Path,
+) -> tuple[dict[int, Path], dict[int, Path], dict[int, Path]]:
+    if root.is_symlink() or not root.is_dir():
+        raise ValueError("CUT3R output root must be an ordinary directory")
+    depth = _validated_source_directory(root, "depth", ".npy")
+    confidence = _validated_source_directory(root, "conf", ".npy")
+    camera = _validated_source_directory(root, "camera", ".npz")
+    if set(depth) != set(confidence) or set(depth) != set(camera):
+        raise ValueError("CUT3R depth, confidence, and camera frame sets disagree")
+    return depth, confidence, camera
+
+
+def _source_tree_byte_count(member_groups: Sequence[Mapping[int, Path]]) -> int:
+    total = 0
+    for members in member_groups:
+        for path in members.values():
+            try:
+                total += int(path.stat().st_size)
+            except OSError as error:
+                raise ValueError(f"cannot stat CUT3R source member {path.name!r}") from error
+    return total
+
+
+def _load_npy(
+    path: Path,
+    *,
+    label: str,
+) -> tuple[np.ndarray, _SourceMemberDescriptor]:
+    root = path.parents[1]
+    before = _file_descriptor(path, root=root)
+    try:
+        loaded = np.load(path, mmap_mode="r", allow_pickle=False)
+    except (OSError, ValueError) as error:
+        raise ValueError(f"cannot load CUT3R {label} member {path.name!r}") from error
+    if not isinstance(loaded, np.ndarray):
+        raise ValueError(f"CUT3R {label} member {path.name!r} must be one NPY array")
+    after = _file_descriptor(path, root=root)
+    if before != after:
+        raise ValueError(f"CUT3R {label} member changed while it was being read")
+    return loaded, before
+
+
+def _load_camera(
+    path: Path,
+) -> tuple[np.ndarray, np.ndarray, _SourceMemberDescriptor]:
+    root = path.parents[1]
+    before = _file_descriptor(path, root=root)
+    try:
+        with np.load(path, allow_pickle=False) as archive:
+            if set(archive.files) != {"pose", "intrinsics"}:
+                raise ValueError("camera archive fields must be exactly pose and intrinsics")
+            pose = np.asarray(archive["pose"], dtype=np.float64)
+            intrinsics = np.asarray(archive["intrinsics"], dtype=np.float64)
+    except (OSError, ValueError) as error:
+        raise ValueError(f"cannot load CUT3R camera member {path.name!r}: {error}") from error
+    after = _file_descriptor(path, root=root)
+    if before != after:
+        raise ValueError("CUT3R camera member changed while it was being read")
+    return pose, intrinsics, before
+
+
+def _verify_source_descriptors(
+    root: Path,
+    descriptors: Sequence[_SourceMemberDescriptor],
+) -> None:
+    for descriptor in descriptors:
+        relative = PurePosixPath(descriptor["path"])
+        candidate = root.joinpath(*relative.parts)
+        if _file_descriptor(candidate, root=root) != descriptor:
+            raise ValueError("CUT3R source tree changed after canonical loading")
+
+
+def _adapter_implementation_sha256() -> str:
+    """Hash the complete adapter implementation, including internal helpers."""
+
+    digest = hashlib.sha256()
+    root = Path(__file__).resolve().parent
+    for name in sorted(_ADAPTER_IMPLEMENTATION_MEMBERS):
+        path = root / name
+        digest.update(name.encode("utf-8"))
+        digest.update(b"\0")
+        try:
+            with path.open("rb") as stream:
+                for block in iter(lambda: stream.read(_MIB), b""):
+                    digest.update(block)
+        except OSError as error:
+            raise ValueError(f"cannot read CUT3R adapter implementation member {name!r}") from error
+    return digest.hexdigest()

--- a/src/prob4d/_cut3r_window.py
+++ b/src/prob4d/_cut3r_window.py
@@ -65,12 +65,8 @@ def _canonical_window(
     depth_members, confidence_members, camera_members = _validated_source_members(root)
     frame_count = len(depth_members)
     if frame_count > limits.max_frames:
-        raise ValueError(
-            f"CUT3R frame count {frame_count} exceeds max_frames={limits.max_frames}"
-        )
-    source_bytes = _source_tree_byte_count(
-        (depth_members, confidence_members, camera_members)
-    )
+        raise ValueError(f"CUT3R frame count {frame_count} exceeds max_frames={limits.max_frames}")
+    source_bytes = _source_tree_byte_count((depth_members, confidence_members, camera_members))
     if source_bytes > limits.max_source_bytes:
         raise ValueError(
             "CUT3R source tree byte count "
@@ -156,9 +152,7 @@ def _canonical_window(
                 point_writer[index] = world
                 mask_writer[index] = valid
                 any_valid = any_valid or bool(np.any(valid))
-                descriptors.extend(
-                    (depth_descriptor, confidence_descriptor, camera_descriptor)
-                )
+                descriptors.extend((depth_descriptor, confidence_descriptor, camera_descriptor))
             finally:
                 _close_memmap(depth)
                 _close_memmap(confidence)

--- a/src/prob4d/_cut3r_window.py
+++ b/src/prob4d/_cut3r_window.py
@@ -163,9 +163,9 @@ def _canonical_window(
         assert point_writer is not None
         assert mask_writer is not None
         assert frame_writer is not None
-        for writer in (point_writer, mask_writer, frame_writer):
-            writer.flush()
-            _close_memmap(writer)
+        for active_writer in (point_writer, mask_writer, frame_writer):
+            active_writer.flush()
+            _close_memmap(active_writer)
         point_writer = None
         mask_writer = None
         frame_writer = None
@@ -190,9 +190,9 @@ def _canonical_window(
         )
         yield window, tuple(descriptors), described_source_bytes, dense_bytes
     finally:
-        for writer in (point_writer, mask_writer, frame_writer):
-            if writer is not None:
-                _close_memmap(writer)
+        for pending_writer in (point_writer, mask_writer, frame_writer):
+            if pending_writer is not None:
+                _close_memmap(pending_writer)
         for value in read_only_maps:
             _close_memmap(value)
         shutil.rmtree(workspace, ignore_errors=True)

--- a/src/prob4d/_cut3r_window.py
+++ b/src/prob4d/_cut3r_window.py
@@ -1,0 +1,256 @@
+"""Bounded-memory canonical prediction windows for CUT3R imports."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path, PurePosixPath
+
+import numpy as np
+
+from ._atomic_file import publish_temporary_file
+from ._cut3r_limits import (
+    Cut3RImportLimits,
+    _dense_array_byte_count,
+    _unproject_world_points,
+    _validated_grid_shape,
+)
+from ._cut3r_source import (
+    _SourceMemberDescriptor,
+    _load_camera,
+    _load_npy,
+    _source_tree_byte_count,
+    _validated_source_members,
+)
+from .data import DenseStorageDType, PredictionWindow
+from .prediction_store import MMapPredictionWindow
+
+
+def _close_memmap(value: np.ndarray) -> None:
+    mapping = getattr(value, "_mmap", None)
+    if mapping is not None:
+        mapping.close()
+
+
+def _load_read_only_npy(path: Path, *, name: str) -> np.ndarray:
+    try:
+        loaded = np.load(path, mmap_mode="r", allow_pickle=False)
+    except (OSError, ValueError) as error:
+        raise ValueError(f"cannot reopen canonical CUT3R {name}") from error
+    if not isinstance(loaded, np.ndarray):
+        raise ValueError(f"canonical CUT3R {name} must be one NPY array")
+    return loaded
+
+
+@contextmanager
+def _canonical_window(
+    root: Path,
+    *,
+    frame_start: int,
+    window_id: str,
+    confidence_threshold: float,
+    storage_dtype: DenseStorageDType,
+    limits: Cut3RImportLimits,
+) -> Iterator[
+    tuple[
+        MMapPredictionWindow,
+        tuple[_SourceMemberDescriptor, ...],
+        int,
+        int,
+    ]
+]:
+    depth_members, confidence_members, camera_members = _validated_source_members(root)
+    frame_count = len(depth_members)
+    if frame_count > limits.max_frames:
+        raise ValueError(
+            f"CUT3R frame count {frame_count} exceeds max_frames={limits.max_frames}"
+        )
+    source_bytes = _source_tree_byte_count(
+        (depth_members, confidence_members, camera_members)
+    )
+    if source_bytes > limits.max_source_bytes:
+        raise ValueError(
+            "CUT3R source tree byte count "
+            f"{source_bytes} exceeds max_source_bytes={limits.max_source_bytes}"
+        )
+
+    workspace = Path(tempfile.mkdtemp(prefix=".prob4d-cut3r-import."))
+    point_writer: np.memmap | None = None
+    mask_writer: np.memmap | None = None
+    frame_writer: np.memmap | None = None
+    read_only_maps: list[np.ndarray] = []
+    try:
+        descriptors: list[_SourceMemberDescriptor] = []
+        shape: tuple[int, int] | None = None
+        dense_bytes = 0
+        any_valid = False
+        dense_dtype = np.float32 if storage_dtype == "float32" else np.float64
+        point_path = workspace / "point_map.npy"
+        mask_path = workspace / "valid_mask.npy"
+        frame_path = workspace / "frame_indices.npy"
+
+        for index in range(frame_count):
+            depth, depth_descriptor = _load_npy(depth_members[index], label="depth")
+            confidence, confidence_descriptor = _load_npy(
+                confidence_members[index],
+                label="confidence",
+            )
+            try:
+                frame_shape = _validated_grid_shape(
+                    depth,
+                    confidence,
+                    limits=limits,
+                    expected_shape=shape,
+                )
+                if shape is None:
+                    shape = frame_shape
+                    dense_bytes = _dense_array_byte_count(
+                        frame_count,
+                        shape[0],
+                        shape[1],
+                        storage_dtype,
+                    )
+                    if dense_bytes > limits.max_dense_bytes:
+                        raise ValueError(
+                            "CUT3R dense array byte count "
+                            f"{dense_bytes} exceeds max_dense_bytes="
+                            f"{limits.max_dense_bytes}"
+                        )
+                    point_writer = np.lib.format.open_memmap(
+                        point_path,
+                        mode="w+",
+                        dtype=dense_dtype,
+                        shape=(frame_count, shape[0], shape[1], 3),
+                    )
+                    mask_writer = np.lib.format.open_memmap(
+                        mask_path,
+                        mode="w+",
+                        dtype=bool,
+                        shape=(frame_count, shape[0], shape[1]),
+                    )
+                    frame_writer = np.lib.format.open_memmap(
+                        frame_path,
+                        mode="w+",
+                        dtype=np.int64,
+                        shape=(frame_count,),
+                    )
+                    frame_writer[:] = np.arange(
+                        frame_start,
+                        frame_start + frame_count,
+                        dtype=np.int64,
+                    )
+
+                pose, intrinsics, camera_descriptor = _load_camera(camera_members[index])
+                world, valid = _unproject_world_points(
+                    depth,
+                    confidence,
+                    pose,
+                    intrinsics,
+                    confidence_threshold=confidence_threshold,
+                )
+                assert point_writer is not None
+                assert mask_writer is not None
+                point_writer[index] = world
+                mask_writer[index] = valid
+                any_valid = any_valid or bool(np.any(valid))
+                descriptors.extend(
+                    (depth_descriptor, confidence_descriptor, camera_descriptor)
+                )
+            finally:
+                _close_memmap(depth)
+                _close_memmap(confidence)
+
+        if not any_valid:
+            raise ValueError("CUT3R output contains no point above the frozen support threshold")
+        assert shape is not None
+        assert point_writer is not None
+        assert mask_writer is not None
+        assert frame_writer is not None
+        for writer in (point_writer, mask_writer, frame_writer):
+            writer.flush()
+            _close_memmap(writer)
+        point_writer = None
+        mask_writer = None
+        frame_writer = None
+
+        described_source_bytes = sum(member["byte_count"] for member in descriptors)
+        if described_source_bytes > limits.max_source_bytes:
+            raise ValueError(
+                "CUT3R described source byte count "
+                f"{described_source_bytes} exceeds max_source_bytes={limits.max_source_bytes}"
+            )
+
+        frame_indices = _load_read_only_npy(frame_path, name="frame indices")
+        point_map = _load_read_only_npy(point_path, name="point map")
+        valid_mask = _load_read_only_npy(mask_path, name="valid mask")
+        read_only_maps.extend((frame_indices, point_map, valid_mask))
+        window = MMapPredictionWindow(
+            window_id=window_id,
+            frame_indices=frame_indices,
+            point_map=point_map,
+            valid_mask=valid_mask,
+            dense_storage_dtype=storage_dtype,
+        )
+        yield window, tuple(descriptors), described_source_bytes, dense_bytes
+    finally:
+        for writer in (point_writer, mask_writer, frame_writer):
+            if writer is not None:
+                _close_memmap(writer)
+        for value in read_only_maps:
+            _close_memmap(value)
+        shutil.rmtree(workspace, ignore_errors=True)
+
+
+def _windows_equal(first: PredictionWindow, second: PredictionWindow) -> bool:
+    return (
+        first.window_id == second.window_id
+        and first.dense_storage_dtype == second.dense_storage_dtype
+        and np.array_equal(first.frame_indices, second.frame_indices)
+        and np.array_equal(first.point_map, second.point_map)
+        and np.array_equal(first.valid_mask, second.valid_mask)
+        and first.scene_flow is None
+        and second.scene_flow is None
+        and first.ray_directions is None
+        and second.ray_directions is None
+    )
+
+
+def _write_window_atomically(path: Path, window: PredictionWindow) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.stem}.",
+        suffix=".npz",
+        dir=path.parent,
+    )
+    os.close(descriptor)
+    temporary = Path(temporary_name)
+    try:
+        window.to_npz(temporary)
+        try:
+            publish_temporary_file(temporary, path, overwrite=False)
+        except FileExistsError:
+            existing = PredictionWindow.from_npz(
+                path,
+                dense_storage_dtype=window.dense_storage_dtype,
+            )
+            if not _windows_equal(existing, window):
+                raise ValueError(
+                    f"refusing to replace different canonical CUT3R payload {path.name!r}"
+                ) from None
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _relative_member(path: Path, *, root: Path) -> str:
+    try:
+        relative = path.resolve().relative_to(root.resolve())
+    except ValueError as error:
+        raise ValueError(
+            "canonical CUT3R payload must lie inside the manifest directory"
+        ) from error
+    if any(part in {"", ".", ".."} for part in relative.parts):
+        raise ValueError("canonical CUT3R payload path is not confined")
+    return PurePosixPath(*relative.parts).as_posix()

--- a/src/prob4d/_cut3r_window.py
+++ b/src/prob4d/_cut3r_window.py
@@ -19,10 +19,10 @@ from ._cut3r_limits import (
     _validated_grid_shape,
 )
 from ._cut3r_source import (
-    _SourceMemberDescriptor,
     _load_camera,
     _load_npy,
     _source_tree_byte_count,
+    _SourceMemberDescriptor,
     _validated_source_members,
 )
 from .data import DenseStorageDType, PredictionWindow

--- a/src/prob4d/cut3r_provider_adapter.py
+++ b/src/prob4d/cut3r_provider_adapter.py
@@ -15,7 +15,7 @@ from typing import Final
 
 import numpy as np
 
-from ._cut3r_limits import Cut3RImportLimits, DEFAULT_CUT3R_IMPORT_LIMITS
+from ._cut3r_limits import DEFAULT_CUT3R_IMPORT_LIMITS, Cut3RImportLimits
 from ._cut3r_source import (
     _adapter_implementation_sha256,
     _file_sha256,

--- a/src/prob4d/cut3r_provider_adapter.py
+++ b/src/prob4d/cut3r_provider_adapter.py
@@ -8,20 +8,23 @@ are bound into the resulting provider manifest.
 
 from __future__ import annotations
 
-import argparse
 import hashlib
-import json
-import os
-import tempfile
-from collections.abc import Mapping, Sequence
-from pathlib import Path, PurePosixPath
-from typing import Any, Final, TypedDict, cast
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Final
 
 import numpy as np
 
-from ._atomic_file import publish_temporary_file
+from ._cut3r_limits import Cut3RImportLimits, DEFAULT_CUT3R_IMPORT_LIMITS
+from ._cut3r_source import (
+    _adapter_implementation_sha256,
+    _file_sha256,
+    _record_id,
+    _verify_source_descriptors,
+)
+from ._cut3r_window import _canonical_window, _relative_member, _write_window_atomically
 from ._strict_json import require_exact_integer, require_revision, require_sha256
-from .data import DENSE_STORAGE_DTYPES, DenseStorageDType, PredictionWindow
+from .data import DENSE_STORAGE_DTYPES, DenseStorageDType
 from .prediction_provider_manifest import (
     PredictionFrameLineageV1,
     PredictionPayloadDescriptorV1,
@@ -39,312 +42,6 @@ _RUN_DOMAIN: Final = "prob4d.cut3r-online-run.v1"
 _MEMBER_DOMAIN: Final = "prob4d.cut3r-online-member.v1"
 
 
-class _SourceMemberDescriptor(TypedDict):
-    """Content descriptor for one exact CUT3R output member."""
-
-    path: str
-    sha256: str
-    byte_count: int
-
-
-def _canonical_json_bytes(value: Mapping[str, Any]) -> bytes:
-    return json.dumps(
-        value,
-        sort_keys=True,
-        separators=(",", ":"),
-        allow_nan=False,
-    ).encode("utf-8")
-
-
-def _record_id(domain: str, value: Mapping[str, Any]) -> str:
-    digest = hashlib.sha256()
-    digest.update(domain.encode("utf-8"))
-    digest.update(b"\0")
-    digest.update(_canonical_json_bytes(value))
-    return digest.hexdigest()
-
-
-def _file_sha256(path: Path) -> str:
-    digest = hashlib.sha256()
-    try:
-        with path.open("rb") as stream:
-            for block in iter(lambda: stream.read(1024 * 1024), b""):
-                digest.update(block)
-    except OSError as error:
-        raise ValueError(f"cannot read CUT3R source member {path.name!r}") from error
-    return digest.hexdigest()
-
-
-def _file_descriptor(path: Path, *, root: Path) -> _SourceMemberDescriptor:
-    if path.is_symlink() or not path.is_file():
-        raise ValueError(f"CUT3R source member {path.name!r} must be an ordinary file")
-    try:
-        relative = path.resolve().relative_to(root.resolve())
-    except ValueError as error:
-        raise ValueError("CUT3R source member escapes the declared output root") from error
-    return {
-        "path": PurePosixPath(*relative.parts).as_posix(),
-        "sha256": _file_sha256(path),
-        "byte_count": int(path.stat().st_size),
-    }
-
-
-def _validated_source_directory(root: Path, name: str, suffix: str) -> dict[int, Path]:
-    directory = root / name
-    if directory.is_symlink() or not directory.is_dir():
-        raise ValueError(f"CUT3R output requires an ordinary {name!r} directory")
-    indexed: dict[int, Path] = {}
-    for member in sorted(directory.iterdir()):
-        if member.is_symlink() or not member.is_file():
-            raise ValueError(f"CUT3R {name!r} directory contains a non-regular member")
-        if member.suffix != suffix or len(member.stem) != 6 or not member.stem.isdigit():
-            raise ValueError(f"CUT3R {name!r} members must use six-digit {suffix} filenames")
-        index = int(member.stem)
-        if index in indexed:
-            raise ValueError(f"duplicate CUT3R frame index {index} in {name!r}")
-        indexed[index] = member
-    if not indexed:
-        raise ValueError(f"CUT3R {name!r} directory is empty")
-    if set(indexed) != set(range(len(indexed))):
-        raise ValueError(f"CUT3R {name!r} frame indices must be contiguous from zero")
-    return indexed
-
-
-def _validated_source_members(
-    root: Path,
-) -> tuple[dict[int, Path], dict[int, Path], dict[int, Path]]:
-    if root.is_symlink() or not root.is_dir():
-        raise ValueError("CUT3R output root must be an ordinary directory")
-    depth = _validated_source_directory(root, "depth", ".npy")
-    confidence = _validated_source_directory(root, "conf", ".npy")
-    camera = _validated_source_directory(root, "camera", ".npz")
-    if set(depth) != set(confidence) or set(depth) != set(camera):
-        raise ValueError("CUT3R depth, confidence, and camera frame sets disagree")
-    return depth, confidence, camera
-
-
-def _load_npy(
-    path: Path,
-    *,
-    label: str,
-) -> tuple[np.ndarray, _SourceMemberDescriptor]:
-    root = path.parents[1]
-    before = _file_descriptor(path, root=root)
-    try:
-        value = np.load(path, allow_pickle=False)
-    except (OSError, ValueError) as error:
-        raise ValueError(f"cannot load CUT3R {label} member {path.name!r}") from error
-    after = _file_descriptor(path, root=root)
-    if before != after:
-        raise ValueError(f"CUT3R {label} member changed while it was being read")
-    return np.asarray(value), before
-
-
-def _load_camera(
-    path: Path,
-) -> tuple[np.ndarray, np.ndarray, _SourceMemberDescriptor]:
-    root = path.parents[1]
-    before = _file_descriptor(path, root=root)
-    try:
-        with np.load(path, allow_pickle=False) as archive:
-            if set(archive.files) != {"pose", "intrinsics"}:
-                raise ValueError("camera archive fields must be exactly pose and intrinsics")
-            pose = np.asarray(archive["pose"], dtype=np.float64)
-            intrinsics = np.asarray(archive["intrinsics"], dtype=np.float64)
-    except (OSError, ValueError) as error:
-        raise ValueError(f"cannot load CUT3R camera member {path.name!r}: {error}") from error
-    after = _file_descriptor(path, root=root)
-    if before != after:
-        raise ValueError("CUT3R camera member changed while it was being read")
-    return pose, intrinsics, before
-
-
-def _validate_camera(pose: np.ndarray, intrinsics: np.ndarray) -> None:
-    if pose.shape != (4, 4):
-        raise ValueError("CUT3R camera pose must have shape (4, 4)")
-    if intrinsics.shape != (3, 3):
-        raise ValueError("CUT3R camera intrinsics must have shape (3, 3)")
-    if not np.all(np.isfinite(pose)) or not np.all(np.isfinite(intrinsics)):
-        raise ValueError("CUT3R camera pose and intrinsics must be finite")
-    if not np.allclose(pose[3], np.asarray([0.0, 0.0, 0.0, 1.0]), atol=1e-7):
-        raise ValueError("CUT3R camera pose must be a homogeneous rigid transform")
-    rotation = pose[:3, :3]
-    if not np.allclose(rotation.T @ rotation, np.eye(3), atol=1e-6, rtol=1e-6):
-        raise ValueError("CUT3R camera rotation must be orthonormal")
-    if not np.isclose(np.linalg.det(rotation), 1.0, atol=1e-6, rtol=1e-6):
-        raise ValueError("CUT3R camera rotation must be proper")
-    if not np.allclose(intrinsics[2], np.asarray([0.0, 0.0, 1.0]), atol=1e-7):
-        raise ValueError("CUT3R camera intrinsics must use the standard final row")
-    if intrinsics[0, 0] <= 0.0 or intrinsics[1, 1] <= 0.0:
-        raise ValueError("CUT3R focal lengths must be strictly positive")
-
-
-def _unproject_world_points(
-    depth: np.ndarray,
-    confidence: np.ndarray,
-    pose: np.ndarray,
-    intrinsics: np.ndarray,
-    *,
-    confidence_threshold: float,
-) -> tuple[np.ndarray, np.ndarray]:
-    if depth.ndim != 2:
-        raise ValueError("CUT3R depth members must have shape (H, W)")
-    if confidence.shape != depth.shape:
-        raise ValueError("CUT3R confidence must match the depth grid")
-    if depth.dtype.kind not in {"f", "i", "u"} or confidence.dtype.kind not in {
-        "f",
-        "i",
-        "u",
-    }:
-        raise ValueError("CUT3R depth and confidence must be real numeric arrays")
-    _validate_camera(pose, intrinsics)
-
-    depth64 = np.asarray(depth, dtype=np.float64)
-    confidence64 = np.asarray(confidence, dtype=np.float64)
-    valid = (
-        np.isfinite(depth64)
-        & np.isfinite(confidence64)
-        & (depth64 > 0.0)
-        & (confidence64 >= confidence_threshold)
-    )
-
-    height, width = depth64.shape
-    rows, columns = np.indices((height, width), dtype=np.float64)
-    homogeneous_pixels = np.stack(
-        (columns, rows, np.ones((height, width), dtype=np.float64)),
-        axis=-1,
-    )
-    camera_rays = np.linalg.solve(
-        intrinsics,
-        homogeneous_pixels.reshape(-1, 3).T,
-    ).T.reshape(height, width, 3)
-    camera_points = camera_rays * depth64[..., None]
-    world = np.einsum("ij,hwj->hwi", pose[:3, :3], camera_points) + pose[:3, 3]
-    valid &= np.all(np.isfinite(world), axis=-1)
-    world[~valid] = 0.0
-    return world, valid
-
-
-def _verify_source_descriptors(
-    root: Path,
-    descriptors: Sequence[_SourceMemberDescriptor],
-) -> None:
-    for descriptor in descriptors:
-        relative = PurePosixPath(descriptor["path"])
-        candidate = root.joinpath(*relative.parts)
-        if _file_descriptor(candidate, root=root) != descriptor:
-            raise ValueError("CUT3R source tree changed after canonical loading")
-
-
-def _canonical_window(
-    root: Path,
-    *,
-    frame_start: int,
-    window_id: str,
-    confidence_threshold: float,
-    storage_dtype: DenseStorageDType,
-) -> tuple[PredictionWindow, tuple[_SourceMemberDescriptor, ...]]:
-    depth_members, confidence_members, camera_members = _validated_source_members(root)
-    points: list[np.ndarray] = []
-    masks: list[np.ndarray] = []
-    descriptors: list[_SourceMemberDescriptor] = []
-    shape: tuple[int, int] | None = None
-    for index in range(len(depth_members)):
-        depth, depth_descriptor = _load_npy(depth_members[index], label="depth")
-        confidence, confidence_descriptor = _load_npy(
-            confidence_members[index],
-            label="confidence",
-        )
-        pose, intrinsics, camera_descriptor = _load_camera(camera_members[index])
-        world, valid = _unproject_world_points(
-            depth,
-            confidence,
-            pose,
-            intrinsics,
-            confidence_threshold=confidence_threshold,
-        )
-        if shape is None:
-            shape = valid.shape
-        elif valid.shape != shape:
-            raise ValueError("CUT3R frames must share one spatial prediction grid")
-        points.append(world)
-        masks.append(valid)
-        descriptors.extend((depth_descriptor, confidence_descriptor, camera_descriptor))
-
-    valid_stack = np.stack(masks, axis=0)
-    if not np.any(valid_stack):
-        raise ValueError("CUT3R output contains no point above the frozen support threshold")
-    dense_dtype = np.float32 if storage_dtype == "float32" else np.float64
-    point_stack = np.asarray(np.stack(points, axis=0), dtype=dense_dtype)
-    frame_count = point_stack.shape[0]
-    return (
-        PredictionWindow(
-            window_id=window_id,
-            frame_indices=np.arange(
-                frame_start,
-                frame_start + frame_count,
-                dtype=np.int64,
-            ),
-            point_map=point_stack,
-            valid_mask=valid_stack,
-            dense_storage_dtype=storage_dtype,
-        ),
-        tuple(descriptors),
-    )
-
-
-def _windows_equal(first: PredictionWindow, second: PredictionWindow) -> bool:
-    return (
-        first.window_id == second.window_id
-        and first.dense_storage_dtype == second.dense_storage_dtype
-        and np.array_equal(first.frame_indices, second.frame_indices)
-        and np.array_equal(first.point_map, second.point_map)
-        and np.array_equal(first.valid_mask, second.valid_mask)
-        and first.scene_flow is None
-        and second.scene_flow is None
-        and first.ray_directions is None
-        and second.ray_directions is None
-    )
-
-
-def _write_window_atomically(path: Path, window: PredictionWindow) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    descriptor, temporary_name = tempfile.mkstemp(
-        prefix=f".{path.stem}.",
-        suffix=".npz",
-        dir=path.parent,
-    )
-    os.close(descriptor)
-    temporary = Path(temporary_name)
-    try:
-        window.to_npz(temporary)
-        try:
-            publish_temporary_file(temporary, path, overwrite=False)
-        except FileExistsError:
-            existing = PredictionWindow.from_npz(
-                path,
-                dense_storage_dtype=window.dense_storage_dtype,
-            )
-            if not _windows_equal(existing, window):
-                raise ValueError(
-                    f"refusing to replace different canonical CUT3R payload {path.name!r}"
-                ) from None
-    finally:
-        temporary.unlink(missing_ok=True)
-
-
-def _relative_member(path: Path, *, root: Path) -> str:
-    try:
-        relative = path.resolve().relative_to(root.resolve())
-    except ValueError as error:
-        raise ValueError(
-            "canonical CUT3R payload must lie inside the manifest directory"
-        ) from error
-    if any(part in {"", ".", ".."} for part in relative.parts):
-        raise ValueError("canonical CUT3R payload path is not confined")
-    return PurePosixPath(*relative.parts).as_posix()
-
-
 def import_cut3r_online_prediction_manifest(
     source_root: str | Path,
     output_manifest_path: str | Path,
@@ -359,6 +56,7 @@ def import_cut3r_online_prediction_manifest(
     window_id: str = "cut3r-online",
     confidence_threshold: float = 1.5,
     storage_dtype: DenseStorageDType = "float32",
+    limits: Cut3RImportLimits | None = None,
 ) -> PredictionProviderManifestV1:
     """Import one exact recurrent-online CUT3R output tree.
 
@@ -390,185 +88,148 @@ def import_cut3r_online_prediction_manifest(
     threshold = float(confidence_threshold)
     if not np.isfinite(threshold) or threshold < 0.0:
         raise ValueError("confidence_threshold must be finite and non-negative")
+    effective_limits = DEFAULT_CUT3R_IMPORT_LIMITS if limits is None else limits
+    if not isinstance(effective_limits, Cut3RImportLimits):
+        raise TypeError("limits must be a Cut3RImportLimits instance")
 
     source = Path(source_root)
-    window, source_members = _canonical_window(
+    output_path = Path(output_manifest_path)
+    manifest_root = output_path.parent.resolve()
+    sequence_token = hashlib.sha256(sequence_id.encode("utf-8")).hexdigest()[:16]
+    payload_path = manifest_root / "payloads" / f"{sequence_token}-cut3r-online.npz"
+
+    with _canonical_window(
         source,
         frame_start=start,
         window_id=window_id,
         confidence_threshold=threshold,
         storage_dtype=storage_dtype,
-    )
-    _verify_source_descriptors(source, source_members)
+        limits=effective_limits,
+    ) as (window, source_members, source_member_bytes, dense_array_bytes):
+        _verify_source_descriptors(source, source_members)
 
-    loader_id = _file_sha256(Path(__file__).resolve())
-    model_set_id = _record_id(
-        _MODEL_SET_DOMAIN,
-        {
-            "official_repository": CUT3R_OFFICIAL_REPOSITORY,
-            "cut3r_revision": revision,
-            "checkpoint_sha256": checkpoint,
-        },
-    )
-    source_bundle_id = _record_id(
-        _SOURCE_BUNDLE_DOMAIN,
-        {
-            "layout": CUT3R_ONLINE_SOURCE_LAYOUT,
-            "members": list(source_members),
-        },
-    )
-    provider_run_id = _record_id(
-        _RUN_DOMAIN,
-        {
-            "model_set_id": model_set_id,
-            "loader_id": loader_id,
-            "source_bundle_id": source_bundle_id,
-            "input_video_sha256": video_sha256,
-            "input_video_byte_count": video_bytes,
-            "frame_start": start,
-            "frame_count": int(window.shape[0]),
-            "confidence_threshold": threshold,
-            "execution_mode": "recurrent-online",
-            "revisit_count": 1,
-            "global_alignment": False,
-        },
-    )
-    stochastic_member_id = _record_id(
-        _MEMBER_DOMAIN,
-        {
-            "model_set_id": model_set_id,
-            "provider_run_id": provider_run_id,
-        },
-    )
+        loader_id = _adapter_implementation_sha256()
+        model_set_id = _record_id(
+            _MODEL_SET_DOMAIN,
+            {
+                "official_repository": CUT3R_OFFICIAL_REPOSITORY,
+                "cut3r_revision": revision,
+                "checkpoint_sha256": checkpoint,
+            },
+        )
+        source_bundle_id = _record_id(
+            _SOURCE_BUNDLE_DOMAIN,
+            {
+                "layout": CUT3R_ONLINE_SOURCE_LAYOUT,
+                "members": list(source_members),
+            },
+        )
+        provider_run_id = _record_id(
+            _RUN_DOMAIN,
+            {
+                "model_set_id": model_set_id,
+                "loader_id": loader_id,
+                "source_bundle_id": source_bundle_id,
+                "input_video_sha256": video_sha256,
+                "input_video_byte_count": video_bytes,
+                "frame_start": start,
+                "frame_count": int(window.shape[0]),
+                "confidence_threshold": threshold,
+                "execution_mode": "recurrent-online",
+                "revisit_count": 1,
+                "global_alignment": False,
+            },
+        )
+        stochastic_member_id = _record_id(
+            _MEMBER_DOMAIN,
+            {
+                "model_set_id": model_set_id,
+                "provider_run_id": provider_run_id,
+            },
+        )
 
-    output_path = Path(output_manifest_path)
-    manifest_root = output_path.parent.resolve()
-    sequence_token = hashlib.sha256(sequence_id.encode("utf-8")).hexdigest()[:16]
-    payload_path = manifest_root / "payloads" / f"{sequence_token}-cut3r-online.npz"
-    _write_window_atomically(payload_path, window)
-    payload = PredictionPayloadDescriptorV1(
-        product_role="external-sequence",
-        window_id=window.window_id,
-        path=_relative_member(payload_path, root=manifest_root),
-        sha256=_file_sha256(payload_path),
-        byte_count=int(payload_path.stat().st_size),
-        view_id=view_id,
-        stochastic_member_id=stochastic_member_id,
-        dependence_group_ids=(
-            f"input-video:{video_sha256}",
-            f"model-set:{model_set_id}",
-            f"provider-run:{provider_run_id}",
-        ),
-        dense_storage_dtype=storage_dtype,
-        has_scene_flow=False,
-        has_ray_directions=False,
-        frame_lineage=tuple(
-            PredictionFrameLineageV1(
-                output_frame_id=int(frame_id),
-                source_frame_start=start,
-                source_frame_stop_exclusive=int(frame_id) + 1,
-                contributor_ids=(provider_run_id,),
-            )
-            for frame_id in window.frame_indices
-        ),
-    )
-    manifest = PredictionProviderManifestV1(
-        sequence_id=sequence_id,
-        provider_family="CUT3R-online",
-        provider_repository=CUT3R_OFFICIAL_REPOSITORY,
-        provider_revision=revision,
-        provider_run_id=provider_run_id,
-        model_set_id=model_set_id,
-        loader_id=loader_id,
-        coordinate_semantics="sequence-local-sim3",
-        point_semantics="dense-point-map",
-        flow_semantics="absent",
-        ray_semantics="absent",
-        payloads=(payload,),
-        metadata={
-            "source_adapter": _ADAPTER_DOMAIN,
-            "source_adapter_sha256": loader_id,
-            "source_layout": CUT3R_ONLINE_SOURCE_LAYOUT,
-            "source_bundle_id": source_bundle_id,
-            "source_member_count": len(source_members),
-            "source_member_total_bytes": sum(member["byte_count"] for member in source_members),
-            "input_video_sha256": video_sha256,
-            "input_video_byte_count": video_bytes,
-            "checkpoint_sha256": checkpoint,
-            "execution_mode": "recurrent-online",
-            "online_prefix_only": True,
-            "revisit_count": 1,
-            "global_alignment": False,
-            "confidence_threshold": threshold,
-            "confidence_is_support_not_reliability": True,
-            "metric_scale_claimed": False,
-            "uses_truth": False,
-            "uses_downstream_physical_innovation": False,
-        },
-    )
-    save_prediction_provider_manifest(output_path, manifest)
-    verify_prediction_provider_manifest(output_path)
-    return manifest
-
-
-def _build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
-        prog="prob4d prediction import-cut3r-online",
-        description=(
-            "convert official recurrent-online CUT3R depth/conf/camera outputs "
-            "into a provider-neutral prediction manifest"
-        ),
-    )
-    parser.add_argument("source_root")
-    parser.add_argument("output")
-    parser.add_argument("--sequence-id", required=True)
-    parser.add_argument("--cut3r-revision", required=True)
-    parser.add_argument("--checkpoint-sha256", required=True)
-    parser.add_argument("--input-video-sha256", required=True)
-    parser.add_argument("--input-video-byte-count", type=int, required=True)
-    parser.add_argument("--frame-start", type=int, default=0)
-    parser.add_argument("--view-id", default="camera-0")
-    parser.add_argument("--window-id", default="cut3r-online")
-    parser.add_argument("--confidence-threshold", type=float, default=1.5)
-    parser.add_argument(
-        "--storage-dtype",
-        choices=DENSE_STORAGE_DTYPES,
-        default="float32",
-    )
-    return parser
+        _write_window_atomically(payload_path, window)
+        payload = PredictionPayloadDescriptorV1(
+            product_role="external-sequence",
+            window_id=window.window_id,
+            path=_relative_member(payload_path, root=manifest_root),
+            sha256=_file_sha256(payload_path),
+            byte_count=int(payload_path.stat().st_size),
+            view_id=view_id,
+            stochastic_member_id=stochastic_member_id,
+            dependence_group_ids=(
+                f"input-video:{video_sha256}",
+                f"model-set:{model_set_id}",
+                f"provider-run:{provider_run_id}",
+            ),
+            dense_storage_dtype=storage_dtype,
+            has_scene_flow=False,
+            has_ray_directions=False,
+            frame_lineage=tuple(
+                PredictionFrameLineageV1(
+                    output_frame_id=int(frame_id),
+                    source_frame_start=start,
+                    source_frame_stop_exclusive=int(frame_id) + 1,
+                    contributor_ids=(provider_run_id,),
+                )
+                for frame_id in window.frame_indices
+            ),
+        )
+        manifest = PredictionProviderManifestV1(
+            sequence_id=sequence_id,
+            provider_family="CUT3R-online",
+            provider_repository=CUT3R_OFFICIAL_REPOSITORY,
+            provider_revision=revision,
+            provider_run_id=provider_run_id,
+            model_set_id=model_set_id,
+            loader_id=loader_id,
+            coordinate_semantics="sequence-local-sim3",
+            point_semantics="dense-point-map",
+            flow_semantics="absent",
+            ray_semantics="absent",
+            payloads=(payload,),
+            metadata={
+                "source_adapter": _ADAPTER_DOMAIN,
+                "source_adapter_sha256": loader_id,
+                "source_layout": CUT3R_ONLINE_SOURCE_LAYOUT,
+                "source_bundle_id": source_bundle_id,
+                "source_member_count": len(source_members),
+                "source_member_total_bytes": source_member_bytes,
+                "dense_array_byte_count": dense_array_bytes,
+                "canonicalization_backend": "frame-streamed-npy-memmap-v1",
+                "sequence_wide_dense_stack_avoided": True,
+                "input_video_sha256": video_sha256,
+                "input_video_byte_count": video_bytes,
+                "checkpoint_sha256": checkpoint,
+                "execution_mode": "recurrent-online",
+                "online_prefix_only": True,
+                "revisit_count": 1,
+                "global_alignment": False,
+                "confidence_threshold": threshold,
+                "confidence_is_support_not_reliability": True,
+                "metric_scale_claimed": False,
+                "uses_truth": False,
+                "uses_downstream_physical_innovation": False,
+            },
+        )
+        save_prediction_provider_manifest(output_path, manifest)
+        verify_prediction_provider_manifest(output_path)
+        return manifest
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    arguments = _build_parser().parse_args(list(argv) if argv is not None else None)
-    manifest = import_cut3r_online_prediction_manifest(
-        arguments.source_root,
-        arguments.output,
-        sequence_id=arguments.sequence_id,
-        cut3r_revision=arguments.cut3r_revision,
-        checkpoint_sha256=arguments.checkpoint_sha256,
-        input_video_sha256=arguments.input_video_sha256,
-        input_video_byte_count=arguments.input_video_byte_count,
-        frame_start=arguments.frame_start,
-        view_id=arguments.view_id,
-        window_id=arguments.window_id,
-        confidence_threshold=arguments.confidence_threshold,
-        storage_dtype=cast(DenseStorageDType, arguments.storage_dtype),
-    )
-    _, report = verify_prediction_provider_manifest(arguments.output)
-    output: dict[str, Any] = {
-        **manifest.summary(),
-        "verified_payload_count": report["verified_payload_count"],
-        "execution_mode": "recurrent-online",
-        "online_prefix_only": True,
-        "global_alignment": False,
-    }
-    print(json.dumps(output, indent=2, sort_keys=True))
-    return 0
+    """Dispatch the grouped CUT3R import command without eager CLI imports."""
+
+    from ._cut3r_cli import main as cli_main
+
+    return cli_main(argv)
 
 
 __all__ = [
     "CUT3R_OFFICIAL_REPOSITORY",
     "CUT3R_ONLINE_SOURCE_LAYOUT",
+    "Cut3RImportLimits",
+    "DEFAULT_CUT3R_IMPORT_LIMITS",
     "import_cut3r_online_prediction_manifest",
     "main",
 ]

--- a/tests/test_cut3r_provider_adapter.py
+++ b/tests/test_cut3r_provider_adapter.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import pytest
 
-from prob4d.cut3r_provider_adapter import import_cut3r_online_prediction_manifest
+from prob4d.cut3r_provider_adapter import (
+    Cut3RImportLimits,
+    import_cut3r_online_prediction_manifest,
+    main as cut3r_main,
+)
 from prob4d.data import PredictionWindow
 from prob4d.prediction_provider_manifest import (
     load_prediction_provider_manifest,
@@ -73,6 +78,10 @@ def test_import_builds_world_points_and_prefix_lineage(tmp_path: Path) -> None:
     assert manifest.coordinate_semantics == "sequence-local-sim3"
     assert manifest.metadata["execution_mode"] == "recurrent-online"
     assert manifest.metadata["metric_scale_claimed"] is False
+    assert manifest.metadata["canonicalization_backend"] == "frame-streamed-npy-memmap-v1"
+    assert manifest.metadata["sequence_wide_dense_stack_avoided"] is True
+    assert manifest.metadata["dense_array_byte_count"] == 120
+    assert manifest.metadata["source_adapter_sha256"] == manifest.loader_id
     assert len(manifest.payloads) == 1
     payload = manifest.payloads[0]
     assert payload.output_frame_ids == (10, 11)
@@ -102,6 +111,42 @@ def test_import_builds_world_points_and_prefix_lineage(tmp_path: Path) -> None:
         expected_first + np.asarray([1.0, 0.0, 0.0]),
     )
     assert np.all(window.point_map[~window.valid_mask] == 0.0)
+
+
+def test_import_streams_without_sequence_wide_vector_stack(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "cut3r"
+    _write_frame(source, 0)
+    _write_frame(source, 1)
+    real_stack = np.stack
+
+    def bounded_stack(arrays: Any, *args: Any, **kwargs: Any) -> np.ndarray:
+        materialized = tuple(arrays)
+        if materialized and np.asarray(materialized[0]).ndim == 3:
+            raise AssertionError("sequence-wide vector stacking is forbidden")
+        return real_stack(materialized, *args, **kwargs)
+
+    monkeypatch.setattr(
+        "prob4d._cut3r_limits.np.stack",
+        bounded_stack,
+    )
+
+    manifest = _import(source, tmp_path / "bundle/provider.json")
+
+    assert manifest.metadata["sequence_wide_dense_stack_avoided"] is True
+
+
+def test_cli_help_exposes_resource_limits(capsys: pytest.CaptureFixture[str]) -> None:
+    with pytest.raises(SystemExit) as exit_info:
+        cut3r_main(["--help"])
+
+    assert exit_info.value.code == 0
+    output = capsys.readouterr().out
+    assert "--max-frames" in output
+    assert "--max-source-bytes" in output
+    assert "--max-dense-bytes" in output
 
 
 def test_identical_import_is_idempotent(tmp_path: Path) -> None:
@@ -147,6 +192,18 @@ def test_import_rejects_nonrigid_camera(tmp_path: Path) -> None:
         _import(source, tmp_path / "bundle/provider.json")
 
 
+def test_import_rejects_singular_intrinsics(tmp_path: Path) -> None:
+    source = tmp_path / "cut3r"
+    intrinsics = np.asarray(
+        [[1.0, 1.0, 0.0], [1.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+        dtype=np.float64,
+    )
+    _write_frame(source, 0, intrinsics=intrinsics)
+
+    with pytest.raises(ValueError, match="nonsingular"):
+        _import(source, tmp_path / "bundle/provider.json")
+
+
 def test_import_rejects_empty_selected_support(tmp_path: Path) -> None:
     source = tmp_path / "cut3r"
     _write_frame(
@@ -169,3 +226,57 @@ def test_import_rejects_boolean_threshold(tmp_path: Path) -> None:
             tmp_path / "bundle/provider.json",
             confidence_threshold=True,
         )
+
+
+def test_import_rejects_frame_count_above_limit(tmp_path: Path) -> None:
+    source = tmp_path / "cut3r"
+    _write_frame(source, 0)
+    _write_frame(source, 1)
+
+    with pytest.raises(ValueError, match="frame count 2 exceeds max_frames=1"):
+        _import(
+            source,
+            tmp_path / "bundle/provider.json",
+            limits=Cut3RImportLimits(max_frames=1),
+        )
+
+
+def test_import_rejects_spatial_grid_above_limit(tmp_path: Path) -> None:
+    source = tmp_path / "cut3r"
+    _write_frame(source, 0)
+
+    with pytest.raises(ValueError, match="height 2 exceeds max_height=1"):
+        _import(
+            source,
+            tmp_path / "bundle/provider.json",
+            limits=Cut3RImportLimits(max_height=1),
+        )
+
+
+def test_import_rejects_source_tree_above_byte_limit(tmp_path: Path) -> None:
+    source = tmp_path / "cut3r"
+    _write_frame(source, 0)
+
+    with pytest.raises(ValueError, match="source tree byte count .* max_source_bytes=1"):
+        _import(
+            source,
+            tmp_path / "bundle/provider.json",
+            limits=Cut3RImportLimits(max_source_bytes=1),
+        )
+
+
+def test_import_rejects_dense_arrays_above_byte_limit(tmp_path: Path) -> None:
+    source = tmp_path / "cut3r"
+    _write_frame(source, 0)
+
+    with pytest.raises(ValueError, match="dense array byte count .* max_dense_bytes=1"):
+        _import(
+            source,
+            tmp_path / "bundle/provider.json",
+            limits=Cut3RImportLimits(max_dense_bytes=1),
+        )
+
+
+def test_import_limits_reject_booleans() -> None:
+    with pytest.raises(ValueError, match="max_frames must be an integer"):
+        Cut3RImportLimits(max_frames=True)

--- a/tests/test_cut3r_provider_adapter.py
+++ b/tests/test_cut3r_provider_adapter.py
@@ -9,8 +9,8 @@ import pytest
 from prob4d.cut3r_provider_adapter import (
     Cut3RImportLimits,
     import_cut3r_online_prediction_manifest,
-    main as cut3r_main,
 )
+from prob4d.cut3r_provider_adapter import main as cut3r_main
 from prob4d.data import PredictionWindow
 from prob4d.prediction_provider_manifest import (
     load_prediction_provider_manifest,


### PR DESCRIPTION
## Superseded

Closed in favor of #245, which contains the same CI diagnostics change on a clean branch with exactly one changed workflow file. This avoids the misleading diff caused by reusing the squash-merged CUT3R branch from #240.

## What changed

Split the generic provider-import contract job into explicit lint, formatting, type-check, test, and compile steps. The formatting step now uses `ruff format --check --diff`, so any future formatting failure exposes the exact patch in the Actions log instead of only listing affected files.

## Why

The CUT3R bounded-import PR exposed that the bundled validation step made a simple formatter failure unnecessarily hard to localize. Separate steps improve failure attribution without changing any runtime, provider, statistical, or scientific contract.

## Scope

Workflow-only change. No production code or evidence thresholds are modified.