### PR TITLE
Add post-selection calibration and moment-collapse diagnostics

### DIFF
--- a/CHANGELOG.d/gaussian-moment-collapse.md
+++ b/CHANGELOG.d/gaussian-moment-collapse.md
@@ -1,0 +1,5 @@
+Add a deterministic controlled diagnostic for replacing a symmetric multimodal
+3-D Gaussian mixture with its moment-matched Gaussian. It reports discriminant
+separation, midpoint density, central-mass inflation, and excess kurtosis under
+frozen thresholds, with strict immutable artifacts and no real-provider claim.
+The diagnostic does not change provider or observation contracts.

--- a/CHANGELOG.d/selective-update-calibration.md
+++ b/CHANGELOG.d/selective-update-calibration.md
@@ -1,0 +1,7 @@
+Add a content-addressed source-validation certificate for calibration after a
+frozen Bayesian update-selection guard. It separates the all-group candidate,
+accepted subset, exact fallback, and deployed policy; requires disjoint guard-fit,
+guard-calibration, and validation object/session groups; evaluates coverage,
+width, proper score, harmful accepted updates, support, and worst-group gates; and
+fails closed on non-exact deployment or target-outcome semantics. This is
+source-validation infrastructure and does not authorize target access.

--- a/docs/examples/moment-collapse-diagnostic-input.json
+++ b/docs/examples/moment-collapse-diagnostic-input.json
@@ -1,0 +1,38 @@
+{
+  "representation_name": "mean-and-covariance-only",
+  "thresholds": {
+    "midpoint_half_width_component_sigma": 1.0,
+    "minimum_component_mean_separation_sigma": 4.0,
+    "maximum_mixture_midpoint_to_component_mean_density_ratio": 0.1,
+    "minimum_moment_gaussian_central_mass_inflation": 0.1
+  },
+  "cases": [
+    {
+      "case_id": "separated-two-mode",
+      "offset_xyz": [3.0, 0.0, 0.0],
+      "component_covariance": [
+        [1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 1.0]
+      ],
+      "metadata": {
+        "mechanism": "symmetric-two-mode"
+      }
+    },
+    {
+      "case_id": "weak-two-mode",
+      "offset_xyz": [0.2, 0.0, 0.0],
+      "component_covariance": [
+        [1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 1.0]
+      ],
+      "metadata": {
+        "mechanism": "near-unimodal-control"
+      }
+    }
+  ],
+  "metadata": {
+    "uses_real_provider_outcomes": false
+  }
+}

--- a/docs/examples/selective-update-calibration-input.json
+++ b/docs/examples/selective-update-calibration-input.json
@@ -1,0 +1,92 @@
+{
+  "protocol_id": "selective-source-validation-v1",
+  "query_definition": "equal-object guarded physical query",
+  "score_definition": "group-mean Gaussian negative log likelihood",
+  "width_unit": "mm",
+  "group_definition": "complete physical object or acquisition session",
+  "selection_lock_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "guard_artifact_id": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "candidate_artifact_id": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+  "fallback_artifact_id": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+  "guard_fit_group_ids": [
+    "source-fit-a",
+    "source-fit-b"
+  ],
+  "guard_calibration_group_ids": [
+    "source-calibration-a",
+    "source-calibration-b"
+  ],
+  "rows": [
+    {
+      "group_id": "source-validation-a",
+      "accepted": true,
+      "candidate_coverage": 0.92,
+      "candidate_width": 9.0,
+      "candidate_score": 0.70,
+      "fallback_coverage": 0.90,
+      "fallback_width": 10.0,
+      "fallback_score": 1.00,
+      "deployed_coverage": 0.92,
+      "deployed_width": 9.0,
+      "deployed_score": 0.70,
+      "metadata": {}
+    },
+    {
+      "group_id": "source-validation-b",
+      "accepted": true,
+      "candidate_coverage": 0.90,
+      "candidate_width": 9.5,
+      "candidate_score": 0.75,
+      "fallback_coverage": 0.90,
+      "fallback_width": 10.0,
+      "fallback_score": 1.00,
+      "deployed_coverage": 0.90,
+      "deployed_width": 9.5,
+      "deployed_score": 0.75,
+      "metadata": {}
+    },
+    {
+      "group_id": "source-validation-c",
+      "accepted": false,
+      "candidate_coverage": 0.80,
+      "candidate_width": 8.0,
+      "candidate_score": 1.30,
+      "fallback_coverage": 0.90,
+      "fallback_width": 10.0,
+      "fallback_score": 1.00,
+      "deployed_coverage": 0.90,
+      "deployed_width": 10.0,
+      "deployed_score": 1.00,
+      "metadata": {}
+    },
+    {
+      "group_id": "source-validation-d",
+      "accepted": false,
+      "candidate_coverage": 0.82,
+      "candidate_width": 8.5,
+      "candidate_score": 1.20,
+      "fallback_coverage": 0.90,
+      "fallback_width": 10.0,
+      "fallback_score": 1.00,
+      "deployed_coverage": 0.90,
+      "deployed_width": 10.0,
+      "deployed_score": 1.00,
+      "metadata": {}
+    }
+  ],
+  "thresholds": {
+    "nominal_coverage": 0.90,
+    "maximum_accepted_coverage_shortfall": 0.05,
+    "maximum_complete_policy_coverage_shortfall": 0.02,
+    "maximum_selection_coverage_drop": 0.05,
+    "maximum_mean_width_ratio_vs_fallback": 1.10,
+    "minimum_mean_score_advantage_vs_fallback": 0.05,
+    "harmful_score_margin": 0.0,
+    "maximum_harmful_accepted_fraction": 0.0,
+    "minimum_accepted_group_count": 2,
+    "maximum_worst_group_coverage_shortfall": 0.05
+  },
+  "metadata": {
+    "split_id": "source-validation-example-v1"
+  }
+}

--- a/docs/gaussian-moment-collapse.md
+++ b/docs/gaussian-moment-collapse.md
@@ -1,0 +1,76 @@
+# Controlled Gaussian moment-collapse diagnostic
+
+Prob4D observation contracts preserve means, covariance, explicit gauge
+uncertainty, association uncertainty, source reliability, and declared dependence.
+A different question is whether a genuinely multimodal point likelihood would be
+reduced to only its first two moments before BayesianPhysTwin consumes it.
+
+`prob4d.moment_collapse_diagnostic` provides a controlled analytic mechanism test.
+It does not claim that any real provider is multimodal and does not change an
+observation schema.
+
+## Symmetric reference mixture
+
+For one 3-D offset `d` and positive-definite component covariance `Sigma`, the
+controlled likelihood is
+
+```text
+p(x) = 0.5 N(x; -d, Sigma) + 0.5 N(x; +d, Sigma).
+```
+
+Its moment-matched Gaussian is
+
+```text
+q(x) = N(x; 0, Sigma + d d^T).
+```
+
+Both representations have the same mean and covariance, but they can assign very
+different probability to the physically implausible midpoint. The diagnostic
+projects onto the Fisher discriminant direction and reports:
+
+- squared Mahalanobis offset `d^T Sigma^-1 d`;
+- component-mean separation in component standard deviations;
+- mixture density at the midpoint relative to a component mean;
+- mixture and moment-Gaussian probability inside a frozen midpoint interval;
+- central-mass inflation under moment matching; and
+- moment-matched projected excess kurtosis.
+
+A case is labelled material only when every frozen threshold passes. The result is
+fully analytic and deterministic; no Monte Carlo tolerance or row order enters its
+identity.
+
+## Running the diagnostic
+
+Use the raw configuration in
+[`examples/moment-collapse-diagnostic-input.json`](examples/moment-collapse-diagnostic-input.json):
+
+```bash
+python -m prob4d.moment_collapse_diagnostic build \
+  docs/examples/moment-collapse-diagnostic-input.json \
+  --output outputs/moment-collapse-diagnostic.json
+
+python -m prob4d.moment_collapse_diagnostic verify \
+  outputs/moment-collapse-diagnostic.json
+```
+
+The artifact is content-addressed, strictly validates all numeric JSON members,
+returns immutable NumPy arrays, rejects non-positive-definite component
+covariance, and publishes without clobbering different retained evidence.
+
+## Decision rule for future schema work
+
+A positive controlled case establishes only that first-two-moment transport can
+lose qualitative information for that constructed mixture. Adding a multimodal
+likelihood payload is scientifically justified only after opened source diagnostics
+show all of the following:
+
+1. a real provider has repeatable multimodal residual structure;
+2. the modes are not already explained by explicit gauge or association nuisance
+   variables;
+3. moment collapse materially changes a preregistered physical query or proper
+   score; and
+4. source/calibration support is sufficient to freeze mixture complexity before a
+   target is opened.
+
+Without that evidence, the diagnostic remains a negative control against
+unnecessary contract growth.

--- a/docs/selective-update-calibration.md
+++ b/docs/selective-update-calibration.md
@@ -1,0 +1,103 @@
+# Calibration after guarded Bayesian update selection
+
+A Bayesian physical-twin guard can select a subset of otherwise calibrated
+observation updates. Calibration of the proposal before selection does not imply
+calibration of the accepted subset. `prob4d.selective_update_calibration` adds a
+source-validation certificate that keeps four populations separate:
+
+1. the candidate update evaluated on every validation object/session;
+2. the candidate restricted to groups accepted by the frozen guard;
+3. the unchanged physical fallback; and
+4. the actually deployed policy, which uses the candidate on acceptance and the
+   exact fallback on rejection.
+
+The artifact is additive. It does not alter provider-v2 observations, the
+BayesianPhysTwin guard, a frozen held-out promotion lock, or any target-access
+rule.
+
+## Statistical and information boundary
+
+Complete physical objects or independently acquired object sessions are the
+independent groups. Frames, points, tracks, cameras, and taxels are not
+independent calibration units.
+
+The certificate binds three disjoint source partitions:
+
+- `guard_fit_group_ids`: groups used to fit guard parameters;
+- `guard_calibration_group_ids`: groups used to choose or calibrate the frozen
+  acceptance rule; and
+- `validation_group_ids`: groups used only to certify post-selection behavior.
+
+Every artifact declares `evidence_partition = "source-validation"` and
+`uses_target_outcomes = false`. Target or confirmation groups must not enter any
+of the three partitions. The proper score is explicitly declared and is always
+interpreted as lower-is-better. Every width uses one declared unit.
+
+## Group rows
+
+Each `SelectiveUpdateGroupV1` row contains candidate, fallback, and deployed
+coverage, width, and proper score, plus the frozen acceptance decision. The
+constructor fails closed unless deployed values equal the candidate for an
+accepted group or the fallback for a rejected group. This makes exact fallback a
+validated semantic condition rather than a report annotation.
+
+Coverage is one group-level coverage statistic at the frozen nominal level. Width
+and proper score must use the same definition in every row. For example, one row
+may contain equal-track 90% coverage, mean full interval width in millimetres, and
+mean Gaussian negative log likelihood for one complete object/session.
+
+## Reported gates
+
+The deterministic report separates proposal, accepted-subset, fallback, and
+complete-policy summaries. Its frozen criteria cover:
+
+- accepted-subset coverage shortfall;
+- complete deployed-policy coverage shortfall;
+- the coverage change induced by selection;
+- accepted-subset width relative to the matched fallback on those same groups;
+- accepted-subset proper-score advantage over the matched fallback;
+- harmful accepted updates;
+- minimum accepted independent-group support; and
+- worst-group deployed coverage shortfall.
+
+The complete-policy score advantage is also reported, but the promotion criterion
+uses the accepted-subset comparison. Otherwise many exact fallback rows could
+dilute either the benefit or harm of the updates that were actually accepted.
+
+Insufficient accepted groups are a valid failed source result. Do not loosen the
+support threshold after inspecting the validation rows.
+
+## Building a certificate
+
+Prepare the raw JSON form shown in
+[`examples/selective-update-calibration-input.json`](examples/selective-update-calibration-input.json),
+then run:
+
+```bash
+python -m prob4d.selective_update_calibration build \
+  docs/examples/selective-update-calibration-input.json \
+  --output outputs/selective-update-calibration.json \
+  --require-pass
+```
+
+A valid failed gate is still written and exits with status 3 when
+`--require-pass` is supplied. Replay a retained artifact with:
+
+```bash
+python -m prob4d.selective_update_calibration verify \
+  outputs/selective-update-calibration.json \
+  --require-pass
+```
+
+The JSON artifact is content-addressed, rejects duplicate keys and non-finite
+constants, and is published atomically without replacing different existing
+bytes.
+
+## Promotion boundary
+
+A passing source-validation certificate authorizes neither target access nor a
+scientific claim. It may be bound into a later target-free promotion lock together
+with the exact guard, candidate, fallback, provider, calibration, and cohort
+identities. The target must still be opened exactly once under its own
+authorization, and provider competence remains separate from downstream physical
+query benefit.

