### PR TITLE
Add target-free held-out study sensitivity preflight

### DIFF
--- a/CHANGELOG.d/study-preflight.md
+++ b/CHANGELOG.d/study-preflight.md
@@ -1,0 +1,3 @@
+Add a high-level target-free held-out study preflight, including source-bound
+paired-effect sensitivity, exact harmful-update rate resolution, immutable JSON
+and Markdown reports, and generated monotonicity tests for the design audit.

--- a/docs/command-line.md
+++ b/docs/command-line.md
@@ -37,8 +37,13 @@ prob4d sintel uncertainty
 prob4d storage benchmark
 prob4d storage materialize
 prob4d storage validate
+prob4d study preflight
 prob4d vggt baseline
 ```
+
+The target-free `prob4d study preflight` route composes the finite-sample
+capability check with a source-bound paired-effect and harmful-update sensitivity
+report. See [held-out study preflight](study-preflight.md).
 
 The bare `prob4d observation export` route prints guidance and deliberately runs
 no exporter. Claim-bearing work must select `export-calibrated`; uncalibrated or

--- a/docs/study-preflight.md
+++ b/docs/study-preflight.md
@@ -1,0 +1,126 @@
+# Held-out study preflight
+
+`prob4d study preflight` is a high-level, target-free design command for one
+sealed held-out provider study. It composes two existing scientific boundaries
+without adding a target-side method or changing the frozen decision:
+
+1. the finite-sample capability report derived from calibration and target
+   object/session counts; and
+2. a source-bound sensitivity report derived from declared paired-difference
+   standard deviations.
+
+The command reads the promotion lock and optional cohort binding. It does not
+read provider payloads, target predictions, physical-query outcomes, or target
+metrics.
+
+## Example
+
+```bash
+prob4d study preflight promotion-lock.json \
+  --cohort-binding deform360-cohort-binding.json \
+  --source-summary-id <source-summary-sha256> \
+  --source-metric deployed_minus_physical_rmse_mm \
+  --paired-sd source-estimate=0.85 \
+  --paired-sd conservative=1.20 \
+  --coverage 0.90 \
+  --coverage 0.95 \
+  --power 0.80 \
+  --power 0.90 \
+  --confidence 0.95 \
+  --accepted-groups 6 \
+  --accepted-groups 12 \
+  --output-dir outputs/study-preflight
+```
+
+The output directory contains:
+
+```text
+finite_sample_capability.json
+finite_sample_capability.md
+study_sensitivity.json
+study_sensitivity.md
+```
+
+Every destination is checked before the first file is written. Existing
+artifacts are never replaced.
+
+## Paired-effect sensitivity
+
+For target-group count `n`, source-declared paired standard deviation `s`, power
+`1-beta`, and confidence `1-alpha`, the reported normal-approximation minimum
+detectable effect is
+
+```text
+MDE = (z_critical + z_(1-beta)) * s / sqrt(n).
+```
+
+For a two-sided interval, `z_critical = z_(1-alpha/2)`; for a one-sided interval,
+`z_critical = z_(1-alpha)`. The report also records the corresponding confidence
+interval half-width and standardized effect size.
+
+The source standard deviations are scenarios, not estimates silently inferred
+from the target. Each scenario has a stable name and is bound to an exact
+`source_summary_id`. A scenario may be a source estimate, an upper confidence
+bound, or another preregistered conservative value. The report does not choose
+between scenarios after target access.
+
+When the promotion lock declares a positive query-superiority margin, each row
+states whether an effect exactly equal to that margin is detectable at the
+requested power under the scenario. A zero margin is reported as not applicable;
+statistical sensitivity cannot certify an effect of exactly zero.
+
+## Harmful-update resolution
+
+The accepted-group count is unknown before the target run, so the command accepts
+one or more explicit denominator scenarios through `--accepted-groups`. The
+default scenario is all frozen target groups.
+
+For each denominator, the report contains:
+
+- the rate contribution of one harmful accepted update;
+- the frozen maximum harmful-update count;
+- an exact one-sided Clopper--Pearson upper rate bound when zero harmful updates
+  are observed; and
+- the corresponding upper rate bound at the frozen allowed count.
+
+These values describe what the group count can resolve. They do not replace the
+frozen count-based decision, predict the accepted-group count, or authorize a
+rate claim on unopened data.
+
+## Python façade
+
+The same target-free composition is available without manually selecting the
+low-level builders:
+
+```python
+from prob4d.study import HeldoutProviderStudy
+from prob4d.study_sensitivity import PairedDifferenceScenarioV1
+
+study = HeldoutProviderStudy.from_lock("promotion-lock.json")
+preflight = study.preflight(
+    source_summary_id="<source-summary-sha256>",
+    source_metric="deployed_minus_physical_rmse_mm",
+    paired_difference_scenarios=(
+        PairedDifferenceScenarioV1("source-estimate", 0.85),
+        PairedDifferenceScenarioV1("conservative", 1.20),
+    ),
+)
+```
+
+The façade is intentionally read-only and target-free. Claim-bearing source
+qualification, one-shot target evaluation, and independent verification remain
+owned by the existing `fresh-provider-readiness`, `evaluate provider`, and
+`experiment heldout-provider` contracts.
+
+## Interpretation boundary
+
+The sensitivity calculation is a transparent normal approximation. It does not
+establish that paired target differences are normal, independent, or
+exchangeable. It must not change the promotion lock, the target roster, the
+bootstrap decision, the fallback rule, or the target-side analysis.
+
+A result that is not decisive with a small frozen target cohort must be reported
+as inconclusive at the declared resolution, not rewritten as evidence of no
+effect. Conversely, an apparently favorable target result does not rescue a
+failed support, mean, identity, gauge/dependence, covariance, or query-relevance
+gate.

--- a/src/prob4d/command_registry.py
+++ b/src/prob4d/command_registry.py
@@ -261,6 +261,17 @@ _COMMAND_ROWS: Final[tuple[CommandRow, ...]] = (
         False,
     ),
     (
+        "study-preflight",
+        "study preflight",
+        "prob4d.study:main",
+        "compose target-free finite-sample and sensitivity reports",
+        D,
+        "heldout-study-design",
+        (),
+        False,
+        False,
+    ),
+    (
         "provider-support-envelope",
         "diagnostic provider-support-envelope",
         "prob4d.provider_support_envelope:main",

--- a/src/prob4d/study.py
+++ b/src/prob4d/study.py
@@ -1,0 +1,306 @@
+"""High-level target-free orchestration for one held-out provider study.
+
+This module composes existing finite-sample capability checks with the additive
+source-derived sensitivity audit. It deliberately stops before provider target
+I/O: claim-bearing qualification, evaluation, and verification remain owned by
+the existing frozen commands and artifacts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from ._finite_sample_capability_common import DEFAULT_COVERAGE_LEVELS, coverage
+from ._finite_sample_capability_model import FiniteSampleCapabilityV1
+from ._finite_sample_capability_output import write_finite_sample_capability
+from ._heldout_promotion_lock import (
+    HeldoutProviderPromotionLockV1,
+    load_promotion_lock,
+)
+from .deform360_cohort_binding import (
+    Deform360OfficialHubCohortBindingV1,
+    load_deform360_cohort_binding,
+)
+from .finite_sample_capability import (
+    build_finite_sample_capability,
+    build_finite_sample_capability_from_cohort_binding,
+)
+from .study_sensitivity import (
+    ALTERNATIVES,
+    DEFAULT_POWER_LEVELS,
+    PairedDifferenceScenarioV1,
+    StudySensitivityV1,
+    build_study_sensitivity,
+    write_study_sensitivity,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class StudyPreflightV1:
+    """In-memory index over the two target-free preflight artifacts."""
+
+    capability: FiniteSampleCapabilityV1
+    sensitivity: StudySensitivityV1
+
+    def __post_init__(self) -> None:
+        if self.capability.promotion_lock_id != self.sensitivity.promotion_lock_id:
+            raise ValueError("preflight artifacts bind different promotion locks")
+        if self.capability.target_group_ids != self.sensitivity.target_group_ids:
+            raise ValueError("preflight artifacts bind different target groups")
+
+    @property
+    def promotion_lock_id(self) -> str:
+        return self.capability.promotion_lock_id
+
+    @property
+    def target_group_count(self) -> int:
+        return len(self.capability.target_group_ids)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "promotion_lock_id": self.promotion_lock_id,
+            "finite_sample_capability_id": self.capability.capability_id,
+            "study_sensitivity_id": self.sensitivity.sensitivity_id,
+            "target_group_count": self.target_group_count,
+            "primary_levels_finite": self.capability.primary_levels_finite,
+            "stratum_levels_finite": self.capability.stratum_levels_finite,
+            "query_margin_detectable": self.sensitivity.query_margin_detectable,
+            "target_outcomes_opened": False,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class HeldoutProviderStudy:
+    """Small read-only façade over one sealed held-out promotion lock."""
+
+    lock: HeldoutProviderPromotionLockV1
+
+    @classmethod
+    def from_lock(cls, path: str | Path) -> HeldoutProviderStudy:
+        return cls(load_promotion_lock(Path(path)))
+
+    @property
+    def promotion_lock_id(self) -> str:
+        return self.lock.promotion_lock_id
+
+    @property
+    def group_counts(self) -> Mapping[str, int]:
+        return {
+            "development": len(self.lock.development_group_ids),
+            "calibration": len(self.lock.calibration_group_ids),
+            "target": len(self.lock.target_group_ids),
+        }
+
+    def finite_sample_capability(
+        self,
+        *,
+        coverage_levels: Sequence[float] = DEFAULT_COVERAGE_LEVELS,
+        cohort_binding: Deform360OfficialHubCohortBindingV1 | None = None,
+    ) -> FiniteSampleCapabilityV1:
+        """Build the existing group-count and split-conformal capability report."""
+
+        if cohort_binding is None:
+            return build_finite_sample_capability(
+                self.lock,
+                coverage_levels=coverage_levels,
+            )
+        return build_finite_sample_capability_from_cohort_binding(
+            self.lock,
+            cohort_binding,
+            coverage_levels=coverage_levels,
+        )
+
+    def sensitivity(
+        self,
+        *,
+        source_summary_id: str,
+        source_metric: str,
+        paired_difference_scenarios: Sequence[PairedDifferenceScenarioV1],
+        power_levels: Sequence[float] = DEFAULT_POWER_LEVELS,
+        confidence_level: float = 0.95,
+        alternative: str = "two-sided",
+        accepted_group_counts: Sequence[int] | None = None,
+    ) -> StudySensitivityV1:
+        """Build the source-bound target-resolution report."""
+
+        return build_study_sensitivity(
+            self.lock,
+            source_summary_id=source_summary_id,
+            source_metric=source_metric,
+            paired_difference_scenarios=paired_difference_scenarios,
+            power_levels=power_levels,
+            confidence_level=confidence_level,
+            alternative=alternative,
+            accepted_group_counts=accepted_group_counts,
+        )
+
+    def preflight(
+        self,
+        *,
+        source_summary_id: str,
+        source_metric: str,
+        paired_difference_scenarios: Sequence[PairedDifferenceScenarioV1],
+        coverage_levels: Sequence[float] = DEFAULT_COVERAGE_LEVELS,
+        power_levels: Sequence[float] = DEFAULT_POWER_LEVELS,
+        confidence_level: float = 0.95,
+        alternative: str = "two-sided",
+        accepted_group_counts: Sequence[int] | None = None,
+        cohort_binding: Deform360OfficialHubCohortBindingV1 | None = None,
+    ) -> StudyPreflightV1:
+        """Compose both target-free design reports without opening target outcomes."""
+
+        return StudyPreflightV1(
+            capability=self.finite_sample_capability(
+                coverage_levels=coverage_levels,
+                cohort_binding=cohort_binding,
+            ),
+            sensitivity=self.sensitivity(
+                source_summary_id=source_summary_id,
+                source_metric=source_metric,
+                paired_difference_scenarios=paired_difference_scenarios,
+                power_levels=power_levels,
+                confidence_level=confidence_level,
+                alternative=alternative,
+                accepted_group_counts=accepted_group_counts,
+            ),
+        )
+
+
+def write_study_preflight(preflight: StudyPreflightV1, output_dir: str | Path) -> None:
+    """Publish both component reports after one all-destination no-clobber check."""
+
+    directory = Path(output_dir)
+    capability_json = directory / "finite_sample_capability.json"
+    capability_markdown = directory / "finite_sample_capability.md"
+    sensitivity_json = directory / "study_sensitivity.json"
+    sensitivity_markdown = directory / "study_sensitivity.md"
+    destinations = (
+        capability_json,
+        capability_markdown,
+        sensitivity_json,
+        sensitivity_markdown,
+    )
+    existing = tuple(path for path in destinations if path.exists())
+    if existing:
+        raise FileExistsError(
+            "study preflight output already exists: "
+            + ", ".join(str(path) for path in existing)
+        )
+    write_finite_sample_capability(
+        preflight.capability,
+        capability_json,
+        markdown=capability_markdown,
+    )
+    write_study_sensitivity(
+        preflight.sensitivity,
+        sensitivity_json,
+        markdown=sensitivity_markdown,
+    )
+
+
+def _coverage_argument(value: str) -> float:
+    try:
+        return coverage(float(value), name="coverage")
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(str(error)) from error
+
+
+def _power_argument(value: str) -> float:
+    try:
+        result = float(value)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("power must be a real number") from error
+    if not 0.5 < result < 1.0:
+        raise argparse.ArgumentTypeError("power must be strictly between 0.5 and 1.0")
+    return result
+
+
+def _scenario_argument(value: str) -> PairedDifferenceScenarioV1:
+    scenario_id, separator, raw_standard_deviation = value.partition("=")
+    if not separator:
+        raise argparse.ArgumentTypeError("paired SD must use SCENARIO_ID=STANDARD_DEVIATION_MM")
+    try:
+        return PairedDifferenceScenarioV1(scenario_id, float(raw_standard_deviation))
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(str(error)) from error
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run one high-level target-free study preflight."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("lock", type=Path)
+    parser.add_argument("--cohort-binding", type=Path)
+    parser.add_argument("--source-summary-id", required=True)
+    parser.add_argument("--source-metric", required=True)
+    parser.add_argument(
+        "--paired-sd",
+        type=_scenario_argument,
+        action="append",
+        required=True,
+        dest="paired_scenarios",
+        metavar="SCENARIO=MM",
+    )
+    parser.add_argument("--coverage", type=_coverage_argument, action="append")
+    parser.add_argument("--power", type=_power_argument, action="append")
+    parser.add_argument("--confidence", type=_power_argument, default=0.95)
+    parser.add_argument("--alternative", choices=ALTERNATIVES, default="two-sided")
+    parser.add_argument(
+        "--accepted-groups",
+        type=int,
+        action="append",
+        dest="accepted_group_counts",
+    )
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--require-primary-finite", action="store_true")
+    parser.add_argument("--require-strata-finite", action="store_true")
+    arguments = parser.parse_args(argv)
+
+    study = HeldoutProviderStudy.from_lock(arguments.lock)
+    cohort_binding = (
+        None
+        if arguments.cohort_binding is None
+        else load_deform360_cohort_binding(arguments.cohort_binding)
+    )
+    preflight = study.preflight(
+        source_summary_id=arguments.source_summary_id,
+        source_metric=arguments.source_metric,
+        paired_difference_scenarios=arguments.paired_scenarios,
+        coverage_levels=(
+            DEFAULT_COVERAGE_LEVELS
+            if arguments.coverage is None
+            else arguments.coverage
+        ),
+        power_levels=DEFAULT_POWER_LEVELS if arguments.power is None else arguments.power,
+        confidence_level=arguments.confidence,
+        alternative=arguments.alternative,
+        accepted_group_counts=arguments.accepted_group_counts,
+        cohort_binding=cohort_binding,
+    )
+    write_study_preflight(preflight, arguments.output_dir)
+    print(json.dumps(preflight.to_dict(), sort_keys=True))
+
+    if arguments.require_primary_finite and not preflight.capability.primary_levels_finite:
+        return 3
+    if (
+        arguments.require_strata_finite
+        and preflight.capability.stratum_levels_finite is not True
+    ):
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "HeldoutProviderStudy",
+    "StudyPreflightV1",
+    "main",
+    "write_study_preflight",
+]

--- a/src/prob4d/study_sensitivity.py
+++ b/src/prob4d/study_sensitivity.py
@@ -1,0 +1,833 @@
+"""Target-free sensitivity audit for held-out provider studies.
+
+The audit binds source-derived paired-difference dispersion to one sealed
+promotion lock and reports the effect sizes and harmful-update rates that the
+frozen target group count can resolve. It never reads provider payloads, target
+predictions, physical-query outcomes, or target metrics.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from statistics import NormalDist
+from typing import Any, Protocol, cast
+
+from ._atomic_file import atomic_write_text
+from ._heldout_promotion_lock import load_promotion_lock
+from ._strict_json import (
+    load_json_object,
+    require_exact_fields,
+    require_exact_integer,
+    require_exact_string,
+    require_json_number,
+    require_mapping,
+    require_sha256,
+    require_string_sequence,
+)
+
+STUDY_SENSITIVITY_SCHEMA = "prob4d.study-sensitivity"
+STUDY_SENSITIVITY_VERSION = 1
+STUDY_SENSITIVITY_CLAIM_BOUNDARY = (
+    "This target-free design audit uses source-declared paired standard deviations and "
+    "a transparent normal approximation to describe statistical resolution. It does "
+    "not open target outcomes, alter the frozen target decision, establish normality "
+    "or exchangeability, prove provider competence, establish BayesianPhysTwin or "
+    "Causal4D benefit, calibrate deployment uncertainty, or support a state-of-the-art "
+    "claim."
+)
+DEFAULT_POWER_LEVELS = (0.80, 0.90)
+ALTERNATIVES = ("one-sided", "two-sided")
+
+
+class PromotionLockLike(Protocol):
+    """Minimal target-free lock surface required by this audit."""
+
+    promotion_lock_id: str
+    target_group_ids: tuple[str, ...]
+    minimum_target_group_count: int
+    query_superiority_margin_mm: float
+    harmful_update_margin_mm: float
+    maximum_harmful_accepted_updates: int
+    maximum_worst_group_regression_mm: float
+
+
+def _canonical_json(value: Mapping[str, object]) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _strict_positive(value: object, *, name: str) -> float:
+    result = require_json_number(value, name=name)
+    if result <= 0.0:
+        raise ValueError(f"{name} must be strictly positive")
+    return result
+
+
+def _strict_nonnegative(value: object, *, name: str) -> float:
+    result = require_json_number(value, name=name)
+    if result < 0.0:
+        raise ValueError(f"{name} must be nonnegative")
+    return result
+
+
+def _strict_probability(value: object, *, name: str) -> float:
+    result = require_json_number(value, name=name)
+    if not 0.5 < result < 1.0:
+        raise ValueError(f"{name} must be strictly between 0.5 and 1.0")
+    return result
+
+
+def _canonical_group_ids(value: object, *, name: str) -> tuple[str, ...]:
+    result = require_string_sequence(value, name=name)
+    if result != tuple(sorted(result)) or len(set(result)) != len(result):
+        raise ValueError(f"{name} must be sorted and unique")
+    return result
+
+
+def _canonical_probabilities(value: object, *, name: str) -> tuple[float, ...]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise ValueError(f"{name} must be a sequence of probabilities")
+    normalized = {
+        _strict_probability(item, name=f"{name}[{index}]")
+        for index, item in enumerate(value)
+    }
+    result = tuple(sorted(normalized))
+    if not result:
+        raise ValueError(f"{name} must not be empty")
+    return result
+
+
+def _canonical_counts(
+    value: object,
+    *,
+    name: str,
+    maximum: int,
+) -> tuple[int, ...]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise ValueError(f"{name} must be a sequence of integers")
+    result = tuple(
+        sorted(
+            {
+                require_exact_integer(item, name=f"{name}[{index}]", minimum=1)
+                for index, item in enumerate(value)
+            }
+        )
+    )
+    if not result:
+        raise ValueError(f"{name} must not be empty")
+    if result[-1] > maximum:
+        raise ValueError(f"{name} cannot exceed the frozen target group count")
+    return result
+
+
+def _normal_critical_value(confidence_level: float, alternative: str) -> float:
+    alpha = 1.0 - confidence_level
+    probability = 1.0 - alpha / 2.0 if alternative == "two-sided" else confidence_level
+    return NormalDist().inv_cdf(probability)
+
+
+def _binomial_cdf(events: int, trials: int, probability: float) -> float:
+    """Return P[X <= events] with stable log-domain summation."""
+
+    if probability <= 0.0:
+        return 1.0
+    if probability >= 1.0:
+        return 1.0 if events >= trials else 0.0
+    if events >= trials:
+        return 1.0
+
+    log_probability = math.log(probability)
+    log_complement = math.log1p(-probability)
+    logs = [
+        math.lgamma(trials + 1)
+        - math.lgamma(index + 1)
+        - math.lgamma(trials - index + 1)
+        + index * log_probability
+        + (trials - index) * log_complement
+        for index in range(events + 1)
+    ]
+    maximum = max(logs)
+    return math.exp(maximum) * sum(math.exp(value - maximum) for value in logs)
+
+
+def one_sided_binomial_upper_bound(
+    events: int,
+    trials: int,
+    confidence_level: float,
+) -> float:
+    """Return the exact Clopper--Pearson one-sided upper rate bound."""
+
+    count = require_exact_integer(events, name="events", minimum=0)
+    total = require_exact_integer(trials, name="trials", minimum=1)
+    confidence = _strict_probability(confidence_level, name="confidence_level")
+    if count > total:
+        raise ValueError("events cannot exceed trials")
+    if count == total:
+        return 1.0
+    alpha = 1.0 - confidence
+    if count == 0:
+        return 1.0 - alpha ** (1.0 / total)
+
+    lower = count / total
+    upper = 1.0
+    for _ in range(100):
+        midpoint = (lower + upper) / 2.0
+        if _binomial_cdf(count, total, midpoint) > alpha:
+            lower = midpoint
+        else:
+            upper = midpoint
+    return upper
+
+
+@dataclass(frozen=True, slots=True)
+class PairedDifferenceScenarioV1:
+    """One source-derived paired-difference dispersion scenario."""
+
+    scenario_id: str
+    paired_standard_deviation_mm: float
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "scenario_id",
+            require_exact_string(self.scenario_id, name="scenario_id"),
+        )
+        object.__setattr__(
+            self,
+            "paired_standard_deviation_mm",
+            _strict_positive(
+                self.paired_standard_deviation_mm,
+                name="paired_standard_deviation_mm",
+            ),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "scenario_id": self.scenario_id,
+            "paired_standard_deviation_mm": self.paired_standard_deviation_mm,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class StudySensitivityV1:
+    """Content-addressed target-free held-out-study sensitivity report."""
+
+    promotion_lock_id: str
+    source_summary_id: str
+    source_metric: str
+    target_group_ids: tuple[str, ...]
+    paired_difference_scenarios: tuple[PairedDifferenceScenarioV1, ...]
+    power_levels: tuple[float, ...] = DEFAULT_POWER_LEVELS
+    confidence_level: float = 0.95
+    alternative: str = "two-sided"
+    accepted_group_counts: tuple[int, ...] = ()
+    minimum_target_group_count: int = 1
+    query_superiority_margin_mm: float = 0.0
+    harmful_update_margin_mm: float = 0.0
+    maximum_harmful_accepted_updates: int = 0
+    maximum_worst_group_regression_mm: float = 0.0
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "promotion_lock_id",
+            require_sha256(self.promotion_lock_id, name="promotion_lock_id"),
+        )
+        object.__setattr__(
+            self,
+            "source_summary_id",
+            require_sha256(self.source_summary_id, name="source_summary_id"),
+        )
+        object.__setattr__(
+            self,
+            "source_metric",
+            require_exact_string(self.source_metric, name="source_metric"),
+        )
+        target_groups = _canonical_group_ids(self.target_group_ids, name="target_group_ids")
+        object.__setattr__(self, "target_group_ids", target_groups)
+
+        scenarios = self.paired_difference_scenarios
+        if type(scenarios) is not tuple or not scenarios:
+            raise ValueError("paired_difference_scenarios must be a nonempty tuple")
+        if not all(isinstance(item, PairedDifferenceScenarioV1) for item in scenarios):
+            raise ValueError(
+                "paired_difference_scenarios must contain PairedDifferenceScenarioV1"
+            )
+        scenario_ids = tuple(item.scenario_id for item in scenarios)
+        if scenario_ids != tuple(sorted(scenario_ids)) or len(set(scenario_ids)) != len(
+            scenario_ids
+        ):
+            raise ValueError("paired_difference_scenarios must be sorted by unique scenario_id")
+
+        object.__setattr__(
+            self,
+            "power_levels",
+            _canonical_probabilities(self.power_levels, name="power_levels"),
+        )
+        object.__setattr__(
+            self,
+            "confidence_level",
+            _strict_probability(self.confidence_level, name="confidence_level"),
+        )
+        alternative = require_exact_string(self.alternative, name="alternative")
+        if alternative not in ALTERNATIVES:
+            raise ValueError(f"alternative must be one of {list(ALTERNATIVES)}")
+        object.__setattr__(self, "alternative", alternative)
+
+        accepted_counts = self.accepted_group_counts or (len(target_groups),)
+        object.__setattr__(
+            self,
+            "accepted_group_counts",
+            _canonical_counts(
+                accepted_counts,
+                name="accepted_group_counts",
+                maximum=len(target_groups),
+            ),
+        )
+        minimum_groups = require_exact_integer(
+            self.minimum_target_group_count,
+            name="minimum_target_group_count",
+            minimum=1,
+        )
+        if len(target_groups) < minimum_groups:
+            raise ValueError("target group count is below the frozen minimum")
+        object.__setattr__(self, "minimum_target_group_count", minimum_groups)
+        object.__setattr__(
+            self,
+            "query_superiority_margin_mm",
+            _strict_nonnegative(
+                self.query_superiority_margin_mm,
+                name="query_superiority_margin_mm",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "harmful_update_margin_mm",
+            _strict_nonnegative(
+                self.harmful_update_margin_mm,
+                name="harmful_update_margin_mm",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "maximum_harmful_accepted_updates",
+            require_exact_integer(
+                self.maximum_harmful_accepted_updates,
+                name="maximum_harmful_accepted_updates",
+                minimum=0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "maximum_worst_group_regression_mm",
+            _strict_nonnegative(
+                self.maximum_worst_group_regression_mm,
+                name="maximum_worst_group_regression_mm",
+            ),
+        )
+
+    @property
+    def target_group_count(self) -> int:
+        return len(self.target_group_ids)
+
+    @property
+    def paired_effect_sensitivity(self) -> tuple[dict[str, object], ...]:
+        critical = _normal_critical_value(self.confidence_level, self.alternative)
+        records: list[dict[str, object]] = []
+        for scenario in self.paired_difference_scenarios:
+            standard_error = scenario.paired_standard_deviation_mm / math.sqrt(
+                self.target_group_count
+            )
+            half_width = critical * standard_error
+            for power in self.power_levels:
+                detectable = (critical + NormalDist().inv_cdf(power)) * standard_error
+                margin_detectable = (
+                    None
+                    if self.query_superiority_margin_mm == 0.0
+                    else detectable <= self.query_superiority_margin_mm
+                )
+                records.append(
+                    {
+                        "scenario_id": scenario.scenario_id,
+                        "paired_standard_deviation_mm": (
+                            scenario.paired_standard_deviation_mm
+                        ),
+                        "target_group_count": self.target_group_count,
+                        "standard_error_mm": standard_error,
+                        "confidence_interval_half_width_mm": half_width,
+                        "power": power,
+                        "minimum_detectable_effect_mm": detectable,
+                        "standardized_minimum_detectable_effect": (
+                            detectable / scenario.paired_standard_deviation_mm
+                        ),
+                        "query_superiority_margin_mm": self.query_superiority_margin_mm,
+                        "query_margin_detectable": margin_detectable,
+                    }
+                )
+        return tuple(records)
+
+    @property
+    def harmful_update_resolution(self) -> tuple[dict[str, object], ...]:
+        records: list[dict[str, object]] = []
+        for accepted_count in self.accepted_group_counts:
+            allowed = min(self.maximum_harmful_accepted_updates, accepted_count)
+            records.append(
+                {
+                    "accepted_group_count_scenario": accepted_count,
+                    "one_event_rate_resolution": 1.0 / accepted_count,
+                    "frozen_maximum_harmful_accepted_updates": (
+                        self.maximum_harmful_accepted_updates
+                    ),
+                    "bounded_event_count": allowed,
+                    "count_criterion_informative": allowed < accepted_count,
+                    "zero_harm_one_sided_upper_rate_bound": (
+                        one_sided_binomial_upper_bound(
+                            0,
+                            accepted_count,
+                            self.confidence_level,
+                        )
+                    ),
+                    "allowed_count_one_sided_upper_rate_bound": (
+                        one_sided_binomial_upper_bound(
+                            allowed,
+                            accepted_count,
+                            self.confidence_level,
+                        )
+                    ),
+                }
+            )
+        return tuple(records)
+
+    @property
+    def target_design_resolution(self) -> dict[str, object]:
+        count = self.target_group_count
+        return {
+            "target_group_count": count,
+            "one_group_mass_resolution": 1.0 / count,
+            "leave_one_group_out_replications": count,
+            "smallest_one_sided_sign_probability": 0.5**count,
+            "smallest_two_sided_sign_probability": min(1.0, 2.0 * 0.5**count),
+        }
+
+    @property
+    def query_margin_detectable(self) -> bool | None:
+        if self.query_superiority_margin_mm == 0.0:
+            return None
+        return all(
+            cast(bool, record["query_margin_detectable"])
+            for record in self.paired_effect_sensitivity
+        )
+
+    def descriptor(self) -> dict[str, object]:
+        return {
+            "schema_name": STUDY_SENSITIVITY_SCHEMA,
+            "schema_version": STUDY_SENSITIVITY_VERSION,
+            "promotion_lock_id": self.promotion_lock_id,
+            "source_summary_id": self.source_summary_id,
+            "source_metric": self.source_metric,
+            "target_group_ids": list(self.target_group_ids),
+            "paired_difference_scenarios": [
+                scenario.to_dict() for scenario in self.paired_difference_scenarios
+            ],
+            "power_levels": list(self.power_levels),
+            "confidence_level": self.confidence_level,
+            "alternative": self.alternative,
+            "accepted_group_counts": list(self.accepted_group_counts),
+            "frozen_decision_thresholds": {
+                "minimum_target_group_count": self.minimum_target_group_count,
+                "query_superiority_margin_mm": self.query_superiority_margin_mm,
+                "harmful_update_margin_mm": self.harmful_update_margin_mm,
+                "maximum_harmful_accepted_updates": (
+                    self.maximum_harmful_accepted_updates
+                ),
+                "maximum_worst_group_regression_mm": (
+                    self.maximum_worst_group_regression_mm
+                ),
+            },
+            "paired_effect_sensitivity": list(self.paired_effect_sensitivity),
+            "harmful_update_resolution": list(self.harmful_update_resolution),
+            "target_design_resolution": self.target_design_resolution,
+            "query_margin_detectable": self.query_margin_detectable,
+            "target_outcomes_opened": False,
+            "claim_boundary": STUDY_SENSITIVITY_CLAIM_BOUNDARY,
+        }
+
+    @property
+    def sensitivity_id(self) -> str:
+        return hashlib.sha256(_canonical_json(self.descriptor())).hexdigest()
+
+    def to_dict(self) -> dict[str, object]:
+        return {**self.descriptor(), "sensitivity_id": self.sensitivity_id}
+
+
+_TOP_LEVEL_FIELDS = frozenset(
+    {
+        "schema_name",
+        "schema_version",
+        "promotion_lock_id",
+        "source_summary_id",
+        "source_metric",
+        "target_group_ids",
+        "paired_difference_scenarios",
+        "power_levels",
+        "confidence_level",
+        "alternative",
+        "accepted_group_counts",
+        "frozen_decision_thresholds",
+        "paired_effect_sensitivity",
+        "harmful_update_resolution",
+        "target_design_resolution",
+        "query_margin_detectable",
+        "target_outcomes_opened",
+        "claim_boundary",
+        "sensitivity_id",
+    }
+)
+_THRESHOLD_FIELDS = frozenset(
+    {
+        "minimum_target_group_count",
+        "query_superiority_margin_mm",
+        "harmful_update_margin_mm",
+        "maximum_harmful_accepted_updates",
+        "maximum_worst_group_regression_mm",
+    }
+)
+_SCENARIO_FIELDS = frozenset({"scenario_id", "paired_standard_deviation_mm"})
+
+
+def _raw_sequence(value: object, *, name: str) -> tuple[Any, ...]:
+    if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
+        raise ValueError(f"{name} must be a sequence")
+    return tuple(value)
+
+
+def build_study_sensitivity(
+    lock: PromotionLockLike,
+    *,
+    source_summary_id: str,
+    source_metric: str,
+    paired_difference_scenarios: Sequence[PairedDifferenceScenarioV1],
+    power_levels: Sequence[float] = DEFAULT_POWER_LEVELS,
+    confidence_level: float = 0.95,
+    alternative: str = "two-sided",
+    accepted_group_counts: Sequence[int] | None = None,
+) -> StudySensitivityV1:
+    """Build one target-free report from a sealed promotion lock."""
+
+    return StudySensitivityV1(
+        promotion_lock_id=lock.promotion_lock_id,
+        source_summary_id=source_summary_id,
+        source_metric=source_metric,
+        target_group_ids=tuple(lock.target_group_ids),
+        paired_difference_scenarios=tuple(
+            sorted(paired_difference_scenarios, key=lambda item: item.scenario_id)
+        ),
+        power_levels=tuple(power_levels),
+        confidence_level=confidence_level,
+        alternative=alternative,
+        accepted_group_counts=(
+            () if accepted_group_counts is None else tuple(accepted_group_counts)
+        ),
+        minimum_target_group_count=lock.minimum_target_group_count,
+        query_superiority_margin_mm=lock.query_superiority_margin_mm,
+        harmful_update_margin_mm=lock.harmful_update_margin_mm,
+        maximum_harmful_accepted_updates=lock.maximum_harmful_accepted_updates,
+        maximum_worst_group_regression_mm=lock.maximum_worst_group_regression_mm,
+    )
+
+
+def study_sensitivity_from_dict(value: Mapping[str, Any]) -> StudySensitivityV1:
+    """Strictly reconstruct and replay a sensitivity report."""
+
+    require_exact_fields(value, _TOP_LEVEL_FIELDS, name="study sensitivity report")
+    if value["schema_name"] != STUDY_SENSITIVITY_SCHEMA:
+        raise ValueError("unsupported study sensitivity schema")
+    if value["schema_version"] != STUDY_SENSITIVITY_VERSION:
+        raise ValueError("unsupported study sensitivity version")
+    if value["target_outcomes_opened"] is not False:
+        raise ValueError("study sensitivity report must remain target-free")
+    if value["claim_boundary"] != STUDY_SENSITIVITY_CLAIM_BOUNDARY:
+        raise ValueError("study sensitivity claim boundary changed")
+
+    raw_scenarios = value["paired_difference_scenarios"]
+    if isinstance(raw_scenarios, (str, bytes)) or not isinstance(raw_scenarios, Sequence):
+        raise ValueError("paired_difference_scenarios must be a sequence")
+    scenarios: list[PairedDifferenceScenarioV1] = []
+    for index, raw in enumerate(raw_scenarios):
+        mapping = require_mapping(raw, name=f"paired_difference_scenarios[{index}]")
+        require_exact_fields(
+            mapping,
+            _SCENARIO_FIELDS,
+            name=f"paired_difference_scenarios[{index}]",
+        )
+        scenarios.append(
+            PairedDifferenceScenarioV1(
+                scenario_id=mapping["scenario_id"],
+                paired_standard_deviation_mm=mapping[
+                    "paired_standard_deviation_mm"
+                ],
+            )
+        )
+
+    thresholds = require_mapping(
+        value["frozen_decision_thresholds"],
+        name="frozen_decision_thresholds",
+    )
+    require_exact_fields(
+        thresholds,
+        _THRESHOLD_FIELDS,
+        name="frozen_decision_thresholds",
+    )
+    report = StudySensitivityV1(
+        promotion_lock_id=value["promotion_lock_id"],
+        source_summary_id=value["source_summary_id"],
+        source_metric=value["source_metric"],
+        target_group_ids=tuple(
+            require_string_sequence(value["target_group_ids"], name="target_group_ids")
+        ),
+        paired_difference_scenarios=tuple(scenarios),
+        power_levels=_raw_sequence(value["power_levels"], name="power_levels"),
+        confidence_level=value["confidence_level"],
+        alternative=value["alternative"],
+        accepted_group_counts=_raw_sequence(
+            value["accepted_group_counts"],
+            name="accepted_group_counts",
+        ),
+        minimum_target_group_count=thresholds["minimum_target_group_count"],
+        query_superiority_margin_mm=thresholds["query_superiority_margin_mm"],
+        harmful_update_margin_mm=thresholds["harmful_update_margin_mm"],
+        maximum_harmful_accepted_updates=thresholds[
+            "maximum_harmful_accepted_updates"
+        ],
+        maximum_worst_group_regression_mm=thresholds[
+            "maximum_worst_group_regression_mm"
+        ],
+    )
+    if report.to_dict() != dict(value):
+        raise ValueError("study sensitivity report failed deterministic replay")
+    return report
+
+
+def load_study_sensitivity(path: str | Path) -> StudySensitivityV1:
+    """Load one strict content-addressed sensitivity report."""
+
+    return study_sensitivity_from_dict(
+        load_json_object(path, name="study sensitivity report")
+    )
+
+
+def render_study_sensitivity_markdown(report: StudySensitivityV1) -> str:
+    """Render a compact deterministic target-free design summary."""
+
+    lines = [
+        "# Held-out study sensitivity preflight",
+        "",
+        f"- sensitivity ID: `{report.sensitivity_id}`",
+        f"- promotion lock: `{report.promotion_lock_id}`",
+        f"- source summary: `{report.source_summary_id}`",
+        f"- source metric: `{report.source_metric}`",
+        f"- target groups: **{report.target_group_count}**",
+        f"- confidence: **{report.confidence_level:.3f}** ({report.alternative})",
+        "",
+        "## Paired effect resolution",
+        "",
+        "| Scenario | Paired SD [mm] | Power | CI half-width [mm] | MDE [mm] | "
+        "Frozen margin detectable |",
+        "| --- | ---: | ---: | ---: | ---: | :---: |",
+    ]
+    for record in report.paired_effect_sensitivity:
+        detectable = record["query_margin_detectable"]
+        display = "—" if detectable is None else ("yes" if detectable else "no")
+        lines.append(
+            f"| {record['scenario_id']} | "
+            f"{cast(float, record['paired_standard_deviation_mm']):.6g} | "
+            f"{cast(float, record['power']):.3f} | "
+            f"{cast(float, record['confidence_interval_half_width_mm']):.6g} | "
+            f"{cast(float, record['minimum_detectable_effect_mm']):.6g} | "
+            f"{display} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Harmful-update count resolution",
+            "",
+            "| Accepted groups (scenario) | One event | Allowed count | "
+            "Zero-harm upper rate | Allowed-count upper rate |",
+            "| ---: | ---: | ---: | ---: | ---: |",
+        ]
+    )
+    for record in report.harmful_update_resolution:
+        lines.append(
+            f"| {record['accepted_group_count_scenario']} | "
+            f"{cast(float, record['one_event_rate_resolution']):.3f} | "
+            f"{record['bounded_event_count']} | "
+            f"{cast(float, record['zero_harm_one_sided_upper_rate_bound']):.3f} | "
+            f"{cast(float, record['allowed_count_one_sided_upper_rate_bound']):.3f} |"
+        )
+
+    resolution = report.target_design_resolution
+    lines.extend(
+        [
+            "",
+            "## Frozen decision context",
+            "",
+            f"- query superiority margin: `{report.query_superiority_margin_mm:.6g} mm`",
+            f"- harmful-update margin: `{report.harmful_update_margin_mm:.6g} mm`",
+            "- maximum harmful accepted updates: "
+            f"`{report.maximum_harmful_accepted_updates}`",
+            "- maximum worst-group regression: "
+            f"`{report.maximum_worst_group_regression_mm:.6g} mm`",
+            "- one target group mass: "
+            f"`{cast(float, resolution['one_group_mass_resolution']):.6g}`",
+            "- smallest one-sided all-favorable sign probability: "
+            f"`{cast(float, resolution['smallest_one_sided_sign_probability']):.6g}`",
+            "",
+            STUDY_SENSITIVITY_CLAIM_BOUNDARY,
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_study_sensitivity(
+    report: StudySensitivityV1,
+    output: str | Path,
+    *,
+    markdown: str | Path | None = None,
+) -> None:
+    """Publish JSON and optional Markdown with no-clobber semantics."""
+
+    output_path = Path(output)
+    markdown_path = None if markdown is None else Path(markdown)
+    destinations = [output_path] if markdown_path is None else [output_path, markdown_path]
+    existing = [path for path in destinations if path.exists()]
+    if existing:
+        raise FileExistsError(
+            "study sensitivity output already exists: "
+            + ", ".join(str(path) for path in existing)
+        )
+    encoded = json.dumps(report.to_dict(), sort_keys=True, indent=2) + "\n"
+    atomic_write_text(output_path, encoded, overwrite=False)
+    if markdown_path is not None:
+        atomic_write_text(
+            markdown_path,
+            render_study_sensitivity_markdown(report),
+            overwrite=False,
+        )
+
+
+def _scenario_argument(value: str) -> PairedDifferenceScenarioV1:
+    scenario_id, separator, raw_standard_deviation = value.partition("=")
+    if not separator:
+        raise argparse.ArgumentTypeError("paired SD must use SCENARIO_ID=STANDARD_DEVIATION_MM")
+    try:
+        standard_deviation = float(raw_standard_deviation)
+        return PairedDifferenceScenarioV1(scenario_id, standard_deviation)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(str(error)) from error
+
+
+def _probability_argument(value: str) -> float:
+    try:
+        return _strict_probability(float(value), name="probability")
+    except ValueError as error:
+        raise argparse.ArgumentTypeError(str(error)) from error
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the installed target-free study-sensitivity command."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("lock", type=Path)
+    parser.add_argument("--source-summary-id", required=True)
+    parser.add_argument("--source-metric", required=True)
+    parser.add_argument(
+        "--paired-sd",
+        type=_scenario_argument,
+        action="append",
+        required=True,
+        dest="paired_scenarios",
+        metavar="SCENARIO=MM",
+        help="source-derived paired-difference SD scenario; may be repeated",
+    )
+    parser.add_argument(
+        "--power",
+        type=_probability_argument,
+        action="append",
+        dest="powers",
+        help="requested power level; may be repeated (default: 0.80, 0.90)",
+    )
+    parser.add_argument(
+        "--confidence",
+        type=_probability_argument,
+        default=0.95,
+    )
+    parser.add_argument("--alternative", choices=ALTERNATIVES, default="two-sided")
+    parser.add_argument(
+        "--accepted-groups",
+        type=int,
+        action="append",
+        dest="accepted_group_counts",
+        help="accepted-group denominator scenario; may be repeated",
+    )
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--markdown", type=Path)
+    arguments = parser.parse_args(argv)
+
+    lock = load_promotion_lock(arguments.lock)
+    report = build_study_sensitivity(
+        lock,
+        source_summary_id=arguments.source_summary_id,
+        source_metric=arguments.source_metric,
+        paired_difference_scenarios=arguments.paired_scenarios,
+        power_levels=DEFAULT_POWER_LEVELS if arguments.powers is None else arguments.powers,
+        confidence_level=arguments.confidence,
+        alternative=arguments.alternative,
+        accepted_group_counts=arguments.accepted_group_counts,
+    )
+    write_study_sensitivity(report, arguments.output, markdown=arguments.markdown)
+    print(
+        json.dumps(
+            {
+                "sensitivity_id": report.sensitivity_id,
+                "target_group_count": report.target_group_count,
+                "query_margin_detectable": report.query_margin_detectable,
+                "output": str(arguments.output),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+
+
+__all__ = [
+    "ALTERNATIVES",
+    "DEFAULT_POWER_LEVELS",
+    "STUDY_SENSITIVITY_CLAIM_BOUNDARY",
+    "STUDY_SENSITIVITY_SCHEMA",
+    "STUDY_SENSITIVITY_VERSION",
+    "PairedDifferenceScenarioV1",
+    "StudySensitivityV1",
+    "build_study_sensitivity",
+    "load_study_sensitivity",
+    "main",
+    "one_sided_binomial_upper_bound",
+    "render_study_sensitivity_markdown",
+    "study_sensitivity_from_dict",
+    "write_study_sensitivity",
+]

--- a/tests/test_study.py
+++ b/tests/test_study.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from prob4d.cli import main as grouped_main
+from prob4d.command_registry import CommandLifecycle, find_command
+from prob4d.study import HeldoutProviderStudy, main, write_study_preflight
+from prob4d.study_sensitivity import PairedDifferenceScenarioV1
+
+
+def _lock() -> SimpleNamespace:
+    return SimpleNamespace(
+        promotion_lock_id="a" * 64,
+        development_group_ids=tuple(f"development-{index:02d}" for index in range(4)),
+        calibration_group_ids=tuple(f"calibration-{index:02d}" for index in range(10)),
+        target_group_ids=tuple(f"target-{index:02d}" for index in range(12)),
+        bootstrap_resamples=5000,
+        minimum_mean_accepted_coverage=0.90,
+        minimum_target_group_count=12,
+        query_superiority_margin_mm=1.0,
+        harmful_update_margin_mm=0.25,
+        maximum_harmful_accepted_updates=0,
+        maximum_worst_group_regression_mm=0.5,
+    )
+
+
+def test_high_level_facade_composes_target_free_reports() -> None:
+    study = HeldoutProviderStudy(_lock())
+    preflight = study.preflight(
+        source_summary_id="b" * 64,
+        source_metric="deployed_minus_physical_rmse_mm",
+        paired_difference_scenarios=(
+            PairedDifferenceScenarioV1("source", 1.0),
+        ),
+        coverage_levels=(0.90,),
+        power_levels=(0.80,),
+    )
+
+    assert study.group_counts == {"development": 4, "calibration": 10, "target": 12}
+    assert preflight.promotion_lock_id == "a" * 64
+    assert preflight.capability.primary_levels_finite is True
+    assert preflight.sensitivity.query_margin_detectable is True
+    assert preflight.to_dict()["target_outcomes_opened"] is False
+
+
+def test_preflight_publication_checks_all_destinations_before_writing(tmp_path) -> None:
+    preflight = HeldoutProviderStudy(_lock()).preflight(
+        source_summary_id="b" * 64,
+        source_metric="metric",
+        paired_difference_scenarios=(PairedDifferenceScenarioV1("source", 1.0),),
+    )
+    output_dir = tmp_path / "preflight"
+    output_dir.mkdir()
+    (output_dir / "study_sensitivity.md").write_text("retained", encoding="utf-8")
+
+    with pytest.raises(FileExistsError, match="already exists"):
+        write_study_preflight(preflight, output_dir)
+    assert not (output_dir / "finite_sample_capability.json").exists()
+
+
+def test_grouped_study_preflight_command_writes_both_reports(
+    tmp_path,
+    monkeypatch,
+    capsys,
+) -> None:
+    monkeypatch.setattr("prob4d.study.load_promotion_lock", lambda _path: _lock())
+    output_dir = tmp_path / "preflight"
+
+    assert (
+        main(
+            [
+                str(tmp_path / "lock.json"),
+                "--source-summary-id",
+                "b" * 64,
+                "--source-metric",
+                "deployed_minus_physical_rmse_mm",
+                "--paired-sd",
+                "source=1.0",
+                "--coverage",
+                "0.90",
+                "--power",
+                "0.80",
+                "--output-dir",
+                str(output_dir),
+            ]
+        )
+        == 0
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["target_group_count"] == 12
+    assert payload["target_outcomes_opened"] is False
+    assert (output_dir / "finite_sample_capability.json").is_file()
+    assert (output_dir / "finite_sample_capability.md").is_file()
+    assert (output_dir / "study_sensitivity.json").is_file()
+    assert (output_dir / "study_sensitivity.md").is_file()
+
+
+def test_command_registry_exposes_non_claim_bearing_study_preflight() -> None:
+    command = find_command("prob4d study preflight")
+    assert command is not None
+    assert command.command_id == "study-preflight"
+    assert command.lifecycle is CommandLifecycle.DIAGNOSTIC
+    assert command.claim_bearing is False
+    assert command.target == "prob4d.study:main"
+
+
+def test_grouped_cli_routes_study_preflight_help(capsys) -> None:
+    with pytest.raises(SystemExit) as exit_info:
+        grouped_main(["study", "preflight", "--help"])
+    assert exit_info.value.code == 0
+    output = capsys.readouterr().out
+    assert "--source-summary-id" in output
+    assert "--paired-sd" in output
+    assert "--output-dir" in output

--- a/tests/test_study_sensitivity.py
+++ b/tests/test_study_sensitivity.py
@@ -217,6 +217,6 @@ def test_generated_binomial_upper_bounds_are_monotone() -> None:
         for earlier, later in zip(
             zero_event_bounds,
             zero_event_bounds[1:],
-            strict=True,
+            strict=False,
         )
     )

--- a/tests/test_study_sensitivity.py
+++ b/tests/test_study_sensitivity.py
@@ -214,5 +214,9 @@ def test_generated_binomial_upper_bounds_are_monotone() -> None:
     ]
     assert all(
         later < earlier
-        for earlier, later in zip(zero_event_bounds, zero_event_bounds[1:])
+        for earlier, later in zip(
+            zero_event_bounds,
+            zero_event_bounds[1:],
+            strict=True,
+        )
     )

--- a/tests/test_study_sensitivity.py
+++ b/tests/test_study_sensitivity.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import json
+import math
+from statistics import NormalDist
+from types import SimpleNamespace
+
+import pytest
+
+from prob4d.study_sensitivity import (
+    STUDY_SENSITIVITY_SCHEMA,
+    PairedDifferenceScenarioV1,
+    build_study_sensitivity,
+    load_study_sensitivity,
+    one_sided_binomial_upper_bound,
+    study_sensitivity_from_dict,
+    write_study_sensitivity,
+)
+
+
+def _lock() -> SimpleNamespace:
+    return SimpleNamespace(
+        promotion_lock_id="a" * 64,
+        target_group_ids=tuple(f"target-{index:02d}" for index in range(12)),
+        minimum_target_group_count=12,
+        query_superiority_margin_mm=1.0,
+        harmful_update_margin_mm=0.25,
+        maximum_harmful_accepted_updates=0,
+        maximum_worst_group_regression_mm=0.5,
+    )
+
+
+def _report():
+    return build_study_sensitivity(
+        _lock(),
+        source_summary_id="b" * 64,
+        source_metric="deployed_minus_physical_rmse_mm",
+        paired_difference_scenarios=(
+            PairedDifferenceScenarioV1("conservative", 1.0),
+            PairedDifferenceScenarioV1("source-estimate", 0.75),
+        ),
+        power_levels=(0.80, 0.90),
+        confidence_level=0.95,
+        alternative="two-sided",
+        accepted_group_counts=(6, 12),
+    )
+
+
+def test_paired_effect_resolution_uses_declared_normal_approximation() -> None:
+    report = _report()
+    records = report.paired_effect_sensitivity
+    conservative_eighty = next(
+        record
+        for record in records
+        if record["scenario_id"] == "conservative" and record["power"] == 0.80
+    )
+    critical = NormalDist().inv_cdf(0.975)
+    expected = (critical + NormalDist().inv_cdf(0.80)) / math.sqrt(12)
+
+    assert conservative_eighty["minimum_detectable_effect_mm"] == pytest.approx(expected)
+    assert conservative_eighty["confidence_interval_half_width_mm"] == pytest.approx(
+        critical / math.sqrt(12)
+    )
+    assert conservative_eighty["query_margin_detectable"] is True
+    assert report.query_margin_detectable is True
+
+
+def test_harmful_update_resolution_reports_exact_upper_rate_bounds() -> None:
+    report = _report()
+    all_groups = next(
+        record
+        for record in report.harmful_update_resolution
+        if record["accepted_group_count_scenario"] == 12
+    )
+
+    expected_zero_upper = 1.0 - 0.05 ** (1.0 / 12)
+    assert all_groups["zero_harm_one_sided_upper_rate_bound"] == pytest.approx(
+        expected_zero_upper
+    )
+    assert all_groups["allowed_count_one_sided_upper_rate_bound"] == pytest.approx(
+        expected_zero_upper
+    )
+    assert all_groups["one_event_rate_resolution"] == pytest.approx(1 / 12)
+    assert one_sided_binomial_upper_bound(12, 12, 0.95) == 1.0
+
+
+def test_report_is_content_addressed_and_replays_derived_values() -> None:
+    report = _report()
+    payload = report.to_dict()
+
+    assert payload["schema_name"] == STUDY_SENSITIVITY_SCHEMA
+    assert payload["target_outcomes_opened"] is False
+    assert len(report.sensitivity_id) == 64
+    assert study_sensitivity_from_dict(payload) == report
+
+    changed = json.loads(json.dumps(payload))
+    changed["paired_effect_sensitivity"][0]["minimum_detectable_effect_mm"] += 0.1
+    with pytest.raises(ValueError, match="deterministic replay"):
+        study_sensitivity_from_dict(changed)
+
+
+def test_strict_loader_and_no_clobber_publication(tmp_path) -> None:
+    report = _report()
+    output = tmp_path / "sensitivity.json"
+    markdown = tmp_path / "sensitivity.md"
+
+    write_study_sensitivity(report, output, markdown=markdown)
+    loaded = load_study_sensitivity(output)
+    assert loaded == report
+    assert report.sensitivity_id in markdown.read_text(encoding="utf-8")
+
+    with pytest.raises(FileExistsError, match="already exists"):
+        write_study_sensitivity(report, output, markdown=markdown)
+
+    duplicate = tmp_path / "duplicate.json"
+    duplicate.write_text('{"schema_name":1,"schema_name":2}', encoding="utf-8")
+    with pytest.raises(ValueError, match="duplicate JSON object key"):
+        load_study_sensitivity(duplicate)
+
+
+def test_invalid_design_inputs_fail_closed() -> None:
+    with pytest.raises(ValueError, match="strictly positive"):
+        PairedDifferenceScenarioV1("invalid", 0.0)
+    with pytest.raises(ValueError, match="sorted by unique scenario_id"):
+        build_study_sensitivity(
+            _lock(),
+            source_summary_id="b" * 64,
+            source_metric="metric",
+            paired_difference_scenarios=(
+                PairedDifferenceScenarioV1("duplicate", 1.0),
+                PairedDifferenceScenarioV1("duplicate", 1.5),
+            ),
+        )
+    with pytest.raises(ValueError, match="cannot exceed"):
+        build_study_sensitivity(
+            _lock(),
+            source_summary_id="b" * 64,
+            source_metric="metric",
+            paired_difference_scenarios=(
+                PairedDifferenceScenarioV1("source", 1.0),
+            ),
+            accepted_group_counts=(13,),
+        )
+
+
+def test_generated_effect_resolution_is_monotone_in_dispersion_and_group_count() -> None:
+    source_id = "b" * 64
+    for target_count in range(4, 25):
+        lock = SimpleNamespace(
+            **{
+                **_lock().__dict__,
+                "target_group_ids": tuple(
+                    f"target-{index:02d}" for index in range(target_count)
+                ),
+                "minimum_target_group_count": target_count,
+            }
+        )
+        previous = None
+        for standard_deviation in (0.25, 0.5, 1.0, 2.0):
+            report = build_study_sensitivity(
+                lock,
+                source_summary_id=source_id,
+                source_metric="metric",
+                paired_difference_scenarios=(
+                    PairedDifferenceScenarioV1("source", standard_deviation),
+                ),
+                power_levels=(0.80,),
+            )
+            effect = report.paired_effect_sensitivity[0][
+                "minimum_detectable_effect_mm"
+            ]
+            assert isinstance(effect, float)
+            if previous is not None:
+                assert effect > previous
+            previous = effect
+
+    small = build_study_sensitivity(
+        _lock(),
+        source_summary_id=source_id,
+        source_metric="metric",
+        paired_difference_scenarios=(PairedDifferenceScenarioV1("source", 1.0),),
+        power_levels=(0.80,),
+    ).paired_effect_sensitivity[0]["minimum_detectable_effect_mm"]
+    larger_lock = SimpleNamespace(
+        **{
+            **_lock().__dict__,
+            "target_group_ids": tuple(f"target-{index:02d}" for index in range(48)),
+            "minimum_target_group_count": 48,
+        }
+    )
+    large = build_study_sensitivity(
+        larger_lock,
+        source_summary_id=source_id,
+        source_metric="metric",
+        paired_difference_scenarios=(PairedDifferenceScenarioV1("source", 1.0),),
+        power_levels=(0.80,),
+    ).paired_effect_sensitivity[0]["minimum_detectable_effect_mm"]
+    assert isinstance(small, float)
+    assert isinstance(large, float)
+    assert large < small
+
+
+def test_generated_binomial_upper_bounds_are_monotone() -> None:
+    for trials in range(2, 40):
+        bounds = [
+            one_sided_binomial_upper_bound(events, trials, 0.95)
+            for events in range(trials + 1)
+        ]
+        assert bounds == sorted(bounds)
+
+    zero_event_bounds = [
+        one_sided_binomial_upper_bound(0, trials, 0.95)
+        for trials in range(2, 40)
+    ]
+    assert all(
+        later < earlier
+        for earlier, later in zip(zero_event_bounds, zero_event_bounds[1:])
+    )


### PR DESCRIPTION
## Summary

- add `prob4d study preflight`, a small target-free orchestration layer over the existing finite-sample capability audit and a new source-bound sensitivity report;
- bind paired-difference dispersion scenarios to the exact promotion lock, source summary, target roster, frozen decision margins, and accepted-group denominator scenarios;
- report transparent normal-approximation confidence half-widths and minimum detectable effects without reading target outcomes;
- report exact one-sided Clopper–Pearson harmful-update rate bounds while preserving the frozen count-based decision;
- publish strict content-addressed JSON and deterministic Markdown with an all-destination no-clobber precheck;
- expose a read-only `HeldoutProviderStudy` Python facade that deliberately stops before claim-bearing source qualification or target evaluation;
- add generated monotonicity, strict-loading, replay, CLI, and no-clobber tests; and
- document the command, formulas, interpretation limits, and one-shot target boundary.

## Motivation

The current held-out provider protocol has strong target-access and finite-sample controls, but collaborators still need a concise target-free answer to two design questions before the sealed cohort is opened:

1. which paired physical-query effects can the frozen target group count resolve under source-derived dispersion scenarios; and
2. what harmful-update rate information can the possible accepted-group denominators support.

This PR answers those questions without introducing another target-side method, changing a promotion threshold, or consuming provider or target payloads.

## Validation

All ten pull-request workflows pass on exact head `b3b8cf4fcd91f7f52b6bd85a3579f651600c5783` against current `main` `deeb07ad4509d8b149ea1d28d7b8c482fea926ca`:

- authoritative Ruff, documentation-surface validation, and stable-interface MyPy;
- complete suites on Python 3.10, 3.11, 3.12, 3.13, and 3.14;
- the complete suite at the declared NumPy 1.24 runtime floor;
- repository, release, API, provider, and distribution policy checks;
- wheel and source-distribution build and validation;
- isolated installed-wheel and installed-sdist grouped-CLI smoke;
- provider batch preflight, target admission, target-free rehearsal, finite-sample capability, source-only visual-bias calibration, and sparse gauge-tree artifact lanes; and
- CodeQL for Python and Actions plus the resolved runtime dependency audit.

Focused development checks additionally covered strict deterministic replay, all-destination no-clobber publication, duplicate-key rejection, source/lock/roster binding, exact binomial bounds, generated monotonicity, and grouped-CLI routing. A standalone mathematical check matched the Clopper–Pearson implementation against SciPy beta quantiles.

## Scientific boundary

This is target-free design and usability infrastructure. It does not open target outcomes, change the frozen provider or BayesianPhysTwin decision, establish normality or exchangeability, prove provider competence, establish BayesianPhysTwin or Causal4D benefit, calibrate deployment uncertainty, authorize a target run, or support a state-of-the-art claim.
