### PR TITLE
Improve provider-import CI diagnostics

### DIFF
--- a/.github/workflows/generic-provider-import.yml
+++ b/.github/workflows/generic-provider-import.yml
@@ -57,7 +57,7 @@ jobs:
           python -m pip install -e ".[dev]" "numpy>=1.24,<2.3"
           python -m pip check
 
-      - name: Validate source and focused contracts
+      - name: Lint focused provider-import sources
         run: |
           python -m ruff check \
             scripts/ci/check_sdist.py \
@@ -73,7 +73,10 @@ jobs:
             tests/test_cut3r_provider_adapter.py \
             tests/test_prediction_provider_import.py \
             tests/test_prediction_provider_scaffold.py
-          python -m ruff format --check \
+
+      - name: Check focused provider-import formatting
+        run: |
+          python -m ruff format --check --diff \
             scripts/ci/check_sdist.py \
             src/prob4d/_cut3r_cli.py \
             src/prob4d/_cut3r_limits.py \
@@ -87,6 +90,9 @@ jobs:
             tests/test_cut3r_provider_adapter.py \
             tests/test_prediction_provider_import.py \
             tests/test_prediction_provider_scaffold.py
+
+      - name: Type-check focused provider-import sources
+        run: |
           python -m mypy \
             src/prob4d/_cut3r_cli.py \
             src/prob4d/_cut3r_limits.py \
@@ -95,6 +101,9 @@ jobs:
             src/prob4d/cut3r_provider_adapter.py \
             src/prob4d/prediction_provider_import.py \
             src/prob4d/prediction_provider_scaffold.py
+
+      - name: Run focused provider-import contracts
+        run: |
           python -m pytest -q \
             tests/test_cli.py \
             tests/test_cut3r_provider_adapter.py \
@@ -103,6 +112,9 @@ jobs:
             tests/test_prediction_provider_scaffold.py \
             tests/test_data.py \
             tests/test_data_storage.py
+
+      - name: Compile focused provider-import sources
+        run: |
           python -m compileall -q src/prob4d
           python -m py_compile scripts/ci/check_sdist.py
 


### PR DESCRIPTION
## What changed

Split the generic provider-import contract job into explicit lint, formatting, type-check, test, and compile steps. The formatting step now uses `ruff format --check --diff`, so future formatting failures expose the exact patch in the Actions log instead of only listing affected files.

## Why

The CUT3R bounded-import work exposed that a bundled validation step made a simple formatter failure unnecessarily hard to localize. Separate steps improve failure attribution without changing runtime, provider, statistical, or scientific contracts.

## Scope

Exactly one workflow file is changed. This clean PR replaces #244, whose reused squash-merged branch made the displayed diff include already-merged CUT3R files.