### PR TITLE
Share sequential gauge estimator control flow

### DIFF
--- a/CHANGELOG.d/share-sequential-gauge-control-flow.md
+++ b/CHANGELOG.d/share-sequential-gauge-control-flow.md
@@ -1,0 +1,4 @@
+Share the sequential gauge graph traversal and covariance-intersection control
+flow between the historical finite-difference estimator and the experimental
+analytic estimator. The propagation policies, public class names, defaults, and
+frozen estimator semantics remain unchanged.

--- a/docs/analytic-gauge-propagation.md
+++ b/docs/analytic-gauge-propagation.md
@@ -44,8 +44,11 @@ from prob4d.gauge_analytic import (
 ```
 
 `AnalyticSequentialGaugeEstimatorV2` preserves the historical transform
-initialization and covariance-intersection policy. Only covariance derivatives
-for composition and inversion change. The class records
+initialization and covariance-intersection policy. Both sequential estimators
+use one internal graph-traversal and covariance-intersection core; only initial
+covariance preparation plus composition and inversion propagation are injected
+as policies. This removes duplicated control flow without changing class names,
+defaults, or frozen estimator semantics. The class records
 `jacobian_method = "analytic_sim3_compose_inverse_v1"` for experiment manifests.
 It is deliberately not exported from the stable `prob4d.api.v2` facade.
 

--- a/src/prob4d/gauge.py
+++ b/src/prob4d/gauge.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
 
 import numpy as np
@@ -359,6 +360,85 @@ def _whitener(covariance: FloatArray, floor: float = 1e-10) -> FloatArray:
     return (eigenvectors * (1.0 / np.sqrt(eigenvalues))) @ eigenvectors.T
 
 
+_ComposeWithCovariance = Callable[
+    [Sim3, FloatArray, Sim3, FloatArray],
+    tuple[Sim3, FloatArray],
+]
+_InvertWithCovariance = Callable[[Sim3, FloatArray], tuple[Sim3, FloatArray]]
+_InitialCovariancePreparer = Callable[[FloatArray], FloatArray]
+
+
+def _estimate_sequential_gauges(
+    ordered_window_ids: list[str],
+    constraints: list[RelativeGaugeConstraint],
+    *,
+    covariance_intersection_grid_size: int,
+    compose_with_covariance: _ComposeWithCovariance,
+    invert_with_covariance: _InvertWithCovariance,
+    initial_transform: Sim3 | None = None,
+    initial_covariance: FloatArray | None = None,
+    prepare_initial_covariance: _InitialCovariancePreparer | None = None,
+) -> dict[str, GaugeEstimate]:
+    """Estimate a gauge tree with an injected covariance-propagation policy."""
+
+    if not ordered_window_ids:
+        raise ValueError("ordered_window_ids must not be empty")
+    if len(set(ordered_window_ids)) != len(ordered_window_ids):
+        raise ValueError("window IDs must be unique")
+    first_id = ordered_window_ids[0]
+    first_transform = initial_transform or Sim3.identity()
+    if initial_covariance is None:
+        first_covariance = np.diag([1e-10] * 7)
+    elif prepare_initial_covariance is None:
+        first_covariance = np.asarray(initial_covariance, dtype=np.float64)
+    else:
+        first_covariance = prepare_initial_covariance(initial_covariance)
+    estimates = {first_id: GaugeEstimate(first_id, first_transform, first_covariance)}
+
+    for window_id in ordered_window_ids[1:]:
+        candidates: list[tuple[Sim3, FloatArray]] = []
+        for constraint in constraints:
+            if constraint.moving_id == window_id and constraint.reference_id in estimates:
+                reference = estimates[constraint.reference_id]
+                candidates.append(
+                    compose_with_covariance(
+                        reference.global_from_local,
+                        reference.covariance,
+                        constraint.reference_from_moving,
+                        constraint.covariance,
+                    )
+                )
+            elif constraint.reference_id == window_id and constraint.moving_id in estimates:
+                moving = estimates[constraint.moving_id]
+                inverse, inverse_covariance = invert_with_covariance(
+                    constraint.reference_from_moving,
+                    constraint.covariance,
+                )
+                candidates.append(
+                    compose_with_covariance(
+                        moving.global_from_local,
+                        moving.covariance,
+                        inverse,
+                        inverse_covariance,
+                    )
+                )
+        if not candidates:
+            raise ValueError(f"window {window_id!r} has no constraint to an initialized gauge")
+
+        minimum_weight = min(0.05, 0.5 / len(candidates))
+        transform, covariance, _ = fuse_sim3_covariance_intersection(
+            candidates,
+            minimum_weight=minimum_weight,
+            max_sweeps=max(16, covariance_intersection_grid_size),
+            line_search_iterations=max(
+                32,
+                2 * covariance_intersection_grid_size,
+            ),
+        )
+        estimates[window_id] = GaugeEstimate(window_id, transform, covariance)
+    return estimates
+
+
 class SequentialGaugeEstimator:
     """Initialize gauges with deterministic multi-estimate covariance intersection."""
 
@@ -375,60 +455,15 @@ class SequentialGaugeEstimator:
         initial_transform: Sim3 | None = None,
         initial_covariance: FloatArray | None = None,
     ) -> dict[str, GaugeEstimate]:
-        if not ordered_window_ids:
-            raise ValueError("ordered_window_ids must not be empty")
-        if len(set(ordered_window_ids)) != len(ordered_window_ids):
-            raise ValueError("window IDs must be unique")
-        first_id = ordered_window_ids[0]
-        first_transform = initial_transform or Sim3.identity()
-        first_covariance = (
-            np.diag([1e-10] * 7)
-            if initial_covariance is None
-            else np.asarray(initial_covariance, dtype=np.float64)
+        return _estimate_sequential_gauges(
+            ordered_window_ids,
+            constraints,
+            covariance_intersection_grid_size=self.covariance_intersection_grid_size,
+            compose_with_covariance=_compose_with_covariance,
+            invert_with_covariance=_inverse_with_covariance,
+            initial_transform=initial_transform,
+            initial_covariance=initial_covariance,
         )
-        estimates = {first_id: GaugeEstimate(first_id, first_transform, first_covariance)}
-
-        for window_id in ordered_window_ids[1:]:
-            candidates: list[tuple[Sim3, FloatArray]] = []
-            for constraint in constraints:
-                if constraint.moving_id == window_id and constraint.reference_id in estimates:
-                    reference = estimates[constraint.reference_id]
-                    candidates.append(
-                        _compose_with_covariance(
-                            reference.global_from_local,
-                            reference.covariance,
-                            constraint.reference_from_moving,
-                            constraint.covariance,
-                        )
-                    )
-                elif constraint.reference_id == window_id and constraint.moving_id in estimates:
-                    moving = estimates[constraint.moving_id]
-                    inverse, inverse_covariance = _inverse_with_covariance(
-                        constraint.reference_from_moving, constraint.covariance
-                    )
-                    candidates.append(
-                        _compose_with_covariance(
-                            moving.global_from_local,
-                            moving.covariance,
-                            inverse,
-                            inverse_covariance,
-                        )
-                    )
-            if not candidates:
-                raise ValueError(f"window {window_id!r} has no constraint to an initialized gauge")
-
-            minimum_weight = min(0.05, 0.5 / len(candidates))
-            transform, covariance, _ = fuse_sim3_covariance_intersection(
-                candidates,
-                minimum_weight=minimum_weight,
-                max_sweeps=max(16, self.covariance_intersection_grid_size),
-                line_search_iterations=max(
-                    32,
-                    2 * self.covariance_intersection_grid_size,
-                ),
-            )
-            estimates[window_id] = GaugeEstimate(window_id, transform, covariance)
-        return estimates
 
 
 def relative_constraint_residual(

--- a/src/prob4d/gauge_analytic.py
+++ b/src/prob4d/gauge_analytic.py
@@ -13,10 +13,13 @@ from numbers import Real
 import numpy as np
 from numpy.typing import NDArray
 
-from ._gauge_ci import fuse_sim3_covariance_intersection
 from .composition_jacobian import analytic_sim3_compose_jacobians
 from .covariance import validated_covariance_psd
-from .gauge import GaugeEstimate, RelativeGaugeConstraint
+from .gauge import (
+    GaugeEstimate,
+    RelativeGaugeConstraint,
+    _estimate_sequential_gauges,
+)
 from .sim3 import Sim3, skew, so3_log, so3_right_jacobian
 
 FloatArray = NDArray[np.floating]
@@ -173,69 +176,48 @@ class AnalyticSequentialGaugeEstimatorV2:
         initial_transform: Sim3 | None = None,
         initial_covariance: FloatArray | None = None,
     ) -> dict[str, GaugeEstimate]:
-        if not ordered_window_ids:
-            raise ValueError("ordered_window_ids must not be empty")
-        if len(set(ordered_window_ids)) != len(ordered_window_ids):
-            raise ValueError("window IDs must be unique")
-        first_id = ordered_window_ids[0]
-        first_transform = initial_transform or Sim3.identity()
-        first_covariance = (
-            np.diag([1e-10] * 7)
-            if initial_covariance is None
-            else validated_covariance_psd(
-                initial_covariance,
+        def prepare_initial_covariance(covariance: FloatArray) -> FloatArray:
+            return validated_covariance_psd(
+                covariance,
                 name="initial gauge covariance",
                 shape=(7, 7),
                 readonly=False,
             )
-        )
-        estimates = {first_id: GaugeEstimate(first_id, first_transform, first_covariance)}
 
-        for window_id in ordered_window_ids[1:]:
-            candidates: list[tuple[Sim3, FloatArray]] = []
-            for constraint in constraints:
-                if constraint.moving_id == window_id and constraint.reference_id in estimates:
-                    reference = estimates[constraint.reference_id]
-                    candidates.append(
-                        compose_sim3_with_covariance_analytic(
-                            reference.global_from_local,
-                            reference.covariance,
-                            constraint.reference_from_moving,
-                            constraint.covariance,
-                            branch_cut_tolerance=self.branch_cut_tolerance,
-                        )
-                    )
-                elif constraint.reference_id == window_id and constraint.moving_id in estimates:
-                    moving = estimates[constraint.moving_id]
-                    inverse, inverse_covariance = invert_sim3_with_covariance_analytic(
-                        constraint.reference_from_moving,
-                        constraint.covariance,
-                        branch_cut_tolerance=self.branch_cut_tolerance,
-                    )
-                    candidates.append(
-                        compose_sim3_with_covariance_analytic(
-                            moving.global_from_local,
-                            moving.covariance,
-                            inverse,
-                            inverse_covariance,
-                            branch_cut_tolerance=self.branch_cut_tolerance,
-                        )
-                    )
-            if not candidates:
-                raise ValueError(f"window {window_id!r} has no constraint to an initialized gauge")
-
-            minimum_weight = min(0.05, 0.5 / len(candidates))
-            transform, covariance, _ = fuse_sim3_covariance_intersection(
-                candidates,
-                minimum_weight=minimum_weight,
-                max_sweeps=max(16, self.covariance_intersection_grid_size),
-                line_search_iterations=max(
-                    32,
-                    2 * self.covariance_intersection_grid_size,
-                ),
+        def compose_with_covariance(
+            first: Sim3,
+            first_covariance: FloatArray,
+            second: Sim3,
+            second_covariance: FloatArray,
+        ) -> tuple[Sim3, FloatArray]:
+            return compose_sim3_with_covariance_analytic(
+                first,
+                first_covariance,
+                second,
+                second_covariance,
+                branch_cut_tolerance=self.branch_cut_tolerance,
             )
-            estimates[window_id] = GaugeEstimate(window_id, transform, covariance)
-        return estimates
+
+        def invert_with_covariance(
+            transform: Sim3,
+            covariance: FloatArray,
+        ) -> tuple[Sim3, FloatArray]:
+            return invert_sim3_with_covariance_analytic(
+                transform,
+                covariance,
+                branch_cut_tolerance=self.branch_cut_tolerance,
+            )
+
+        return _estimate_sequential_gauges(
+            ordered_window_ids,
+            constraints,
+            covariance_intersection_grid_size=self.covariance_intersection_grid_size,
+            compose_with_covariance=compose_with_covariance,
+            invert_with_covariance=invert_with_covariance,
+            initial_transform=initial_transform,
+            initial_covariance=initial_covariance,
+            prepare_initial_covariance=prepare_initial_covariance,
+        )
 
 
 __all__ = [

--- a/tests/test_sequential_gauge_control_flow.py
+++ b/tests/test_sequential_gauge_control_flow.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import numpy as np
+
+from prob4d.gauge import RelativeGaugeConstraint, SequentialGaugeEstimator
+from prob4d.gauge_analytic import AnalyticSequentialGaugeEstimatorV2
+from prob4d.sim3 import Sim3
+
+
+def _relative_constraint(
+    reference_id: str,
+    moving_id: str,
+    reference: Sim3,
+    moving: Sim3,
+    covariance_scale: float,
+) -> RelativeGaugeConstraint:
+    return RelativeGaugeConstraint(
+        reference_id=reference_id,
+        moving_id=moving_id,
+        reference_from_moving=reference.inverse().compose(moving),
+        covariance=np.diag(np.linspace(1e-5, 7e-5, 7) * covariance_scale),
+    )
+
+
+def test_sequential_estimators_share_multi_parent_and_reverse_edge_control_flow() -> None:
+    gauges = {
+        "w0": Sim3.identity(),
+        "w1": Sim3.from_vector(
+            np.array([0.05, 0.12, -0.04, 0.03, 0.3, -0.1, 0.2])
+        ),
+        "w2": Sim3.from_vector(
+            np.array([-0.03, -0.07, 0.09, 0.02, -0.2, 0.4, 0.1])
+        ),
+        "w3": Sim3.from_vector(
+            np.array([0.02, 0.04, 0.03, -0.08, 0.1, 0.2, -0.3])
+        ),
+    }
+    constraints = [
+        _relative_constraint("w0", "w1", gauges["w0"], gauges["w1"], 1.0),
+        _relative_constraint("w1", "w2", gauges["w1"], gauges["w2"], 2.0),
+        _relative_constraint("w2", "w0", gauges["w2"], gauges["w0"], 3.0),
+        _relative_constraint("w2", "w3", gauges["w2"], gauges["w3"], 4.0),
+        _relative_constraint("w3", "w1", gauges["w3"], gauges["w1"], 5.0),
+    ]
+    initial_covariance = np.diag(np.linspace(1e-6, 7e-6, 7))
+    ordered_ids = list(gauges)
+
+    legacy = SequentialGaugeEstimator(covariance_intersection_grid_size=23).estimate(
+        ordered_ids,
+        constraints,
+        initial_covariance=initial_covariance,
+    )
+    analytic = AnalyticSequentialGaugeEstimatorV2(
+        covariance_intersection_grid_size=23
+    ).estimate(
+        ordered_ids,
+        constraints,
+        initial_covariance=initial_covariance,
+    )
+
+    for window_id, expected in gauges.items():
+        np.testing.assert_allclose(
+            legacy[window_id].global_from_local.as_vector(),
+            expected.as_vector(),
+            atol=1e-12,
+        )
+        np.testing.assert_allclose(
+            analytic[window_id].global_from_local.as_vector(),
+            legacy[window_id].global_from_local.as_vector(),
+            atol=1e-12,
+        )
+        np.testing.assert_allclose(
+            analytic[window_id].covariance,
+            legacy[window_id].covariance,
+            rtol=5e-5,
+            atol=2e-9,
+        )


### PR DESCRIPTION
## Summary

- centralize sequential gauge graph traversal, candidate construction, reverse-edge handling, and deterministic covariance-intersection settings in one private helper
- keep the historical finite-difference and experimental analytic `Sim(3)` propagation paths as injected policies
- preserve public classes, defaults, branch-cut behavior, initial-covariance handling, and estimator outputs
- add a multi-parent/reverse-edge regression test plus documentation and changelog coverage

## Scope and scientific boundary

This is an internal maintainability refactor. It does not change the default estimator, artifact schemas or identities, provider admission, calibration, CUT3R protocol, BayesianPhysTwin/Causal4D semantics, or any scientific claim.

## Validation

- exact pre/post parity across 12 randomized multi-parent and reverse-edge cases for both legacy and analytic estimators
- focused analytic and new regression tests: **16 passed**
- `compileall` and changed-file line-length checks passed

GitHub Actions on the exact pull-request head remain authoritative for the complete Python matrix, Ruff, mypy, packaging, security, provider, and ecosystem checks.