### PR TITLE
Add group-aware pathwise uncertainty calibration

### DIFF
--- a/CHANGELOG.d/group-aware-pathwise-calibration.md
+++ b/CHANGELOG.d/group-aware-pathwise-calibration.md
@@ -1,0 +1,7 @@
+Add source-only pathwise maximum calibration that counts complete physical
+objects or acquisition sessions as the independent units. The immutable
+calibration record binds the full trajectory-to-group assignment, conformal rank
+uses only distinct groups, target diagnostics are equal-weighted by group, and
+overlapping calibration/target group IDs are rejected. Track count cannot inflate
+finite-sample coverage claims. This does not promote a provider or open target
+data.

--- a/docs/observation-covariance-queries.md
+++ b/docs/observation-covariance-queries.md
@@ -50,17 +50,66 @@ The `component` argument can select `"conditional"`, `"gauge"`, or
 certificate: downstream code can hold the observation mean and physical query
 fixed while changing only the admitted uncertainty representation.
 
-## Ownership and evidence boundary
+## Group-aware pathwise calibration
 
-Prob4D supplies generic observation-space moments and matrix-free projections.
-BayesianPhysTwin owns the physical residual or query Jacobian, update guard, and
-exact physical fallback. Causal4D consumes the accepted BayesianPhysTwin belief
-and owns intervention contrasts.
+Marginal 95% point coverage does not imply that every admitted trajectory from a
+physical object or acquisition session is covered jointly. The first array axis
+may still enumerate material-point trajectories, but trajectories are not
+independent calibration units. Every trajectory must therefore be assigned to a
+complete, frozen object or session group:
 
-These functions propagate an already admitted covariance representation. They
-do not calibrate uncertainty, define simultaneous trajectory coverage, select
-exchangeability units, promote a provider, or establish physical or causal
-benefit. Any future finite-sample calibration must preserve complete physical
-objects or acquisition sessions as the independent calibration and evaluation
-units; tracks, points, frames, views, and taxels must not be counted as
-independent replicates.
+```python
+from prob4d.api.v2 import (
+    fit_pathwise_maximum_calibration,
+    pathwise_uncertainty_diagnostics,
+)
+
+calibration = fit_pathwise_maximum_calibration(
+    calibration_residuals,       # (P_cal, T, 3)
+    calibration_covariances,     # (P_cal, T, 3, 3)
+    group_ids=calibration_group_ids,  # one object/session ID per trajectory
+    independent_unit="physical-object",
+    valid_mask=calibration_valid,
+    miscoverage=0.05,
+)
+
+diagnostics = pathwise_uncertainty_diagnostics(
+    target_residuals,
+    target_covariances,
+    group_ids=target_group_ids,
+    independent_unit="physical-object",
+    valid_mask=target_valid,
+    calibration=calibration,
+)
+```
+
+`independent_unit` must be either `"physical-object"` or
+`"acquisition-session"`. IDs must be stable, opaque identifiers from the frozen
+cohort lock, not track IDs and not labels derived after outcomes are opened. The
+calibration artifact stores the complete trajectory-to-group assignment and its
+SHA-256 digest. Target evaluation rejects any group ID that also appears in the
+calibration artifact.
+
+For each independent group, the calibration statistic is the maximum squared
+Mahalanobis error over every admitted trajectory and valid step in that group.
+The split-conformal rank is computed from the number of distinct groups. Adding
+more tracks from an existing object or session cannot increase the finite-sample
+sample size. At 5% miscoverage, at least 19 independent groups are required for a
+finite threshold.
+
+Target coverage, maximum-error quantiles, valid-support fractions, and Gaussian
+score use equal group weighting. Fields describing longest failure or unsupported
+runs remain explicitly per-trajectory diagnostics. `all_groups_inside_marginal_*`
+uses a pointwise chi-squared threshold throughout each group and remains a
+diagnostic rather than a simultaneous confidence statement. A calibrated
+simultaneous group-coverage result is emitted only when an independently fitted
+`PathwiseMaximumCalibrationV1` is supplied.
+
+## Ownership boundary
+
+Prob4D supplies generic observation-space moments, matrix-free projections, and
+group-aware source/calibration diagnostics. BayesianPhysTwin owns the physical
+residual or query Jacobian, update guard, and exact physical fallback. Causal4D
+consumes the accepted BayesianPhysTwin belief and owns intervention contrasts.
+These APIs do not by themselves establish provider competence, physical benefit,
+causal benefit, deployment safety, or scientific promotion.

--- a/docs/public-api.md
+++ b/docs/public-api.md
@@ -34,6 +34,7 @@ exploratory provider-v2 work. It exposes:
 - sparse and tree-sparse execution contracts and strict loaders;
 - portable causal gauge-tree priors and artifacts;
 - matrix-free observation covariance actions and linear-query projections;
+- source-only group-aware pathwise calibration and equal-group diagnostics;
 - `Sim3`, project identity, and required serialization helpers; and
 - explicit provider-v2 export and validation contracts.
 
@@ -42,18 +43,22 @@ provider-evaluation studies, and paper-specific evidence code remain outside the
 façade. A breaking current ecosystem change requires a new façade such as
 `prob4d.api.v3`; it must not silently alter `prob4d.api.v2`.
 
-## Structured covariance queries
+## Structured covariance queries and pathwise diagnostics
 
 `project_observation_covariance` computes the exact requested
 `A @ Sigma @ A.T` from dense, sparse, or tree-sparse observation factors without
 materializing the full observation covariance. The result separates conditional
