### PR TITLE
Freeze CUT3R comparison and additive compatibility semantics

### DIFF
--- a/.github/workflows/fail-closed-quality.yml
+++ b/.github/workflows/fail-closed-quality.yml
@@ -75,6 +75,25 @@ jobs:
           set -o pipefail
           python scripts/ci/check_documentation_surface.py \
             2>&1 | tee documentation-surface-output.txt
+      - name: Verify additive compatibility and CUT3R protocol examples
+        if: always()
+        shell: bash
+        run: |
+          set -o pipefail
+          python -m prob4d.semantic_compatibility build \
+            --output semantic-compatibility.json \
+            2>&1 | tee semantic-compatibility-output.txt
+          python -m prob4d.semantic_compatibility verify \
+            semantic-compatibility.json \
+            --require-current \
+            2>&1 | tee -a semantic-compatibility-output.txt
+          python -m prob4d.cut3r_comparison build \
+            docs/examples/cut3r-comparison-spec.json \
+            --output cut3r-comparison-lock.json \
+            2>&1 | tee cut3r-comparison-output.txt
+          python -m prob4d.cut3r_comparison verify \
+            cut3r-comparison-lock.json \
+            2>&1 | tee -a cut3r-comparison-output.txt
       - name: Run stable-interface mypy with fail-closed diagnostics
         if: always()
         shell: bash
@@ -93,6 +112,7 @@ jobs:
             src/prob4d/calibration_compatibility.py \
             src/prob4d/composition_jacobian.py \
             src/prob4d/covariance_root.py \
+            src/prob4d/cut3r_comparison.py \
             src/prob4d/material_identity_cli.py \
             src/prob4d/material_identity_weight_calibration.py \
             src/prob4d/observation_factor_stream.py \
@@ -115,6 +135,7 @@ jobs:
             src/prob4d/provider_v2_loading.py \
             src/prob4d/public_api_manifest.py \
             src/prob4d/runtime_revision.py \
+            src/prob4d/semantic_compatibility.py \
             src/prob4d/source_diagnostics.py \
             src/prob4d/sparse_observation_factors.py \
             2>&1 | tee mypy-output.txt
@@ -128,5 +149,9 @@ jobs:
             documentation-surface-output.txt
             ruff-output.txt
             mypy-output.txt
+            semantic-compatibility.json
+            semantic-compatibility-output.txt
+            cut3r-comparison-lock.json
+            cut3r-comparison-output.txt
           if-no-files-found: warn
           retention-days: 14

--- a/CHANGELOG.d/cut3r-comparison-lock.md
+++ b/CHANGELOG.d/cut3r-comparison-lock.md
@@ -1,0 +1,5 @@
+Add a strict, content-addressed, source-only CUT3R comparison lock that freezes
+native continuous recurrence, restarted newest-window, restarted Prob4D fusion,
+and optional noncausal revisiting arms over complete object/session groups. The
+registered contrasts isolate Prob4D fusion from provider recurrence without
+opening target outcomes.

--- a/CHANGELOG.d/semantic-compatibility.md
+++ b/CHANGELOG.d/semantic-compatibility.md
@@ -1,0 +1,5 @@
+Add an additive semantic-compatibility manifest for named mandatory contract
+vectors, API majors, and capabilities. Ordinary consumers no longer need to pin
+the total conformance-corpus inventory, while claim-bearing runs continue to
+require exact revisions, distributions, complete corpus identities, and artifact
+digests.

--- a/docs/cut3r-comparison.md
+++ b/docs/cut3r-comparison.md
@@ -1,0 +1,75 @@
+# CUT3R native-versus-Prob4D comparison
+
+`prob4d prediction cut3r-comparison` freezes the source-only experiment that
+separates CUT3R's own recurrent-state value from the value of Prob4D fusion.
+The lock is outcome-blind and content-addressed. It does not execute CUT3R or
+open a target cohort.
+
+## Frozen arms
+
+The lock always declares four arms:
+
+| Arm | Purpose | Causal | Claim eligible |
+| --- | --- | --- | --- |
+| `native-continuous` | One uninterrupted recurrent-online CUT3R pass | yes | yes |
+| `restarted-newest` | Fresh CUT3R state for each overlapping causal window; retain the newest eligible prediction | yes | yes |
+| `restarted-prob4d-fused` | The same restarted windows fused through Prob4D | yes | yes |
+| `revisit-diagnostic` | Provider revisiting as a noncausal upper-bound diagnostic | no | never |
+
+The primary contrast is `restarted-prob4d-fused` versus `restarted-newest`.
+Because both arms use exactly the same restarted source windows, this contrast
+isolates the contribution of Prob4D fusion. The contextual
+`native-continuous` versus `restarted-newest` contrast measures how much value
+comes from CUT3R's persistent recurrent state.
+
+The revisiting arm remains present even when disabled. Its causal and claim
+flags are immutable, so it cannot silently become promotion evidence.
+
+## Independent evidence units
+
+Frames, points, tracks, and views are nested observations. The lock accepts only
+complete `physical-object-or-acquisition-session` groups and partitions every
+group exactly once into:
+
+- development;
+- calibration; or
+- source evaluation.
+
+The three roles must be nonempty and disjoint. Every case binds the input-video
+digest, byte count, complete source interval, and a common evaluation interval.
+Across-group reporting must give complete groups equal weight.
+
+## Build and verify
+
+Start from the checked-in example and replace every placeholder revision,
+distribution digest, video digest, and group roster with the exact source-only
+experiment identities:
+
+```bash
+prob4d prediction cut3r-comparison build \
+  docs/examples/cut3r-comparison-spec.json \
+  --output outputs/cut3r/comparison-lock.json
+
+prob4d prediction cut3r-comparison verify \
+  outputs/cut3r/comparison-lock.json
+
+prob4d prediction cut3r-comparison summarize \
+  outputs/cut3r/comparison-lock.json \
+  --json
+```
+
+Publication is atomic and no-clobber. Repeating an identical write is
+idempotent; a different lock at the same path is rejected.
+
+## Registered provider endpoints
+
+The lock freezes support and technical-failure accounting, point or track error,
+seam and drift error, 50/90/95% coverage, proper score, normalized NEES, full
+covariance width, identity retention, selective risk, and worst-group coverage
+shortfall. It intentionally contains no observed outcome values and authorizes
+no target access.
+
+A passing source comparison is not a held-out promotion result. A later target
+experiment must use the independently frozen held-out provider and
+BayesianPhysTwin gate, with provider competence and downstream physical-query
+benefit reported separately.

--- a/docs/examples/cut3r-comparison-spec.json
+++ b/docs/examples/cut3r-comparison-spec.json
@@ -1,0 +1,72 @@
+{
+  "checkpoint_sha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "confidence_threshold": 1.5,
+  "group_roles": {
+    "calibration": [
+      "object-calibration"
+    ],
+    "development": [
+      "object-development"
+    ],
+    "source_evaluation": [
+      "object-source-evaluation"
+    ]
+  },
+  "groups": [
+    {
+      "cases": [
+        {
+          "case_id": "development-sequence",
+          "evaluation_frame_start": 20,
+          "evaluation_frame_stop_exclusive": 180,
+          "frame_start": 0,
+          "frame_stop_exclusive": 200,
+          "input_video_byte_count": 1000000,
+          "input_video_sha256": "1111111111111111111111111111111111111111111111111111111111111111"
+        }
+      ],
+      "group_id": "object-development"
+    },
+    {
+      "cases": [
+        {
+          "case_id": "calibration-sequence",
+          "evaluation_frame_start": 20,
+          "evaluation_frame_stop_exclusive": 180,
+          "frame_start": 0,
+          "frame_stop_exclusive": 200,
+          "input_video_byte_count": 1000000,
+          "input_video_sha256": "2222222222222222222222222222222222222222222222222222222222222222"
+        }
+      ],
+      "group_id": "object-calibration"
+    },
+    {
+      "cases": [
+        {
+          "case_id": "source-evaluation-sequence",
+          "evaluation_frame_start": 20,
+          "evaluation_frame_stop_exclusive": 180,
+          "frame_start": 0,
+          "frame_stop_exclusive": 200,
+          "input_video_byte_count": 1000000,
+          "input_video_sha256": "3333333333333333333333333333333333333333333333333333333333333333"
+        }
+      ],
+      "group_id": "object-source-evaluation"
+    }
+  ],
+  "include_revisit_diagnostic": false,
+  "overlap": 8,
+  "prob4d_distribution_sha256": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+  "prob4d_revision": "cccccccccccccccccccccccccccccccccccccccc",
+  "protocol_name": "cut3r-source-comparison-v1",
+  "provider_revision": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "random_seeds": [
+    7,
+    11,
+    19
+  ],
+  "storage_dtype": "float32",
+  "window_size": 25
+}

