### PR TITLE
Add provider-neutral execution attestations

### DIFF
--- a/.github/workflows/fail-closed-quality.yml
+++ b/.github/workflows/fail-closed-quality.yml
@@ -96,6 +96,7 @@ jobs:
             src/prob4d/project_identity.py \
             src/prob4d/provider_attestation.py \
             src/prob4d/provider_evaluation_identity.py \
+            src/prob4d/provider_execution_attestation.py \
             src/prob4d/provider_manifest.py \
             src/prob4d/provider_manifest_cli.py \
             src/prob4d/provider_v1.py \

--- a/CHANGELOG.d/provider-execution-attestation.md
+++ b/CHANGELOG.d/provider-execution-attestation.md
@@ -1,0 +1,7 @@
+Add a strict provider-neutral execution-attestation contract for external 4-D
+providers. It content-binds exact code, model, loader, command, causal, runtime,
+input, output, wrapper-evidence, and provider-manifest identities; hashes rather
+than publishes allow-listed environment values; derives evidence completeness;
+and publishes atomically without clobbering different bytes. This establishes
+execution provenance only and does not promote a provider or authorize target
+access.

--- a/docs/examples/provider-execution-attestation-spec.json
+++ b/docs/examples/provider-execution-attestation-spec.json
@@ -1,0 +1,68 @@
+{
+  "causal_declarations": {
+    "future_frame_postprocessing": false,
+    "global_alignment": false,
+    "online_prefix_only": true,
+    "revisit_count": 1,
+    "source_order_preserved": true
+  },
+  "command_argv": [
+    "python",
+    "demo.py",
+    "--input",
+    "sequence-a.mp4",
+    "--revisit",
+    "1"
+  ],
+  "completed_at_utc": "2026-08-18T01:04:05Z",
+  "environment_variables": [
+    {
+      "name": "CUDA_VISIBLE_DEVICES",
+      "value_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
+    {
+      "name": "PYTHONHASHSEED",
+      "value_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ],
+  "execution_evidence_mode": "wrapper-observed-v1",
+  "execution_evidence_sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "execution_mode": "recurrent-online",
+  "input_artifacts": [
+    {
+      "byte_count": 456,
+      "name": "checkpoint",
+      "sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
+    {
+      "byte_count": 123,
+      "name": "input-video",
+      "sha256": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+    }
+  ],
+  "loader_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "metadata": {
+    "runner_class": "reviewed-external-wrapper"
+  },
+  "model_set_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "output_artifacts": [
+    {
+      "byte_count": 789,
+      "name": "provider-manifest",
+      "sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+    }
+  ],
+  "prediction_provider_manifest_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+  "provider_repository": "example/provider",
+  "provider_revision": "1111111111111111111111111111111111111111",
+  "provider_run_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "runtime": {
+    "container_image_digest": "sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+    "environment_lock_sha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "implementation": "CPython",
+    "platform": "Linux-x86_64",
+    "python_version": "3.12.11"
+  },
+  "started_at_utc": "2026-08-18T01:02:03Z",
+  "terminal_status": "succeeded"
+}

--- a/docs/provider-execution-attestation.md
+++ b/docs/provider-execution-attestation.md
@@ -2,9 +2,9 @@
 
 Prob4D can bind how an external 4-D provider was executed without importing the
 provider, its model weights, or its runtime dependencies. The content-addressed
-`ProviderExecutionAttestationV1` sidecar records exact code and model identities,
-command arguments, causal declarations, runtime fingerprints, and input/output
-bytes.
+version-1 `prob4d.provider-execution-attestation` sidecar records exact code and
+model identities, command arguments, causal declarations, runtime fingerprints,
+and input/output bytes.
 
 This contract complements `PredictionProviderManifestV1`:
 

--- a/docs/provider-execution-attestation.md
+++ b/docs/provider-execution-attestation.md
@@ -16,10 +16,12 @@ external provider execution
     -> Prob4D readiness gates
 ```
 
-A valid attestation establishes strict artifact integrity and declared execution
-lineage. It does not establish provider accuracy, calibrated uncertainty,
-BayesianPhysTwin benefit, Causal4D intervention benefit, target authorization, or
-deployment safety.
+A valid attestation establishes the integrity of the attestation itself and binds
+the declared identities of referenced artifacts and execution lineage. Prob4D
+does not reopen those external bytes through this contract. The attestation does
+not establish provider accuracy, calibrated uncertainty, BayesianPhysTwin
+benefit, Causal4D intervention benefit, target authorization, or deployment
+safety.
 
 ## Evidence modes
 
@@ -42,6 +44,10 @@ Raw environment-variable values are not stored. Each allow-listed variable is
 recorded as a name and SHA-256 digest of its exact value. Do not include secret
 names or publish digests where the value has a small guessable domain unless that
 risk is acceptable for the execution environment.
+
+Command arguments, artifact names, timestamps, and metadata are retained
+verbatim. They must not contain credentials, access tokens, private paths, or
+other protected values.
 
 The runtime record binds:
 

--- a/docs/provider-execution-attestation.md
+++ b/docs/provider-execution-attestation.md
@@ -1,0 +1,111 @@
+# Provider execution attestation
+
+Prob4D can bind how an external 4-D provider was executed without importing the
+provider, its model weights, or its runtime dependencies. The content-addressed
+`ProviderExecutionAttestationV1` sidecar records exact code and model identities,
+command arguments, causal declarations, runtime fingerprints, and input/output
+bytes.
+
+This contract complements `PredictionProviderManifestV1`:
+
+```text
+external provider execution
+    -> provider execution attestation
+    -> canonical PredictionWindow payloads
+    -> PredictionProviderManifestV1
+    -> Prob4D readiness gates
+```
+
+A valid attestation establishes strict artifact integrity and declared execution
+lineage. It does not establish provider accuracy, calibrated uncertainty,
+BayesianPhysTwin benefit, Causal4D intervention benefit, target authorization, or
+deployment safety.
+
+## Evidence modes
+
+The contract keeps two evidence levels explicit:
+
+- `declarative-only-v1` records a declaration without claiming wrapper-observed
+  execution bytes. `execution_evidence_sha256` must be `null`.
+- `wrapper-observed-v1` binds the exact output of an execution wrapper or external
+  attestation through `execution_evidence_sha256`.
+
+`execution_evidence_complete` is derived rather than caller-controlled. It is
+true only when the execution succeeded, wrapper-observed evidence is bound, an
+immutable runtime identity is present, at least one input and output artifact is
+bound, and the resulting provider-manifest semantic ID is recorded. Completeness
+is provenance evidence only; it is not provider admission.
+
+## Privacy-preserving runtime identity
+
+Raw environment-variable values are not stored. Each allow-listed variable is
+recorded as a name and SHA-256 digest of its exact value. Do not include secret
+names or publish digests where the value has a small guessable domain unless that
+risk is acceptable for the execution environment.
+
+The runtime record binds:
+
+- Python version and implementation;
+- platform identity;
+- an optional OCI/container digest in `sha256:<digest>` form; and
+- an optional environment-lock digest.
+
+At least one container or environment-lock digest is required for complete
+wrapper-observed evidence.
+
+## Specification
+
+Start from the checked-in
+[example provider-execution specification](examples/provider-execution-attestation-spec.json).
+
+Important fields are:
+
+- exact provider repository and revision;
+- provider-run, model-set, and loader content IDs;
+- the complete argument vector, without shell interpolation;
+- source-order, online-prefix, revisit, global-alignment, and future-processing
+  declarations;
+- hashed input and output artifact rosters with byte counts;
+- execution start and completion times in canonical UTC `Z` form;
+- terminal status; and
+- the semantic `PredictionProviderManifestV1` ID, when already available.
+
+Artifact and environment-variable records are sorted canonically by name.
+Duplicate names, unknown fields, non-finite JSON, coercive Boolean/integer aliases,
+invalid revisions, time reversal, and content-ID mismatches fail closed.
+
+## Create and verify
+
+The initial additive command is available through the module entry point so the
+stable `prob4d.api.v2` export inventory remains unchanged:
+
+```bash
+python -m prob4d.provider_execution_attestation create \
+  docs/examples/provider-execution-attestation-spec.json \
+  --output outputs/provider-execution-attestation.json
+
+python -m prob4d.provider_execution_attestation verify \
+  outputs/provider-execution-attestation.json \
+  --require-complete
+```
+
+Publication is atomic and no-clobber. Repeating an identical write is idempotent;
+a different artifact at the same destination is rejected.
+
+## Recommended wrapper order
+
+For CUT3R or another external provider, the execution wrapper should:
+
+1. snapshot the exact provider revision, checkpoint, input, loader, and runtime
+   identities;
+2. record the argument vector and causal declarations before inference;
+3. execute the provider;
+4. hash every retained input, wrapper log, and generated output byte;
+5. import or produce the canonical provider-neutral manifest;
+6. bind that manifest's semantic ID into the final attestation; and
+7. publish the attestation and provider manifest without replacing existing
+   different bytes.
+
+Prob4D can verify this sidecar but cannot infer trust in the external wrapper.
+Claim-bearing experiments must separately attest the runner or build provenance,
+freeze source/calibration gates, and retain exact fallback in BayesianPhysTwin.

--- a/src/prob4d/provider_execution_attestation.py
+++ b/src/prob4d/provider_execution_attestation.py
@@ -1,0 +1,533 @@
+"""Provider-neutral, content-addressed external execution attestations.
+
+The contract binds how an external 4-D provider was executed without importing
+that provider or its runtime stack. It records exact code and model identities,
+command arguments, causal declarations, runtime fingerprints, and input/output
+bytes. Validation establishes artifact integrity and declared execution lineage;
+it does not establish provider accuracy, calibration, physical-query benefit,
+or causal-intervention benefit.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Final, Literal, cast
+
+from ._atomic_file import atomic_write_text
+from ._immutable_json import frozen_finite_json_mapping, plain_json
+from ._strict_json import (
+    load_json_object,
+    require_exact_fields,
+    require_exact_integer,
+    require_exact_string,
+    require_finite_json_mapping,
+    require_mapping,
+    require_revision,
+    require_sha256,
+)
+
+PROVIDER_EXECUTION_ATTESTATION_SCHEMA: Final = "prob4d.provider-execution-attestation"
+PROVIDER_EXECUTION_ATTESTATION_VERSION: Final = 1
+PROVIDER_EXECUTION_ATTESTATION_CLAIM_BOUNDARY: Final = (
+    "This artifact binds declared external-provider execution identity, runtime "
+    "fingerprints, causal settings, and exact input/output bytes. It does not by "
+    "itself prove that an untrusted wrapper executed those settings, establish "
+    "provider accuracy or uncertainty calibration, authorize protected target "
+    "access, justify a BayesianPhysTwin update, establish Causal4D intervention "
+    "benefit, deployment safety, or state of the art."
+)
+
+TerminalStatus = Literal["succeeded", "failed", "cancelled"]
+ExecutionEvidenceMode = Literal["declarative-only-v1", "wrapper-observed-v1"]
+
+_REPOSITORY = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+_ENVIRONMENT_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_UTC_TIMESTAMP = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?Z$"
+)
+
+_SPEC_FIELDS = frozenset(
+    {
+        "provider_repository",
+        "provider_revision",
+        "provider_run_id",
+        "model_set_id",
+        "loader_id",
+        "execution_mode",
+        "command_argv",
+        "causal_declarations",
+        "runtime",
+        "environment_variables",
+        "input_artifacts",
+        "output_artifacts",
+        "execution_evidence_mode",
+        "execution_evidence_sha256",
+        "prediction_provider_manifest_id",
+        "started_at_utc",
+        "completed_at_utc",
+        "terminal_status",
+        "metadata",
+    }
+)
+_ATTESTATION_FIELDS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        *_SPEC_FIELDS,
+        "execution_evidence_complete",
+        "claim_boundary",
+        "provider_execution_attestation_id",
+    }
+)
+_CAUSAL_FIELDS = frozenset(
+    {
+        "source_order_preserved",
+        "online_prefix_only",
+        "revisit_count",
+        "global_alignment",
+        "future_frame_postprocessing",
+    }
+)
+_RUNTIME_FIELDS = frozenset(
+    {
+        "python_version",
+        "implementation",
+        "platform",
+        "container_image_digest",
+        "environment_lock_sha256",
+    }
+)
+_ENVIRONMENT_FIELDS = frozenset({"name", "value_sha256"})
+_ARTIFACT_FIELDS = frozenset({"name", "sha256", "byte_count"})
+
+
+def _canonical_json(value: Mapping[str, Any], *, pretty: bool = False) -> bytes:
+    return (
+        json.dumps(
+            plain_json(value),
+            sort_keys=True,
+            indent=2 if pretty else None,
+            separators=None if pretty else (",", ":"),
+            allow_nan=False,
+        )
+        + ("\n" if pretty else "")
+    ).encode("utf-8")
+
+
+def _attestation_id(value: Mapping[str, Any]) -> str:
+    unsigned = dict(plain_json(value))
+    unsigned.pop("provider_execution_attestation_id", None)
+    return hashlib.sha256(_canonical_json(unsigned)).hexdigest()
+
+
+def _exact_bool(value: object, *, name: str) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be a Boolean")
+    return value
+
+
+def _nullable_sha256(value: object, *, name: str) -> str | None:
+    if value is None:
+        return None
+    return require_sha256(value, name=name)
+
+
+def _container_digest(value: object) -> str | None:
+    if value is None:
+        return None
+    digest = require_exact_string(value, name="runtime.container_image_digest")
+    if not digest.startswith("sha256:"):
+        raise ValueError("runtime.container_image_digest must use the sha256:<digest> form")
+    require_sha256(digest.removeprefix("sha256:"), name="runtime.container_image_digest")
+    return digest
+
+
+def _utc_timestamp(value: object, *, name: str) -> tuple[str, datetime]:
+    text = require_exact_string(value, name=name)
+    if _UTC_TIMESTAMP.fullmatch(text) is None:
+        raise ValueError(f"{name} must be a canonical UTC timestamp ending in Z")
+    try:
+        parsed = datetime.fromisoformat(text[:-1] + "+00:00")
+    except ValueError as error:
+        raise ValueError(f"{name} must be a valid UTC timestamp") from error
+    if parsed.tzinfo != timezone.utc:
+        raise ValueError(f"{name} must be UTC")
+    return text, parsed
+
+
+def _repository(value: object) -> str:
+    repository = require_exact_string(value, name="provider_repository")
+    if _REPOSITORY.fullmatch(repository) is None:
+        raise ValueError("provider_repository must use owner/name form")
+    owner, name = repository.split("/", maxsplit=1)
+    if owner in {".", ".."} or name in {".", ".."}:
+        raise ValueError("provider_repository must use a canonical owner/name")
+    return repository
+
+
+def _command_argv(value: object) -> list[str]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence) or not value:
+        raise ValueError("command_argv must be a nonempty JSON array")
+    result: list[str] = []
+    for index, item in enumerate(value):
+        argument = require_exact_string(item, name=f"command_argv[{index}]")
+        if "\x00" in argument:
+            raise ValueError("command_argv must not contain NUL characters")
+        result.append(argument)
+    return result
+
+
+def _causal_declarations(value: object) -> dict[str, object]:
+    mapping = require_mapping(value, name="causal_declarations")
+    require_exact_fields(mapping, _CAUSAL_FIELDS, name="causal_declarations")
+    return {
+        "source_order_preserved": _exact_bool(
+            mapping["source_order_preserved"],
+            name="causal_declarations.source_order_preserved",
+        ),
+        "online_prefix_only": _exact_bool(
+            mapping["online_prefix_only"],
+            name="causal_declarations.online_prefix_only",
+        ),
+        "revisit_count": require_exact_integer(
+            mapping["revisit_count"],
+            name="causal_declarations.revisit_count",
+            minimum=0,
+        ),
+        "global_alignment": _exact_bool(
+            mapping["global_alignment"],
+            name="causal_declarations.global_alignment",
+        ),
+        "future_frame_postprocessing": _exact_bool(
+            mapping["future_frame_postprocessing"],
+            name="causal_declarations.future_frame_postprocessing",
+        ),
+    }
+
+
+def _runtime(value: object) -> dict[str, object]:
+    mapping = require_mapping(value, name="runtime")
+    require_exact_fields(mapping, _RUNTIME_FIELDS, name="runtime")
+    return {
+        "python_version": require_exact_string(
+            mapping["python_version"],
+            name="runtime.python_version",
+        ),
+        "implementation": require_exact_string(
+            mapping["implementation"],
+            name="runtime.implementation",
+        ),
+        "platform": require_exact_string(mapping["platform"], name="runtime.platform"),
+        "container_image_digest": _container_digest(mapping["container_image_digest"]),
+        "environment_lock_sha256": _nullable_sha256(
+            mapping["environment_lock_sha256"],
+            name="runtime.environment_lock_sha256",
+        ),
+    }
+
+
+def _environment_variables(value: object) -> list[dict[str, object]]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise ValueError("environment_variables must be a JSON array")
+    result: list[dict[str, object]] = []
+    names: set[str] = set()
+    for index, item in enumerate(value):
+        mapping = require_mapping(item, name=f"environment_variables[{index}]")
+        require_exact_fields(
+            mapping,
+            _ENVIRONMENT_FIELDS,
+            name=f"environment_variables[{index}]",
+        )
+        name = require_exact_string(
+            mapping["name"],
+            name=f"environment_variables[{index}].name",
+        )
+        if _ENVIRONMENT_NAME.fullmatch(name) is None:
+            raise ValueError("environment variable names must be portable identifiers")
+        if name in names:
+            raise ValueError(f"duplicate environment variable name: {name}")
+        names.add(name)
+        result.append(
+            {
+                "name": name,
+                "value_sha256": require_sha256(
+                    mapping["value_sha256"],
+                    name=f"environment_variables[{index}].value_sha256",
+                ),
+            }
+        )
+    return sorted(result, key=lambda record: cast(str, record["name"]))
+
+
+def _artifacts(value: object, *, name: str) -> list[dict[str, object]]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise ValueError(f"{name} must be a JSON array")
+    result: list[dict[str, object]] = []
+    names: set[str] = set()
+    for index, item in enumerate(value):
+        mapping = require_mapping(item, name=f"{name}[{index}]")
+        require_exact_fields(mapping, _ARTIFACT_FIELDS, name=f"{name}[{index}]")
+        artifact_name = require_exact_string(
+            mapping["name"],
+            name=f"{name}[{index}].name",
+        )
+        if artifact_name in names:
+            raise ValueError(f"duplicate {name} name: {artifact_name}")
+        names.add(artifact_name)
+        result.append(
+            {
+                "name": artifact_name,
+                "sha256": require_sha256(
+                    mapping["sha256"],
+                    name=f"{name}[{index}].sha256",
+                ),
+                "byte_count": require_exact_integer(
+                    mapping["byte_count"],
+                    name=f"{name}[{index}].byte_count",
+                    minimum=0,
+                ),
+            }
+        )
+    return sorted(result, key=lambda record: cast(str, record["name"]))
+
+
+def _evidence_mode(value: object) -> ExecutionEvidenceMode:
+    mode = require_exact_string(value, name="execution_evidence_mode")
+    if mode not in {"declarative-only-v1", "wrapper-observed-v1"}:
+        raise ValueError("unsupported execution_evidence_mode")
+    return cast(ExecutionEvidenceMode, mode)
+
+
+def _terminal_status(value: object) -> TerminalStatus:
+    status = require_exact_string(value, name="terminal_status")
+    if status not in {"succeeded", "failed", "cancelled"}:
+        raise ValueError("unsupported terminal_status")
+    return cast(TerminalStatus, status)
+
+
+def _normalize_spec(value: object) -> dict[str, Any]:
+    mapping = require_mapping(value, name="provider execution attestation specification")
+    require_exact_fields(
+        mapping,
+        _SPEC_FIELDS,
+        name="provider execution attestation specification",
+    )
+    started_text, started = _utc_timestamp(mapping["started_at_utc"], name="started_at_utc")
+    completed_text, completed = _utc_timestamp(
+        mapping["completed_at_utc"],
+        name="completed_at_utc",
+    )
+    if completed < started:
+        raise ValueError("completed_at_utc must not precede started_at_utc")
+
+    evidence_mode = _evidence_mode(mapping["execution_evidence_mode"])
+    evidence_sha = _nullable_sha256(
+        mapping["execution_evidence_sha256"],
+        name="execution_evidence_sha256",
+    )
+    if evidence_mode == "wrapper-observed-v1" and evidence_sha is None:
+        raise ValueError("wrapper-observed execution evidence requires its exact SHA-256")
+    if evidence_mode == "declarative-only-v1" and evidence_sha is not None:
+        raise ValueError("declarative-only execution evidence cannot claim wrapper bytes")
+
+    status = _terminal_status(mapping["terminal_status"])
+    outputs = _artifacts(mapping["output_artifacts"], name="output_artifacts")
+    if status == "succeeded" and not outputs:
+        raise ValueError("a successful provider execution must bind at least one output artifact")
+
+    manifest_id = _nullable_sha256(
+        mapping["prediction_provider_manifest_id"],
+        name="prediction_provider_manifest_id",
+    )
+    metadata = require_finite_json_mapping(mapping["metadata"], name="metadata")
+    return {
+        "provider_repository": _repository(mapping["provider_repository"]),
+        "provider_revision": require_revision(
+            mapping["provider_revision"],
+            name="provider_revision",
+        ),
+        "provider_run_id": require_sha256(
+            mapping["provider_run_id"],
+            name="provider_run_id",
+        ),
+        "model_set_id": require_sha256(mapping["model_set_id"], name="model_set_id"),
+        "loader_id": require_sha256(mapping["loader_id"], name="loader_id"),
+        "execution_mode": require_exact_string(
+            mapping["execution_mode"],
+            name="execution_mode",
+        ),
+        "command_argv": _command_argv(mapping["command_argv"]),
+        "causal_declarations": _causal_declarations(mapping["causal_declarations"]),
+        "runtime": _runtime(mapping["runtime"]),
+        "environment_variables": _environment_variables(mapping["environment_variables"]),
+        "input_artifacts": _artifacts(mapping["input_artifacts"], name="input_artifacts"),
+        "output_artifacts": outputs,
+        "execution_evidence_mode": evidence_mode,
+        "execution_evidence_sha256": evidence_sha,
+        "prediction_provider_manifest_id": manifest_id,
+        "started_at_utc": started_text,
+        "completed_at_utc": completed_text,
+        "terminal_status": status,
+        "metadata": plain_json(metadata),
+    }
+
+
+def build_provider_execution_attestation(value: object) -> Mapping[str, Any]:
+    """Build one canonical content-addressed execution attestation from a strict spec."""
+
+    specification = _normalize_spec(value)
+    runtime = cast(Mapping[str, object], specification["runtime"])
+    runtime_identity_bound = bool(
+        runtime["container_image_digest"] is not None
+        or runtime["environment_lock_sha256"] is not None
+    )
+    evidence_complete = bool(
+        specification["execution_evidence_mode"] == "wrapper-observed-v1"
+        and specification["execution_evidence_sha256"] is not None
+        and specification["terminal_status"] == "succeeded"
+        and specification["prediction_provider_manifest_id"] is not None
+        and specification["input_artifacts"]
+        and specification["output_artifacts"]
+        and runtime_identity_bound
+    )
+    payload: dict[str, Any] = {
+        "schema": PROVIDER_EXECUTION_ATTESTATION_SCHEMA,
+        "schema_version": PROVIDER_EXECUTION_ATTESTATION_VERSION,
+        **specification,
+        "execution_evidence_complete": evidence_complete,
+        "claim_boundary": PROVIDER_EXECUTION_ATTESTATION_CLAIM_BOUNDARY,
+    }
+    payload["provider_execution_attestation_id"] = _attestation_id(payload)
+    return frozen_finite_json_mapping(payload, name="provider execution attestation")
+
+
+def validate_provider_execution_attestation(value: object) -> Mapping[str, Any]:
+    """Validate an attestation, including canonical ordering and its content address."""
+
+    mapping = require_mapping(value, name="provider execution attestation")
+    require_exact_fields(mapping, _ATTESTATION_FIELDS, name="provider execution attestation")
+    if mapping["schema"] != PROVIDER_EXECUTION_ATTESTATION_SCHEMA:
+        raise ValueError("unsupported provider execution attestation schema")
+    schema_version = require_exact_integer(
+        mapping["schema_version"],
+        name="provider execution attestation schema_version",
+        minimum=1,
+    )
+    if schema_version != PROVIDER_EXECUTION_ATTESTATION_VERSION:
+        raise ValueError("unsupported provider execution attestation version")
+    if mapping["claim_boundary"] != PROVIDER_EXECUTION_ATTESTATION_CLAIM_BOUNDARY:
+        raise ValueError("provider execution attestation claim boundary changed")
+    _exact_bool(
+        mapping["execution_evidence_complete"],
+        name="execution_evidence_complete",
+    )
+
+    specification = {name: mapping[name] for name in _SPEC_FIELDS}
+    rebuilt = build_provider_execution_attestation(specification)
+    expected = plain_json(rebuilt)
+    observed = plain_json(mapping)
+    if observed != expected:
+        declared = require_sha256(
+            mapping["provider_execution_attestation_id"],
+            name="provider_execution_attestation_id",
+        )
+        if declared != _attestation_id(mapping):
+            raise ValueError("provider execution attestation ID does not match its content")
+        raise ValueError("provider execution attestation is not in canonical form")
+    return rebuilt
+
+
+def load_provider_execution_attestation(path: str | Path) -> Mapping[str, Any]:
+    """Load strict JSON and validate one execution attestation."""
+
+    payload = load_json_object(path, name="provider execution attestation")
+    return validate_provider_execution_attestation(payload)
+
+
+def write_provider_execution_attestation(
+    path: str | Path,
+    attestation: object,
+) -> Mapping[str, Any]:
+    """Publish one canonical attestation atomically without replacing different bytes."""
+
+    validated = validate_provider_execution_attestation(attestation)
+    destination = Path(path)
+    if destination.is_symlink():
+        raise ValueError("provider execution attestation destination must not be a symbolic link")
+    content = _canonical_json(validated, pretty=True).decode("utf-8")
+    if destination.exists():
+        existing = load_provider_execution_attestation(destination)
+        if plain_json(existing) != plain_json(validated):
+            raise FileExistsError(
+                f"refusing to replace a different provider execution attestation: {destination}"
+            )
+        return existing
+    atomic_write_text(destination, content, overwrite=False)
+    reloaded = load_provider_execution_attestation(destination)
+    if plain_json(reloaded) != plain_json(validated):
+        raise RuntimeError("published provider execution attestation changed during verification")
+    return reloaded
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    create = subparsers.add_parser("create", help="build an attestation from a strict JSON spec")
+    create.add_argument("specification", type=Path)
+    create.add_argument("--output", type=Path, required=True)
+    create.set_defaults(handler=_create_command)
+
+    verify = subparsers.add_parser("verify", help="validate a persisted execution attestation")
+    verify.add_argument("attestation", type=Path)
+    verify.add_argument("--require-complete", action="store_true")
+    verify.set_defaults(handler=_verify_command)
+    return parser
+
+
+def _create_command(arguments: argparse.Namespace) -> int:
+    specification = load_json_object(
+        arguments.specification,
+        name="provider execution attestation specification",
+    )
+    attestation = build_provider_execution_attestation(specification)
+    written = write_provider_execution_attestation(arguments.output, attestation)
+    print(written["provider_execution_attestation_id"])
+    return 0
+
+
+def _verify_command(arguments: argparse.Namespace) -> int:
+    attestation = load_provider_execution_attestation(arguments.attestation)
+    if arguments.require_complete and attestation["execution_evidence_complete"] is not True:
+        raise ValueError("provider execution attestation lacks complete wrapper-observed evidence")
+    print(attestation["provider_execution_attestation_id"])
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Build or verify provider-neutral execution attestations."""
+
+    arguments = _build_parser().parse_args(list(argv) if argv is not None else None)
+    return int(arguments.handler(arguments))
+
+
+__all__ = [
+    "PROVIDER_EXECUTION_ATTESTATION_CLAIM_BOUNDARY",
+    "PROVIDER_EXECUTION_ATTESTATION_SCHEMA",
+    "PROVIDER_EXECUTION_ATTESTATION_VERSION",
+    "build_provider_execution_attestation",
+    "load_provider_execution_attestation",
+    "main",
+    "validate_provider_execution_attestation",
+    "write_provider_execution_attestation",
+]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_provider_execution_attestation.py
+++ b/tests/test_provider_execution_attestation.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from prob4d._immutable_json import plain_json
+from prob4d.provider_execution_attestation import (
+    PROVIDER_EXECUTION_ATTESTATION_SCHEMA,
+    build_provider_execution_attestation,
+    load_provider_execution_attestation,
+    main,
+    validate_provider_execution_attestation,
+    write_provider_execution_attestation,
+)
+
+DIGEST_A = "a" * 64
+DIGEST_B = "b" * 64
+DIGEST_C = "c" * 64
+DIGEST_D = "d" * 64
+
+
+def _spec() -> dict[str, object]:
+    return {
+        "provider_repository": "example/provider",
+        "provider_revision": "1" * 40,
+        "provider_run_id": DIGEST_A,
+        "model_set_id": DIGEST_B,
+        "loader_id": DIGEST_C,
+        "execution_mode": "recurrent-online",
+        "command_argv": ["python", "demo.py", "--revisit", "1"],
+        "causal_declarations": {
+            "source_order_preserved": True,
+            "online_prefix_only": True,
+            "revisit_count": 1,
+            "global_alignment": False,
+            "future_frame_postprocessing": False,
+        },
+        "runtime": {
+            "python_version": "3.12.11",
+            "implementation": "CPython",
+            "platform": "Linux-x86_64",
+            "container_image_digest": f"sha256:{DIGEST_D}",
+            "environment_lock_sha256": DIGEST_A,
+        },
+        "environment_variables": [
+            {"name": "CUDA_VISIBLE_DEVICES", "value_sha256": DIGEST_B},
+            {"name": "PYTHONHASHSEED", "value_sha256": DIGEST_A},
+        ],
+        "input_artifacts": [
+            {"name": "input-video", "sha256": DIGEST_C, "byte_count": 123},
+            {"name": "checkpoint", "sha256": DIGEST_B, "byte_count": 456},
+        ],
+        "output_artifacts": [
+            {"name": "provider-manifest", "sha256": DIGEST_D, "byte_count": 789},
+        ],
+        "execution_evidence_mode": "wrapper-observed-v1",
+        "execution_evidence_sha256": DIGEST_C,
+        "prediction_provider_manifest_id": DIGEST_D,
+        "started_at_utc": "2026-08-18T01:02:03Z",
+        "completed_at_utc": "2026-08-18T01:04:05.123456Z",
+        "terminal_status": "succeeded",
+        "metadata": {"runner": "workstation2", "attempt": 1},
+    }
+
+
+def test_build_is_content_addressed_canonical_and_immutable() -> None:
+    specification = _spec()
+    specification["environment_variables"] = list(
+        reversed(specification["environment_variables"])  # type: ignore[arg-type]
+    )
+    attestation = build_provider_execution_attestation(specification)
+
+    assert attestation["schema"] == PROVIDER_EXECUTION_ATTESTATION_SCHEMA
+    assert attestation["execution_evidence_complete"] is True
+    names = [row["name"] for row in attestation["environment_variables"]]
+    assert names == ["CUDA_VISIBLE_DEVICES", "PYTHONHASHSEED"]
+    assert len(attestation["provider_execution_attestation_id"]) == 64
+    with pytest.raises(TypeError):
+        attestation["metadata"]["runner"] = "other"  # type: ignore[index]
+
+
+def test_round_trip_is_idempotent_and_refuses_different_bytes(tmp_path: Path) -> None:
+    destination = tmp_path / "attestation.json"
+    attestation = build_provider_execution_attestation(_spec())
+
+    written = write_provider_execution_attestation(destination, attestation)
+    repeated = write_provider_execution_attestation(destination, attestation)
+    loaded = load_provider_execution_attestation(destination)
+
+    assert plain_json(written) == plain_json(repeated) == plain_json(loaded)
+    changed = _spec()
+    changed["completed_at_utc"] = "2026-08-18T01:04:06Z"
+    with pytest.raises(FileExistsError):
+        write_provider_execution_attestation(
+            destination,
+            build_provider_execution_attestation(changed),
+        )
+
+
+def test_validation_rejects_mutation_and_noncanonical_order() -> None:
+    attestation = plain_json(build_provider_execution_attestation(_spec()))
+    mutated = copy.deepcopy(attestation)
+    mutated["terminal_status"] = "failed"
+    with pytest.raises(ValueError, match="ID does not match"):
+        validate_provider_execution_attestation(mutated)
+
+    noncanonical = copy.deepcopy(attestation)
+    noncanonical["input_artifacts"].reverse()
+    unsigned = copy.deepcopy(noncanonical)
+    unsigned.pop("provider_execution_attestation_id")
+    encoded = json.dumps(
+        unsigned,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+    noncanonical["provider_execution_attestation_id"] = hashlib.sha256(encoded).hexdigest()
+    with pytest.raises(ValueError, match="canonical form"):
+        validate_provider_execution_attestation(noncanonical)
+
+
+def test_strict_contract_rejects_missing_evidence_duplicates_and_time_reversal() -> None:
+    specification = _spec()
+    specification["execution_evidence_sha256"] = None
+    with pytest.raises(ValueError, match="requires its exact SHA-256"):
+        build_provider_execution_attestation(specification)
+
+    specification = _spec()
+    specification["environment_variables"] = [
+        {"name": "A", "value_sha256": DIGEST_A},
+        {"name": "A", "value_sha256": DIGEST_B},
+    ]
+    with pytest.raises(ValueError, match="duplicate environment variable"):
+        build_provider_execution_attestation(specification)
+
+    specification = _spec()
+    specification["completed_at_utc"] = "2026-08-17T23:59:59Z"
+    with pytest.raises(ValueError, match="must not precede"):
+        build_provider_execution_attestation(specification)
+
+
+def test_validation_rejects_coercive_schema_and_boolean_aliases() -> None:
+    attestation = plain_json(build_provider_execution_attestation(_spec()))
+    attestation["schema_version"] = True
+    with pytest.raises(ValueError, match="schema_version"):
+        validate_provider_execution_attestation(attestation)
+
+    attestation = plain_json(build_provider_execution_attestation(_spec()))
+    attestation["execution_evidence_complete"] = 1
+    with pytest.raises(ValueError, match="must be a Boolean"):
+        validate_provider_execution_attestation(attestation)
+
+
+def test_declarative_failure_is_valid_but_incomplete() -> None:
+    specification = _spec()
+    specification.update(
+        {
+            "terminal_status": "failed",
+            "execution_evidence_mode": "declarative-only-v1",
+            "execution_evidence_sha256": None,
+            "prediction_provider_manifest_id": None,
+        }
+    )
+    attestation = build_provider_execution_attestation(specification)
+    assert attestation["execution_evidence_complete"] is False
+
+
+def test_loader_rejects_duplicate_json_keys(tmp_path: Path) -> None:
+    destination = tmp_path / "duplicate.json"
+    destination.write_text('{"schema": "a", "schema": "b"}', encoding="utf-8")
+    with pytest.raises(ValueError, match="duplicate JSON object key"):
+        load_provider_execution_attestation(destination)
+
+
+def test_cli_create_and_verify_complete(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    specification = tmp_path / "specification.json"
+    output = tmp_path / "attestation.json"
+    specification.write_text(json.dumps(_spec()), encoding="utf-8")
+
+    assert main(["create", str(specification), "--output", str(output)]) == 0
+    created_id = capsys.readouterr().out.strip()
+    assert main(["verify", str(output), "--require-complete"]) == 0
+    verified_id = capsys.readouterr().out.strip()
+    assert created_id == verified_id


### PR DESCRIPTION
## What changed

- add a strict, content-addressed provider-execution attestation for external 4-D providers;
- bind exact provider code, model set, loader, argument vector, causal declarations, runtime identity, input/output bytes, wrapper evidence, timestamps, and resulting provider-manifest identity;
- hash allow-listed environment-variable values instead of publishing raw values;
- derive evidence completeness rather than accepting a caller-controlled claim;
- provide atomic no-clobber creation and strict verification through `python -m prob4d.provider_execution_attestation`;
- add adversarial regression coverage for mutation, coercive scalar aliases, duplicate keys/names, noncanonical ordering, missing evidence, time reversal, and no-clobber publication;
- add an executable specification example, operator documentation, changelog entry, and authoritative mypy coverage.

## Why

Provider-neutral prediction manifests bind generated bytes and declared causal lineage, but external adapters cannot currently content-bind their declared execution process and runtime identity. This sidecar records that provenance without importing CUT3R, VGGT, Torch, model weights, or another provider runtime into Prob4D. It explicitly does not infer trust in the external wrapper or independently reopen referenced external bytes.

## Compatibility and scientific boundary

This is additive provenance infrastructure. It changes no estimator equation, `prob4d.api.v2` export inventory, provider-v1/provider-v2 artifact schema, prediction-manifest semantics, calibration, target-access authorization, BayesianPhysTwin guard, exact fallback, Causal4D handoff, or scientific result. Complete execution evidence is not provider competence or deployment authorization.

## Validation

Exact head: `2aa53aee55720fffb906c6ad80e9c742e274d135`.

All triggered exact-head workflows passed:

- `Tests` across Python 3.10, 3.11, 3.12, 3.13, and 3.14;
- declared NumPy/runtime dependency floor on Python 3.10;
- wheel and source-distribution build, audit, and isolated installation smoke;
- `Fail-closed quality` with Ruff, authoritative mypy, and documentation-surface validation;
- `Security scanning`;
- `Provider batch preflight`; and
- `Project identity and source diagnostic contracts`.

Focused pre-publication validation additionally passed 8 adversarial tests, Python byte-compilation, and a create/verify CLI round trip with identical content IDs.