### PR TITLE
[Superseded by #249] Make provider evaluation identity provider-neutral

### DIFF
--- a/.github/workflows/fail-closed-quality.yml
+++ b/.github/workflows/fail-closed-quality.yml
@@ -83,6 +83,7 @@ jobs:
           python -m mypy \
             src/prob4d/_version.py \
             src/prob4d/_provider_export_core.py \
+            src/prob4d/_provider_evaluation_provider_neutral.py \
             src/prob4d/api/v2.py \
             src/prob4d/cli.py \
             src/prob4d/calibration_compatibility.py \
@@ -94,6 +95,7 @@ jobs:
             src/prob4d/prediction_store_cli.py \
             src/prob4d/project_identity.py \
             src/prob4d/provider_attestation.py \
+            src/prob4d/provider_evaluation_identity.py \
             src/prob4d/provider_manifest.py \
             src/prob4d/provider_manifest_cli.py \
             src/prob4d/provider_v1.py \

--- a/docs/provider-evaluation-identity.md
+++ b/docs/provider-evaluation-identity.md
@@ -1,0 +1,72 @@
+# Provider-neutral evaluation identity
+
+Claim-bearing `prob4d evaluate provider` inputs may use any prediction provider
+that is represented by `PredictionProviderManifestV1`. A fused prediction archive
+binds that provider through the `provider_identity` object inside its artifact
+metadata. CUT3R, VGGT, MotionCrafter, and future providers use the same evaluator;
+provider-specific field names are not required.
+
+## Version 1 record
+
+```json
+{
+  "provider_identity": {
+    "schema_name": "prob4d.provider-evaluation-provider-identity",
+    "schema_version": 1,
+    "provider_manifest_id": "<sha256 content identity>",
+    "provider_manifest_sha256": "<sha256 exact manifest bytes>",
+    "provider_family": "cut3r",
+    "provider_repository": "naver/CUT3R",
+    "provider_revision": "<exact 40- or 64-character revision>",
+    "provider_run_id": "<sha256 run identity>",
+    "model_set_id": "<sha256 model-set identity>",
+    "loader_id": "<sha256 loader identity>",
+    "coordinate_semantics": "sequence-local-sim3",
+    "point_semantics": "dense-point-map",
+    "flow_semantics": "absent",
+    "ray_semantics": "absent",
+    "source_dependency_semantics": "per-output-exclusive-source-frame-interval-v1"
+  }
+}
+```
+
+The values and allowed semantics are shared with
+`PredictionProviderManifestV1`. The evaluator rejects unknown fields, malformed
+revisions or digests, unsupported coordinate/payload semantics, and a changed
+source-dependency contract.
+
+Three values are intentionally case-local:
+
+- `provider_manifest_id`;
+- `provider_manifest_sha256`;
+- `provider_run_id`.
+
+They authenticate the exact source sequence and execution used by one case, so
+they normally differ across held-out objects or sessions. The cross-case method
+signature instead freezes provider family, repository, revision, model set,
+loader, coordinate and payload semantics, source-dependency semantics, Prob4D
+revision, fusion/covariance meaning, gauge estimator, and calibration identities.
+This separates legitimate case identity changes from method drift.
+
+## Historical MotionCrafter replay
+
+Existing MotionCrafter fused artifacts remain readable without rewriting their
+bytes or identifiers. When `provider_identity` is absent, evaluation validates
+the historical fields:
+
+- `motioncrafter_revision`;
+- `motioncrafter_model_set_sha256`;
+- `motioncrafter_seed_policy`;
+- `prediction_manifest_sha256`.
+
+This adapter is replay-only. New provider exports should emit the generic record.
+A MotionCrafter export may temporarily retain all four historical fields alongside
+the generic record, but the revision, model set, and manifest digest must agree
+exactly. Partial or contradictory mirrors fail closed.
+
+## Claim boundary
+
+The record authenticates provider and execution semantics for observation-level
+evaluation. It does not establish source-mean competence, calibrated uncertainty,
+BayesianPhysTwin update acceptance, physical-query benefit, Causal4D intervention
+benefit, deployment safety, or state of the art. Those remain separate gates.

--- a/docs/provider-evaluation.md
+++ b/docs/provider-evaluation.md
@@ -9,11 +9,13 @@ The evaluator is deliberately paired and fail-closed:
 - every case must contain the same method set;
 - every prediction archive must carry its fusion, covariance, and dependence
   semantics;
-- one method cannot mix Prob4D revisions, MotionCrafter revisions, model-set
-  identities, seed policies, gauge estimators, or calibration statuses across
-  cases;
-- every nonlegacy archive binds the exact prediction-manifest SHA-256 and declares
-  that covariance fields are present;
+- one method cannot mix Prob4D revisions, provider contracts, model-set and
+  loader identities, coordinate or payload semantics, gauge estimators, or
+  calibration statuses across cases;
+- every generic nonlegacy archive binds a content-addressed provider-manifest ID,
+  the exact manifest-byte SHA-256, and the provider run ID;
+- historical MotionCrafter archives retain their exact legacy identity adapter
+  and are never rewritten;
 - historical archives without embedded semantics are rejected unless the run is
   explicitly labelled with `--allow-legacy-artifacts`;
 - primary metrics use only frames and pixels supported by truth and every
@@ -47,17 +49,32 @@ covariance field has one of three explicit meanings:
 
 These meanings are not interchangeable. The evaluator verifies that the
 manifest method label agrees with the archive and that one method retains one
-semantic signature across all held-out cases. Nonlegacy artifacts must also
-declare exact Prob4D and MotionCrafter revisions, the immutable
-`prob4d.motioncrafter-model-set.v1` digest, MotionCrafter seed policy, gauge
-estimator, uncertainty-calibration status, and the prediction-manifest digest.
+semantic signature across all held-out cases. Generic artifacts declare the
+provider family, repository and exact revision, model set, loader, coordinate,
+point, flow, ray and source-dependency semantics through the versioned
+`provider_identity` record. Per-case manifest IDs, manifest-byte digests and run
+IDs are validated and retained but may differ across objects or sessions.
+See [provider-neutral evaluation identity](provider-evaluation-identity.md).
+
+Historical MotionCrafter archives remain replayable through their original exact
+MotionCrafter revision, model-set digest, seed policy and prediction-manifest
+digest. That compatibility path does not require rewriting old evidence and is
+not the schema for new CUT3R, VGGT or other provider exports.
 
 ## Producing evaluable benchmark artifacts
 
-`prob4d benchmark` uses the same immutable model-source contract as the
-MotionCrafter producer while preserving one model-loading session for the
-complete batch. Supply either local content-addressed snapshots or exact remote
-revisions for the UNet, geometry/motion VAE, and base pipeline:
+Provider-neutral imports first produce and verify
+`PredictionProviderManifestV1` payloads. A fused evaluation export then copies the
+manifest identity and contract into `metadata.provider_identity` as specified in
+[provider-neutral evaluation identity](provider-evaluation-identity.md). This
+keeps source lineage and provider semantics explicit without requiring a
+provider-specific evaluator.
+
+The MotionCrafter benchmark producer remains available as a historical and
+comparison route. It uses the same immutable model-source contract while
+preserving one model-loading session for the complete batch. Supply either local
+content-addressed snapshots or exact remote revisions for the UNet,
+geometry/motion VAE, and base pipeline:
 
 ```bash
 prob4d benchmark \
@@ -80,8 +97,8 @@ manifest records the complete compact model-source manifest, model-set digest,
 Prob4D and MotionCrafter revisions, inference/loading/fusion/export timings, and
 method semantics.
 
-`--skip-existing` is not a file-existence shortcut. Before skipping one case it
-validates:
+`--skip-existing` is not a file-existence shortcut. Before skipping one
+MotionCrafter case it validates:
 
 - the prediction manifest's MotionCrafter revision, seed policy, and model-set
   identity;

--- a/src/prob4d/_provider_evaluation_provider_neutral.py
+++ b/src/prob4d/_provider_evaluation_provider_neutral.py
@@ -1,0 +1,165 @@
+"""Provider-neutral case evaluation with legacy MotionCrafter replay.
+
+Aggregation and metric computation remain in ``_provider_evaluation_compute``.
+This module replaces only the artifact-identity boundary so claim-bearing
+provider evaluation can consume any validated ``PredictionProviderManifestV1``
+route without fabricating MotionCrafter fields.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ._provider_evaluation_compute import (
+    _method_support_summary,
+    _numeric_leaves,
+    _paired_common_support,
+    aggregate_provider_records,
+)
+from ._provider_evaluation_manifest import ProviderEvaluationCase
+from .evaluation_modes import EvaluationModes, evaluate_sequence_modes
+from .io import FusedPredictionArtifact, load_fused_prediction_artifact, load_truth
+from .metrics import DEFAULT_EVALUATION_CHUNK_SIZE
+from .provider_evaluation_identity import (
+    PROVIDER_EVALUATION_IDENTITY_METADATA_KEY,
+    ProviderEvaluationIdentity,
+    provider_evaluation_method_signature,
+    provider_identity_report_record,
+    validate_provider_evaluation_metadata,
+)
+
+
+def evaluate_provider_cases(
+    cases: list[ProviderEvaluationCase],
+    *,
+    allow_legacy_artifacts: bool,
+    evaluation_chunk_size: int = DEFAULT_EVALUATION_CHUNK_SIZE,
+) -> tuple[list[dict[str, Any]], dict[str, dict[str, Any]]]:
+    """Evaluate paired cases and enforce one provider contract per method."""
+
+    if evaluation_chunk_size < 1:
+        raise ValueError("evaluation_chunk_size must be positive")
+    records: list[dict[str, Any]] = []
+    signatures: dict[str, tuple[object, ...]] = {}
+    method_metadata: dict[str, dict[str, Any]] = {}
+    for case in cases:
+        truth = load_truth(case.truth_path)
+        artifacts: dict[str, FusedPredictionArtifact] = {}
+        identities: dict[str, ProviderEvaluationIdentity] = {}
+        for method_id, prediction_path in sorted(case.predictions.items()):
+            artifact = load_fused_prediction_artifact(prediction_path)
+            artifacts[method_id] = artifact
+            metadata = artifact.metadata
+            if metadata.legacy_unspecified and not allow_legacy_artifacts:
+                raise ValueError(
+                    f"{prediction_path} has legacy unspecified covariance semantics; "
+                    "regenerate it or pass --allow-legacy-artifacts for an explicitly "
+                    "non-claim-bearing diagnostic"
+                )
+            if not metadata.legacy_unspecified and metadata.method_id != method_id:
+                raise ValueError(
+                    f"prediction method label {method_id!r} disagrees with artifact "
+                    f"method_id {metadata.method_id!r}"
+                )
+            identity = None
+            if not metadata.legacy_unspecified:
+                identity = validate_provider_evaluation_metadata(
+                    metadata,
+                    path=Path(prediction_path),
+                )
+                identities[method_id] = identity
+            signature = (
+                (
+                    metadata.fusion_method,
+                    metadata.covariance_semantics,
+                    metadata.correlation_assumption,
+                )
+                if identity is None
+                else provider_evaluation_method_signature(metadata, identity)
+            )
+            previous = signatures.setdefault(method_id, signature)
+            if signature != previous:
+                raise ValueError(
+                    f"method {method_id!r} mixes covariance, model, estimator, "
+                    "revision, or provider semantics"
+                )
+            reported_metadata = metadata.to_dict()
+            if (
+                identity is not None
+                and identity.identity_format == "prediction-provider-manifest-v1"
+            ):
+                artifact_details = reported_metadata.get("metadata")
+                if not isinstance(artifact_details, dict):
+                    raise AssertionError("validated fused metadata is not a mapping")
+                invariant_details = dict(artifact_details)
+                invariant_details.pop(PROVIDER_EVALUATION_IDENTITY_METADATA_KEY)
+                reported_metadata["metadata"] = invariant_details
+                reported_metadata["provider_contract"] = identity.contract_record()
+            method_metadata.setdefault(method_id, reported_metadata)
+
+        common_point_support, common_flow_support, paired_support = (
+            _paired_common_support(
+                truth,
+                {
+                    method_id: artifact.sequence
+                    for method_id, artifact in artifacts.items()
+                },
+            )
+        )
+        for method_id, prediction_path in sorted(case.predictions.items()):
+            artifact = artifacts[method_id]
+            native_modes: EvaluationModes = evaluate_sequence_modes(
+                artifact.sequence,
+                truth,
+                boundary_frames=list(case.boundary_frames),
+                prefix_frame_stop_exclusive=case.prefix_frame_stop_exclusive,
+                evaluation_chunk_size=evaluation_chunk_size,
+            )
+            common_modes: EvaluationModes = evaluate_sequence_modes(
+                artifact.sequence,
+                truth,
+                boundary_frames=list(case.boundary_frames),
+                prefix_frame_stop_exclusive=case.prefix_frame_stop_exclusive,
+                truth_support_mask=common_point_support,
+                truth_flow_support_mask=common_flow_support,
+                evaluation_chunk_size=evaluation_chunk_size,
+            )
+            evaluation = common_modes.to_dict()
+            native_evaluation = native_modes.to_dict()
+            support = _method_support_summary(
+                common=common_modes,
+                native=native_modes,
+                paired=paired_support,
+            )
+            numeric = _numeric_leaves(evaluation)
+            numeric.update(
+                _numeric_leaves(
+                    native_evaluation,
+                    prefix="native_support",
+                )
+            )
+            numeric.update(_numeric_leaves(support, prefix="support"))
+            record: dict[str, Any] = {
+                "case_id": case.case_id,
+                "group_id": case.group_id,
+                "method_id": method_id,
+                "prediction_path": str(prediction_path),
+                "truth_path": str(case.truth_path),
+                "artifact": artifact.metadata.to_dict(),
+                "evaluation": evaluation,
+                "native_support_evaluation": native_evaluation,
+                "support": support,
+                "_numeric": numeric,
+            }
+            identity = identities.get(method_id)
+            if (
+                identity is not None
+                and identity.identity_format == "prediction-provider-manifest-v1"
+            ):
+                record["provider_identity"] = provider_identity_report_record(identity)
+            records.append(record)
+    return records, method_metadata
+
+
+__all__ = ["aggregate_provider_records", "evaluate_provider_cases"]

--- a/src/prob4d/provider_evaluation.py
+++ b/src/prob4d/provider_evaluation.py
@@ -8,10 +8,6 @@ from pathlib import Path
 from typing import Any
 
 from ._heldout_promotion_lock import load_promotion_lock
-from ._provider_evaluation_compute import (
-    aggregate_provider_records,
-    evaluate_provider_cases,
-)
 from ._provider_evaluation_decision import evaluate_provider_decision_policy
 from ._provider_evaluation_manifest import (
     PROVIDER_EVALUATION_DECISION_VERSION,
@@ -25,6 +21,10 @@ from ._provider_evaluation_manifest import (
     validate_finite_json,
 )
 from ._provider_evaluation_output import write_provider_evaluation_outputs
+from ._provider_evaluation_provider_neutral import (
+    aggregate_provider_records,
+    evaluate_provider_cases,
+)
 from .metrics import DEFAULT_EVALUATION_CHUNK_SIZE
 from .provider_evaluation_target_authorization import (
     PROVIDER_EVALUATION_TARGET_AUTHORIZATION_FIELD,

--- a/src/prob4d/provider_evaluation_identity.py
+++ b/src/prob4d/provider_evaluation_identity.py
@@ -1,0 +1,424 @@
+"""Provider-neutral identity validation for claim-bearing provider evaluation.
+
+Current fused prediction artifacts carry a free-form metadata mapping. This
+module gives provider evaluation one strict, versioned identity record inside
+that mapping while preserving deterministic replay of historical MotionCrafter
+artifacts. Per-case manifest and run identities are validated and reported, but
+only provider-contract fields participate in the cross-case method signature.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final, Literal, cast
+
+from ._immutable_json import plain_json
+from ._strict_json import (
+    require_exact_fields,
+    require_exact_integer,
+    require_exact_string,
+    require_mapping,
+    require_revision,
+    require_sha256,
+)
+from .data import DENSE_STORAGE_DTYPES
+from .io import FusedPredictionMetadata
+from .prediction_provider_manifest import (
+    COORDINATE_SEMANTICS,
+    FLOW_SEMANTICS,
+    POINT_SEMANTICS,
+    RAY_SEMANTICS,
+    SOURCE_DEPENDENCY_SEMANTICS,
+)
+
+PROVIDER_EVALUATION_IDENTITY_METADATA_KEY: Final = "provider_identity"
+PROVIDER_EVALUATION_IDENTITY_SCHEMA: Final = (
+    "prob4d.provider-evaluation-provider-identity"
+)
+PROVIDER_EVALUATION_IDENTITY_VERSION: Final = 1
+
+IdentityFormat = Literal[
+    "prediction-provider-manifest-v1",
+    "motioncrafter-legacy-v1",
+]
+
+_GENERIC_IDENTITY_FIELDS: Final = frozenset(
+    {
+        "schema_name",
+        "schema_version",
+        "provider_manifest_id",
+        "provider_manifest_sha256",
+        "provider_family",
+        "provider_repository",
+        "provider_revision",
+        "provider_run_id",
+        "model_set_id",
+        "loader_id",
+        "coordinate_semantics",
+        "point_semantics",
+        "flow_semantics",
+        "ray_semantics",
+        "source_dependency_semantics",
+    }
+)
+_LEGACY_MOTIONCRAFTER_FIELDS: Final = frozenset(
+    {
+        "motioncrafter_revision",
+        "motioncrafter_model_set_sha256",
+        "motioncrafter_seed_policy",
+        "prediction_manifest_sha256",
+    }
+)
+_LEGACY_SEED_POLICIES: Final = frozenset({"legacy-common", "derived-per-call"})
+
+
+def _repository(value: object, *, name: str) -> str:
+    result = require_exact_string(value, name=name)
+    if result.count("/") != 1 or result.startswith("/") or result.endswith("/"):
+        raise ValueError(f"{name} must use canonical owner/name form")
+    return result
+
+
+def _choice(value: object, choices: tuple[str, ...], *, name: str) -> str:
+    result = require_exact_string(value, name=name)
+    if result not in choices:
+        raise ValueError(f"{name} must be one of {list(choices)}")
+    return result
+
+
+def _legacy_seed_policy(value: object, *, name: str) -> str:
+    result = require_exact_string(value, name=name)
+    if result not in _LEGACY_SEED_POLICIES:
+        raise ValueError(
+            f"{name} must declare one of {sorted(_LEGACY_SEED_POLICIES)}"
+        )
+    return result
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderEvaluationIdentity:
+    """Validated provider identity normalized across generic and legacy inputs."""
+
+    identity_format: IdentityFormat
+    provider_revision: str
+    model_set_id: str
+    provider_manifest_sha256: str
+    provider_family: str | None = None
+    provider_repository: str | None = None
+    provider_run_id: str | None = None
+    provider_manifest_id: str | None = None
+    loader_id: str | None = None
+    coordinate_semantics: str | None = None
+    point_semantics: str | None = None
+    flow_semantics: str | None = None
+    ray_semantics: str | None = None
+    source_dependency_semantics: str | None = None
+    legacy_seed_policy: str | None = None
+
+    def contract_signature(self) -> tuple[object, ...]:
+        """Return the provider contract that must remain stable across cases."""
+
+        if self.identity_format == "motioncrafter-legacy-v1":
+            return (
+                self.identity_format,
+                self.provider_revision,
+                self.model_set_id,
+                self.legacy_seed_policy,
+            )
+        return (
+            self.identity_format,
+            self.provider_family,
+            self.provider_repository,
+            self.provider_revision,
+            self.model_set_id,
+            self.loader_id,
+            self.coordinate_semantics,
+            self.point_semantics,
+            self.flow_semantics,
+            self.ray_semantics,
+            self.source_dependency_semantics,
+        )
+
+    def contract_record(self) -> dict[str, object]:
+        """Return report-safe provider fields that are invariant across cases."""
+
+        if self.identity_format == "motioncrafter-legacy-v1":
+            return {
+                "identity_format": self.identity_format,
+                "provider_revision": self.provider_revision,
+                "model_set_id": self.model_set_id,
+                "legacy_seed_policy": self.legacy_seed_policy,
+            }
+        return {
+            "identity_format": self.identity_format,
+            "provider_family": self.provider_family,
+            "provider_repository": self.provider_repository,
+            "provider_revision": self.provider_revision,
+            "model_set_id": self.model_set_id,
+            "loader_id": self.loader_id,
+            "coordinate_semantics": self.coordinate_semantics,
+            "point_semantics": self.point_semantics,
+            "flow_semantics": self.flow_semantics,
+            "ray_semantics": self.ray_semantics,
+            "source_dependency_semantics": self.source_dependency_semantics,
+        }
+
+    def evidence_record(self) -> dict[str, object]:
+        """Return the complete normalized per-case identity for diagnostics."""
+
+        return {
+            **self.contract_record(),
+            "provider_manifest_id": self.provider_manifest_id,
+            "provider_manifest_sha256": self.provider_manifest_sha256,
+            "provider_run_id": self.provider_run_id,
+        }
+
+
+def _generic_identity(value: object, *, path: Path) -> ProviderEvaluationIdentity:
+    mapping = require_mapping(
+        value,
+        name=f"{path} metadata.{PROVIDER_EVALUATION_IDENTITY_METADATA_KEY}",
+    )
+    require_exact_fields(
+        mapping,
+        _GENERIC_IDENTITY_FIELDS,
+        name=f"{path} provider identity",
+    )
+    if mapping["schema_name"] != PROVIDER_EVALUATION_IDENTITY_SCHEMA:
+        raise ValueError(f"{path} provider identity schema changed")
+    version = require_exact_integer(
+        mapping["schema_version"],
+        name=f"{path} provider identity schema_version",
+        minimum=1,
+    )
+    if version != PROVIDER_EVALUATION_IDENTITY_VERSION:
+        raise ValueError(f"{path} provider identity version changed")
+    source_semantics = require_exact_string(
+        mapping["source_dependency_semantics"],
+        name=f"{path} provider identity source_dependency_semantics",
+    )
+    if source_semantics != SOURCE_DEPENDENCY_SEMANTICS:
+        raise ValueError(f"{path} provider identity source dependency semantics changed")
+    return ProviderEvaluationIdentity(
+        identity_format="prediction-provider-manifest-v1",
+        provider_family=require_exact_string(
+            mapping["provider_family"],
+            name=f"{path} provider identity provider_family",
+        ),
+        provider_repository=_repository(
+            mapping["provider_repository"],
+            name=f"{path} provider identity provider_repository",
+        ),
+        provider_revision=require_revision(
+            mapping["provider_revision"],
+            name=f"{path} provider identity provider_revision",
+        ),
+        provider_run_id=require_sha256(
+            mapping["provider_run_id"],
+            name=f"{path} provider identity provider_run_id",
+        ),
+        provider_manifest_id=require_sha256(
+            mapping["provider_manifest_id"],
+            name=f"{path} provider identity provider_manifest_id",
+        ),
+        provider_manifest_sha256=require_sha256(
+            mapping["provider_manifest_sha256"],
+            name=f"{path} provider identity provider_manifest_sha256",
+        ),
+        model_set_id=require_sha256(
+            mapping["model_set_id"],
+            name=f"{path} provider identity model_set_id",
+        ),
+        loader_id=require_sha256(
+            mapping["loader_id"],
+            name=f"{path} provider identity loader_id",
+        ),
+        coordinate_semantics=_choice(
+            mapping["coordinate_semantics"],
+            COORDINATE_SEMANTICS,
+            name=f"{path} provider identity coordinate_semantics",
+        ),
+        point_semantics=_choice(
+            mapping["point_semantics"],
+            POINT_SEMANTICS,
+            name=f"{path} provider identity point_semantics",
+        ),
+        flow_semantics=_choice(
+            mapping["flow_semantics"],
+            FLOW_SEMANTICS,
+            name=f"{path} provider identity flow_semantics",
+        ),
+        ray_semantics=_choice(
+            mapping["ray_semantics"],
+            RAY_SEMANTICS,
+            name=f"{path} provider identity ray_semantics",
+        ),
+        source_dependency_semantics=source_semantics,
+    )
+
+
+def _legacy_identity(
+    details: Mapping[str, Any],
+    *,
+    path: Path,
+) -> ProviderEvaluationIdentity:
+    missing = sorted(_LEGACY_MOTIONCRAFTER_FIELDS - set(details))
+    if missing:
+        raise ValueError(
+            f"{path} metadata requires provider_identity or the complete historical "
+            f"MotionCrafter identity; missing={missing}"
+        )
+    return ProviderEvaluationIdentity(
+        identity_format="motioncrafter-legacy-v1",
+        provider_revision=require_revision(
+            details["motioncrafter_revision"],
+            name=f"{path} metadata.motioncrafter_revision",
+        ),
+        model_set_id=require_sha256(
+            details["motioncrafter_model_set_sha256"],
+            name=f"{path} metadata.motioncrafter_model_set_sha256",
+        ),
+        provider_manifest_sha256=require_sha256(
+            details["prediction_manifest_sha256"],
+            name=f"{path} metadata.prediction_manifest_sha256",
+        ),
+        legacy_seed_policy=_legacy_seed_policy(
+            details["motioncrafter_seed_policy"],
+            name=f"{path} metadata.motioncrafter_seed_policy",
+        ),
+    )
+
+
+def _validate_optional_legacy_mirror(
+    details: Mapping[str, Any],
+    identity: ProviderEvaluationIdentity,
+    *,
+    path: Path,
+) -> None:
+    present = _LEGACY_MOTIONCRAFTER_FIELDS & set(details)
+    if not present:
+        return
+    missing = sorted(_LEGACY_MOTIONCRAFTER_FIELDS - set(details))
+    if missing:
+        raise ValueError(
+            f"{path} metadata mixes generic and partial MotionCrafter identity; "
+            f"missing={missing}"
+        )
+    legacy_revision = require_revision(
+        details["motioncrafter_revision"],
+        name=f"{path} metadata.motioncrafter_revision",
+    )
+    legacy_model_set = require_sha256(
+        details["motioncrafter_model_set_sha256"],
+        name=f"{path} metadata.motioncrafter_model_set_sha256",
+    )
+    legacy_manifest_sha256 = require_sha256(
+        details["prediction_manifest_sha256"],
+        name=f"{path} metadata.prediction_manifest_sha256",
+    )
+    _legacy_seed_policy(
+        details["motioncrafter_seed_policy"],
+        name=f"{path} metadata.motioncrafter_seed_policy",
+    )
+    if identity.provider_family != "motioncrafter":
+        raise ValueError(
+            f"{path} metadata carries MotionCrafter compatibility fields for a "
+            "different provider_family"
+        )
+    if legacy_revision != identity.provider_revision:
+        raise ValueError(f"{path} MotionCrafter compatibility revision changed")
+    if legacy_model_set != identity.model_set_id:
+        raise ValueError(f"{path} MotionCrafter compatibility model set changed")
+    if legacy_manifest_sha256 != identity.provider_manifest_sha256:
+        raise ValueError(f"{path} MotionCrafter compatibility manifest digest changed")
+
+
+def provider_identity_from_metadata(
+    details: Mapping[str, Any],
+    *,
+    path: Path,
+) -> ProviderEvaluationIdentity:
+    """Load a generic provider identity or replay the historical adapter."""
+
+    if PROVIDER_EVALUATION_IDENTITY_METADATA_KEY not in details:
+        return _legacy_identity(details, path=path)
+    identity = _generic_identity(
+        details[PROVIDER_EVALUATION_IDENTITY_METADATA_KEY],
+        path=path,
+    )
+    _validate_optional_legacy_mirror(details, identity, path=path)
+    return identity
+
+
+def validate_provider_evaluation_metadata(
+    metadata: FusedPredictionMetadata,
+    *,
+    path: Path,
+) -> ProviderEvaluationIdentity:
+    """Validate common estimator metadata and return normalized provider identity."""
+
+    details = metadata.metadata
+    require_revision(
+        details.get("prob4d_revision"),
+        name=f"{path} metadata.prob4d_revision",
+    )
+    identity = provider_identity_from_metadata(details, path=path)
+    if details.get("includes_covariance") is not True:
+        raise ValueError(
+            f"{path} metadata.includes_covariance must be true for provider evaluation"
+        )
+    dense_storage_dtype = details.get("dense_storage_dtype", "float64")
+    if dense_storage_dtype not in DENSE_STORAGE_DTYPES:
+        raise ValueError(
+            f"{path} metadata.dense_storage_dtype must be one of "
+            + ", ".join(DENSE_STORAGE_DTYPES)
+        )
+    for field in ("gauge_estimator", "uncertainty_calibration"):
+        value = details.get(field)
+        if not isinstance(value, str) or not value.strip():
+            raise ValueError(f"{path} metadata.{field} must be nonempty text")
+    return identity
+
+
+def provider_evaluation_method_signature(
+    metadata: FusedPredictionMetadata,
+    identity: ProviderEvaluationIdentity,
+) -> tuple[object, ...]:
+    """Build the cross-case signature without case-local manifest identities."""
+
+    details = metadata.metadata
+    return (
+        metadata.fusion_method,
+        metadata.covariance_semantics,
+        metadata.correlation_assumption,
+        details.get("prob4d_revision"),
+        *identity.contract_signature(),
+        details.get("dense_storage_dtype", "float64"),
+        details.get("gauge_estimator"),
+        details.get("uncertainty_calibration"),
+        details.get("gauge_covariance_calibration_artifact_id"),
+        details.get("point_uncertainty_calibration_artifact_id"),
+        details.get("source_reliability_artifact_id"),
+    )
+
+
+def provider_identity_report_record(
+    identity: ProviderEvaluationIdentity,
+) -> dict[str, object]:
+    """Return a detached finite JSON record for provider-evaluation output."""
+
+    return cast(dict[str, object], plain_json(identity.evidence_record()))
+
+
+__all__ = [
+    "PROVIDER_EVALUATION_IDENTITY_METADATA_KEY",
+    "PROVIDER_EVALUATION_IDENTITY_SCHEMA",
+    "PROVIDER_EVALUATION_IDENTITY_VERSION",
+    "ProviderEvaluationIdentity",
+    "provider_evaluation_method_signature",
+    "provider_identity_from_metadata",
+    "provider_identity_report_record",
+    "validate_provider_evaluation_metadata",
+]

--- a/tests/test_provider_evaluation_identity.py
+++ b/tests/test_provider_evaluation_identity.py
@@ -1,0 +1,321 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from prob4d._provider_evaluation_compute import (
+    evaluate_provider_cases as evaluate_legacy_provider_cases,
+)
+from prob4d._provider_evaluation_manifest import ProviderEvaluationCase
+from prob4d._provider_evaluation_provider_neutral import (
+    evaluate_provider_cases as evaluate_provider_neutral_cases,
+)
+from prob4d.fusion import FusedSequence
+from prob4d.io import save_fused_prediction, save_truth
+from prob4d.metrics import TruthSequence
+from prob4d.prediction_provider_manifest import SOURCE_DEPENDENCY_SEMANTICS
+from prob4d.provider_evaluation import run_provider_evaluation
+from prob4d.provider_evaluation_identity import (
+    PROVIDER_EVALUATION_IDENTITY_SCHEMA,
+    PROVIDER_EVALUATION_IDENTITY_VERSION,
+)
+
+
+def _truth() -> TruthSequence:
+    points = np.array(
+        [
+            [[[0.0, 0.0, 1.0]]],
+            [[[1.0, 0.0, 1.0]]],
+        ]
+    )
+    return TruthSequence(
+        frame_indices=np.array([0, 1]),
+        point_map=points,
+        valid_mask=np.ones((2, 1, 1), dtype=bool),
+    )
+
+
+def _prediction(truth: TruthSequence, error: float) -> FusedSequence:
+    points = truth.point_map.copy()
+    points[..., 0] += error
+    covariance = np.broadcast_to(np.eye(3), points.shape + (3,)).copy()
+    return FusedSequence(
+        frame_indices=truth.frame_indices,
+        point_map=points,
+        valid_mask=truth.valid_mask,
+        point_covariance=covariance,
+        contributors=np.ones(truth.valid_mask.shape, dtype=np.uint16),
+    )
+
+
+def _metadata(
+    *,
+    provider_manifest_id: str,
+    provider_manifest_sha256: str,
+    provider_run_id: str,
+    loader_id: str = "6" * 64,
+) -> dict[str, object]:
+    return {
+        "prob4d_revision": "a" * 40,
+        "provider_identity": {
+            "schema_name": PROVIDER_EVALUATION_IDENTITY_SCHEMA,
+            "schema_version": PROVIDER_EVALUATION_IDENTITY_VERSION,
+            "provider_manifest_id": provider_manifest_id,
+            "provider_manifest_sha256": provider_manifest_sha256,
+            "provider_family": "cut3r",
+            "provider_repository": "naver/CUT3R",
+            "provider_revision": "b" * 40,
+            "provider_run_id": provider_run_id,
+            "model_set_id": "c" * 64,
+            "loader_id": loader_id,
+            "coordinate_semantics": "sequence-local-sim3",
+            "point_semantics": "dense-point-map",
+            "flow_semantics": "absent",
+            "ray_semantics": "absent",
+            "source_dependency_semantics": SOURCE_DEPENDENCY_SEMANTICS,
+        },
+        "includes_covariance": True,
+        "gauge_estimator": "sequential",
+        "uncertainty_calibration": "held_out",
+    }
+
+
+def _legacy_motioncrafter_metadata() -> dict[str, object]:
+    return {
+        "prob4d_revision": "a" * 40,
+        "motioncrafter_revision": "b" * 40,
+        "motioncrafter_seed_policy": "derived-per-call",
+        "motioncrafter_model_set_sha256": "c" * 64,
+        "prediction_manifest_sha256": "d" * 64,
+        "includes_covariance": True,
+        "gauge_estimator": "sequential",
+        "uncertainty_calibration": "held_out",
+    }
+
+
+def _case(
+    root: Path,
+    case_id: str,
+    group_id: str,
+    *,
+    identity_digit: str,
+    loader_id: str = "6" * 64,
+) -> dict[str, object]:
+    truth = _truth()
+    truth_path = root / f"{case_id}-truth.npz"
+    prediction_path = root / f"{case_id}-cut3r.npz"
+    save_truth(truth_path, truth)
+    save_fused_prediction(
+        prediction_path,
+        _prediction(truth, 0.25),
+        method_id="cut3r",
+        fusion_method="covariance_intersection",
+        metadata=_metadata(
+            provider_manifest_id=identity_digit * 64,
+            provider_manifest_sha256=chr(ord(identity_digit) + 1) * 64,
+            provider_run_id=chr(ord(identity_digit) + 2) * 64,
+            loader_id=loader_id,
+        ),
+    )
+    return {
+        "case_id": case_id,
+        "group_id": group_id,
+        "truth": truth_path.name,
+        "predictions": {"cut3r": prediction_path.name},
+        "boundary_frames": [],
+        "prefix_frame_stop_exclusive": None,
+    }
+
+
+def _manifest(root: Path, cases: list[dict[str, object]]) -> Path:
+    path = root / "evaluation.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_name": "prob4d.provider-evaluation",
+                "schema_version": 1,
+                "primary_mode": "metric",
+                "reference_method": "cut3r",
+                "cases": cases,
+                "metadata": {"split": "fresh-provider"},
+            }
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_cut3r_evaluates_without_motioncrafter_metadata(tmp_path: Path) -> None:
+    path = _manifest(
+        tmp_path,
+        [
+            _case(tmp_path, "case-1", "group-1", identity_digit="1"),
+            _case(tmp_path, "case-2", "group-2", identity_digit="4"),
+        ],
+    )
+
+    report = run_provider_evaluation(
+        path,
+        tmp_path / "output",
+        bootstrap_resamples=10,
+    )
+
+    contract = report["method_metadata"]["cut3r"]["provider_contract"]
+    assert contract["provider_family"] == "cut3r"
+    assert contract["provider_repository"] == "naver/CUT3R"
+    assert contract["coordinate_semantics"] == "sequence-local-sim3"
+    assert contract["identity_format"] == "prediction-provider-manifest-v1"
+    assert report["aggregate"]["cut3r"]["group_count"] == 2
+    artifact_metadata = report["cases"][0]["artifact"]["metadata"]
+    assert "motioncrafter_revision" not in artifact_metadata
+    assert "provider_identity" not in report["method_metadata"]["cut3r"]["metadata"]
+
+
+def test_case_local_manifest_and_run_id_changes_are_not_contract_drift(
+    tmp_path: Path,
+) -> None:
+    path = _manifest(
+        tmp_path,
+        [
+            _case(tmp_path, "case-1", "group-1", identity_digit="1"),
+            _case(tmp_path, "case-2", "group-2", identity_digit="4"),
+        ],
+    )
+
+    report = run_provider_evaluation(path, tmp_path / "output", bootstrap_resamples=10)
+
+    first_identity = report["cases"][0]["provider_identity"]
+    second_identity = report["cases"][1]["provider_identity"]
+    assert first_identity["provider_manifest_id"] != second_identity["provider_manifest_id"]
+    assert first_identity["provider_run_id"] != second_identity["provider_run_id"]
+
+
+def test_generic_provider_contract_drift_is_rejected(tmp_path: Path) -> None:
+    path = _manifest(
+        tmp_path,
+        [
+            _case(tmp_path, "case-1", "group-1", identity_digit="1"),
+            _case(
+                tmp_path,
+                "case-2",
+                "group-2",
+                identity_digit="4",
+                loader_id="7" * 64,
+            ),
+        ],
+    )
+
+    with pytest.raises(ValueError, match="provider semantics"):
+        run_provider_evaluation(path, tmp_path / "output", bootstrap_resamples=10)
+
+
+def test_generic_provider_identity_rejects_unknown_fields(tmp_path: Path) -> None:
+    truth = _truth()
+    truth_path = tmp_path / "truth.npz"
+    prediction_path = tmp_path / "prediction.npz"
+    save_truth(truth_path, truth)
+    metadata = _metadata(
+        provider_manifest_id="1" * 64,
+        provider_manifest_sha256="2" * 64,
+        provider_run_id="3" * 64,
+    )
+    identity = metadata["provider_identity"]
+    assert isinstance(identity, dict)
+    identity["unregistered_field"] = "not admitted"
+    save_fused_prediction(
+        prediction_path,
+        _prediction(truth, 0.25),
+        method_id="cut3r",
+        fusion_method="covariance_intersection",
+        metadata=metadata,
+    )
+    path = _manifest(
+        tmp_path,
+        [
+            {
+                "case_id": "case-1",
+                "group_id": "group-1",
+                "truth": truth_path.name,
+                "predictions": {"cut3r": prediction_path.name},
+                "boundary_frames": [],
+                "prefix_frame_stop_exclusive": None,
+            }
+        ],
+    )
+
+    with pytest.raises(ValueError, match="provider identity fields changed"):
+        run_provider_evaluation(path, tmp_path / "output", bootstrap_resamples=10)
+
+
+def test_generic_identity_rejects_partial_motioncrafter_mirror(tmp_path: Path) -> None:
+    truth = _truth()
+    truth_path = tmp_path / "truth.npz"
+    prediction_path = tmp_path / "prediction.npz"
+    save_truth(truth_path, truth)
+    metadata = _metadata(
+        provider_manifest_id="1" * 64,
+        provider_manifest_sha256="2" * 64,
+        provider_run_id="3" * 64,
+    )
+    metadata["motioncrafter_revision"] = "b" * 40
+    save_fused_prediction(
+        prediction_path,
+        _prediction(truth, 0.25),
+        method_id="cut3r",
+        fusion_method="covariance_intersection",
+        metadata=metadata,
+    )
+    path = _manifest(
+        tmp_path,
+        [
+            {
+                "case_id": "case-1",
+                "group_id": "group-1",
+                "truth": truth_path.name,
+                "predictions": {"cut3r": prediction_path.name},
+                "boundary_frames": [],
+                "prefix_frame_stop_exclusive": None,
+            }
+        ],
+    )
+
+    with pytest.raises(ValueError, match="partial MotionCrafter identity"):
+        run_provider_evaluation(path, tmp_path / "output", bootstrap_resamples=10)
+
+
+def test_historical_motioncrafter_evaluation_records_remain_identical(
+    tmp_path: Path,
+) -> None:
+    truth = _truth()
+    truth_path = tmp_path / "truth.npz"
+    prediction_path = tmp_path / "motioncrafter.npz"
+    save_truth(truth_path, truth)
+    save_fused_prediction(
+        prediction_path,
+        _prediction(truth, 0.25),
+        method_id="motioncrafter",
+        fusion_method="uniform",
+        metadata=_legacy_motioncrafter_metadata(),
+    )
+    case = ProviderEvaluationCase(
+        case_id="case-1",
+        group_id="group-1",
+        truth_path=truth_path,
+        predictions={"motioncrafter": prediction_path},
+    )
+
+    historical = evaluate_legacy_provider_cases(
+        [case],
+        allow_legacy_artifacts=False,
+        evaluation_chunk_size=1,
+    )
+    provider_neutral = evaluate_provider_neutral_cases(
+        [case],
+        allow_legacy_artifacts=False,
+        evaluation_chunk_size=1,
+    )
+
+    assert provider_neutral == historical


### PR DESCRIPTION
## Superseded

Closed in favor of #249, which carries the identical head commit `c9c9796d0d1bc962340799166f8398885f370b4b` and was merged into `main` as `16952e8bd444b8c880a178d83a8d6143b08cb294`. Keeping one review surface avoids duplicate maintenance and ambiguity.

## Original summary

- add a strict, versioned `provider_identity` record aligned with `PredictionProviderManifestV1`
- let CUT3R, VGGT, MotionCrafter, and future providers use the same held-out evaluator without fabricated MotionCrafter fields
- distinguish case-local manifest/run identities from the provider contract that must remain stable across held-out cases
- preserve the historical MotionCrafter evaluation path and report structure exactly
- add focused regression tests, documentation, and mypy coverage for the new boundary

## Compatibility and fail-closed behavior

- existing MotionCrafter fused artifacts remain readable without rewriting bytes or identifiers
- generic identities reject unknown fields, malformed revisions/digests, unsupported semantic values, contract drift, and partial or contradictory MotionCrafter mirrors
- `provider_manifest_id`, exact manifest-byte SHA-256, and `provider_run_id` are validated and retained per case but intentionally excluded from cross-case method drift because they normally change across objects or sessions
- provider family, repository, revision, model set, loader, coordinate/payload semantics, source-dependency semantics, Prob4D revision, fusion/covariance meaning, gauge estimator, and calibration identities remain frozen across cases

## Validation

- Python compilation passed for all changed modules
- isolated contract/evaluator harness passed generic CUT3R-like inputs, case-local identity changes, contract-drift rejection, strict legacy validation, and unchanged historical MotionCrafter report records
- repository Actions provide the authoritative Ruff, mypy, documentation-surface, and pytest results

## Scope

This PR changes the observation-level provider evaluator only. The separately frozen held-out promotion-lock and target-admission schemas still contain historical MotionCrafter-specific fields; migrating those requires a coordinated versioned schema change and is intentionally left out of this compatibility-focused patch.