### PR TITLE
Add evidence-first provider portfolio and capability façades

### DIFF
--- a/CHANGELOG.d/capability-facades.md
+++ b/CHANGELOG.d/capability-facades.md
@@ -1,0 +1,3 @@
+Add preview version-1 geometry, artifact, covariance, calibration, and provider
+façades under `prob4d.api.*_v1` that mirror curated `prob4d.api.v2` objects
+without changing the normative public API or loading optional GPU stacks.

--- a/CHANGELOG.d/numerical-property-tests.md
+++ b/CHANGELOG.d/numerical-property-tests.md
@@ -1,0 +1,2 @@
+Add deterministic randomized `Sim(3)` group-action, inverse, covariance, and
+near-branch-cut rotation property tests.

--- a/CHANGELOG.d/provider-portfolio-budget.md
+++ b/CHANGELOG.d/provider-portfolio-budget.md
@@ -1,0 +1,4 @@
+Add a content-addressed evidence-first provider portfolio with one-primary and
+one-alternative work-in-progress budgets, ordered readiness gates, explicit
+negative-result retention, and source-localized authorization before conditional
+point-covariance development.

--- a/docs/capability-facades.md
+++ b/docs/capability-facades.md
@@ -1,0 +1,58 @@
+# Capability-specific Python façades
+
+Prob4D's normative ecosystem boundary remains `prob4d.api.v2`. Five narrower,
+collision-free version-1 preview façades now mirror curated subsets of that API
+for consumers that need only one capability:
+
+| Capability | Import |
+| --- | --- |
+| Similarity-transform geometry | `prob4d.api.geometry_v1` |
+| Portable artifacts and streams | `prob4d.api.artifacts_v1` |
+| Structured covariance queries | `prob4d.api.covariance_v1` |
+| Calibration contracts | `prob4d.api.calibration_v1` |
+| Provider admission and attestation | `prob4d.api.provider_v1` |
+
+For example:
+
+```python
+from prob4d.api.covariance_v1 import project_observation_covariance
+from prob4d.api.geometry_v1 import Sim3
+```
+
+Every exported object is the identical object exposed by `prob4d.api.v2`; the
+façades contain no wrapper implementations and do not change serialization,
+estimator, calibration, or fallback semantics. Importing them also retains the
+lightweight runtime boundary and does not load Torch, Diffusers, or Decord.
+
+## Lifecycle
+
+Each module declares:
+
+```python
+FACADE_VERSION = 1
+LIFECYCLE = "preview"
+```
+
+Preview means that the import split is available for integration testing but is
+not yet listed as an independent compatibility surface in the content-addressed
+public API manifest. `prob4d.api.v2` remains the required dependency boundary for
+claim-bearing external integrations. Promotion should occur only after installed
+wheel and three-repository consumer tests have exercised the narrower imports.
+
+The explicit `__all__` inventory of every façade is regression-tested. A future
+breaking change must use a new module version rather than silently changing a
+promoted façade.
+
+## Ownership boundary
+
+The split is organizational rather than scientific:
+
+- geometry owns `Sim(3)` representation and point Jacobians;
+- artifacts owns portable records and persistence operations;
+- covariance owns exact structured covariance actions and projections;
+- calibration owns source-fitted calibration contracts; and
+- provider owns strict admission, provider identity, and runtime attestation.
+
+None of these import paths establishes provider competence, calibrated physical
+uncertainty, BayesianPhysTwin benefit, Causal4D intervention benefit, deployment
+safety, or state of the art.