--- a/docs/semantic-compatibility.md
+++ b/docs/semantic-compatibility.md
@@ -1,0 +1,62 @@
+# Semantic compatibility versus frozen evidence
+
+Prob4D now distinguishes ordinary consumer compatibility from exact scientific
+reproduction.
+
+## Semantic compatibility
+
+`prob4d prediction compatibility` describes the minimum interface semantics a
+consumer requires:
+
+- the stable `prob4d.api.v2` major and provider API majors;
+- the observation-belief and provider-v2 contract identities and versions;
+- named mandatory valid conformance vectors and their individual content IDs;
+- required capabilities such as causal source lineage, joint gauge covariance,
+  strict artifact loading, exact invalid fallback, and tree-sparse factors.
+
+It deliberately does **not** bind the complete corpus digest or the total number
+of valid and invalid vectors. A provider may add new conformance vectors and new
+capabilities without invalidating an older consumer requirement. Existing named
+vectors may not disappear or change.
+
+```bash
+prob4d prediction compatibility build \
+  --output outputs/semantic-compatibility.json
+
+prob4d prediction compatibility verify \
+  outputs/semantic-compatibility.json \
+  --require-current
+```
+
+Compare a consumer requirement against a provider manifest with:
+
+```bash
+prob4d prediction compatibility check \
+  consumer-required.json \
+  provider-available.json
+```
+
+The command returns success only when the provider contains every required
+named vector with the same digest and every required capability.
+
+## Claim-bearing evidence pin
+
+A semantic-compatibility result is infrastructure evidence only. A frozen
+scientific run must additionally bind:
+
+- exact Prob4D, BayesianPhysTwin, and Causal4D revisions;
+- exact wheel or source-distribution hashes;
+- complete normative contract-corpus identities;
+- provider/model/runtime and calibration identities;
+- protocol, input, output, and decision-artifact digests.
+
+This separation prevents ordinary development from becoming brittle when an
+additional adversarial test vector is added, while preserving byte-exact
+reproduction for every claim-bearing result.
+
+## Additive rule
+
+Compatibility is directional. A provider manifest satisfies a consumer manifest
+when the API and contract major identities match and the provider is a superset
+of the consumer's named vectors and capabilities. Equality of the complete
+manifest is neither required nor sufficient to replace the frozen evidence pin.

