### PR TITLE
Add provider-neutral held-out promotion locks

### DIFF
--- a/CHANGELOG.d/provider-neutral-promotion-lock.md
+++ b/CHANGELOG.d/provider-neutral-promotion-lock.md
@@ -1,0 +1,7 @@
+Add an additive provider-neutral version of the held-out promotion lock and its
+paper-facing evidence card. New locks freeze the complete
+`PredictionProviderManifestV1` contract for CUT3R, VGGT, MotionCrafter, or future
+providers, and target admission checks every invariant provider field. Historical
+MotionCrafter lock and evidence-card descriptors remain byte- and identity-stable.
+This changes no estimator, calibration, target access, fallback, or scientific
+claim.

--- a/docs/examples/heldout-provider-promotion-config-v2.json
+++ b/docs/examples/heldout-provider-promotion-config-v2.json
@@ -1,0 +1,120 @@
+{
+  "arms": [
+    {
+      "arm_id": "fallback",
+      "metadata": {},
+      "provider_method_id": null,
+      "query_method_id": "bpt-physical-fallback",
+      "role": "physical_fallback",
+      "sensor_assisted": false
+    },
+    {
+      "arm_id": "framewise",
+      "metadata": {},
+      "provider_method_id": "prob4d-framewise-explicit-joint-gauge",
+      "query_method_id": "bpt-framewise-explicit-joint-gauge",
+      "role": "framewise_explicit_joint_gauge",
+      "sensor_assisted": false
+    },
+    {
+      "arm_id": "identity",
+      "metadata": {},
+      "provider_method_id": "prob4d-cross-window-identity-mixture",
+      "query_method_id": "bpt-cross-window-identity-mixture",
+      "role": "cross_window_identity_marginalized",
+      "sensor_assisted": false
+    },
+    {
+      "arm_id": "persistent",
+      "metadata": {},
+      "provider_method_id": "prob4d-persistent-explicit-joint-gauge",
+      "query_method_id": "bpt-persistent-explicit-joint-gauge",
+      "role": "persistent_explicit_joint_gauge",
+      "sensor_assisted": false
+    },
+    {
+      "arm_id": "rowwise",
+      "metadata": {},
+      "provider_method_id": "prob4d-persistent-rowwise-gauge",
+      "query_method_id": "bpt-persistent-rowwise-gauge",
+      "role": "rowwise_gauge_marginalized",
+      "sensor_assisted": false
+    },
+    {
+      "arm_id": "sensor-anchor",
+      "metadata": {
+        "claim_label": "sensor-assisted"
+      },
+      "provider_method_id": "prob4d-independent-metric-anchor",
+      "query_method_id": "bpt-independent-metric-anchor",
+      "role": "sensor_assisted",
+      "sensor_assisted": true
+    },
+    {
+      "arm_id": "visual",
+      "metadata": {},
+      "provider_method_id": "last-frame-visual-baseline",
+      "query_method_id": "bpt-last-frame-visual-baseline",
+      "role": "visual_baseline",
+      "sensor_assisted": false
+    }
+  ],
+  "bayesian_phystwin_repository": "IPS-Stuttgart/BayesianPhysTwin",
+  "bayesian_phystwin_revision": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "bootstrap_resamples": 10000,
+  "bootstrap_seed": 1729,
+  "calibration_group_ids": [
+    "calibration-object-01",
+    "calibration-object-02"
+  ],
+  "development_group_ids": [
+    "development-object-01",
+    "development-object-02"
+  ],
+  "experiment_id": "heldout-real-provider-v2",
+  "frozen_artifact_ids": {
+    "bayesian_guard_configuration": "6666666666666666666666666666666666666666666666666666666666666666",
+    "gauge_calibration": "1111111111111111111111111111111111111111111111111111111111111111",
+    "material_identity_calibration": "4444444444444444444444444444444444444444444444444444444444444444",
+    "point_calibration": "2222222222222222222222222222222222222222222222222222222222222222",
+    "provider_configuration": "0000000000000000000000000000000000000000000000000000000000000000",
+    "selection_lock": "5555555555555555555555555555555555555555555555555555555555555555",
+    "source_reliability_calibration": "3333333333333333333333333333333333333333333333333333333333333333"
+  },
+  "harmful_update_margin_mm": 0.0,
+  "maximum_harmful_accepted_updates": 0,
+  "maximum_technical_failures": 0,
+  "maximum_worst_group_regression_mm": 0.0,
+  "metadata": {
+    "split_semantics": "complete-object-or-session-v1",
+    "target_access": "sealed-before-outcomes"
+  },
+  "minimum_mean_accepted_coverage": 0.9,
+  "minimum_target_group_count": 3,
+  "prediction_run_spec_id": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+  "primary_query_arm_id": "identity",
+  "provider_evaluation_manifest_sha256": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "provider_identity": {
+    "coordinate_semantics": "sequence-local-sim3",
+    "flow_semantics": "absent",
+    "loader_id": "8888888888888888888888888888888888888888888888888888888888888888",
+    "model_set_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "point_semantics": "dense-point-map",
+    "provider_family": "cut3r",
+    "provider_repository": "naver/CUT3R",
+    "provider_revision": "cccccccccccccccccccccccccccccccccccccccc",
+    "ray_semantics": "absent",
+    "schema_name": "prob4d.provider-promotion-identity",
+    "schema_version": 1,
+    "source_dependency_semantics": "per-output-exclusive-source-frame-interval-v1"
+  },
+  "provider_reference_arm_id": "visual",
+  "query_superiority_margin_mm": 0.25,
+  "source_repository": "IPS-Stuttgart/Prob4D",
+  "source_revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "target_group_ids": [
+    "target-object-01",
+    "target-object-02",
+    "target-object-03"
+  ]
+}

--- a/docs/provider-neutral-heldout-promotion.md
+++ b/docs/provider-neutral-heldout-promotion.md
@@ -1,0 +1,78 @@
+# Provider-neutral held-out promotion lock
+
+Prob4D's original held-out promotion lock was created for the historical
+MotionCrafter route. Its version-1 descriptor stores
+`motioncrafter_revision` and `model_set_id` directly. Those artifacts remain
+strictly readable and retain their original bytes and content identities.
+
+New claim-bearing provider studies should use the additive version-2 lock. It
+replaces the two MotionCrafter-specific fields with one strict
+`provider_identity` record aligned with `PredictionProviderManifestV1`:
+
+```json
+{
+  "provider_identity": {
+    "schema_name": "prob4d.provider-promotion-identity",
+    "schema_version": 1,
+    "provider_family": "cut3r",
+    "provider_repository": "naver/CUT3R",
+    "provider_revision": "<exact 40- or 64-character revision>",
+    "model_set_id": "<SHA-256>",
+    "loader_id": "<SHA-256>",
+    "coordinate_semantics": "sequence-local-sim3",
+    "point_semantics": "dense-point-map",
+    "flow_semantics": "absent",
+    "ray_semantics": "absent",
+    "source_dependency_semantics":
+      "per-output-exclusive-source-frame-interval-v1"
+  }
+}
+```
+
+The provider family, repository, exact revision, model set, loader, coordinate
+and payload semantics, and source-dependency semantics are immutable across the
+frozen source, calibration, and target groups. Case-local manifest identities,
+manifest-byte digests, and provider run IDs remain in the corresponding
+provider-manifest and target-admission artifacts; they are not method invariants
+and therefore do not belong in the promotion lock.
+
+Start from the provider-neutral example:
+
+```bash
+cp docs/examples/heldout-provider-promotion-config-v2.json protocol.json
+
+prob4d experiment heldout-provider freeze protocol.json \
+  --output promotion-lock.json
+```
+
+The existing `run`, `verify`, target-admission, and cohort-binding commands accept
+both lock versions. For a version-2 lock, target admission fails closed unless
+every admitted manifest matches the complete frozen provider contract. A changed
+loader, repository, coordinate system, payload meaning, or source-dependency
+semantics is rejected even when the provider revision and model-set digest are
+unchanged.
+
+Promotion evidence cards are versioned in parallel. Historical lock version 1
+continues to produce the historical evidence-card layout with a
+`repositories.motioncrafter` record. Lock version 2 produces evidence-card
+version 2 with the complete generic provider identity under
+`repositories.provider`.
+
+## Compatibility boundary
+
+- Version-1 lock descriptors, IDs, reports, and evidence cards are not rewritten.
+- Version-2 is additive and uses the same registered comparison arms, grouped
+  bootstrap, provider gate, guarded-query gate, and exact-fallback semantics.
+- A configuration cannot mix `provider_identity` with the historical
+  `motioncrafter_revision` or top-level `model_set_id` fields.
+- The target-provider admission schema remains unchanged because it was already
+  provider-neutral; version-2 locks strengthen its lock-consistency check to the
+  complete provider contract.
+
+## Scientific boundary
+
+Provider-neutral identities authenticate a frozen method and its information
+semantics. They do not establish source support, provider accuracy, uncertainty
+calibration, BayesianPhysTwin update value, Causal4D intervention benefit,
+deployment safety, or state of the art. No target outcome is needed to create or
+validate either lock version.

--- a/src/prob4d/_heldout_promotion_lock.py
+++ b/src/prob4d/_heldout_promotion_lock.py
@@ -32,19 +32,199 @@ from ._heldout_promotion_common import (
 )
 from ._immutable_json import frozen_finite_json_mapping, plain_json
 from ._selection_evidence_common import _sha256_json, _strict_integer
