### PR TITLE
[Superseded by #271] Document scientific kernel and CUT3R source qualification

### DIFF
--- a/CHANGELOG.d/scientific-kernel-cut3r-priority.md
+++ b/CHANGELOG.d/scientific-kernel-cut3r-priority.md
@@ -1,0 +1,5 @@
+- Added a concise scientific-kernel guide and a runnable CUT3R source-qualification
+  runbook for the real-provider gate tracked in issue #49.
+- Documented an evidence-first development rule: new provider, gauge, association,
+  covariance, or calibration work must cite a source-localized failure rather than
+  green CI, adapter maturity, synthetic evidence, or target-side outcomes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,32 @@ identity, or evidence admission require focused adversarial tests and correspond
 changelog documentation. Exact fallback and causal-prefix invariants must remain
 fail-closed.
 
+## Evidence-first scientific changes
+
+Before adding another provider, association mechanism, gauge estimator, covariance
+model, or calibration layer, identify the exact upstream gate that failed and link the
+immutable source or calibration evidence. The accepted progression is summarized in
+[`docs/scientific-kernel.md`](docs/scientific-kernel.md).
+
+The following are implementation or mechanism evidence, not authorization for another
+claim-bearing method:
+
+- green CI or installed-wheel compatibility;
+- a mature adapter or complete artifact schema;
+- controlled synthetic success;
+- an already-open target-side outcome; and
+- a downstream result that would rescue a failed upstream gate.
+
+A provider version that is negative at support, source means, identity/reliability,
+gauge/dependence, linearization closure, calibration, or query relevance must stop or be
+replaced by a separately frozen source protocol. Only a
+`point-covariance-localized` source decision authorizes richer point uncertainty.
+
+The current real-provider execution is the frozen CUT3R source qualification in
+[`docs/cut3r-source-qualification.md`](docs/cut3r-source-qualification.md), tied to
+issue #49. Claim-bearing method PRs in that path should either execute the frozen
+protocol or cite the retained failure that specifically authorizes their change.
+
 ## Privileged validation
 
 Ordinary pull-request workflows must remain on ephemeral GitHub-hosted runners. Do not

--- a/docs/cut3r-source-qualification.md
+++ b/docs/cut3r-source-qualification.md
@@ -1,0 +1,301 @@
+# CUT3R source qualification runbook
+
+This runbook executes the already-frozen source-only comparison for the
+recurrent-online CUT3R provider and prepares the real-provider decision tracked
+in [issue #49](https://github.com/IPS-Stuttgart/Prob4D/issues/49). It stops before
+opening any held-out target outcome.
+
+The decisive source contrast is:
+
+```text
+restarted-prob4d-fused versus restarted-newest.
+```
+
+Both arms must use the exact same restarted causal window outputs. Their
+difference therefore isolates Prob4D fusion from CUT3R's internal recurrent
+memory. The contextual contrast
+
+```text
+native-continuous versus restarted-newest
+```
+
+measures the value of CUT3R's persistent recurrent state. A revisit arm is a
+noncausal diagnostic and can never become claim-bearing evidence.
+
+## 1. Freeze before any residual or outcome is opened
+
+Create one immutable source design containing:
+
+- exact CUT3R repository revision and checkpoint SHA-256;
+- exact Prob4D revision and installed-distribution SHA-256;
+- complete physical-object or acquisition-session groups;
+- disjoint development, calibration, and source-evaluation roles;
+- every required stream and camera for every group;
+- input-video SHA-256 and byte count for every case;
+- source and evaluation frame intervals;
+- window size, overlap, confidence threshold, storage dtype, and seeds;
+- technical-failure and unsupported-case policy; and
+- whether the noncausal revisit diagnostic is disabled.
+
+Frames, points, tracks, views, and cameras are nested observations. They must not
+be entered as independent groups.
+
+Start from the checked-in example:
+
+```bash
+OUT=outputs/cut3r-source-qualification-v1
+mkdir -p "$OUT"
+cp docs/examples/cut3r-comparison-spec.json "$OUT/comparison-spec.json"
+"${EDITOR:-vi}" "$OUT/comparison-spec.json"
+
+prob4d prediction cut3r-comparison build \
+  "$OUT/comparison-spec.json" \
+  --output "$OUT/comparison-lock.json"
+
+prob4d prediction cut3r-comparison verify \
+  "$OUT/comparison-lock.json"
+
+prob4d prediction cut3r-comparison summarize \
+  "$OUT/comparison-lock.json" \
+  --json > "$OUT/comparison-lock-summary.json"
+```
+
+Do not build the lock with placeholder revisions, digests, group names, or byte
+counts. Rebuilding a different lock after source outcomes are visible is a new
+protocol, not a repair.
+
+## 2. Produce the frozen CUT3R arms
+
+CUT3R inference remains external to Prob4D. Retain the exact command line,
+environment, model bytes, input bytes, and output members for every run.
+
+For each case:
+
+1. run one uninterrupted recurrent-online pass for `native-continuous`;
+2. run fresh recurrent state for every frozen overlapping causal window;
+3. retain the newest eligible prediction from those restarted windows for
+   `restarted-newest`;
+4. fuse those same restarted window bytes through Prob4D for
+   `restarted-prob4d-fused`; and
+5. run revisiting only when the lock enables it, label it noncausal, and exclude
+   it from every promotion decision.
+
+Import each admissible recurrent-online CUT3R output with its exact identities:
+
+```bash
+prob4d prediction import-cut3r-online \
+  "$CUT3R_OUTPUT_ROOT" \
+  "$PROVIDER_MANIFEST" \
+  --sequence-id "$CASE_ID" \
+  --cut3r-revision "$CUT3R_REVISION" \
+  --checkpoint-sha256 "$CHECKPOINT_SHA256" \
+  --input-video-sha256 "$INPUT_VIDEO_SHA256" \
+  --input-video-byte-count "$INPUT_VIDEO_BYTE_COUNT" \
+  --frame-start "$FRAME_START" \
+  --confidence-threshold "$CONFIDENCE_THRESHOLD"
+```
+
+The importer must report recurrent online execution, prefix-only dependence,
+`revisit_count=1`, and no global alignment. The canonical coordinate declaration
+remains `sequence-local-sim3` until an independent metric anchor is admitted.
+
+The `restarted-newest` and `restarted-prob4d-fused` arms must reference identical
+provider-window identities and payload digests. A second provider rerun for only
+one arm invalidates the isolating contrast.
+
+## 3. Complete-stream support gate before residuals
+
+Freeze a `ProviderSupportFeasibilityRequestV1` for the exact provider, object or
+session roster, streams, causal spans, camera geometry, robot geometry, metric
+anchor, and physical-query mapping. Derive and verify the contiguous support
+envelope without opening prediction residuals:
+
+```bash
+prob4d diagnostic provider-support-envelope derive \
+  --request "$OUT/support-request.json" \
+  --output "$OUT/support-envelope.json"
+
+prob4d diagnostic provider-support-envelope verify \
+  --artifact "$OUT/support-envelope.json"
+```
+
+Stop immediately when any required stream is support-negative under the frozen
+complete-stream rule. Retain that negative result. Do not delete cameras, shorten
+the prefix, substitute partial streams, fit only supported rows, or inspect
+downstream outcomes under the same provider identity.
+
+A technical failure follows only the predeclared technical-failure policy. It
+must not be relabelled as a scientific support negative, and a support negative
+must not be relabelled as a software failure.
+
+## 4. Evaluate source means and identities
+
+Only a support-positive provider version may open the registered source residuals.
+
+Build one provider-evaluation manifest with:
+
+- `reference_method` equal to `restarted-newest`;
+- the same method set in every case;
+- `group_id` equal to the complete object or acquisition session;
+- common-support primary evaluation;
+- native-support retention as a secondary diagnostic; and
+- one frozen primary alignment mode.
+
+Run:
+
+```bash
+prob4d evaluate provider \
+  "$OUT/provider-evaluation-manifest.json" \
+  --output-dir "$OUT/provider-evaluation" \
+  --bootstrap-resamples 2000 \
+  --evaluation-chunk-size 65536 \
+  --seed 7
+```
+
+The primary source comparison is the equal-group paired difference between
+`restarted-prob4d-fused` and `restarted-newest`. Report at least:
+
+- support and technical-failure accounting;
+- point and endpoint error;
+- seam and drift error;
+- identity retention and association precision;
+- common/native support retention;
+- 50%, 90%, and 95% coverage;
+- Gaussian proper score and normalized NEES;
+- covariance width and worst-group coverage shortfall; and
+- selective risk.
+
+Construct and retain `SourceProviderCompetenceReportV1` from the exact evaluation
+groups and a source-frozen policy. Mean quality and identity/reliability are
+separate decisions. A failed mean gate is terminal for that provider version even
+when its covariance looks conservative.
+
+## 5. Localize gauge, dependence, and covariance only after useful means
+
+When source means and identities pass, create matched source residuals with the
+strict joint-covariance schema and evaluate:
+
+```bash
+prob4d diagnostic joint-covariance \
+  "$OUT/matched-source-residuals.npz" \
+  --output "$OUT/joint-covariance.json"
+
+python -m prob4d.joint_covariance_ablation \
+  "$OUT/matched-source-residuals.npz" \
+  --output "$OUT/joint-covariance-ablation.json" \
+  --bootstrap-replicates 2000 \
+  --bootstrap-seed 7 \
+  --confidence-level 0.95
+```
+
+Run the joint `Sim(3)` linearization-closure diagnostic before assigning any
+remaining failure to conditional point covariance:
+
+```bash
+python -m prob4d.gauge_linearization_closure --help
+```
+
+Then bind source competence and joint diagnostics through the frozen localization
+policy:
+
+```bash
+prob4d diagnostic source-covariance-localization evaluate \
+  --source-competence "$OUT/source-provider-competence.json" \
+  --joint-diagnostic "$OUT/joint-covariance.json" \
+  --policy "$OUT/covariance-localization-policy.json" \
+  --output "$OUT/covariance-localization.json"
+
+prob4d diagnostic source-covariance-localization verify \
+  --artifact "$OUT/covariance-localization.json"
+```
+
+Interpret the terminal result as follows:
+
+| Result | Required action |
+| --- | --- |
+| source-mean negative | Stop; do not change covariance |
+| identity/reliability negative | Stop; repair identities under a new source protocol |
+| gauge-or-dependence negative | Redirect gauge/dependence modelling |
+| linearization-closure negative | Redirect propagation or query linearization |
+| point-covariance-localized | Point-uncertainty development is authorized on source data only |
+| covariance-adequate | Continue to physical-query relevance |
+
+A joint-NEES failure that is not localized to the conditional subspace is not
+authorization for a richer point model.
+
+## 6. Query relevance and complete readiness
+
+BayesianPhysTwin owns the physical query and its target-blind Jacobian. Bind the
+exact query projection, row order, source observation, provider manifest,
+conditional covariance, and shared factor before evaluating relevance.
+
+Compose all target-free gates:
+
+```bash
+prob4d experiment fresh-provider-readiness evaluate \
+  --request "$OUT/readiness-request.json" \
+  --output "$OUT/readiness-decision.json"
+```
+
+Only the exact classification
+
+```text
+ready-for-one-target-evaluation
+```
+
+permits one evaluation of the bound unopened target roster. Before that one-shot
+execution, run the target-free observation rehearsal and independently verify the
+positive and adversarial controls:
+
+```bash
+prob4d diagnostic target-free-rehearsal --help
+```
+
+This runbook does not execute the target evaluation.
+
+## 7. Frozen target design after a positive source decision
+
+The later issue-#49 target run must score these arms on the same complete target
+objects or sessions:
+
+1. unchanged physical fallback;
+2. one simple direct visual or `last_residual` comparator;
+3. one source-selected Prob4D candidate with complete joint gauge uncertainty;
+4. exact physical fallback for every unsupported, invalid, rejected, or
+   unidentifiable candidate.
+
+Provider competence and downstream BayesianPhysTwin value remain separate
+conjunctive endpoints. A downstream improvement cannot rescue failed support,
+means, identities, or calibration. Causal4D may consume only the selected
+BayesianPhysTwin belief under a separately registered downstream query.
+
+## 8. Retained evidence
+
+Retain at minimum:
+
+- comparison spec and content-addressed lock;
+- exact provider, model, environment, and distribution identities;
+- every input and generated source-member digest;
+- imported provider manifests and execution attestations;
+- support request, feasibility result, and support envelope;
+- provider-evaluation manifest and complete report;
+- source-competence report and policy;
+- joint covariance and dependence-ablation reports;
+- linearization-closure artifact;
+- covariance-localization decision;
+- query-projection binding and relevance result;
+- complete readiness request and terminal decision; and
+- an explicit statement that zero target outcomes were opened.
+
+A valid negative at any gate is a complete result for that provider version.
+Do not retune it on the same opened source or target cohort.
+
+Related documentation:
+
+- [CUT3R recurrent-online adapter](cut3r-online-provider.md)
+- [Frozen native-versus-Prob4D comparison](cut3r-comparison.md)
+- [Provider evaluation](provider-evaluation.md)
+- [Source-only provider competence](source-provider-competence.md)
+- [Joint covariance diagnostics](joint-covariance-diagnostics.md)
+- [Provider readiness localization](provider-readiness-localization.md)
+- [Scientific kernel](scientific-kernel.md)

--- a/docs/provider-evidence-status.md
+++ b/docs/provider-evidence-status.md
@@ -6,11 +6,17 @@ Exact revisions, cohort rosters, target-access decisions, and generated results
 remain bound inside their owning immutable artifacts rather than this mutable
 summary.
 
+For the compact method and ownership model, see the
+[Prob4D scientific kernel](scientific-kernel.md). The current executable
+real-provider priority is the
+[CUT3R source qualification](cut3r-source-qualification.md) under
+[issue #49](https://github.com/IPS-Stuttgart/Prob4D/issues/49).
+
 | Boundary | Current public status | Required next action |
 | --- | --- | --- |
 | Correlation-aware gauge mechanism | Implemented and supported by controlled mechanism studies | Retain the production causal gauge tree unless a source-localized failure identifies a concrete defect |
 | Real MotionCrafter feeder | Not promoted | Do not retune on the already-open diagnostic cohort; a materially new provider or protocol requires a fresh source design |
-| CUT3R recurrent-online feeder | Byte-level adapter, causal lineage, and bounded import are implemented | Execute support, source-mean, identity, gauge/dependence, and query-value qualification on complete source objects/sessions |
+| CUT3R recurrent-online feeder | Byte-level adapter, causal lineage, bounded import, and a frozen isolating comparison are implemented | Execute the [source qualification runbook](cut3r-source-qualification.md) on complete source objects or sessions |
 | Cross-window material identity | Append-only hypotheses and uncertainty marginalization are implemented | Freeze and run a source/calibration-separated newest-window versus hard-link versus marginalized-identity study |
 | Joint `Sim(3)` linearization | Analytic first-order propagation is implemented | Run the [linearization-closure diagnostic](gauge-linearization-closure.md) before assigning remaining failure to point covariance |
 | Richer point covariance | Not automatically authorized | Require the existing source-localization decision `point-covariance-localized` after support, means, identities, gauge/dependence, and closure are adequate |
@@ -38,8 +44,19 @@ A failure at one boundary redirects or stops that provider version. Downstream
 performance must not rescue an upstream negative, and a valid negative result
 must not be retuned on the same opened target cohort.
 
+## Evidence-first development rule
+
+Claim-bearing provider, association, gauge, covariance, and calibration changes
+must identify the exact source or calibration gate that failed. Green CI,
+adapter maturity, controlled synthetic evidence, or a target-side outcome is not
+authorization for another method layer. Until the CUT3R source execution
+localizes a failure, the priority is execution and retained evidence rather than
+additional provider or covariance variants.
+
 ## Related entry points
 
+- [Prob4D scientific kernel](scientific-kernel.md)
+- [CUT3R source qualification](cut3r-source-qualification.md)
 - [CUT3R recurrent-online provider](cut3r-online-provider.md)
 - [Provider readiness localization](provider-readiness-localization.md)
 - [Held-out provider promotion](heldout-provider-promotion.md)

--- a/docs/scientific-kernel.md
+++ b/docs/scientific-kernel.md
@@ -1,0 +1,206 @@
+# Prob4D scientific kernel
+
+This page is the shortest claim-safe description of Prob4D's statistical model,
+recursive uncertainty propagation, and ownership boundary. Detailed schemas,
+commands, and experiment protocols remain in the linked documents.
+
+## 1. Causal overlapping-window observation model
+
+Let \(w=1,\ldots,K\) index independently decoded causal prediction windows. A
+local point \(p_{wi}\in\mathbb{R}^3\) has conditional covariance
+\(R^{\mathrm{local}}_{wi}\). Window \(w\) has an uncertain global
+\(Sim(3)\) gauge \(g_w\in\mathbb{R}^7\). Around the estimated gauge
+\(\bar g_w\),
+
+```text
+y_wi = Sim3(g_w) p_wi + epsilon_wi
+
+delta y_wi
+  approximately A_wi delta p_wi + J_wi delta g_w,
+```
+
+where \(A_{wi}\) maps local point perturbations into the world frame and
+\(J_{wi}\) is the point-to-gauge Jacobian.
+
+After stacking all admitted rows,
+
+```text
+Sigma_y = R_cond + J_g Sigma_g J_g^T.
+```
+
+Here:
+
+- `R_cond` is the block-diagonal conditional world-point covariance;
+- `Sigma_g` is the ordered joint covariance of all retained gauges; and
+- `J_g` is sparse because each observation row depends on its own window gauge.
+
+The off-diagonal blocks of `Sigma_g` matter. A shared metric anchor and recursive
+relative-gauge propagation induce covariance between observations from different
+windows. Replacing `Sigma_g` by independent marginal blocks preserves individual
+row variances but destroys that cross-row dependence.
+
+Prob4D can export the shared term through a low-rank factor `U` satisfying
+
+```text
+U U^T approximately J_g Sigma_g J_g^T.
+```
+
+Rank reduction is accepted only under the declared retained-covariance criterion;
+otherwise the full factor or exact fallback is retained.
+
+## 2. Recursive gauge estimation
+
+The production gauge path starts from an independently fitted metric anchor and
+propagates relative `Sim(3)` alignments in causal source order. The default
+sequential tree avoids treating redundant edges as independent measurements.
+Composition Jacobians propagate both marginal and cross-window covariance, so a
+new window remains correlated with all ancestors that share anchor or transition
+uncertainty.
+
+When contributor cross-correlation is unknown, covariance intersection provides
+a conservative fusion rule. It can protect consistency but does not guarantee a
+better realized mean. Additional graph edges, normalized cycle guards, and
+analytic propagation remain admissible only under their registered source-side
+guards and closure tests.
+
+First-order propagation is not assumed valid merely because the algebra is
+implemented. The joint `Sim(3)` linearization-closure diagnostic compares the
+analytic result with a deterministic nonlinear reference before a remaining
+failure can be assigned to conditional point covariance.
+
+## 3. Two valid downstream covariance representations
+
+A consumer must choose exactly one of the following representations.
+
+### Explicit gauge nuisance variables
+
+Use:
+
+```text
+conditional point covariance
++ point-to-gauge Jacobian
++ full joint gauge prior covariance.
+```
+
+This is the richer `ObservationFactorBundle` path. It lets BayesianPhysTwin keep
+gauge errors as explicit nuisance variables.
+
+### Marginalized portable observation
+
+Use:
+
+```text
+conditional point covariance
++ shared low-rank gauge factor.
+```
+
+This is the portable `ObservationBeliefV1` path.
+
+Do not combine marginal point covariance with explicit gauge variables, and do
+not add the shared factor twice. Either mistake double-counts the same gauge
+uncertainty.
+
+For repeated Gaussian scoring or inference, Prob4D supplies structured covariance
+actions, inverse actions, precision quadratics, log determinants, and negative log
+likelihoods without materializing the dense `3N x 3N` covariance.
+
+## 4. Reliability and dependence are separate quantities
+
+The observation contracts deliberately keep these values distinct:
+
+- `association_probability`: support for the named point or material identity;
+- `prior_reliability`: source-only evidence that the row is nominal;
+- `prior_nominal_probability`: the nominal-component prior for a dependence
+  group; and
+- `composite_weight`: the amount of independent likelihood mass assigned to that
+  dependent group.
+
+A downstream physical innovation may influence BayesianPhysTwin's likelihood or
+guard, but it must not be fed back into Prob4D's prior reliability. Rows, pixels,
+frames, tracks, and views from one object or acquisition session remain nested
+observations, not independent calibration replicates.
+
+## 5. Causal and repository ownership boundary
+
+Every claim-bearing row satisfies the exclusive cutoff
+
+```text
+source_frame < causal_frame_stop.
+```
+
+Appending future windows must not change an already valid prefix artifact.
+
+The one-way ownership chain is:
+
+```text
+4-D provider
+    -> Prob4D uncertain observation
+    -> BayesianPhysTwin candidate belief and exact accept/fallback decision
+    -> Causal4D factual abduction, intervention, and held-out prediction.
+```
+
+Prob4D owns provider-side gauges, covariance, source reliability, causal lineage,
+and portable artifacts. It does not decide whether a physical-state update is
+accepted. BayesianPhysTwin owns physical-query identifiability, the
+baseline-relative guard, and exact complete-belief fallback. Causal4D consumes
+only the selected BayesianPhysTwin belief; raw Prob4D output cannot rescue a
+failed upstream gate.
+
+## 6. Evidence-first progression
+
+A real provider advances only through this order:
+
+```text
+support feasibility
+  -> source mean quality
+  -> identity and reliability
+  -> gauge and dependence
+  -> linearization closure
+  -> conditional point covariance
+  -> physical-query relevance
+  -> one frozen target evaluation.
+```
+
+A failure stops or redirects that exact provider version. In particular:
+
+- bad or drifting means do not authorize a richer covariance model;
+- broken identities do not authorize a richer covariance model;
+- failed gauge/dependence or linearization closure redirects the gauge model;
+- only `point-covariance-localized` authorizes point-uncertainty development; and
+- only `ready-for-one-target-evaluation` authorizes opening the exact bound target
+  roster once.
+
+The current executable real-provider priority is the frozen CUT3R source
+qualification. See [the runbook](cut3r-source-qualification.md) and
+[issue #49](https://github.com/IPS-Stuttgart/Prob4D/issues/49).
+
+## 7. Minimal validated handoff
+
+```python
+from prob4d.api.v2 import load_claim_bearing_observation_belief
+
+observation = load_claim_bearing_observation_belief(
+    "outputs/sequence/observation_belief.npz"
+)
+```
+
+Loading revalidates the closed schema, causal cutoff, covariance structure,
+identities, provenance, and content address. It establishes artifact validity,
+not provider accuracy or physical benefit.
+
+## Claim boundary
+
+Green CI, immutable artifacts, a mature adapter, controlled synthetic success, or
+good marginal coverage is not by itself real-provider competence. Provider
+accuracy, dependence calibration, BayesianPhysTwin physical-query value, and
+Causal4D intervention value are separate conjunctive claims.
+
+Further detail:
+
+- [Architecture and repository boundary](architecture.md)
+- [Unfused observation-factor bundle](observation-factor-bundle.md)
+- [Observation-belief export](observation-belief-export.md)
+- [Structured observation covariance queries](observation-covariance-queries.md)
+- [Joint covariance diagnostics](joint-covariance-diagnostics.md)
+- [Provider readiness localization](provider-readiness-localization.md)
+- [What uncertainty can improve](theoretical-benefit.md)


### PR DESCRIPTION
## Superseded

Closed without merge because #271 landed from the same base with the complete scientific-kernel guide, end-to-end CUT3R qualification runbook, comparison-document linkage, evidence-first policy updates, and changelog coverage. #271 is the authoritative review and implementation history; do not reopen this duplicate.

## Summary

- add a concise, claim-safe scientific kernel for Prob4D's causal overlapping-window model, joint `Sim(3)` gauge covariance, downstream representations, reliability semantics, and Prob4D → BayesianPhysTwin → Causal4D ownership boundary;
- add a runnable source-only CUT3R qualification runbook tied to #49, with the isolating `restarted-prob4d-fused` versus `restarted-newest` contrast, complete-stream support gate, source mean/identity gate, covariance localization, closure, query relevance, and one-shot target stop rule;
- update provider status and contribution guidance with an evidence-first development rule: new provider, association, gauge, covariance, or calibration layers must cite the exact source/calibration failure that authorizes them; and
- add a changelog fragment.

## Why

Prob4D already has extensive provider, uncertainty, calibration, artifact, and readiness infrastructure. The current scientific bottleneck is a decisive real-provider result rather than another method layer. The CUT3R comparison is already frozen to separate Prob4D fusion from CUT3R recurrent-state value; this PR makes that next execution understandable and operational without changing the protocol.

## Scope and scientific boundary

This is documentation and development-policy work only. It changes no estimator equation, provider or observation schema, public API, command registration, workflow, calibration, target-access rule, exact fallback, or retained evidence artifact.

It does not execute CUT3R, open source or target outcomes, promote a provider, establish uncertainty calibration, establish BayesianPhysTwin physical-query benefit, establish Causal4D intervention benefit, authorize deployment, or support a state-of-the-art claim.

## Validation

Exact commit: `cc7f08b122581eb51375f910837df63173b38c76`.

- one commit directly on exact base `5b95a23f8658609393c790bb63d271c12fda3638`;
- five intended files only: two new guides, provider-status and contribution updates, and one changelog fragment;
- every documented grouped command was cross-checked against the current CUT3R, provider-evaluation, joint-covariance, and readiness documentation;
- no generated artifact or external data was read or modified; and
- GitHub Actions remain authoritative for the repository documentation-surface and policy checks.

Relates to #49.