### PR TITLE
Add fail-closed artifact explanations and provider status

### DIFF
--- a/CHANGELOG.d/artifact-explain.md
+++ b/CHANGELOG.d/artifact-explain.md
@@ -1,0 +1,4 @@
+Add `prob4d artifact explain` for strict, human-readable inspection of known
+content-addressed artifacts and explicitly labelled structural inspection of
+unknown JSON or NPZ containers, together with a README provider-evidence status
+boundary.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,24 @@ calibrates conditional and shared covariance, preserves causal source lineage,
 and exports portable observations for BayesianPhysTwin. Causal4D consumes the
 resulting BayesianPhysTwin belief rather than raw Prob4D artifacts.
 
+## Provider evidence status
+
+Snapshot: **2026-08-18**. Adapter maturity and scientific evidence are separate.
+The authoritative claim and data-access status remains in
+[`FlorianPfaff/BayesianPhysTwin-Paper`](https://github.com/FlorianPfaff/BayesianPhysTwin-Paper).
+
+| Provider route | Implementation state | Current evidence boundary |
+| --- | --- | --- |
+| Controlled synthetic provider | Stable mechanism study | Positive controlled evidence only; not real-provider competence |
+| MotionCrafter | Mature producer and causal-window path | Frozen retrospective real transfer negative; not a promotion candidate on the opened cohort |
+| Deform360 official-Hub route | Executed under a sealed support protocol | Terminal source-support negative; confirmation remains closed |
+| CUT3R recurrent-online | Causal adapter ready | Source mean, identity, and uncertainty competence not yet evaluated |
+| VGGT | Baseline/export adapter ready | Diagnostic baseline only |
+
+A production-quality artifact path is not evidence of production-quality
+perception. Every real provider must still pass support, mean, identity,
+gauge/dependence, covariance, query-relevance, and exact-fallback gates.
+
 ## Install and test
 
 ```bash
@@ -46,6 +64,22 @@ print(prob4d.__version__)
 Use `prob4d commands list` and `prob4d commands describe ...` to inspect the
 canonical grouped command registry.
 
+## Artifact inspection
+
+Explain an observation, sparse gauge prior, tree-sparse factor artifact,
+prediction store, or strict JSON record without guessing that an unknown schema
+is valid:
+
+```bash
+prob4d artifact explain outputs/sequence_name/observation_belief.npz
+prob4d artifact explain outputs/sequence_name/observation_belief.npz --json
+prob4d artifact explain artifact.json --require-strict
+```
+
+Known schemas use their existing strict content-addressed loader. Unknown JSON
+and NPZ containers are labelled `structural-only`; `--require-strict` rejects
+them. See [artifact explanation](docs/artifact-explain.md).
+
 ## Quick benchmark
 
 ```bash
@@ -58,7 +92,7 @@ The ablation runner evaluates disjoint windows, latent-space overlap blending,
 decoded `Sim(3)` alignment, precision fusion, covariance intersection,
 fixed-lag gauge smoothing, and sparse metric anchors.
 
-## MotionCrafter production
+## MotionCrafter producer and historical evaluation path
 
 Create the optional GPU environment:
 
@@ -185,6 +219,7 @@ Passing infrastructure checks is not scientific promotion.
 ## Additional grouped routes
 
 ```bash
+prob4d artifact explain --help
 prob4d diagnostic provider-support-envelope --help
 prob4d diagnostic source-covariance-localization --help
 prob4d evaluate provider --help

--- a/docs/artifact-explain.md
+++ b/docs/artifact-explain.md
@@ -1,0 +1,73 @@
+# Artifact explanation
+
+`prob4d artifact explain` gives collaborators a compact, human-readable view of
+one Prob4D artifact without weakening its validation boundary.
+
+```bash
+prob4d artifact explain outputs/sequence/observation_belief.npz
+prob4d artifact explain outputs/sequence/observation_belief.npz --json
+prob4d artifact explain outputs/sequence/observation_belief.npz --arrays
+```
+
+The command automatically recognizes these current artifact families:
+
+- `ObservationBeliefV1` NPZ files;
+- portable sparse gauge-tree prior manifests and their NPY sidecars;
+- tree-sparse observation manifests, their NPY members, and their bound sparse
+  gauge-tree prior;
+- content-addressed prediction-bundle stores; and
+- strict finite JSON objects that do not yet have a registered explanation
+  handler.
+
+Known artifacts are opened through their existing strict loader. The explanation
+then reports the schema, content identity, causal/source context, and a compact
+artifact-specific summary. It never substitutes a new validation path for the
+normative loader.
+
+## Strict versus structural output
+
+A recognized artifact that passes its normative loader reports:
+
+```text
+Status: valid
+Validation: strict-schema-and-content-address
+```
+
+An unrecognized JSON or NPZ container can still be inspected, but it reports:
+
+```text
+Status: structural-only
+```
+
+For structural-only JSON, duplicate keys and non-finite values are rejected, but
+no artifact-specific schema or digest is claimed as verified. For structural-only
+NPZ, the archive is opened with `allow_pickle=False`; no semantic or content-ID
+claim is made.
+
+Use `--require-strict` in automated or claim-bearing workflows:
+
+```bash
+prob4d artifact explain artifact.json --require-strict --json
+```
+
+The command exits with status 2 when no registered strict loader matches or when
+the matched loader rejects the artifact.
+
+## Array inventory
+
+NPZ array values are not summarized by default. `--arrays` adds only member
+names, dtypes, shapes, and uncompressed byte counts:
+
+```bash
+prob4d artifact explain observation_belief.npz --arrays
+```
+
+This option does not print observations, target outcomes, calibration residuals,
+or other payload values.
+
+## Scientific boundary
+
+An explanation is an inspection aid. A `valid` explanation establishes only that
+the existing strict loader accepted the artifact and its content identity. It does
+not establish provider competence, calibrated uncertainty, BayesianPhysTwin
+benefit, Causal4D intervention benefit, deployment safety, or state of the art.

--- a/src/prob4d/artifact_explain.py
+++ b/src/prob4d/artifact_explain.py
@@ -15,8 +15,10 @@ from ._strict_json import load_json_object, loads_json_object
 from .gauge_tree_prior_artifact import (
     GAUGE_TREE_PRIOR_ARTIFACT_SCHEMA,
     GAUGE_TREE_PRIOR_ARTIFACT_VERSION,
-    artifact_summary as gauge_tree_prior_summary,
     load_gauge_tree_prior_artifact,
+)
+from .gauge_tree_prior_artifact import (
+    artifact_summary as gauge_tree_prior_summary,
 )
 from .observation_contract import OBSERVATION_BELIEF_SCHEMA, OBSERVATION_BELIEF_VERSION
 from .observation_validation import load_observation_belief_export, validation_summary

--- a/src/prob4d/artifact_explain.py
+++ b/src/prob4d/artifact_explain.py
@@ -1,0 +1,432 @@
+"""Human-readable, fail-closed explanations for Prob4D artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+import numpy as np
+
+from ._strict_json import load_json_object, loads_json_object
+from .gauge_tree_prior_artifact import (
+    GAUGE_TREE_PRIOR_ARTIFACT_SCHEMA,
+    GAUGE_TREE_PRIOR_ARTIFACT_VERSION,
+    artifact_summary as gauge_tree_prior_summary,
+    load_gauge_tree_prior_artifact,
+)
+from .observation_contract import OBSERVATION_BELIEF_SCHEMA, OBSERVATION_BELIEF_VERSION
+from .observation_validation import load_observation_belief_export, validation_summary
+from .prediction_store import (
+    PREDICTION_BUNDLE_STORE_SCHEMA,
+    PREDICTION_BUNDLE_STORE_VERSION,
+    PREDICTION_STORE_MANIFEST,
+    prediction_bundle_store_summary,
+)
+from .tree_sparse_observation_artifact import (
+    TREE_SPARSE_OBSERVATION_ARTIFACT_SCHEMA,
+    TREE_SPARSE_OBSERVATION_ARTIFACT_VERSION,
+    load_tree_sparse_observation_artifact,
+)
+
+_IDENTITY_KEYS: Final = (
+    "artifact_id",
+    "manifest_id",
+    "store_id",
+    "portfolio_id",
+    "report_id",
+    "receipt_id",
+    "decision_id",
+    "authorization_id",
+    "lock_id",
+    "bundle_id",
+    "prior_id",
+    "calibration_id",
+    "model_set_id",
+)
+_CONTEXT_KEYS: Final = (
+    "sequence_id",
+    "case_id",
+    "stream_id",
+    "provider_id",
+    "provider_name",
+    "provider_version",
+    "provider_revision",
+    "causal_frame_stop",
+    "source_repository",
+    "source_revision",
+    "source_artifact_sha256",
+    "claim_boundary",
+    "storage_semantics",
+)
+
+
+def _descriptor_text(value: np.ndarray) -> str:
+    array = np.asarray(value)
+    if array.shape != () or array.dtype.kind not in {"U", "S"}:
+        raise ValueError("NPZ descriptor_json must be one scalar UTF-8 string")
+    item = array.item()
+    if isinstance(item, bytes):
+        try:
+            return item.decode("utf-8")
+        except UnicodeDecodeError as error:
+            raise ValueError("NPZ descriptor_json must contain UTF-8 text") from error
+    if type(item) is not str:
+        raise ValueError("NPZ descriptor_json must be one scalar UTF-8 string")
+    return item
+
+
+def _schema_name(value: Mapping[str, Any]) -> str | None:
+    for key in ("schema_name", "schema"):
+        candidate = value.get(key)
+        if type(candidate) is str and candidate:
+            return candidate
+    return None
+
+
+def _schema_version(value: Mapping[str, Any]) -> int | None:
+    candidate = value.get("schema_version")
+    return candidate if type(candidate) is int else None
+
+
+def _selected_fields(
+    value: Mapping[str, Any],
+    keys: Sequence[str],
+) -> dict[str, Any]:
+    return {key: value[key] for key in keys if key in value}
+
+
+def _known_explanation(
+    *,
+    path: Path,
+    artifact_format: str,
+    artifact_kind: str,
+    schema: str,
+    schema_version: int,
+    summary: Mapping[str, Any],
+) -> dict[str, Any]:
+    normalized = dict(summary)
+    normalized.pop("status", None)
+    normalized.pop("valid", None)
+    identity = _selected_fields(normalized, _IDENTITY_KEYS)
+    context = _selected_fields(normalized, _CONTEXT_KEYS)
+    details = {
+        key: value
+        for key, value in normalized.items()
+        if key not in identity
+        and key not in context
+        and key not in {"schema", "schema_name", "schema_version"}
+    }
+    return {
+        "status": "valid",
+        "path": str(path),
+        "format": artifact_format,
+        "artifact_kind": artifact_kind,
+        "validation_scope": "strict-schema-and-content-address",
+        "schema": schema,
+        "schema_version": schema_version,
+        "identity": identity,
+        "context": context,
+        "summary": details,
+    }
+
+
+def _structural_explanation(
+    *,
+    path: Path,
+    artifact_format: str,
+    artifact_kind: str,
+    descriptor: Mapping[str, Any],
+    members: Sequence[Mapping[str, Any]] = (),
+) -> dict[str, Any]:
+    explanation: dict[str, Any] = {
+        "status": "structural-only",
+        "path": str(path),
+        "format": artifact_format,
+        "artifact_kind": artifact_kind,
+        "validation_scope": (
+            "strict-JSON-object-syntax-only"
+            if artifact_format == "json"
+            else "non-pickled-NPZ-container-only"
+        ),
+        "schema": _schema_name(descriptor),
+        "schema_version": _schema_version(descriptor),
+        "identity": _selected_fields(descriptor, _IDENTITY_KEYS),
+        "context": _selected_fields(descriptor, _CONTEXT_KEYS),
+        "descriptor_fields": sorted(descriptor),
+        "warnings": [
+            "No registered strict loader matched this artifact; no schema semantics "
+            "or content digest were verified."
+        ],
+    }
+    if members:
+        explanation["members"] = list(members)
+    return explanation
+
+
+def _tree_sparse_summary(path: Path) -> dict[str, Any]:
+    loaded = load_tree_sparse_observation_artifact(path)
+    manifest = loaded.manifest
+    return {
+        "artifact_id": manifest.artifact_id,
+        "sequence_id": manifest.sequence_id,
+        "case_id": manifest.case_id,
+        "stream_id": manifest.stream_id,
+        "causal_frame_stop": manifest.causal_frame_stop,
+        "observation_count": manifest.observation_count,
+        "gauge_count": len(manifest.gauge_ids),
+        "view_count": len(manifest.view_id_table),
+        "factor_count": len(manifest.factor_id_table),
+        "correlation_group_count": len(manifest.correlation_group_id_table),
+        "gauge_tree_prior_artifact_id": manifest.gauge_tree_prior_artifact_id,
+        "source_repository": manifest.source_repository,
+        "source_revision": manifest.source_revision,
+        "claim_boundary": manifest.claim_boundary,
+        "storage_semantics": manifest.storage_semantics,
+    }
+
+
+def _explain_json(path: Path, *, require_strict: bool) -> dict[str, Any]:
+    descriptor = load_json_object(path, name="Prob4D artifact")
+    schema = _schema_name(descriptor)
+    if schema == GAUGE_TREE_PRIOR_ARTIFACT_SCHEMA:
+        summary = gauge_tree_prior_summary(load_gauge_tree_prior_artifact(path))
+        return _known_explanation(
+            path=path,
+            artifact_format="json-with-npy-sidecars",
+            artifact_kind="gauge-tree-prior-artifact-v1",
+            schema=GAUGE_TREE_PRIOR_ARTIFACT_SCHEMA,
+            schema_version=GAUGE_TREE_PRIOR_ARTIFACT_VERSION,
+            summary=summary,
+        )
+    if schema == TREE_SPARSE_OBSERVATION_ARTIFACT_SCHEMA:
+        return _known_explanation(
+            path=path,
+            artifact_format="json-with-npy-sidecars",
+            artifact_kind="tree-sparse-observation-artifact-v1",
+            schema=TREE_SPARSE_OBSERVATION_ARTIFACT_SCHEMA,
+            schema_version=TREE_SPARSE_OBSERVATION_ARTIFACT_VERSION,
+            summary=_tree_sparse_summary(path),
+        )
+    if schema == PREDICTION_BUNDLE_STORE_SCHEMA:
+        return _known_explanation(
+            path=path.parent,
+            artifact_format="directory-with-json-and-npy-members",
+            artifact_kind="prediction-bundle-store-v1",
+            schema=PREDICTION_BUNDLE_STORE_SCHEMA,
+            schema_version=PREDICTION_BUNDLE_STORE_VERSION,
+            summary=prediction_bundle_store_summary(path.parent),
+        )
+    if require_strict:
+        raise ValueError(
+            "artifact has no registered strict loader; rerun without --require-strict "
+            "for a structural explanation"
+        )
+    return _structural_explanation(
+        path=path,
+        artifact_format="json",
+        artifact_kind="unrecognized-json-object",
+        descriptor=descriptor,
+    )
+
+
+def _npz_members(
+    archive: np.lib.npyio.NpzFile,
+    *,
+    include_arrays: bool,
+) -> list[dict[str, Any]]:
+    members: list[dict[str, Any]] = []
+    for name in sorted(archive.files):
+        member: dict[str, Any] = {"name": name}
+        if include_arrays:
+            array = np.asarray(archive[name])
+            member.update(
+                {
+                    "dtype": array.dtype.str,
+                    "shape": list(array.shape),
+                    "nbytes": int(array.nbytes),
+                }
+            )
+        members.append(member)
+    return members
+
+
+def _explain_npz(
+    path: Path,
+    *,
+    require_strict: bool,
+    include_arrays: bool,
+) -> dict[str, Any]:
+    try:
+        with np.load(path, allow_pickle=False) as archive:
+            members = _npz_members(archive, include_arrays=include_arrays)
+            if "descriptor_json" not in archive:
+                descriptor: dict[str, Any] = {}
+            else:
+                descriptor = loads_json_object(
+                    _descriptor_text(archive["descriptor_json"]),
+                    name="NPZ descriptor_json",
+                )
+    except OSError as error:
+        raise ValueError("artifact is not a valid non-pickled NPZ") from error
+    except ValueError as error:
+        if str(error).startswith("NPZ descriptor_json"):
+            raise
+        raise ValueError("artifact is not a valid non-pickled NPZ") from error
+
+    if _schema_name(descriptor) == OBSERVATION_BELIEF_SCHEMA:
+        artifact = load_observation_belief_export(path)
+        explanation = _known_explanation(
+            path=path,
+            artifact_format="npz",
+            artifact_kind="observation-belief-v1",
+            schema=OBSERVATION_BELIEF_SCHEMA,
+            schema_version=OBSERVATION_BELIEF_VERSION,
+            summary=validation_summary(artifact),
+        )
+        if include_arrays:
+            explanation["members"] = members
+        return explanation
+    if require_strict:
+        raise ValueError(
+            "NPZ artifact has no registered strict loader; rerun without "
+            "--require-strict for a structural explanation"
+        )
+    return _structural_explanation(
+        path=path,
+        artifact_format="npz",
+        artifact_kind="unrecognized-npz",
+        descriptor=descriptor,
+        members=members,
+    )
+
+
+def _explain_directory(path: Path, *, require_strict: bool) -> dict[str, Any]:
+    manifest = path / PREDICTION_STORE_MANIFEST
+    if manifest.is_symlink():
+        raise ValueError("artifact directory manifest must not be a symbolic link")
+    if not manifest.is_file():
+        raise ValueError(
+            f"artifact directory has no regular {PREDICTION_STORE_MANIFEST}"
+        )
+    return _explain_json(manifest, require_strict=require_strict)
+
+
+def explain_artifact(
+    artifact: str | Path,
+    *,
+    require_strict: bool = False,
+    include_arrays: bool = False,
+) -> dict[str, Any]:
+    """Explain one artifact without overstating unrecognized structural checks."""
+
+    path = Path(artifact)
+    if path.is_symlink():
+        raise ValueError("artifact path must not be a symbolic link")
+    if path.is_dir():
+        return _explain_directory(path, require_strict=require_strict)
+    if not path.is_file():
+        raise ValueError(f"artifact is not a regular file or directory: {path}")
+    if path.suffix.lower() == ".npz":
+        return _explain_npz(
+            path,
+            require_strict=require_strict,
+            include_arrays=include_arrays,
+        )
+    return _explain_json(path, require_strict=require_strict)
+
+
+def _format_value(value: Any) -> str:
+    if isinstance(value, (Mapping, list, tuple)) or value is None or isinstance(value, bool):
+        return json.dumps(value, sort_keys=True, allow_nan=False)
+    return str(value)
+
+
+def render_text(explanation: Mapping[str, Any]) -> str:
+    """Render a deterministic human-readable explanation."""
+
+    lines = [
+        f"Artifact: {explanation['path']}",
+        f"Kind: {explanation['artifact_kind']}",
+        f"Format: {explanation['format']}",
+        f"Status: {explanation['status']}",
+        f"Validation: {explanation['validation_scope']}",
+    ]
+    schema = explanation.get("schema")
+    if schema is not None:
+        lines.append(f"Schema: {schema} v{explanation.get('schema_version')}")
+    for section in ("identity", "context", "summary"):
+        values = explanation.get(section)
+        if not isinstance(values, Mapping) or not values:
+            continue
+        lines.extend(["", section.capitalize() + ":"])
+        for key in sorted(values):
+            lines.append(f"  {key}: {_format_value(values[key])}")
+    members = explanation.get("members")
+    if isinstance(members, list) and members:
+        lines.extend(["", "Members:"])
+        for member in members:
+            if not isinstance(member, Mapping):
+                continue
+            name = member.get("name", "<unnamed>")
+            details = ", ".join(
+                f"{key}={_format_value(member[key])}"
+                for key in ("dtype", "shape", "nbytes")
+                if key in member
+            )
+            lines.append(f"  {name}" + (f" ({details})" if details else ""))
+    warnings = explanation.get("warnings")
+    if isinstance(warnings, list) and warnings:
+        lines.extend(["", "Warnings:"])
+        lines.extend(f"  {warning}" for warning in warnings)
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the grouped ``prob4d artifact explain`` command."""
+
+    parser = argparse.ArgumentParser(
+        prog="prob4d artifact explain",
+        description=(
+            "Explain a Prob4D JSON, NPZ, or prediction-store artifact. Known "
+            "schemas use their strict loader; unknown artifacts are clearly "
+            "reported as structural-only."
+        )
+    )
+    parser.add_argument("artifact", type=Path)
+    parser.add_argument("--json", action="store_true", dest="json_output")
+    parser.add_argument(
+        "--require-strict",
+        action="store_true",
+        help="reject artifacts without a registered strict schema loader",
+    )
+    parser.add_argument(
+        "--arrays",
+        action="store_true",
+        help="include NPZ member dtype, shape, and uncompressed byte counts",
+    )
+    arguments = parser.parse_args(list(argv) if argv is not None else None)
+    try:
+        explanation = explain_artifact(
+            arguments.artifact,
+            require_strict=arguments.require_strict,
+            include_arrays=arguments.arrays,
+        )
+    except (OSError, ValueError) as error:
+        print(f"unable to explain artifact: {error}", file=sys.stderr)
+        return 2
+    if arguments.json_output:
+        print(json.dumps(explanation, indent=2, sort_keys=True, allow_nan=False))
+    else:
+        print(render_text(explanation), end="")
+    return 0
+
+
+__all__ = ["explain_artifact", "main", "render_text"]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/prob4d/command_registry.py
+++ b/src/prob4d/command_registry.py
@@ -107,6 +107,17 @@ _COMMAND_ROWS: Final[tuple[CommandRow, ...]] = (
         False,
     ),
     (
+        "artifact-explain",
+        "artifact explain",
+        "prob4d.artifact_explain:main",
+        "explain validated or structural Prob4D artifacts",
+        S,
+        "artifact-inspection",
+        (),
+        False,
+        False,
+    ),
+    (
         "ablation",
         "ablate",
         "prob4d.experiments:main",

--- a/tests/test_artifact_explain.py
+++ b/tests/test_artifact_explain.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from prob4d.artifact_explain import explain_artifact, main, render_text
+from prob4d.cli import main as grouped_main
+from prob4d.gauge_tree_prior import GaugeTreeSquareRootPriorV1
+from prob4d.gauge_tree_prior_artifact import write_gauge_tree_prior_artifact
+from prob4d.observation_contract import (
+    ObservationBeliefExportV1,
+    save_observation_belief_export,
+)
+
+
+def _observation() -> ObservationBeliefExportV1:
+    return ObservationBeliefExportV1(
+        case_id="case-1",
+        stream_id="prob4d:points",
+        causal_frame_stop=12,
+        view_names=("camera0",),
+        window_names=("window0",),
+        factor_names=(),
+        source_repository="IPS-Stuttgart/Prob4D",
+        source_revision="a" * 40,
+        source_artifact_sha256="b" * 64,
+        declared_frame_ids=np.asarray([8]),
+        mean_xyz_m=np.asarray([[0.0, 0.0, 1.0]]),
+        frame_ids=np.asarray([8]),
+        entity_ids=np.asarray([0]),
+        view_indices=np.asarray([0]),
+        window_indices=np.asarray([0]),
+        correlation_group_ids=np.asarray([0]),
+        factor_group_ids=np.asarray([0]),
+        prior_reliability=np.asarray([0.9]),
+        association_probability=np.asarray([1.0]),
+        local_covariance_m2=np.eye(3)[None] * 1e-4,
+        low_rank_factor_m=np.zeros((1, 3, 0)),
+        group_ids=np.asarray([0]),
+        group_prior_nominal_probability=np.asarray([0.9]),
+        group_composite_weight=np.asarray([1.0]),
+        metadata={"causal_source": "prefix only"},
+    )
+
+
+def _gauge_prior() -> GaugeTreeSquareRootPriorV1:
+    transitions = np.zeros((2, 7, 7), dtype=np.float64)
+    transitions[1] = np.eye(7) * 0.8
+    scales = np.repeat(np.eye(7, dtype=np.float64)[None], 2, axis=0) * 0.1
+    return GaugeTreeSquareRootPriorV1(
+        gauge_ids=("gauge-0", "gauge-1"),
+        parent_indices=np.asarray([-1, 0]),
+        transition_matrices=transitions,
+        innovation_scale_tril=scales,
+        source_joint_covariance_sha256="c" * 64,
+    )
+
+
+def test_explain_observation_uses_strict_loader(tmp_path: Path) -> None:
+    path = tmp_path / "observation.npz"
+    artifact = _observation()
+    save_observation_belief_export(path, artifact)
+
+    explanation = explain_artifact(path, require_strict=True)
+
+    assert explanation["status"] == "valid"
+    assert explanation["artifact_kind"] == "observation-belief-v1"
+    assert explanation["identity"]["artifact_id"] == artifact.artifact_id
+    assert explanation["context"]["case_id"] == "case-1"
+    assert explanation["summary"]["observation_count"] == 1
+    assert "Members:" not in render_text(explanation)
+
+
+def test_explain_observation_can_include_array_inventory(tmp_path: Path) -> None:
+    path = tmp_path / "observation.npz"
+    save_observation_belief_export(path, _observation())
+
+    explanation = explain_artifact(path, include_arrays=True)
+
+    members = {member["name"]: member for member in explanation["members"]}
+    assert members["mean_xyz_m"]["shape"] == [1, 3]
+    assert members["mean_xyz_m"]["dtype"] == "<f8"
+    assert members["descriptor_json"]["shape"] == []
+
+
+def test_explain_gauge_tree_prior_uses_sidecar_validation(tmp_path: Path) -> None:
+    path = tmp_path / "prior.json"
+    loaded = write_gauge_tree_prior_artifact(_gauge_prior(), path)
+
+    explanation = explain_artifact(path, require_strict=True)
+
+    assert explanation["status"] == "valid"
+    assert explanation["artifact_kind"] == "gauge-tree-prior-artifact-v1"
+    assert explanation["identity"]["artifact_id"] == loaded.manifest.artifact_id
+    assert explanation["summary"]["gauge_count"] == 2
+
+
+def test_unknown_json_is_never_reported_as_valid(tmp_path: Path) -> None:
+    path = tmp_path / "unknown.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema": "example.unknown",
+                "schema_version": 1,
+                "artifact_id": "d" * 64,
+                "case_id": "case-unknown",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    explanation = explain_artifact(path)
+
+    assert explanation["status"] == "structural-only"
+    assert explanation["validation_scope"] == "strict-JSON-object-syntax-only"
+    assert explanation["identity"]["artifact_id"] == "d" * 64
+    assert explanation["warnings"]
+
+
+def test_require_strict_rejects_unknown_json(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = tmp_path / "unknown.json"
+    path.write_text('{"schema":"example.unknown","schema_version":1}', encoding="utf-8")
+
+    assert main([str(path), "--require-strict"]) == 2
+    assert "no registered strict loader" in capsys.readouterr().err
+
+
+def test_json_parser_rejects_duplicate_keys(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = tmp_path / "duplicate.json"
+    path.write_text('{"schema":"first","schema":"second"}', encoding="utf-8")
+
+    assert main([str(path)]) == 2
+    assert "duplicate JSON object key" in capsys.readouterr().err
+
+
+def test_npz_descriptor_error_is_not_hidden(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = tmp_path / "duplicate-descriptor.npz"
+    np.savez_compressed(
+        path,
+        descriptor_json=np.asarray(
+            '{"schema_name":"first","schema_name":"second"}'
+        ),
+    )
+
+    assert main([str(path)]) == 2
+    assert "duplicate JSON object key" in capsys.readouterr().err
+
+
+def test_grouped_cli_prints_machine_readable_explanation(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    path = tmp_path / "observation.npz"
+    save_observation_belief_export(path, _observation())
+
+    assert grouped_main(["artifact", "explain", str(path), "--json"]) == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "valid"
+    assert payload["artifact_kind"] == "observation-belief-v1"
+
+
+def test_grouped_cli_help_is_registered(capsys: pytest.CaptureFixture[str]) -> None:
+    assert grouped_main(["artifact", "--help"]) == 0
+    output = capsys.readouterr().out
+    assert "explain" in output


### PR DESCRIPTION
## What

- add `prob4d artifact explain` with strict loaders for known content-addressed artifacts;
- label unknown JSON and NPZ containers as `structural-only`, with `--require-strict` for automated or claim-bearing workflows;
- provide optional NPZ member dtype, shape, and uncompressed-byte inventory without printing payload values;
- document the current provider-evidence boundary and clarify that a mature producer path is not scientific provider promotion.

## Why

Prob4D has rigorous content-addressed artifacts, but collaborators lacked a concise way to inspect their identity, causal/source context, and validation scope. The README also needed to separate adapter maturity from the current controlled, retrospective, and source-support evidence boundaries.

## Integration update

The branch is mergeable against current `main` after PRs #259–#261. GitHub's generated merge commit resolves the README-only overlap while retaining both the provider-evidence status and the joint `Sim(3)` closure documentation.

## Validation

All eleven pull-request workflows pass on exact head `b0347d469ef747bdb81d156e8b0bd002535474d6` against current `main`:

- authoritative Ruff, documentation-surface validation, and mypy;
- complete test suites on Python 3.10, 3.11, 3.12, 3.13, and 3.14;
- complete suite at the declared NumPy 1.24 runtime floor;
- repository, release, API, provider, and distribution policy checks;
- wheel and source-distribution build and validation;
- isolated installed-wheel and installed-sdist CLI smoke;
- provider batch preflight, target admission, held-out promotion, finite-sample, target-free rehearsal, visual-bias calibration, and sparse gauge-tree artifact lanes; and
- CodeQL plus resolved runtime dependency audit.

The sole initial CI failure was Ruff import ordering in `artifact_explain.py`; commit `b0347d4` applies exactly the prescribed import split. Mypy, documentation validation, tests, and runtime behavior were already passing.

Focused tests cover strict known-artifact loading, explicit structural-only results for unknown JSON and NPZ containers, `--require-strict` failure, duplicate/non-finite JSON rejection, non-pickled NPZ handling, symlink rejection, prediction stores, sparse gauge artifacts, observation beliefs, deterministic text/JSON rendering, and array metadata without payload values.

## Scientific boundary

This is artifact-inspection and documentation infrastructure. It changes no estimator equation, calibration fit, provider artifact, cohort, target-access decision, BayesianPhysTwin update guard, exact fallback, Causal4D intervention result, deployment claim, or state-of-the-art claim.