--- a/docs/examples/provider-portfolio-spec.json
+++ b/docs/examples/provider-portfolio-spec.json
@@ -1,0 +1,80 @@
+{
+  "entries": [
+    {
+      "gates": {
+        "conditional-covariance": {
+          "decision": "not-started",
+          "evidence_id": null
+        },
+        "gauge-dependence": {
+          "decision": "in-progress",
+          "evidence_id": null
+        },
+        "identity": {
+          "decision": "passed",
+          "evidence_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+        },
+        "means": {
+          "decision": "passed",
+          "evidence_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+        },
+        "query-value": {
+          "decision": "not-started",
+          "evidence_id": null
+        },
+        "support": {
+          "decision": "passed",
+          "evidence_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        }
+      },
+      "metadata": {
+        "representation": "recurrent-online"
+      },
+      "point_covariance_development_authorized": false,
+      "provider_family": "cut3r",
+      "provider_id": "cut3r-recurrent-v1",
+      "role": "primary",
+      "status": "active"
+    },
+    {
+      "gates": {
+        "conditional-covariance": {
+          "decision": "not-started",
+          "evidence_id": null
+        },
+        "gauge-dependence": {
+          "decision": "not-started",
+          "evidence_id": null
+        },
+        "identity": {
+          "decision": "not-started",
+          "evidence_id": null
+        },
+        "means": {
+          "decision": "not-started",
+          "evidence_id": null
+        },
+        "query-value": {
+          "decision": "not-started",
+          "evidence_id": null
+        },
+        "support": {
+          "decision": "in-progress",
+          "evidence_id": null
+        }
+      },
+      "metadata": {
+        "representation": "overlapping-window"
+      },
+      "point_covariance_development_authorized": false,
+      "provider_family": "motioncrafter",
+      "provider_id": "motioncrafter-provider-v2",
+      "role": "alternative",
+      "status": "active"
+    }
+  ],
+  "metadata": {
+    "information_boundary": "source-only",
+    "target_outcomes_opened": false
+  }
+}

--- a/docs/provider-portfolio.md
+++ b/docs/provider-portfolio.md
@@ -1,0 +1,67 @@
+# Evidence-first provider portfolio budget
+
+Prob4D can now record a content-addressed portfolio of provider families through
+`prob4d.provider_portfolio`. The artifact prevents provider breadth from growing
+without an explicit scientific budget and preserves the ordered readiness gates:
+
+```text
+support
+  -> means
+  -> identity
+  -> gauge-dependence
+  -> conditional-covariance
+  -> query-value
+```
+
+The default policy allows at most one active primary provider and one active
+alternative. An alternative may be active only while a primary is active. Other
+providers must be parked, promoted, rejected, or archived.
+
+## Build and verify
+
+Start from the checked-in
+[portfolio specification](examples/provider-portfolio-spec.json):
+
+```bash
+python -m prob4d.provider_portfolio build \
+  docs/examples/provider-portfolio-spec.json \
+  --output outputs/provider-portfolio.json
+
+python -m prob4d.provider_portfolio verify \
+  outputs/provider-portfolio.json
+
+python -m prob4d.provider_portfolio summarize \
+  outputs/provider-portfolio.json
+```
+
+Publication is atomic and no-clobber. Repeating an identical write is
+idempotent; a different artifact at the same destination is rejected.
+
+## Gate semantics
+
+Every provider has exactly one record for every gate. Decisions are one of:
+
+- `not-started`, without an evidence digest;
+- `in-progress`, without an evidence digest;
+- `passed`, with the exact evidence digest; or
+- `failed`, with the exact negative-result digest.
+
+A provider may advance only after every preceding gate has passed. An active
+provider has exactly one in-progress gate. A rejected provider has exactly one
+failed gate and no later decisions. Parked and archived providers retain a
+completed prefix but no active or failed gate.
+
+Conditional point-covariance development has an additional stop rule. It may be
+in progress only when
+`point_covariance_development_authorized=true`, which is intended to bind the
+existing source-localization result. A support, mean, identity, or
+gauge/dependence failure therefore cannot be converted into permission for a
+more complex point model.
+
+## Information boundary
+
+A valid portfolio establishes governance, ordering, and content identity only.
+It does not run a provider, evaluate accuracy, authorize protected target access,
+calibrate uncertainty, select a BayesianPhysTwin update, or establish Causal4D
+benefit. Negative provider evidence remains a complete terminal result and must
+not be rescued by activating another unbudgeted branch on the same opened target.

--- a/src/prob4d/_provider_portfolio_model.py
+++ b/src/prob4d/_provider_portfolio_model.py
@@ -1,0 +1,309 @@
+"""Strict ordered-gate model for the provider portfolio artifact."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Final, Literal, cast
+
+from ._immutable_json import plain_json
+from ._strict_json import (
+    require_exact_fields,
+    require_exact_string,
+    require_finite_json_mapping,
+    require_mapping,
+    require_sha256,
+)
+
+PROVIDER_PORTFOLIO_SCHEMA: Final = "prob4d.provider-portfolio"
+PROVIDER_PORTFOLIO_VERSION: Final = 1
+PROVIDER_PORTFOLIO_CLAIM_BOUNDARY: Final = (
+    "This artifact constrains provider-development concurrency and records ordered "
+    "gate evidence. It does not establish provider accuracy, uncertainty calibration, "
+    "physical-query improvement, BayesianPhysTwin admission, Causal4D intervention "
+    "benefit, protected-target authorization, deployment safety, or state of the art."
+)
+
+ProviderRole = Literal["primary", "alternative", "parked"]
+ProviderStatus = Literal["active", "parked", "promoted", "rejected", "archived"]
+GateDecision = Literal["not-started", "in-progress", "passed", "failed"]
+
+PROVIDER_STAGES: Final[tuple[str, ...]] = (
+    "support",
+    "means",
+    "identity",
+    "gauge-dependence",
+    "conditional-covariance",
+    "query-value",
+)
+ACTIVE_PROVIDER_ROLES: Final[tuple[ProviderRole, ...]] = ("primary", "alternative")
+MAX_ACTIVE_PRIMARY: Final = 1
+MAX_ACTIVE_ALTERNATIVE: Final = 1
+
+ENTRY_FIELDS: Final = frozenset(
+    {
+        "provider_id",
+        "provider_family",
+        "role",
+        "status",
+        "gates",
+        "point_covariance_development_authorized",
+        "metadata",
+    }
+)
+GATE_FIELDS: Final = frozenset({"decision", "evidence_id"})
+POLICY_FIELDS: Final = frozenset(
+    {
+        "ordered_stages",
+        "max_active_primary",
+        "max_active_alternative",
+        "active_roles",
+    }
+)
+
+
+def canonical_policy() -> dict[str, object]:
+    return {
+        "ordered_stages": list(PROVIDER_STAGES),
+        "max_active_primary": MAX_ACTIVE_PRIMARY,
+        "max_active_alternative": MAX_ACTIVE_ALTERNATIVE,
+        "active_roles": list(ACTIVE_PROVIDER_ROLES),
+    }
+
+
+def _exact_bool(value: object, *, name: str) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be a Boolean")
+    return cast(bool, value)
+
+
+def _exact_list(value: object, *, name: str) -> list[Any]:
+    if type(value) is not list:
+        raise ValueError(f"{name} must be a JSON array")
+    return cast(list[Any], value)
+
+
+def _role(value: object, *, name: str) -> ProviderRole:
+    role = require_exact_string(value, name=name)
+    if role not in {"primary", "alternative", "parked"}:
+        raise ValueError(f"{name} is not a supported provider role")
+    return cast(ProviderRole, role)
+
+
+def _status(value: object, *, name: str) -> ProviderStatus:
+    status = require_exact_string(value, name=name)
+    if status not in {"active", "parked", "promoted", "rejected", "archived"}:
+        raise ValueError(f"{name} is not a supported provider status")
+    return cast(ProviderStatus, status)
+
+
+def _decision(value: object, *, name: str) -> GateDecision:
+    decision = require_exact_string(value, name=name)
+    if decision not in {"not-started", "in-progress", "passed", "failed"}:
+        raise ValueError(f"{name} is not a supported gate decision")
+    return cast(GateDecision, decision)
+
+
+def _evidence_digest(value: object, *, name: str) -> str | None:
+    if value is None:
+        return None
+    return require_sha256(value, name=name)
+
+
+def _normalize_gate(
+    value: object,
+    *,
+    provider_id: str,
+    stage: str,
+) -> dict[str, object]:
+    name = f"entry {provider_id!r} gate {stage!r}"
+    gate = require_mapping(value, name=name)
+    require_exact_fields(gate, GATE_FIELDS, name=name)
+    decision = _decision(gate["decision"], name=f"{name}.decision")
+    evidence_id = _evidence_digest(gate["evidence_id"], name=f"{name}.evidence_id")
+    if decision in {"passed", "failed"} and evidence_id is None:
+        raise ValueError(f"{name} requires an evidence digest")
+    if decision in {"not-started", "in-progress"} and evidence_id is not None:
+        raise ValueError(f"{name} cannot bind evidence before a decision")
+    return {"decision": decision, "evidence_id": evidence_id}
+
+
+def _decisions(gates: Mapping[str, object]) -> tuple[object, ...]:
+    return tuple(
+        cast(Mapping[str, object], gates[stage])["decision"]
+        for stage in PROVIDER_STAGES
+    )
+
+
+def _validate_gate_order(gates: Mapping[str, object], *, provider_id: str) -> None:
+    decisions = _decisions(gates)
+    active = tuple(index for index, value in enumerate(decisions) if value == "in-progress")
+    failed = tuple(index for index, value in enumerate(decisions) if value == "failed")
+    if len(active) > 1:
+        raise ValueError(f"entry {provider_id!r} has more than one in-progress gate")
+    if len(failed) > 1:
+        raise ValueError(f"entry {provider_id!r} has more than one failed gate")
+
+    terminal = active + failed
+    if terminal:
+        stop = terminal[0]
+        if decisions[:stop] != ("passed",) * stop:
+            raise ValueError(
+                f"entry {provider_id!r} must pass every earlier gate before advancing"
+            )
+        if any(value != "not-started" for value in decisions[stop + 1 :]):
+            raise ValueError(
+                f"entry {provider_id!r} has decisions after its active or failed gate"
+            )
+        return
+
+    passed = 0
+    for value in decisions:
+        if value != "passed":
+            break
+        passed += 1
+    if any(value != "not-started" for value in decisions[passed:]):
+        raise ValueError(
+            f"entry {provider_id!r} gate decisions must form one passed prefix"
+        )
+
+
+def _normalize_gates(value: object, *, provider_id: str) -> dict[str, object]:
+    gates = require_mapping(value, name=f"entry {provider_id!r}.gates")
+    require_exact_fields(
+        gates,
+        frozenset(PROVIDER_STAGES),
+        name=f"entry {provider_id!r}.gates",
+    )
+    normalized = {
+        stage: _normalize_gate(gates[stage], provider_id=provider_id, stage=stage)
+        for stage in PROVIDER_STAGES
+    }
+    _validate_gate_order(normalized, provider_id=provider_id)
+    return normalized
+
+
+def _validate_status(
+    *,
+    provider_id: str,
+    role: ProviderRole,
+    status: ProviderStatus,
+    gates: Mapping[str, object],
+    point_authorized: bool,
+) -> None:
+    decisions = _decisions(gates)
+    in_progress = tuple(value for value in decisions if value == "in-progress")
+    failed = tuple(value for value in decisions if value == "failed")
+    all_passed = all(value == "passed" for value in decisions)
+
+    if status == "active":
+        if role not in ACTIVE_PROVIDER_ROLES:
+            raise ValueError(f"active entry {provider_id!r} must have an active role")
+        if len(in_progress) != 1 or failed or all_passed:
+            raise ValueError(
+                f"active entry {provider_id!r} requires exactly one in-progress gate"
+            )
+    elif status == "promoted":
+        if role != "primary" or not all_passed:
+            raise ValueError(
+                f"promoted entry {provider_id!r} must be primary with every gate passed"
+            )
+    elif status == "rejected":
+        if role not in ACTIVE_PROVIDER_ROLES:
+            raise ValueError(
+                f"rejected entry {provider_id!r} must retain its primary or alternative role"
+            )
+        if len(failed) != 1 or in_progress:
+            raise ValueError(
+                f"rejected entry {provider_id!r} requires exactly one failed gate"
+            )
+    elif status in {"parked", "archived"}:
+        if in_progress or failed:
+            raise ValueError(
+                f"{status} entry {provider_id!r} cannot have an active or failed gate"
+            )
+        if status == "parked" and role != "parked":
+            raise ValueError(f"parked entry {provider_id!r} must use the parked role")
+
+    if point_authorized and decisions[:4] != ("passed",) * 4:
+        raise ValueError(
+            f"entry {provider_id!r} cannot authorize conditional covariance before "
+            "support, means, identity, and gauge-dependence pass"
+        )
+    conditional = decisions[4]
+    if conditional == "in-progress" and not point_authorized:
+        raise ValueError(
+            f"entry {provider_id!r} cannot develop conditional covariance without "
+            "source-localization authorization"
+        )
+
+
+def _normalize_entry(value: object, *, index: int) -> dict[str, object]:
+    entry = require_mapping(value, name=f"entries[{index}]")
+    require_exact_fields(entry, ENTRY_FIELDS, name=f"entries[{index}]")
+    provider_id = require_exact_string(
+        entry["provider_id"],
+        name=f"entries[{index}].provider_id",
+    )
+    provider_family = require_exact_string(
+        entry["provider_family"],
+        name=f"entry {provider_id!r}.provider_family",
+    )
+    role = _role(entry["role"], name=f"entry {provider_id!r}.role")
+    status = _status(entry["status"], name=f"entry {provider_id!r}.status")
+    gates = _normalize_gates(entry["gates"], provider_id=provider_id)
+    point_authorized = _exact_bool(
+        entry["point_covariance_development_authorized"],
+        name=f"entry {provider_id!r}.point_covariance_development_authorized",
+    )
+    metadata = require_finite_json_mapping(
+        entry["metadata"],
+        name=f"entry {provider_id!r}.metadata",
+    )
+    _validate_status(
+        provider_id=provider_id,
+        role=role,
+        status=status,
+        gates=gates,
+        point_authorized=point_authorized,
+    )
+    return {
+        "provider_id": provider_id,
+        "provider_family": provider_family,
+        "role": role,
+        "status": status,
+        "gates": gates,
+        "point_covariance_development_authorized": point_authorized,
+        "metadata": plain_json(metadata),
+    }
+
+
+def normalize_entries(value: object) -> list[dict[str, object]]:
+    entries = [
+        _normalize_entry(item, index=index)
+        for index, item in enumerate(_exact_list(value, name="entries"))
+    ]
+    if not entries:
+        raise ValueError("entries must contain at least one provider")
+    identifiers = [cast(str, entry["provider_id"]) for entry in entries]
+    if len(identifiers) != len(set(identifiers)):
+        raise ValueError("provider_id values must be unique")
+    entries.sort(key=lambda entry: cast(str, entry["provider_id"]))
+    _validate_budget(entries)
+    return entries
+
+
+def _validate_budget(entries: Sequence[Mapping[str, object]]) -> None:
+    primary = sum(
+        entry["status"] == "active" and entry["role"] == "primary"
+        for entry in entries
+    )
+    alternative = sum(
+        entry["status"] == "active" and entry["role"] == "alternative"
+        for entry in entries
+    )
+    if primary > MAX_ACTIVE_PRIMARY:
+        raise ValueError("provider portfolio exceeds the active-primary budget")
+    if alternative > MAX_ACTIVE_ALTERNATIVE:
+        raise ValueError("provider portfolio exceeds the active-alternative budget")
+    if alternative and not primary:
+        raise ValueError("an active alternative requires one active primary provider")

--- a/src/prob4d/api/artifacts_v1.py
+++ b/src/prob4d/api/artifacts_v1.py
@@ -1,0 +1,58 @@
+"""Preview version-1 portable-artifact façade backed by :mod:`prob4d.api.v2`."""
+
+from __future__ import annotations
+
+from typing import Final
+
+from .v2 import (
+    GaugeTreePriorArtifactV1,
+    LoadedGaugeTreePriorArtifactV1,
+    LoadedTreeSparseObservationArtifactV1,
+    ObservationBeliefExportV1,
+    ObservationFactor,
+    ObservationFactorBundle,
+    ObservationFactorStreamUpdateV1,
+    ObservationFactorStreamV1,
+    TreeSparseObservationArtifactV1,
+    append_observation_factor_bundle,
+    gauge_tree_prior_artifact_id,
+    load_gauge_tree_prior_artifact,
+    load_observation_belief_export,
+    load_observation_factor_bundle,
+    load_observation_factor_stream,
+    load_tree_sparse_observation_artifact,
+    save_observation_belief_export,
+    write_gauge_tree_prior_artifact,
+    write_observation_factor_bundle,
+    write_observation_factor_stream,
+    write_tree_sparse_observation_artifact,
+)
+
+FACADE_VERSION: Final = 1
+LIFECYCLE: Final = "preview"
+
+__all__ = [
+    "FACADE_VERSION",
+    "GaugeTreePriorArtifactV1",
+    "LIFECYCLE",
+    "LoadedGaugeTreePriorArtifactV1",
+    "LoadedTreeSparseObservationArtifactV1",
+    "ObservationBeliefExportV1",
+    "ObservationFactor",
+    "ObservationFactorBundle",
+    "ObservationFactorStreamUpdateV1",
+    "ObservationFactorStreamV1",
+    "TreeSparseObservationArtifactV1",
+    "append_observation_factor_bundle",
+    "gauge_tree_prior_artifact_id",
+    "load_gauge_tree_prior_artifact",
+    "load_observation_belief_export",
+    "load_observation_factor_bundle",
+    "load_observation_factor_stream",
+    "load_tree_sparse_observation_artifact",
+    "save_observation_belief_export",
+    "write_gauge_tree_prior_artifact",
+    "write_observation_factor_bundle",
+    "write_observation_factor_stream",
+    "write_tree_sparse_observation_artifact",
+]

--- a/src/prob4d/api/calibration_v1.py
+++ b/src/prob4d/api/calibration_v1.py
@@ -1,0 +1,50 @@
+"""Preview version-1 calibration façade backed by :mod:`prob4d.api.v2`."""
+
+from __future__ import annotations
+
+from typing import Final
+
+from .v2 import (
+    CalibrationCompatibilityError,
+    GaugeCovarianceCalibrationV1,
+    MetricGaugeAnchor,
+    PathwiseMaximumCalibrationV1,
+    PathwiseUncertaintyDiagnostics,
+    PointUncertaintyCalibrationV1,
+    PredictionCalibrationTargetV1,
+    assert_calibration_pair_compatible,
+    fit_pathwise_maximum_calibration,
+    load_gauge_covariance_calibration,
+    load_metric_gauge_anchor,
+    load_point_uncertainty_calibration,
+    load_prediction_calibration_target,
+    pathwise_uncertainty_diagnostics,
+    save_gauge_covariance_calibration,
+    save_metric_gauge_anchor,
+    save_point_uncertainty_calibration,
+)
+
+FACADE_VERSION: Final = 1
+LIFECYCLE: Final = "preview"
+
+__all__ = [
+    "CalibrationCompatibilityError",
+    "FACADE_VERSION",
+    "GaugeCovarianceCalibrationV1",
+    "LIFECYCLE",
+    "MetricGaugeAnchor",
+    "PathwiseMaximumCalibrationV1",
+    "PathwiseUncertaintyDiagnostics",
+    "PointUncertaintyCalibrationV1",
+    "PredictionCalibrationTargetV1",
+    "assert_calibration_pair_compatible",
+    "fit_pathwise_maximum_calibration",
+    "load_gauge_covariance_calibration",
+    "load_metric_gauge_anchor",
+    "load_point_uncertainty_calibration",
+    "load_prediction_calibration_target",
+    "pathwise_uncertainty_diagnostics",
+    "save_gauge_covariance_calibration",
+    "save_metric_gauge_anchor",
+    "save_point_uncertainty_calibration",
+]

--- a/src/prob4d/api/covariance_v1.py
+++ b/src/prob4d/api/covariance_v1.py
@@ -1,0 +1,40 @@
+"""Preview version-1 structured-covariance façade backed by :mod:`prob4d.api.v2`."""
+
+from __future__ import annotations
+
+from typing import Final
+
+from .v2 import (
+    CovarianceComponent,
+    ObservationFactorStack,
+    ProjectedObservationCovariance,
+    SparseStackedObservationFactors,
+    StackedObservationFactors,
+    TreeSparseStackedObservationFactors,
+    observation_covariance_action,
+    observation_covariance_quadratic,
+    project_observation_covariance,
+    stack_observation_factors,
+    stack_sparse_observation_factors,
+    stack_tree_sparse_observation_factors,
+)
+
+FACADE_VERSION: Final = 1
+LIFECYCLE: Final = "preview"
+
+__all__ = [
+    "CovarianceComponent",
+    "FACADE_VERSION",
+    "LIFECYCLE",
+    "ObservationFactorStack",
+    "ProjectedObservationCovariance",
+    "SparseStackedObservationFactors",
+    "StackedObservationFactors",
+    "TreeSparseStackedObservationFactors",
+    "observation_covariance_action",
+    "observation_covariance_quadratic",
+    "project_observation_covariance",
+    "stack_observation_factors",
+    "stack_sparse_observation_factors",
+    "stack_tree_sparse_observation_factors",
+]

--- a/src/prob4d/api/geometry_v1.py
+++ b/src/prob4d/api/geometry_v1.py
@@ -1,0 +1,26 @@
+"""Preview version-1 geometry façade backed by :mod:`prob4d.api.v2`."""
+
+from __future__ import annotations
+
+from typing import Final
+
+from .v2 import (
+    GAUGE_DIMENSION,
+    GAUGE_PARAMETERIZATION,
+    GaugeEstimate,
+    Sim3,
+    sim3_point_jacobian,
+)
+
+FACADE_VERSION: Final = 1
+LIFECYCLE: Final = "preview"
+
+__all__ = [
+    "FACADE_VERSION",
+    "GAUGE_DIMENSION",
+    "GAUGE_PARAMETERIZATION",
+    "GaugeEstimate",
+    "LIFECYCLE",
+    "Sim3",
+    "sim3_point_jacobian",
+]

--- a/src/prob4d/api/provider_v1.py
+++ b/src/prob4d/api/provider_v1.py
@@ -1,0 +1,60 @@
+"""Preview version-1 provider-boundary façade backed by :mod:`prob4d.api.v2`."""
+
+from __future__ import annotations
+
+from typing import Final
+
+from .v2 import (
+    RuntimeRevisionAttestation,
+    ValidatedClaimBearingObservation,
+    ValidatedClaimBearingObservationFactorBundle,
+    ValidatedClaimBearingTreeSparseObservation,
+    assert_runtime_revision,
+    build_provider_attestation,
+    compute_provider_manifest_id,
+    export_calibrated_observation_belief,
+    export_exploratory_observation_belief,
+    inspect_runtime_revision,
+    load_claim_bearing_observation_belief,
+    load_claim_bearing_observation_factor_bundle,
+    load_claim_bearing_tree_sparse_observation,
+    prob4d_project_identity,
+    prob4d_provider_manifest,
+    prob4d_tree_sparse_provider_manifest,
+    validate_claim_bearing_observation_belief,
+    validate_claim_bearing_observation_factor_bundle,
+    validate_claim_bearing_tree_sparse_observation,
+    validate_prob4d_project_identity,
+    validate_provider_attestation,
+    validate_provider_manifest,
+)
+
+FACADE_VERSION: Final = 1
+LIFECYCLE: Final = "preview"
+
+__all__ = [
+    "FACADE_VERSION",
+    "LIFECYCLE",
+    "RuntimeRevisionAttestation",
+    "ValidatedClaimBearingObservation",
+    "ValidatedClaimBearingObservationFactorBundle",
+    "ValidatedClaimBearingTreeSparseObservation",
+    "assert_runtime_revision",
+    "build_provider_attestation",
+    "compute_provider_manifest_id",
+    "export_calibrated_observation_belief",
+    "export_exploratory_observation_belief",
+    "inspect_runtime_revision",
+    "load_claim_bearing_observation_belief",
+    "load_claim_bearing_observation_factor_bundle",
+    "load_claim_bearing_tree_sparse_observation",
+    "prob4d_project_identity",
+    "prob4d_provider_manifest",
+    "prob4d_tree_sparse_provider_manifest",
+    "validate_claim_bearing_observation_belief",
+    "validate_claim_bearing_observation_factor_bundle",
+    "validate_claim_bearing_tree_sparse_observation",
+    "validate_prob4d_project_identity",
+    "validate_provider_attestation",
+    "validate_provider_manifest",
+]

--- a/src/prob4d/provider_portfolio.py
+++ b/src/prob4d/provider_portfolio.py
@@ -1,0 +1,258 @@
+"""Content-addressed evidence-first budgets for competing 4-D providers."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final, cast
+
+from ._atomic_file import atomic_write_bytes
+from ._immutable_json import plain_json
+from ._provider_portfolio_model import (
+    ACTIVE_PROVIDER_ROLES,
+    MAX_ACTIVE_ALTERNATIVE,
+    MAX_ACTIVE_PRIMARY,
+    POLICY_FIELDS,
+    PROVIDER_PORTFOLIO_CLAIM_BOUNDARY,
+    PROVIDER_PORTFOLIO_SCHEMA,
+    PROVIDER_PORTFOLIO_VERSION,
+    PROVIDER_STAGES,
+    canonical_policy,
+    normalize_entries,
+)
+from ._strict_json import (
+    load_json_object,
+    require_exact_fields,
+    require_exact_string,
+    require_finite_json_mapping,
+    require_mapping,
+    require_sha256,
+)
+
+_SPEC_FIELDS: Final = frozenset({"entries", "metadata"})
+_PORTFOLIO_FIELDS: Final = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "policy",
+        "entries",
+        "metadata",
+        "claim_boundary",
+        "portfolio_id",
+    }
+)
+
+
+def _canonical_json(value: Mapping[str, Any], *, pretty: bool = False) -> bytes:
+    return (
+        json.dumps(
+            plain_json(value),
+            sort_keys=True,
+            indent=2 if pretty else None,
+            separators=None if pretty else (",", ":"),
+            allow_nan=False,
+        )
+        + ("\n" if pretty else "")
+    ).encode("utf-8")
+
+
+def _portfolio_id(value: Mapping[str, Any]) -> str:
+    unsigned = dict(plain_json(value))
+    unsigned.pop("portfolio_id", None)
+    return hashlib.sha256(_canonical_json(unsigned)).hexdigest()
+
+
+def build_provider_portfolio(specification: Mapping[str, Any]) -> dict[str, Any]:
+    """Build one canonical content-addressed portfolio from a strict specification."""
+
+    spec = require_mapping(specification, name="provider portfolio specification")
+    require_exact_fields(spec, _SPEC_FIELDS, name="provider portfolio specification")
+    payload: dict[str, Any] = {
+        "schema": PROVIDER_PORTFOLIO_SCHEMA,
+        "schema_version": PROVIDER_PORTFOLIO_VERSION,
+        "policy": canonical_policy(),
+        "entries": normalize_entries(spec["entries"]),
+        "metadata": plain_json(
+            require_finite_json_mapping(spec["metadata"], name="metadata")
+        ),
+        "claim_boundary": PROVIDER_PORTFOLIO_CLAIM_BOUNDARY,
+    }
+    payload["portfolio_id"] = _portfolio_id(payload)
+    return validate_provider_portfolio(payload)
+
+
+def _validated_policy(value: object) -> dict[str, object]:
+    policy = require_mapping(value, name="policy")
+    require_exact_fields(policy, POLICY_FIELDS, name="policy")
+    if plain_json(policy) != canonical_policy():
+        raise ValueError("provider portfolio policy is not canonical")
+    return canonical_policy()
+
+
+def validate_provider_portfolio(value: object) -> dict[str, Any]:
+    """Validate a persisted provider portfolio and return canonical plain data."""
+
+    portfolio = require_mapping(value, name="provider portfolio")
+    require_exact_fields(portfolio, _PORTFOLIO_FIELDS, name="provider portfolio")
+    if require_exact_string(portfolio["schema"], name="schema") != PROVIDER_PORTFOLIO_SCHEMA:
+        raise ValueError("unsupported provider portfolio schema")
+    version = portfolio["schema_version"]
+    if type(version) is not int or version != PROVIDER_PORTFOLIO_VERSION:
+        raise ValueError("unsupported provider portfolio schema version")
+    if (
+        require_exact_string(portfolio["claim_boundary"], name="claim_boundary")
+        != PROVIDER_PORTFOLIO_CLAIM_BOUNDARY
+    ):
+        raise ValueError("provider portfolio claim boundary is not canonical")
+
+    normalized: dict[str, Any] = {
+        "schema": PROVIDER_PORTFOLIO_SCHEMA,
+        "schema_version": PROVIDER_PORTFOLIO_VERSION,
+        "policy": _validated_policy(portfolio["policy"]),
+        "entries": normalize_entries(portfolio["entries"]),
+        "metadata": plain_json(
+            require_finite_json_mapping(portfolio["metadata"], name="metadata")
+        ),
+        "claim_boundary": PROVIDER_PORTFOLIO_CLAIM_BOUNDARY,
+        "portfolio_id": require_sha256(portfolio["portfolio_id"], name="portfolio_id"),
+    }
+    if normalized["portfolio_id"] != _portfolio_id(normalized):
+        raise ValueError("portfolio_id does not match the canonical portfolio content")
+    return cast(dict[str, Any], json.loads(_canonical_json(normalized)))
+
+
+def load_provider_portfolio(path: str | Path) -> dict[str, Any]:
+    """Load and validate one strict finite-JSON provider portfolio."""
+
+    return validate_provider_portfolio(
+        load_json_object(path, name="provider portfolio artifact")
+    )
+
+
+def write_provider_portfolio(
+    path: str | Path,
+    portfolio: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Publish a portfolio atomically without replacing different existing bytes."""
+
+    validated = validate_provider_portfolio(portfolio)
+    destination = Path(path)
+    if destination.is_symlink():
+        raise ValueError("provider portfolio destination must not be a symbolic link")
+    encoded = _canonical_json(validated, pretty=True)
+    try:
+        atomic_write_bytes(destination, encoded, overwrite=False)
+    except FileExistsError:
+        existing = load_provider_portfolio(destination)
+        if existing != validated:
+            raise FileExistsError(
+                f"refusing to replace a different provider portfolio: {destination}"
+            ) from None
+        return existing
+    return validated
+
+
+def provider_portfolio_summary(portfolio: Mapping[str, Any]) -> dict[str, object]:
+    """Return an operational summary without changing the validated artifact."""
+
+    validated = validate_provider_portfolio(portfolio)
+    entries = cast(list[dict[str, object]], validated["entries"])
+    counts = {
+        status: sum(entry["status"] == status for entry in entries)
+        for status in ("active", "parked", "promoted", "rejected", "archived")
+    }
+    active: list[dict[str, object]] = []
+    for entry in entries:
+        if entry["status"] != "active":
+            continue
+        gates = cast(Mapping[str, object], entry["gates"])
+        stage = next(
+            candidate
+            for candidate in PROVIDER_STAGES
+            if cast(Mapping[str, object], gates[candidate])["decision"]
+            == "in-progress"
+        )
+        active.append(
+            {
+                "provider_id": entry["provider_id"],
+                "role": entry["role"],
+                "stage": stage,
+            }
+        )
+    return {
+        "portfolio_id": validated["portfolio_id"],
+        "entry_count": len(entries),
+        "status_counts": counts,
+        "active": active,
+        "claim_boundary": PROVIDER_PORTFOLIO_CLAIM_BOUNDARY,
+    }
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    build = subparsers.add_parser("build", help="build a portfolio from a JSON spec")
+    build.add_argument("specification")
+    build.add_argument("--output", required=True)
+    build.set_defaults(handler=_build_command)
+
+    verify = subparsers.add_parser("verify", help="verify a persisted portfolio")
+    verify.add_argument("portfolio")
+    verify.set_defaults(handler=_verify_command)
+
+    summarize = subparsers.add_parser("summarize", help="summarize a portfolio")
+    summarize.add_argument("portfolio")
+    summarize.set_defaults(handler=_summarize_command)
+    return parser
+
+
+def _build_command(arguments: argparse.Namespace) -> int:
+    spec = load_json_object(arguments.specification, name="provider portfolio specification")
+    portfolio = build_provider_portfolio(spec)
+    write_provider_portfolio(arguments.output, portfolio)
+    print(portfolio["portfolio_id"])
+    return 0
+
+
+def _verify_command(arguments: argparse.Namespace) -> int:
+    portfolio = load_provider_portfolio(arguments.portfolio)
+    print(portfolio["portfolio_id"])
+    return 0
+
+
+def _summarize_command(arguments: argparse.Namespace) -> int:
+    summary = provider_portfolio_summary(load_provider_portfolio(arguments.portfolio))
+    print(json.dumps(summary, sort_keys=True, indent=2, allow_nan=False))
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the provider-portfolio command-line interface."""
+
+    arguments = _parser().parse_args(list(argv) if argv is not None else None)
+    return int(arguments.handler(arguments))
+
+
+__all__ = [
+    "ACTIVE_PROVIDER_ROLES",
+    "MAX_ACTIVE_ALTERNATIVE",
+    "MAX_ACTIVE_PRIMARY",
+    "PROVIDER_PORTFOLIO_CLAIM_BOUNDARY",
+    "PROVIDER_PORTFOLIO_SCHEMA",
+    "PROVIDER_PORTFOLIO_VERSION",
+    "PROVIDER_STAGES",
+    "build_provider_portfolio",
+    "load_provider_portfolio",
+    "main",
+    "provider_portfolio_summary",
+    "validate_provider_portfolio",
+    "write_provider_portfolio",
+]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_capability_facades.py
+++ b/tests/test_capability_facades.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+from types import ModuleType
+
+from prob4d.api import artifacts_v1, calibration_v1, covariance_v1, geometry_v1, provider_v1
+from prob4d.api import v2 as api_v2
+
+_FACADES: tuple[ModuleType, ...] = (
+    geometry_v1,
+    artifacts_v1,
+    covariance_v1,
+    calibration_v1,
+    provider_v1,
+)
+
+
+def test_capability_facades_are_exact_additive_api_v2_aliases() -> None:
+    for facade in _FACADES:
+        assert facade.FACADE_VERSION == 1
+        assert facade.LIFECYCLE == "preview"
+        assert facade.__all__ == sorted(facade.__all__)
+        assert len(facade.__all__) == len(set(facade.__all__))
+        for name in facade.__all__:
+            assert not name.startswith("_")
+            if name in {"FACADE_VERSION", "LIFECYCLE"}:
+                continue
+            assert name in api_v2.__all__
+            assert getattr(facade, name) is getattr(api_v2, name)
+
+
+def test_capability_facades_do_not_load_optional_gpu_stacks() -> None:
+    script = """
+import sys
+
+import prob4d.api.artifacts_v1
+import prob4d.api.calibration_v1
+import prob4d.api.covariance_v1
+import prob4d.api.geometry_v1
+import prob4d.api.provider_v1
+
+forbidden = {"torch", "diffusers", "decord"}
+loaded = sorted(forbidden & set(sys.modules))
+if loaded:
+    raise SystemExit(f"optional GPU dependencies loaded: {loaded}")
+"""
+    subprocess.run([sys.executable, "-c", script], check=True)

--- a/tests/test_provider_portfolio.py
+++ b/tests/test_provider_portfolio.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+
+import pytest
+
+from prob4d.provider_portfolio import (
+    PROVIDER_PORTFOLIO_CLAIM_BOUNDARY,
+    PROVIDER_STAGES,
+    build_provider_portfolio,
+    load_provider_portfolio,
+    main,
+    provider_portfolio_summary,
+    validate_provider_portfolio,
+    write_provider_portfolio,
+)
+
+
+def _digest(character: str) -> str:
+    return character * 64
+
+
+def _gates(
+    *,
+    passed: int,
+    in_progress: int | None = None,
+    failed: int | None = None,
+) -> dict[str, dict[str, object]]:
+    result: dict[str, dict[str, object]] = {}
+    for index, stage in enumerate(PROVIDER_STAGES):
+        if index < passed:
+            result[stage] = {
+                "decision": "passed",
+                "evidence_id": _digest(chr(ord("a") + index)),
+            }
+        elif index == in_progress:
+            result[stage] = {"decision": "in-progress", "evidence_id": None}
+        elif index == failed:
+            result[stage] = {
+                "decision": "failed",
+                "evidence_id": _digest("f"),
+            }
+        else:
+            result[stage] = {"decision": "not-started", "evidence_id": None}
+    return result
+
+
+def _entry(
+    provider_id: str,
+    *,
+    role: str,
+    status: str,
+    passed: int,
+    in_progress: int | None = None,
+    failed: int | None = None,
+    point_authorized: bool = False,
+) -> dict[str, object]:
+    return {
+        "provider_id": provider_id,
+        "provider_family": provider_id.split("-")[0],
+        "role": role,
+        "status": status,
+        "gates": _gates(
+            passed=passed,
+            in_progress=in_progress,
+            failed=failed,
+        ),
+        "point_covariance_development_authorized": point_authorized,
+        "metadata": {"owner": "provider-readiness"},
+    }
+
+
+def _spec() -> dict[str, object]:
+    return {
+        "entries": [
+            _entry(
+                "cut3r-recurrent-v1",
+                role="primary",
+                status="active",
+                passed=3,
+                in_progress=3,
+            ),
+            _entry(
+                "motioncrafter-v2",
+                role="alternative",
+                status="active",
+                passed=0,
+                in_progress=0,
+            ),
+            _entry(
+                "vggt-baseline-v1",
+                role="parked",
+                status="parked",
+                passed=1,
+            ),
+        ],
+        "metadata": {"split": "source-only", "target_outcomes_opened": False},
+    }
+
+
+def test_provider_portfolio_is_deterministic_and_order_invariant() -> None:
+    first = build_provider_portfolio(_spec())
+    reversed_spec = _spec()
+    reversed_spec["entries"] = list(reversed(reversed_spec["entries"]))
+    second = build_provider_portfolio(reversed_spec)
+
+    assert first == second
+    assert first["claim_boundary"] == PROVIDER_PORTFOLIO_CLAIM_BOUNDARY
+    assert [entry["provider_id"] for entry in first["entries"]] == [
+        "cut3r-recurrent-v1",
+        "motioncrafter-v2",
+        "vggt-baseline-v1",
+    ]
+    assert validate_provider_portfolio(first) == first
+
+    summary = provider_portfolio_summary(first)
+    assert summary["entry_count"] == 3
+    assert summary["status_counts"]["active"] == 2
+    assert summary["active"] == [
+        {
+            "provider_id": "cut3r-recurrent-v1",
+            "role": "primary",
+            "stage": "gauge-dependence",
+        },
+        {
+            "provider_id": "motioncrafter-v2",
+            "role": "alternative",
+            "stage": "support",
+        },
+    ]
+
+
+def test_provider_portfolio_enforces_active_work_in_progress_budget() -> None:
+    spec = _spec()
+    spec["entries"].append(
+        _entry(
+            "second-primary-v1",
+            role="primary",
+            status="active",
+            passed=0,
+            in_progress=0,
+        )
+    )
+    with pytest.raises(ValueError, match="active-primary budget"):
+        build_provider_portfolio(spec)
+
+    without_primary = _spec()
+    without_primary["entries"] = [without_primary["entries"][1]]
+    with pytest.raises(ValueError, match="alternative requires"):
+        build_provider_portfolio(without_primary)
+
+
+def test_provider_portfolio_enforces_ordered_scientific_gates() -> None:
+    spec = _spec()
+    entry = spec["entries"][0]
+    entry["gates"]["identity"] = {
+        "decision": "not-started",
+        "evidence_id": None,
+    }
+    with pytest.raises(ValueError, match="pass every earlier gate"):
+        build_provider_portfolio(spec)
+
+    rejected = {
+        "entries": [
+            _entry(
+                "negative-provider-v1",
+                role="primary",
+                status="rejected",
+                passed=1,
+                failed=1,
+            )
+        ],
+        "metadata": {},
+    }
+    artifact = build_provider_portfolio(rejected)
+    assert artifact["entries"][0]["gates"]["means"]["decision"] == "failed"
+
+
+def test_point_covariance_work_requires_localization_authorization() -> None:
+    unauthorized = {
+        "entries": [
+            _entry(
+                "provider-v1",
+                role="primary",
+                status="active",
+                passed=4,
+                in_progress=4,
+                point_authorized=False,
+            )
+        ],
+        "metadata": {},
+    }
+    with pytest.raises(ValueError, match="localization authorization"):
+        build_provider_portfolio(unauthorized)
+
+    authorized = deepcopy(unauthorized)
+    authorized["entries"][0]["point_covariance_development_authorized"] = True
+    artifact = build_provider_portfolio(authorized)
+    assert artifact["entries"][0]["status"] == "active"
+
+
+def test_point_covariance_authorization_requires_completed_localization() -> None:
+    premature = {
+        "entries": [
+            _entry(
+                "provider-v1",
+                role="primary",
+                status="active",
+                passed=2,
+                in_progress=2,
+                point_authorized=True,
+            )
+        ],
+        "metadata": {},
+    }
+    with pytest.raises(ValueError, match="before support, means, identity"):
+        build_provider_portfolio(premature)
+
+
+def test_portfolio_rejects_coercive_types_and_tampering() -> None:
+    coercive = _spec()
+    coercive["entries"][0]["point_covariance_development_authorized"] = 1
+    with pytest.raises(ValueError, match="must be a Boolean"):
+        build_provider_portfolio(coercive)
+
+    artifact = build_provider_portfolio(_spec())
+    tampered = deepcopy(artifact)
+    tampered["entries"][0]["provider_family"] = "changed"
+    with pytest.raises(ValueError, match="portfolio_id"):
+        validate_provider_portfolio(tampered)
+
+
+def test_portfolio_round_trip_no_clobber_and_cli(tmp_path: Path, capsys) -> None:
+    artifact = build_provider_portfolio(_spec())
+    output = tmp_path / "portfolio.json"
+    assert write_provider_portfolio(output, artifact) == artifact
+    assert write_provider_portfolio(output, artifact) == artifact
+    assert load_provider_portfolio(output) == artifact
+
+    different = build_provider_portfolio(
+        {
+            "entries": [
+                _entry(
+                    "other-v1",
+                    role="primary",
+                    status="active",
+                    passed=0,
+                    in_progress=0,
+                )
+            ],
+            "metadata": {},
+        }
+    )
+    with pytest.raises(FileExistsError, match="different provider portfolio"):
+        write_provider_portfolio(output, different)
+
+    spec_path = tmp_path / "spec.json"
+    spec_path.write_text(json.dumps(_spec()), encoding="utf-8")
+    cli_output = tmp_path / "cli-portfolio.json"
+    assert main(["build", str(spec_path), "--output", str(cli_output)]) == 0
+    built_id = capsys.readouterr().out.strip()
+    assert built_id == load_provider_portfolio(cli_output)["portfolio_id"]
+
+    assert main(["verify", str(cli_output)]) == 0
+    assert capsys.readouterr().out.strip() == built_id
+
+    assert main(["summarize", str(cli_output)]) == 0
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["portfolio_id"] == built_id
+
+
+def test_loader_rejects_duplicate_json_keys(tmp_path: Path) -> None:
+    path = tmp_path / "duplicate.json"
+    path.write_text('{"schema":"a","schema":"b"}', encoding="utf-8")
+    with pytest.raises(ValueError, match="duplicate JSON object key"):
+        load_provider_portfolio(path)

--- a/tests/test_sim3_properties.py
+++ b/tests/test_sim3_properties.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import numpy as np
+
+from prob4d.sim3 import Sim3, so3_exp, so3_log
+
+
+def _random_sim3(rng: np.random.Generator) -> Sim3:
+    axis = rng.normal(size=3)
+    axis /= np.linalg.norm(axis)
+    angle = rng.uniform(-2.8, 2.8)
+    return Sim3.from_vector(
+        np.concatenate(
+            (
+                [rng.uniform(-1.5, 1.5)],
+                axis * angle,
+                rng.normal(scale=4.0, size=3),
+            )
+        )
+    )
+
+
+def test_sim3_composition_matches_sequential_point_action() -> None:
+    rng = np.random.default_rng(20260818)
+    for _ in range(64):
+        first = _random_sim3(rng)
+        second = _random_sim3(rng)
+        points = rng.normal(size=(32, 3))
+        sequential = first.transform_points(second.transform_points(points))
+        composed = first.compose(second).transform_points(points)
+        np.testing.assert_allclose(composed, sequential, rtol=2e-12, atol=2e-12)
+
+
+def test_sim3_inverse_and_associativity_hold_on_actions() -> None:
+    rng = np.random.default_rng(90210)
+    for _ in range(48):
+        first = _random_sim3(rng)
+        second = _random_sim3(rng)
+        third = _random_sim3(rng)
+        points = rng.normal(size=(16, 3))
+
+        identity_action = first.compose(first.inverse()).transform_points(points)
+        np.testing.assert_allclose(identity_action, points, rtol=3e-12, atol=3e-12)
+
+        left = first.compose(second).compose(third).transform_points(points)
+        right = first.compose(second.compose(third)).transform_points(points)
+        np.testing.assert_allclose(left, right, rtol=4e-12, atol=4e-12)
+
+
+def test_sim3_covariance_action_matches_sample_transform() -> None:
+    rng = np.random.default_rng(1234)
+    for _ in range(24):
+        transform = _random_sim3(rng)
+        factor = rng.normal(size=(3, 3))
+        covariance = factor @ factor.T + 0.05 * np.eye(3)
+        transformed = transform.transform_covariances(covariance)
+        linear = transform.scale * transform.rotation
+        expected = linear @ covariance @ linear.T
+        np.testing.assert_allclose(transformed, expected, rtol=2e-12, atol=2e-12)
+        np.testing.assert_allclose(transformed, transformed.T, rtol=0.0, atol=2e-12)
+        assert float(np.linalg.eigvalsh(transformed)[0]) >= -1e-10
+
+
+def test_so3_round_trip_covers_small_and_near_pi_rotations() -> None:
+    vectors = (
+        np.array([1e-12, -2e-12, 3e-12]),
+        np.array([0.2, -0.3, 0.4]),
+        np.array([np.pi - 2e-6, 0.0, 0.0]),
+    )
+    for vector in vectors:
+        rotation = so3_exp(vector)
+        reconstructed = so3_exp(so3_log(rotation))
+        np.testing.assert_allclose(reconstructed, rotation, rtol=1e-9, atol=1e-9)


### PR DESCRIPTION
## Summary

This PR implements three evidence-first repository improvements without changing estimator or scientific semantics:

1. **Provider portfolio budget**
   - adds a strict, content-addressed `prob4d.provider-portfolio` artifact;
   - enforces the ordered gates `support -> means -> identity -> gauge-dependence -> conditional-covariance -> query-value`;
   - allows at most one active primary and one active alternative provider;
   - retains passed and negative gate evidence by SHA-256 identity;
   - permits conditional-covariance development only after source-localized authorization;
   - provides atomic no-clobber build, verify, and summarize module commands.

2. **Capability-specific preview façades**
   - adds collision-free `prob4d.api.geometry_v1`, `prob4d.api.artifacts_v1`, `prob4d.api.covariance_v1`, `prob4d.api.calibration_v1`, and `prob4d.api.provider_v1` modules;
   - every exported value is the identical object already exposed by `prob4d.api.v2`;
   - keeps `prob4d.api.v2` as the normative public manifest surface while the narrower imports remain explicitly `preview`;
   - avoids shadowing the existing core modules such as `prob4d.covariance`.

3. **Numerical and import regression tests**
   - deterministic randomized `Sim(3)` composition, inverse, associativity, covariance, and near-π rotation checks;
   - exact façade inventory and object-identity checks;
   - isolated-process verification that the façade imports do not load Torch, Diffusers, or Decord;
   - adversarial portfolio tests for ordering, concurrency budgets, coercive types, tampering, duplicate JSON keys, no-clobber publication, and covariance-development authorization.

## Validation performed

- `14 passed` for the three focused test modules after the collision-free namespace update;
- all added Python files compiled with `compileall`;
- 100-character line and trailing-whitespace checks passed for all added Python files;
- branch is one commit ahead of exact base `2fa1c49327a2ac13f77760436d2fd620b48d4d88` with no unrelated changes.

Full repository, distribution, portability, typing, security, and ecosystem checks are left to the existing GitHub Actions matrix.

## Scientific boundary

This PR does **not** run or promote a provider, open a protected target cohort, establish uncertainty calibration, select a BayesianPhysTwin update, establish Causal4D intervention benefit, alter exact fallback, or make a state-of-the-art claim. Fresh physical evaluation and release/ruleset administration remain separate tracked work.