+from .prediction_provider_manifest import (
+    COORDINATE_SEMANTICS,
+    FLOW_SEMANTICS,
+    POINT_SEMANTICS,
+    RAY_SEMANTICS,
+    SOURCE_DEPENDENCY_SEMANTICS,
+)
+
+HELDOUT_PROMOTION_LOCK_PROVIDER_NEUTRAL_VERSION = 2
+PROVIDER_PROMOTION_IDENTITY_SCHEMA = "prob4d.provider-promotion-identity"
+PROVIDER_PROMOTION_IDENTITY_VERSION = 1
+
+_PROVIDER_IDENTITY_FIELDS = {
+    "schema_name",
+    "schema_version",
+    "provider_family",
+    "provider_repository",
+    "provider_revision",
+    "model_set_id",
+    "loader_id",
+    "coordinate_semantics",
+    "point_semantics",
+    "flow_semantics",
+    "ray_semantics",
+    "source_dependency_semantics",
+}
+
+
+def _semantic_choice(value: object, choices: tuple[str, ...], *, name: str) -> str:
+    result = _strict_string(value, name=name)
+    if result not in choices:
+        raise ValueError(f"{name} must be one of {list(choices)}")
+    return result
+
+
+@dataclass(frozen=True, slots=True)
+class ProviderPromotionIdentityV1:
+    """Invariant provider contract frozen before held-out target access."""
+
+    provider_family: str
+    provider_repository: str
+    provider_revision: str
+    model_set_id: str
+    loader_id: str
+    coordinate_semantics: str
+    point_semantics: str
+    flow_semantics: str
+    ray_semantics: str
+    source_dependency_semantics: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "provider_family",
+            _strict_string(self.provider_family, name="provider_family"),
+        )
+        object.__setattr__(
+            self,
+            "provider_repository",
+            _repository(self.provider_repository, name="provider_repository"),
+        )
+        object.__setattr__(
+            self,
+            "provider_revision",
+            _revision(self.provider_revision, name="provider_revision"),
+        )
+        for field_name in ("model_set_id", "loader_id"):
+            object.__setattr__(
+                self,
+                field_name,
+                _strict_digest(
+                    getattr(self, field_name),
+                    name=field_name,
+                    pattern=_SHA256,
+                ),
+            )
+        object.__setattr__(
+            self,
+            "coordinate_semantics",
+            _semantic_choice(
+                self.coordinate_semantics,
+                COORDINATE_SEMANTICS,
+                name="coordinate_semantics",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "point_semantics",
+            _semantic_choice(
+                self.point_semantics,
+                POINT_SEMANTICS,
+                name="point_semantics",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "flow_semantics",
+            _semantic_choice(
+                self.flow_semantics,
+                FLOW_SEMANTICS,
+                name="flow_semantics",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "ray_semantics",
+            _semantic_choice(
+                self.ray_semantics,
+                RAY_SEMANTICS,
+                name="ray_semantics",
+            ),
+        )
+        source_semantics = _strict_string(
+            self.source_dependency_semantics,
+            name="source_dependency_semantics",
+        )
+        if source_semantics != SOURCE_DEPENDENCY_SEMANTICS:
+            raise ValueError("source_dependency_semantics changed")
+        object.__setattr__(self, "source_dependency_semantics", source_semantics)
+
+    @property
+    def contract_signature(self) -> tuple[str, ...]:
+        return (
+            self.provider_family,
+            self.provider_repository,
+            self.provider_revision,
+            self.model_set_id,
+            self.loader_id,
+            self.coordinate_semantics,
+            self.point_semantics,
+            self.flow_semantics,
+            self.ray_semantics,
+            self.source_dependency_semantics,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_name": PROVIDER_PROMOTION_IDENTITY_SCHEMA,
+            "schema_version": PROVIDER_PROMOTION_IDENTITY_VERSION,
+            "provider_family": self.provider_family,
+            "provider_repository": self.provider_repository,
+            "provider_revision": self.provider_revision,
+            "model_set_id": self.model_set_id,
+            "loader_id": self.loader_id,
+            "coordinate_semantics": self.coordinate_semantics,
+            "point_semantics": self.point_semantics,
+            "flow_semantics": self.flow_semantics,
+            "ray_semantics": self.ray_semantics,
+            "source_dependency_semantics": self.source_dependency_semantics,
+        }
+
+    @classmethod
+    def from_dict(cls, value: object) -> ProviderPromotionIdentityV1:
+        mapping = _strict_mapping(value, name="provider promotion identity")
+        _exact_keys(
+            mapping,
+            _PROVIDER_IDENTITY_FIELDS,
+            name="provider promotion identity",
+        )
+        if mapping["schema_name"] != PROVIDER_PROMOTION_IDENTITY_SCHEMA:
+            raise ValueError("unsupported provider promotion identity schema")
+        version = _strict_integer(
+            mapping["schema_version"],
+            name="provider promotion identity schema_version",
+            minimum=1,
+        )
+        if version != PROVIDER_PROMOTION_IDENTITY_VERSION:
+            raise ValueError("unsupported provider promotion identity version")
+        return cls(
+            provider_family=mapping["provider_family"],
+            provider_repository=mapping["provider_repository"],
+            provider_revision=mapping["provider_revision"],
+            model_set_id=mapping["model_set_id"],
+            loader_id=mapping["loader_id"],
+            coordinate_semantics=mapping["coordinate_semantics"],
+            point_semantics=mapping["point_semantics"],
+            flow_semantics=mapping["flow_semantics"],
+            ray_semantics=mapping["ray_semantics"],
+            source_dependency_semantics=mapping["source_dependency_semantics"],
+        )
 
 
 @dataclass(frozen=True, slots=True)
 class HeldoutProviderPromotionLockV1:
-    """Target-free lock for the decisive real provider and guarded-query gate."""
+    """Runtime representation of historical V1 and provider-neutral V2 locks."""
 
     experiment_id: str
     source_repository: str
     source_revision: str
     bayesian_phystwin_repository: str
     bayesian_phystwin_revision: str
-    motioncrafter_revision: str
-    model_set_id: str
+    motioncrafter_revision: str | None
+    model_set_id: str | None
     prediction_run_spec_id: str
     provider_evaluation_manifest_sha256: str
     frozen_artifact_ids: Mapping[str, Any]
@@ -64,6 +244,7 @@ class HeldoutProviderPromotionLockV1:
     maximum_technical_failures: int
     minimum_mean_accepted_coverage: float | None = None
     metadata: Mapping[str, Any] = field(default_factory=dict)
+    provider_identity: ProviderPromotionIdentityV1 | None = None
 
     def __post_init__(self) -> None:
         object.__setattr__(
@@ -97,13 +278,52 @@ class HeldoutProviderPromotionLockV1:
                 name="bayesian_phystwin_revision",
             ),
         )
-        object.__setattr__(
-            self,
-            "motioncrafter_revision",
-            _revision(self.motioncrafter_revision, name="motioncrafter_revision"),
-        )
+
+        identity = self.provider_identity
+        if identity is None:
+            if self.motioncrafter_revision is None or self.model_set_id is None:
+                raise ValueError(
+                    "historical V1 locks require motioncrafter_revision and model_set_id"
+                )
+            provider_revision = _revision(
+                self.motioncrafter_revision,
+                name="motioncrafter_revision",
+            )
+            provider_model_set = _strict_digest(
+                self.model_set_id,
+                name="model_set_id",
+                pattern=_SHA256,
+            )
+        else:
+            if not isinstance(identity, ProviderPromotionIdentityV1):
+                raise ValueError(
+                    "provider_identity must be ProviderPromotionIdentityV1 or None"
+                )
+            provider_revision = identity.provider_revision
+            provider_model_set = identity.model_set_id
+            if self.motioncrafter_revision is not None:
+                legacy_revision = _revision(
+                    self.motioncrafter_revision,
+                    name="motioncrafter_revision",
+                )
+                if legacy_revision != provider_revision:
+                    raise ValueError(
+                        "legacy provider revision disagrees with provider_identity"
+                    )
+            if self.model_set_id is not None:
+                legacy_model_set = _strict_digest(
+                    self.model_set_id,
+                    name="model_set_id",
+                    pattern=_SHA256,
+                )
+                if legacy_model_set != provider_model_set:
+                    raise ValueError(
+                        "legacy model set disagrees with provider_identity"
+                    )
+        object.__setattr__(self, "motioncrafter_revision", provider_revision)
+        object.__setattr__(self, "model_set_id", provider_model_set)
+
         for field_name in (
-            "model_set_id",
             "prediction_run_spec_id",
             "provider_evaluation_manifest_sha256",
         ):
@@ -270,6 +490,32 @@ class HeldoutProviderPromotionLockV1:
         )
 
     @property
+    def schema_version(self) -> int:
+        return (
+            HELDOUT_PROMOTION_LOCK_VERSION
+            if self.provider_identity is None
+            else HELDOUT_PROMOTION_LOCK_PROVIDER_NEUTRAL_VERSION
+        )
+
+    @property
+    def provider_revision(self) -> str:
+        assert self.motioncrafter_revision is not None
+        return self.motioncrafter_revision
+
+    @property
+    def provider_model_set_id(self) -> str:
+        assert self.model_set_id is not None
+        return self.model_set_id
+
+    @property
+    def provider_contract_signature(self) -> tuple[str, ...] | None:
+        return (
+            None
+            if self.provider_identity is None
+            else self.provider_identity.contract_signature
+        )
+
+    @property
     def arms_by_id(self) -> Mapping[str, PromotionArmV1]:
         return {arm.arm_id: arm for arm in self.arms}
 
@@ -294,16 +540,23 @@ class HeldoutProviderPromotionLockV1:
         return method
 
     def descriptor(self) -> dict[str, object]:
+        provider_fields: dict[str, object]
+        if self.provider_identity is None:
+            provider_fields = {
+                "motioncrafter_revision": self.provider_revision,
+                "model_set_id": self.provider_model_set_id,
+            }
+        else:
+            provider_fields = {"provider_identity": self.provider_identity.to_dict()}
         return {
             "schema_name": HELDOUT_PROMOTION_LOCK_SCHEMA,
-            "schema_version": HELDOUT_PROMOTION_LOCK_VERSION,
+            "schema_version": self.schema_version,
             "experiment_id": self.experiment_id,
             "source_repository": self.source_repository,
             "source_revision": self.source_revision,
             "bayesian_phystwin_repository": self.bayesian_phystwin_repository,
             "bayesian_phystwin_revision": self.bayesian_phystwin_revision,
-            "motioncrafter_revision": self.motioncrafter_revision,
-            "model_set_id": self.model_set_id,
+            **provider_fields,
             "prediction_run_spec_id": self.prediction_run_spec_id,
             "provider_evaluation_manifest_sha256": (self.provider_evaluation_manifest_sha256),
             "frozen_artifact_ids": plain_json(self.frozen_artifact_ids),
@@ -334,7 +587,9 @@ class HeldoutProviderPromotionLockV1:
         return {**self.descriptor(), "promotion_lock_id": self.promotion_lock_id}
 
 
-_LOCK_FIELDS = {
+HeldoutProviderPromotionLockV2 = HeldoutProviderPromotionLockV1
+
+_COMMON_LOCK_FIELDS = {
     "schema_name",
     "schema_version",
     "experiment_id",
@@ -342,8 +597,6 @@ _LOCK_FIELDS = {
     "source_revision",
     "bayesian_phystwin_repository",
     "bayesian_phystwin_revision",
-    "motioncrafter_revision",
-    "model_set_id",
     "prediction_run_spec_id",
     "provider_evaluation_manifest_sha256",
     "frozen_artifact_ids",
@@ -366,15 +619,26 @@ _LOCK_FIELDS = {
     "claim_boundary",
     "promotion_lock_id",
 }
-_LOCK_CONFIG_FIELDS = _LOCK_FIELDS - {
+_LOCK_V1_FIELDS = _COMMON_LOCK_FIELDS | {"motioncrafter_revision", "model_set_id"}
+_LOCK_V2_FIELDS = _COMMON_LOCK_FIELDS | {"provider_identity"}
+_COMMON_CONFIG_FIELDS = _COMMON_LOCK_FIELDS - {
     "schema_name",
     "schema_version",
     "claim_boundary",
     "promotion_lock_id",
 }
+_LOCK_V1_CONFIG_FIELDS = _COMMON_CONFIG_FIELDS | {
+    "motioncrafter_revision",
+    "model_set_id",
+}
+_LOCK_V2_CONFIG_FIELDS = _COMMON_CONFIG_FIELDS | {"provider_identity"}
 
 
-def _lock_from_mapping(mapping: Mapping[str, Any]) -> HeldoutProviderPromotionLockV1:
+def _lock_from_mapping(
+    mapping: Mapping[str, Any],
+    *,
+    schema_version: int,
+) -> HeldoutProviderPromotionLockV1:
     raw_arms = _strict_list(mapping["arms"], name="arms")
     arms = tuple(
         sorted(
@@ -382,14 +646,27 @@ def _lock_from_mapping(mapping: Mapping[str, Any]) -> HeldoutProviderPromotionLo
             key=lambda arm: arm.arm_id,
         )
     )
+    provider_identity = (
+        None
+        if schema_version == HELDOUT_PROMOTION_LOCK_VERSION
+        else ProviderPromotionIdentityV1.from_dict(mapping["provider_identity"])
+    )
     return HeldoutProviderPromotionLockV1(
         experiment_id=mapping["experiment_id"],
         source_repository=mapping["source_repository"],
         source_revision=mapping["source_revision"],
         bayesian_phystwin_repository=mapping["bayesian_phystwin_repository"],
         bayesian_phystwin_revision=mapping["bayesian_phystwin_revision"],
-        motioncrafter_revision=mapping["motioncrafter_revision"],
-        model_set_id=mapping["model_set_id"],
+        motioncrafter_revision=(
+            mapping["motioncrafter_revision"]
+            if schema_version == HELDOUT_PROMOTION_LOCK_VERSION
+            else None
+        ),
+        model_set_id=(
+            mapping["model_set_id"]
+            if schema_version == HELDOUT_PROMOTION_LOCK_VERSION
+            else None
+        ),
         prediction_run_spec_id=mapping["prediction_run_spec_id"],
         provider_evaluation_manifest_sha256=mapping["provider_evaluation_manifest_sha256"],
         frozen_artifact_ids=mapping["frozen_artifact_ids"],
@@ -418,29 +695,52 @@ def _lock_from_mapping(mapping: Mapping[str, Any]) -> HeldoutProviderPromotionLo
         maximum_technical_failures=mapping["maximum_technical_failures"],
         minimum_mean_accepted_coverage=mapping["minimum_mean_accepted_coverage"],
         metadata=_strict_mapping(mapping["metadata"], name="promotion lock metadata"),
+        provider_identity=provider_identity,
     )
 
 
 def promotion_lock_from_config(value: Any) -> HeldoutProviderPromotionLockV1:
-    """Build a canonical lock from target-free configuration fields."""
+    """Build a canonical V1 or provider-neutral V2 target-free lock."""
 
     mapping = _strict_mapping(value, name="promotion lock configuration")
-    _exact_keys(mapping, _LOCK_CONFIG_FIELDS, name="promotion lock configuration")
-    return _lock_from_mapping(mapping)
+    if "provider_identity" in mapping:
+        _exact_keys(
+            mapping,
+            _LOCK_V2_CONFIG_FIELDS,
+            name="promotion lock configuration",
+        )
+        schema_version = HELDOUT_PROMOTION_LOCK_PROVIDER_NEUTRAL_VERSION
+    else:
+        _exact_keys(
+            mapping,
+            _LOCK_V1_CONFIG_FIELDS,
+            name="promotion lock configuration",
+        )
+        schema_version = HELDOUT_PROMOTION_LOCK_VERSION
+    return _lock_from_mapping(mapping, schema_version=schema_version)
 
 
 def promotion_lock_from_dict(value: Any) -> HeldoutProviderPromotionLockV1:
-    """Load and independently validate one canonical promotion lock."""
+    """Load and independently validate one canonical V1 or V2 promotion lock."""
 
     mapping = _strict_mapping(value, name="promotion lock")
-    _exact_keys(mapping, _LOCK_FIELDS, name="promotion lock")
-    if mapping["schema_name"] != HELDOUT_PROMOTION_LOCK_SCHEMA:
+    if mapping.get("schema_name") != HELDOUT_PROMOTION_LOCK_SCHEMA:
         raise ValueError("unsupported held-out promotion lock schema")
-    if mapping["schema_version"] != HELDOUT_PROMOTION_LOCK_VERSION:
+    schema_version = _strict_integer(
+        mapping.get("schema_version"),
+        name="schema_version",
+        minimum=1,
+    )
+    if schema_version == HELDOUT_PROMOTION_LOCK_VERSION:
+        fields = _LOCK_V1_FIELDS
+    elif schema_version == HELDOUT_PROMOTION_LOCK_PROVIDER_NEUTRAL_VERSION:
+        fields = _LOCK_V2_FIELDS
+    else:
         raise ValueError("unsupported held-out promotion lock version")
+    _exact_keys(mapping, fields, name="promotion lock")
     if mapping["claim_boundary"] != LOCK_CLAIM_BOUNDARY:
         raise ValueError("promotion lock claim boundary changed")
-    lock = _lock_from_mapping(mapping)
+    lock = _lock_from_mapping(mapping, schema_version=schema_version)
     supplied = _strict_digest(
         mapping["promotion_lock_id"],
         name="promotion_lock_id",
@@ -467,3 +767,17 @@ def load_promotion_lock(
 ) -> HeldoutProviderPromotionLockV1:
     mapping, _ = _load_json(Path(path), name="promotion lock")
     return promotion_lock_from_dict(mapping)
+
+
+__all__ = [
+    "HELDOUT_PROMOTION_LOCK_PROVIDER_NEUTRAL_VERSION",
+    "PROVIDER_PROMOTION_IDENTITY_SCHEMA",
+    "PROVIDER_PROMOTION_IDENTITY_VERSION",
+    "HeldoutProviderPromotionLockV1",
+    "HeldoutProviderPromotionLockV2",
+    "ProviderPromotionIdentityV1",
+    "load_promotion_lock",
+    "promotion_lock_from_config",
+    "promotion_lock_from_dict",
+    "write_promotion_lock",
+]

--- a/src/prob4d/_promotion_evidence_v1.py
+++ b/src/prob4d/_promotion_evidence_v1.py
@@ -1,0 +1,818 @@
+"""Content-addressed evidence cards for held-out promotion reports."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from ._heldout_promotion_common import (
+    _SHA256,
+    REPORT_CLAIM_BOUNDARY,
+    _load_json,
+    _repository,
+    _revision,
+)
+from ._heldout_promotion_lock import promotion_lock_from_dict
+from ._heldout_promotion_report import promotion_report_from_dict
+from ._immutable_json import plain_json
+from ._selection_evidence_common import (
+    _exact_keys,
+    _sha256_json,
+    _strict_bool,
+    _strict_digest,
+    _strict_integer,
+    _strict_list,
+    _strict_mapping,
+    _strict_real,
+    _strict_string,
+)
+
+PROMOTION_EVIDENCE_CARD_SCHEMA = "prob4d.heldout-provider-evidence-card"
+PROMOTION_EVIDENCE_CARD_VERSION = 1
+
+_NON_CLAIMS = (
+    "No Causal4D intervention-benefit claim.",
+    "No general state-of-the-art claim.",
+    "No extrapolation beyond frozen objects, sessions, and source identities.",
+)
+_ALLOWED_ARM_ROLES = frozenset(
+    {
+        "physical_fallback",
+        "visual_baseline",
+        "rowwise_gauge_marginalized",
+        "framewise_explicit_joint_gauge",
+        "persistent_explicit_joint_gauge",
+        "cross_window_identity_marginalized",
+        "sensor_assisted",
+        "diagnostic",
+    }
+)
+_REQUIRED_ARM_ROLES = _ALLOWED_ARM_ROLES - {"diagnostic"}
+_REQUIRED_FROZEN_ARTIFACTS = frozenset(
+    {
+        "provider_configuration",
+        "gauge_calibration",
+        "point_calibration",
+        "source_reliability_calibration",
+        "material_identity_calibration",
+        "selection_lock",
+        "bayesian_guard_configuration",
+    }
+)
+_FIELDS = {
+    "schema_name",
+    "schema_version",
+    "evidence_card_id",
+    "experiment_id",
+    "promotion_lock_id",
+    "promotion_report_id",
+    "overall_passed",
+    "status",
+    "statistical_unit",
+    "repositories",
+    "cohort",
+    "comparison_arms",
+    "frozen_inputs",
+    "provider_gate",
+    "guarded_query",
+    "claim_boundary",
+    "explicit_non_claims",
+}
+_REPOSITORY_GROUP_FIELDS = {"prob4d", "bayesian_phystwin", "motioncrafter"}
+_CODE_REPOSITORY_FIELDS = {"repository", "revision"}
+_MOTIONCRAFTER_FIELDS = {"revision", "model_set_id"}
+_COHORT_FIELDS = {
+    "development_group_count",
+    "calibration_group_count",
+    "target_group_count",
+    "target_group_ids",
+}
+_ARM_FIELDS = {
+    "arm_id",
+    "role",
+    "provider_method_id",
+    "query_method_id",
+    "sensor_assisted",
+}
+_FROZEN_INPUT_FIELDS = {
+    "prediction_run_spec_id",
+    "provider_evaluation_manifest_sha256",
+    "frozen_artifact_ids",
+    "provider_report_sha256",
+    "query_results_id",
+}
+_PROVIDER_GATE_FIELDS = {
+    "passed",
+    "reference_method",
+    "case_count",
+    "group_count",
+    "decision_policy_id",
+}
+_GUARDED_QUERY_FIELDS = {
+    "passed",
+    "primary_arm_id",
+    "physical_fallback_arm_id",
+    "paired_candidate_minus_fallback_mm",
+    "mean_query_rmse_mm",
+    "accepted_update_count",
+    "rejected_update_count",
+    "harmful_accepted_update_count",
+    "technical_failure_count",
+    "worst_group_regression_mm",
+    "mean_accepted_coverage",
+    "mean_accepted_width_mm",
+    "exact_fallback_failure_count",
+}
+_PAIRED_EFFECT_FIELDS = {
+    "mean",
+    "ci95_lower",
+    "ci95_upper",
+    "group_count",
+    "semantics",
+}
+_PAIRED_EFFECT_SEMANTICS = "paired-target-group-bootstrap-candidate-minus-physical-fallback-v1"
+
+
+def _optional_string(value: Any, *, name: str) -> str | None:
+    return None if value is None else _strict_string(value, name=name)
+
+
+def _optional_real(
+    value: Any,
+    *,
+    name: str,
+    minimum: float | None = None,
+    maximum: float | None = None,
+) -> float | None:
+    if value is None:
+        return None
+    result = _strict_real(value, name=name)
+    if minimum is not None and result < minimum:
+        raise ValueError(f"{name} must be at least {minimum}")
+    if maximum is not None and result > maximum:
+        raise ValueError(f"{name} must be at most {maximum}")
+    return result
+
+
+def _canonical_string_list(
+    value: Any,
+    *,
+    name: str,
+    nonempty: bool = True,
+) -> list[str]:
+    items = _strict_list(value, name=name)
+    result = [_strict_string(item, name=f"{name}[{index}]") for index, item in enumerate(items)]
+    if nonempty and not result:
+        raise ValueError(f"{name} must not be empty")
+    if result != sorted(result) or len(set(result)) != len(result):
+        raise ValueError(f"{name} must be sorted and unique")
+    return result
+
+
+def _nonnegative_integer(value: Any, *, name: str) -> int:
+    return _strict_integer(value, name=name, minimum=0)
+
+
+def _nonnegative_real(value: Any, *, name: str) -> float:
+    result = _strict_real(value, name=name)
+    if result < 0.0:
+        raise ValueError(f"{name} must be non-negative")
+    return result
+
+
+def _digest(value: Any, *, name: str) -> str:
+    return _strict_digest(value, name=name, pattern=_SHA256)
+
+
+def _optional_policy_id(value: Any) -> str | None:
+    return _optional_string(value, name="provider_gate.decision_policy_id")
+
+
+def _validate_artifact_ids(value: Any) -> dict[str, str]:
+    mapping = _strict_mapping(value, name="frozen_inputs.frozen_artifact_ids")
+    if not mapping:
+        raise ValueError("frozen_inputs.frozen_artifact_ids must not be empty")
+    result: dict[str, str] = {}
+    for raw_key, raw_digest in mapping.items():
+        key = _strict_string(
+            raw_key,
+            name="frozen_inputs.frozen_artifact_ids key",
+        )
+        result[key] = _digest(
+            raw_digest,
+            name=f"frozen_inputs.frozen_artifact_ids[{key!r}]",
+        )
+    missing = sorted(_REQUIRED_FROZEN_ARTIFACTS - set(result))
+    if missing:
+        raise ValueError(
+            f"frozen_inputs.frozen_artifact_ids is missing required identities: {missing}"
+        )
+    return result
+
+
+def _validate_repositories(value: Any) -> None:
+    repositories = _strict_mapping(value, name="repositories")
+    _exact_keys(
+        repositories,
+        _REPOSITORY_GROUP_FIELDS,
+        name="repositories",
+    )
+    for key in ("prob4d", "bayesian_phystwin"):
+        repository = _strict_mapping(
+            repositories[key],
+            name=f"repositories.{key}",
+        )
+        _exact_keys(
+            repository,
+            _CODE_REPOSITORY_FIELDS,
+            name=f"repositories.{key}",
+        )
+        _repository(
+            repository["repository"],
+            name=f"repositories.{key}.repository",
+        )
+        _revision(
+            repository["revision"],
+            name=f"repositories.{key}.revision",
+        )
+    motioncrafter = _strict_mapping(
+        repositories["motioncrafter"],
+        name="repositories.motioncrafter",
+    )
+    _exact_keys(
+        motioncrafter,
+        _MOTIONCRAFTER_FIELDS,
+        name="repositories.motioncrafter",
+    )
+    _revision(
+        motioncrafter["revision"],
+        name="repositories.motioncrafter.revision",
+    )
+    _digest(
+        motioncrafter["model_set_id"],
+        name="repositories.motioncrafter.model_set_id",
+    )
+
+
+def _validate_cohort(value: Any) -> tuple[int, list[str]]:
+    cohort = _strict_mapping(value, name="cohort")
+    _exact_keys(cohort, _COHORT_FIELDS, name="cohort")
+    _strict_integer(
+        cohort["development_group_count"],
+        name="cohort.development_group_count",
+        minimum=1,
+    )
+    _strict_integer(
+        cohort["calibration_group_count"],
+        name="cohort.calibration_group_count",
+        minimum=1,
+    )
+    target_count = _strict_integer(
+        cohort["target_group_count"],
+        name="cohort.target_group_count",
+        minimum=1,
+    )
+    target_ids = _canonical_string_list(
+        cohort["target_group_ids"],
+        name="cohort.target_group_ids",
+    )
+    if target_count != len(target_ids):
+        raise ValueError("cohort.target_group_count must match cohort.target_group_ids")
+    return target_count, target_ids
+
+
+def _validate_arms(value: Any) -> dict[str, Mapping[str, Any]]:
+    raw_arms = _strict_list(value, name="comparison_arms")
+    if not raw_arms:
+        raise ValueError("comparison_arms must not be empty")
+    arms: list[Mapping[str, Any]] = []
+    for index, raw_arm in enumerate(raw_arms):
+        arm = _strict_mapping(raw_arm, name=f"comparison_arms[{index}]")
+        _exact_keys(
+            arm,
+            _ARM_FIELDS,
+            name=f"comparison_arms[{index}]",
+        )
+        _strict_string(
+            arm["arm_id"],
+            name=f"comparison_arms[{index}].arm_id",
+        )
+        role = _strict_string(
+            arm["role"],
+            name=f"comparison_arms[{index}].role",
+        )
+        if role not in _ALLOWED_ARM_ROLES:
+            raise ValueError(f"comparison_arms[{index}].role is not registered")
+        provider_method = _optional_string(
+            arm["provider_method_id"],
+            name=f"comparison_arms[{index}].provider_method_id",
+        )
+        _strict_string(
+            arm["query_method_id"],
+            name=f"comparison_arms[{index}].query_method_id",
+        )
+        sensor_assisted = _strict_bool(
+            arm["sensor_assisted"],
+            name=f"comparison_arms[{index}].sensor_assisted",
+        )
+        if role == "physical_fallback":
+            if provider_method is not None:
+                raise ValueError("the physical fallback arm must not have a provider method")
+        elif provider_method is None:
+            raise ValueError("every non-fallback comparison arm requires a provider method")
+        if sensor_assisted != (role == "sensor_assisted"):
+            raise ValueError("sensor_assisted must be true exactly for the sensor-assisted role")
+        arms.append(arm)
+    arm_ids = [str(arm["arm_id"]) for arm in arms]
+    if arm_ids != sorted(arm_ids) or len(set(arm_ids)) != len(arm_ids):
+        raise ValueError("comparison_arms must be sorted by unique arm_id")
+    roles = [str(arm["role"]) for arm in arms]
+    for role in _REQUIRED_ARM_ROLES:
+        if roles.count(role) != 1:
+            raise ValueError(f"required comparison role {role!r} must occur exactly once")
+    provider_methods = [
+        str(arm["provider_method_id"]) for arm in arms if arm["provider_method_id"] is not None
+    ]
+    query_methods = [str(arm["query_method_id"]) for arm in arms]
+    if len(provider_methods) != len(set(provider_methods)):
+        raise ValueError("comparison provider methods must be unique")
+    if len(query_methods) != len(set(query_methods)):
+        raise ValueError("comparison query methods must be unique")
+    return {str(arm["arm_id"]): arm for arm in arms}
+
+
+def _validate_frozen_inputs(value: Any) -> None:
+    frozen = _strict_mapping(value, name="frozen_inputs")
+    _exact_keys(
+        frozen,
+        _FROZEN_INPUT_FIELDS,
+        name="frozen_inputs",
+    )
+    for field_name in (
+        "prediction_run_spec_id",
+        "provider_evaluation_manifest_sha256",
+        "provider_report_sha256",
+        "query_results_id",
+    ):
+        _digest(
+            frozen[field_name],
+            name=f"frozen_inputs.{field_name}",
+        )
+    _validate_artifact_ids(frozen["frozen_artifact_ids"])
+
+
+def _validate_provider_gate(
+    value: Any,
+    *,
+    target_count: int,
+    arms_by_id: Mapping[str, Mapping[str, Any]],
+) -> bool:
+    provider = _strict_mapping(value, name="provider_gate")
+    _exact_keys(
+        provider,
+        _PROVIDER_GATE_FIELDS,
+        name="provider_gate",
+    )
+    passed = _strict_bool(provider["passed"], name="provider_gate.passed")
+    reference_method = _strict_string(
+        provider["reference_method"],
+        name="provider_gate.reference_method",
+    )
+    case_count = _strict_integer(
+        provider["case_count"],
+        name="provider_gate.case_count",
+        minimum=1,
+    )
+    group_count = _strict_integer(
+        provider["group_count"],
+        name="provider_gate.group_count",
+        minimum=1,
+    )
+    _optional_policy_id(provider["decision_policy_id"])
+    if group_count != target_count:
+        raise ValueError("provider_gate.group_count must match cohort.target_group_count")
+    if case_count < group_count:
+        raise ValueError("provider_gate.case_count cannot be smaller than its group count")
+    registered_provider_methods = {
+        arm["provider_method_id"]
+        for arm in arms_by_id.values()
+        if arm["provider_method_id"] is not None
+    }
+    if reference_method not in registered_provider_methods:
+        raise ValueError("provider_gate.reference_method is not a registered provider method")
+    return passed
+
+
+def _validate_guarded_query(
+    value: Any,
+    *,
+    target_count: int,
+    arms_by_id: Mapping[str, Mapping[str, Any]],
+) -> bool:
+    query = _strict_mapping(value, name="guarded_query")
+    _exact_keys(query, _GUARDED_QUERY_FIELDS, name="guarded_query")
+    passed = _strict_bool(query["passed"], name="guarded_query.passed")
+    primary_id = _strict_string(
+        query["primary_arm_id"],
+        name="guarded_query.primary_arm_id",
+    )
+    fallback_id = _strict_string(
+        query["physical_fallback_arm_id"],
+        name="guarded_query.physical_fallback_arm_id",
+    )
+    if primary_id not in arms_by_id:
+        raise ValueError("guarded_query.primary_arm_id is not registered")
+    if fallback_id not in arms_by_id:
+        raise ValueError("guarded_query.physical_fallback_arm_id is not registered")
+    primary = arms_by_id[primary_id]
+    fallback = arms_by_id[fallback_id]
+    if fallback["role"] != "physical_fallback":
+        raise ValueError("guarded_query.physical_fallback_arm_id has the wrong role")
+    if primary["role"] in {
+        "physical_fallback",
+        "sensor_assisted",
+        "diagnostic",
+    }:
+        raise ValueError("guarded_query.primary_arm_id must be a non-sensor candidate")
+
+    paired = _strict_mapping(
+        query["paired_candidate_minus_fallback_mm"],
+        name="guarded_query.paired_candidate_minus_fallback_mm",
+    )
+    _exact_keys(
+        paired,
+        _PAIRED_EFFECT_FIELDS,
+        name="guarded_query.paired_candidate_minus_fallback_mm",
+    )
+    _strict_real(
+        paired["mean"],
+        name="guarded_query.paired_candidate_minus_fallback_mm.mean",
+    )
+    lower = _strict_real(
+        paired["ci95_lower"],
+        name="guarded_query.paired_candidate_minus_fallback_mm.ci95_lower",
+    )
+    upper = _strict_real(
+        paired["ci95_upper"],
+        name="guarded_query.paired_candidate_minus_fallback_mm.ci95_upper",
+    )
+    if lower > upper:
+        raise ValueError("guarded_query paired interval lower bound exceeds its upper bound")
+    paired_count = _strict_integer(
+        paired["group_count"],
+        name="guarded_query.paired_candidate_minus_fallback_mm.group_count",
+        minimum=1,
+    )
+    if paired_count != target_count:
+        raise ValueError("guarded_query paired group count must match the target cohort")
+    semantics = _strict_string(
+        paired["semantics"],
+        name="guarded_query.paired_candidate_minus_fallback_mm.semantics",
+    )
+    if semantics != _PAIRED_EFFECT_SEMANTICS:
+        raise ValueError("guarded_query paired-effect semantics changed")
+
+    _nonnegative_real(
+        query["mean_query_rmse_mm"],
+        name="guarded_query.mean_query_rmse_mm",
+    )
+    accepted_count = _nonnegative_integer(
+        query["accepted_update_count"],
+        name="guarded_query.accepted_update_count",
+    )
+    rejected_count = _nonnegative_integer(
+        query["rejected_update_count"],
+        name="guarded_query.rejected_update_count",
+    )
+    if accepted_count + rejected_count != target_count:
+        raise ValueError("guarded_query accepted and rejected counts must cover the target cohort")
+    harmful_count = _nonnegative_integer(
+        query["harmful_accepted_update_count"],
+        name="guarded_query.harmful_accepted_update_count",
+    )
+    if harmful_count > accepted_count:
+        raise ValueError("guarded_query harmful accepted updates exceed accepted updates")
+    technical_count = _nonnegative_integer(
+        query["technical_failure_count"],
+        name="guarded_query.technical_failure_count",
+    )
+    if technical_count > rejected_count:
+        raise ValueError("guarded_query technical failures exceed rejected updates")
+    _strict_real(
+        query["worst_group_regression_mm"],
+        name="guarded_query.worst_group_regression_mm",
+    )
+    _optional_real(
+        query["mean_accepted_coverage"],
+        name="guarded_query.mean_accepted_coverage",
+        minimum=0.0,
+        maximum=1.0,
+    )
+    _optional_real(
+        query["mean_accepted_width_mm"],
+        name="guarded_query.mean_accepted_width_mm",
+        minimum=0.0,
+    )
+    _nonnegative_integer(
+        query["exact_fallback_failure_count"],
+        name="guarded_query.exact_fallback_failure_count",
+    )
+    return passed
+
+
+def _validate_descriptor(card: Mapping[str, Any]) -> None:
+    if (
+        card["schema_name"],
+        card["schema_version"],
+    ) != (
+        PROMOTION_EVIDENCE_CARD_SCHEMA,
+        PROMOTION_EVIDENCE_CARD_VERSION,
+    ):
+        raise ValueError("unsupported promotion evidence card schema")
+    _strict_string(card["experiment_id"], name="experiment_id")
+    _digest(card["promotion_lock_id"], name="promotion_lock_id")
+    _digest(card["promotion_report_id"], name="promotion_report_id")
+    overall_passed = _strict_bool(
+        card["overall_passed"],
+        name="overall_passed",
+    )
+    status = _strict_string(card["status"], name="status")
+    expected_status = "PASS" if overall_passed else "FAIL"
+    if status != expected_status:
+        raise ValueError("promotion evidence status disagrees with overall_passed")
+    _strict_string(card["statistical_unit"], name="statistical_unit")
+    _validate_repositories(card["repositories"])
+    target_count, _ = _validate_cohort(card["cohort"])
+    arms_by_id = _validate_arms(card["comparison_arms"])
+    _validate_frozen_inputs(card["frozen_inputs"])
+    provider_passed = _validate_provider_gate(
+        card["provider_gate"],
+        target_count=target_count,
+        arms_by_id=arms_by_id,
+    )
+    query_passed = _validate_guarded_query(
+        card["guarded_query"],
+        target_count=target_count,
+        arms_by_id=arms_by_id,
+    )
+    if overall_passed != (provider_passed and query_passed):
+        raise ValueError("overall_passed must equal the conjunction of provider and query gates")
+    if card["claim_boundary"] != REPORT_CLAIM_BOUNDARY:
+        raise ValueError("promotion evidence claim boundary changed")
+    non_claims = _canonical_string_list(
+        card["explicit_non_claims"],
+        name="explicit_non_claims",
+    )
+    if tuple(non_claims) != tuple(sorted(_NON_CLAIMS)):
+        raise ValueError("promotion evidence explicit non-claims changed")
+
+
+def build_promotion_evidence_card(
+    promotion_lock: Mapping[str, Any],
+    promotion_report: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Derive a compact paper-facing summary from a validated lock and report."""
+
+    lock = promotion_lock_from_dict(promotion_lock)
+    report = promotion_report_from_dict(promotion_report)
+    if report.promotion_lock_id != lock.promotion_lock_id:
+        raise ValueError("promotion report references a different promotion lock")
+
+    audit = _strict_mapping(report.provider_audit, name="provider_audit")
+    provider = _strict_mapping(
+        report.provider_decision,
+        name="provider_decision",
+    )
+    query = _strict_mapping(report.query_decision, name="query_decision")
+    aggregates = _strict_mapping(
+        report.query_aggregate,
+        name="query_aggregate",
+    )
+    primary = _strict_mapping(
+        aggregates.get(lock.primary_query_arm_id),
+        name="primary query aggregate",
+    )
+    paired = _strict_mapping(
+        query.get("paired_bootstrap"),
+        name="paired_bootstrap",
+    )
+    statistical_unit = lock.metadata.get(
+        "statistical_unit",
+        lock.metadata.get("split_semantics"),
+    )
+    if type(statistical_unit) is not str or not statistical_unit:
+        statistical_unit = "complete physical object or acquisition session"
+
+    descriptor: dict[str, Any] = {
+        "schema_name": PROMOTION_EVIDENCE_CARD_SCHEMA,
+        "schema_version": PROMOTION_EVIDENCE_CARD_VERSION,
+        "experiment_id": lock.experiment_id,
+        "promotion_lock_id": lock.promotion_lock_id,
+        "promotion_report_id": report.report_id,
+        "overall_passed": report.overall_passed,
+        "status": "PASS" if report.overall_passed else "FAIL",
+        "statistical_unit": statistical_unit,
+        "repositories": {
+            "prob4d": {
+                "repository": lock.source_repository,
+                "revision": lock.source_revision,
+            },
+            "bayesian_phystwin": {
+                "repository": lock.bayesian_phystwin_repository,
+                "revision": lock.bayesian_phystwin_revision,
+            },
+            "motioncrafter": {
+                "revision": lock.motioncrafter_revision,
+                "model_set_id": lock.model_set_id,
+            },
+        },
+        "cohort": {
+            "development_group_count": len(lock.development_group_ids),
+            "calibration_group_count": len(lock.calibration_group_ids),
+            "target_group_count": len(lock.target_group_ids),
+            "target_group_ids": list(lock.target_group_ids),
+        },
+        "comparison_arms": [
+            {
+                "arm_id": arm.arm_id,
+                "role": arm.role,
+                "provider_method_id": arm.provider_method_id,
+                "query_method_id": arm.query_method_id,
+                "sensor_assisted": arm.sensor_assisted,
+            }
+            for arm in lock.arms
+        ],
+        "frozen_inputs": {
+            "prediction_run_spec_id": lock.prediction_run_spec_id,
+            "provider_evaluation_manifest_sha256": (lock.provider_evaluation_manifest_sha256),
+            "frozen_artifact_ids": dict(lock.frozen_artifact_ids),
+            "provider_report_sha256": report.provider_report_sha256,
+            "query_results_id": report.query_results_id,
+        },
+        "provider_gate": {
+            "passed": provider.get("overall_passed"),
+            "reference_method": audit.get("reference_method"),
+            "case_count": audit.get("case_count"),
+            "group_count": audit.get("group_count"),
+            "decision_policy_id": audit.get("decision_policy_id"),
+        },
+        "guarded_query": {
+            "passed": query.get("overall_passed"),
+            "primary_arm_id": lock.primary_query_arm_id,
+            "physical_fallback_arm_id": query.get("physical_fallback_arm_id"),
+            "paired_candidate_minus_fallback_mm": {
+                "mean": paired.get("mean"),
+                "ci95_lower": paired.get("ci95_lower"),
+                "ci95_upper": paired.get("ci95_upper"),
+                "group_count": paired.get("group_count"),
+                "semantics": paired.get("semantics"),
+            },
+            "mean_query_rmse_mm": primary.get("mean_query_rmse_mm"),
+            "accepted_update_count": primary.get("accepted_update_count"),
+            "rejected_update_count": primary.get("rejected_update_count"),
+            "harmful_accepted_update_count": primary.get("harmful_accepted_update_count"),
+            "technical_failure_count": primary.get("technical_failure_count"),
+            "worst_group_regression_mm": primary.get("worst_group_regression_mm"),
+            "mean_accepted_coverage": primary.get("mean_accepted_coverage"),
+            "mean_accepted_width_mm": primary.get("mean_accepted_width_mm"),
+            "exact_fallback_failure_count": query.get("exact_fallback_failure_count"),
+        },
+        "claim_boundary": REPORT_CLAIM_BOUNDARY,
+        "explicit_non_claims": list(sorted(_NON_CLAIMS)),
+    }
+    card = {**descriptor, "evidence_card_id": _sha256_json(descriptor)}
+    return promotion_evidence_card_from_dict(card)
+
+
+def promotion_evidence_card_from_dict(value: object) -> dict[str, Any]:
+    card = _strict_mapping(value, name="promotion evidence card")
+    _exact_keys(card, _FIELDS, name="promotion evidence card")
+    _validate_descriptor(card)
+    supplied = _digest(
+        card["evidence_card_id"],
+        name="evidence_card_id",
+    )
+    descriptor = {key: item for key, item in card.items() if key != "evidence_card_id"}
+    if supplied != _sha256_json(descriptor):
+        raise ValueError("promotion evidence card ID mismatch")
+    return dict(card)
+
+
+def load_promotion_evidence_card(path: str | Path) -> dict[str, Any]:
+    mapping, _ = _load_json(
+        Path(path),
+        name="promotion evidence card",
+    )
+    return promotion_evidence_card_from_dict(mapping)
+
+
+def render_promotion_evidence_markdown(card: Mapping[str, Any]) -> str:
+    value = promotion_evidence_card_from_dict(card)
+    repositories = _strict_mapping(value["repositories"], name="repositories")
+    prob4d = _strict_mapping(repositories["prob4d"], name="prob4d")
+    bpt = _strict_mapping(
+        repositories["bayesian_phystwin"],
+        name="bayesian_phystwin",
+    )
+    query = _strict_mapping(value["guarded_query"], name="guarded_query")
+    paired = _strict_mapping(
+        query["paired_candidate_minus_fallback_mm"],
+        name="paired effect",
+    )
+    return "\n".join(
+        [
+            "# Held-out Prob4D promotion evidence card",
+            "",
+            f"Evidence card: `{value['evidence_card_id']}`.",
+            f"Promotion report: `{value['promotion_report_id']}`.",
+            f"Overall decision: **{value['status']}**.",
+            "",
+            f"- Prob4D: `{prob4d['repository']}@{prob4d['revision']}`",
+            f"- BayesianPhysTwin: `{bpt['repository']}@{bpt['revision']}`",
+            "",
+            "| Guarded-query result | Value |",
+            "| --- | ---: |",
+            f"| Primary arm | `{query['primary_arm_id']}` |",
+            (f"| Mean candidate-minus-fallback RMSE | {float(paired['mean']):.6g} mm |"),
+            (f"| Harmful accepted updates | {query['harmful_accepted_update_count']} |"),
+            (f"| Exact fallback failures | {query['exact_fallback_failure_count']} |"),
+            "",
+            str(value["claim_boundary"]),
+            "",
+        ]
+    )
+
+
+def _atomic_write_text(path: Path, content: str) -> None:
+    """Publish complete text without replacing a concurrently created path."""
+
+    if path.exists():
+        raise FileExistsError(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=path.parent,
+        prefix=f".{path.name}.tmp-",
+        text=True,
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            stream.write(content)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.link(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _atomic_write_json(path: Path, value: Mapping[str, Any]) -> None:
+    encoded = (
+        json.dumps(
+            plain_json(value),
+            sort_keys=True,
+            indent=2,
+            allow_nan=False,
+        )
+        + "\n"
+    )
+    _atomic_write_text(path, encoded)
+
+
+def write_promotion_evidence_card(
+    card: Mapping[str, Any],
+    json_path: str | Path,
+    markdown_path: str | Path,
+) -> None:
+    value = promotion_evidence_card_from_dict(card)
+    json_destination = Path(json_path)
+    markdown_destination = Path(markdown_path)
+    if json_destination == markdown_destination:
+        raise ValueError("JSON and Markdown evidence-card paths must differ")
+    if json_destination.exists():
+        raise FileExistsError(json_destination)
+    if markdown_destination.exists():
+        raise FileExistsError(markdown_destination)
+    _atomic_write_json(json_destination, value)
+    try:
+        _atomic_write_text(
+            markdown_destination,
+            render_promotion_evidence_markdown(value),
+        )
+    except Exception:
+        json_destination.unlink(missing_ok=True)
+        raise
+
+
+__all__ = [
+    "PROMOTION_EVIDENCE_CARD_SCHEMA",
+    "PROMOTION_EVIDENCE_CARD_VERSION",
+    "build_promotion_evidence_card",
+    "load_promotion_evidence_card",
+    "promotion_evidence_card_from_dict",
+    "render_promotion_evidence_markdown",
+    "write_promotion_evidence_card",
+]

--- a/src/prob4d/promotion_evidence.py
+++ b/src/prob4d/promotion_evidence.py
@@ -1,785 +1,150 @@
-"""Content-addressed evidence cards for held-out promotion reports."""
+"""Version-dispatched evidence cards for held-out provider promotion."""
 
 from __future__ import annotations
 
-import json
-import os
-import tempfile
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
-from ._heldout_promotion_common import (
-    _SHA256,
-    REPORT_CLAIM_BOUNDARY,
-    _load_json,
-    _repository,
-    _revision,
+from . import _promotion_evidence_v1 as _v1
+from ._heldout_promotion_common import _load_json
+from ._heldout_promotion_lock import (
+    HELDOUT_PROMOTION_LOCK_PROVIDER_NEUTRAL_VERSION,
+    ProviderPromotionIdentityV1,
+    promotion_lock_from_dict,
 )
-from ._heldout_promotion_lock import promotion_lock_from_dict
-from ._heldout_promotion_report import promotion_report_from_dict
 from ._immutable_json import plain_json
-from ._selection_evidence_common import (
-    _exact_keys,
-    _sha256_json,
-    _strict_bool,
-    _strict_digest,
-    _strict_integer,
-    _strict_list,
-    _strict_mapping,
-    _strict_real,
-    _strict_string,
-)
+from ._selection_evidence_common import _sha256_json
 
-PROMOTION_EVIDENCE_CARD_SCHEMA = "prob4d.heldout-provider-evidence-card"
-PROMOTION_EVIDENCE_CARD_VERSION = 1
+PROMOTION_EVIDENCE_CARD_SCHEMA = _v1.PROMOTION_EVIDENCE_CARD_SCHEMA
+PROMOTION_EVIDENCE_CARD_VERSION = _v1.PROMOTION_EVIDENCE_CARD_VERSION
+PROMOTION_EVIDENCE_CARD_PROVIDER_NEUTRAL_VERSION = 2
 
-_NON_CLAIMS = (
-    "No Causal4D intervention-benefit claim.",
-    "No general state-of-the-art claim.",
-    "No extrapolation beyond frozen objects, sessions, and source identities.",
-)
-_ALLOWED_ARM_ROLES = frozenset(
-    {
-        "physical_fallback",
-        "visual_baseline",
-        "rowwise_gauge_marginalized",
-        "framewise_explicit_joint_gauge",
-        "persistent_explicit_joint_gauge",
-        "cross_window_identity_marginalized",
-        "sensor_assisted",
-        "diagnostic",
+_REPOSITORY_FIELDS_V2 = {
+    "prob4d",
+    "bayesian_phystwin",
+    "provider",
+}
+
+
+def _descriptor(value: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        key: plain_json(item)
+        for key, item in value.items()
+        if key != "evidence_card_id"
     }
-)
-_REQUIRED_ARM_ROLES = _ALLOWED_ARM_ROLES - {"diagnostic"}
-_REQUIRED_FROZEN_ARTIFACTS = frozenset(
-    {
-        "provider_configuration",
-        "gauge_calibration",
-        "point_calibration",
-        "source_reliability_calibration",
-        "material_identity_calibration",
-        "selection_lock",
-        "bayesian_guard_configuration",
-    }
-)
-_FIELDS = {
-    "schema_name",
-    "schema_version",
-    "evidence_card_id",
-    "experiment_id",
-    "promotion_lock_id",
-    "promotion_report_id",
-    "overall_passed",
-    "status",
-    "statistical_unit",
-    "repositories",
-    "cohort",
-    "comparison_arms",
-    "frozen_inputs",
-    "provider_gate",
-    "guarded_query",
-    "claim_boundary",
-    "explicit_non_claims",
-}
-_REPOSITORY_GROUP_FIELDS = {"prob4d", "bayesian_phystwin", "motioncrafter"}
-_CODE_REPOSITORY_FIELDS = {"repository", "revision"}
-_MOTIONCRAFTER_FIELDS = {"revision", "model_set_id"}
-_COHORT_FIELDS = {
-    "development_group_count",
-    "calibration_group_count",
-    "target_group_count",
-    "target_group_ids",
-}
-_ARM_FIELDS = {
-    "arm_id",
-    "role",
-    "provider_method_id",
-    "query_method_id",
-    "sensor_assisted",
-}
-_FROZEN_INPUT_FIELDS = {
-    "prediction_run_spec_id",
-    "provider_evaluation_manifest_sha256",
-    "frozen_artifact_ids",
-    "provider_report_sha256",
-    "query_results_id",
-}
-_PROVIDER_GATE_FIELDS = {
-    "passed",
-    "reference_method",
-    "case_count",
-    "group_count",
-    "decision_policy_id",
-}
-_GUARDED_QUERY_FIELDS = {
-    "passed",
-    "primary_arm_id",
-    "physical_fallback_arm_id",
-    "paired_candidate_minus_fallback_mm",
-    "mean_query_rmse_mm",
-    "accepted_update_count",
-    "rejected_update_count",
-    "harmful_accepted_update_count",
-    "technical_failure_count",
-    "worst_group_regression_mm",
-    "mean_accepted_coverage",
-    "mean_accepted_width_mm",
-    "exact_fallback_failure_count",
-}
-_PAIRED_EFFECT_FIELDS = {
-    "mean",
-    "ci95_lower",
-    "ci95_upper",
-    "group_count",
-    "semantics",
-}
-_PAIRED_EFFECT_SEMANTICS = "paired-target-group-bootstrap-candidate-minus-physical-fallback-v1"
 
 
-def _optional_string(value: Any, *, name: str) -> str | None:
-    return None if value is None else _strict_string(value, name=name)
-
-
-def _optional_real(
-    value: Any,
-    *,
-    name: str,
-    minimum: float | None = None,
-    maximum: float | None = None,
-) -> float | None:
-    if value is None:
-        return None
-    result = _strict_real(value, name=name)
-    if minimum is not None and result < minimum:
-        raise ValueError(f"{name} must be at least {minimum}")
-    if maximum is not None and result > maximum:
-        raise ValueError(f"{name} must be at most {maximum}")
-    return result
-
-
-def _canonical_string_list(
-    value: Any,
-    *,
-    name: str,
-    nonempty: bool = True,
-) -> list[str]:
-    items = _strict_list(value, name=name)
-    result = [_strict_string(item, name=f"{name}[{index}]") for index, item in enumerate(items)]
-    if nonempty and not result:
-        raise ValueError(f"{name} must not be empty")
-    if result != sorted(result) or len(set(result)) != len(result):
-        raise ValueError(f"{name} must be sorted and unique")
-    return result
-
-
-def _nonnegative_integer(value: Any, *, name: str) -> int:
-    return _strict_integer(value, name=name, minimum=0)
-
-
-def _nonnegative_real(value: Any, *, name: str) -> float:
-    result = _strict_real(value, name=name)
-    if result < 0.0:
-        raise ValueError(f"{name} must be non-negative")
-    return result
-
-
-def _digest(value: Any, *, name: str) -> str:
-    return _strict_digest(value, name=name, pattern=_SHA256)
-
-
-def _optional_policy_id(value: Any) -> str | None:
-    return _optional_string(value, name="provider_gate.decision_policy_id")
-
-
-def _validate_artifact_ids(value: Any) -> dict[str, str]:
-    mapping = _strict_mapping(value, name="frozen_inputs.frozen_artifact_ids")
-    if not mapping:
-        raise ValueError("frozen_inputs.frozen_artifact_ids must not be empty")
-    result: dict[str, str] = {}
-    for raw_key, raw_digest in mapping.items():
-        key = _strict_string(
-            raw_key,
-            name="frozen_inputs.frozen_artifact_ids key",
-        )
-        result[key] = _digest(
-            raw_digest,
-            name=f"frozen_inputs.frozen_artifact_ids[{key!r}]",
-        )
-    missing = sorted(_REQUIRED_FROZEN_ARTIFACTS - set(result))
-    if missing:
-        raise ValueError(
-            f"frozen_inputs.frozen_artifact_ids is missing required identities: {missing}"
-        )
-    return result
-
-
-def _validate_repositories(value: Any) -> None:
-    repositories = _strict_mapping(value, name="repositories")
-    _exact_keys(
+def _provider_identity(value: Mapping[str, Any]) -> ProviderPromotionIdentityV1:
+    repositories = _v1._strict_mapping(value["repositories"], name="repositories")
+    _v1._exact_keys(
         repositories,
-        _REPOSITORY_GROUP_FIELDS,
+        _REPOSITORY_FIELDS_V2,
         name="repositories",
     )
-    for key in ("prob4d", "bayesian_phystwin"):
-        repository = _strict_mapping(
-            repositories[key],
-            name=f"repositories.{key}",
-        )
-        _exact_keys(
-            repository,
-            _CODE_REPOSITORY_FIELDS,
-            name=f"repositories.{key}",
-        )
-        _repository(
-            repository["repository"],
-            name=f"repositories.{key}.repository",
-        )
-        _revision(
-            repository["revision"],
-            name=f"repositories.{key}.revision",
-        )
-    motioncrafter = _strict_mapping(
-        repositories["motioncrafter"],
-        name="repositories.motioncrafter",
-    )
-    _exact_keys(
-        motioncrafter,
-        _MOTIONCRAFTER_FIELDS,
-        name="repositories.motioncrafter",
-    )
-    _revision(
-        motioncrafter["revision"],
-        name="repositories.motioncrafter.revision",
-    )
-    _digest(
-        motioncrafter["model_set_id"],
-        name="repositories.motioncrafter.model_set_id",
-    )
+    return ProviderPromotionIdentityV1.from_dict(repositories["provider"])
 
 
-def _validate_cohort(value: Any) -> tuple[int, list[str]]:
-    cohort = _strict_mapping(value, name="cohort")
-    _exact_keys(cohort, _COHORT_FIELDS, name="cohort")
-    _strict_integer(
-        cohort["development_group_count"],
-        name="cohort.development_group_count",
-        minimum=1,
-    )
-    _strict_integer(
-        cohort["calibration_group_count"],
-        name="cohort.calibration_group_count",
-        minimum=1,
-    )
-    target_count = _strict_integer(
-        cohort["target_group_count"],
-        name="cohort.target_group_count",
-        minimum=1,
-    )
-    target_ids = _canonical_string_list(
-        cohort["target_group_ids"],
-        name="cohort.target_group_ids",
-    )
-    if target_count != len(target_ids):
-        raise ValueError("cohort.target_group_count must match cohort.target_group_ids")
-    return target_count, target_ids
+def _as_legacy_card(value: Mapping[str, Any]) -> dict[str, Any]:
+    """Create a validation-only V1 view without rewriting retained V2 bytes."""
 
-
-def _validate_arms(value: Any) -> dict[str, Mapping[str, Any]]:
-    raw_arms = _strict_list(value, name="comparison_arms")
-    if not raw_arms:
-        raise ValueError("comparison_arms must not be empty")
-    arms: list[Mapping[str, Any]] = []
-    for index, raw_arm in enumerate(raw_arms):
-        arm = _strict_mapping(raw_arm, name=f"comparison_arms[{index}]")
-        _exact_keys(
-            arm,
-            _ARM_FIELDS,
-            name=f"comparison_arms[{index}]",
-        )
-        _strict_string(
-            arm["arm_id"],
-            name=f"comparison_arms[{index}].arm_id",
-        )
-        role = _strict_string(
-            arm["role"],
-            name=f"comparison_arms[{index}].role",
-        )
-        if role not in _ALLOWED_ARM_ROLES:
-            raise ValueError(f"comparison_arms[{index}].role is not registered")
-        provider_method = _optional_string(
-            arm["provider_method_id"],
-            name=f"comparison_arms[{index}].provider_method_id",
-        )
-        _strict_string(
-            arm["query_method_id"],
-            name=f"comparison_arms[{index}].query_method_id",
-        )
-        sensor_assisted = _strict_bool(
-            arm["sensor_assisted"],
-            name=f"comparison_arms[{index}].sensor_assisted",
-        )
-        if role == "physical_fallback":
-            if provider_method is not None:
-                raise ValueError("the physical fallback arm must not have a provider method")
-        elif provider_method is None:
-            raise ValueError("every non-fallback comparison arm requires a provider method")
-        if sensor_assisted != (role == "sensor_assisted"):
-            raise ValueError("sensor_assisted must be true exactly for the sensor-assisted role")
-        arms.append(arm)
-    arm_ids = [str(arm["arm_id"]) for arm in arms]
-    if arm_ids != sorted(arm_ids) or len(set(arm_ids)) != len(arm_ids):
-        raise ValueError("comparison_arms must be sorted by unique arm_id")
-    roles = [str(arm["role"]) for arm in arms]
-    for role in _REQUIRED_ARM_ROLES:
-        if roles.count(role) != 1:
-            raise ValueError(f"required comparison role {role!r} must occur exactly once")
-    provider_methods = [
-        str(arm["provider_method_id"]) for arm in arms if arm["provider_method_id"] is not None
-    ]
-    query_methods = [str(arm["query_method_id"]) for arm in arms]
-    if len(provider_methods) != len(set(provider_methods)):
-        raise ValueError("comparison provider methods must be unique")
-    if len(query_methods) != len(set(query_methods)):
-        raise ValueError("comparison query methods must be unique")
-    return {str(arm["arm_id"]): arm for arm in arms}
-
-
-def _validate_frozen_inputs(value: Any) -> None:
-    frozen = _strict_mapping(value, name="frozen_inputs")
-    _exact_keys(
-        frozen,
-        _FROZEN_INPUT_FIELDS,
-        name="frozen_inputs",
-    )
-    for field_name in (
-        "prediction_run_spec_id",
-        "provider_evaluation_manifest_sha256",
-        "provider_report_sha256",
-        "query_results_id",
-    ):
-        _digest(
-            frozen[field_name],
-            name=f"frozen_inputs.{field_name}",
-        )
-    _validate_artifact_ids(frozen["frozen_artifact_ids"])
-
-
-def _validate_provider_gate(
-    value: Any,
-    *,
-    target_count: int,
-    arms_by_id: Mapping[str, Mapping[str, Any]],
-) -> bool:
-    provider = _strict_mapping(value, name="provider_gate")
-    _exact_keys(
-        provider,
-        _PROVIDER_GATE_FIELDS,
-        name="provider_gate",
-    )
-    passed = _strict_bool(provider["passed"], name="provider_gate.passed")
-    reference_method = _strict_string(
-        provider["reference_method"],
-        name="provider_gate.reference_method",
-    )
-    case_count = _strict_integer(
-        provider["case_count"],
-        name="provider_gate.case_count",
-        minimum=1,
-    )
-    group_count = _strict_integer(
-        provider["group_count"],
-        name="provider_gate.group_count",
-        minimum=1,
-    )
-    _optional_policy_id(provider["decision_policy_id"])
-    if group_count != target_count:
-        raise ValueError("provider_gate.group_count must match cohort.target_group_count")
-    if case_count < group_count:
-        raise ValueError("provider_gate.case_count cannot be smaller than its group count")
-    registered_provider_methods = {
-        arm["provider_method_id"]
-        for arm in arms_by_id.values()
-        if arm["provider_method_id"] is not None
+    identity = _provider_identity(value)
+    repositories = _v1._strict_mapping(value["repositories"], name="repositories")
+    legacy = plain_json(value)
+    if not isinstance(legacy, dict):
+        raise AssertionError("promotion evidence card is not a mapping")
+    legacy["schema_version"] = PROMOTION_EVIDENCE_CARD_VERSION
+    legacy["repositories"] = {
+        "prob4d": plain_json(repositories["prob4d"]),
+        "bayesian_phystwin": plain_json(repositories["bayesian_phystwin"]),
+        "motioncrafter": {
+            "revision": identity.provider_revision,
+            "model_set_id": identity.model_set_id,
+        },
     }
-    if reference_method not in registered_provider_methods:
-        raise ValueError("provider_gate.reference_method is not a registered provider method")
-    return passed
-
-
-def _validate_guarded_query(
-    value: Any,
-    *,
-    target_count: int,
-    arms_by_id: Mapping[str, Mapping[str, Any]],
-) -> bool:
-    query = _strict_mapping(value, name="guarded_query")
-    _exact_keys(query, _GUARDED_QUERY_FIELDS, name="guarded_query")
-    passed = _strict_bool(query["passed"], name="guarded_query.passed")
-    primary_id = _strict_string(
-        query["primary_arm_id"],
-        name="guarded_query.primary_arm_id",
-    )
-    fallback_id = _strict_string(
-        query["physical_fallback_arm_id"],
-        name="guarded_query.physical_fallback_arm_id",
-    )
-    if primary_id not in arms_by_id:
-        raise ValueError("guarded_query.primary_arm_id is not registered")
-    if fallback_id not in arms_by_id:
-        raise ValueError("guarded_query.physical_fallback_arm_id is not registered")
-    primary = arms_by_id[primary_id]
-    fallback = arms_by_id[fallback_id]
-    if fallback["role"] != "physical_fallback":
-        raise ValueError("guarded_query.physical_fallback_arm_id has the wrong role")
-    if primary["role"] in {
-        "physical_fallback",
-        "sensor_assisted",
-        "diagnostic",
-    }:
-        raise ValueError("guarded_query.primary_arm_id must be a non-sensor candidate")
-
-    paired = _strict_mapping(
-        query["paired_candidate_minus_fallback_mm"],
-        name="guarded_query.paired_candidate_minus_fallback_mm",
-    )
-    _exact_keys(
-        paired,
-        _PAIRED_EFFECT_FIELDS,
-        name="guarded_query.paired_candidate_minus_fallback_mm",
-    )
-    _strict_real(
-        paired["mean"],
-        name="guarded_query.paired_candidate_minus_fallback_mm.mean",
-    )
-    lower = _strict_real(
-        paired["ci95_lower"],
-        name="guarded_query.paired_candidate_minus_fallback_mm.ci95_lower",
-    )
-    upper = _strict_real(
-        paired["ci95_upper"],
-        name="guarded_query.paired_candidate_minus_fallback_mm.ci95_upper",
-    )
-    if lower > upper:
-        raise ValueError("guarded_query paired interval lower bound exceeds its upper bound")
-    paired_count = _strict_integer(
-        paired["group_count"],
-        name="guarded_query.paired_candidate_minus_fallback_mm.group_count",
-        minimum=1,
-    )
-    if paired_count != target_count:
-        raise ValueError("guarded_query paired group count must match the target cohort")
-    semantics = _strict_string(
-        paired["semantics"],
-        name="guarded_query.paired_candidate_minus_fallback_mm.semantics",
-    )
-    if semantics != _PAIRED_EFFECT_SEMANTICS:
-        raise ValueError("guarded_query paired-effect semantics changed")
-
-    _nonnegative_real(
-        query["mean_query_rmse_mm"],
-        name="guarded_query.mean_query_rmse_mm",
-    )
-    accepted_count = _nonnegative_integer(
-        query["accepted_update_count"],
-        name="guarded_query.accepted_update_count",
-    )
-    rejected_count = _nonnegative_integer(
-        query["rejected_update_count"],
-        name="guarded_query.rejected_update_count",
-    )
-    if accepted_count + rejected_count != target_count:
-        raise ValueError("guarded_query accepted and rejected counts must cover the target cohort")
-    harmful_count = _nonnegative_integer(
-        query["harmful_accepted_update_count"],
-        name="guarded_query.harmful_accepted_update_count",
-    )
-    if harmful_count > accepted_count:
-        raise ValueError("guarded_query harmful accepted updates exceed accepted updates")
-    technical_count = _nonnegative_integer(
-        query["technical_failure_count"],
-        name="guarded_query.technical_failure_count",
-    )
-    if technical_count > rejected_count:
-        raise ValueError("guarded_query technical failures exceed rejected updates")
-    _strict_real(
-        query["worst_group_regression_mm"],
-        name="guarded_query.worst_group_regression_mm",
-    )
-    _optional_real(
-        query["mean_accepted_coverage"],
-        name="guarded_query.mean_accepted_coverage",
-        minimum=0.0,
-        maximum=1.0,
-    )
-    _optional_real(
-        query["mean_accepted_width_mm"],
-        name="guarded_query.mean_accepted_width_mm",
-        minimum=0.0,
-    )
-    _nonnegative_integer(
-        query["exact_fallback_failure_count"],
-        name="guarded_query.exact_fallback_failure_count",
-    )
-    return passed
-
-
-def _validate_descriptor(card: Mapping[str, Any]) -> None:
-    if (
-        card["schema_name"],
-        card["schema_version"],
-    ) != (
-        PROMOTION_EVIDENCE_CARD_SCHEMA,
-        PROMOTION_EVIDENCE_CARD_VERSION,
-    ):
-        raise ValueError("unsupported promotion evidence card schema")
-    _strict_string(card["experiment_id"], name="experiment_id")
-    _digest(card["promotion_lock_id"], name="promotion_lock_id")
-    _digest(card["promotion_report_id"], name="promotion_report_id")
-    overall_passed = _strict_bool(
-        card["overall_passed"],
-        name="overall_passed",
-    )
-    status = _strict_string(card["status"], name="status")
-    expected_status = "PASS" if overall_passed else "FAIL"
-    if status != expected_status:
-        raise ValueError("promotion evidence status disagrees with overall_passed")
-    _strict_string(card["statistical_unit"], name="statistical_unit")
-    _validate_repositories(card["repositories"])
-    target_count, _ = _validate_cohort(card["cohort"])
-    arms_by_id = _validate_arms(card["comparison_arms"])
-    _validate_frozen_inputs(card["frozen_inputs"])
-    provider_passed = _validate_provider_gate(
-        card["provider_gate"],
-        target_count=target_count,
-        arms_by_id=arms_by_id,
-    )
-    query_passed = _validate_guarded_query(
-        card["guarded_query"],
-        target_count=target_count,
-        arms_by_id=arms_by_id,
-    )
-    if overall_passed != (provider_passed and query_passed):
-        raise ValueError("overall_passed must equal the conjunction of provider and query gates")
-    if card["claim_boundary"] != REPORT_CLAIM_BOUNDARY:
-        raise ValueError("promotion evidence claim boundary changed")
-    non_claims = _canonical_string_list(
-        card["explicit_non_claims"],
-        name="explicit_non_claims",
-    )
-    if tuple(non_claims) != tuple(sorted(_NON_CLAIMS)):
-        raise ValueError("promotion evidence explicit non-claims changed")
+    legacy["evidence_card_id"] = _sha256_json(_descriptor(legacy))
+    return legacy
 
 
 def build_promotion_evidence_card(
-    promotion_lock: Mapping[str, Any],
-    promotion_report: Mapping[str, Any],
+    lock_value: object,
+    report_value: object,
 ) -> dict[str, Any]:
-    """Derive a compact paper-facing summary from a validated lock and report."""
+    """Build a V1 replay card or a provider-neutral V2 evidence card."""
 
-    lock = promotion_lock_from_dict(promotion_lock)
-    report = promotion_report_from_dict(promotion_report)
-    if report.promotion_lock_id != lock.promotion_lock_id:
-        raise ValueError("promotion report references a different promotion lock")
-
-    audit = _strict_mapping(report.provider_audit, name="provider_audit")
-    provider = _strict_mapping(
-        report.provider_decision,
-        name="provider_decision",
-    )
-    query = _strict_mapping(report.query_decision, name="query_decision")
-    aggregates = _strict_mapping(
-        report.query_aggregate,
-        name="query_aggregate",
-    )
-    primary = _strict_mapping(
-        aggregates.get(lock.primary_query_arm_id),
-        name="primary query aggregate",
-    )
-    paired = _strict_mapping(
-        query.get("paired_bootstrap"),
-        name="paired_bootstrap",
-    )
-    statistical_unit = lock.metadata.get(
-        "statistical_unit",
-        lock.metadata.get("split_semantics"),
-    )
-    if type(statistical_unit) is not str or not statistical_unit:
-        statistical_unit = "complete physical object or acquisition session"
-
-    descriptor: dict[str, Any] = {
-        "schema_name": PROMOTION_EVIDENCE_CARD_SCHEMA,
-        "schema_version": PROMOTION_EVIDENCE_CARD_VERSION,
-        "experiment_id": lock.experiment_id,
-        "promotion_lock_id": lock.promotion_lock_id,
-        "promotion_report_id": report.report_id,
-        "overall_passed": report.overall_passed,
-        "status": "PASS" if report.overall_passed else "FAIL",
-        "statistical_unit": statistical_unit,
-        "repositories": {
-            "prob4d": {
-                "repository": lock.source_repository,
-                "revision": lock.source_revision,
-            },
-            "bayesian_phystwin": {
-                "repository": lock.bayesian_phystwin_repository,
-                "revision": lock.bayesian_phystwin_revision,
-            },
-            "motioncrafter": {
-                "revision": lock.motioncrafter_revision,
-                "model_set_id": lock.model_set_id,
-            },
-        },
-        "cohort": {
-            "development_group_count": len(lock.development_group_ids),
-            "calibration_group_count": len(lock.calibration_group_ids),
-            "target_group_count": len(lock.target_group_ids),
-            "target_group_ids": list(lock.target_group_ids),
-        },
-        "comparison_arms": [
-            {
-                "arm_id": arm.arm_id,
-                "role": arm.role,
-                "provider_method_id": arm.provider_method_id,
-                "query_method_id": arm.query_method_id,
-                "sensor_assisted": arm.sensor_assisted,
-            }
-            for arm in lock.arms
-        ],
-        "frozen_inputs": {
-            "prediction_run_spec_id": lock.prediction_run_spec_id,
-            "provider_evaluation_manifest_sha256": (lock.provider_evaluation_manifest_sha256),
-            "frozen_artifact_ids": dict(lock.frozen_artifact_ids),
-            "provider_report_sha256": report.provider_report_sha256,
-            "query_results_id": report.query_results_id,
-        },
-        "provider_gate": {
-            "passed": provider.get("overall_passed"),
-            "reference_method": audit.get("reference_method"),
-            "case_count": audit.get("case_count"),
-            "group_count": audit.get("group_count"),
-            "decision_policy_id": audit.get("decision_policy_id"),
-        },
-        "guarded_query": {
-            "passed": query.get("overall_passed"),
-            "primary_arm_id": lock.primary_query_arm_id,
-            "physical_fallback_arm_id": query.get("physical_fallback_arm_id"),
-            "paired_candidate_minus_fallback_mm": {
-                "mean": paired.get("mean"),
-                "ci95_lower": paired.get("ci95_lower"),
-                "ci95_upper": paired.get("ci95_upper"),
-                "group_count": paired.get("group_count"),
-                "semantics": paired.get("semantics"),
-            },
-            "mean_query_rmse_mm": primary.get("mean_query_rmse_mm"),
-            "accepted_update_count": primary.get("accepted_update_count"),
-            "rejected_update_count": primary.get("rejected_update_count"),
-            "harmful_accepted_update_count": primary.get("harmful_accepted_update_count"),
-            "technical_failure_count": primary.get("technical_failure_count"),
-            "worst_group_regression_mm": primary.get("worst_group_regression_mm"),
-            "mean_accepted_coverage": primary.get("mean_accepted_coverage"),
-            "mean_accepted_width_mm": primary.get("mean_accepted_width_mm"),
-            "exact_fallback_failure_count": query.get("exact_fallback_failure_count"),
-        },
-        "claim_boundary": REPORT_CLAIM_BOUNDARY,
-        "explicit_non_claims": list(sorted(_NON_CLAIMS)),
+    lock = promotion_lock_from_dict(lock_value)
+    card = _v1.build_promotion_evidence_card(lock_value, report_value)
+    if lock.schema_version != HELDOUT_PROMOTION_LOCK_PROVIDER_NEUTRAL_VERSION:
+        return card
+    identity = lock.provider_identity
+    if identity is None:
+        raise AssertionError("provider-neutral lock has no provider identity")
+    repositories = _v1._strict_mapping(card["repositories"], name="repositories")
+    descriptor = _descriptor(card)
+    descriptor["schema_version"] = PROMOTION_EVIDENCE_CARD_PROVIDER_NEUTRAL_VERSION
+    descriptor["repositories"] = {
+        "prob4d": plain_json(repositories["prob4d"]),
+        "bayesian_phystwin": plain_json(repositories["bayesian_phystwin"]),
+        "provider": identity.to_dict(),
     }
-    card = {**descriptor, "evidence_card_id": _sha256_json(descriptor)}
-    return promotion_evidence_card_from_dict(card)
+    return promotion_evidence_card_from_dict(
+        {
+            **descriptor,
+            "evidence_card_id": _sha256_json(descriptor),
+        }
+    )
 
 
 def promotion_evidence_card_from_dict(value: object) -> dict[str, Any]:
-    card = _strict_mapping(value, name="promotion evidence card")
-    _exact_keys(card, _FIELDS, name="promotion evidence card")
-    _validate_descriptor(card)
-    supplied = _digest(
-        card["evidence_card_id"],
-        name="evidence_card_id",
+    """Validate historical V1 and provider-neutral V2 evidence cards."""
+
+    card = _v1._strict_mapping(value, name="promotion evidence card")
+    version = _v1._strict_integer(
+        card.get("schema_version"),
+        name="schema_version",
+        minimum=1,
     )
-    descriptor = {key: item for key, item in card.items() if key != "evidence_card_id"}
-    if supplied != _sha256_json(descriptor):
+    if version == PROMOTION_EVIDENCE_CARD_VERSION:
+        return _v1.promotion_evidence_card_from_dict(card)
+    if version != PROMOTION_EVIDENCE_CARD_PROVIDER_NEUTRAL_VERSION:
+        raise ValueError("unsupported promotion evidence card version")
+    if card.get("schema_name") != PROMOTION_EVIDENCE_CARD_SCHEMA:
+        raise ValueError("unsupported promotion evidence card schema")
+
+    _v1.promotion_evidence_card_from_dict(_as_legacy_card(card))
+    _provider_identity(card)
+    supplied = _v1._digest(card["evidence_card_id"], name="evidence_card_id")
+    if supplied != _sha256_json(_descriptor(card)):
         raise ValueError("promotion evidence card ID mismatch")
-    return dict(card)
+    result = plain_json(card)
+    if not isinstance(result, dict):
+        raise AssertionError("validated promotion evidence card is not a mapping")
+    return result
 
 
 def load_promotion_evidence_card(path: str | Path) -> dict[str, Any]:
-    mapping, _ = _load_json(
-        Path(path),
-        name="promotion evidence card",
-    )
+    mapping, _ = _load_json(Path(path), name="promotion evidence card")
     return promotion_evidence_card_from_dict(mapping)
 
 
 def render_promotion_evidence_markdown(card: Mapping[str, Any]) -> str:
     value = promotion_evidence_card_from_dict(card)
-    repositories = _strict_mapping(value["repositories"], name="repositories")
-    prob4d = _strict_mapping(repositories["prob4d"], name="prob4d")
-    bpt = _strict_mapping(
-        repositories["bayesian_phystwin"],
-        name="bayesian_phystwin",
-    )
-    query = _strict_mapping(value["guarded_query"], name="guarded_query")
-    paired = _strict_mapping(
-        query["paired_candidate_minus_fallback_mm"],
-        name="paired effect",
-    )
-    return "\n".join(
-        [
-            "# Held-out Prob4D promotion evidence card",
-            "",
-            f"Evidence card: `{value['evidence_card_id']}`.",
-            f"Promotion report: `{value['promotion_report_id']}`.",
-            f"Overall decision: **{value['status']}**.",
-            "",
-            f"- Prob4D: `{prob4d['repository']}@{prob4d['revision']}`",
-            f"- BayesianPhysTwin: `{bpt['repository']}@{bpt['revision']}`",
-            "",
-            "| Guarded-query result | Value |",
-            "| --- | ---: |",
-            f"| Primary arm | `{query['primary_arm_id']}` |",
-            (f"| Mean candidate-minus-fallback RMSE | {float(paired['mean']):.6g} mm |"),
-            (f"| Harmful accepted updates | {query['harmful_accepted_update_count']} |"),
-            (f"| Exact fallback failures | {query['exact_fallback_failure_count']} |"),
-            "",
-            str(value["claim_boundary"]),
-            "",
-        ]
-    )
+    if value["schema_version"] == PROMOTION_EVIDENCE_CARD_VERSION:
+        return _v1.render_promotion_evidence_markdown(value)
 
-
-def _atomic_write_text(path: Path, content: str) -> None:
-    """Publish complete text without replacing a concurrently created path."""
-
-    if path.exists():
-        raise FileExistsError(path)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    descriptor, temporary_name = tempfile.mkstemp(
-        dir=path.parent,
-        prefix=f".{path.name}.tmp-",
-        text=True,
+    identity = _provider_identity(value)
+    legacy = _as_legacy_card(value)
+    rendered = _v1.render_promotion_evidence_markdown(legacy)
+    anchor = next(
+        line
+        for line in rendered.splitlines()
+        if line.startswith("- BayesianPhysTwin:")
     )
-    temporary = Path(temporary_name)
-    try:
-        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
-            stream.write(content)
-            stream.flush()
-            os.fsync(stream.fileno())
-        os.link(temporary, path)
-    finally:
-        temporary.unlink(missing_ok=True)
-
-
-def _atomic_write_json(path: Path, value: Mapping[str, Any]) -> None:
-    encoded = (
-        json.dumps(
-            plain_json(value),
-            sort_keys=True,
-            indent=2,
-            allow_nan=False,
-        )
-        + "\n"
+    provider_line = (
+        f"- Provider: `{identity.provider_family}` from "
+        f"`{identity.provider_repository}@{identity.provider_revision}`"
     )
-    _atomic_write_text(path, encoded)
+    return rendered.replace(anchor, f"{anchor}\n{provider_line}", 1)
 
 
 def write_promotion_evidence_card(
@@ -796,9 +161,9 @@ def write_promotion_evidence_card(
         raise FileExistsError(json_destination)
     if markdown_destination.exists():
         raise FileExistsError(markdown_destination)
-    _atomic_write_json(json_destination, value)
+    _v1._atomic_write_json(json_destination, value)
     try:
-        _atomic_write_text(
+        _v1._atomic_write_text(
             markdown_destination,
             render_promotion_evidence_markdown(value),
         )
@@ -808,6 +173,7 @@ def write_promotion_evidence_card(
 
 
 __all__ = [
+    "PROMOTION_EVIDENCE_CARD_PROVIDER_NEUTRAL_VERSION",
     "PROMOTION_EVIDENCE_CARD_SCHEMA",
     "PROMOTION_EVIDENCE_CARD_VERSION",
     "build_promotion_evidence_card",

--- a/src/prob4d/target_provider_admission.py
+++ b/src/prob4d/target_provider_admission.py
@@ -40,7 +40,9 @@ from .prediction_provider_manifest import (
     load_prediction_provider_manifest,
 )
 
-TARGET_PROVIDER_ADMISSION_CONFIG_SCHEMA = "prob4d.heldout-target-provider-admission-config"
+TARGET_PROVIDER_ADMISSION_CONFIG_SCHEMA = (
+    "prob4d.heldout-target-provider-admission-config"
+)
 TARGET_PROVIDER_ADMISSION_CONFIG_VERSION = 1
 TARGET_PROVIDER_ADMISSION_SCHEMA = "prob4d.heldout-target-provider-admission"
 TARGET_PROVIDER_ADMISSION_VERSION = 1
@@ -203,7 +205,11 @@ class TargetProviderManifestRequestV1:
     causal_frame_stop: int
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "group_id", _strict_string(self.group_id, name="group_id"))
+        object.__setattr__(
+            self,
+            "group_id",
+            _strict_string(self.group_id, name="group_id"),
+        )
         object.__setattr__(
             self,
             "expected_sequence_id",
@@ -217,7 +223,11 @@ class TargetProviderManifestRequestV1:
         object.__setattr__(
             self,
             "causal_frame_stop",
-            _strict_integer(self.causal_frame_stop, name="causal_frame_stop", minimum=1),
+            _strict_integer(
+                self.causal_frame_stop,
+                name="causal_frame_stop",
+                minimum=1,
+            ),
         )
 
     @classmethod
@@ -266,7 +276,9 @@ class AdmittedTargetPayloadV1:
             minimum=1,
         )
         if stop <= start:
-            raise ValueError("source_frame_stop_exclusive must exceed source_frame_start")
+            raise ValueError(
+                "source_frame_stop_exclusive must exceed source_frame_start"
+            )
         groups = _canonical_strings(
             self.dependence_group_ids,
             name="dependence_group_ids",
@@ -277,7 +289,10 @@ class AdmittedTargetPayloadV1:
         object.__setattr__(self, "dependence_group_ids", groups)
 
     @classmethod
-    def from_descriptor(cls, value: PredictionPayloadDescriptorV1) -> AdmittedTargetPayloadV1:
+    def from_descriptor(
+        cls,
+        value: PredictionPayloadDescriptorV1,
+    ) -> AdmittedTargetPayloadV1:
         if value.payload_id is None:
             raise ValueError("provider payload ID is not materialized")
         return cls(
@@ -334,7 +349,11 @@ class TargetProviderManifestAdmissionV1:
     admitted_payloads: tuple[AdmittedTargetPayloadV1, ...]
 
     def __post_init__(self) -> None:
-        object.__setattr__(self, "group_id", _strict_string(self.group_id, name="group_id"))
+        object.__setattr__(
+            self,
+            "group_id",
+            _strict_string(self.group_id, name="group_id"),
+        )
         object.__setattr__(
             self,
             "episode_id",
@@ -346,7 +365,11 @@ class TargetProviderManifestAdmissionV1:
             "sequence_id",
             _strict_string(self.sequence_id, name="sequence_id"),
         )
-        for field_name in ("manifest_sha256", "manifest_artifact_id", "provider_run_id"):
+        for field_name in (
+            "manifest_sha256",
+            "manifest_artifact_id",
+            "provider_run_id",
+        ):
             object.__setattr__(
                 self,
                 field_name,
@@ -363,9 +386,13 @@ class TargetProviderManifestAdmissionV1:
         )
         if type(self.admitted_payloads) is not tuple or not self.admitted_payloads:
             raise ValueError("admitted_payloads must be a nonempty tuple")
-        payloads = tuple(sorted(self.admitted_payloads, key=lambda item: item.payload_id))
+        payloads = tuple(
+            sorted(self.admitted_payloads, key=lambda item: item.payload_id)
+        )
         if not all(isinstance(item, AdmittedTargetPayloadV1) for item in payloads):
-            raise ValueError("admitted_payloads must contain AdmittedTargetPayloadV1 values")
+            raise ValueError(
+                "admitted_payloads must contain AdmittedTargetPayloadV1 values"
+            )
         payload_ids = tuple(item.payload_id for item in payloads)
         if len(payload_ids) != len(set(payload_ids)):
             raise ValueError("admitted payload IDs must be unique")
@@ -391,7 +418,10 @@ class TargetProviderManifestAdmissionV1:
     def from_dict(cls, value: object) -> TargetProviderManifestAdmissionV1:
         mapping = _strict_mapping(value, name="target provider manifest admission")
         _exact_keys(mapping, _ENTRY_FIELDS, name="target provider manifest admission")
-        raw_payloads = _strict_list(mapping["admitted_payloads"], name="admitted_payloads")
+        raw_payloads = _strict_list(
+            mapping["admitted_payloads"],
+            name="admitted_payloads",
+        )
         return cls(
             group_id=mapping["group_id"],
             episode_id=mapping["episode_id"],
@@ -484,14 +514,21 @@ class HeldoutTargetProviderAdmissionV1:
                 field_name,
                 _strict_string(getattr(self, field_name), name=field_name),
             )
-        target_used = _strict_bool(self.target_outcomes_used, name="target_outcomes_used")
+        target_used = _strict_bool(
+            self.target_outcomes_used,
+            name="target_outcomes_used",
+        )
         if target_used:
             raise ValueError("target provider admission must not use target outcomes")
         if type(self.entries) is not tuple or not self.entries:
             raise ValueError("entries must be a nonempty tuple")
         entries = tuple(sorted(self.entries, key=lambda item: item.group_id))
-        if not all(isinstance(item, TargetProviderManifestAdmissionV1) for item in entries):
-            raise ValueError("entries must contain TargetProviderManifestAdmissionV1 values")
+        if not all(
+            isinstance(item, TargetProviderManifestAdmissionV1) for item in entries
+        ):
+            raise ValueError(
+                "entries must contain TargetProviderManifestAdmissionV1 values"
+            )
         group_ids = tuple(item.group_id for item in entries)
         if len(group_ids) != len(set(group_ids)):
             raise ValueError("target provider admission group IDs must be unique")
@@ -500,12 +537,30 @@ class HeldoutTargetProviderAdmissionV1:
         object.__setattr__(
             self,
             "metadata",
-            frozen_finite_json_mapping(self.metadata, name="target admission metadata"),
+            frozen_finite_json_mapping(
+                self.metadata,
+                name="target admission metadata",
+            ),
         )
 
     @property
     def target_group_ids(self) -> tuple[str, ...]:
         return tuple(item.group_id for item in self.entries)
+
+    @property
+    def provider_contract_signature(self) -> tuple[str, ...]:
+        return (
+            self.provider_family,
+            self.provider_repository,
+            self.provider_revision,
+            self.model_set_id,
+            self.loader_id,
+            self.coordinate_semantics,
+            self.point_semantics,
+            self.flow_semantics,
+            self.ray_semantics,
+            self.source_dependency_semantics,
+        )
 
     def descriptor(self) -> dict[str, object]:
         return {
@@ -550,7 +605,11 @@ def target_provider_admission_from_dict(
     _exact_keys(mapping, _ADMISSION_FIELDS, name="target provider admission")
     if mapping["schema_name"] != TARGET_PROVIDER_ADMISSION_SCHEMA:
         raise ValueError("unsupported target provider admission schema")
-    version = _strict_integer(mapping["schema_version"], name="schema_version", minimum=1)
+    version = _strict_integer(
+        mapping["schema_version"],
+        name="schema_version",
+        minimum=1,
+    )
     if version != TARGET_PROVIDER_ADMISSION_VERSION:
         raise ValueError("unsupported target provider admission version")
     if mapping["claim_boundary"] != TARGET_PROVIDER_ADMISSION_CLAIM_BOUNDARY:
@@ -573,8 +632,14 @@ def target_provider_admission_from_dict(
         ray_semantics=mapping["ray_semantics"],
         source_dependency_semantics=mapping["source_dependency_semantics"],
         target_outcomes_used=mapping["target_outcomes_used"],
-        entries=tuple(TargetProviderManifestAdmissionV1.from_dict(item) for item in raw_entries),
-        metadata=_strict_mapping(mapping["metadata"], name="target admission metadata"),
+        entries=tuple(
+            TargetProviderManifestAdmissionV1.from_dict(item)
+            for item in raw_entries
+        ),
+        metadata=_strict_mapping(
+            mapping["metadata"],
+            name="target admission metadata",
+        ),
     )
     supplied = _strict_digest(
         mapping["target_provider_admission_id"],
@@ -586,7 +651,9 @@ def target_provider_admission_from_dict(
     return result
 
 
-def load_target_provider_admission(path: str | Path) -> HeldoutTargetProviderAdmissionV1:
+def load_target_provider_admission(
+    path: str | Path,
+) -> HeldoutTargetProviderAdmissionV1:
     mapping, _ = _load_json(Path(path), name="target provider admission")
     return target_provider_admission_from_dict(mapping)
 
@@ -610,7 +677,9 @@ def _validate_lock_and_binding(
     binding: Deform360OfficialHubCohortBindingV1,
 ) -> None:
     if lock.calibration_group_ids != binding.calibration_group_ids:
-        raise ValueError("cohort binding calibration groups differ from promotion lock")
+        raise ValueError(
+            "cohort binding calibration groups differ from promotion lock"
+        )
     if lock.target_group_ids != binding.target_group_ids:
         raise ValueError("cohort binding target groups differ from promotion lock")
     if lock.bayesian_phystwin_repository != binding.source_repository:
@@ -636,6 +705,44 @@ def _provider_contract(manifest: PredictionProviderManifestV1) -> tuple[str, ...
     )
 
 
+def _require_lock_provider_contract(
+    lock: HeldoutProviderPromotionLockV1,
+    contract: tuple[str, ...],
+) -> None:
+    """Preserve V1 replay while enforcing the complete V2 provider contract."""
+
+    if lock.provider_identity is None:
+        if contract[2] != lock.provider_revision:
+            raise ValueError("target provider revision differs from promotion lock")
+        if contract[3] != lock.provider_model_set_id:
+            raise ValueError("target provider model set differs from promotion lock")
+        return
+    expected = lock.provider_contract_signature
+    assert expected is not None
+    if contract != expected:
+        fields = (
+            "provider_family",
+            "provider_repository",
+            "provider_revision",
+            "model_set_id",
+            "loader_id",
+            "coordinate_semantics",
+            "point_semantics",
+            "flow_semantics",
+            "ray_semantics",
+            "source_dependency_semantics",
+        )
+        changed = [
+            field_name
+            for field_name, observed, frozen in zip(fields, contract, expected, strict=True)
+            if observed != frozen
+        ]
+        raise ValueError(
+            "target provider contract differs from provider-neutral promotion lock: "
+            + ", ".join(changed)
+        )
+
+
 def _entry_from_manifest(
     request: TargetProviderManifestRequestV1,
     *,
@@ -645,11 +752,14 @@ def _entry_from_manifest(
     manifest: PredictionProviderManifestV1,
 ) -> TargetProviderManifestAdmissionV1:
     if manifest.sequence_id != request.expected_sequence_id:
-        raise ValueError(f"provider sequence changed for target group {request.group_id!r}")
+        raise ValueError(
+            f"provider sequence changed for target group {request.group_id!r}"
+        )
     admitted = manifest.admitted_payloads(request.causal_frame_stop)
     if not admitted:
         raise ValueError(
-            f"no provider payload is causally admitted for target group {request.group_id!r}"
+            "no provider payload is causally admitted for target group "
+            f"{request.group_id!r}"
         )
     if manifest.artifact_id is None:
         raise ValueError("provider manifest artifact ID is not materialized")
@@ -662,7 +772,9 @@ def _entry_from_manifest(
         manifest_artifact_id=manifest.artifact_id,
         provider_run_id=manifest.provider_run_id,
         causal_frame_stop=request.causal_frame_stop,
-        admitted_payloads=tuple(AdmittedTargetPayloadV1.from_descriptor(item) for item in admitted),
+        admitted_payloads=tuple(
+            AdmittedTargetPayloadV1.from_descriptor(item) for item in admitted
+        ),
     )
 
 
@@ -676,11 +788,22 @@ def build_target_provider_admission(
     """Build an outcome-blind admission from exact target manifest metadata."""
 
     _validate_lock_and_binding(lock, binding)
-    mapping = _strict_mapping(config, name="target provider admission configuration")
-    _exact_keys(mapping, _CONFIG_FIELDS, name="target provider admission configuration")
+    mapping = _strict_mapping(
+        config,
+        name="target provider admission configuration",
+    )
+    _exact_keys(
+        mapping,
+        _CONFIG_FIELDS,
+        name="target provider admission configuration",
+    )
     if mapping["schema_name"] != TARGET_PROVIDER_ADMISSION_CONFIG_SCHEMA:
         raise ValueError("unsupported target provider admission configuration schema")
-    version = _strict_integer(mapping["schema_version"], name="schema_version", minimum=1)
+    version = _strict_integer(
+        mapping["schema_version"],
+        name="schema_version",
+        minimum=1,
+    )
     if version != TARGET_PROVIDER_ADMISSION_CONFIG_VERSION:
         raise ValueError("unsupported target provider admission configuration version")
     run_spec_id = _strict_digest(
@@ -689,20 +812,30 @@ def build_target_provider_admission(
         pattern=_SHA256,
     )
     if run_spec_id != lock.prediction_run_spec_id:
-        raise ValueError("target request prediction run-spec differs from promotion lock")
-    target_used = _strict_bool(mapping["target_outcomes_used"], name="target_outcomes_used")
+        raise ValueError(
+            "target request prediction run-spec differs from promotion lock"
+        )
+    target_used = _strict_bool(
+        mapping["target_outcomes_used"],
+        name="target_outcomes_used",
+    )
     if target_used:
         raise ValueError("target provider admission cannot use target outcomes")
     raw_requests = _strict_list(mapping["entries"], name="entries")
     requests = tuple(
         sorted(
-            (TargetProviderManifestRequestV1.from_dict(item) for item in raw_requests),
+            (
+                TargetProviderManifestRequestV1.from_dict(item)
+                for item in raw_requests
+            ),
             key=lambda item: item.group_id,
         )
     )
     request_group_ids = tuple(item.group_id for item in requests)
     if request_group_ids != lock.target_group_ids:
-        raise ValueError("target provider requests must cover the exact frozen target groups")
+        raise ValueError(
+            "target provider requests must cover the exact frozen target groups"
+        )
     if len(request_group_ids) != len(set(request_group_ids)):
         raise ValueError("target provider request group IDs must be unique")
 
@@ -713,18 +846,21 @@ def build_target_provider_admission(
     first_manifest: PredictionProviderManifestV1 | None = None
     for request in requests:
         unit = units[request.group_id]
-        path = _resolve_member(root, request.manifest_path, name="provider manifest path")
+        path = _resolve_member(
+            root,
+            request.manifest_path,
+            name="provider manifest path",
+        )
         manifest, manifest_sha256 = _snapshot_manifest(path)
-        if manifest.provider_revision != lock.motioncrafter_revision:
-            raise ValueError("target provider revision differs from promotion lock")
-        if manifest.model_set_id != lock.model_set_id:
-            raise ValueError("target provider model set differs from promotion lock")
         contract = _provider_contract(manifest)
+        _require_lock_provider_contract(lock, contract)
         if expected_contract is None:
             expected_contract = contract
             first_manifest = manifest
         elif contract != expected_contract:
-            raise ValueError("target provider contract drifts across frozen target groups")
+            raise ValueError(
+                "target provider contract drifts across frozen target groups"
+            )
         entries.append(
             _entry_from_manifest(
                 request,
@@ -736,7 +872,10 @@ def build_target_provider_admission(
         )
     if first_manifest is None:
         raise ValueError("target provider admission requires at least one manifest")
-    metadata = _strict_mapping(mapping["metadata"], name="target admission metadata")
+    metadata = _strict_mapping(
+        mapping["metadata"],
+        name="target admission metadata",
+    )
     return HeldoutTargetProviderAdmissionV1(
         promotion_lock_id=lock.promotion_lock_id,
         cohort_binding_id=binding.cohort_binding_id,
@@ -763,7 +902,7 @@ def validate_target_provider_admission_against_lock(
     admission: HeldoutTargetProviderAdmissionV1,
     lock: HeldoutProviderPromotionLockV1,
 ) -> None:
-    """Require exact promotion-lock and target-group agreement."""
+    """Require exact promotion-lock, provider-contract, and target-group agreement."""
 
     if admission.promotion_lock_id != lock.promotion_lock_id:
         raise ValueError("target provider admission uses another promotion lock")
@@ -773,10 +912,16 @@ def validate_target_provider_admission_against_lock(
         raise ValueError("target provider admission source revision changed")
     if admission.prediction_run_spec_id != lock.prediction_run_spec_id:
         raise ValueError("target provider admission prediction run-spec changed")
-    if admission.provider_revision != lock.motioncrafter_revision:
-        raise ValueError("target provider admission provider revision changed")
-    if admission.model_set_id != lock.model_set_id:
-        raise ValueError("target provider admission model set changed")
+    if lock.provider_identity is None:
+        if admission.provider_revision != lock.provider_revision:
+            raise ValueError("target provider admission provider revision changed")
+        if admission.model_set_id != lock.provider_model_set_id:
+            raise ValueError("target provider admission model set changed")
+    else:
+        _require_lock_provider_contract(
+            lock,
+            admission.provider_contract_signature,
+        )
     if admission.target_group_ids != lock.target_group_ids:
         raise ValueError("target provider admission target groups changed")
     if lock.frozen_artifact_ids.get("cohort_binding") != admission.cohort_binding_id:
@@ -800,7 +945,9 @@ def verify_target_provider_admission(
         request_root=request_root,
     )
     if observed.to_dict() != replayed.to_dict():
-        raise ValueError("target provider admission does not match deterministic replay")
+        raise ValueError(
+            "target provider admission does not match deterministic replay"
+        )
     return replayed
 
 
@@ -816,7 +963,10 @@ def admit_cli(arguments: Sequence[str]) -> int:
     parsed = parser.parse_args(arguments)
     lock = load_promotion_lock(parsed.lock)
     binding = load_deform360_cohort_binding(parsed.cohort_binding)
-    config, _ = _load_json(parsed.config, name="target provider admission configuration")
+    config, _ = _load_json(
+        parsed.config,
+        name="target provider admission configuration",
+    )
     admission = build_target_provider_admission(
         lock,
         binding,
@@ -841,7 +991,10 @@ def verify_cli(arguments: Sequence[str]) -> int:
     observed = load_target_provider_admission(parsed.admission)
     lock = load_promotion_lock(parsed.lock)
     binding = load_deform360_cohort_binding(parsed.cohort_binding)
-    config, _ = _load_json(parsed.config, name="target provider admission configuration")
+    config, _ = _load_json(
+        parsed.config,
+        name="target provider admission configuration",
+    )
     replayed = verify_target_provider_admission(
         observed,
         lock,
@@ -852,7 +1005,9 @@ def verify_cli(arguments: Sequence[str]) -> int:
     print(
         json.dumps(
             {
-                "target_provider_admission_id": replayed.target_provider_admission_id,
+                "target_provider_admission_id": (
+                    replayed.target_provider_admission_id
+                ),
                 "promotion_lock_id": replayed.promotion_lock_id,
                 "cohort_binding_id": replayed.cohort_binding_id,
                 "target_group_count": len(replayed.entries),

--- a/tests/test_provider_neutral_promotion.py
+++ b/tests/test_provider_neutral_promotion.py
@@ -1,0 +1,328 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import Any
+
+import pytest
+
+from prob4d._heldout_promotion_lock import (
+    HELDOUT_PROMOTION_LOCK_PROVIDER_NEUTRAL_VERSION,
+    ProviderPromotionIdentityV1,
+    promotion_lock_from_config,
+    promotion_lock_from_dict,
+)
+from prob4d.heldout_promotion import (
+    PromotionQueryRowV1,
+    build_query_results,
+    evaluate_heldout_promotion,
+)
+from prob4d.promotion_evidence import (
+    PROMOTION_EVIDENCE_CARD_PROVIDER_NEUTRAL_VERSION,
+    build_promotion_evidence_card,
+    promotion_evidence_card_from_dict,
+    render_promotion_evidence_markdown,
+)
+from prob4d.target_provider_admission import (
+    AdmittedTargetPayloadV1,
+    HeldoutTargetProviderAdmissionV1,
+    TargetProviderManifestAdmissionV1,
+    validate_target_provider_admission_against_lock,
+)
+
+_ROLES = (
+    ("fallback", "physical_fallback", None, "bpt-fallback", False),
+    (
+        "framewise",
+        "framewise_explicit_joint_gauge",
+        "provider-framewise",
+        "bpt-framewise",
+        False,
+    ),
+    (
+        "identity",
+        "cross_window_identity_marginalized",
+        "provider-identity",
+        "bpt-identity",
+        False,
+    ),
+    (
+        "persistent",
+        "persistent_explicit_joint_gauge",
+        "provider-persistent",
+        "bpt-persistent",
+        False,
+    ),
+    (
+        "rowwise",
+        "rowwise_gauge_marginalized",
+        "provider-rowwise",
+        "bpt-rowwise",
+        False,
+    ),
+    ("sensor", "sensor_assisted", "provider-sensor", "bpt-sensor", True),
+    ("visual", "visual_baseline", "provider-visual", "bpt-visual", False),
+)
+
+
+def _arms() -> list[dict[str, object]]:
+    return [
+        {
+            "arm_id": arm_id,
+            "role": role,
+            "provider_method_id": provider_method,
+            "query_method_id": query_method,
+            "sensor_assisted": sensor_assisted,
+            "metadata": {},
+        }
+        for arm_id, role, provider_method, query_method, sensor_assisted in _ROLES
+    ]
+
+
+def _common_config() -> dict[str, Any]:
+    return {
+        "experiment_id": "provider-neutral-heldout-v2",
+        "source_repository": "IPS-Stuttgart/Prob4D",
+        "source_revision": "a" * 40,
+        "bayesian_phystwin_repository": "IPS-Stuttgart/BayesianPhysTwin",
+        "bayesian_phystwin_revision": "b" * 40,
+        "prediction_run_spec_id": "e" * 64,
+        "provider_evaluation_manifest_sha256": "f" * 64,
+        "frozen_artifact_ids": {
+            "provider_configuration": "0" * 64,
+            "gauge_calibration": "1" * 64,
+            "point_calibration": "2" * 64,
+            "source_reliability_calibration": "3" * 64,
+            "material_identity_calibration": "4" * 64,
+            "selection_lock": "5" * 64,
+            "bayesian_guard_configuration": "6" * 64,
+            "cohort_binding": "7" * 64,
+        },
+        "development_group_ids": ["dev-1"],
+        "calibration_group_ids": ["cal-1"],
+        "target_group_ids": ["target-1", "target-2"],
+        "arms": _arms(),
+        "provider_reference_arm_id": "visual",
+        "primary_query_arm_id": "identity",
+        "bootstrap_resamples": 500,
+        "bootstrap_seed": 11,
+        "minimum_target_group_count": 2,
+        "query_superiority_margin_mm": 0.1,
+        "harmful_update_margin_mm": 0.0,
+        "maximum_harmful_accepted_updates": 0,
+        "maximum_worst_group_regression_mm": 0.0,
+        "maximum_technical_failures": 0,
+        "minimum_mean_accepted_coverage": 0.9,
+        "metadata": {"split_semantics": "complete-object-session-v1"},
+    }
+
+
+def _provider_identity() -> dict[str, object]:
+    return {
+        "schema_name": "prob4d.provider-promotion-identity",
+        "schema_version": 1,
+        "provider_family": "cut3r",
+        "provider_repository": "naver/CUT3R",
+        "provider_revision": "c" * 40,
+        "model_set_id": "d" * 64,
+        "loader_id": "8" * 64,
+        "coordinate_semantics": "sequence-local-sim3",
+        "point_semantics": "dense-point-map",
+        "flow_semantics": "absent",
+        "ray_semantics": "absent",
+        "source_dependency_semantics": (
+            "per-output-exclusive-source-frame-interval-v1"
+        ),
+    }
+
+
+def _v1_config() -> dict[str, Any]:
+    config = _common_config()
+    config["motioncrafter_revision"] = "c" * 40
+    config["model_set_id"] = "d" * 64
+    return config
+
+
+def _v2_config() -> dict[str, Any]:
+    config = _common_config()
+    config["provider_identity"] = _provider_identity()
+    return config
+
+
+def _provider_report(lock: Any) -> dict[str, Any]:
+    return {
+        "schema_name": "prob4d.provider-evaluation-report",
+        "schema_version": 3,
+        "source_manifest_sha256": lock.provider_evaluation_manifest_sha256,
+        "primary_mode": "metric",
+        "primary_support": "common_across_registered_methods",
+        "reference_method": lock.provider_reference_method_id,
+        "bootstrap_resamples": lock.bootstrap_resamples,
+        "bootstrap_seed": lock.bootstrap_seed,
+        "legacy_artifacts_allowed": False,
+        "cases": [
+            {
+                "case_id": f"{group_id}-case",
+                "group_id": group_id,
+                "method_id": method_id,
+            }
+            for group_id in lock.target_group_ids
+            for method_id in lock.provider_method_ids
+        ],
+        "decision": {
+            "policy_id": "provider-v2",
+            "overall_passed": True,
+            "rules": [],
+        },
+    }
+
+
+def _query_rows(lock: Any) -> tuple[PromotionQueryRowV1, ...]:
+    rows: list[PromotionQueryRowV1] = []
+    for group_id in lock.target_group_ids:
+        fallback_id = hashlib.sha256(f"fallback-{group_id}".encode()).hexdigest()
+        rows.append(
+            PromotionQueryRowV1(
+                group_id=group_id,
+                arm_id="fallback",
+                query_rmse_mm=5.0,
+                deployed_artifact_id=fallback_id,
+                fallback_artifact_id=fallback_id,
+                accepted=None,
+                exact_fallback_reproduced=None,
+                accepted_coverage=None,
+                accepted_width_mm=None,
+            )
+        )
+        for arm in lock.arms:
+            if arm.role == "physical_fallback":
+                continue
+            rows.append(
+                PromotionQueryRowV1(
+                    group_id=group_id,
+                    arm_id=arm.arm_id,
+                    query_rmse_mm=4.0,
+                    deployed_artifact_id=hashlib.sha256(
+                        f"deployed-{group_id}-{arm.arm_id}".encode()
+                    ).hexdigest(),
+                    fallback_artifact_id=fallback_id,
+                    accepted=True,
+                    exact_fallback_reproduced=None,
+                    accepted_coverage=0.94,
+                    accepted_width_mm=1.2,
+                )
+            )
+    return tuple(rows)
+
+
+def _admission(lock: Any, *, loader_id: str = "8" * 64) -> HeldoutTargetProviderAdmissionV1:
+    payload = AdmittedTargetPayloadV1(
+        payload_id="9" * 64,
+        window_id="window-0",
+        output_frame_ids=(0,),
+        source_frame_start=0,
+        source_frame_stop_exclusive=1,
+        dependence_group_ids=("shared-model",),
+    )
+    entries = tuple(
+        TargetProviderManifestAdmissionV1(
+            group_id=group_id,
+            episode_id=index,
+            stratum="sheet",
+            sequence_id=f"{group_id}-sequence",
+            manifest_sha256=f"{index + 10:064x}",
+            manifest_artifact_id=f"{index + 20:064x}",
+            provider_run_id=f"{index + 30:064x}",
+            causal_frame_stop=2,
+            admitted_payloads=(payload,),
+        )
+        for index, group_id in enumerate(lock.target_group_ids)
+    )
+    return HeldoutTargetProviderAdmissionV1(
+        promotion_lock_id=lock.promotion_lock_id,
+        cohort_binding_id="7" * 64,
+        source_repository=lock.source_repository,
+        source_revision=lock.source_revision,
+        prediction_run_spec_id=lock.prediction_run_spec_id,
+        provider_family="cut3r",
+        provider_repository="naver/CUT3R",
+        provider_revision="c" * 40,
+        model_set_id="d" * 64,
+        loader_id=loader_id,
+        coordinate_semantics="sequence-local-sim3",
+        point_semantics="dense-point-map",
+        flow_semantics="absent",
+        ray_semantics="absent",
+        source_dependency_semantics=(
+            "per-output-exclusive-source-frame-interval-v1"
+        ),
+        target_outcomes_used=False,
+        entries=entries,
+        metadata={},
+    )
+
+
+def test_v1_lock_descriptor_and_identity_remain_legacy() -> None:
+    lock = promotion_lock_from_config(_v1_config())
+    encoded = lock.to_dict()
+
+    assert encoded["schema_version"] == 1
+    assert encoded["motioncrafter_revision"] == "c" * 40
+    assert encoded["model_set_id"] == "d" * 64
+    assert "provider_identity" not in encoded
+    assert promotion_lock_from_dict(encoded) == lock
+
+
+def test_provider_neutral_v2_lock_round_trip() -> None:
+    lock = promotion_lock_from_config(_v2_config())
+    encoded = lock.to_dict()
+
+    assert lock.schema_version == HELDOUT_PROMOTION_LOCK_PROVIDER_NEUTRAL_VERSION
+    assert isinstance(lock.provider_identity, ProviderPromotionIdentityV1)
+    assert encoded["schema_version"] == 2
+    assert encoded["provider_identity"] == _provider_identity()
+    assert "motioncrafter_revision" not in encoded
+    assert "model_set_id" not in encoded
+    assert promotion_lock_from_dict(encoded) == lock
+
+
+def test_v2_target_admission_binds_complete_provider_contract() -> None:
+    lock = promotion_lock_from_config(_v2_config())
+    validate_target_provider_admission_against_lock(_admission(lock), lock)
+
+    with pytest.raises(ValueError, match="loader_id"):
+        validate_target_provider_admission_against_lock(
+            _admission(lock, loader_id="0" * 64),
+            lock,
+        )
+
+
+def test_provider_neutral_evidence_card_uses_provider_identity() -> None:
+    lock = promotion_lock_from_config(_v2_config())
+    query_results = build_query_results(lock, rows=_query_rows(lock))
+    provider_report = _provider_report(lock)
+    provider_bytes = json.dumps(provider_report, sort_keys=True).encode()
+    report = evaluate_heldout_promotion(
+        lock,
+        query_results,
+        provider_report,
+        provider_report_sha256=hashlib.sha256(provider_bytes).hexdigest(),
+    )
+
+    card = build_promotion_evidence_card(lock.to_dict(), report.to_dict())
+
+    assert card["schema_version"] == (
+        PROMOTION_EVIDENCE_CARD_PROVIDER_NEUTRAL_VERSION
+    )
+    assert card["repositories"]["provider"] == _provider_identity()
+    assert "motioncrafter" not in card["repositories"]
+    assert promotion_evidence_card_from_dict(card) == card
+    assert "Provider: `cut3r`" in render_promotion_evidence_markdown(card)
+
+
+def test_v2_rejects_mixed_legacy_and_provider_neutral_fields() -> None:
+    config = _v2_config()
+    config["motioncrafter_revision"] = "c" * 40
+
+    with pytest.raises(ValueError, match="fields"):
+        promotion_lock_from_config(config)


### PR DESCRIPTION
## Summary

- add an additive provider-neutral v2 held-out promotion lock aligned with `PredictionProviderManifestV1`
- preserve historical MotionCrafter v1 lock descriptors, content IDs, reports, and evidence cards through the exact original implementation blob
- require complete provider-contract agreement for v2 target admission
- emit provider-neutral v2 promotion evidence cards
- add focused compatibility, drift-rejection, documentation, and example coverage

## Compatibility

Historical v1 artifacts remain readable and are never rewritten. V2 replaces only the top-level `motioncrafter_revision` and `model_set_id` fields with a nested, versioned provider identity. Existing evaluator, guarded-query, bootstrap, and exact-fallback semantics are unchanged.

The version dispatcher retains the exact pre-change evidence-card implementation as `_promotion_evidence_v1.py`; v1 callers and content identities continue through that unchanged logic, while v2 cards replace only the provider-specific repository record.

## Validation

- local Python compilation passed for all changed source and tests
- the provider-neutral example JSON parses successfully
- every uploaded Git blob matched the locally validated Git object hash
- repository Actions are the authoritative Ruff, mypy, pytest, package, provider, ecosystem, portability, and security validation

## Scientific and information boundary

This changes provider/lock identity and target-admission validation only. It opens no source, calibration, target, or held-out outcome; changes no estimator, calibration, comparison arm, guard, fallback, or scientific claim; and produces no physical evidence.