--- a/src/prob4d/moment_collapse_diagnostic.py
+++ b/src/prob4d/moment_collapse_diagnostic.py
@@ -1,0 +1,675 @@
+"""Controlled diagnostic for Gaussian moment collapse of multimodal 3-D evidence.
+
+The current observation-factor contracts preserve means, covariance, gauges, and
+source dependence.  A genuinely bimodal point likelihood can nevertheless be
+made qualitatively different when it is replaced by its moment-matched Gaussian.
+This module quantifies that mechanism for symmetric Gaussian mixtures without
+claiming that any real provider exhibits it.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, TypeAlias
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ._atomic_file import atomic_write_text
+from ._immutable_array import immutable_array
+from ._immutable_json import frozen_finite_json_mapping, plain_json
+from ._selection_evidence_common import (
+    _SHA256,
+    _exact_keys,
+    _sha256_json,
+    _strict_bool,
+    _strict_digest,
+    _strict_integer,
+    _strict_list,
+    _strict_mapping,
+    _strict_real,
+    _strict_string,
+)
+
+FloatArray: TypeAlias = NDArray[np.float64]
+
+MOMENT_COLLAPSE_DIAGNOSTIC_SCHEMA = "prob4d.gaussian-moment-collapse-diagnostic"
+MOMENT_COLLAPSE_DIAGNOSTIC_VERSION = 1
+MOMENT_COLLAPSE_DIAGNOSTIC_CLAIM_BOUNDARY = (
+    "This artifact is controlled mechanism evidence for a symmetric Gaussian-mixture "
+    "replacement by its moment-matched Gaussian. It does not establish that a real "
+    "provider is multimodal, that the current Prob4D contract loses material evidence, "
+    "or that BayesianPhysTwin or Causal4D performance improves."
+)
+
+
+def _positive_real(value: Any, *, name: str) -> float:
+    result = _strict_real(value, name=name)
+    if result <= 0.0:
+        raise ValueError(f"{name} must be positive")
+    return result
+
+
+def _nonnegative_real(value: Any, *, name: str) -> float:
+    result = _strict_real(value, name=name)
+    if result < 0.0:
+        raise ValueError(f"{name} must be non-negative")
+    return result
+
+
+def _probability(value: Any, *, name: str) -> float:
+    result = _nonnegative_real(value, name=name)
+    if result > 1.0:
+        raise ValueError(f"{name} must lie in [0, 1]")
+    return result
+
+
+def _standard_normal_cdf(value: float) -> float:
+    return 0.5 * (1.0 + math.erf(value / math.sqrt(2.0)))
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON key {key!r}")
+        result[key] = value
+    return result
+
+
+def _reject_nonfinite_constant(value: str) -> None:
+    raise ValueError(f"non-finite JSON constant is forbidden: {value}")
+
+
+def _load_json(path: str | Path, *, name: str) -> Mapping[str, Any]:
+    source = Path(path)
+    try:
+        value = json.loads(
+            source.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_keys,
+            parse_constant=_reject_nonfinite_constant,
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"{name} is unreadable or invalid JSON: {source}") from error
+    mapping = _strict_mapping(value, name=name)
+    if any(type(key) is not str for key in mapping):
+        raise ValueError(f"{name} keys must be strings")
+    return mapping
+
+
+@dataclass(frozen=True, slots=True)
+class SymmetricGaussianMixtureCaseV1:
+    """One 50/50 mixture with component means ``-offset`` and ``+offset``."""
+
+    case_id: str
+    offset_xyz: FloatArray
+    component_covariance: FloatArray
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        case_id = _strict_string(self.case_id, name="case_id")
+        offset = np.asarray(self.offset_xyz, dtype=np.float64)
+        covariance = np.asarray(self.component_covariance, dtype=np.float64)
+        if offset.shape != (3,):
+            raise ValueError("offset_xyz must have shape (3,)")
+        if covariance.shape != (3, 3):
+            raise ValueError("component_covariance must have shape (3, 3)")
+        if not np.all(np.isfinite(offset)) or not np.all(np.isfinite(covariance)):
+            raise ValueError("mixture case arrays must be finite")
+        if not np.allclose(covariance, covariance.T, atol=1e-12, rtol=0.0):
+            raise ValueError("component_covariance must be symmetric")
+        try:
+            np.linalg.cholesky(covariance)
+        except np.linalg.LinAlgError as error:
+            raise ValueError("component_covariance must be positive definite") from error
+        if not np.any(offset != 0.0):
+            raise ValueError("offset_xyz must define two distinct component means")
+        object.__setattr__(self, "case_id", case_id)
+        object.__setattr__(self, "offset_xyz", immutable_array(offset, dtype=np.float64))
+        object.__setattr__(
+            self,
+            "component_covariance",
+            immutable_array(covariance, dtype=np.float64),
+        )
+        object.__setattr__(
+            self,
+            "metadata",
+            frozen_finite_json_mapping(self.metadata, name="moment collapse case metadata"),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "case_id": self.case_id,
+            "offset_xyz": self.offset_xyz.tolist(),
+            "component_covariance": self.component_covariance.tolist(),
+            "metadata": plain_json(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, value: Any) -> SymmetricGaussianMixtureCaseV1:
+        mapping = _strict_mapping(value, name="moment collapse case")
+        _exact_keys(
+            mapping,
+            {"case_id", "offset_xyz", "component_covariance", "metadata"},
+            name="moment collapse case",
+        )
+        offset_items = _strict_list(mapping["offset_xyz"], name="offset_xyz")
+        offset = [
+            _strict_real(item, name=f"offset_xyz[{index}]")
+            for index, item in enumerate(offset_items)
+        ]
+        covariance_rows = _strict_list(
+            mapping["component_covariance"],
+            name="component_covariance",
+        )
+        covariance = [
+            [
+                _strict_real(
+                    item,
+                    name=f"component_covariance[{row_index}][{column_index}]",
+                )
+                for column_index, item in enumerate(
+                    _strict_list(
+                        row,
+                        name=f"component_covariance[{row_index}]",
+                    )
+                )
+            ]
+            for row_index, row in enumerate(covariance_rows)
+        ]
+        return cls(
+            case_id=mapping["case_id"],
+            offset_xyz=np.asarray(offset, dtype=np.float64),
+            component_covariance=np.asarray(covariance, dtype=np.float64),
+            metadata=_strict_mapping(mapping["metadata"], name="case metadata"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class MomentCollapseThresholdsV1:
+    """Frozen criteria for a material moment-collapse mechanism."""
+
+    midpoint_half_width_component_sigma: float
+    minimum_component_mean_separation_sigma: float
+    maximum_mixture_midpoint_to_component_mean_density_ratio: float
+    minimum_moment_gaussian_central_mass_inflation: float
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "midpoint_half_width_component_sigma",
+            _positive_real(
+                self.midpoint_half_width_component_sigma,
+                name="midpoint_half_width_component_sigma",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "minimum_component_mean_separation_sigma",
+            _positive_real(
+                self.minimum_component_mean_separation_sigma,
+                name="minimum_component_mean_separation_sigma",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "maximum_mixture_midpoint_to_component_mean_density_ratio",
+            _nonnegative_real(
+                self.maximum_mixture_midpoint_to_component_mean_density_ratio,
+                name="maximum_mixture_midpoint_to_component_mean_density_ratio",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "minimum_moment_gaussian_central_mass_inflation",
+            _probability(
+                self.minimum_moment_gaussian_central_mass_inflation,
+                name="minimum_moment_gaussian_central_mass_inflation",
+            ),
+        )
+
+    def to_dict(self) -> dict[str, float]:
+        return {
+            "midpoint_half_width_component_sigma": (
+                self.midpoint_half_width_component_sigma
+            ),
+            "minimum_component_mean_separation_sigma": (
+                self.minimum_component_mean_separation_sigma
+            ),
+            "maximum_mixture_midpoint_to_component_mean_density_ratio": (
+                self.maximum_mixture_midpoint_to_component_mean_density_ratio
+            ),
+            "minimum_moment_gaussian_central_mass_inflation": (
+                self.minimum_moment_gaussian_central_mass_inflation
+            ),
+        }
+
+    @classmethod
+    def from_dict(cls, value: Any) -> MomentCollapseThresholdsV1:
+        mapping = _strict_mapping(value, name="moment collapse thresholds")
+        _exact_keys(mapping, set(cls.__dataclass_fields__), name="moment collapse thresholds")
+        return cls(**mapping)
+
+
+@dataclass(frozen=True, slots=True)
+class MomentCollapseCaseReportV1:
+    """Analytic one-dimensional discriminant diagnostics for one case."""
+
+    case_id: str
+    mahalanobis_offset_squared: float
+    component_mean_separation_sigma: float
+    mixture_midpoint_to_component_mean_density_ratio: float
+    mixture_central_mass: float
+    moment_gaussian_central_mass: float
+    moment_gaussian_central_mass_inflation: float
+    moment_matched_excess_kurtosis: float
+    material_moment_collapse: bool
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "case_id", _strict_string(self.case_id, name="case_id"))
+        for field_name in (
+            "mahalanobis_offset_squared",
+            "component_mean_separation_sigma",
+        ):
+            value = _strict_real(getattr(self, field_name), name=field_name)
+            if value < 0.0:
+                raise ValueError(f"{field_name} must be non-negative")
+            object.__setattr__(self, field_name, value)
+        density_ratio = _strict_real(
+            self.mixture_midpoint_to_component_mean_density_ratio,
+            name="mixture_midpoint_to_component_mean_density_ratio",
+        )
+        if density_ratio < 0.0:
+            raise ValueError(
+                "mixture_midpoint_to_component_mean_density_ratio must be non-negative"
+            )
+        object.__setattr__(
+            self,
+            "mixture_midpoint_to_component_mean_density_ratio",
+            density_ratio,
+        )
+        for field_name in (
+            "mixture_central_mass",
+            "moment_gaussian_central_mass",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _probability(getattr(self, field_name), name=field_name),
+            )
+        inflation = _strict_real(
+            self.moment_gaussian_central_mass_inflation,
+            name="moment_gaussian_central_mass_inflation",
+        )
+        if inflation < -1.0 or inflation > 1.0:
+            raise ValueError("central-mass inflation must lie in [-1, 1]")
+        object.__setattr__(
+            self,
+            "moment_gaussian_central_mass_inflation",
+            inflation,
+        )
+        kurtosis = _strict_real(
+            self.moment_matched_excess_kurtosis,
+            name="moment_matched_excess_kurtosis",
+        )
+        if kurtosis < -2.0 - 1e-12 or kurtosis > 0.0 + 1e-12:
+            raise ValueError("symmetric-mixture excess kurtosis must lie in [-2, 0]")
+        object.__setattr__(self, "moment_matched_excess_kurtosis", kurtosis)
+        object.__setattr__(
+            self,
+            "material_moment_collapse",
+            _strict_bool(
+                self.material_moment_collapse,
+                name="material_moment_collapse",
+            ),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            field_name: getattr(self, field_name)
+            for field_name in self.__dataclass_fields__
+        }
+
+    @classmethod
+    def from_dict(cls, value: Any) -> MomentCollapseCaseReportV1:
+        mapping = _strict_mapping(value, name="moment collapse case report")
+        _exact_keys(mapping, set(cls.__dataclass_fields__), name="moment collapse case report")
+        return cls(**mapping)
+
+
+def moment_matched_gaussian(
+    case: SymmetricGaussianMixtureCaseV1,
+) -> tuple[FloatArray, FloatArray]:
+    """Return the zero mean and covariance matching the mixture's first two moments."""
+
+    if not isinstance(case, SymmetricGaussianMixtureCaseV1):
+        raise ValueError("case must be SymmetricGaussianMixtureCaseV1")
+    mean = immutable_array(np.zeros(3, dtype=np.float64), dtype=np.float64)
+    covariance = case.component_covariance + np.outer(case.offset_xyz, case.offset_xyz)
+    return mean, immutable_array(covariance, dtype=np.float64)
+
+
+def evaluate_moment_collapse_case(
+    case: SymmetricGaussianMixtureCaseV1,
+    thresholds: MomentCollapseThresholdsV1,
+) -> MomentCollapseCaseReportV1:
+    """Compute analytic Fisher-axis diagnostics for one symmetric mixture."""
+
+    if not isinstance(case, SymmetricGaussianMixtureCaseV1):
+        raise ValueError("case must be SymmetricGaussianMixtureCaseV1")
+    if not isinstance(thresholds, MomentCollapseThresholdsV1):
+        raise ValueError("thresholds must be MomentCollapseThresholdsV1")
+    solved = np.linalg.solve(case.component_covariance, case.offset_xyz)
+    mahalanobis_squared = float(case.offset_xyz @ solved)
+    offset_sigma = math.sqrt(max(0.0, mahalanobis_squared))
+    separation = 2.0 * offset_sigma
+    midpoint_ratio = (
+        2.0 * math.exp(-0.5 * mahalanobis_squared)
+        / (1.0 + math.exp(-2.0 * mahalanobis_squared))
+    )
+    half_width = thresholds.midpoint_half_width_component_sigma
+    mixture_mass = _standard_normal_cdf(half_width - offset_sigma) - _standard_normal_cdf(
+        -half_width - offset_sigma
+    )
+    matched_standard_deviation = math.sqrt(1.0 + mahalanobis_squared)
+    gaussian_mass = 2.0 * _standard_normal_cdf(
+        half_width / matched_standard_deviation
+    ) - 1.0
+    inflation = gaussian_mass - mixture_mass
+    excess_kurtosis = (
+        -2.0
+        * mahalanobis_squared**2
+        / (1.0 + mahalanobis_squared) ** 2
+    )
+    material = (
+        separation >= thresholds.minimum_component_mean_separation_sigma
+        and midpoint_ratio
+        <= thresholds.maximum_mixture_midpoint_to_component_mean_density_ratio
+        and inflation
+        >= thresholds.minimum_moment_gaussian_central_mass_inflation
+    )
+    return MomentCollapseCaseReportV1(
+        case_id=case.case_id,
+        mahalanobis_offset_squared=mahalanobis_squared,
+        component_mean_separation_sigma=separation,
+        mixture_midpoint_to_component_mean_density_ratio=midpoint_ratio,
+        mixture_central_mass=mixture_mass,
+        moment_gaussian_central_mass=gaussian_mass,
+        moment_gaussian_central_mass_inflation=inflation,
+        moment_matched_excess_kurtosis=excess_kurtosis,
+        material_moment_collapse=material,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class MomentCollapseDiagnosticV1:
+    """Content-addressed controlled mechanism study over canonical cases."""
+
+    representation_name: str
+    thresholds: MomentCollapseThresholdsV1
+    cases: tuple[SymmetricGaussianMixtureCaseV1, ...]
+    reports: tuple[MomentCollapseCaseReportV1, ...]
+    material_case_count: int
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        representation = _strict_string(
+            self.representation_name,
+            name="representation_name",
+        )
+        if not isinstance(self.thresholds, MomentCollapseThresholdsV1):
+            raise ValueError("thresholds must be MomentCollapseThresholdsV1")
+        if type(self.cases) is not tuple or not self.cases or not all(
+            isinstance(case, SymmetricGaussianMixtureCaseV1) for case in self.cases
+        ):
+            raise ValueError("cases must be a nonempty tuple of mixture cases")
+        case_ids = tuple(case.case_id for case in self.cases)
+        if case_ids != tuple(sorted(case_ids)) or len(case_ids) != len(set(case_ids)):
+            raise ValueError("cases must be sorted by unique case_id")
+        if type(self.reports) is not tuple or not all(
+            isinstance(report, MomentCollapseCaseReportV1) for report in self.reports
+        ):
+            raise ValueError("reports must be a tuple of case reports")
+        replayed = tuple(
+            evaluate_moment_collapse_case(case, self.thresholds)
+            for case in self.cases
+        )
+        if [report.to_dict() for report in self.reports] != [
+            report.to_dict() for report in replayed
+        ]:
+            raise ValueError("moment collapse reports do not match deterministic replay")
+        material_count = _strict_integer(
+            self.material_case_count,
+            name="material_case_count",
+            minimum=0,
+        )
+        expected_count = sum(report.material_moment_collapse for report in replayed)
+        if material_count != expected_count:
+            raise ValueError("material_case_count does not match replayed reports")
+        object.__setattr__(self, "representation_name", representation)
+        object.__setattr__(self, "reports", replayed)
+        object.__setattr__(self, "material_case_count", material_count)
+        object.__setattr__(
+            self,
+            "metadata",
+            frozen_finite_json_mapping(self.metadata, name="moment collapse metadata"),
+        )
+
+    @property
+    def any_material_moment_collapse(self) -> bool:
+        return self.material_case_count > 0
+
+    def descriptor(self) -> dict[str, object]:
+        return {
+            "schema_name": MOMENT_COLLAPSE_DIAGNOSTIC_SCHEMA,
+            "schema_version": MOMENT_COLLAPSE_DIAGNOSTIC_VERSION,
+            "representation_name": self.representation_name,
+            "thresholds": self.thresholds.to_dict(),
+            "cases": [case.to_dict() for case in self.cases],
+            "reports": [report.to_dict() for report in self.reports],
+            "material_case_count": self.material_case_count,
+            "any_material_moment_collapse": self.any_material_moment_collapse,
+            "metadata": plain_json(self.metadata),
+            "claim_boundary": MOMENT_COLLAPSE_DIAGNOSTIC_CLAIM_BOUNDARY,
+        }
+
+    @property
+    def artifact_id(self) -> str:
+        return _sha256_json(self.descriptor())
+
+    def to_dict(self) -> dict[str, object]:
+        return {**self.descriptor(), "artifact_id": self.artifact_id}
+
+    @classmethod
+    def from_dict(cls, value: Any) -> MomentCollapseDiagnosticV1:
+        mapping = _strict_mapping(value, name="moment collapse diagnostic")
+        _exact_keys(
+            mapping,
+            {
+                "schema_name",
+                "schema_version",
+                "representation_name",
+                "thresholds",
+                "cases",
+                "reports",
+                "material_case_count",
+                "any_material_moment_collapse",
+                "metadata",
+                "claim_boundary",
+                "artifact_id",
+            },
+            name="moment collapse diagnostic",
+        )
+        if mapping["schema_name"] != MOMENT_COLLAPSE_DIAGNOSTIC_SCHEMA:
+            raise ValueError("unsupported moment collapse diagnostic schema")
+        if mapping["schema_version"] != MOMENT_COLLAPSE_DIAGNOSTIC_VERSION:
+            raise ValueError("unsupported moment collapse diagnostic version")
+        if mapping["claim_boundary"] != MOMENT_COLLAPSE_DIAGNOSTIC_CLAIM_BOUNDARY:
+            raise ValueError("moment collapse claim boundary changed")
+        cases = tuple(
+            SymmetricGaussianMixtureCaseV1.from_dict(case)
+            for case in _strict_list(mapping["cases"], name="cases")
+        )
+        reports = tuple(
+            MomentCollapseCaseReportV1.from_dict(report)
+            for report in _strict_list(mapping["reports"], name="reports")
+        )
+        artifact = cls(
+            representation_name=mapping["representation_name"],
+            thresholds=MomentCollapseThresholdsV1.from_dict(mapping["thresholds"]),
+            cases=cases,
+            reports=reports,
+            material_case_count=mapping["material_case_count"],
+            metadata=_strict_mapping(mapping["metadata"], name="metadata"),
+        )
+        supplied_any = _strict_bool(
+            mapping["any_material_moment_collapse"],
+            name="any_material_moment_collapse",
+        )
+        if supplied_any != artifact.any_material_moment_collapse:
+            raise ValueError("any_material_moment_collapse does not match reports")
+        supplied_id = _strict_digest(
+            mapping["artifact_id"],
+            name="artifact_id",
+            pattern=_SHA256,
+        )
+        if supplied_id != artifact.artifact_id:
+            raise ValueError("moment collapse diagnostic artifact_id mismatch")
+        return artifact
+
+
+def build_moment_collapse_diagnostic(
+    *,
+    representation_name: str,
+    cases: Sequence[SymmetricGaussianMixtureCaseV1],
+    thresholds: MomentCollapseThresholdsV1,
+    metadata: Mapping[str, Any] | None = None,
+) -> MomentCollapseDiagnosticV1:
+    """Canonicalize cases and build a replayable controlled diagnostic."""
+
+    supplied_cases = tuple(cases)
+    if not supplied_cases or not all(
+        isinstance(case, SymmetricGaussianMixtureCaseV1) for case in supplied_cases
+    ):
+        raise ValueError(
+            "cases must be a nonempty sequence of SymmetricGaussianMixtureCaseV1"
+        )
+    ordered_cases = tuple(sorted(supplied_cases, key=lambda case: case.case_id))
+    reports = tuple(
+        evaluate_moment_collapse_case(case, thresholds)
+        for case in ordered_cases
+    )
+    return MomentCollapseDiagnosticV1(
+        representation_name=representation_name,
+        thresholds=thresholds,
+        cases=ordered_cases,
+        reports=reports,
+        material_case_count=sum(report.material_moment_collapse for report in reports),
+        metadata={} if metadata is None else metadata,
+    )
+
+
+def moment_collapse_diagnostic_from_raw(value: Any) -> MomentCollapseDiagnosticV1:
+    mapping = _strict_mapping(value, name="raw moment collapse diagnostic")
+    _exact_keys(
+        mapping,
+        {"representation_name", "thresholds", "cases", "metadata"},
+        name="raw moment collapse diagnostic",
+    )
+    return build_moment_collapse_diagnostic(
+        representation_name=mapping["representation_name"],
+        thresholds=MomentCollapseThresholdsV1.from_dict(mapping["thresholds"]),
+        cases=tuple(
+            SymmetricGaussianMixtureCaseV1.from_dict(case)
+            for case in _strict_list(mapping["cases"], name="cases")
+        ),
+        metadata=_strict_mapping(mapping["metadata"], name="metadata"),
+    )
+
+
+def write_moment_collapse_diagnostic(
+    artifact: MomentCollapseDiagnosticV1,
+    path: str | Path,
+) -> None:
+    if not isinstance(artifact, MomentCollapseDiagnosticV1):
+        raise ValueError("artifact must be MomentCollapseDiagnosticV1")
+    destination = Path(path)
+    payload = json.dumps(
+        artifact.to_dict(),
+        sort_keys=True,
+        indent=2,
+        allow_nan=False,
+    ) + "\n"
+    try:
+        atomic_write_text(destination, payload, overwrite=False)
+    except FileExistsError:
+        existing = load_moment_collapse_diagnostic(destination)
+        if existing.to_dict() == artifact.to_dict():
+            return
+        raise FileExistsError(
+            f"refusing to replace a different moment collapse diagnostic: {destination}"
+        ) from None
+
+
+def load_moment_collapse_diagnostic(path: str | Path) -> MomentCollapseDiagnosticV1:
+    return MomentCollapseDiagnosticV1.from_dict(
+        _load_json(path, name="moment collapse diagnostic")
+    )
+
+
+def _build_cli(arguments: argparse.Namespace) -> int:
+    artifact = moment_collapse_diagnostic_from_raw(
+        _load_json(arguments.input, name="raw moment collapse diagnostic")
+    )
+    write_moment_collapse_diagnostic(artifact, arguments.output)
+    print(artifact.artifact_id)
+    return 0
+
+
+def _verify_cli(arguments: argparse.Namespace) -> int:
+    artifact = load_moment_collapse_diagnostic(arguments.artifact)
+    print(artifact.artifact_id)
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Build or verify the controlled Gaussian moment-collapse diagnostic."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    build = subparsers.add_parser("build", help="build the controlled diagnostic")
+    build.add_argument("input", type=Path)
+    build.add_argument("--output", type=Path, required=True)
+    build.set_defaults(handler=_build_cli)
+    verify = subparsers.add_parser("verify", help="verify and replay a diagnostic")
+    verify.add_argument("artifact", type=Path)
+    verify.set_defaults(handler=_verify_cli)
+    arguments = parser.parse_args(argv)
+    return int(arguments.handler(arguments))
+
+
+__all__ = [
+    "MOMENT_COLLAPSE_DIAGNOSTIC_CLAIM_BOUNDARY",
+    "MOMENT_COLLAPSE_DIAGNOSTIC_SCHEMA",
+    "MOMENT_COLLAPSE_DIAGNOSTIC_VERSION",
+    "MomentCollapseCaseReportV1",
+    "MomentCollapseDiagnosticV1",
+    "MomentCollapseThresholdsV1",
+    "SymmetricGaussianMixtureCaseV1",
+    "build_moment_collapse_diagnostic",
+    "evaluate_moment_collapse_case",
+    "load_moment_collapse_diagnostic",
+    "main",
+    "moment_collapse_diagnostic_from_raw",
+    "moment_matched_gaussian",
+    "write_moment_collapse_diagnostic",
+]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/prob4d/selective_update_calibration.py
+++ b/src/prob4d/selective_update_calibration.py
@@ -1,0 +1,1116 @@
+"""Source-validation calibration after a guarded Bayesian update decision.
+
+A proposal can be calibrated before a BayesianPhysTwin guard is applied while the
+accepted subset is not.  This module records one equal-object/session validation
+row per independent group, separates the unselected candidate, the accepted
+subset, the exact fallback, and the deployed policy, and evaluates frozen gates
+without inspecting target outcomes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from ._atomic_file import atomic_write_text
+from ._immutable_json import frozen_finite_json_mapping, plain_json
+from ._selection_evidence_common import (
+    _SHA256,
+    _exact_keys,
+    _sha256_json,
+    _strict_bool,
+    _strict_digest,
+    _strict_integer,
+    _strict_list,
+    _strict_mapping,
+    _strict_real,
+    _strict_string,
+)
+
+SELECTIVE_UPDATE_CALIBRATION_SCHEMA = "prob4d.selective-update-calibration"
+SELECTIVE_UPDATE_CALIBRATION_VERSION = 1
+SELECTIVE_UPDATE_EVIDENCE_PARTITION = "source-validation"
+SELECTIVE_UPDATE_SCORE_DIRECTION = "lower-is-better"
+SELECTIVE_UPDATE_USES_TARGET_OUTCOMES = False
+SELECTIVE_UPDATE_CALIBRATION_CLAIM_BOUNDARY = (
+    "This artifact certifies source-validation calibration after one frozen "
+    "Bayesian update-selection guard. Complete physical objects or acquisition "
+    "sessions are the independent groups. It does not establish target calibration, "
+    "unseen-object benefit, Causal4D intervention benefit, deployment safety, or "
+    "state of the art."
+)
+
+_CRITERION_NAMES = (
+    "accepted_coverage",
+    "complete_policy_coverage",
+    "harmful_accepted_fraction",
+    "mean_score_advantage",
+    "mean_width_ratio",
+    "minimum_accepted_group_count",
+    "selection_coverage_drop",
+    "worst_group_coverage",
+)
+
+
+def _probability(value: Any, *, name: str) -> float:
+    result = _strict_real(value, name=name)
+    if result < 0.0 or result > 1.0:
+        raise ValueError(f"{name} must lie in [0, 1]")
+    return result
+
+
+def _positive_real(value: Any, *, name: str) -> float:
+    result = _strict_real(value, name=name)
+    if result <= 0.0:
+        raise ValueError(f"{name} must be positive")
+    return result
+
+
+def _nonnegative_real(value: Any, *, name: str) -> float:
+    result = _strict_real(value, name=name)
+    if result < 0.0:
+        raise ValueError(f"{name} must be non-negative")
+    return result
+
+
+def _optional_real(value: Any, *, name: str) -> float | None:
+    return None if value is None else _strict_real(value, name=name)
+
+
+def _canonical_string_tuple(values: Sequence[Any], *, name: str) -> tuple[str, ...]:
+    result = tuple(
+        _strict_string(value, name=f"{name}[{index}]")
+        for index, value in enumerate(values)
+    )
+    if not result:
+        raise ValueError(f"{name} must not be empty")
+    if result != tuple(sorted(result)) or len(result) != len(set(result)):
+        raise ValueError(f"{name} must be sorted and unique")
+    return result
+
+
+def _string_tuple_from_json(value: Any, *, name: str) -> tuple[str, ...]:
+    return _canonical_string_tuple(_strict_list(value, name=name), name=name)
+
+
+def _same_metric(observed: float, expected: float) -> bool:
+    return observed == expected or math.isclose(
+        observed,
+        expected,
+        rel_tol=0.0,
+        abs_tol=1e-12,
+    )
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON key {key!r}")
+        result[key] = value
+    return result
+
+
+def _reject_nonfinite_constant(value: str) -> None:
+    raise ValueError(f"non-finite JSON constant is forbidden: {value}")
+
+
+def _load_json(path: str | Path, *, name: str) -> Mapping[str, Any]:
+    source = Path(path)
+    try:
+        value = json.loads(
+            source.read_text(encoding="utf-8"),
+            object_pairs_hook=_reject_duplicate_keys,
+            parse_constant=_reject_nonfinite_constant,
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"{name} is unreadable or invalid JSON: {source}") from error
+    mapping = _strict_mapping(value, name=name)
+    if any(type(key) is not str for key in mapping):
+        raise ValueError(f"{name} keys must be strings")
+    return mapping
+
+
+@dataclass(frozen=True, slots=True)
+class SelectiveUpdateGroupV1:
+    """One equal-mass independent source-validation group."""
+
+    group_id: str
+    accepted: bool
+    candidate_coverage: float
+    candidate_width: float
+    candidate_score: float
+    fallback_coverage: float
+    fallback_width: float
+    fallback_score: float
+    deployed_coverage: float
+    deployed_width: float
+    deployed_score: float
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "group_id", _strict_string(self.group_id, name="group_id"))
+        object.__setattr__(self, "accepted", _strict_bool(self.accepted, name="accepted"))
+        for field_name in ("candidate_coverage", "fallback_coverage", "deployed_coverage"):
+            object.__setattr__(
+                self,
+                field_name,
+                _probability(getattr(self, field_name), name=field_name),
+            )
+        for field_name in ("candidate_width", "fallback_width", "deployed_width"):
+            object.__setattr__(
+                self,
+                field_name,
+                _positive_real(getattr(self, field_name), name=field_name),
+            )
+        for field_name in ("candidate_score", "fallback_score", "deployed_score"):
+            object.__setattr__(
+                self,
+                field_name,
+                _strict_real(getattr(self, field_name), name=field_name),
+            )
+        expected_prefix = "candidate" if self.accepted else "fallback"
+        for suffix in ("coverage", "width", "score"):
+            deployed_name = f"deployed_{suffix}"
+            observed = float(getattr(self, deployed_name))
+            expected = float(getattr(self, f"{expected_prefix}_{suffix}"))
+            if not _same_metric(observed, expected):
+                raise ValueError(
+                    "deployed metrics must equal the accepted candidate or exact fallback"
+                )
+            object.__setattr__(self, deployed_name, expected)
+        object.__setattr__(
+            self,
+            "metadata",
+            frozen_finite_json_mapping(self.metadata, name="selective update group metadata"),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "group_id": self.group_id,
+            "accepted": self.accepted,
+            "candidate_coverage": self.candidate_coverage,
+            "candidate_width": self.candidate_width,
+            "candidate_score": self.candidate_score,
+            "fallback_coverage": self.fallback_coverage,
+            "fallback_width": self.fallback_width,
+            "fallback_score": self.fallback_score,
+            "deployed_coverage": self.deployed_coverage,
+            "deployed_width": self.deployed_width,
+            "deployed_score": self.deployed_score,
+            "metadata": plain_json(self.metadata),
+        }
+
+    @classmethod
+    def from_dict(cls, value: Any) -> SelectiveUpdateGroupV1:
+        mapping = _strict_mapping(value, name="selective update group")
+        _exact_keys(
+            mapping,
+            {
+                "group_id",
+                "accepted",
+                "candidate_coverage",
+                "candidate_width",
+                "candidate_score",
+                "fallback_coverage",
+                "fallback_width",
+                "fallback_score",
+                "deployed_coverage",
+                "deployed_width",
+                "deployed_score",
+                "metadata",
+            },
+            name="selective update group",
+        )
+        return cls(
+            group_id=mapping["group_id"],
+            accepted=mapping["accepted"],
+            candidate_coverage=mapping["candidate_coverage"],
+            candidate_width=mapping["candidate_width"],
+            candidate_score=mapping["candidate_score"],
+            fallback_coverage=mapping["fallback_coverage"],
+            fallback_width=mapping["fallback_width"],
+            fallback_score=mapping["fallback_score"],
+            deployed_coverage=mapping["deployed_coverage"],
+            deployed_width=mapping["deployed_width"],
+            deployed_score=mapping["deployed_score"],
+            metadata=_strict_mapping(mapping["metadata"], name="group metadata"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class SelectiveUpdateThresholdsV1:
+    """Frozen source-validation gates for the guarded deployment policy."""
+
+    nominal_coverage: float
+    maximum_accepted_coverage_shortfall: float
+    maximum_complete_policy_coverage_shortfall: float
+    maximum_selection_coverage_drop: float
+    maximum_mean_width_ratio_vs_fallback: float
+    minimum_mean_score_advantage_vs_fallback: float
+    harmful_score_margin: float
+    maximum_harmful_accepted_fraction: float
+    minimum_accepted_group_count: int
+    maximum_worst_group_coverage_shortfall: float
+
+    def __post_init__(self) -> None:
+        nominal = _probability(self.nominal_coverage, name="nominal_coverage")
+        if nominal <= 0.0:
+            raise ValueError("nominal_coverage must be positive")
+        object.__setattr__(self, "nominal_coverage", nominal)
+        for field_name in (
+            "maximum_accepted_coverage_shortfall",
+            "maximum_complete_policy_coverage_shortfall",
+            "maximum_selection_coverage_drop",
+            "maximum_harmful_accepted_fraction",
+            "maximum_worst_group_coverage_shortfall",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _probability(getattr(self, field_name), name=field_name),
+            )
+        object.__setattr__(
+            self,
+            "maximum_mean_width_ratio_vs_fallback",
+            _positive_real(
+                self.maximum_mean_width_ratio_vs_fallback,
+                name="maximum_mean_width_ratio_vs_fallback",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "minimum_mean_score_advantage_vs_fallback",
+            _nonnegative_real(
+                self.minimum_mean_score_advantage_vs_fallback,
+                name="minimum_mean_score_advantage_vs_fallback",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "harmful_score_margin",
+            _nonnegative_real(self.harmful_score_margin, name="harmful_score_margin"),
+        )
+        object.__setattr__(
+            self,
+            "minimum_accepted_group_count",
+            _strict_integer(
+                self.minimum_accepted_group_count,
+                name="minimum_accepted_group_count",
+                minimum=1,
+            ),
+        )
+
+    def to_dict(self) -> dict[str, int | float]:
+        return {
+            "nominal_coverage": self.nominal_coverage,
+            "maximum_accepted_coverage_shortfall": (
+                self.maximum_accepted_coverage_shortfall
+            ),
+            "maximum_complete_policy_coverage_shortfall": (
+                self.maximum_complete_policy_coverage_shortfall
+            ),
+            "maximum_selection_coverage_drop": self.maximum_selection_coverage_drop,
+            "maximum_mean_width_ratio_vs_fallback": (
+                self.maximum_mean_width_ratio_vs_fallback
+            ),
+            "minimum_mean_score_advantage_vs_fallback": (
+                self.minimum_mean_score_advantage_vs_fallback
+            ),
+            "harmful_score_margin": self.harmful_score_margin,
+            "maximum_harmful_accepted_fraction": (
+                self.maximum_harmful_accepted_fraction
+            ),
+            "minimum_accepted_group_count": self.minimum_accepted_group_count,
+            "maximum_worst_group_coverage_shortfall": (
+                self.maximum_worst_group_coverage_shortfall
+            ),
+        }
+
+    @classmethod
+    def from_dict(cls, value: Any) -> SelectiveUpdateThresholdsV1:
+        mapping = _strict_mapping(value, name="selective update thresholds")
+        _exact_keys(
+            mapping,
+            {
+                "nominal_coverage",
+                "maximum_accepted_coverage_shortfall",
+                "maximum_complete_policy_coverage_shortfall",
+                "maximum_selection_coverage_drop",
+                "maximum_mean_width_ratio_vs_fallback",
+                "minimum_mean_score_advantage_vs_fallback",
+                "harmful_score_margin",
+                "maximum_harmful_accepted_fraction",
+                "minimum_accepted_group_count",
+                "maximum_worst_group_coverage_shortfall",
+            },
+            name="selective update thresholds",
+        )
+        return cls(**mapping)
+
+
+@dataclass(frozen=True, slots=True)
+class SelectiveUpdateCalibrationReportV1:
+    """Equal-group proposal, selected-subset, fallback, and deployed diagnostics."""
+
+    group_count: int
+    accepted_group_count: int
+    rejected_group_count: int
+    candidate_mean_coverage: float
+    accepted_mean_coverage: float | None
+    fallback_mean_coverage: float
+    deployed_mean_coverage: float
+    selection_coverage_drop: float | None
+    candidate_mean_width: float
+    accepted_mean_width: float | None
+    accepted_fallback_mean_width: float | None
+    accepted_to_fallback_width_ratio: float | None
+    fallback_mean_width: float
+    deployed_mean_width: float
+    deployed_to_fallback_width_ratio: float
+    candidate_mean_score: float
+    accepted_candidate_mean_score: float | None
+    accepted_fallback_mean_score: float | None
+    accepted_score_advantage_vs_fallback: float | None
+    fallback_mean_score: float
+    deployed_mean_score: float
+    deployed_score_advantage_vs_fallback: float
+    harmful_accepted_count: int
+    harmful_accepted_fraction: float
+    worst_group_deployed_coverage_shortfall: float
+    criteria: Mapping[str, Any]
+    passed: bool
+
+    def __post_init__(self) -> None:
+        group_count = _strict_integer(self.group_count, name="group_count", minimum=1)
+        accepted = _strict_integer(
+            self.accepted_group_count,
+            name="accepted_group_count",
+            minimum=0,
+        )
+        rejected = _strict_integer(
+            self.rejected_group_count,
+            name="rejected_group_count",
+            minimum=0,
+        )
+        if accepted + rejected != group_count:
+            raise ValueError("accepted and rejected counts must sum to group_count")
+        harmful = _strict_integer(
+            self.harmful_accepted_count,
+            name="harmful_accepted_count",
+            minimum=0,
+        )
+        if harmful > accepted:
+            raise ValueError("harmful accepted count exceeds accepted count")
+        object.__setattr__(self, "group_count", group_count)
+        object.__setattr__(self, "accepted_group_count", accepted)
+        object.__setattr__(self, "rejected_group_count", rejected)
+        object.__setattr__(self, "harmful_accepted_count", harmful)
+        for field_name in (
+            "candidate_mean_coverage",
+            "fallback_mean_coverage",
+            "deployed_mean_coverage",
+            "harmful_accepted_fraction",
+            "worst_group_deployed_coverage_shortfall",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _probability(getattr(self, field_name), name=field_name),
+            )
+        accepted_coverage = _optional_real(
+            self.accepted_mean_coverage,
+            name="accepted_mean_coverage",
+        )
+        if accepted_coverage is not None:
+            accepted_coverage = _probability(
+                accepted_coverage,
+                name="accepted_mean_coverage",
+            )
+        object.__setattr__(self, "accepted_mean_coverage", accepted_coverage)
+        selection_drop = _optional_real(
+            self.selection_coverage_drop,
+            name="selection_coverage_drop",
+        )
+        object.__setattr__(self, "selection_coverage_drop", selection_drop)
+        for field_name in (
+            "candidate_mean_width",
+            "fallback_mean_width",
+            "deployed_mean_width",
+            "deployed_to_fallback_width_ratio",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _positive_real(getattr(self, field_name), name=field_name),
+            )
+        for field_name in (
+            "accepted_mean_width",
+            "accepted_fallback_mean_width",
+            "accepted_to_fallback_width_ratio",
+        ):
+            value = _optional_real(getattr(self, field_name), name=field_name)
+            if value is not None and value <= 0.0:
+                raise ValueError(f"{field_name} must be positive when present")
+            object.__setattr__(self, field_name, value)
+        for field_name in (
+            "candidate_mean_score",
+            "fallback_mean_score",
+            "deployed_mean_score",
+            "deployed_score_advantage_vs_fallback",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _strict_real(getattr(self, field_name), name=field_name),
+            )
+        for field_name in (
+            "accepted_candidate_mean_score",
+            "accepted_fallback_mean_score",
+            "accepted_score_advantage_vs_fallback",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _optional_real(getattr(self, field_name), name=field_name),
+            )
+        optional_fields = (
+            self.accepted_mean_coverage,
+            self.accepted_mean_width,
+            self.accepted_fallback_mean_width,
+            self.accepted_to_fallback_width_ratio,
+            self.accepted_candidate_mean_score,
+            self.accepted_fallback_mean_score,
+            self.accepted_score_advantage_vs_fallback,
+        )
+        if accepted == 0 and any(value is not None for value in optional_fields):
+            raise ValueError("accepted-subset diagnostics require accepted groups")
+        if accepted > 0 and any(value is None for value in optional_fields):
+            raise ValueError("accepted groups require complete accepted-subset diagnostics")
+        criteria = _strict_mapping(self.criteria, name="selective update criteria")
+        if set(criteria) != set(_CRITERION_NAMES):
+            raise ValueError("selective update criteria names changed")
+        normalized_criteria = {
+            name: _strict_bool(criteria[name], name=f"criteria[{name!r}]")
+            for name in _CRITERION_NAMES
+        }
+        passed = _strict_bool(self.passed, name="passed")
+        if passed != all(normalized_criteria.values()):
+            raise ValueError("passed must equal the conjunction of all criteria")
+        object.__setattr__(
+            self,
+            "criteria",
+            frozen_finite_json_mapping(normalized_criteria, name="criteria"),
+        )
+        object.__setattr__(self, "passed", passed)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "group_count": self.group_count,
+            "accepted_group_count": self.accepted_group_count,
+            "rejected_group_count": self.rejected_group_count,
+            "candidate_mean_coverage": self.candidate_mean_coverage,
+            "accepted_mean_coverage": self.accepted_mean_coverage,
+            "fallback_mean_coverage": self.fallback_mean_coverage,
+            "deployed_mean_coverage": self.deployed_mean_coverage,
+            "selection_coverage_drop": self.selection_coverage_drop,
+            "candidate_mean_width": self.candidate_mean_width,
+            "accepted_mean_width": self.accepted_mean_width,
+            "accepted_fallback_mean_width": self.accepted_fallback_mean_width,
+            "accepted_to_fallback_width_ratio": (
+                self.accepted_to_fallback_width_ratio
+            ),
+            "fallback_mean_width": self.fallback_mean_width,
+            "deployed_mean_width": self.deployed_mean_width,
+            "deployed_to_fallback_width_ratio": (
+                self.deployed_to_fallback_width_ratio
+            ),
+            "candidate_mean_score": self.candidate_mean_score,
+            "accepted_candidate_mean_score": (
+                self.accepted_candidate_mean_score
+            ),
+            "accepted_fallback_mean_score": (
+                self.accepted_fallback_mean_score
+            ),
+            "accepted_score_advantage_vs_fallback": (
+                self.accepted_score_advantage_vs_fallback
+            ),
+            "fallback_mean_score": self.fallback_mean_score,
+            "deployed_mean_score": self.deployed_mean_score,
+            "deployed_score_advantage_vs_fallback": (
+                self.deployed_score_advantage_vs_fallback
+            ),
+            "harmful_accepted_count": self.harmful_accepted_count,
+            "harmful_accepted_fraction": self.harmful_accepted_fraction,
+            "worst_group_deployed_coverage_shortfall": (
+                self.worst_group_deployed_coverage_shortfall
+            ),
+            "criteria": plain_json(self.criteria),
+            "passed": self.passed,
+        }
+
+    @classmethod
+    def from_dict(cls, value: Any) -> SelectiveUpdateCalibrationReportV1:
+        mapping = _strict_mapping(value, name="selective update report")
+        _exact_keys(mapping, set(cls.__dataclass_fields__), name="selective update report")
+        return cls(**mapping)
+
+
+def _mean(rows: Sequence[SelectiveUpdateGroupV1], field_name: str) -> float:
+    return math.fsum(float(getattr(row, field_name)) for row in rows) / len(rows)
+
+
+def evaluate_selective_update_calibration(
+    rows: Sequence[SelectiveUpdateGroupV1],
+    thresholds: SelectiveUpdateThresholdsV1,
+) -> SelectiveUpdateCalibrationReportV1:
+    """Evaluate equal-group calibration and policy regret under frozen thresholds."""
+
+    if not isinstance(thresholds, SelectiveUpdateThresholdsV1):
+        raise ValueError("thresholds must be SelectiveUpdateThresholdsV1")
+    ordered = tuple(rows)
+    if not ordered or not all(isinstance(row, SelectiveUpdateGroupV1) for row in ordered):
+        raise ValueError("rows must be a nonempty sequence of SelectiveUpdateGroupV1")
+    group_ids = tuple(row.group_id for row in ordered)
+    if group_ids != tuple(sorted(group_ids)) or len(group_ids) != len(set(group_ids)):
+        raise ValueError("rows must be sorted by unique group_id")
+    accepted_rows = tuple(row for row in ordered if row.accepted)
+    accepted_count = len(accepted_rows)
+    rejected_count = len(ordered) - accepted_count
+
+    candidate_coverage = _mean(ordered, "candidate_coverage")
+    fallback_coverage = _mean(ordered, "fallback_coverage")
+    deployed_coverage = _mean(ordered, "deployed_coverage")
+    accepted_coverage = (
+        _mean(accepted_rows, "candidate_coverage") if accepted_rows else None
+    )
+    selection_drop = (
+        candidate_coverage - accepted_coverage
+        if accepted_coverage is not None
+        else None
+    )
+
+    candidate_width = _mean(ordered, "candidate_width")
+    fallback_width = _mean(ordered, "fallback_width")
+    deployed_width = _mean(ordered, "deployed_width")
+    accepted_width = _mean(accepted_rows, "candidate_width") if accepted_rows else None
+    accepted_fallback_width = (
+        _mean(accepted_rows, "fallback_width") if accepted_rows else None
+    )
+    accepted_width_ratio = (
+        accepted_width / accepted_fallback_width
+        if accepted_width is not None and accepted_fallback_width is not None
+        else None
+    )
+    width_ratio = deployed_width / fallback_width
+
+    candidate_score = _mean(ordered, "candidate_score")
+    fallback_score = _mean(ordered, "fallback_score")
+    deployed_score = _mean(ordered, "deployed_score")
+    accepted_candidate_score = (
+        _mean(accepted_rows, "candidate_score") if accepted_rows else None
+    )
+    accepted_fallback_score = (
+        _mean(accepted_rows, "fallback_score") if accepted_rows else None
+    )
+    accepted_score_advantage = (
+        accepted_fallback_score - accepted_candidate_score
+        if accepted_candidate_score is not None and accepted_fallback_score is not None
+        else None
+    )
+    score_advantage = fallback_score - deployed_score
+    harmful_count = sum(
+        row.candidate_score > row.fallback_score + thresholds.harmful_score_margin
+        for row in accepted_rows
+    )
+    harmful_fraction = harmful_count / accepted_count if accepted_count else 0.0
+    worst_shortfall = max(
+        max(0.0, thresholds.nominal_coverage - row.deployed_coverage)
+        for row in ordered
+    )
+    accepted_shortfall = (
+        max(0.0, thresholds.nominal_coverage - accepted_coverage)
+        if accepted_coverage is not None
+        else None
+    )
+    deployed_shortfall = max(
+        0.0,
+        thresholds.nominal_coverage - deployed_coverage,
+    )
+
+    criteria = {
+        "accepted_coverage": (
+            accepted_shortfall is not None
+            and accepted_shortfall <= thresholds.maximum_accepted_coverage_shortfall
+        ),
+        "complete_policy_coverage": (
+            deployed_shortfall
+            <= thresholds.maximum_complete_policy_coverage_shortfall
+        ),
+        "harmful_accepted_fraction": (
+            harmful_fraction <= thresholds.maximum_harmful_accepted_fraction
+        ),
+        "mean_score_advantage": (
+            accepted_score_advantage is not None
+            and accepted_score_advantage
+            >= thresholds.minimum_mean_score_advantage_vs_fallback
+        ),
+        "mean_width_ratio": (
+            accepted_width_ratio is not None
+            and accepted_width_ratio
+            <= thresholds.maximum_mean_width_ratio_vs_fallback
+        ),
+        "minimum_accepted_group_count": (
+            accepted_count >= thresholds.minimum_accepted_group_count
+        ),
+        "selection_coverage_drop": (
+            selection_drop is not None
+            and selection_drop <= thresholds.maximum_selection_coverage_drop
+        ),
+        "worst_group_coverage": (
+            worst_shortfall
+            <= thresholds.maximum_worst_group_coverage_shortfall
+        ),
+    }
+    return SelectiveUpdateCalibrationReportV1(
+        group_count=len(ordered),
+        accepted_group_count=accepted_count,
+        rejected_group_count=rejected_count,
+        candidate_mean_coverage=candidate_coverage,
+        accepted_mean_coverage=accepted_coverage,
+        fallback_mean_coverage=fallback_coverage,
+        deployed_mean_coverage=deployed_coverage,
+        selection_coverage_drop=selection_drop,
+        candidate_mean_width=candidate_width,
+        accepted_mean_width=accepted_width,
+        accepted_fallback_mean_width=accepted_fallback_width,
+        accepted_to_fallback_width_ratio=accepted_width_ratio,
+        fallback_mean_width=fallback_width,
+        deployed_mean_width=deployed_width,
+        deployed_to_fallback_width_ratio=width_ratio,
+        candidate_mean_score=candidate_score,
+        accepted_candidate_mean_score=accepted_candidate_score,
+        accepted_fallback_mean_score=accepted_fallback_score,
+        accepted_score_advantage_vs_fallback=accepted_score_advantage,
+        fallback_mean_score=fallback_score,
+        deployed_mean_score=deployed_score,
+        deployed_score_advantage_vs_fallback=score_advantage,
+        harmful_accepted_count=harmful_count,
+        harmful_accepted_fraction=harmful_fraction,
+        worst_group_deployed_coverage_shortfall=worst_shortfall,
+        criteria=criteria,
+        passed=all(criteria.values()),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class SelectiveUpdateCalibrationV1:
+    """Content-addressed source-validation certificate for a frozen guard."""
+
+    protocol_id: str
+    query_definition: str
+    score_definition: str
+    width_unit: str
+    group_definition: str
+    selection_lock_id: str
+    guard_artifact_id: str
+    candidate_artifact_id: str
+    fallback_artifact_id: str
+    guard_fit_group_ids: tuple[str, ...]
+    guard_calibration_group_ids: tuple[str, ...]
+    validation_group_ids: tuple[str, ...]
+    rows: tuple[SelectiveUpdateGroupV1, ...]
+    thresholds: SelectiveUpdateThresholdsV1
+    report: SelectiveUpdateCalibrationReportV1
+    metadata: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "protocol_id",
+            "query_definition",
+            "score_definition",
+            "width_unit",
+            "group_definition",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _strict_string(getattr(self, field_name), name=field_name),
+            )
+        for field_name in (
+            "selection_lock_id",
+            "guard_artifact_id",
+            "candidate_artifact_id",
+            "fallback_artifact_id",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _strict_digest(
+                    getattr(self, field_name),
+                    name=field_name,
+                    pattern=_SHA256,
+                ),
+            )
+        fit_ids = _canonical_string_tuple(
+            self.guard_fit_group_ids,
+            name="guard_fit_group_ids",
+        )
+        calibration_ids = _canonical_string_tuple(
+            self.guard_calibration_group_ids,
+            name="guard_calibration_group_ids",
+        )
+        validation_ids = _canonical_string_tuple(
+            self.validation_group_ids,
+            name="validation_group_ids",
+        )
+        if set(fit_ids) & set(calibration_ids):
+            raise ValueError("guard-fit and guard-calibration groups must be disjoint")
+        if set(fit_ids) & set(validation_ids):
+            raise ValueError("guard-fit and validation groups must be disjoint")
+        if set(calibration_ids) & set(validation_ids):
+            raise ValueError("guard-calibration and validation groups must be disjoint")
+        if type(self.rows) is not tuple or not self.rows or not all(
+            isinstance(row, SelectiveUpdateGroupV1) for row in self.rows
+        ):
+            raise ValueError("rows must be a nonempty tuple of SelectiveUpdateGroupV1")
+        rows = tuple(self.rows)
+        row_ids = tuple(row.group_id for row in rows)
+        if row_ids != validation_ids:
+            raise ValueError("rows must match the ordered validation_group_ids exactly")
+        if not isinstance(self.thresholds, SelectiveUpdateThresholdsV1):
+            raise ValueError("thresholds must be SelectiveUpdateThresholdsV1")
+        if not isinstance(self.report, SelectiveUpdateCalibrationReportV1):
+            raise ValueError("report must be SelectiveUpdateCalibrationReportV1")
+        replayed = evaluate_selective_update_calibration(rows, self.thresholds)
+        if self.report.to_dict() != replayed.to_dict():
+            raise ValueError("selective update report does not match deterministic replay")
+        object.__setattr__(self, "guard_fit_group_ids", fit_ids)
+        object.__setattr__(self, "guard_calibration_group_ids", calibration_ids)
+        object.__setattr__(self, "validation_group_ids", validation_ids)
+        object.__setattr__(self, "rows", rows)
+        object.__setattr__(
+            self,
+            "metadata",
+            frozen_finite_json_mapping(
+                self.metadata,
+                name="selective update calibration metadata",
+            ),
+        )
+
+    def descriptor(self) -> dict[str, object]:
+        return {
+            "schema_name": SELECTIVE_UPDATE_CALIBRATION_SCHEMA,
+            "schema_version": SELECTIVE_UPDATE_CALIBRATION_VERSION,
+            "protocol_id": self.protocol_id,
+            "query_definition": self.query_definition,
+            "score_definition": self.score_definition,
+            "score_direction": SELECTIVE_UPDATE_SCORE_DIRECTION,
+            "width_unit": self.width_unit,
+            "group_definition": self.group_definition,
+            "evidence_partition": SELECTIVE_UPDATE_EVIDENCE_PARTITION,
+            "uses_target_outcomes": SELECTIVE_UPDATE_USES_TARGET_OUTCOMES,
+            "selection_lock_id": self.selection_lock_id,
+            "guard_artifact_id": self.guard_artifact_id,
+            "candidate_artifact_id": self.candidate_artifact_id,
+            "fallback_artifact_id": self.fallback_artifact_id,
+            "guard_fit_group_ids": list(self.guard_fit_group_ids),
+            "guard_calibration_group_ids": list(self.guard_calibration_group_ids),
+            "validation_group_ids": list(self.validation_group_ids),
+            "rows": [row.to_dict() for row in self.rows],
+            "thresholds": self.thresholds.to_dict(),
+            "report": self.report.to_dict(),
+            "metadata": plain_json(self.metadata),
+            "claim_boundary": SELECTIVE_UPDATE_CALIBRATION_CLAIM_BOUNDARY,
+        }
+
+    @property
+    def artifact_id(self) -> str:
+        return _sha256_json(self.descriptor())
+
+    def to_dict(self) -> dict[str, object]:
+        return {**self.descriptor(), "artifact_id": self.artifact_id}
+
+    @classmethod
+    def from_dict(cls, value: Any) -> SelectiveUpdateCalibrationV1:
+        mapping = _strict_mapping(value, name="selective update calibration")
+        _exact_keys(
+            mapping,
+            {
+                "schema_name",
+                "schema_version",
+                "protocol_id",
+                "query_definition",
+                "score_definition",
+                "score_direction",
+                "width_unit",
+                "group_definition",
+                "evidence_partition",
+                "uses_target_outcomes",
+                "selection_lock_id",
+                "guard_artifact_id",
+                "candidate_artifact_id",
+                "fallback_artifact_id",
+                "guard_fit_group_ids",
+                "guard_calibration_group_ids",
+                "validation_group_ids",
+                "rows",
+                "thresholds",
+                "report",
+                "metadata",
+                "claim_boundary",
+                "artifact_id",
+            },
+            name="selective update calibration",
+        )
+        if mapping["schema_name"] != SELECTIVE_UPDATE_CALIBRATION_SCHEMA:
+            raise ValueError("unsupported selective update calibration schema")
+        if mapping["schema_version"] != SELECTIVE_UPDATE_CALIBRATION_VERSION:
+            raise ValueError("unsupported selective update calibration version")
+        if mapping["claim_boundary"] != SELECTIVE_UPDATE_CALIBRATION_CLAIM_BOUNDARY:
+            raise ValueError("selective update calibration claim boundary changed")
+        if mapping["score_direction"] != SELECTIVE_UPDATE_SCORE_DIRECTION:
+            raise ValueError("selective update score direction changed")
+        if mapping["evidence_partition"] != SELECTIVE_UPDATE_EVIDENCE_PARTITION:
+            raise ValueError("selective update evidence partition changed")
+        if _strict_bool(
+            mapping["uses_target_outcomes"],
+            name="uses_target_outcomes",
+        ) is not SELECTIVE_UPDATE_USES_TARGET_OUTCOMES:
+            raise ValueError("selective update artifact must not use target outcomes")
+        rows = tuple(
+            SelectiveUpdateGroupV1.from_dict(row)
+            for row in _strict_list(mapping["rows"], name="rows")
+        )
+        artifact = cls(
+            protocol_id=mapping["protocol_id"],
+            query_definition=mapping["query_definition"],
+            score_definition=mapping["score_definition"],
+            width_unit=mapping["width_unit"],
+            group_definition=mapping["group_definition"],
+            selection_lock_id=mapping["selection_lock_id"],
+            guard_artifact_id=mapping["guard_artifact_id"],
+            candidate_artifact_id=mapping["candidate_artifact_id"],
+            fallback_artifact_id=mapping["fallback_artifact_id"],
+            guard_fit_group_ids=_string_tuple_from_json(
+                mapping["guard_fit_group_ids"],
+                name="guard_fit_group_ids",
+            ),
+            guard_calibration_group_ids=_string_tuple_from_json(
+                mapping["guard_calibration_group_ids"],
+                name="guard_calibration_group_ids",
+            ),
+            validation_group_ids=_string_tuple_from_json(
+                mapping["validation_group_ids"],
+                name="validation_group_ids",
+            ),
+            rows=rows,
+            thresholds=SelectiveUpdateThresholdsV1.from_dict(mapping["thresholds"]),
+            report=SelectiveUpdateCalibrationReportV1.from_dict(mapping["report"]),
+            metadata=_strict_mapping(mapping["metadata"], name="metadata"),
+        )
+        supplied = _strict_digest(
+            mapping["artifact_id"],
+            name="artifact_id",
+            pattern=_SHA256,
+        )
+        if supplied != artifact.artifact_id:
+            raise ValueError("selective update calibration artifact_id mismatch")
+        return artifact
+
+
+def build_selective_update_calibration(
+    *,
+    protocol_id: str,
+    query_definition: str,
+    score_definition: str,
+    width_unit: str,
+    group_definition: str,
+    selection_lock_id: str,
+    guard_artifact_id: str,
+    candidate_artifact_id: str,
+    fallback_artifact_id: str,
+    guard_fit_group_ids: Sequence[str],
+    guard_calibration_group_ids: Sequence[str],
+    rows: Sequence[SelectiveUpdateGroupV1],
+    thresholds: SelectiveUpdateThresholdsV1,
+    metadata: Mapping[str, Any] | None = None,
+) -> SelectiveUpdateCalibrationV1:
+    """Build a canonical certificate from one source-validation group table."""
+
+    supplied_rows = tuple(rows)
+    if not supplied_rows or not all(
+        isinstance(row, SelectiveUpdateGroupV1) for row in supplied_rows
+    ):
+        raise ValueError("rows must be a nonempty sequence of SelectiveUpdateGroupV1")
+    ordered_rows = tuple(sorted(supplied_rows, key=lambda row: row.group_id))
+    validation_group_ids = tuple(row.group_id for row in ordered_rows)
+    report = evaluate_selective_update_calibration(ordered_rows, thresholds)
+    return SelectiveUpdateCalibrationV1(
+        protocol_id=protocol_id,
+        query_definition=query_definition,
+        score_definition=score_definition,
+        width_unit=width_unit,
+        group_definition=group_definition,
+        selection_lock_id=selection_lock_id,
+        guard_artifact_id=guard_artifact_id,
+        candidate_artifact_id=candidate_artifact_id,
+        fallback_artifact_id=fallback_artifact_id,
+        guard_fit_group_ids=tuple(sorted(guard_fit_group_ids)),
+        guard_calibration_group_ids=tuple(sorted(guard_calibration_group_ids)),
+        validation_group_ids=validation_group_ids,
+        rows=ordered_rows,
+        thresholds=thresholds,
+        report=report,
+        metadata={} if metadata is None else metadata,
+    )
+
+
+def selective_update_calibration_from_raw(value: Any) -> SelectiveUpdateCalibrationV1:
+    mapping = _strict_mapping(value, name="raw selective update calibration")
+    _exact_keys(
+        mapping,
+        {
+            "protocol_id",
+            "query_definition",
+            "score_definition",
+            "width_unit",
+            "group_definition",
+            "selection_lock_id",
+            "guard_artifact_id",
+            "candidate_artifact_id",
+            "fallback_artifact_id",
+            "guard_fit_group_ids",
+            "guard_calibration_group_ids",
+            "rows",
+            "thresholds",
+            "metadata",
+        },
+        name="raw selective update calibration",
+    )
+    return build_selective_update_calibration(
+        protocol_id=mapping["protocol_id"],
+        query_definition=mapping["query_definition"],
+        score_definition=mapping["score_definition"],
+        width_unit=mapping["width_unit"],
+        group_definition=mapping["group_definition"],
+        selection_lock_id=mapping["selection_lock_id"],
+        guard_artifact_id=mapping["guard_artifact_id"],
+        candidate_artifact_id=mapping["candidate_artifact_id"],
+        fallback_artifact_id=mapping["fallback_artifact_id"],
+        guard_fit_group_ids=_strict_list(
+            mapping["guard_fit_group_ids"],
+            name="guard_fit_group_ids",
+        ),
+        guard_calibration_group_ids=_strict_list(
+            mapping["guard_calibration_group_ids"],
+            name="guard_calibration_group_ids",
+        ),
+        rows=tuple(
+            SelectiveUpdateGroupV1.from_dict(row)
+            for row in _strict_list(mapping["rows"], name="rows")
+        ),
+        thresholds=SelectiveUpdateThresholdsV1.from_dict(mapping["thresholds"]),
+        metadata=_strict_mapping(mapping["metadata"], name="metadata"),
+    )
+
+
+def write_selective_update_calibration(
+    artifact: SelectiveUpdateCalibrationV1,
+    path: str | Path,
+) -> None:
+    if not isinstance(artifact, SelectiveUpdateCalibrationV1):
+        raise ValueError("artifact must be SelectiveUpdateCalibrationV1")
+    destination = Path(path)
+    payload = (
+        json.dumps(
+            artifact.to_dict(),
+            sort_keys=True,
+            indent=2,
+            allow_nan=False,
+        )
+        + "\n"
+    )
+    try:
+        atomic_write_text(destination, payload, overwrite=False)
+    except FileExistsError:
+        existing = load_selective_update_calibration(destination)
+        if existing.to_dict() == artifact.to_dict():
+            return
+        raise FileExistsError(
+            f"refusing to replace a different selective update calibration: {destination}"
+        ) from None
+
+
+def load_selective_update_calibration(
+    path: str | Path,
+) -> SelectiveUpdateCalibrationV1:
+    return SelectiveUpdateCalibrationV1.from_dict(
+        _load_json(path, name="selective update calibration")
+    )
+
+
+def _build_cli(arguments: argparse.Namespace) -> int:
+    artifact = selective_update_calibration_from_raw(
+        _load_json(arguments.input, name="raw selective update calibration")
+    )
+    write_selective_update_calibration(artifact, arguments.output)
+    print(artifact.artifact_id)
+    if arguments.require_pass and not artifact.report.passed:
+        return 3
+    return 0
+
+
+def _verify_cli(arguments: argparse.Namespace) -> int:
+    artifact = load_selective_update_calibration(arguments.artifact)
+    print(artifact.artifact_id)
+    if arguments.require_pass and not artifact.report.passed:
+        return 3
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Build or verify a source-validation selective-calibration certificate."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    build = subparsers.add_parser("build", help="build a content-addressed certificate")
+    build.add_argument("input", type=Path)
+    build.add_argument("--output", type=Path, required=True)
+    build.add_argument("--require-pass", action="store_true")
+    build.set_defaults(handler=_build_cli)
+    verify = subparsers.add_parser("verify", help="verify and replay a certificate")
+    verify.add_argument("artifact", type=Path)
+    verify.add_argument("--require-pass", action="store_true")
+    verify.set_defaults(handler=_verify_cli)
+    arguments = parser.parse_args(argv)
+    return int(arguments.handler(arguments))
+
+
+__all__ = [
+    "SELECTIVE_UPDATE_CALIBRATION_CLAIM_BOUNDARY",
+    "SELECTIVE_UPDATE_CALIBRATION_SCHEMA",
+    "SELECTIVE_UPDATE_CALIBRATION_VERSION",
+    "SELECTIVE_UPDATE_EVIDENCE_PARTITION",
+    "SELECTIVE_UPDATE_SCORE_DIRECTION",
+    "SELECTIVE_UPDATE_USES_TARGET_OUTCOMES",
+    "SelectiveUpdateCalibrationReportV1",
+    "SelectiveUpdateCalibrationV1",
+    "SelectiveUpdateGroupV1",
+    "SelectiveUpdateThresholdsV1",
+    "build_selective_update_calibration",
+    "evaluate_selective_update_calibration",
+    "load_selective_update_calibration",
+    "main",
+    "selective_update_calibration_from_raw",
+    "write_selective_update_calibration",
+]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_moment_collapse_diagnostic.py
+++ b/tests/test_moment_collapse_diagnostic.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+import numpy as np
+import pytest
+
+from prob4d.moment_collapse_diagnostic import (
+    MomentCollapseDiagnosticV1,
+    MomentCollapseThresholdsV1,
+    SymmetricGaussianMixtureCaseV1,
+    build_moment_collapse_diagnostic,
+    evaluate_moment_collapse_case,
+    load_moment_collapse_diagnostic,
+    main,
+    moment_matched_gaussian,
+    write_moment_collapse_diagnostic,
+)
+
+
+def thresholds() -> MomentCollapseThresholdsV1:
+    return MomentCollapseThresholdsV1(
+        midpoint_half_width_component_sigma=1.0,
+        minimum_component_mean_separation_sigma=4.0,
+        maximum_mixture_midpoint_to_component_mean_density_ratio=0.1,
+        minimum_moment_gaussian_central_mass_inflation=0.1,
+    )
+
+
+def separated_case(case_id: str = "separated") -> SymmetricGaussianMixtureCaseV1:
+    return SymmetricGaussianMixtureCaseV1(
+        case_id=case_id,
+        offset_xyz=np.array([3.0, 0.0, 0.0]),
+        component_covariance=np.eye(3),
+        metadata={"mechanism": "symmetric-two-mode"},
+    )
+
+
+def weak_case(case_id: str = "weak") -> SymmetricGaussianMixtureCaseV1:
+    return SymmetricGaussianMixtureCaseV1(
+        case_id=case_id,
+        offset_xyz=np.array([0.2, 0.0, 0.0]),
+        component_covariance=np.eye(3),
+    )
+
+
+def test_separated_mixture_exposes_material_moment_collapse() -> None:
+    report = evaluate_moment_collapse_case(separated_case(), thresholds())
+
+    assert report.mahalanobis_offset_squared == pytest.approx(9.0)
+    assert report.component_mean_separation_sigma == pytest.approx(6.0)
+    assert report.mixture_midpoint_to_component_mean_density_ratio < 0.03
+    assert report.mixture_central_mass < 0.03
+    assert report.moment_gaussian_central_mass > 0.24
+    assert report.moment_gaussian_central_mass_inflation > 0.20
+    assert report.moment_matched_excess_kurtosis == pytest.approx(-1.62)
+    assert report.material_moment_collapse is True
+
+
+def test_weak_mixture_does_not_pass_materiality_gates() -> None:
+    report = evaluate_moment_collapse_case(weak_case(), thresholds())
+
+    assert report.component_mean_separation_sigma == pytest.approx(0.4)
+    assert report.material_moment_collapse is False
+
+
+def test_moment_matched_gaussian_preserves_only_first_two_moments() -> None:
+    case = separated_case()
+    mean, covariance = moment_matched_gaussian(case)
+
+    np.testing.assert_array_equal(mean, np.zeros(3))
+    np.testing.assert_array_equal(covariance, np.diag([10.0, 1.0, 1.0]))
+    assert mean.flags.writeable is False
+    assert covariance.flags.writeable is False
+    with pytest.raises(ValueError):
+        covariance.setflags(write=True)
+
+
+def test_case_rejects_nonpositive_definite_covariance() -> None:
+    with pytest.raises(ValueError, match="positive definite"):
+        SymmetricGaussianMixtureCaseV1(
+            case_id="invalid",
+            offset_xyz=np.ones(3),
+            component_covariance=np.diag([1.0, 0.0, 1.0]),
+        )
+
+
+
+def test_case_loader_rejects_coercive_numeric_strings() -> None:
+    payload = separated_case().to_dict()
+    payload["offset_xyz"][0] = "3.0"
+    with pytest.raises(ValueError, match="real number"):
+        SymmetricGaussianMixtureCaseV1.from_dict(payload)
+
+
+def test_diagnostic_is_permutation_invariant() -> None:
+    first = build_moment_collapse_diagnostic(
+        representation_name="mean-and-covariance-only",
+        cases=(separated_case(), weak_case()),
+        thresholds=thresholds(),
+        metadata={"uses_real_provider_outcomes": False},
+    )
+    second = build_moment_collapse_diagnostic(
+        representation_name="mean-and-covariance-only",
+        cases=(weak_case(), separated_case()),
+        thresholds=thresholds(),
+        metadata={"uses_real_provider_outcomes": False},
+    )
+
+    assert first.artifact_id == second.artifact_id
+    assert first.material_case_count == 1
+    assert first.any_material_moment_collapse is True
+    assert first.to_dict() == second.to_dict()
+
+
+def test_round_trip_tamper_rejection_and_no_clobber(tmp_path) -> None:
+    artifact = build_moment_collapse_diagnostic(
+        representation_name="mean-and-covariance-only",
+        cases=(separated_case(), weak_case()),
+        thresholds=thresholds(),
+    )
+    path = tmp_path / "moment-collapse.json"
+    write_moment_collapse_diagnostic(artifact, path)
+
+    loaded = load_moment_collapse_diagnostic(path)
+    assert loaded.to_dict() == artifact.to_dict()
+    write_moment_collapse_diagnostic(artifact, path)
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["reports"][0]["moment_gaussian_central_mass"] -= 0.1
+    with pytest.raises(ValueError, match="deterministic replay"):
+        MomentCollapseDiagnosticV1.from_dict(payload)
+
+    different = replace(artifact, metadata={"variant": "different"})
+    with pytest.raises(FileExistsError, match="refusing to replace"):
+        write_moment_collapse_diagnostic(different, path)
+
+
+def test_loader_rejects_duplicate_keys_and_nonfinite_values(tmp_path) -> None:
+    artifact = build_moment_collapse_diagnostic(
+        representation_name="mean-and-covariance-only",
+        cases=(separated_case(),),
+        thresholds=thresholds(),
+    )
+    path = tmp_path / "moment-collapse.json"
+    write_moment_collapse_diagnostic(artifact, path)
+    original = path.read_text(encoding="utf-8")
+
+    schema_line = f'  "schema_name": "{artifact.to_dict()["schema_name"]}",'
+    path.write_text(
+        original.replace(schema_line, f"{schema_line}\n{schema_line}", 1),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="duplicate JSON key"):
+        load_moment_collapse_diagnostic(path)
+
+    path.write_text(
+        original.replace(
+            '  "representation_name":',
+            '  "poison": NaN,\n  "representation_name":',
+            1,
+        ),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="non-finite JSON constant"):
+        load_moment_collapse_diagnostic(path)
+
+
+def test_cli_build_and_verify(tmp_path, capsys) -> None:
+    artifact = build_moment_collapse_diagnostic(
+        representation_name="mean-and-covariance-only",
+        cases=(separated_case(), weak_case()),
+        thresholds=thresholds(),
+    )
+    raw = artifact.to_dict()
+    for key in (
+        "schema_name",
+        "schema_version",
+        "reports",
+        "material_case_count",
+        "any_material_moment_collapse",
+        "claim_boundary",
+        "artifact_id",
+    ):
+        raw.pop(key)
+    input_path = tmp_path / "raw.json"
+    output_path = tmp_path / "artifact.json"
+    input_path.write_text(json.dumps(raw), encoding="utf-8")
+
+    assert main(["build", str(input_path), "--output", str(output_path)]) == 0
+    assert capsys.readouterr().out.strip() == artifact.artifact_id
+    assert main(["verify", str(output_path)]) == 0
+    assert capsys.readouterr().out.strip() == artifact.artifact_id

--- a/tests/test_selective_update_calibration.py
+++ b/tests/test_selective_update_calibration.py
@@ -1,0 +1,301 @@
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+
+import pytest
+
+from prob4d.selective_update_calibration import (
+    SelectiveUpdateCalibrationV1,
+    SelectiveUpdateGroupV1,
+    SelectiveUpdateThresholdsV1,
+    build_selective_update_calibration,
+    load_selective_update_calibration,
+    main,
+    write_selective_update_calibration,
+)
+
+DIGEST_A = "a" * 64
+DIGEST_B = "b" * 64
+DIGEST_C = "c" * 64
+DIGEST_D = "d" * 64
+
+
+def thresholds() -> SelectiveUpdateThresholdsV1:
+    return SelectiveUpdateThresholdsV1(
+        nominal_coverage=0.9,
+        maximum_accepted_coverage_shortfall=0.05,
+        maximum_complete_policy_coverage_shortfall=0.02,
+        maximum_selection_coverage_drop=0.05,
+        maximum_mean_width_ratio_vs_fallback=1.1,
+        minimum_mean_score_advantage_vs_fallback=0.05,
+        harmful_score_margin=0.0,
+        maximum_harmful_accepted_fraction=0.0,
+        minimum_accepted_group_count=2,
+        maximum_worst_group_coverage_shortfall=0.05,
+    )
+
+
+def row(
+    group_id: str,
+    *,
+    accepted: bool,
+    candidate_coverage: float,
+    candidate_width: float,
+    candidate_score: float,
+    fallback_coverage: float = 0.9,
+    fallback_width: float = 10.0,
+    fallback_score: float = 1.0,
+) -> SelectiveUpdateGroupV1:
+    if accepted:
+        deployed_coverage = candidate_coverage
+        deployed_width = candidate_width
+        deployed_score = candidate_score
+    else:
+        deployed_coverage = fallback_coverage
+        deployed_width = fallback_width
+        deployed_score = fallback_score
+    return SelectiveUpdateGroupV1(
+        group_id=group_id,
+        accepted=accepted,
+        candidate_coverage=candidate_coverage,
+        candidate_width=candidate_width,
+        candidate_score=candidate_score,
+        fallback_coverage=fallback_coverage,
+        fallback_width=fallback_width,
+        fallback_score=fallback_score,
+        deployed_coverage=deployed_coverage,
+        deployed_width=deployed_width,
+        deployed_score=deployed_score,
+        metadata={"source_partition": "validation"},
+    )
+
+
+def passing_rows() -> tuple[SelectiveUpdateGroupV1, ...]:
+    return (
+        row(
+            "validation-a",
+            accepted=True,
+            candidate_coverage=0.92,
+            candidate_width=9.0,
+            candidate_score=0.70,
+        ),
+        row(
+            "validation-b",
+            accepted=True,
+            candidate_coverage=0.90,
+            candidate_width=9.5,
+            candidate_score=0.75,
+        ),
+        row(
+            "validation-c",
+            accepted=False,
+            candidate_coverage=0.80,
+            candidate_width=8.0,
+            candidate_score=1.30,
+        ),
+        row(
+            "validation-d",
+            accepted=False,
+            candidate_coverage=0.82,
+            candidate_width=8.5,
+            candidate_score=1.20,
+        ),
+    )
+
+
+def build(
+    rows: tuple[SelectiveUpdateGroupV1, ...] | None = None,
+) -> SelectiveUpdateCalibrationV1:
+    selected_rows = passing_rows() if rows is None else rows
+    return build_selective_update_calibration(
+        protocol_id="selective-source-validation-v1",
+        query_definition="equal-object guarded physical query",
+        score_definition="group-mean Gaussian negative log likelihood",
+        width_unit="mm",
+        group_definition="complete physical object or acquisition session",
+        selection_lock_id=DIGEST_A,
+        guard_artifact_id=DIGEST_B,
+        candidate_artifact_id=DIGEST_C,
+        fallback_artifact_id=DIGEST_D,
+        guard_fit_group_ids=("fit-a", "fit-b"),
+        guard_calibration_group_ids=("cal-a", "cal-b"),
+        rows=selected_rows,
+        thresholds=thresholds(),
+        metadata={"uses_target_outcomes": False},
+    )
+
+
+def test_selective_update_certificate_passes_and_separates_all_populations() -> None:
+    artifact = build()
+    report = artifact.report
+
+    assert report.passed is True
+    assert report.group_count == 4
+    assert report.accepted_group_count == 2
+    assert report.rejected_group_count == 2
+    assert report.accepted_mean_coverage == pytest.approx(0.91)
+    assert report.candidate_mean_coverage == pytest.approx(0.86)
+    assert report.deployed_mean_coverage == pytest.approx(0.905)
+    assert report.selection_coverage_drop == pytest.approx(-0.05)
+    assert report.accepted_score_advantage_vs_fallback == pytest.approx(0.275)
+    assert report.deployed_score_advantage_vs_fallback == pytest.approx(0.1375)
+    assert report.accepted_to_fallback_width_ratio == pytest.approx(0.925)
+    assert report.harmful_accepted_count == 0
+    assert all(report.criteria.values())
+
+
+def test_selection_induced_undercoverage_fails_even_when_complete_policy_is_calibrated() -> None:
+    rows = [
+        row(
+            "validation-a",
+            accepted=True,
+            candidate_coverage=0.50,
+            candidate_width=5.0,
+            candidate_score=0.70,
+        ),
+        row(
+            "validation-b",
+            accepted=True,
+            candidate_coverage=0.55,
+            candidate_width=5.0,
+            candidate_score=0.70,
+        ),
+    ]
+    rows.extend(
+        row(
+            f"validation-{index}",
+            accepted=False,
+            candidate_coverage=1.0,
+            candidate_width=12.0,
+            candidate_score=1.30,
+            fallback_coverage=1.0,
+        )
+        for index in range(2, 10)
+    )
+    artifact = build(tuple(rows))
+
+    assert artifact.report.deployed_mean_coverage == pytest.approx(0.905)
+    assert artifact.report.accepted_mean_coverage == pytest.approx(0.525)
+    assert artifact.report.selection_coverage_drop == pytest.approx(0.38)
+    assert artifact.report.criteria["complete_policy_coverage"] is True
+    assert artifact.report.criteria["accepted_coverage"] is False
+    assert artifact.report.criteria["selection_coverage_drop"] is False
+    assert artifact.report.passed is False
+
+
+def test_harmful_accepted_update_is_detected() -> None:
+    rows = list(passing_rows())
+    rows[0] = row(
+        "validation-a",
+        accepted=True,
+        candidate_coverage=0.92,
+        candidate_width=9.0,
+        candidate_score=1.20,
+    )
+    artifact = build(tuple(rows))
+
+    assert artifact.report.harmful_accepted_count == 1
+    assert artifact.report.harmful_accepted_fraction == pytest.approx(0.5)
+    assert artifact.report.criteria["harmful_accepted_fraction"] is False
+    assert artifact.report.passed is False
+
+
+def test_deployed_metrics_must_match_candidate_or_fallback() -> None:
+    with pytest.raises(ValueError, match="deployed metrics"):
+        SelectiveUpdateGroupV1(
+            group_id="validation-a",
+            accepted=False,
+            candidate_coverage=0.8,
+            candidate_width=8.0,
+            candidate_score=1.2,
+            fallback_coverage=0.9,
+            fallback_width=10.0,
+            fallback_score=1.0,
+            deployed_coverage=0.9,
+            deployed_width=10.0,
+            deployed_score=0.9,
+        )
+
+
+def test_split_overlap_is_rejected() -> None:
+    artifact = build()
+    with pytest.raises(ValueError, match="disjoint"):
+        replace(
+            artifact,
+            guard_calibration_group_ids=("cal-a", "fit-a"),
+        )
+
+
+def test_artifact_is_permutation_invariant() -> None:
+    first = build(passing_rows())
+    second = build(tuple(reversed(passing_rows())))
+
+    assert first.artifact_id == second.artifact_id
+    assert first.to_dict() == second.to_dict()
+
+
+def test_round_trip_tamper_rejection_and_no_clobber(tmp_path) -> None:
+    artifact = build()
+    path = tmp_path / "selective-update-calibration.json"
+    write_selective_update_calibration(artifact, path)
+
+    loaded = load_selective_update_calibration(path)
+    assert loaded.to_dict() == artifact.to_dict()
+    write_selective_update_calibration(artifact, path)
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    payload["report"]["deployed_mean_coverage"] -= 0.1
+    with pytest.raises(ValueError, match="deterministic replay"):
+        SelectiveUpdateCalibrationV1.from_dict(payload)
+
+    different = replace(artifact, metadata={"variant": "different"})
+    with pytest.raises(FileExistsError, match="refusing to replace"):
+        write_selective_update_calibration(different, path)
+
+
+def test_loader_rejects_duplicate_keys_and_nonfinite_values(tmp_path) -> None:
+    artifact = build()
+    path = tmp_path / "selective-update-calibration.json"
+    write_selective_update_calibration(artifact, path)
+    original = path.read_text(encoding="utf-8")
+
+    schema_line = f'  "schema_name": "{artifact.to_dict()["schema_name"]}",'
+    path.write_text(
+        original.replace(schema_line, f"{schema_line}\n{schema_line}", 1),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="duplicate JSON key"):
+        load_selective_update_calibration(path)
+
+    path.write_text(
+        original.replace('  "protocol_id":', '  "poison": NaN,\n  "protocol_id":', 1),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="non-finite JSON constant"):
+        load_selective_update_calibration(path)
+
+
+def test_cli_build_and_verify(tmp_path, capsys) -> None:
+    artifact = build()
+    raw = artifact.to_dict()
+    for key in (
+        "schema_name",
+        "schema_version",
+        "score_direction",
+        "evidence_partition",
+        "uses_target_outcomes",
+        "validation_group_ids",
+        "report",
+        "claim_boundary",
+        "artifact_id",
+    ):
+        raw.pop(key)
+    input_path = tmp_path / "raw.json"
+    output_path = tmp_path / "artifact.json"
+    input_path.write_text(json.dumps(raw), encoding="utf-8")
+
+    assert main(["build", str(input_path), "--output", str(output_path), "--require-pass"]) == 0
+    assert capsys.readouterr().out.strip() == artifact.artifact_id
+    assert main(["verify", str(output_path), "--require-pass"]) == 0
+    assert capsys.readouterr().out.strip() == artifact.artifact_id


### PR DESCRIPTION
## Purpose

Add two evidence-first diagnostics for the Prob4D → BayesianPhysTwin boundary without opening target outcomes or changing provider contracts.

### Post-selection calibration

`SelectiveUpdateCalibrationV1` certifies calibration after one frozen Bayesian acceptance guard on complete source-validation objects/sessions. It:

- binds disjoint guard-fit, guard-calibration, and validation group rosters;
- separates the all-group candidate, accepted subset, unchanged physical fallback, and deployed policy;
- validates exact candidate-on-acceptance / fallback-on-rejection semantics;
- reports selection-induced coverage loss, accepted and complete-policy coverage, matched width and proper-score comparisons, harmful accepted updates, support, and worst-group coverage;
- writes a strict, content-addressed, append-only JSON artifact; and
- treats insufficient accepted independent groups as a valid failed source result.

### Gaussian moment-collapse diagnostic

`MomentCollapseDiagnosticV1` analytically compares a symmetric two-mode 3-D Gaussian mixture with its moment-matched Gaussian. It reports:

- discriminant separation;
- midpoint-to-mode density ratio;
- central probability mass under both representations;
- central-mass inflation after moment matching; and
- projected excess kurtosis.

This is a controlled mechanism test. It does not claim that a real provider is multimodal and does not introduce a multimodal observation schema.

## Included

- two implementation modules;
- 18 focused regression tests;
- strict JSON, immutable arrays, deterministic identities, and non-clobbering persistence tests;
- executable examples;
- technical documentation; and
- changelog fragments.

## Validation

Exact head: `cb13b8ba7444ed7ff98142fb1fd238f93d154c5b`.

All repository checks passed:

- complete pytest suite on Python 3.10, 3.11, 3.12, 3.13, and 3.14;
- complete suite at the declared Python/NumPy runtime floor;
- wheel and source-distribution build/validation;
- isolated wheel and sdist installation plus canonical CLI smoke tests;
- repository, release, API, runtime-attestation, and provider-contract checks;
- authoritative Ruff, stable-interface mypy, and documentation-surface validation;
- CodeQL for Python and Actions;
- resolved runtime-dependency audit; and
- causal provider batch/terminal preflight.

The focused development gate additionally produced `18 passed`, replayed both documented build/verify examples, and explicitly confirmed a material controlled moment-collapse case.

## Scientific boundary

These additions provide source-validation infrastructure and controlled mechanism evidence only. They do not authorize target access, promote a real provider, establish unseen-object BayesianPhysTwin benefit, establish Causal4D intervention benefit, change exact fallback, or support a state-of-the-art claim.
