### PR TITLE
Reject coercive held-out schema-version aliases

### DIFF
--- a/CHANGELOG.d/strict-provider-promotion-identity-version.md
+++ b/CHANGELOG.d/strict-provider-promotion-identity-version.md
@@ -1,0 +1,4 @@
+Reject boolean and floating-point aliases for the nested provider-promotion
+identity `schema_version` before a held-out lock is constructed or replayed.
+Preserve every valid v1/v2 lock byte, content identity, target-admission rule,
+fallback decision, target-access boundary, and scientific claim.

--- a/src/prob4d/_heldout_promotion_common.py
+++ b/src/prob4d/_heldout_promotion_common.py
@@ -19,9 +19,11 @@ from ._selection_evidence_common import (
     _strict_digest,
     _strict_integer,
     _strict_list,
-    _strict_mapping as _base_strict_mapping,
     _strict_real,
     _strict_string,
+)
+from ._selection_evidence_common import (
+    _strict_mapping as _base_strict_mapping,
 )
 
 HELDOUT_PROMOTION_LOCK_SCHEMA = "prob4d.heldout-provider-promotion-lock"

--- a/src/prob4d/_heldout_promotion_common.py
+++ b/src/prob4d/_heldout_promotion_common.py
@@ -17,8 +17,9 @@ from ._selection_evidence_common import (
     _exact_keys,
     _strict_bool,
     _strict_digest,
+    _strict_integer,
     _strict_list,
-    _strict_mapping,
+    _strict_mapping as _base_strict_mapping,
     _strict_real,
     _strict_string,
 )
@@ -83,6 +84,20 @@ REPORT_CLAIM_BOUNDARY = (
     "identities. It does not establish Causal4D intervention benefit or general "
     "state of the art."
 )
+
+
+def _strict_mapping(value: Any, *, name: str) -> Mapping[str, Any]:
+    """Validate mappings and fail closed on coercive schema header aliases."""
+
+    mapping = _base_strict_mapping(value, name=name)
+    if "schema_name" in mapping and "schema_version" in mapping:
+        _strict_string(mapping["schema_name"], name=f"{name}.schema_name")
+        _strict_integer(
+            mapping["schema_version"],
+            name=f"{name}.schema_version",
+            minimum=1,
+        )
+    return mapping
 
 
 def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:

--- a/tests/test_provider_promotion_identity_strict_version.py
+++ b/tests/test_provider_promotion_identity_strict_version.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+
+from prob4d._heldout_promotion_lock import ProviderPromotionIdentityV1
+
+
+def _provider_identity() -> dict[str, object]:
+    return {
+        "schema_name": "prob4d.heldout-provider-promotion-identity",
+        "schema_version": 1,
+        "provider_family": "cut3r",
+        "provider_repository": "naver/CUT3R",
+        "provider_revision": "c" * 40,
+        "model_set_id": "d" * 64,
+        "loader_id": "7" * 64,
+        "coordinate_semantics": "sequence-local-sim3",
+        "point_semantics": "dense-point-map",
+        "flow_semantics": "absent",
+        "ray_semantics": "absent",
+        "source_dependency_semantics": (
+            "per-output-exclusive-source-frame-interval-v1"
+        ),
+    }
+
+
+@pytest.mark.parametrize("coercive_version", [True, 1.0])
+def test_provider_promotion_identity_rejects_coercive_schema_versions(
+    coercive_version: object,
+) -> None:
+    identity = _provider_identity()
+    identity["schema_version"] = coercive_version
+
+    with pytest.raises(ValueError, match="schema_version"):
+        ProviderPromotionIdentityV1.from_dict(identity)


### PR DESCRIPTION
## Summary

- harden the shared held-out promotion mapping validator so every declared `schema_name` / `schema_version` header requires a strict string and integer
- reject JSON aliases such as `true` and `1.0` for the nested provider-promotion identity version
- add focused adversarial regressions for both coercive values
- preserve every valid v1/v2 lock, evidence-card, target-admission, and authorization identity

## Root cause

The newly added provider-neutral identity compared its nested `schema_version` directly with integer `1`. In Python, `True == 1` and `1.0 == 1`, so coercive JSON values could pass the version check even though the repository's artifact contracts otherwise require exact JSON scalar types.

The fix is centralized in the held-out promotion mapping validator: when a mapping declares both schema header fields, it validates them with the existing strict scalar helpers before any schema-specific comparison.

## Validation

- focused tests explicitly require rejection of `schema_version: true` and `schema_version: 1.0`
- valid schema headers and all existing descriptor serialization remain unchanged
- repository Actions are the authoritative Ruff, mypy, pytest, package, provider, ecosystem, portability, and security validation

## Scientific and information boundary

This is adversarial contract hardening only. It changes no estimator, covariance fit, provider output, cohort, target access, guard, fallback decision, physical evidence, or scientific claim.