-point uncertainty from shared gauge uncertainty. The accompanying covariance
-action and quadratic-form functions support iterative algorithms and scalar
-diagnostics without constructing the joint matrix.
+point uncertainty from shared gauge uncertainty.
+
+`fit_pathwise_maximum_calibration` and `pathwise_uncertainty_diagnostics` require
+one frozen physical-object or acquisition-session ID per trajectory. The
+calibration maximum, conformal rank, target coverage, and Gaussian score are
+computed at that independent-group level. The immutable calibration record binds
+the complete trajectory-to-group assignment and rejects overlapping target group
+IDs; track count cannot inflate the finite-sample sample size.
 
 See [structured observation covariance queries](observation-covariance-queries.md)
-for semantics, examples, and the BayesianPhysTwin/Causal4D ownership and evidence
-boundary.
+for semantics, examples, and the BayesianPhysTwin/Causal4D ownership boundary.
 
 ## Historical provider-v1 artifacts
 

--- a/src/prob4d/api/v2.py
+++ b/src/prob4d/api/v2.py
@@ -41,6 +41,12 @@ from ..observation_covariance_queries import (
     observation_covariance_quadratic,
     project_observation_covariance,
 )
+from ..pathwise_uncertainty import (
+    PathwiseMaximumCalibrationV1,
+    PathwiseUncertaintyDiagnostics,
+    fit_pathwise_maximum_calibration,
+    pathwise_uncertainty_diagnostics,
+)
 from ..project_identity import (
     PROB4D_CANONICAL_REPOSITORY,
     PROB4D_FROZEN_ARTIFACT_REPOSITORY,
@@ -244,6 +250,8 @@ __all__ = [
     "ObservationFactorStack",
     "ObservationFactorStreamUpdateV1",
     "ObservationFactorStreamV1",
+    "PathwiseMaximumCalibrationV1",
+    "PathwiseUncertaintyDiagnostics",
     "PointUncertaintyCalibrationV1",
     "PredictionCalibrationTargetV1",
     "ProjectedObservationCovariance",
@@ -271,6 +279,7 @@ __all__ = [
     "compute_provider_manifest_id",
     "export_calibrated_observation_belief",
     "export_exploratory_observation_belief",
+    "fit_pathwise_maximum_calibration",
     "gauge_tree_prior_artifact_id",
     "inspect_runtime_revision",
     "is_prob4d_repository",
@@ -289,6 +298,7 @@ __all__ = [
     "motioncrafter_model_identifier",
     "observation_covariance_action",
     "observation_covariance_quadratic",
+    "pathwise_uncertainty_diagnostics",
     "prob4d_project_identity",
     "prob4d_provider_manifest",
     "prob4d_tree_sparse_provider_manifest",

--- a/src/prob4d/pathwise_uncertainty.py
+++ b/src/prob4d/pathwise_uncertainty.py
@@ -1,0 +1,647 @@
+"""Group-aware pathwise uncertainty diagnostics and source-only calibration."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass
+from numbers import Integral, Real
+from typing import Literal, TypeAlias, cast
+
+import numpy as np
+
+from .covariance import covariance_statistics
+
+_CHI_SQUARED_3 = {
+    0.50: 2.3659738843753377,
+    0.80: 4.64162767608745,
+    0.90: 6.251388631170325,
+    0.95: 7.814727903251179,
+}
+IndependentUnit: TypeAlias = Literal["physical-object", "acquisition-session"]
+_INDEPENDENT_UNITS = frozenset({"physical-object", "acquisition-session"})
+
+
+def _validated_independent_unit(value: object) -> IndependentUnit:
+    if type(value) is not str:
+        raise TypeError("independent_unit must be a string")
+    if value not in _INDEPENDENT_UNITS:
+        raise ValueError(
+            "independent_unit must be 'physical-object' or 'acquisition-session'"
+        )
+    return cast(IndependentUnit, value)
+
+
+def _validated_integer(value: object, *, name: str, minimum: int = 1) -> int:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Integral):
+        raise TypeError(f"{name} must be an integer")
+    result = int(value)
+    if result < minimum:
+        raise ValueError(f"{name} must be at least {minimum}")
+    return result
+
+
+def _validated_group_id(value: object, *, index: int) -> str:
+    if type(value) is not str:
+        raise TypeError(f"group_ids[{index}] must be a string")
+    if not value or value != value.strip():
+        raise ValueError(f"group_ids[{index}] must be a nonempty trimmed string")
+    if len(value.encode("utf-8")) > 128:
+        raise ValueError(f"group_ids[{index}] must contain at most 128 UTF-8 bytes")
+    if any(ord(character) < 32 or ord(character) == 127 for character in value):
+        raise ValueError(f"group_ids[{index}] must not contain control characters")
+    return cast(str, value)
+
+
+def _group_assignment_sha256(group_ids: tuple[str, ...]) -> str:
+    payload = json.dumps(
+        group_ids,
+        ensure_ascii=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _validated_sha256(value: object, *, name: str) -> str:
+    if type(value) is not str or len(value) != 64:
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    if any(character not in "0123456789abcdef" for character in value):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return cast(str, value)
+
+
+def _validated_grouping(
+    group_ids: Sequence[str],
+    *,
+    trajectory_count: int,
+) -> tuple[
+    tuple[str, ...],
+    tuple[str, ...],
+    tuple[tuple[int, ...], ...],
+    str,
+]:
+    if isinstance(group_ids, (str, bytes)):
+        raise TypeError("group_ids must be a sequence with one entry per trajectory")
+    supplied = tuple(group_ids)
+    if len(supplied) != trajectory_count:
+        raise ValueError(
+            "group_ids must contain exactly one entry per first-axis trajectory"
+        )
+    validated = tuple(
+        _validated_group_id(value, index=index)
+        for index, value in enumerate(supplied)
+    )
+    unique = tuple(sorted(set(validated)))
+    members = tuple(
+        tuple(index for index, group_id in enumerate(validated) if group_id == selected)
+        for selected in unique
+    )
+    return validated, unique, members, _group_assignment_sha256(validated)
+
+
+@dataclass(frozen=True, slots=True)
+class PathwiseMaximumCalibrationV1:
+    """Frozen split-conformal threshold over independent object/session groups."""
+
+    requested_miscoverage: float
+    independent_unit: IndependentUnit
+    calibration_trajectory_group_ids: tuple[str, ...]
+    calibration_group_assignment_sha256: str
+    calibration_trajectory_count: int
+    calibration_group_count: int
+    order_statistic_rank: int
+    finite_sample_coverage_level: float
+    maximum_mahalanobis_squared_threshold: float
+
+    def __post_init__(self) -> None:
+        if isinstance(self.requested_miscoverage, (bool, np.bool_)) or not isinstance(
+            self.requested_miscoverage,
+            Real,
+        ):
+            raise TypeError("requested_miscoverage must be a real scalar")
+        if not isinstance(self.calibration_trajectory_group_ids, tuple):
+            raise TypeError("calibration_trajectory_group_ids must be a tuple")
+        miscoverage = float(self.requested_miscoverage)
+        independent_unit = _validated_independent_unit(self.independent_unit)
+        trajectory_count = _validated_integer(
+            self.calibration_trajectory_count,
+            name="calibration_trajectory_count",
+        )
+        group_count = _validated_integer(
+            self.calibration_group_count,
+            name="calibration_group_count",
+        )
+        rank = _validated_integer(
+            self.order_statistic_rank,
+            name="order_statistic_rank",
+        )
+        if isinstance(self.finite_sample_coverage_level, (bool, np.bool_)) or not isinstance(
+            self.finite_sample_coverage_level,
+            Real,
+        ):
+            raise TypeError("finite_sample_coverage_level must be a real scalar")
+        if isinstance(
+            self.maximum_mahalanobis_squared_threshold,
+            (bool, np.bool_),
+        ) or not isinstance(self.maximum_mahalanobis_squared_threshold, Real):
+            raise TypeError("maximum Mahalanobis threshold must be a real scalar")
+        finite_level = float(self.finite_sample_coverage_level)
+        threshold = float(self.maximum_mahalanobis_squared_threshold)
+        if not math.isfinite(miscoverage) or not 0.0 < miscoverage < 1.0:
+            raise ValueError("requested_miscoverage must lie in (0, 1)")
+        grouping, unique, _, digest = _validated_grouping(
+            self.calibration_trajectory_group_ids,
+            trajectory_count=trajectory_count,
+        )
+        supplied_digest = _validated_sha256(
+            self.calibration_group_assignment_sha256,
+            name="calibration_group_assignment_sha256",
+        )
+        if supplied_digest != digest:
+            raise ValueError("calibration group-assignment digest does not match group_ids")
+        if group_count != len(unique):
+            raise ValueError("calibration_group_count does not match distinct group_ids")
+        if not 1 <= rank <= group_count:
+            raise ValueError("calibration group count and order-statistic rank are inconsistent")
+        if not math.isfinite(finite_level) or not 0.0 < finite_level < 1.0:
+            raise ValueError("finite_sample_coverage_level must lie in (0, 1)")
+        expected_level = rank / (group_count + 1)
+        if not math.isclose(finite_level, expected_level, rel_tol=0.0, abs_tol=1e-15):
+            raise ValueError(
+                "finite_sample_coverage_level does not match rank/(group_count+1)"
+            )
+        if not math.isfinite(threshold) or threshold < 0.0:
+            raise ValueError("maximum Mahalanobis threshold must be finite and non-negative")
+        object.__setattr__(self, "requested_miscoverage", miscoverage)
+        object.__setattr__(self, "independent_unit", independent_unit)
+        object.__setattr__(self, "calibration_trajectory_group_ids", grouping)
+        object.__setattr__(self, "calibration_group_assignment_sha256", digest)
+        object.__setattr__(self, "calibration_trajectory_count", trajectory_count)
+        object.__setattr__(self, "calibration_group_count", group_count)
+        object.__setattr__(self, "order_statistic_rank", rank)
+        object.__setattr__(self, "finite_sample_coverage_level", finite_level)
+        object.__setattr__(self, "maximum_mahalanobis_squared_threshold", threshold)
+
+    @property
+    def requested_coverage(self) -> float:
+        return 1.0 - self.requested_miscoverage
+
+    @property
+    def calibration_group_ids(self) -> tuple[str, ...]:
+        return tuple(sorted(set(self.calibration_trajectory_group_ids)))
+
+    @property
+    def calibration_group_trajectory_counts(self) -> tuple[int, ...]:
+        return tuple(
+            self.calibration_trajectory_group_ids.count(group_id)
+            for group_id in self.calibration_group_ids
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        result: dict[str, object] = asdict(self)
+        result["requested_coverage"] = self.requested_coverage
+        result["calibration_group_ids"] = self.calibration_group_ids
+        result["calibration_group_trajectory_counts"] = (
+            self.calibration_group_trajectory_counts
+        )
+        return result
+
+
+@dataclass(frozen=True, slots=True)
+class PathwiseUncertaintyDiagnostics:
+    """Equal-group pathwise diagnostics with per-trajectory run descriptions."""
+
+    independent_unit: IndependentUnit
+    target_trajectory_group_ids: tuple[str, ...]
+    target_group_assignment_sha256: str
+    group_count: int
+    trajectory_count: int
+    evaluated_step_count: int
+    mean_group_valid_step_fraction: float
+    minimum_group_valid_step_fraction: float
+    equal_group_marginal_coverage_50: float
+    equal_group_marginal_coverage_80: float
+    equal_group_marginal_coverage_90: float
+    equal_group_marginal_coverage_95: float
+    all_groups_inside_marginal_50_fraction: float
+    all_groups_inside_marginal_80_fraction: float
+    all_groups_inside_marginal_90_fraction: float
+    all_groups_inside_marginal_95_fraction: float
+    equal_group_independence_reference_all_steps_50_fraction: float
+    equal_group_independence_reference_all_steps_80_fraction: float
+    equal_group_independence_reference_all_steps_90_fraction: float
+    equal_group_independence_reference_all_steps_95_fraction: float
+    mean_group_max_mahalanobis_squared: float
+    median_group_max_mahalanobis_squared: float
+    p90_group_max_mahalanobis_squared: float
+    p95_group_max_mahalanobis_squared: float
+    mean_trajectory_longest_marginal_95_failure_run: float
+    p90_trajectory_longest_marginal_95_failure_run: float
+    maximum_trajectory_longest_marginal_95_failure_run: int
+    mean_trajectory_longest_unsupported_run: float
+    maximum_trajectory_longest_unsupported_run: int
+    equal_group_gaussian_nll_per_dimension: float
+    simultaneous_nominal_group_coverage: float | None
+    simultaneous_group_maximum_threshold: float | None
+    simultaneous_group_coverage: float | None
+    simultaneous_group_coverage_shortfall: float | None
+
+    def __post_init__(self) -> None:
+        independent_unit = _validated_independent_unit(self.independent_unit)
+        trajectory_count = _validated_integer(
+            self.trajectory_count,
+            name="trajectory_count",
+        )
+        group_count = _validated_integer(self.group_count, name="group_count")
+        grouping, unique, _, digest = _validated_grouping(
+            self.target_trajectory_group_ids,
+            trajectory_count=trajectory_count,
+        )
+        supplied_digest = _validated_sha256(
+            self.target_group_assignment_sha256,
+            name="target_group_assignment_sha256",
+        )
+        if supplied_digest != digest:
+            raise ValueError("target group-assignment digest does not match group_ids")
+        if group_count != len(unique):
+            raise ValueError("group_count does not match distinct target group_ids")
+        simultaneous = (
+            self.simultaneous_nominal_group_coverage,
+            self.simultaneous_group_maximum_threshold,
+            self.simultaneous_group_coverage,
+            self.simultaneous_group_coverage_shortfall,
+        )
+        if any(value is None for value in simultaneous) and not all(
+            value is None for value in simultaneous
+        ):
+            raise ValueError("simultaneous group diagnostics must be all present or all absent")
+        object.__setattr__(self, "independent_unit", independent_unit)
+        object.__setattr__(self, "target_trajectory_group_ids", grouping)
+        object.__setattr__(self, "target_group_assignment_sha256", digest)
+        object.__setattr__(self, "group_count", group_count)
+        object.__setattr__(self, "trajectory_count", trajectory_count)
+
+    @property
+    def target_group_ids(self) -> tuple[str, ...]:
+        return tuple(sorted(set(self.target_trajectory_group_ids)))
+
+    @property
+    def target_group_trajectory_counts(self) -> tuple[int, ...]:
+        return tuple(
+            self.target_trajectory_group_ids.count(group_id)
+            for group_id in self.target_group_ids
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        result: dict[str, object] = asdict(self)
+        result["target_group_ids"] = self.target_group_ids
+        result["target_group_trajectory_counts"] = self.target_group_trajectory_counts
+        return result
+
+
+def _validated_inputs(
+    residual_xyz_m: object,
+    covariance_m2: object,
+    valid_mask: object | None,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    residual = np.asarray(residual_xyz_m, dtype=np.float64)
+    covariance = np.asarray(covariance_m2, dtype=np.float64)
+    single_trajectory = residual.ndim == 2
+    if single_trajectory:
+        if residual.shape[1:] != (3,):
+            raise ValueError("residual_xyz_m must have shape (P, T, 3) or (T, 3)")
+        residual = residual[None]
+        if covariance.shape == (residual.shape[1], 3, 3):
+            covariance = covariance[None]
+    if residual.ndim != 3 or residual.shape[0] < 1 or residual.shape[1] < 1:
+        raise ValueError("residual_xyz_m must have nonempty shape (P, T, 3)")
+    if residual.shape[2] != 3:
+        raise ValueError("residual_xyz_m must have shape (P, T, 3)")
+    if covariance.shape != (*residual.shape[:2], 3, 3):
+        raise ValueError("covariance_m2 must have shape (P, T, 3, 3)")
+    if valid_mask is None:
+        valid = np.ones(residual.shape[:2], dtype=bool)
+    else:
+        raw_valid = np.asarray(valid_mask)
+        if raw_valid.dtype != np.dtype(bool):
+            raise TypeError("valid_mask must contain genuine booleans")
+        valid = np.asarray(raw_valid, dtype=bool)
+        if single_trajectory and valid.shape == (residual.shape[1],):
+            valid = valid[None]
+        if valid.shape != residual.shape[:2]:
+            raise ValueError("valid_mask must have shape (P, T)")
+    if np.any(np.count_nonzero(valid, axis=1) == 0):
+        raise ValueError("every trajectory must contain at least one valid step")
+    if not np.all(np.isfinite(residual[valid])):
+        raise ValueError("valid residual_xyz_m entries must be finite")
+    if not np.all(np.isfinite(covariance[valid])):
+        raise ValueError("valid covariance_m2 entries must be finite")
+    return residual, covariance, valid
+
+
+def _mahalanobis_and_nll(
+    residual: np.ndarray,
+    covariance: np.ndarray,
+    valid: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    selected_covariance = covariance[valid]
+    symmetric, inverse, log_determinant = covariance_statistics(
+        selected_covariance,
+        name="pathwise covariance",
+    )
+    selected_residual = residual[valid]
+    mahalanobis = np.einsum(
+        "ni,nij,nj->n",
+        selected_residual,
+        inverse,
+        selected_residual,
+        optimize=True,
+    )
+    gaussian_nll = 0.5 * (
+        3.0 * math.log(2.0 * math.pi) + log_determinant + mahalanobis
+    )
+    if not np.all(np.isfinite(symmetric)):
+        raise ValueError("pathwise covariance normalization failed")
+    mahalanobis_matrix = np.full(valid.shape, np.nan, dtype=np.float64)
+    nll_matrix = np.full(valid.shape, np.nan, dtype=np.float64)
+    mahalanobis_matrix[valid] = mahalanobis
+    nll_matrix[valid] = gaussian_nll
+    return mahalanobis_matrix, nll_matrix
+
+
+def _at_most(value: np.ndarray, threshold: float) -> np.ndarray:
+    tolerance = 1e-12 * max(abs(float(threshold)), 1.0)
+    return np.asarray(value, dtype=np.float64) <= float(threshold) + tolerance
+
+
+def _longest_true_run(value: np.ndarray) -> int:
+    longest = 0
+    current = 0
+    for selected in np.asarray(value, dtype=bool):
+        if selected:
+            current += 1
+            longest = max(longest, current)
+        else:
+            current = 0
+    return longest
+
+
+def _trajectory_maxima(mahalanobis: np.ndarray, valid: np.ndarray) -> np.ndarray:
+    return np.asarray(
+        [float(np.max(mahalanobis[index][valid[index]])) for index in range(len(valid))],
+        dtype=np.float64,
+    )
+
+
+def _group_maxima(
+    trajectory_maxima: np.ndarray,
+    members: tuple[tuple[int, ...], ...],
+) -> np.ndarray:
+    return np.asarray(
+        [float(np.max(trajectory_maxima[list(indices)])) for indices in members],
+        dtype=np.float64,
+    )
+
+
+def fit_pathwise_maximum_calibration(
+    residual_xyz_m: object,
+    covariance_m2: object,
+    *,
+    group_ids: Sequence[str],
+    independent_unit: IndependentUnit,
+    valid_mask: object | None = None,
+    miscoverage: float = 0.05,
+) -> PathwiseMaximumCalibrationV1:
+    """Fit a finite-sample maximum threshold over independent object/session groups.
+
+    The first axis still indexes trajectories, but ``group_ids`` assigns every
+    trajectory to one complete physical object or acquisition session. The
+    conformal statistic is the maximum over all admitted trajectories and valid
+    steps in one group. The number of groups, never the number of tracks, sets the
+    finite-sample rank.
+    """
+
+    if isinstance(miscoverage, (bool, np.bool_)) or not isinstance(miscoverage, Real):
+        raise TypeError("miscoverage must be a real scalar")
+    alpha = float(miscoverage)
+    if not math.isfinite(alpha) or not 0.0 < alpha < 1.0:
+        raise ValueError("miscoverage must lie in (0, 1)")
+    unit = _validated_independent_unit(independent_unit)
+    residual, covariance, valid = _validated_inputs(
+        residual_xyz_m,
+        covariance_m2,
+        valid_mask,
+    )
+    grouping, unique, members, digest = _validated_grouping(
+        group_ids,
+        trajectory_count=len(residual),
+    )
+    mahalanobis, _ = _mahalanobis_and_nll(residual, covariance, valid)
+    maxima = _group_maxima(_trajectory_maxima(mahalanobis, valid), members)
+    count = int(maxima.size)
+    rank = int(math.ceil((count + 1) * (1.0 - alpha)))
+    if rank > count:
+        minimum_count = int(math.ceil((1.0 - alpha) / alpha))
+        raise ValueError(
+            "finite pathwise calibration is unavailable at the requested "
+            f"miscoverage with {count} independent groups; at least "
+            f"{minimum_count} independent groups are required"
+        )
+    threshold = float(np.partition(maxima, rank - 1)[rank - 1])
+    return PathwiseMaximumCalibrationV1(
+        requested_miscoverage=alpha,
+        independent_unit=unit,
+        calibration_trajectory_group_ids=grouping,
+        calibration_group_assignment_sha256=digest,
+        calibration_trajectory_count=len(grouping),
+        calibration_group_count=len(unique),
+        order_statistic_rank=rank,
+        finite_sample_coverage_level=rank / (count + 1),
+        maximum_mahalanobis_squared_threshold=threshold,
+    )
+
+
+def pathwise_uncertainty_diagnostics(
+    residual_xyz_m: object,
+    covariance_m2: object,
+    *,
+    group_ids: Sequence[str],
+    independent_unit: IndependentUnit,
+    valid_mask: object | None = None,
+    calibration: PathwiseMaximumCalibrationV1 | None = None,
+) -> PathwiseUncertaintyDiagnostics:
+    """Evaluate pathwise uncertainty with equal object/session-group weighting.
+
+    Per-trajectory failure and support runs remain descriptive. Coverage, maximum
+    statistics, Gaussian score, and any calibrated simultaneous claim are
+    aggregated over complete independent groups.
+    """
+
+    if calibration is not None and not isinstance(calibration, PathwiseMaximumCalibrationV1):
+        raise TypeError("calibration must be a PathwiseMaximumCalibrationV1")
+    unit = _validated_independent_unit(independent_unit)
+    residual, covariance, valid = _validated_inputs(
+        residual_xyz_m,
+        covariance_m2,
+        valid_mask,
+    )
+    grouping, unique, members, digest = _validated_grouping(
+        group_ids,
+        trajectory_count=len(residual),
+    )
+    if calibration is not None:
+        if calibration.independent_unit != unit:
+            raise ValueError("calibration and target independent_unit must match")
+        overlap = sorted(set(calibration.calibration_group_ids) & set(unique))
+        if overlap:
+            raise ValueError(
+                "calibration and target group_ids must be disjoint; "
+                f"overlap={overlap}"
+            )
+
+    mahalanobis, gaussian_nll = _mahalanobis_and_nll(residual, covariance, valid)
+    trajectory_count, step_count = valid.shape
+    trajectory_valid_counts = np.count_nonzero(valid, axis=1)
+    evaluated_step_count = int(np.sum(trajectory_valid_counts))
+    group_valid_counts = np.asarray(
+        [int(np.count_nonzero(valid[list(indices)])) for indices in members],
+        dtype=np.int64,
+    )
+    group_possible_counts = np.asarray(
+        [len(indices) * step_count for indices in members],
+        dtype=np.int64,
+    )
+    trajectory_maxima = _trajectory_maxima(mahalanobis, valid)
+    group_maxima = _group_maxima(trajectory_maxima, members)
+
+    marginal_coverages: dict[float, float] = {}
+    all_group_coverages: dict[float, float] = {}
+    independence_references: dict[float, float] = {}
+    for level, threshold in _CHI_SQUARED_3.items():
+        inside = valid & _at_most(mahalanobis, threshold)
+        per_group = np.asarray(
+            [
+                np.count_nonzero(inside[list(indices)]) / group_valid_counts[index]
+                for index, indices in enumerate(members)
+            ],
+            dtype=np.float64,
+        )
+        marginal_coverages[level] = float(np.mean(per_group))
+        all_group_coverages[level] = float(
+            np.mean(
+                [
+                    bool(
+                        np.all(
+                            _at_most(
+                                mahalanobis[list(indices)][valid[list(indices)]],
+                                threshold,
+                            )
+                        )
+                    )
+                    for indices in members
+                ]
+            )
+        )
+        independence_references[level] = float(
+            np.mean(level**group_valid_counts)
+        )
+
+    marginal_95_failures = valid & ~_at_most(mahalanobis, _CHI_SQUARED_3[0.95])
+    failure_runs = np.asarray(
+        [_longest_true_run(row) for row in marginal_95_failures],
+        dtype=np.int64,
+    )
+    unsupported_runs = np.asarray(
+        [_longest_true_run(~row) for row in valid],
+        dtype=np.int64,
+    )
+    group_nll_per_dimension = np.asarray(
+        [
+            float(
+                np.sum(gaussian_nll[list(indices)][valid[list(indices)]])
+                / (3 * group_valid_counts[index])
+            )
+            for index, indices in enumerate(members)
+        ],
+        dtype=np.float64,
+    )
+
+    simultaneous_nominal: float | None = None
+    simultaneous_threshold: float | None = None
+    simultaneous_coverage: float | None = None
+    simultaneous_shortfall: float | None = None
+    if calibration is not None:
+        simultaneous_nominal = calibration.requested_coverage
+        simultaneous_threshold = calibration.maximum_mahalanobis_squared_threshold
+        simultaneous_coverage = float(
+            np.mean(_at_most(group_maxima, simultaneous_threshold))
+        )
+        simultaneous_shortfall = max(
+            0.0,
+            simultaneous_nominal - simultaneous_coverage,
+        )
+
+    return PathwiseUncertaintyDiagnostics(
+        independent_unit=unit,
+        target_trajectory_group_ids=grouping,
+        target_group_assignment_sha256=digest,
+        group_count=len(unique),
+        trajectory_count=trajectory_count,
+        evaluated_step_count=evaluated_step_count,
+        mean_group_valid_step_fraction=float(
+            np.mean(group_valid_counts / group_possible_counts)
+        ),
+        minimum_group_valid_step_fraction=float(
+            np.min(group_valid_counts / group_possible_counts)
+        ),
+        equal_group_marginal_coverage_50=marginal_coverages[0.50],
+        equal_group_marginal_coverage_80=marginal_coverages[0.80],
+        equal_group_marginal_coverage_90=marginal_coverages[0.90],
+        equal_group_marginal_coverage_95=marginal_coverages[0.95],
+        all_groups_inside_marginal_50_fraction=all_group_coverages[0.50],
+        all_groups_inside_marginal_80_fraction=all_group_coverages[0.80],
+        all_groups_inside_marginal_90_fraction=all_group_coverages[0.90],
+        all_groups_inside_marginal_95_fraction=all_group_coverages[0.95],
+        equal_group_independence_reference_all_steps_50_fraction=(
+            independence_references[0.50]
+        ),
+        equal_group_independence_reference_all_steps_80_fraction=(
+            independence_references[0.80]
+        ),
+        equal_group_independence_reference_all_steps_90_fraction=(
+            independence_references[0.90]
+        ),
+        equal_group_independence_reference_all_steps_95_fraction=(
+            independence_references[0.95]
+        ),
+        mean_group_max_mahalanobis_squared=float(np.mean(group_maxima)),
+        median_group_max_mahalanobis_squared=float(np.median(group_maxima)),
+        p90_group_max_mahalanobis_squared=float(np.quantile(group_maxima, 0.90)),
+        p95_group_max_mahalanobis_squared=float(np.quantile(group_maxima, 0.95)),
+        mean_trajectory_longest_marginal_95_failure_run=float(np.mean(failure_runs)),
+        p90_trajectory_longest_marginal_95_failure_run=float(
+            np.quantile(failure_runs, 0.90)
+        ),
+        maximum_trajectory_longest_marginal_95_failure_run=int(
+            np.max(failure_runs)
+        ),
+        mean_trajectory_longest_unsupported_run=float(np.mean(unsupported_runs)),
+        maximum_trajectory_longest_unsupported_run=int(np.max(unsupported_runs)),
+        equal_group_gaussian_nll_per_dimension=float(
+            np.mean(group_nll_per_dimension)
+        ),
+        simultaneous_nominal_group_coverage=simultaneous_nominal,
+        simultaneous_group_maximum_threshold=simultaneous_threshold,
+        simultaneous_group_coverage=simultaneous_coverage,
+        simultaneous_group_coverage_shortfall=simultaneous_shortfall,
+    )
+
+
+__all__ = [
+    "PathwiseMaximumCalibrationV1",
+    "PathwiseUncertaintyDiagnostics",
+    "fit_pathwise_maximum_calibration",
+    "pathwise_uncertainty_diagnostics",
+]

--- a/tests/test_pathwise_uncertainty.py
+++ b/tests/test_pathwise_uncertainty.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from prob4d.api.v2 import (
+    PathwiseMaximumCalibrationV1,
+    fit_pathwise_maximum_calibration,
+    pathwise_uncertainty_diagnostics,
+)
+
+
+def _residuals_from_mahalanobis(values: np.ndarray) -> np.ndarray:
+    result = np.zeros((*values.shape, 3), dtype=np.float64)
+    result[..., 0] = np.sqrt(values)
+    return result
+
+
+def _identity_covariance(shape: tuple[int, int]) -> np.ndarray:
+    return np.broadcast_to(np.eye(3, dtype=np.float64), (*shape, 3, 3)).copy()
+
+
+def _calibration(
+    group_count: int = 20,
+    *,
+    maximum: float = 20.0,
+) -> PathwiseMaximumCalibrationV1:
+    maxima = np.repeat(
+        np.linspace(maximum / group_count, maximum, group_count, dtype=np.float64),
+        2,
+    )[:, None]
+    group_ids = tuple(
+        f"calibration-object-{index:02d}"
+        for index in range(group_count)
+        for _ in range(2)
+    )
+    return fit_pathwise_maximum_calibration(
+        _residuals_from_mahalanobis(maxima),
+        _identity_covariance(maxima.shape),
+        group_ids=group_ids,
+        independent_unit="physical-object",
+        miscoverage=0.05,
+    )
+
+
+def test_pathwise_maximum_calibration_uses_independent_group_rank() -> None:
+    calibration = _calibration()
+
+    assert isinstance(calibration, PathwiseMaximumCalibrationV1)
+    assert calibration.calibration_trajectory_count == 40
+    assert calibration.calibration_group_count == 20
+    assert calibration.calibration_group_trajectory_counts == (2,) * 20
+    assert calibration.order_statistic_rank == 20
+    assert calibration.finite_sample_coverage_level == pytest.approx(20 / 21)
+    assert calibration.maximum_mahalanobis_squared_threshold == pytest.approx(20.0)
+    assert len(calibration.calibration_group_assignment_sha256) == 64
+    assert calibration.to_dict()["calibration_group_ids"] == (
+        calibration.calibration_group_ids
+    )
+
+    too_few_group_ids = tuple(
+        f"calibration-object-{index:02d}"
+        for index in range(18)
+        for _ in range(10)
+    )
+    too_few = np.ones((len(too_few_group_ids), 1), dtype=np.float64)
+    with pytest.raises(ValueError, match="at least 19 independent groups"):
+        fit_pathwise_maximum_calibration(
+            _residuals_from_mahalanobis(too_few),
+            _identity_covariance(too_few.shape),
+            group_ids=too_few_group_ids,
+            independent_unit="physical-object",
+            miscoverage=0.05,
+        )
+
+
+def test_calibration_artifact_binds_complete_group_assignment() -> None:
+    calibration = _calibration()
+    with pytest.raises(ValueError, match="digest does not match"):
+        replace(
+            calibration,
+            calibration_group_assignment_sha256="0" * 64,
+        )
+
+
+def test_pathwise_diagnostics_weight_complete_groups_equally() -> None:
+    mahalanobis = np.asarray(
+        [
+            [1.0, 2.0, 3.0, 4.0, 5.0],
+            [1.0, 9.0, 10.0, 2.0, 1.0],
+            [1.0, 2.0, 0.0, 0.0, 12.0],
+        ],
+        dtype=np.float64,
+    )
+    valid = np.asarray(
+        [
+            [True, True, True, True, True],
+            [True, True, True, True, True],
+            [True, True, False, False, True],
+        ]
+    )
+    diagnostics = pathwise_uncertainty_diagnostics(
+        _residuals_from_mahalanobis(mahalanobis),
+        _identity_covariance(mahalanobis.shape),
+        group_ids=("target-object-a", "target-object-a", "target-object-b"),
+        independent_unit="physical-object",
+        valid_mask=valid,
+        calibration=_calibration(maximum=10.0),
+    )
+
+    assert diagnostics.group_count == 2
+    assert diagnostics.trajectory_count == 3
+    assert diagnostics.evaluated_step_count == 13
+    assert diagnostics.equal_group_marginal_coverage_95 == pytest.approx(
+        (0.8 + 2 / 3) / 2
+    )
+    assert diagnostics.all_groups_inside_marginal_95_fraction == 0.0
+    assert diagnostics.maximum_trajectory_longest_marginal_95_failure_run == 2
+    assert diagnostics.mean_trajectory_longest_marginal_95_failure_run == pytest.approx(
+        1.0
+    )
+    assert diagnostics.maximum_trajectory_longest_unsupported_run == 2
+    assert diagnostics.simultaneous_nominal_group_coverage == pytest.approx(0.95)
+    assert diagnostics.simultaneous_group_coverage == pytest.approx(0.5)
+    assert diagnostics.simultaneous_group_coverage_shortfall == pytest.approx(0.45)
+    assert diagnostics.to_dict()["target_group_trajectory_counts"] == (2, 1)
+
+
+def test_all_group_marginal_fraction_is_not_simultaneous_coverage() -> None:
+    mahalanobis = np.ones((2, 3), dtype=np.float64)
+    diagnostics = pathwise_uncertainty_diagnostics(
+        _residuals_from_mahalanobis(mahalanobis),
+        _identity_covariance(mahalanobis.shape),
+        group_ids=("target-session-a", "target-session-b"),
+        independent_unit="acquisition-session",
+    )
+
+    assert diagnostics.all_groups_inside_marginal_95_fraction == 1.0
+    assert diagnostics.simultaneous_nominal_group_coverage is None
+    assert diagnostics.simultaneous_group_maximum_threshold is None
+    assert diagnostics.simultaneous_group_coverage is None
+    assert diagnostics.simultaneous_group_coverage_shortfall is None
+
+
+def test_target_groups_must_be_disjoint_from_calibration_groups() -> None:
+    calibration = _calibration()
+    mahalanobis = np.ones((1, 2), dtype=np.float64)
+    with pytest.raises(ValueError, match="must be disjoint"):
+        pathwise_uncertainty_diagnostics(
+            _residuals_from_mahalanobis(mahalanobis),
+            _identity_covariance(mahalanobis.shape),
+            group_ids=(calibration.calibration_group_ids[0],),
+            independent_unit="physical-object",
+            calibration=calibration,
+        )
+
+
+def test_pathwise_inputs_reject_invalid_grouping_and_calibration_types() -> None:
+    mahalanobis = np.ones((2, 2), dtype=np.float64)
+    valid = np.asarray([[True, True], [False, False]])
+    with pytest.raises(ValueError, match="at least one valid step"):
+        pathwise_uncertainty_diagnostics(
+            _residuals_from_mahalanobis(mahalanobis),
+            _identity_covariance(mahalanobis.shape),
+            group_ids=("object-a", "object-b"),
+            independent_unit="physical-object",
+            valid_mask=valid,
+        )
+    with pytest.raises(ValueError, match="one entry per"):
+        pathwise_uncertainty_diagnostics(
+            _residuals_from_mahalanobis(mahalanobis),
+            _identity_covariance(mahalanobis.shape),
+            group_ids=("object-a",),
+            independent_unit="physical-object",
+        )
+    with pytest.raises(ValueError, match="independent_unit"):
+        pathwise_uncertainty_diagnostics(
+            _residuals_from_mahalanobis(mahalanobis),
+            _identity_covariance(mahalanobis.shape),
+            group_ids=("track-a", "track-b"),
+            independent_unit="trajectory",  # type: ignore[arg-type]
+        )
+    with pytest.raises(TypeError, match="PathwiseMaximumCalibrationV1"):
+        pathwise_uncertainty_diagnostics(
+            _residuals_from_mahalanobis(mahalanobis),
+            _identity_covariance(mahalanobis.shape),
+            group_ids=("object-a", "object-b"),
+            independent_unit="physical-object",
+            calibration=object(),  # type: ignore[arg-type]
+        )


### PR DESCRIPTION
## Summary

Build on the structured observation covariance queries merged in #246 with a scientifically admissible pathwise calibration surface:

- require one frozen physical-object or acquisition-session ID per first-axis trajectory;
- aggregate maximum Mahalanobis error over every admitted trajectory and valid step in each independent group;
- compute the split-conformal rank from the number of distinct groups, never the number of tracks;
- bind the complete trajectory-to-group assignment and its canonical SHA-256 digest in the immutable calibration record;
- reject overlapping calibration and target group IDs and mismatched independent-unit declarations;
- report target coverage, maximum-error quantiles, support fractions, and Gaussian score with equal group weighting;
- keep longest failure and unsupported runs explicitly labelled as per-trajectory diagnostics; and
- expose the corrected surface through `prob4d.api.v2` with documentation and focused regressions.

## Scientific correction

The superseded #242 design counted trajectories as exchangeability units. Multiple tracks from one physical object or acquisition session share provider, gauge, scene, action, and calibration errors, so that design could pseudo-replicate evidence and overstate finite-sample coverage.

This PR accepts only `independent_unit="physical-object"` or `"acquisition-session"`. Adding tracks to an existing group cannot increase the conformal sample count. At 5% miscoverage, the finite threshold therefore requires at least 19 independent groups.

## Validation on exact head

All workflows passed on `c721427b6c78a0d0ab433e6a71321cd0b5d7001b`:

- focused group-aware calibration regressions;
- fail-closed Ruff lint, canonical formatting, strict MyPy, and documentation-surface checks;
- repository, release, public-API, provider, and distribution contract checks;
- complete suites on Python 3.10, 3.11, 3.12, 3.13, and 3.14;
- complete suite at the declared NumPy 1.24.0 runtime floor;
- wheel and source-distribution construction and validation;
- isolated installed-wheel and installed-sdist CLI smoke tests;
- downstream installed-wheel typing positive and negative controls;
- hosted macOS and Windows immutable-publication/storage tests;
- provider batch preflight; and
- dependency audit plus Python and Actions CodeQL security scanning.

The branch is one commit ahead of exact current `main` and changes six intended files.

## Data and ownership boundary

No target cohort, provider residual, or physical-query outcome was opened. Group IDs must come from a frozen cohort lock and must not be derived after outcomes are observed. Prob4D owns generic observation-space calibration diagnostics; BayesianPhysTwin continues to own physical query Jacobians, update guards, and exact fallback, while Causal4D owns intervention contrasts.

This adds calibration infrastructure only. It does not promote a provider, establish physical or causal benefit, authorize target retuning, or claim deployment safety or state of the art.