--- a/src/prob4d/cut3r_comparison.py
+++ b/src/prob4d/cut3r_comparison.py
@@ -1,0 +1,728 @@
+"""Freeze a group-aware CUT3R native-versus-Prob4D comparison.
+
+The lock isolates the value of Prob4D fusion from CUT3R's own recurrent state.
+It is source-only, outcome-blind, and treats complete physical objects or
+acquisition sessions—not frames—as independent evidence units.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final, cast
+
+from ._atomic_file import atomic_write_bytes
+from .project_identity import PROB4D_PROJECT_ID
+
+CUT3R_COMPARISON_SCHEMA: Final = "prob4d.cut3r-comparison-lock"
+CUT3R_COMPARISON_VERSION: Final = 1
+CUT3R_REPOSITORY: Final = "CUT3R/CUT3R"
+CUT3R_COMPARISON_GROUP_UNIT: Final = "physical-object-or-acquisition-session"
+CUT3R_COMPARISON_CLAIM_BOUNDARY: Final = (
+    "This lock freezes a source-only provider comparison. It does not establish "
+    "held-out provider competence, BayesianPhysTwin benefit, Causal4D intervention "
+    "benefit, deployment safety, or state of the art. Frames, points, tracks, and "
+    "views remain nested observations inside complete object/session groups."
+)
+CUT3R_PROVIDER_ENDPOINTS: Final[tuple[str, ...]] = (
+    "support-rate",
+    "technical-failure-rate",
+    "point-or-track-error",
+    "seam-error",
+    "drift-error",
+    "coverage-50",
+    "coverage-90",
+    "coverage-95",
+    "proper-score",
+    "normalized-nees",
+    "full-covariance-width",
+    "identity-retention",
+    "selective-risk",
+    "worst-group-coverage-shortfall",
+)
+
+_LOCK_FIELDS: Final = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "protocol_name",
+        "provider",
+        "prob4d",
+        "windowing",
+        "group_unit",
+        "groups",
+        "group_roles",
+        "random_seeds",
+        "arms",
+        "registered_contrasts",
+        "provider_endpoints",
+        "weighting",
+        "source_access",
+        "target_access",
+        "claim_boundary",
+        "lock_id",
+    }
+)
+_SPEC_FIELDS: Final = frozenset(
+    {
+        "protocol_name",
+        "provider_revision",
+        "checkpoint_sha256",
+        "prob4d_revision",
+        "prob4d_distribution_sha256",
+        "window_size",
+        "overlap",
+        "confidence_threshold",
+        "storage_dtype",
+        "random_seeds",
+        "groups",
+        "group_roles",
+        "include_revisit_diagnostic",
+    }
+)
+_PROVIDER_FIELDS: Final = frozenset(
+    {"repository", "revision", "checkpoint_sha256"}
+)
+_PROB4D_FIELDS: Final = frozenset(
+    {"project_id", "revision", "distribution_sha256"}
+)
+_WINDOW_FIELDS: Final = frozenset(
+    {
+        "window_size",
+        "overlap",
+        "stride",
+        "confidence_threshold",
+        "storage_dtype",
+        "restart_policy",
+    }
+)
+_GROUP_FIELDS: Final = frozenset({"group_id", "cases"})
+_CASE_FIELDS: Final = frozenset(
+    {
+        "case_id",
+        "input_video_sha256",
+        "input_video_byte_count",
+        "frame_start",
+        "frame_stop_exclusive",
+        "evaluation_frame_start",
+        "evaluation_frame_stop_exclusive",
+    }
+)
+_ROLE_NAMES: Final = ("development", "calibration", "source_evaluation")
+_WEIGHTING: Final = {
+    "within_group": "endpoint-specific-nested-observations-v1",
+    "across_groups": "equal-complete-group-weight-v1",
+}
+
+
+def _canonical_json(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _record_id(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json(value)).hexdigest()
+
+
+def _strict_mapping(value: Any, *, name: str) -> Mapping[str, Any]:
+    if type(value) is not dict or any(type(key) is not str for key in value):
+        raise ValueError(f"{name} must be a JSON object with exact string keys")
+    return cast(Mapping[str, Any], value)
+
+
+def _exact_keys(value: Mapping[str, Any], expected: set[str] | frozenset[str], *, name: str) -> None:
+    keys = set(value)
+    if keys != set(expected):
+        missing = sorted(set(expected) - keys)
+        extra = sorted(keys - set(expected))
+        raise ValueError(f"{name} has noncanonical keys; missing={missing}, extra={extra}")
+
+
+def _strict_string(value: Any, *, name: str) -> str:
+    if type(value) is not str or not value or value != value.strip():
+        raise ValueError(
+            f"{name} must be a nonempty exact string without surrounding whitespace"
+        )
+    return cast(str, value)
+
+
+def _strict_integer(value: Any, *, name: str, minimum: int = 0) -> int:
+    if type(value) is not int or value < minimum:
+        raise ValueError(f"{name} must be a genuine integer >= {minimum}")
+    return cast(int, value)
+
+
+def _strict_boolean(value: Any, *, name: str) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be a genuine Boolean")
+    return cast(bool, value)
+
+
+def _sha256(value: Any, *, name: str) -> str:
+    digest = _strict_string(value, name=name)
+    if len(digest) != 64 or any(character not in "0123456789abcdef" for character in digest):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return digest
+
+
+def _revision(value: Any, *, name: str) -> str:
+    revision = _strict_string(value, name=name)
+    if len(revision) != 40 or any(character not in "0123456789abcdef" for character in revision):
+        raise ValueError(f"{name} must be an exact lowercase 40-character Git revision")
+    return revision
+
+
+def _finite_nonnegative(value: Any, *, name: str) -> float:
+    if type(value) not in {int, float}:
+        raise ValueError(f"{name} must be a genuine finite number")
+    normalized = float(value)
+    if not math.isfinite(normalized) or normalized < 0.0:
+        raise ValueError(f"{name} must be finite and non-negative")
+    return normalized
+
+
+def _canonical_arms(include_revisit: bool) -> list[dict[str, Any]]:
+    return [
+        {
+            "arm_id": "native-continuous",
+            "execution_mode": "recurrent-online-continuous-v1",
+            "causal": True,
+            "claim_eligible": True,
+            "enabled": True,
+        },
+        {
+            "arm_id": "restarted-newest",
+            "execution_mode": "fresh-state-overlapping-windows-newest-only-v1",
+            "causal": True,
+            "claim_eligible": True,
+            "enabled": True,
+        },
+        {
+            "arm_id": "restarted-prob4d-fused",
+            "execution_mode": "fresh-state-overlapping-windows-prob4d-fusion-v1",
+            "causal": True,
+            "claim_eligible": True,
+            "enabled": True,
+        },
+        {
+            "arm_id": "revisit-diagnostic",
+            "execution_mode": "provider-revisit-noncausal-v1",
+            "causal": False,
+            "claim_eligible": False,
+            "enabled": include_revisit,
+        },
+    ]
+
+
+def _canonical_contrasts(include_revisit: bool) -> list[dict[str, Any]]:
+    return [
+        {
+            "contrast_id": "prob4d-fusion-value",
+            "treatment_arm": "restarted-prob4d-fused",
+            "control_arm": "restarted-newest",
+            "claim_eligible": True,
+            "enabled": True,
+        },
+        {
+            "contrast_id": "provider-recurrence-value",
+            "treatment_arm": "native-continuous",
+            "control_arm": "restarted-newest",
+            "claim_eligible": True,
+            "enabled": True,
+        },
+        {
+            "contrast_id": "noncausal-revisit-upper-bound",
+            "treatment_arm": "revisit-diagnostic",
+            "control_arm": "native-continuous",
+            "claim_eligible": False,
+            "enabled": include_revisit,
+        },
+    ]
+
+
+def _normalize_cases(value: Any, *, group_id: str) -> list[dict[str, Any]]:
+    if type(value) is not list or not value:
+        raise ValueError(f"group {group_id!r} must contain a nonempty cases array")
+    cases: list[dict[str, Any]] = []
+    identifiers: set[str] = set()
+    for index, raw_case in enumerate(value):
+        case = _strict_mapping(raw_case, name=f"groups[{group_id}].cases[{index}]")
+        _exact_keys(case, _CASE_FIELDS, name=f"groups[{group_id}].cases[{index}]")
+        case_id = _strict_string(case["case_id"], name="case_id")
+        if case_id in identifiers:
+            raise ValueError(f"group {group_id!r} repeats case_id {case_id!r}")
+        identifiers.add(case_id)
+        frame_start = _strict_integer(case["frame_start"], name=f"{case_id}.frame_start")
+        frame_stop = _strict_integer(
+            case["frame_stop_exclusive"],
+            name=f"{case_id}.frame_stop_exclusive",
+            minimum=1,
+        )
+        evaluation_start = _strict_integer(
+            case["evaluation_frame_start"],
+            name=f"{case_id}.evaluation_frame_start",
+        )
+        evaluation_stop = _strict_integer(
+            case["evaluation_frame_stop_exclusive"],
+            name=f"{case_id}.evaluation_frame_stop_exclusive",
+            minimum=1,
+        )
+        if frame_stop <= frame_start:
+            raise ValueError(f"case {case_id!r} has an empty source interval")
+        if not (
+            frame_start <= evaluation_start < evaluation_stop <= frame_stop
+        ):
+            raise ValueError(
+                f"case {case_id!r} evaluation interval must lie inside its source interval"
+            )
+        cases.append(
+            {
+                "case_id": case_id,
+                "input_video_sha256": _sha256(
+                    case["input_video_sha256"],
+                    name=f"{case_id}.input_video_sha256",
+                ),
+                "input_video_byte_count": _strict_integer(
+                    case["input_video_byte_count"],
+                    name=f"{case_id}.input_video_byte_count",
+                    minimum=1,
+                ),
+                "frame_start": frame_start,
+                "frame_stop_exclusive": frame_stop,
+                "evaluation_frame_start": evaluation_start,
+                "evaluation_frame_stop_exclusive": evaluation_stop,
+            }
+        )
+    return sorted(cases, key=lambda item: cast(str, item["case_id"]))
+
+
+def _normalize_groups(value: Any) -> list[dict[str, Any]]:
+    if type(value) is not list or len(value) < 3:
+        raise ValueError("groups must contain at least three independent complete groups")
+    groups: list[dict[str, Any]] = []
+    group_ids: set[str] = set()
+    case_ids: set[str] = set()
+    for index, raw_group in enumerate(value):
+        group = _strict_mapping(raw_group, name=f"groups[{index}]")
+        _exact_keys(group, _GROUP_FIELDS, name=f"groups[{index}]")
+        group_id = _strict_string(group["group_id"], name=f"groups[{index}].group_id")
+        if group_id in group_ids:
+            raise ValueError(f"duplicate group_id {group_id!r}")
+        group_ids.add(group_id)
+        cases = _normalize_cases(group["cases"], group_id=group_id)
+        for case in cases:
+            case_id = cast(str, case["case_id"])
+            if case_id in case_ids:
+                raise ValueError(f"case_id {case_id!r} appears in multiple groups")
+            case_ids.add(case_id)
+        groups.append({"group_id": group_id, "cases": cases})
+    return sorted(groups, key=lambda item: cast(str, item["group_id"]))
+
+
+def _normalize_group_roles(value: Any, *, group_ids: set[str]) -> dict[str, list[str]]:
+    roles = _strict_mapping(value, name="group_roles")
+    _exact_keys(roles, set(_ROLE_NAMES), name="group_roles")
+    normalized: dict[str, list[str]] = {}
+    assigned: list[str] = []
+    for role in _ROLE_NAMES:
+        raw_ids = roles[role]
+        if type(raw_ids) is not list or not raw_ids:
+            raise ValueError(f"group_roles.{role} must be a nonempty JSON array")
+        identifiers = [
+            _strict_string(item, name=f"group_roles.{role}[{index}]")
+            for index, item in enumerate(raw_ids)
+        ]
+        if len(identifiers) != len(set(identifiers)):
+            raise ValueError(f"group_roles.{role} must not repeat group IDs")
+        normalized[role] = sorted(identifiers)
+        assigned.extend(identifiers)
+    if len(assigned) != len(set(assigned)):
+        raise ValueError("development, calibration, and source-evaluation groups must be disjoint")
+    if set(assigned) != group_ids:
+        missing = sorted(group_ids - set(assigned))
+        unknown = sorted(set(assigned) - group_ids)
+        raise ValueError(
+            f"group_roles must partition every group exactly once; missing={missing}, unknown={unknown}"
+        )
+    return normalized
+
+
+def _normalize_seeds(value: Any) -> list[int]:
+    if type(value) is not list or not value:
+        raise ValueError("random_seeds must be a nonempty JSON array")
+    seeds = [
+        _strict_integer(item, name=f"random_seeds[{index}]")
+        for index, item in enumerate(value)
+    ]
+    if len(seeds) != len(set(seeds)):
+        raise ValueError("random_seeds must be unique")
+    return sorted(seeds)
+
+
+def build_cut3r_comparison_lock(specification: Any) -> dict[str, Any]:
+    """Build a canonical source-only comparison lock from an outcome-blind spec."""
+
+    spec = _strict_mapping(specification, name="CUT3R comparison specification")
+    _exact_keys(spec, _SPEC_FIELDS, name="CUT3R comparison specification")
+    protocol_name = _strict_string(spec["protocol_name"], name="protocol_name")
+    groups = _normalize_groups(spec["groups"])
+    group_ids = {cast(str, group["group_id"]) for group in groups}
+    group_roles = _normalize_group_roles(spec["group_roles"], group_ids=group_ids)
+    random_seeds = _normalize_seeds(spec["random_seeds"])
+
+    window_size = _strict_integer(spec["window_size"], name="window_size", minimum=2)
+    overlap = _strict_integer(spec["overlap"], name="overlap", minimum=1)
+    if overlap >= window_size:
+        raise ValueError("overlap must be smaller than window_size")
+    storage_dtype = _strict_string(spec["storage_dtype"], name="storage_dtype")
+    if storage_dtype not in {"float32", "float64"}:
+        raise ValueError("storage_dtype must be float32 or float64")
+    include_revisit = _strict_boolean(
+        spec["include_revisit_diagnostic"],
+        name="include_revisit_diagnostic",
+    )
+
+    payload: dict[str, Any] = {
+        "schema": CUT3R_COMPARISON_SCHEMA,
+        "schema_version": CUT3R_COMPARISON_VERSION,
+        "protocol_name": protocol_name,
+        "provider": {
+            "repository": CUT3R_REPOSITORY,
+            "revision": _revision(spec["provider_revision"], name="provider_revision"),
+            "checkpoint_sha256": _sha256(
+                spec["checkpoint_sha256"],
+                name="checkpoint_sha256",
+            ),
+        },
+        "prob4d": {
+            "project_id": PROB4D_PROJECT_ID,
+            "revision": _revision(spec["prob4d_revision"], name="prob4d_revision"),
+            "distribution_sha256": _sha256(
+                spec["prob4d_distribution_sha256"],
+                name="prob4d_distribution_sha256",
+            ),
+        },
+        "windowing": {
+            "window_size": window_size,
+            "overlap": overlap,
+            "stride": window_size - overlap,
+            "confidence_threshold": _finite_nonnegative(
+                spec["confidence_threshold"],
+                name="confidence_threshold",
+            ),
+            "storage_dtype": storage_dtype,
+            "restart_policy": "fresh-state-per-window-v1",
+        },
+        "group_unit": CUT3R_COMPARISON_GROUP_UNIT,
+        "groups": groups,
+        "group_roles": group_roles,
+        "random_seeds": random_seeds,
+        "arms": _canonical_arms(include_revisit),
+        "registered_contrasts": _canonical_contrasts(include_revisit),
+        "provider_endpoints": list(CUT3R_PROVIDER_ENDPOINTS),
+        "weighting": dict(_WEIGHTING),
+        "source_access": "source-only",
+        "target_access": "forbidden",
+        "claim_boundary": CUT3R_COMPARISON_CLAIM_BOUNDARY,
+    }
+    payload["lock_id"] = _record_id(payload)
+    return validate_cut3r_comparison_lock(payload)
+
+
+def validate_cut3r_comparison_lock(value: Any) -> dict[str, Any]:
+    """Strictly validate a persisted CUT3R comparison lock."""
+
+    payload = _strict_mapping(value, name="CUT3R comparison lock")
+    _exact_keys(payload, _LOCK_FIELDS, name="CUT3R comparison lock")
+    if _strict_string(payload["schema"], name="schema") != CUT3R_COMPARISON_SCHEMA:
+        raise ValueError("unsupported CUT3R comparison schema")
+    if (
+        _strict_integer(payload["schema_version"], name="schema_version", minimum=1)
+        != CUT3R_COMPARISON_VERSION
+    ):
+        raise ValueError("unsupported CUT3R comparison schema version")
+    protocol_name = _strict_string(payload["protocol_name"], name="protocol_name")
+
+    provider = _strict_mapping(payload["provider"], name="provider")
+    _exact_keys(provider, _PROVIDER_FIELDS, name="provider")
+    if _strict_string(provider["repository"], name="provider.repository") != CUT3R_REPOSITORY:
+        raise ValueError("CUT3R comparison provider repository is not canonical")
+    normalized_provider = {
+        "repository": CUT3R_REPOSITORY,
+        "revision": _revision(provider["revision"], name="provider.revision"),
+        "checkpoint_sha256": _sha256(
+            provider["checkpoint_sha256"],
+            name="provider.checkpoint_sha256",
+        ),
+    }
+
+    prob4d = _strict_mapping(payload["prob4d"], name="prob4d")
+    _exact_keys(prob4d, _PROB4D_FIELDS, name="prob4d")
+    if _strict_string(prob4d["project_id"], name="prob4d.project_id") != PROB4D_PROJECT_ID:
+        raise ValueError("CUT3R comparison Prob4D project identity changed")
+    normalized_prob4d = {
+        "project_id": PROB4D_PROJECT_ID,
+        "revision": _revision(prob4d["revision"], name="prob4d.revision"),
+        "distribution_sha256": _sha256(
+            prob4d["distribution_sha256"],
+            name="prob4d.distribution_sha256",
+        ),
+    }
+
+    windowing = _strict_mapping(payload["windowing"], name="windowing")
+    _exact_keys(windowing, _WINDOW_FIELDS, name="windowing")
+    window_size = _strict_integer(windowing["window_size"], name="window_size", minimum=2)
+    overlap = _strict_integer(windowing["overlap"], name="overlap", minimum=1)
+    if overlap >= window_size:
+        raise ValueError("overlap must be smaller than window_size")
+    stride = _strict_integer(windowing["stride"], name="stride", minimum=1)
+    if stride != window_size - overlap:
+        raise ValueError("stride must equal window_size minus overlap")
+    storage_dtype = _strict_string(windowing["storage_dtype"], name="storage_dtype")
+    if storage_dtype not in {"float32", "float64"}:
+        raise ValueError("storage_dtype must be float32 or float64")
+    restart_policy = _strict_string(windowing["restart_policy"], name="restart_policy")
+    if restart_policy != "fresh-state-per-window-v1":
+        raise ValueError("CUT3R restart policy is not canonical")
+    normalized_windowing = {
+        "window_size": window_size,
+        "overlap": overlap,
+        "stride": stride,
+        "confidence_threshold": _finite_nonnegative(
+            windowing["confidence_threshold"],
+            name="confidence_threshold",
+        ),
+        "storage_dtype": storage_dtype,
+        "restart_policy": restart_policy,
+    }
+
+    if _strict_string(payload["group_unit"], name="group_unit") != CUT3R_COMPARISON_GROUP_UNIT:
+        raise ValueError("independent evidence unit must be the complete object/session group")
+    groups = _normalize_groups(payload["groups"])
+    group_ids = {cast(str, group["group_id"]) for group in groups}
+    group_roles = _normalize_group_roles(payload["group_roles"], group_ids=group_ids)
+    random_seeds = _normalize_seeds(payload["random_seeds"])
+
+    raw_arms = payload["arms"]
+    if type(raw_arms) is not list or len(raw_arms) != 4:
+        raise ValueError("CUT3R comparison must retain exactly four declared arms")
+    revisit = _strict_mapping(raw_arms[3], name="arms[3]")
+    include_revisit = _strict_boolean(revisit.get("enabled"), name="revisit enabled")
+    expected_arms = _canonical_arms(include_revisit)
+    if raw_arms != expected_arms:
+        raise ValueError("CUT3R comparison arms changed from the frozen causal contract")
+    expected_contrasts = _canonical_contrasts(include_revisit)
+    if payload["registered_contrasts"] != expected_contrasts:
+        raise ValueError("CUT3R registered contrasts changed from the frozen contract")
+    if payload["provider_endpoints"] != list(CUT3R_PROVIDER_ENDPOINTS):
+        raise ValueError("CUT3R provider endpoints changed from the frozen contract")
+    if payload["weighting"] != _WEIGHTING:
+        raise ValueError("CUT3R weighting must give complete groups equal weight")
+    if _strict_string(payload["source_access"], name="source_access") != "source-only":
+        raise ValueError("CUT3R comparison lock must remain source-only")
+    if _strict_string(payload["target_access"], name="target_access") != "forbidden":
+        raise ValueError("CUT3R comparison lock may not authorize target access")
+    claim_boundary = _strict_string(payload["claim_boundary"], name="claim_boundary")
+    if claim_boundary != CUT3R_COMPARISON_CLAIM_BOUNDARY:
+        raise ValueError("CUT3R comparison claim boundary is not canonical")
+
+    lock_id = _sha256(payload["lock_id"], name="lock_id")
+    normalized: dict[str, Any] = {
+        "schema": CUT3R_COMPARISON_SCHEMA,
+        "schema_version": CUT3R_COMPARISON_VERSION,
+        "protocol_name": protocol_name,
+        "provider": normalized_provider,
+        "prob4d": normalized_prob4d,
+        "windowing": normalized_windowing,
+        "group_unit": CUT3R_COMPARISON_GROUP_UNIT,
+        "groups": groups,
+        "group_roles": group_roles,
+        "random_seeds": random_seeds,
+        "arms": expected_arms,
+        "registered_contrasts": expected_contrasts,
+        "provider_endpoints": list(CUT3R_PROVIDER_ENDPOINTS),
+        "weighting": dict(_WEIGHTING),
+        "source_access": "source-only",
+        "target_access": "forbidden",
+        "claim_boundary": claim_boundary,
+        "lock_id": lock_id,
+    }
+    unsigned = dict(normalized)
+    unsigned.pop("lock_id")
+    if lock_id != _record_id(unsigned):
+        raise ValueError("lock_id does not match the canonical comparison content")
+    return cast(dict[str, Any], json.loads(_canonical_json(normalized)))
+
+
+def load_cut3r_comparison_lock(path: str | Path) -> dict[str, Any]:
+    """Load strict JSON and validate a CUT3R comparison lock."""
+
+    def reject_constant(value: str) -> None:
+        raise ValueError(f"non-finite JSON constant is forbidden: {value}")
+
+    def unique_object(pairs: Sequence[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, item in pairs:
+            if key in result:
+                raise ValueError(f"duplicate JSON key: {key}")
+            result[key] = item
+        return result
+
+    payload = json.loads(
+        Path(path).read_text(encoding="utf-8"),
+        parse_constant=reject_constant,
+        object_pairs_hook=unique_object,
+    )
+    return validate_cut3r_comparison_lock(payload)
+
+
+def write_cut3r_comparison_lock(
+    path: str | Path,
+    lock: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Publish one no-clobber comparison lock, allowing idempotent writes."""
+
+    payload = validate_cut3r_comparison_lock(lock)
+    destination = Path(path)
+    if destination.is_symlink():
+        raise ValueError("CUT3R comparison lock destination must not be a symbolic link")
+    encoded = _canonical_json(payload) + b"\n"
+    try:
+        atomic_write_bytes(destination, encoded, overwrite=False)
+    except FileExistsError:
+        existing = load_cut3r_comparison_lock(destination)
+        if existing != payload:
+            raise FileExistsError(
+                f"refusing to replace a different CUT3R comparison lock: {destination}"
+            ) from None
+        return existing
+    return payload
+
+
+def cut3r_comparison_summary(lock: Any) -> dict[str, Any]:
+    """Return a compact scientific-boundary summary."""
+
+    payload = validate_cut3r_comparison_lock(lock)
+    return {
+        "lock_id": payload["lock_id"],
+        "protocol_name": payload["protocol_name"],
+        "independent_group_count": len(payload["groups"]),
+        "case_count": sum(len(group["cases"]) for group in payload["groups"]),
+        "group_role_counts": {
+            role: len(payload["group_roles"][role]) for role in _ROLE_NAMES
+        },
+        "enabled_arms": [arm["arm_id"] for arm in payload["arms"] if arm["enabled"]],
+        "claim_eligible_contrasts": [
+            contrast["contrast_id"]
+            for contrast in payload["registered_contrasts"]
+            if contrast["enabled"] and contrast["claim_eligible"]
+        ],
+        "source_access": payload["source_access"],
+        "target_access": payload["target_access"],
+        "group_unit": payload["group_unit"],
+    }
+
+
+def _load_specification(path: str | Path) -> Mapping[str, Any]:
+    def reject_constant(value: str) -> None:
+        raise ValueError(f"non-finite JSON constant is forbidden: {value}")
+
+    def unique_object(pairs: Sequence[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, item in pairs:
+            if key in result:
+                raise ValueError(f"duplicate JSON key: {key}")
+            result[key] = item
+        return result
+
+    payload = json.loads(
+        Path(path).read_text(encoding="utf-8"),
+        parse_constant=reject_constant,
+        object_pairs_hook=unique_object,
+    )
+    return _strict_mapping(payload, name="CUT3R comparison specification")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="prob4d prediction cut3r-comparison",
+        description=__doc__,
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    build = subparsers.add_parser("build", help="freeze a source-only comparison")
+    build.add_argument("specification")
+    build.add_argument("--output", required=True)
+    build.set_defaults(handler=_build_command)
+
+    verify = subparsers.add_parser("verify", help="verify a frozen comparison lock")
+    verify.add_argument("lock")
+    verify.set_defaults(handler=_verify_command)
+
+    summarize = subparsers.add_parser("summarize", help="summarize a comparison lock")
+    summarize.add_argument("lock")
+    summarize.add_argument("--json", action="store_true")
+    summarize.set_defaults(handler=_summarize_command)
+    return parser
+
+
+def _build_command(arguments: argparse.Namespace) -> int:
+    lock = build_cut3r_comparison_lock(_load_specification(arguments.specification))
+    write_cut3r_comparison_lock(arguments.output, lock)
+    print(lock["lock_id"])
+    return 0
+
+
+def _verify_command(arguments: argparse.Namespace) -> int:
+    lock = load_cut3r_comparison_lock(arguments.lock)
+    print(lock["lock_id"])
+    return 0
+
+
+def _summarize_command(arguments: argparse.Namespace) -> int:
+    summary = cut3r_comparison_summary(load_cut3r_comparison_lock(arguments.lock))
+    if arguments.json:
+        print(json.dumps(summary, sort_keys=True, indent=2, allow_nan=False))
+    else:
+        print(f"lock_id: {summary['lock_id']}")
+        print(f"independent groups: {summary['independent_group_count']}")
+        print(f"cases: {summary['case_count']}")
+        print("enabled arms: " + ", ".join(summary["enabled_arms"]))
+        print("claim contrasts: " + ", ".join(summary["claim_eligible_contrasts"]))
+        print(f"target access: {summary['target_access']}")
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the CUT3R comparison-lock command."""
+
+    arguments = _parser().parse_args(list(argv) if argv is not None else None)
+    return int(arguments.handler(arguments))
+
+
+__all__ = [
+    "CUT3R_COMPARISON_CLAIM_BOUNDARY",
+    "CUT3R_COMPARISON_GROUP_UNIT",
+    "CUT3R_COMPARISON_SCHEMA",
+    "CUT3R_COMPARISON_VERSION",
+    "CUT3R_PROVIDER_ENDPOINTS",
+    "build_cut3r_comparison_lock",
+    "cut3r_comparison_summary",
+    "load_cut3r_comparison_lock",
+    "main",
+    "validate_cut3r_comparison_lock",
+    "write_cut3r_comparison_lock",
+]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/prob4d/cut3r_comparison.py
+++ b/src/prob4d/cut3r_comparison.py
@@ -139,7 +139,12 @@ def _strict_mapping(value: Any, *, name: str) -> Mapping[str, Any]:
     return cast(Mapping[str, Any], value)
 
 
-def _exact_keys(value: Mapping[str, Any], expected: set[str] | frozenset[str], *, name: str) -> None:
+def _exact_keys(
+    value: Mapping[str, Any],
+    expected: set[str] | frozenset[str],
+    *,
+    name: str,
+) -> None:
     keys = set(value)
     if keys != set(expected):
         missing = sorted(set(expected) - keys)
@@ -351,7 +356,8 @@ def _normalize_group_roles(value: Any, *, group_ids: set[str]) -> dict[str, list
         missing = sorted(group_ids - set(assigned))
         unknown = sorted(set(assigned) - group_ids)
         raise ValueError(
-            f"group_roles must partition every group exactly once; missing={missing}, unknown={unknown}"
+            "group_roles must partition every group exactly once; "
+            f"missing={missing}, unknown={unknown}"
         )
     return normalized
 

--- a/src/prob4d/prediction_cli.py
+++ b/src/prob4d/prediction_cli.py
@@ -28,6 +28,14 @@ def _help_parser() -> argparse.ArgumentParser:
         help="convert official recurrent-online CUT3R outputs",
     )
     subparsers.add_parser(
+        "cut3r-comparison",
+        help="freeze or inspect a group-aware native-versus-fused CUT3R comparison",
+    )
+    subparsers.add_parser(
+        "compatibility",
+        help="build or compare additive semantic-compatibility manifests",
+    )
+    subparsers.add_parser(
         "import-generic",
         help="import external canonical PredictionWindow payloads",
     )
@@ -62,6 +70,14 @@ def main(argv: Sequence[str] | None = None) -> int:
         from .cut3r_provider_adapter import main as cut3r_main
 
         return int(cut3r_main(arguments[1:]))
+    if arguments[0] == "cut3r-comparison":
+        from .cut3r_comparison import main as cut3r_comparison_main
+
+        return int(cut3r_comparison_main(arguments[1:]))
+    if arguments[0] == "compatibility":
+        from .semantic_compatibility import main as compatibility_main
+
+        return int(compatibility_main(arguments[1:]))
     if arguments[0] == "import-generic":
         from .prediction_provider_import import main as generic_main
 

--- a/src/prob4d/semantic_compatibility.py
+++ b/src/prob4d/semantic_compatibility.py
@@ -100,7 +100,12 @@ def _strict_mapping(value: Any, *, name: str) -> Mapping[str, Any]:
     return cast(Mapping[str, Any], value)
 
 
-def _exact_keys(value: Mapping[str, Any], expected: set[str] | frozenset[str], *, name: str) -> None:
+def _exact_keys(
+    value: Mapping[str, Any],
+    expected: set[str] | frozenset[str],
+    *,
+    name: str,
+) -> None:
     keys = set(value)
     if keys != set(expected):
         missing = sorted(set(expected) - keys)

--- a/src/prob4d/semantic_compatibility.py
+++ b/src/prob4d/semantic_compatibility.py
@@ -1,0 +1,492 @@
+"""Build and compare additive semantic-compatibility manifests.
+
+The semantic manifest is deliberately weaker than a claim-bearing evidence pin:
+it records the API major, named mandatory conformance vectors, and required
+capabilities without binding the complete corpus inventory or repository revision.
+Frozen scientific runs must continue to bind exact distributions, revisions, and
+content-addressed artifact bundles.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final, cast
+
+from ._atomic_file import atomic_write_bytes
+from ._immutable_json import plain_json
+from ._provider_v2_contract_common import (
+    PROVIDER_V2_CONTRACT_BUNDLE,
+    PROVIDER_V2_CONTRACT_BUNDLE_VERSION,
+    provider_v2_contract_vector,
+)
+from .api import v2 as api_v2
+from .observation_contract_bundle import (
+    OBSERVATION_BELIEF_CONTRACT_BUNDLE,
+    OBSERVATION_BELIEF_CONTRACT_BUNDLE_VERSION,
+    observation_contract_vector,
+)
+from .project_identity import PROB4D_PROJECT_ID
+
+SEMANTIC_COMPATIBILITY_SCHEMA: Final = "prob4d.semantic-compatibility"
+SEMANTIC_COMPATIBILITY_VERSION: Final = 1
+SEMANTIC_COMPATIBILITY_CLAIM_BOUNDARY: Final = (
+    "Semantic compatibility establishes only that named interfaces, contract "
+    "vectors, and capabilities are available. Claim-bearing runs must additionally "
+    "bind exact Prob4D, BayesianPhysTwin, and Causal4D distributions, revisions, "
+    "complete contract-corpus identities, protocols, and input/output artifacts."
+)
+PROVIDED_CAPABILITIES: Final[tuple[str, ...]] = tuple(
+    sorted(
+        {
+            "causal-source-lineage-v1",
+            "content-addressed-artifacts-v1",
+            "exact-invalid-fallback-v1",
+            "joint-gauge-covariance-v1",
+            "strict-artifact-loading-v1",
+            "tree-sparse-observation-factors-v1",
+        }
+    )
+)
+
+_MANIFEST_FIELDS: Final = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "project_id",
+        "python_api",
+        "contracts",
+        "capabilities",
+        "claim_bearing_evidence_pin_required",
+        "claim_boundary",
+        "manifest_id",
+    }
+)
+_API_FIELDS: Final = frozenset(
+    {
+        "module",
+        "api_version",
+        "provider_api_version",
+        "provider_factor_api_version",
+        "lifecycle",
+    }
+)
+_CONTRACT_FIELDS: Final = frozenset(
+    {"contract_id", "contract_version", "required_vectors"}
+)
+_CONTRACT_NAMES: Final = ("observation_belief", "provider_v2_factors")
+
+
+def _canonical_json(value: Mapping[str, Any]) -> bytes:
+    return json.dumps(
+        plain_json(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _manifest_id(value: Mapping[str, Any]) -> str:
+    return hashlib.sha256(_canonical_json(value)).hexdigest()
+
+
+def _strict_mapping(value: Any, *, name: str) -> Mapping[str, Any]:
+    if type(value) is not dict or any(type(key) is not str for key in value):
+        raise ValueError(f"{name} must be a JSON object with exact string keys")
+    return cast(Mapping[str, Any], value)
+
+
+def _exact_keys(value: Mapping[str, Any], expected: set[str] | frozenset[str], *, name: str) -> None:
+    keys = set(value)
+    if keys != set(expected):
+        missing = sorted(set(expected) - keys)
+        extra = sorted(keys - set(expected))
+        raise ValueError(f"{name} has noncanonical keys; missing={missing}, extra={extra}")
+
+
+def _strict_string(value: Any, *, name: str) -> str:
+    if type(value) is not str or not value or value != value.strip():
+        raise ValueError(
+            f"{name} must be a nonempty exact string without surrounding whitespace"
+        )
+    return cast(str, value)
+
+
+def _strict_integer(value: Any, *, name: str, minimum: int = 1) -> int:
+    if type(value) is not int or value < minimum:
+        raise ValueError(f"{name} must be a genuine integer >= {minimum}")
+    return cast(int, value)
+
+
+def _sha256(value: Any, *, name: str) -> str:
+    digest = _strict_string(value, name=name)
+    if len(digest) != 64 or any(character not in "0123456789abcdef" for character in digest):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return digest
+
+
+def _validate_vectors(value: Any, *, name: str) -> dict[str, str]:
+    mapping = _strict_mapping(value, name=name)
+    if not mapping:
+        raise ValueError(f"{name} must contain at least one named vector")
+    vectors: dict[str, str] = {}
+    for vector_name, digest in sorted(mapping.items()):
+        normalized_name = _strict_string(vector_name, name=f"{name} vector name")
+        vectors[normalized_name] = _sha256(
+            digest,
+            name=f"{name}.{normalized_name}",
+        )
+    return vectors
+
+
+def _validate_contract(
+    value: Any,
+    *,
+    name: str,
+    expected_id: str,
+) -> dict[str, Any]:
+    contract = _strict_mapping(value, name=name)
+    _exact_keys(contract, _CONTRACT_FIELDS, name=name)
+    contract_id = _strict_string(contract["contract_id"], name=f"{name}.contract_id")
+    if contract_id != expected_id:
+        raise ValueError(f"{name}.contract_id is not supported")
+    contract_version = _strict_integer(
+        contract["contract_version"],
+        name=f"{name}.contract_version",
+    )
+    required_vectors = _validate_vectors(
+        contract["required_vectors"],
+        name=f"{name}.required_vectors",
+    )
+    return {
+        "contract_id": contract_id,
+        "contract_version": contract_version,
+        "required_vectors": required_vectors,
+    }
+
+
+def _provider_vector_sha256(name: str) -> str:
+    vector = provider_v2_contract_vector(name)
+    return hashlib.sha256(_canonical_json(vector.payload)).hexdigest()
+
+
+def build_semantic_compatibility_manifest() -> dict[str, Any]:
+    """Build the additive compatibility descriptor for this installation."""
+
+    observation_vectors = {
+        name: observation_contract_vector(name).expected_artifact_id
+        for name in ("minimal", "zero_rank")
+    }
+    provider_vectors = {"minimal": _provider_vector_sha256("minimal")}
+    payload: dict[str, Any] = {
+        "schema": SEMANTIC_COMPATIBILITY_SCHEMA,
+        "schema_version": SEMANTIC_COMPATIBILITY_VERSION,
+        "project_id": PROB4D_PROJECT_ID,
+        "python_api": {
+            "module": "prob4d.api.v2",
+            "api_version": api_v2.API_VERSION,
+            "provider_api_version": api_v2.PROVIDER_API_VERSION,
+            "provider_factor_api_version": api_v2.PROVIDER_FACTOR_API_VERSION,
+            "lifecycle": "current",
+        },
+        "contracts": {
+            "observation_belief": {
+                "contract_id": OBSERVATION_BELIEF_CONTRACT_BUNDLE,
+                "contract_version": OBSERVATION_BELIEF_CONTRACT_BUNDLE_VERSION,
+                "required_vectors": observation_vectors,
+            },
+            "provider_v2_factors": {
+                "contract_id": PROVIDER_V2_CONTRACT_BUNDLE,
+                "contract_version": PROVIDER_V2_CONTRACT_BUNDLE_VERSION,
+                "required_vectors": provider_vectors,
+            },
+        },
+        "capabilities": list(PROVIDED_CAPABILITIES),
+        "claim_bearing_evidence_pin_required": True,
+        "claim_boundary": SEMANTIC_COMPATIBILITY_CLAIM_BOUNDARY,
+    }
+    payload["manifest_id"] = _manifest_id(payload)
+    return validate_semantic_compatibility_manifest(payload)
+
+
+def validate_semantic_compatibility_manifest(value: Any) -> dict[str, Any]:
+    """Strictly validate one semantic-compatibility manifest."""
+
+    payload = _strict_mapping(value, name="semantic compatibility manifest")
+    _exact_keys(payload, _MANIFEST_FIELDS, name="semantic compatibility manifest")
+    if _strict_string(payload["schema"], name="schema") != SEMANTIC_COMPATIBILITY_SCHEMA:
+        raise ValueError("unsupported semantic-compatibility schema")
+    if (
+        _strict_integer(payload["schema_version"], name="schema_version")
+        != SEMANTIC_COMPATIBILITY_VERSION
+    ):
+        raise ValueError("unsupported semantic-compatibility schema version")
+    if _strict_string(payload["project_id"], name="project_id") != PROB4D_PROJECT_ID:
+        raise ValueError("semantic compatibility project identity is not Prob4D")
+
+    raw_api = _strict_mapping(payload["python_api"], name="python_api")
+    _exact_keys(raw_api, _API_FIELDS, name="python_api")
+    module = _strict_string(raw_api["module"], name="python_api.module")
+    if module != "prob4d.api.v2":
+        raise ValueError("semantic compatibility requires prob4d.api.v2")
+    python_api = {
+        "module": module,
+        "api_version": _strict_integer(raw_api["api_version"], name="python_api.api_version"),
+        "provider_api_version": _strict_integer(
+            raw_api["provider_api_version"],
+            name="python_api.provider_api_version",
+        ),
+        "provider_factor_api_version": _strict_integer(
+            raw_api["provider_factor_api_version"],
+            name="python_api.provider_factor_api_version",
+        ),
+        "lifecycle": _strict_string(raw_api["lifecycle"], name="python_api.lifecycle"),
+    }
+    if python_api["lifecycle"] != "current":
+        raise ValueError("semantic compatibility Python API must be current")
+
+    raw_contracts = _strict_mapping(payload["contracts"], name="contracts")
+    _exact_keys(raw_contracts, set(_CONTRACT_NAMES), name="contracts")
+    contracts = {
+        "observation_belief": _validate_contract(
+            raw_contracts["observation_belief"],
+            name="contracts.observation_belief",
+            expected_id=OBSERVATION_BELIEF_CONTRACT_BUNDLE,
+        ),
+        "provider_v2_factors": _validate_contract(
+            raw_contracts["provider_v2_factors"],
+            name="contracts.provider_v2_factors",
+            expected_id=PROVIDER_V2_CONTRACT_BUNDLE,
+        ),
+    }
+
+    raw_capabilities = payload["capabilities"]
+    if type(raw_capabilities) is not list:
+        raise ValueError("capabilities must be a JSON array")
+    capabilities = [
+        _strict_string(item, name=f"capabilities[{index}]")
+        for index, item in enumerate(raw_capabilities)
+    ]
+    if not capabilities or capabilities != sorted(capabilities):
+        raise ValueError("capabilities must be nonempty and sorted canonically")
+    if len(capabilities) != len(set(capabilities)):
+        raise ValueError("capabilities must be unique")
+
+    if payload["claim_bearing_evidence_pin_required"] is not True:
+        raise ValueError("semantic compatibility may not replace the evidence pin")
+    claim_boundary = _strict_string(payload["claim_boundary"], name="claim_boundary")
+    if claim_boundary != SEMANTIC_COMPATIBILITY_CLAIM_BOUNDARY:
+        raise ValueError("semantic compatibility claim boundary is not canonical")
+
+    manifest_id = _sha256(payload["manifest_id"], name="manifest_id")
+    normalized: dict[str, Any] = {
+        "schema": SEMANTIC_COMPATIBILITY_SCHEMA,
+        "schema_version": SEMANTIC_COMPATIBILITY_VERSION,
+        "project_id": PROB4D_PROJECT_ID,
+        "python_api": python_api,
+        "contracts": contracts,
+        "capabilities": capabilities,
+        "claim_bearing_evidence_pin_required": True,
+        "claim_boundary": claim_boundary,
+        "manifest_id": manifest_id,
+    }
+    unsigned = dict(normalized)
+    unsigned.pop("manifest_id")
+    if manifest_id != _manifest_id(unsigned):
+        raise ValueError("manifest_id does not match the canonical manifest content")
+    return cast(dict[str, Any], json.loads(_canonical_json(normalized)))
+
+
+def semantic_compatibility_report(
+    required: Any,
+    provided: Any,
+) -> dict[str, Any]:
+    """Report whether *provided* satisfies all additive requirements."""
+
+    requirement = validate_semantic_compatibility_manifest(required)
+    implementation = validate_semantic_compatibility_manifest(provided)
+    reasons: list[str] = []
+
+    if requirement["python_api"] != implementation["python_api"]:
+        reasons.append("python-api-mismatch")
+
+    missing_or_changed_vectors: list[str] = []
+    for contract_name in _CONTRACT_NAMES:
+        required_contract = requirement["contracts"][contract_name]
+        provided_contract = implementation["contracts"][contract_name]
+        if (
+            required_contract["contract_id"] != provided_contract["contract_id"]
+            or required_contract["contract_version"]
+            != provided_contract["contract_version"]
+        ):
+            reasons.append(f"{contract_name}-identity-mismatch")
+            continue
+        for vector_name, digest in required_contract["required_vectors"].items():
+            if provided_contract["required_vectors"].get(vector_name) != digest:
+                missing_or_changed_vectors.append(f"{contract_name}:{vector_name}")
+
+    required_capabilities = set(requirement["capabilities"])
+    provided_capabilities = set(implementation["capabilities"])
+    missing_capabilities = sorted(required_capabilities - provided_capabilities)
+    if missing_or_changed_vectors:
+        reasons.append("mandatory-vector-mismatch")
+    if missing_capabilities:
+        reasons.append("missing-capability")
+
+    return {
+        "compatible": not reasons,
+        "required_manifest_id": requirement["manifest_id"],
+        "provided_manifest_id": implementation["manifest_id"],
+        "missing_or_changed_vectors": sorted(missing_or_changed_vectors),
+        "missing_capabilities": missing_capabilities,
+        "reasons": reasons,
+    }
+
+
+def load_semantic_compatibility_manifest(path: str | Path) -> dict[str, Any]:
+    """Load strict JSON and validate a semantic-compatibility manifest."""
+
+    def reject_constant(value: str) -> None:
+        raise ValueError(f"non-finite JSON constant is forbidden: {value}")
+
+    def unique_object(pairs: Sequence[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, item in pairs:
+            if key in result:
+                raise ValueError(f"duplicate JSON key: {key}")
+            result[key] = item
+        return result
+
+    payload = json.loads(
+        Path(path).read_text(encoding="utf-8"),
+        parse_constant=reject_constant,
+        object_pairs_hook=unique_object,
+    )
+    return validate_semantic_compatibility_manifest(payload)
+
+
+def write_semantic_compatibility_manifest(
+    path: str | Path,
+    manifest: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Publish one no-clobber semantic manifest, allowing idempotent writes."""
+
+    payload = (
+        build_semantic_compatibility_manifest()
+        if manifest is None
+        else validate_semantic_compatibility_manifest(manifest)
+    )
+    destination = Path(path)
+    if destination.is_symlink():
+        raise ValueError("semantic compatibility destination must not be a symbolic link")
+    encoded = _canonical_json(payload) + b"\n"
+    try:
+        atomic_write_bytes(destination, encoded, overwrite=False)
+    except FileExistsError:
+        existing = load_semantic_compatibility_manifest(destination)
+        if existing != payload:
+            raise FileExistsError(
+                f"refusing to replace a different semantic compatibility manifest: {destination}"
+            ) from None
+        return existing
+    return payload
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="prob4d prediction compatibility",
+        description=__doc__,
+    )
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    show = subparsers.add_parser("print", help="print the current semantic manifest")
+    show.set_defaults(handler=_print_command)
+
+    build = subparsers.add_parser("build", help="write the current semantic manifest")
+    build.add_argument("--output", required=True)
+    build.set_defaults(handler=_build_command)
+
+    verify = subparsers.add_parser("verify", help="verify one semantic manifest")
+    verify.add_argument("manifest")
+    verify.add_argument(
+        "--require-current",
+        action="store_true",
+        help="require the executing installation to satisfy the manifest",
+    )
+    verify.set_defaults(handler=_verify_command)
+
+    check = subparsers.add_parser("check", help="compare required and provided manifests")
+    check.add_argument("required")
+    check.add_argument("provided")
+    check.set_defaults(handler=_check_command)
+    return parser
+
+
+def _print_command(arguments: argparse.Namespace) -> int:
+    del arguments
+    print(
+        json.dumps(
+            build_semantic_compatibility_manifest(),
+            sort_keys=True,
+            indent=2,
+            allow_nan=False,
+        )
+    )
+    return 0
+
+
+def _build_command(arguments: argparse.Namespace) -> int:
+    manifest = write_semantic_compatibility_manifest(arguments.output)
+    print(manifest["manifest_id"])
+    return 0
+
+
+def _verify_command(arguments: argparse.Namespace) -> int:
+    manifest = load_semantic_compatibility_manifest(arguments.manifest)
+    if arguments.require_current:
+        report = semantic_compatibility_report(
+            manifest,
+            build_semantic_compatibility_manifest(),
+        )
+        if not report["compatible"]:
+            raise ValueError(f"current installation is incompatible: {report['reasons']}")
+    print(manifest["manifest_id"])
+    return 0
+
+
+def _check_command(arguments: argparse.Namespace) -> int:
+    report = semantic_compatibility_report(
+        load_semantic_compatibility_manifest(arguments.required),
+        load_semantic_compatibility_manifest(arguments.provided),
+    )
+    print(json.dumps(report, sort_keys=True, indent=2, allow_nan=False))
+    return 0 if report["compatible"] else 2
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the semantic-compatibility command."""
+
+    arguments = _parser().parse_args(list(argv) if argv is not None else None)
+    return int(arguments.handler(arguments))
+
+
+__all__ = [
+    "PROVIDED_CAPABILITIES",
+    "SEMANTIC_COMPATIBILITY_CLAIM_BOUNDARY",
+    "SEMANTIC_COMPATIBILITY_SCHEMA",
+    "SEMANTIC_COMPATIBILITY_VERSION",
+    "build_semantic_compatibility_manifest",
+    "load_semantic_compatibility_manifest",
+    "main",
+    "semantic_compatibility_report",
+    "validate_semantic_compatibility_manifest",
+    "write_semantic_compatibility_manifest",
+]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cut3r_comparison.py
+++ b/tests/test_cut3r_comparison.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from prob4d.cut3r_comparison import (
+    CUT3R_COMPARISON_GROUP_UNIT,
+    CUT3R_COMPARISON_SCHEMA,
+    CUT3R_PROVIDER_ENDPOINTS,
+    build_cut3r_comparison_lock,
+    cut3r_comparison_summary,
+    load_cut3r_comparison_lock,
+    main,
+    validate_cut3r_comparison_lock,
+    write_cut3r_comparison_lock,
+)
+
+
+def _case(case_id: str, digest_character: str) -> dict[str, Any]:
+    return {
+        "case_id": case_id,
+        "input_video_sha256": digest_character * 64,
+        "input_video_byte_count": 1000,
+        "frame_start": 0,
+        "frame_stop_exclusive": 100,
+        "evaluation_frame_start": 20,
+        "evaluation_frame_stop_exclusive": 90,
+    }
+
+
+def _specification() -> dict[str, Any]:
+    return {
+        "protocol_name": "cut3r-source-comparison-v1",
+        "provider_revision": "a" * 40,
+        "checkpoint_sha256": "b" * 64,
+        "prob4d_revision": "c" * 40,
+        "prob4d_distribution_sha256": "d" * 64,
+        "window_size": 25,
+        "overlap": 8,
+        "confidence_threshold": 1.5,
+        "storage_dtype": "float32",
+        "random_seeds": [7, 11],
+        "groups": [
+            {"group_id": "object-a", "cases": [_case("case-a", "1")]},
+            {"group_id": "object-b", "cases": [_case("case-b", "2")]},
+            {"group_id": "object-c", "cases": [_case("case-c", "3")]},
+        ],
+        "group_roles": {
+            "development": ["object-a"],
+            "calibration": ["object-b"],
+            "source_evaluation": ["object-c"],
+        },
+        "include_revisit_diagnostic": True,
+    }
+
+
+def test_lock_is_deterministic_group_aware_and_source_only() -> None:
+    first = build_cut3r_comparison_lock(_specification())
+    second = build_cut3r_comparison_lock(_specification())
+
+    assert first == second
+    assert first["schema"] == CUT3R_COMPARISON_SCHEMA
+    assert first["group_unit"] == CUT3R_COMPARISON_GROUP_UNIT
+    assert first["source_access"] == "source-only"
+    assert first["target_access"] == "forbidden"
+    assert first["windowing"]["stride"] == 17
+    assert first["provider_endpoints"] == list(CUT3R_PROVIDER_ENDPOINTS)
+    assert [arm["arm_id"] for arm in first["arms"]] == [
+        "native-continuous",
+        "restarted-newest",
+        "restarted-prob4d-fused",
+        "revisit-diagnostic",
+    ]
+    assert first["arms"][-1]["causal"] is False
+    assert first["arms"][-1]["claim_eligible"] is False
+    assert validate_cut3r_comparison_lock(first) == first
+
+    summary = cut3r_comparison_summary(first)
+    assert summary["independent_group_count"] == 3
+    assert summary["case_count"] == 3
+    assert summary["group_role_counts"] == {
+        "development": 1,
+        "calibration": 1,
+        "source_evaluation": 1,
+    }
+    assert summary["claim_eligible_contrasts"] == [
+        "prob4d-fusion-value",
+        "provider-recurrence-value",
+    ]
+
+
+def test_revisit_arm_can_be_disabled_but_never_promoted() -> None:
+    specification = _specification()
+    specification["include_revisit_diagnostic"] = False
+    lock = build_cut3r_comparison_lock(specification)
+
+    assert lock["arms"][-1]["enabled"] is False
+    assert lock["registered_contrasts"][-1]["enabled"] is False
+
+    tampered = deepcopy(lock)
+    tampered["arms"][-1]["claim_eligible"] = True
+    with pytest.raises(ValueError, match="arms changed"):
+        validate_cut3r_comparison_lock(tampered)
+
+
+def test_group_roles_must_be_disjoint_and_complete() -> None:
+    specification = _specification()
+    specification["group_roles"]["calibration"] = ["object-a"]
+
+    with pytest.raises(ValueError, match="must be disjoint"):
+        build_cut3r_comparison_lock(specification)
+
+    specification = _specification()
+    specification["group_roles"]["source_evaluation"] = ["unknown"]
+    with pytest.raises(ValueError, match="partition every group"):
+        build_cut3r_comparison_lock(specification)
+
+
+def test_cases_cannot_cross_groups_or_escape_source_interval() -> None:
+    specification = _specification()
+    specification["groups"][1]["cases"][0]["case_id"] = "case-a"
+    with pytest.raises(ValueError, match="appears in multiple groups"):
+        build_cut3r_comparison_lock(specification)
+
+    specification = _specification()
+    specification["groups"][0]["cases"][0]["evaluation_frame_stop_exclusive"] = 101
+    with pytest.raises(ValueError, match="must lie inside"):
+        build_cut3r_comparison_lock(specification)
+
+
+def test_lock_round_trip_is_no_clobber(tmp_path: Path) -> None:
+    destination = tmp_path / "cut3r-comparison-lock.json"
+    lock = build_cut3r_comparison_lock(_specification())
+
+    assert write_cut3r_comparison_lock(destination, lock) == lock
+    assert load_cut3r_comparison_lock(destination) == lock
+    assert write_cut3r_comparison_lock(destination, lock) == lock
+
+    changed_specification = _specification()
+    changed_specification["protocol_name"] = "different-protocol"
+    different = build_cut3r_comparison_lock(changed_specification)
+    with pytest.raises(FileExistsError, match="refusing to replace"):
+        write_cut3r_comparison_lock(destination, different)
+
+
+def test_loader_rejects_duplicate_keys(tmp_path: Path) -> None:
+    path = tmp_path / "duplicate.json"
+    path.write_text('{"schema":"a","schema":"b"}', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="duplicate JSON key"):
+        load_cut3r_comparison_lock(path)
+
+
+def test_cli_build_verify_and_summarize(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    specification = tmp_path / "specification.json"
+    lock_path = tmp_path / "lock.json"
+    specification.write_text(
+        json.dumps(_specification(), sort_keys=True),
+        encoding="utf-8",
+    )
+
+    assert main(["build", str(specification), "--output", str(lock_path)]) == 0
+    lock_id = capsys.readouterr().out.strip()
+    assert lock_id == load_cut3r_comparison_lock(lock_path)["lock_id"]
+
+    assert main(["verify", str(lock_path)]) == 0
+    assert capsys.readouterr().out.strip() == lock_id
+
+    assert main(["summarize", str(lock_path), "--json"]) == 0
+    summary = json.loads(capsys.readouterr().out)
+    assert summary["independent_group_count"] == 3
+    assert summary["target_access"] == "forbidden"

--- a/tests/test_prediction_cli_extensions.py
+++ b/tests/test_prediction_cli_extensions.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from prob4d.prediction_cli import main
+from prob4d.semantic_compatibility import build_semantic_compatibility_manifest
+
+
+def _case(case_id: str, digest_character: str) -> dict[str, Any]:
+    return {
+        "case_id": case_id,
+        "input_video_sha256": digest_character * 64,
+        "input_video_byte_count": 1000,
+        "frame_start": 0,
+        "frame_stop_exclusive": 50,
+        "evaluation_frame_start": 10,
+        "evaluation_frame_stop_exclusive": 40,
+    }
+
+
+def _cut3r_specification() -> dict[str, Any]:
+    return {
+        "protocol_name": "cli-dispatch-test",
+        "provider_revision": "a" * 40,
+        "checkpoint_sha256": "b" * 64,
+        "prob4d_revision": "c" * 40,
+        "prob4d_distribution_sha256": "d" * 64,
+        "window_size": 25,
+        "overlap": 8,
+        "confidence_threshold": 0.0,
+        "storage_dtype": "float32",
+        "random_seeds": [7],
+        "groups": [
+            {"group_id": "development", "cases": [_case("case-a", "1")]},
+            {"group_id": "calibration", "cases": [_case("case-b", "2")]},
+            {"group_id": "source-evaluation", "cases": [_case("case-c", "3")]},
+        ],
+        "group_roles": {
+            "development": ["development"],
+            "calibration": ["calibration"],
+            "source_evaluation": ["source-evaluation"],
+        },
+        "include_revisit_diagnostic": False,
+    }
+
+
+def test_prediction_cli_dispatches_semantic_compatibility(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert main(["compatibility", "print"]) == 0
+    assert json.loads(capsys.readouterr().out) == build_semantic_compatibility_manifest()
+
+
+def test_prediction_cli_dispatches_cut3r_comparison(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    specification = tmp_path / "specification.json"
+    lock = tmp_path / "lock.json"
+    specification.write_text(
+        json.dumps(_cut3r_specification(), sort_keys=True),
+        encoding="utf-8",
+    )
+
+    assert (
+        main(
+            [
+                "cut3r-comparison",
+                "build",
+                str(specification),
+                "--output",
+                str(lock),
+            ]
+        )
+        == 0
+    )
+    lock_id = capsys.readouterr().out.strip()
+    assert len(lock_id) == 64
+    assert main(["cut3r-comparison", "verify", str(lock)]) == 0
+    assert capsys.readouterr().out.strip() == lock_id

--- a/tests/test_semantic_compatibility.py
+++ b/tests/test_semantic_compatibility.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from prob4d.semantic_compatibility import (
+    PROVIDED_CAPABILITIES,
+    SEMANTIC_COMPATIBILITY_SCHEMA,
+    SEMANTIC_COMPATIBILITY_VERSION,
+    build_semantic_compatibility_manifest,
+    load_semantic_compatibility_manifest,
+    main,
+    semantic_compatibility_report,
+    validate_semantic_compatibility_manifest,
+    write_semantic_compatibility_manifest,
+)
+
+
+def _rehash(manifest: dict[str, Any]) -> dict[str, Any]:
+    payload = deepcopy(manifest)
+    payload.pop("manifest_id", None)
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+    payload["manifest_id"] = hashlib.sha256(encoded).hexdigest()
+    return payload
+
+
+def test_semantic_manifest_is_deterministic_and_named_vector_based() -> None:
+    first = build_semantic_compatibility_manifest()
+    second = build_semantic_compatibility_manifest()
+
+    assert first == second
+    assert first["schema"] == SEMANTIC_COMPATIBILITY_SCHEMA
+    assert first["schema_version"] == SEMANTIC_COMPATIBILITY_VERSION == 1
+    assert first["claim_bearing_evidence_pin_required"] is True
+    assert first["capabilities"] == list(PROVIDED_CAPABILITIES)
+    assert set(first["contracts"]["observation_belief"]["required_vectors"]) == {
+        "minimal",
+        "zero_rank",
+    }
+    assert set(first["contracts"]["provider_v2_factors"]["required_vectors"]) == {
+        "minimal"
+    }
+    assert "bundle_sha256" not in first["contracts"]["observation_belief"]
+    assert validate_semantic_compatibility_manifest(first) == first
+
+
+def test_additive_capability_does_not_break_existing_requirement() -> None:
+    required = build_semantic_compatibility_manifest()
+    provided = deepcopy(required)
+    provided["capabilities"].append("z-additive-capability-v1")
+    provided["capabilities"].sort()
+    provided = _rehash(provided)
+
+    report = semantic_compatibility_report(required, provided)
+
+    assert report["compatible"] is True
+    assert report["missing_capabilities"] == []
+    assert report["missing_or_changed_vectors"] == []
+
+
+def test_missing_capability_and_changed_named_vector_fail_closed() -> None:
+    required = build_semantic_compatibility_manifest()
+    provided = deepcopy(required)
+    provided["capabilities"] = provided["capabilities"][1:]
+    provided["contracts"]["observation_belief"]["required_vectors"]["minimal"] = (
+        "0" * 64
+    )
+    provided = _rehash(provided)
+
+    report = semantic_compatibility_report(required, provided)
+
+    assert report["compatible"] is False
+    assert report["missing_capabilities"] == [required["capabilities"][0]]
+    assert report["missing_or_changed_vectors"] == ["observation_belief:minimal"]
+    assert "mandatory-vector-mismatch" in report["reasons"]
+    assert "missing-capability" in report["reasons"]
+
+
+def test_manifest_round_trip_is_atomic_and_no_clobber(tmp_path: Path) -> None:
+    destination = tmp_path / "semantic-compatibility.json"
+    expected = build_semantic_compatibility_manifest()
+
+    assert write_semantic_compatibility_manifest(destination) == expected
+    assert load_semantic_compatibility_manifest(destination) == expected
+    assert write_semantic_compatibility_manifest(destination) == expected
+
+    different = deepcopy(expected)
+    different["capabilities"].append("z-different-v1")
+    different["capabilities"].sort()
+    different = _rehash(different)
+    with pytest.raises(FileExistsError, match="refusing to replace"):
+        write_semantic_compatibility_manifest(destination, different)
+
+
+def test_loader_rejects_duplicate_keys(tmp_path: Path) -> None:
+    path = tmp_path / "duplicate.json"
+    path.write_text('{"schema":"a","schema":"b"}', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="duplicate JSON key"):
+        load_semantic_compatibility_manifest(path)
+
+
+def test_cli_print_build_verify_and_check(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert main(["print"]) == 0
+    assert json.loads(capsys.readouterr().out) == build_semantic_compatibility_manifest()
+
+    required = tmp_path / "required.json"
+    provided = tmp_path / "provided.json"
+    assert main(["build", "--output", str(required)]) == 0
+    built_id = capsys.readouterr().out.strip()
+    assert built_id == build_semantic_compatibility_manifest()["manifest_id"]
+    assert main(["verify", str(required), "--require-current"]) == 0
+    assert capsys.readouterr().out.strip() == built_id
+
+    write_semantic_compatibility_manifest(provided)
+    assert main(["check", str(required), str(provided)]) == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["compatible"] is True


### PR DESCRIPTION
## Summary

- add a strict content-addressed CUT3R source-comparison lock over complete object/session groups
- freeze native continuous, restarted-newest, restarted-Prob4D-fused, and optional noncausal revisit arms
- register the causal contrasts that isolate Prob4D fusion from CUT3R recurrence
- add an additive semantic-compatibility manifest based on API majors, named mandatory vectors, and capabilities
- preserve exact revisions, distributions, complete corpus identities, and artifact digests as a separate claim-bearing evidence requirement
- expose both features under the grouped `prob4d prediction` CLI
- add focused tests, documentation, valid example inputs, changelog fragments, and fail-closed CI checks

## Scientific boundary

This PR adds source-only experiment freezing and interoperability infrastructure. It does not execute CUT3R, open a target cohort, establish real-provider competence, show BayesianPhysTwin or Causal4D benefit, change estimator semantics, or establish state of the art.

## Validation

The draft PR is intended to run the repository's authoritative Ruff, mypy, documentation-surface, full test, portability, security, provider, and ecosystem checks. The new CI step also builds and verifies the checked-in semantic-compatibility manifest and CUT3R comparison example.

## Follow-up outside this source PR

Repository branch protection and release publication remain tracked in issue #243 because they require repository settings and signed release actions rather than source changes.