### PR TITLE
Bind CUT3R source competence to exact common support

### DIFF
--- a/CHANGELOG.d/cut3r-common-support-v2.md
+++ b/CHANGELOG.d/cut3r-common-support-v2.md
@@ -1,0 +1,5 @@
+- Add an additive CUT3R source-competence v2 layer that requires exact paired
+  metric-support identities, restricts source-mean proper scoring to an
+  arm-neutral fixed scale, retains both-arm seam/drift/identity/support endpoints,
+  emits readiness-compatible paired decisions, and freezes the complete four-group
+  Deform360 source policy without opening source scores or target data.

--- a/docs/cut3r-source-competence-v2.md
+++ b/docs/cut3r-source-competence-v2.md
@@ -1,0 +1,184 @@
+# CUT3R common-support source competence v2
+
+`prob4d.cut3r_source_competence_v2` is an additive claim-integrity layer for the
+frozen CUT3R source comparison. It preserves the existing comparison lock,
+`SourceProviderCompetencePolicyV1`, stable v1 report, and readiness order while
+adding two requirements:
+
+1. candidate and baseline primary metrics must use exactly the same frozen
+   support; and
+2. seam, drift, association, identity retention, and support retention are
+   retained and evaluated as paired endpoints.
+
+This layer is source-only. It does not execute CUT3R, open a confirmation object,
+authorize a target run, or change the production Prob4D estimator.
+
+## Why exact support identity is required
+
+A scalar error and a retained-count value do not prove that two arms were scored
+on the same material points. Equal-sized but different support sets can make an
+apparently paired contrast unpaired. Version 2 therefore requires one
+`metric_support` object in every frame-level arm record:
+
+```json
+{
+  "point_support_sha256": "<sha256>",
+  "point_support_count": 128,
+  "endpoint_support_sha256": "<sha256>",
+  "endpoint_support_count": 1,
+  "proper_score_support_sha256": "<sha256>",
+  "proper_score_dimension": 384,
+  "proper_score_semantics": "arm-neutral-fixed-scale-gaussian-score-v1",
+  "seam_support_sha256": "<sha256-or-null>",
+  "seam_support_count": 64
+}
+```
+
+For each frozen `(group, case, frame, seed)` tuple, the candidate and baseline
+objects must be byte-identical after canonicalization. This binds the row set,
+row order, dimension, and proper-score convention. A shifted, filtered, or
+arm-specific scoring support fails before aggregation.
+
+The exact canonical row identifiers for the Deform360 execution are frozen in
+`protocols/cut3r_deform360_common_support_definition_v2.json`.
+
+## Arm-neutral source-mean proper score
+
+The source-mean gate asks whether the provider mean is useful. It must not fail
+only because an otherwise useful mean has a poor arm-specific covariance model.
+The v2 lock therefore permits only:
+
+```text
+arm-neutral-fixed-scale-gaussian-score-v1
+```
+
+The scale or covariance is fitted from development/calibration information and
+is byte-identical across both arms. Joint NLL, normalized NEES, coverage, width,
+shared-subspace energy, and conditional-subspace energy remain in the later
+covariance-localization gate.
+
+## Freeze the additive lock
+
+First build the existing v1 source-competence lock with the exact provider
+manifests and the `source_competence_policy` contained in the v2 specification.
+Then freeze the common-support supplement before source-evaluation scores are
+read:
+
+```bash
+python -m prob4d.cut3r_source_competence_v2 freeze \
+  outputs/cut3r/cut3r-comparison-lock.json \
+  outputs/cut3r/source-competence-lock.json \
+  protocols/cut3r_deform360_source_competence_v2_spec.json \
+  --output outputs/cut3r/common-support-lock-v2.json
+
+python -m prob4d.cut3r_source_competence_v2 verify-lock \
+  outputs/cut3r/cut3r-comparison-lock.json \
+  outputs/cut3r/source-competence-lock.json \
+  outputs/cut3r/common-support-lock-v2.json
+```
+
+The supplement binds the existing comparison and v1 lock identities, exact v1
+policy, source groups, seeds, contrast, record-definition digest, common-support
+definition digest, proper-score semantics, and paired decision margins.
+
+For the frozen Deform360 source comparison it additionally requires:
+
+- all four source-evaluation object sessions to be evaluable;
+- zero permitted technical failures;
+- no mean point, endpoint, or fixed-scale proper-score regression;
+- no mean seam or drift regression and at most 20% worst-group regression;
+- mean association, identity, and support loss no worse than 0.02;
+- worst-group loss no worse than 0.05; and
+- at least three of four groups passing each paired endpoint family.
+
+The four independent source-evaluation groups remain:
+
+- `036-napkin-cloth-episode-0009`;
+- `058-roll-napkin-episode-0001`;
+- `152-slime-episode-0008`; and
+- `198-kneepad-cloth-episode-0002`.
+
+Frames, cameras, seeds, points, and support rows remain nested observations.
+
+## Version-2 record envelope
+
+The v2 record artifact retains the complete v1 record values and adds the
+common-support lock and support-definition identities:
+
+```json
+{
+  "schema": "prob4d.cut3r-source-competence-records",
+  "schema_version": 2,
+  "comparison_lock_id": "<sha256>",
+  "source_competence_lock_id": "<sha256>",
+  "common_support_lock_id": "<sha256>",
+  "record_definition_sha256": "<sha256>",
+  "common_support_definition_sha256": "<sha256>",
+  "source_truth_used": true,
+  "target_payloads_opened": false,
+  "target_outcomes_opened": false,
+  "group_failures": [],
+  "records": []
+}
+```
+
+The implementation strips only the v2 support envelope and sends the resulting
+records through the stable v1 builder. The v1 builder remains authoritative for
+complete-roster checks, arm-neutral reference counts, positive denominators,
+hierarchical weighting, and the stable `SourceProviderCompetenceReportV1`.
+
+## Build and verify the report
+
+```bash
+python -m prob4d.cut3r_source_competence_v2 report \
+  outputs/cut3r/cut3r-comparison-lock.json \
+  outputs/cut3r/source-competence-lock.json \
+  outputs/cut3r/common-support-lock-v2.json \
+  outputs/cut3r/source-competence-records-v2.json \
+  --output outputs/cut3r/source-competence-v2.json \
+  --v1-output outputs/cut3r/source-provider-competence-v1.json \
+  --require-pass
+
+python -m prob4d.cut3r_source_competence_v2 verify-report \
+  outputs/cut3r/cut3r-comparison-lock.json \
+  outputs/cut3r/source-competence-lock.json \
+  outputs/cut3r/common-support-lock-v2.json \
+  outputs/cut3r/source-competence-records-v2.json \
+  outputs/cut3r/source-competence-v2.json \
+  --require-pass
+```
+
+A valid negative report is written before exit status `3` is returned. The
+self-contained v2 report includes the exact stable v1 report, both-arm metrics
+for every complete group, paired ratios and deltas, group-level reasons,
+aggregate decisions, and all content identities.
+
+## Readiness gates
+
+Emit readiness-compatible source-mean and identity gates with:
+
+```bash
+python -m prob4d.cut3r_source_competence_v2 gates \
+  outputs/cut3r/cut3r-comparison-lock.json \
+  outputs/cut3r/source-competence-lock.json \
+  outputs/cut3r/common-support-lock-v2.json \
+  outputs/cut3r/source-competence-records-v2.json \
+  outputs/cut3r/source-competence-v2.json
+```
+
+Identity is `not-evaluated` after a source-mean failure. A v1 absolute pass cannot
+rescue a v2 common-support or paired-endpoint failure.
+
+## Ordered next action
+
+After the lock is frozen, execute exactly the three already registered causal
+arms on the retained Deform360 source inputs:
+
+1. `native-continuous`;
+2. `restarted-newest`; and
+3. `restarted-prob4d-fused`.
+
+The primary Prob4D contrast remains `restarted-prob4d-fused` versus
+`restarted-newest`. Stop at the first negative ordered gate. Do not open any of
+the twelve confirmation object sessions unless every target-free readiness gate
+returns `ready-for-one-target-evaluation`.

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -14,3 +14,6 @@ with the exact content identity from the frozen provider protocol.
   through `prob4d identity calibrate-mixture`.
 - `material-identity-mixture-config.json` remains the lower-level example for
   externally supplied calibrated log weights.
+- `cut3r-source-competence-v2-spec.json` freezes exact common metric support,
+  arm-neutral source-mean proper-score semantics, and paired source endpoints on
+  top of an existing CUT3R source-competence v1 lock.

--- a/docs/examples/cut3r-source-competence-v2-spec.json
+++ b/docs/examples/cut3r-source-competence-v2-spec.json
@@ -1,0 +1,35 @@
+{
+  "common_support_definition_sha256": "3333333333333333333333333333333333333333333333333333333333333333",
+  "paired_policy": {
+    "maximum_mean_absolute_drift_slope_ratio": 1.0,
+    "maximum_mean_seam_rmse_ratio": 1.0,
+    "maximum_worst_group_absolute_drift_slope_ratio": 1.2,
+    "maximum_worst_group_seam_rmse_ratio": 1.2,
+    "minimum_mean_association_precision_delta": -0.02,
+    "minimum_mean_identity_retention_delta": -0.02,
+    "minimum_mean_support_retention_delta": -0.02,
+    "minimum_paired_identity_group_pass_fraction": 0.75,
+    "minimum_paired_quality_group_pass_fraction": 0.75,
+    "minimum_worst_group_association_precision_delta": -0.05,
+    "minimum_worst_group_identity_retention_delta": -0.05,
+    "minimum_worst_group_support_retention_delta": -0.05
+  },
+  "proper_score_semantics": "arm-neutral-fixed-scale-gaussian-score-v1",
+  "require_complete_source_roster": true,
+  "source_competence_policy": {
+    "maximum_mean_absolute_drift_slope_m_per_frame": 0.001,
+    "maximum_mean_endpoint_rmse_ratio": 1.0,
+    "maximum_mean_point_rmse_ratio": 1.0,
+    "maximum_mean_proper_score_delta": 0.0,
+    "maximum_mean_seam_rmse_m": 0.01,
+    "maximum_technical_failures": 0,
+    "maximum_worst_group_point_rmse_ratio": 1.2,
+    "minimum_evaluable_groups": 4,
+    "minimum_identity_group_pass_fraction": 0.75,
+    "minimum_mean_association_precision": 0.9,
+    "minimum_mean_identity_retention": 0.8,
+    "minimum_mean_quality_group_pass_fraction": 0.75,
+    "minimum_mean_support_retention": 0.8,
+    "permitted_technical_failure_codes": []
+  }
+}

--- a/protocols/cut3r_deform360_common_support_definition_v2.json
+++ b/protocols/cut3r_deform360_common_support_definition_v2.json
@@ -1,0 +1,30 @@
+{
+  "canonical_hash_encoding": "UTF-8 JSON with sorted keys, compact separators, finite numbers only, and an ordered array of canonical support-row identifiers",
+  "claim_boundary": "This source-only definition binds common metric support for the frozen CUT3R Deform360 source comparison. It does not open source scores or target data, establish provider competence, authorize BayesianPhysTwin or Causal4D use, or establish state of the art.",
+  "group_unit": "complete-physical-object-session",
+  "metric_support": {
+    "endpoint_support_count": "number of ordered 3-D endpoint residual vectors entering endpoint_error_m",
+    "endpoint_support_sha256": "SHA-256 of the canonical ordered endpoint-row identifier array",
+    "point_support_count": "number of ordered 3-D material-point residual vectors entering point_error_m",
+    "point_support_sha256": "SHA-256 of the canonical ordered point-row identifier array",
+    "proper_score_dimension": "scalar residual dimension entering the arm-neutral fixed-scale Gaussian score",
+    "proper_score_semantics": "arm-neutral-fixed-scale-gaussian-score-v1",
+    "proper_score_support_sha256": "SHA-256 of the canonical ordered residual-row identifier array entering proper_score",
+    "seam_support_count": "number of ordered 3-D overlap-seam residual vectors entering seam_error_m; zero when seam_error_m is absent",
+    "seam_support_sha256": "SHA-256 of the canonical ordered seam-row identifier array; null when seam_support_count is zero"
+  },
+  "paired_rule": "For every frozen (group, case, frame, seed) record, candidate and baseline metric_support objects must be byte-identical after canonicalization.",
+  "primary_score_rule": "The primary paired score uses only the exact common support. Full-reference deployment error and selective risk-coverage are separate diagnostics and cannot replace or rescue the primary result.",
+  "proper_score_rule": "The source-mean proper score uses one scale or covariance fitted from development/calibration information and byte-identical across arms. Arm-specific predicted covariance is evaluated only in the later covariance gate.",
+  "record_unit": "one frozen (group_id, case_id, frame_index, random_seed, arm_id) row",
+  "schema": "prob4d.cut3r-deform360-common-support-definition",
+  "schema_version": 2,
+  "support_row_identifier": {
+    "endpoint": "[group_id, case_id, frame_index, endpoint_role, material_identity_id, coordinate_frame_id]",
+    "point": "[group_id, case_id, frame_index, material_identity_id, coordinate_frame_id]",
+    "proper_score": "[group_id, case_id, frame_index, material_identity_id, coordinate_axis, coordinate_frame_id]",
+    "seam": "[group_id, case_id, frame_index, window_left_id, window_right_id, material_identity_id, coordinate_frame_id]"
+  },
+  "target_outcomes_opened": false,
+  "target_payloads_opened": false
+}

--- a/protocols/cut3r_deform360_source_competence_v2_spec.json
+++ b/protocols/cut3r_deform360_source_competence_v2_spec.json
@@ -1,0 +1,35 @@
+{
+  "common_support_definition_sha256": "c7873ffe65fd6ac97721d2ab17328710a5879f9947c6c6ad55a491f1bd867ae3",
+  "paired_policy": {
+    "maximum_mean_absolute_drift_slope_ratio": 1.0,
+    "maximum_mean_seam_rmse_ratio": 1.0,
+    "maximum_worst_group_absolute_drift_slope_ratio": 1.2,
+    "maximum_worst_group_seam_rmse_ratio": 1.2,
+    "minimum_mean_association_precision_delta": -0.02,
+    "minimum_mean_identity_retention_delta": -0.02,
+    "minimum_mean_support_retention_delta": -0.02,
+    "minimum_paired_identity_group_pass_fraction": 0.75,
+    "minimum_paired_quality_group_pass_fraction": 0.75,
+    "minimum_worst_group_association_precision_delta": -0.05,
+    "minimum_worst_group_identity_retention_delta": -0.05,
+    "minimum_worst_group_support_retention_delta": -0.05
+  },
+  "proper_score_semantics": "arm-neutral-fixed-scale-gaussian-score-v1",
+  "require_complete_source_roster": true,
+  "source_competence_policy": {
+    "maximum_mean_absolute_drift_slope_m_per_frame": 0.001,
+    "maximum_mean_endpoint_rmse_ratio": 1.0,
+    "maximum_mean_point_rmse_ratio": 1.0,
+    "maximum_mean_proper_score_delta": 0.0,
+    "maximum_mean_seam_rmse_m": 0.01,
+    "maximum_technical_failures": 0,
+    "maximum_worst_group_point_rmse_ratio": 1.2,
+    "minimum_evaluable_groups": 4,
+    "minimum_identity_group_pass_fraction": 0.75,
+    "minimum_mean_association_precision": 0.9,
+    "minimum_mean_identity_retention": 0.8,
+    "minimum_mean_quality_group_pass_fraction": 0.75,
+    "minimum_mean_support_retention": 0.8,
+    "permitted_technical_failure_codes": []
+  }
+}

--- a/src/prob4d/_cut3r_source_competence_v2_common.py
+++ b/src/prob4d/_cut3r_source_competence_v2_common.py
@@ -1,0 +1,275 @@
+"""Shared strict definitions for CUT3R source competence v2."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Final, Literal, cast
+
+from .cut3r_source_competence import (
+    _exact_keys,
+    _finite_number,
+    _sha256,
+    _strict_integer,
+    _strict_mapping,
+    _strict_string,
+)
+
+LOCK_SCHEMA: Final = "prob4d.cut3r-source-competence-common-support-lock"
+RECORDS_SCHEMA: Final = "prob4d.cut3r-source-competence-records"
+REPORT_SCHEMA: Final = "prob4d.cut3r-source-competence-report"
+VERSION: Final = 2
+PROPER_SCORE_SEMANTICS: Final = "arm-neutral-fixed-scale-gaussian-score-v1"
+CLAIM_BOUNDARY: Final = (
+    "This source-only artifact proves exact paired metric support and evaluates "
+    "paired CUT3R source competence on complete frozen physical object/session "
+    "groups. It cannot change the arms, omit nested records, use arm-specific "
+    "covariance in the source-mean score, authorize target access, establish "
+    "BayesianPhysTwin or Causal4D benefit, or establish state of the art."
+)
+WEIGHTING: Final = {
+    "within_case": "equal-frame-mean-within-each-frozen-seed-v1",
+    "within_group": "equal-seed-means-then-equal-case-means-v1",
+    "across_groups": "equal-complete-group-mean-v1",
+    "technical_failures": "retain-complete-group-without-scored-metrics-v1",
+    "paired_support": "exact-byte-identical-metric-support-v2",
+}
+Status = Literal["pass", "fail", "technical-failure", "not-evaluated"]
+
+_LOCK_SPEC_FIELDS = frozenset(
+    {
+        "source_competence_policy",
+        "common_support_definition_sha256",
+        "proper_score_semantics",
+        "paired_policy",
+        "require_complete_source_roster",
+    }
+)
+_LOCK_FIELDS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "comparison_lock_id",
+        "source_competence_lock_id",
+        "record_definition_sha256",
+        "common_support_definition_sha256",
+        "source_evaluation_group_ids",
+        "random_seeds",
+        "contrast",
+        "source_competence_policy",
+        "proper_score_semantics",
+        "paired_policy",
+        "require_complete_source_roster",
+        "weighting",
+        "source_truth_required",
+        "target_access",
+        "claim_boundary",
+        "common_support_lock_id",
+    }
+)
+_POLICY_FIELDS = frozenset(
+    {
+        "maximum_mean_seam_rmse_ratio",
+        "maximum_worst_group_seam_rmse_ratio",
+        "maximum_mean_absolute_drift_slope_ratio",
+        "maximum_worst_group_absolute_drift_slope_ratio",
+        "minimum_mean_association_precision_delta",
+        "minimum_worst_group_association_precision_delta",
+        "minimum_mean_identity_retention_delta",
+        "minimum_worst_group_identity_retention_delta",
+        "minimum_mean_support_retention_delta",
+        "minimum_worst_group_support_retention_delta",
+        "minimum_paired_quality_group_pass_fraction",
+        "minimum_paired_identity_group_pass_fraction",
+    }
+)
+_RECORDS_FIELDS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "comparison_lock_id",
+        "source_competence_lock_id",
+        "common_support_lock_id",
+        "record_definition_sha256",
+        "common_support_definition_sha256",
+        "source_truth_used",
+        "target_payloads_opened",
+        "target_outcomes_opened",
+        "group_failures",
+        "records",
+    }
+)
+_RECORD_FIELDS = frozenset(
+    {
+        "group_id",
+        "case_id",
+        "frame_index",
+        "random_seed",
+        "arm_id",
+        "point_error_m",
+        "endpoint_error_m",
+        "proper_score",
+        "seam_error_m",
+        "association_correct_count",
+        "association_predicted_count",
+        "identity_retained_count",
+        "identity_reference_count",
+        "support_retained_count",
+        "support_reference_count",
+        "metric_support",
+    }
+)
+
+_REPORT_FIELDS = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "comparison_lock_id",
+        "source_competence_lock_id",
+        "common_support_lock_id",
+        "records_id",
+        "v1_source_provider_competence_id",
+        "v1_report",
+        "paired_policy",
+        "groups",
+        "aggregate",
+        "mean_quality_status",
+        "identity_reliability_status",
+        "mean_quality_reasons",
+        "identity_reliability_reasons",
+        "source_competence_pass",
+        "source_truth_used",
+        "target_payloads_opened",
+        "target_outcomes_opened",
+        "weighting",
+        "claim_boundary",
+        "source_competence_report_v2_id",
+    }
+)
+_SUPPORT_FIELDS = frozenset(
+    {
+        "point_support_sha256",
+        "point_support_count",
+        "endpoint_support_sha256",
+        "endpoint_support_count",
+        "proper_score_support_sha256",
+        "proper_score_dimension",
+        "proper_score_semantics",
+        "seam_support_sha256",
+        "seam_support_count",
+    }
+)
+
+
+def _positive(value: Any, *, name: str) -> float:
+    result = _finite_number(value, name=name, nonnegative=True)
+    if result <= 0.0:
+        raise ValueError(f"{name} must be positive")
+    return result
+
+
+def _probability(value: Any, *, name: str) -> float:
+    result = _finite_number(value, name=name, nonnegative=True)
+    if result > 1.0:
+        raise ValueError(f"{name} must lie in [0, 1]")
+    return result
+
+
+def _delta(value: Any, *, name: str) -> float:
+    result = _finite_number(value, name=name, nonnegative=False)
+    if not -1.0 <= result <= 1.0:
+        raise ValueError(f"{name} must lie in [-1, 1]")
+    return result
+
+
+def _paired_policy(value: Any) -> dict[str, float]:
+    mapping = _strict_mapping(value, name="paired policy")
+    _exact_keys(mapping, _POLICY_FIELDS, name="paired policy")
+    result: dict[str, float] = {}
+    for name in (
+        "maximum_mean_seam_rmse_ratio",
+        "maximum_worst_group_seam_rmse_ratio",
+        "maximum_mean_absolute_drift_slope_ratio",
+        "maximum_worst_group_absolute_drift_slope_ratio",
+    ):
+        result[name] = _positive(mapping[name], name=name)
+    for name in (
+        "minimum_mean_association_precision_delta",
+        "minimum_worst_group_association_precision_delta",
+        "minimum_mean_identity_retention_delta",
+        "minimum_worst_group_identity_retention_delta",
+        "minimum_mean_support_retention_delta",
+        "minimum_worst_group_support_retention_delta",
+    ):
+        result[name] = _delta(mapping[name], name=name)
+    for name in (
+        "minimum_paired_quality_group_pass_fraction",
+        "minimum_paired_identity_group_pass_fraction",
+    ):
+        result[name] = _probability(mapping[name], name=name)
+    return result
+
+
+def _support(value: Any, *, seam_present: bool) -> dict[str, Any]:
+    mapping = _strict_mapping(value, name="metric_support")
+    _exact_keys(mapping, _SUPPORT_FIELDS, name="metric_support")
+    semantics = _strict_string(
+        mapping["proper_score_semantics"],
+        name="proper_score_semantics",
+    )
+    if semantics != PROPER_SCORE_SEMANTICS:
+        raise ValueError(
+            "source-mean proper score must use arm-neutral fixed-scale semantics"
+        )
+    seam_count = _strict_integer(
+        mapping["seam_support_count"],
+        name="seam_support_count",
+    )
+    raw_seam_digest = mapping["seam_support_sha256"]
+    seam_digest = None if raw_seam_digest is None else _sha256(
+        raw_seam_digest,
+        name="seam_support_sha256",
+    )
+    if seam_present:
+        if seam_count <= 0 or seam_digest is None:
+            raise ValueError("seam error and seam support identity disagree")
+    elif seam_count != 0 or seam_digest is not None:
+        raise ValueError("absent seam error requires zero count and null digest")
+    return {
+        "point_support_sha256": _sha256(
+            mapping["point_support_sha256"],
+            name="point_support_sha256",
+        ),
+        "point_support_count": _strict_integer(
+            mapping["point_support_count"],
+            name="point_support_count",
+            minimum=1,
+        ),
+        "endpoint_support_sha256": _sha256(
+            mapping["endpoint_support_sha256"],
+            name="endpoint_support_sha256",
+        ),
+        "endpoint_support_count": _strict_integer(
+            mapping["endpoint_support_count"],
+            name="endpoint_support_count",
+            minimum=1,
+        ),
+        "proper_score_support_sha256": _sha256(
+            mapping["proper_score_support_sha256"],
+            name="proper_score_support_sha256",
+        ),
+        "proper_score_dimension": _strict_integer(
+            mapping["proper_score_dimension"],
+            name="proper_score_dimension",
+            minimum=1,
+        ),
+        "proper_score_semantics": semantics,
+        "seam_support_sha256": seam_digest,
+        "seam_support_count": seam_count,
+    }
+
+
+def _source_group_ids(source_lock: Mapping[str, Any]) -> list[str]:
+    return [
+        cast(str, group["group_id"])
+        for group in cast(list[dict[str, Any]], source_lock["source_evaluation_groups"])
+    ]

--- a/src/prob4d/_cut3r_source_competence_v2_lock.py
+++ b/src/prob4d/_cut3r_source_competence_v2_lock.py
@@ -1,0 +1,185 @@
+"""Content-addressed common-support lock for CUT3R source competence v2."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any, cast
+
+from ._cut3r_source_competence_v2_common import (
+    CLAIM_BOUNDARY,
+    LOCK_SCHEMA,
+    PROPER_SCORE_SEMANTICS,
+    VERSION,
+    WEIGHTING,
+    _LOCK_FIELDS,
+    _LOCK_SPEC_FIELDS,
+    _paired_policy,
+    _source_group_ids,
+)
+from .cut3r_comparison import validate_cut3r_comparison_lock
+from .cut3r_source_competence import (
+    _canonical_json,
+    _exact_keys,
+    _record_id,
+    _sha256,
+    _strict_boolean,
+    _strict_mapping,
+    _strict_string,
+    validate_cut3r_source_competence_lock,
+)
+from .source_provider_competence import SourceProviderCompetencePolicyV1
+
+
+def build_cut3r_source_competence_v2_lock(
+    comparison_lock: Any,
+    source_competence_lock: Any,
+    specification: Any,
+) -> dict[str, Any]:
+    comparison = validate_cut3r_comparison_lock(comparison_lock)
+    source_lock = validate_cut3r_source_competence_lock(
+        comparison,
+        source_competence_lock,
+    )
+    spec = _strict_mapping(specification, name="source competence v2 specification")
+    _exact_keys(spec, _LOCK_SPEC_FIELDS, name="source competence v2 specification")
+    policy = SourceProviderCompetencePolicyV1.from_dict(
+        spec["source_competence_policy"]
+    )
+    if policy.to_dict() != source_lock["policy"]:
+        raise ValueError("v2 specification does not match the frozen v1 source policy")
+    semantics = _strict_string(
+        spec["proper_score_semantics"],
+        name="proper_score_semantics",
+    )
+    if semantics != PROPER_SCORE_SEMANTICS:
+        raise ValueError("v2 proper score must be arm-neutral and fixed-scale")
+    complete = _strict_boolean(
+        spec["require_complete_source_roster"],
+        name="require_complete_source_roster",
+    )
+    group_ids = _source_group_ids(source_lock)
+    if complete and (
+        policy.minimum_evaluable_groups != len(group_ids)
+        or policy.maximum_technical_failures != 0
+    ):
+        raise ValueError(
+            "complete source roster requires every frozen group and zero technical failures"
+        )
+    payload: dict[str, Any] = {
+        "schema": LOCK_SCHEMA,
+        "schema_version": VERSION,
+        "comparison_lock_id": comparison["lock_id"],
+        "source_competence_lock_id": source_lock["source_competence_lock_id"],
+        "record_definition_sha256": source_lock["record_definition_sha256"],
+        "common_support_definition_sha256": _sha256(
+            spec["common_support_definition_sha256"],
+            name="common_support_definition_sha256",
+        ),
+        "source_evaluation_group_ids": group_ids,
+        "random_seeds": list(source_lock["random_seeds"]),
+        "contrast": dict(source_lock["contrast"]),
+        "source_competence_policy": policy.to_dict(),
+        "proper_score_semantics": semantics,
+        "paired_policy": _paired_policy(spec["paired_policy"]),
+        "require_complete_source_roster": complete,
+        "weighting": dict(WEIGHTING),
+        "source_truth_required": True,
+        "target_access": "forbidden",
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+    payload["common_support_lock_id"] = _record_id(payload)
+    return validate_cut3r_source_competence_v2_lock(
+        comparison,
+        source_lock,
+        payload,
+    )
+
+
+def validate_cut3r_source_competence_v2_lock(
+    comparison_lock: Any,
+    source_competence_lock: Any,
+    value: Any,
+) -> dict[str, Any]:
+    comparison = validate_cut3r_comparison_lock(comparison_lock)
+    source_lock = validate_cut3r_source_competence_lock(
+        comparison,
+        source_competence_lock,
+    )
+    payload = _strict_mapping(value, name="source competence v2 lock")
+    _exact_keys(payload, _LOCK_FIELDS, name="source competence v2 lock")
+    if payload["schema"] != LOCK_SCHEMA or payload["schema_version"] != VERSION:
+        raise ValueError("unsupported source competence v2 lock")
+    spec = {
+        "source_competence_policy": payload["source_competence_policy"],
+        "common_support_definition_sha256": payload[
+            "common_support_definition_sha256"
+        ],
+        "proper_score_semantics": payload["proper_score_semantics"],
+        "paired_policy": payload["paired_policy"],
+        "require_complete_source_roster": payload[
+            "require_complete_source_roster"
+        ],
+    }
+    expected = build_cut3r_source_competence_v2_lock_unchecked(
+        comparison,
+        source_lock,
+        spec,
+    )
+    if payload != expected:
+        raise ValueError("source competence v2 lock changed from its frozen inputs")
+    return cast(dict[str, Any], json.loads(_canonical_json(expected)))
+
+
+def build_cut3r_source_competence_v2_lock_unchecked(
+    comparison: Mapping[str, Any],
+    source_lock: Mapping[str, Any],
+    specification: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Internal nonrecursive lock reconstruction after outer validation."""
+
+    policy = SourceProviderCompetencePolicyV1.from_dict(
+        specification["source_competence_policy"]
+    )
+    if policy.to_dict() != source_lock["policy"]:
+        raise ValueError("v2 source policy changed")
+    semantics = _strict_string(
+        specification["proper_score_semantics"],
+        name="proper_score_semantics",
+    )
+    if semantics != PROPER_SCORE_SEMANTICS:
+        raise ValueError("v2 proper score semantics changed")
+    complete = _strict_boolean(
+        specification["require_complete_source_roster"],
+        name="require_complete_source_roster",
+    )
+    group_ids = _source_group_ids(source_lock)
+    if complete and (
+        policy.minimum_evaluable_groups != len(group_ids)
+        or policy.maximum_technical_failures != 0
+    ):
+        raise ValueError("complete source roster policy changed")
+    result: dict[str, Any] = {
+        "schema": LOCK_SCHEMA,
+        "schema_version": VERSION,
+        "comparison_lock_id": comparison["lock_id"],
+        "source_competence_lock_id": source_lock["source_competence_lock_id"],
+        "record_definition_sha256": source_lock["record_definition_sha256"],
+        "common_support_definition_sha256": _sha256(
+            specification["common_support_definition_sha256"],
+            name="common_support_definition_sha256",
+        ),
+        "source_evaluation_group_ids": group_ids,
+        "random_seeds": list(source_lock["random_seeds"]),
+        "contrast": dict(source_lock["contrast"]),
+        "source_competence_policy": policy.to_dict(),
+        "proper_score_semantics": semantics,
+        "paired_policy": _paired_policy(specification["paired_policy"]),
+        "require_complete_source_roster": complete,
+        "weighting": dict(WEIGHTING),
+        "source_truth_required": True,
+        "target_access": "forbidden",
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+    result["common_support_lock_id"] = _record_id(result)
+    return result

--- a/src/prob4d/_cut3r_source_competence_v2_lock.py
+++ b/src/prob4d/_cut3r_source_competence_v2_lock.py
@@ -7,13 +7,13 @@ from collections.abc import Mapping
 from typing import Any, cast
 
 from ._cut3r_source_competence_v2_common import (
+    _LOCK_FIELDS,
+    _LOCK_SPEC_FIELDS,
     CLAIM_BOUNDARY,
     LOCK_SCHEMA,
     PROPER_SCORE_SEMANTICS,
     VERSION,
     WEIGHTING,
-    _LOCK_FIELDS,
-    _LOCK_SPEC_FIELDS,
     _paired_policy,
     _source_group_ids,
 )

--- a/src/prob4d/_cut3r_source_competence_v2_records.py
+++ b/src/prob4d/_cut3r_source_competence_v2_records.py
@@ -1,0 +1,225 @@
+"""Exact paired metric-support validation for CUT3R source competence v2."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from typing import Any, cast
+
+from ._cut3r_source_competence_v2_common import (
+    RECORDS_SCHEMA,
+    VERSION,
+    _RECORD_FIELDS,
+    _RECORDS_FIELDS,
+    _support,
+)
+from ._cut3r_source_competence_v2_lock import (
+    validate_cut3r_source_competence_v2_lock,
+)
+from .cut3r_comparison import validate_cut3r_comparison_lock
+from .cut3r_source_competence import (
+    CUT3R_SOURCE_COMPETENCE_RECORDS_SCHEMA,
+    _canonical_json,
+    _exact_keys,
+    _normalize_records,
+    _sha256,
+    _strict_boolean,
+    _strict_integer,
+    _strict_mapping,
+    _strict_string,
+    validate_cut3r_source_competence_lock,
+)
+
+
+def _record_key(record: Mapping[str, Any]) -> tuple[str, str, int, int, str]:
+    return (
+        cast(str, record["group_id"]),
+        cast(str, record["case_id"]),
+        cast(int, record["frame_index"]),
+        cast(int, record["random_seed"]),
+        cast(str, record["arm_id"]),
+    )
+
+
+def _normalize_v2_records(
+    comparison_lock: Any,
+    source_competence_lock: Any,
+    common_support_lock: Any,
+    value: Any,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    comparison = validate_cut3r_comparison_lock(comparison_lock)
+    source_lock = validate_cut3r_source_competence_lock(
+        comparison,
+        source_competence_lock,
+    )
+    v2_lock = validate_cut3r_source_competence_v2_lock(
+        comparison,
+        source_lock,
+        common_support_lock,
+    )
+    payload = _strict_mapping(value, name="source competence v2 records")
+    _exact_keys(payload, _RECORDS_FIELDS, name="source competence v2 records")
+    if payload["schema"] != RECORDS_SCHEMA or payload["schema_version"] != VERSION:
+        raise ValueError("unsupported source competence v2 records")
+    expected_ids = {
+        "comparison_lock_id": comparison["lock_id"],
+        "source_competence_lock_id": source_lock["source_competence_lock_id"],
+        "common_support_lock_id": v2_lock["common_support_lock_id"],
+        "record_definition_sha256": source_lock["record_definition_sha256"],
+        "common_support_definition_sha256": v2_lock[
+            "common_support_definition_sha256"
+        ],
+    }
+    for name, expected in expected_ids.items():
+        if _sha256(payload[name], name=name) != expected:
+            raise ValueError(f"v2 records use a different {name}")
+    if not _strict_boolean(payload["source_truth_used"], name="source_truth_used"):
+        raise ValueError("v2 records require source truth")
+    if _strict_boolean(payload["target_payloads_opened"], name="target_payloads_opened"):
+        raise ValueError("v2 records may not open target payloads")
+    if _strict_boolean(payload["target_outcomes_opened"], name="target_outcomes_opened"):
+        raise ValueError("v2 records may not open target outcomes")
+    raw_records = payload["records"]
+    if type(raw_records) is not list:
+        raise ValueError("records must be a JSON array")
+    supports: dict[tuple[str, str, int, int, str], dict[str, Any]] = {}
+    stripped_records: list[dict[str, Any]] = []
+    for index, raw_record in enumerate(raw_records):
+        record = _strict_mapping(raw_record, name=f"records[{index}]")
+        _exact_keys(record, _RECORD_FIELDS, name=f"records[{index}]")
+        stripped = {name: record[name] for name in _RECORD_FIELDS if name != "metric_support"}
+        key = (
+            _strict_string(record["group_id"], name="group_id"),
+            _strict_string(record["case_id"], name="case_id"),
+            _strict_integer(record["frame_index"], name="frame_index"),
+            _strict_integer(record["random_seed"], name="random_seed"),
+            _strict_string(record["arm_id"], name="arm_id"),
+        )
+        if key in supports:
+            raise ValueError("v2 records contain duplicate frame-arm keys")
+        supports[key] = _support(
+            record["metric_support"],
+            seam_present=record["seam_error_m"] is not None,
+        )
+        stripped_records.append(stripped)
+    v1_input = {
+        "schema": CUT3R_SOURCE_COMPETENCE_RECORDS_SCHEMA,
+        "schema_version": 1,
+        "comparison_lock_id": comparison["lock_id"],
+        "source_competence_lock_id": source_lock["source_competence_lock_id"],
+        "record_definition_sha256": source_lock["record_definition_sha256"],
+        "source_truth_used": True,
+        "target_payloads_opened": False,
+        "target_outcomes_opened": False,
+        "group_failures": payload["group_failures"],
+        "records": stripped_records,
+    }
+    normalized_v1 = _normalize_records(comparison, source_lock, v1_input)
+    normalized_records: list[dict[str, Any]] = []
+    for v1_record in cast(list[dict[str, Any]], normalized_v1["records"]):
+        key = _record_key(v1_record)
+        normalized_records.append({**v1_record, "metric_support": supports[key]})
+    treatment = cast(str, v2_lock["contrast"]["treatment_arm"])
+    control = cast(str, v2_lock["contrast"]["control_arm"])
+    lookup = {_record_key(record): record for record in normalized_records}
+    pair_keys = sorted({key[:-1] for key in lookup})
+    for pair_key in pair_keys:
+        candidate = lookup[(*pair_key, treatment)]
+        baseline = lookup[(*pair_key, control)]
+        if candidate["metric_support"] != baseline["metric_support"]:
+            raise ValueError(
+                "paired arms use different exact metric support "
+                f"at {pair_key!r}"
+            )
+    normalized = {
+        "schema": RECORDS_SCHEMA,
+        "schema_version": VERSION,
+        **expected_ids,
+        "source_truth_used": True,
+        "target_payloads_opened": False,
+        "target_outcomes_opened": False,
+        "group_failures": normalized_v1["group_failures"],
+        "records": normalized_records,
+    }
+    return (
+        cast(dict[str, Any], json.loads(_canonical_json(normalized))),
+        normalized_v1,
+    )
+
+
+def _safe_ratio(candidate: float, baseline: float) -> tuple[float | None, str | None]:
+    if baseline > 0.0:
+        return candidate / baseline, None
+    if candidate == 0.0:
+        return 1.0, None
+    return None, "baseline-zero-with-positive-candidate"
+
+
+def _group_pair(
+    group_id: str,
+    candidate: Mapping[str, float],
+    baseline: Mapping[str, float],
+    policy: Mapping[str, float],
+) -> dict[str, Any]:
+    seam_ratio, seam_reason = _safe_ratio(
+        candidate["seam_rmse_m"], baseline["seam_rmse_m"]
+    )
+    drift_ratio, drift_reason = _safe_ratio(
+        candidate["absolute_drift_slope_m_per_frame"],
+        baseline["absolute_drift_slope_m_per_frame"],
+    )
+    association_delta = candidate["association_precision"] - baseline[
+        "association_precision"
+    ]
+    identity_delta = candidate["identity_retention"] - baseline["identity_retention"]
+    support_delta = candidate["support_retention"] - baseline["support_retention"]
+    quality_reasons = []
+    identity_reasons = []
+    if seam_reason:
+        quality_reasons.append(f"seam-{seam_reason}")
+    elif seam_ratio is not None and seam_ratio > policy[
+        "maximum_worst_group_seam_rmse_ratio"
+    ]:
+        quality_reasons.append("seam-rmse-ratio-exceeded")
+    if drift_reason:
+        quality_reasons.append(f"drift-{drift_reason}")
+    elif drift_ratio is not None and drift_ratio > policy[
+        "maximum_worst_group_absolute_drift_slope_ratio"
+    ]:
+        quality_reasons.append("drift-slope-ratio-exceeded")
+    for name, delta, threshold in (
+        (
+            "association-precision",
+            association_delta,
+            policy["minimum_worst_group_association_precision_delta"],
+        ),
+        (
+            "identity-retention",
+            identity_delta,
+            policy["minimum_worst_group_identity_retention_delta"],
+        ),
+        (
+            "support-retention",
+            support_delta,
+            policy["minimum_worst_group_support_retention_delta"],
+        ),
+    ):
+        if delta < threshold:
+            identity_reasons.append(f"{name}-delta-below-minimum")
+    return {
+        "group_id": group_id,
+        "technical_failure_code": None,
+        "candidate": dict(candidate),
+        "baseline": dict(baseline),
+        "paired": {
+            "seam_rmse_ratio": seam_ratio,
+            "absolute_drift_slope_ratio": drift_ratio,
+            "association_precision_delta": association_delta,
+            "identity_retention_delta": identity_delta,
+            "support_retention_delta": support_delta,
+        },
+        "paired_quality_pass": not quality_reasons,
+        "paired_identity_pass": not identity_reasons,
+        "paired_quality_reasons": sorted(quality_reasons),
+        "paired_identity_reasons": sorted(identity_reasons),
+    }

--- a/src/prob4d/_cut3r_source_competence_v2_records.py
+++ b/src/prob4d/_cut3r_source_competence_v2_records.py
@@ -7,10 +7,10 @@ from collections.abc import Mapping
 from typing import Any, cast
 
 from ._cut3r_source_competence_v2_common import (
-    RECORDS_SCHEMA,
-    VERSION,
     _RECORD_FIELDS,
     _RECORDS_FIELDS,
+    RECORDS_SCHEMA,
+    VERSION,
     _support,
 )
 from ._cut3r_source_competence_v2_lock import (

--- a/src/prob4d/_cut3r_source_competence_v2_report.py
+++ b/src/prob4d/_cut3r_source_competence_v2_report.py
@@ -8,12 +8,12 @@ from collections.abc import Mapping, Sequence
 from typing import Any, cast
 
 from ._cut3r_source_competence_v2_common import (
+    _REPORT_FIELDS,
     CLAIM_BOUNDARY,
     REPORT_SCHEMA,
     VERSION,
     WEIGHTING,
     Status,
-    _REPORT_FIELDS,
 )
 from ._cut3r_source_competence_v2_lock import (
     validate_cut3r_source_competence_v2_lock,

--- a/src/prob4d/_cut3r_source_competence_v2_report.py
+++ b/src/prob4d/_cut3r_source_competence_v2_report.py
@@ -1,0 +1,371 @@
+"""Paired source-competence reporting and readiness adaptation."""
+
+from __future__ import annotations
+
+import json
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from typing import Any, cast
+
+from ._cut3r_source_competence_v2_common import (
+    CLAIM_BOUNDARY,
+    REPORT_SCHEMA,
+    VERSION,
+    WEIGHTING,
+    Status,
+    _REPORT_FIELDS,
+)
+from ._cut3r_source_competence_v2_lock import (
+    validate_cut3r_source_competence_v2_lock,
+)
+from ._cut3r_source_competence_v2_records import (
+    _group_pair,
+    _normalize_v2_records,
+)
+from .cut3r_comparison import validate_cut3r_comparison_lock
+from .cut3r_source_competence import (
+    _canonical_json,
+    _comparison_context,
+    _exact_keys,
+    _hierarchical_group_metrics,
+    _mean,
+    _record_id,
+    _sha256,
+    _strict_boolean,
+    _strict_mapping,
+    build_cut3r_source_competence_report,
+    validate_cut3r_source_competence_lock,
+)
+from .fresh_provider_readiness import ReadinessGateV1
+from .source_provider_competence import SourceProviderCompetenceReportV1
+
+
+def _aggregate(groups: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    evaluable = [group for group in groups if group["technical_failure_code"] is None]
+    if not evaluable:
+        return {"evaluable_group_count": 0}
+    paired = [cast(Mapping[str, Any], group["paired"]) for group in evaluable]
+    seam = [item["seam_rmse_ratio"] for item in paired]
+    drift = [item["absolute_drift_slope_ratio"] for item in paired]
+    complete_seam = all(value is not None for value in seam)
+    complete_drift = all(value is not None for value in drift)
+    values = {
+        "association_precision": [
+            cast(float, item["association_precision_delta"]) for item in paired
+        ],
+        "identity_retention": [
+            cast(float, item["identity_retention_delta"]) for item in paired
+        ],
+        "support_retention": [
+            cast(float, item["support_retention_delta"]) for item in paired
+        ],
+    }
+    return {
+        "evaluable_group_count": len(evaluable),
+        "mean_seam_rmse_ratio": (
+            _mean([cast(float, value) for value in seam]) if complete_seam else None
+        ),
+        "worst_group_seam_rmse_ratio": (
+            max(cast(list[float], seam)) if complete_seam else None
+        ),
+        "mean_absolute_drift_slope_ratio": (
+            _mean([cast(float, value) for value in drift]) if complete_drift else None
+        ),
+        "worst_group_absolute_drift_slope_ratio": (
+            max(cast(list[float], drift)) if complete_drift else None
+        ),
+        "mean_association_precision_delta": _mean(values["association_precision"]),
+        "worst_group_association_precision_delta": min(
+            values["association_precision"]
+        ),
+        "mean_identity_retention_delta": _mean(values["identity_retention"]),
+        "worst_group_identity_retention_delta": min(values["identity_retention"]),
+        "mean_support_retention_delta": _mean(values["support_retention"]),
+        "worst_group_support_retention_delta": min(values["support_retention"]),
+        "paired_quality_group_pass_fraction": _mean(
+            [1.0 if group["paired_quality_pass"] else 0.0 for group in evaluable]
+        ),
+        "paired_identity_group_pass_fraction": _mean(
+            [1.0 if group["paired_identity_pass"] else 0.0 for group in evaluable]
+        ),
+    }
+
+
+def _statuses(
+    v1_report: SourceProviderCompetenceReportV1,
+    aggregate: Mapping[str, Any],
+    policy: Mapping[str, float],
+) -> tuple[Status, list[str], Status, list[str]]:
+    mean_reasons = list(v1_report.mean_quality_reasons)
+    if v1_report.mean_quality_status == "technical-failure":
+        return "technical-failure", mean_reasons, "not-evaluated", []
+    if v1_report.mean_quality_status != "pass":
+        return "fail", mean_reasons, "not-evaluated", []
+    for name, threshold in (
+        ("mean_seam_rmse_ratio", policy["maximum_mean_seam_rmse_ratio"]),
+        (
+            "worst_group_seam_rmse_ratio",
+            policy["maximum_worst_group_seam_rmse_ratio"],
+        ),
+        (
+            "mean_absolute_drift_slope_ratio",
+            policy["maximum_mean_absolute_drift_slope_ratio"],
+        ),
+        (
+            "worst_group_absolute_drift_slope_ratio",
+            policy["maximum_worst_group_absolute_drift_slope_ratio"],
+        ),
+    ):
+        if aggregate.get(name) is None:
+            mean_reasons.append(f"{name.replace('_', '-')}-undefined")
+        elif aggregate[name] > threshold:
+            mean_reasons.append(f"{name.replace('_', '-')}-exceeded")
+    if aggregate["paired_quality_group_pass_fraction"] < policy[
+        "minimum_paired_quality_group_pass_fraction"
+    ]:
+        mean_reasons.append("paired-quality-group-pass-fraction-below-minimum")
+    if mean_reasons:
+        return "fail", sorted(set(mean_reasons)), "not-evaluated", []
+    identity_reasons = list(v1_report.identity_reliability_reasons)
+    if v1_report.identity_reliability_status != "pass":
+        status = cast(Status, v1_report.identity_reliability_status)
+        return "pass", [], status, sorted(set(identity_reasons))
+    for name, threshold in (
+        (
+            "mean_association_precision_delta",
+            policy["minimum_mean_association_precision_delta"],
+        ),
+        (
+            "worst_group_association_precision_delta",
+            policy["minimum_worst_group_association_precision_delta"],
+        ),
+        (
+            "mean_identity_retention_delta",
+            policy["minimum_mean_identity_retention_delta"],
+        ),
+        (
+            "worst_group_identity_retention_delta",
+            policy["minimum_worst_group_identity_retention_delta"],
+        ),
+        (
+            "mean_support_retention_delta",
+            policy["minimum_mean_support_retention_delta"],
+        ),
+        (
+            "worst_group_support_retention_delta",
+            policy["minimum_worst_group_support_retention_delta"],
+        ),
+    ):
+        if aggregate[name] < threshold:
+            identity_reasons.append(f"{name.replace('_', '-')}-below-minimum")
+    if aggregate["paired_identity_group_pass_fraction"] < policy[
+        "minimum_paired_identity_group_pass_fraction"
+    ]:
+        identity_reasons.append("paired-identity-group-pass-fraction-below-minimum")
+    return "pass", [], "pass" if not identity_reasons else "fail", sorted(
+        set(identity_reasons)
+    )
+
+
+def _build_report(
+    comparison: Mapping[str, Any],
+    source_lock: Mapping[str, Any],
+    v2_lock: Mapping[str, Any],
+    records: Any,
+) -> dict[str, Any]:
+    normalized, v1_records = _normalize_v2_records(
+        comparison,
+        source_lock,
+        v2_lock,
+        records,
+    )
+    v1_report = build_cut3r_source_competence_report(
+        comparison,
+        source_lock,
+        v1_records,
+    )
+    context = _comparison_context(comparison)
+    cases = cast(dict[str, dict[str, tuple[int, int]]], context["cases_by_group"])
+    seeds = cast(list[int], v2_lock["random_seeds"])
+    treatment = cast(str, v2_lock["contrast"]["treatment_arm"])
+    control = cast(str, v2_lock["contrast"]["control_arm"])
+    nested: dict[tuple[str, str, int, str], list[Mapping[str, Any]]] = defaultdict(list)
+    for record in cast(list[dict[str, Any]], normalized["records"]):
+        nested[
+            (
+                cast(str, record["group_id"]),
+                cast(str, record["case_id"]),
+                cast(int, record["random_seed"]),
+                cast(str, record["arm_id"]),
+            )
+        ].append(record)
+    failures = {
+        cast(str, item["group_id"]): cast(str, item["technical_failure_code"])
+        for item in cast(list[dict[str, Any]], normalized["group_failures"])
+    }
+    policy = cast(dict[str, float], v2_lock["paired_policy"])
+    groups = []
+    for group_id in cast(list[str], v2_lock["source_evaluation_group_ids"]):
+        if group_id in failures:
+            groups.append(
+                {
+                    "group_id": group_id,
+                    "technical_failure_code": failures[group_id],
+                    "candidate": None,
+                    "baseline": None,
+                    "paired": None,
+                    "paired_quality_pass": False,
+                    "paired_identity_pass": False,
+                    "paired_quality_reasons": ["technical-failure"],
+                    "paired_identity_reasons": ["technical-failure"],
+                }
+            )
+            continue
+        candidate = _hierarchical_group_metrics(
+            group_id,
+            treatment,
+            cases=cases[group_id],
+            seeds=seeds,
+            record_lookup=nested,
+        )
+        baseline = _hierarchical_group_metrics(
+            group_id,
+            control,
+            cases=cases[group_id],
+            seeds=seeds,
+            record_lookup=nested,
+        )
+        groups.append(_group_pair(group_id, candidate, baseline, policy))
+    aggregate = _aggregate(groups)
+    mean_status, mean_reasons, identity_status, identity_reasons = _statuses(
+        v1_report,
+        aggregate,
+        policy,
+    )
+    payload: dict[str, Any] = {
+        "schema": REPORT_SCHEMA,
+        "schema_version": VERSION,
+        "comparison_lock_id": comparison["lock_id"],
+        "source_competence_lock_id": source_lock["source_competence_lock_id"],
+        "common_support_lock_id": v2_lock["common_support_lock_id"],
+        "records_id": _record_id(normalized),
+        "v1_source_provider_competence_id": v1_report.source_provider_competence_id,
+        "v1_report": v1_report.to_dict(),
+        "paired_policy": policy,
+        "groups": groups,
+        "aggregate": aggregate,
+        "mean_quality_status": mean_status,
+        "identity_reliability_status": identity_status,
+        "mean_quality_reasons": mean_reasons,
+        "identity_reliability_reasons": identity_reasons,
+        "source_competence_pass": mean_status == "pass" and identity_status == "pass",
+        "source_truth_used": True,
+        "target_payloads_opened": False,
+        "target_outcomes_opened": False,
+        "weighting": dict(WEIGHTING),
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+    payload["source_competence_report_v2_id"] = _record_id(payload)
+    return cast(dict[str, Any], json.loads(_canonical_json(payload)))
+
+
+def build_cut3r_source_competence_v2_report(
+    comparison_lock: Any,
+    source_competence_lock: Any,
+    common_support_lock: Any,
+    records: Any,
+) -> dict[str, Any]:
+    comparison = validate_cut3r_comparison_lock(comparison_lock)
+    source_lock = validate_cut3r_source_competence_lock(
+        comparison,
+        source_competence_lock,
+    )
+    v2_lock = validate_cut3r_source_competence_v2_lock(
+        comparison,
+        source_lock,
+        common_support_lock,
+    )
+    return _build_report(comparison, source_lock, v2_lock, records)
+
+
+def validate_cut3r_source_competence_v2_report(
+    comparison_lock: Any,
+    source_competence_lock: Any,
+    common_support_lock: Any,
+    records: Any,
+    report: Any,
+) -> dict[str, Any]:
+    supplied = _strict_mapping(report, name="source competence v2 report")
+    expected = build_cut3r_source_competence_v2_report(
+        comparison_lock,
+        source_competence_lock,
+        common_support_lock,
+        records,
+    )
+    if supplied != expected:
+        raise ValueError("source competence v2 report does not match the bound records")
+    return expected
+
+
+def source_competence_gates_v2(
+    report: Mapping[str, Any],
+) -> tuple[ReadinessGateV1, ReadinessGateV1]:
+    artifact = _strict_mapping(report, name="source competence v2 report")
+    _exact_keys(artifact, _REPORT_FIELDS, name="source competence v2 report")
+    if artifact["schema"] != REPORT_SCHEMA or artifact["schema_version"] != VERSION:
+        raise ValueError("unsupported source competence v2 report")
+    if artifact["claim_boundary"] != CLAIM_BOUNDARY:
+        raise ValueError("source competence v2 claim boundary changed")
+    if not _strict_boolean(artifact["source_truth_used"], name="source_truth_used"):
+        raise ValueError("source competence v2 report requires source truth")
+    if _strict_boolean(artifact["target_payloads_opened"], name="target_payloads_opened"):
+        raise ValueError("source competence v2 report may not open target payloads")
+    if _strict_boolean(artifact["target_outcomes_opened"], name="target_outcomes_opened"):
+        raise ValueError("source competence v2 report may not open target outcomes")
+    report_id = _sha256(
+        artifact["source_competence_report_v2_id"],
+        name="source_competence_report_v2_id",
+    )
+    unsigned = dict(artifact)
+    unsigned.pop("source_competence_report_v2_id")
+    if _record_id(unsigned) != report_id:
+        raise ValueError("source competence v2 report content identity changed")
+    report = artifact
+    mean_status = cast(Status, report["mean_quality_status"])
+    mean_gate = ReadinessGateV1(
+        gate_name="source-mean",
+        status=cast(Any, mean_status),
+        evidence_id=report_id,
+        reason_codes=(
+            () if mean_status == "pass" else tuple(report["mean_quality_reasons"])
+        ),
+        metadata={
+            "common_support_lock_id": report["common_support_lock_id"],
+            "v1_source_provider_competence_id": report[
+                "v1_source_provider_competence_id"
+            ],
+        },
+    )
+    if mean_status != "pass":
+        return mean_gate, ReadinessGateV1(
+            gate_name="identity-reliability",
+            status="not-evaluated",
+            evidence_id=None,
+        )
+    identity_status = cast(Status, report["identity_reliability_status"])
+    return mean_gate, ReadinessGateV1(
+        gate_name="identity-reliability",
+        status=cast(Any, identity_status),
+        evidence_id=report_id,
+        reason_codes=(
+            ()
+            if identity_status == "pass"
+            else tuple(report["identity_reliability_reasons"])
+        ),
+        metadata={
+            "common_support_lock_id": report["common_support_lock_id"],
+            "v1_source_provider_competence_id": report[
+                "v1_source_provider_competence_id"
+            ],
+        },
+    )

--- a/src/prob4d/cut3r_source_competence_v2.py
+++ b/src/prob4d/cut3r_source_competence_v2.py
@@ -1,0 +1,252 @@
+"""Exact common-support and paired-endpoint CUT3R source competence.
+
+This additive version-2 layer keeps the existing CUT3R comparison lock and stable
+``SourceProviderCompetenceReportV1``. It proves that candidate and baseline
+metrics use identical frozen support, restricts the source-mean proper score to
+one arm-neutral fixed scale, and adds paired seam, drift, association, identity,
+and support decisions. Target access remains forbidden.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from ._cut3r_source_competence_v2_common import (
+    PROPER_SCORE_SEMANTICS,
+    RECORDS_SCHEMA,
+)
+from ._cut3r_source_competence_v2_lock import (
+    build_cut3r_source_competence_v2_lock,
+    validate_cut3r_source_competence_v2_lock,
+)
+from ._cut3r_source_competence_v2_report import (
+    build_cut3r_source_competence_v2_report,
+    source_competence_gates_v2,
+    validate_cut3r_source_competence_v2_report,
+)
+from ._cut3r_source_competence_v2_records import _normalize_v2_records
+from .cut3r_comparison import load_cut3r_comparison_lock
+from .cut3r_source_competence import (
+    _publish_json,
+    _strict_json,
+    build_cut3r_source_competence_report,
+    load_cut3r_source_competence_lock,
+    write_cut3r_source_competence_report,
+)
+
+
+def write_cut3r_source_competence_v2_lock(
+    comparison_lock: Any,
+    source_competence_lock: Any,
+    path: str | Path,
+    lock: Mapping[str, Any],
+) -> dict[str, Any]:
+    payload = validate_cut3r_source_competence_v2_lock(
+        comparison_lock,
+        source_competence_lock,
+        lock,
+    )
+    return _publish_json(
+        path,
+        payload,
+        load_existing=lambda existing: load_cut3r_source_competence_v2_lock(
+            comparison_lock,
+            source_competence_lock,
+            existing,
+        ),
+    )
+
+
+def load_cut3r_source_competence_v2_lock(
+    comparison_lock: Any,
+    source_competence_lock: Any,
+    path: str | Path,
+) -> dict[str, Any]:
+    return validate_cut3r_source_competence_v2_lock(
+        comparison_lock,
+        source_competence_lock,
+        _strict_json(path),
+    )
+
+
+def write_cut3r_source_competence_v2_report(
+    comparison_lock: Any,
+    source_competence_lock: Any,
+    common_support_lock: Any,
+    records: Any,
+    path: str | Path,
+    report: Mapping[str, Any],
+) -> dict[str, Any]:
+    payload = validate_cut3r_source_competence_v2_report(
+        comparison_lock,
+        source_competence_lock,
+        common_support_lock,
+        records,
+        report,
+    )
+    return _publish_json(
+        path,
+        payload,
+        load_existing=lambda existing: load_cut3r_source_competence_v2_report(
+            comparison_lock,
+            source_competence_lock,
+            common_support_lock,
+            records,
+            existing,
+        ),
+    )
+
+
+def load_cut3r_source_competence_v2_report(
+    comparison_lock: Any,
+    source_competence_lock: Any,
+    common_support_lock: Any,
+    records: Any,
+    path: str | Path,
+) -> dict[str, Any]:
+    return validate_cut3r_source_competence_v2_report(
+        comparison_lock,
+        source_competence_lock,
+        common_support_lock,
+        records,
+        _strict_json(path),
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    freeze = commands.add_parser("freeze")
+    freeze.add_argument("comparison_lock")
+    freeze.add_argument("source_competence_lock")
+    freeze.add_argument("specification")
+    freeze.add_argument("--output", required=True)
+    verify_lock = commands.add_parser("verify-lock")
+    verify_lock.add_argument("comparison_lock")
+    verify_lock.add_argument("source_competence_lock")
+    verify_lock.add_argument("common_support_lock")
+    report = commands.add_parser("report")
+    report.add_argument("comparison_lock")
+    report.add_argument("source_competence_lock")
+    report.add_argument("common_support_lock")
+    report.add_argument("records")
+    report.add_argument("--output", required=True)
+    report.add_argument("--v1-output")
+    report.add_argument("--require-pass", action="store_true")
+    verify_report = commands.add_parser("verify-report")
+    verify_report.add_argument("comparison_lock")
+    verify_report.add_argument("source_competence_lock")
+    verify_report.add_argument("common_support_lock")
+    verify_report.add_argument("records")
+    verify_report.add_argument("report")
+    verify_report.add_argument("--require-pass", action="store_true")
+    gates = commands.add_parser("gates")
+    gates.add_argument("comparison_lock")
+    gates.add_argument("source_competence_lock")
+    gates.add_argument("common_support_lock")
+    gates.add_argument("records")
+    gates.add_argument("report")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _parser().parse_args(argv)
+    comparison = load_cut3r_comparison_lock(arguments.comparison_lock)
+    source_lock = load_cut3r_source_competence_lock(
+        comparison,
+        arguments.source_competence_lock,
+    )
+    if arguments.command == "freeze":
+        lock = build_cut3r_source_competence_v2_lock(
+            comparison,
+            source_lock,
+            _strict_json(arguments.specification),
+        )
+        write_cut3r_source_competence_v2_lock(
+            comparison,
+            source_lock,
+            arguments.output,
+            lock,
+        )
+        print(lock["common_support_lock_id"])
+        return 0
+    v2_lock = load_cut3r_source_competence_v2_lock(
+        comparison,
+        source_lock,
+        arguments.common_support_lock,
+    )
+    if arguments.command == "verify-lock":
+        print(v2_lock["common_support_lock_id"])
+        return 0
+    records = _strict_json(arguments.records)
+    if arguments.command == "report":
+        report = build_cut3r_source_competence_v2_report(
+            comparison,
+            source_lock,
+            v2_lock,
+            records,
+        )
+        write_cut3r_source_competence_v2_report(
+            comparison,
+            source_lock,
+            v2_lock,
+            records,
+            arguments.output,
+            report,
+        )
+        if arguments.v1_output:
+            _, v1_records = _normalize_v2_records(
+                comparison,
+                source_lock,
+                v2_lock,
+                records,
+            )
+            v1_report = build_cut3r_source_competence_report(
+                comparison,
+                source_lock,
+                v1_records,
+            )
+            write_cut3r_source_competence_report(
+                comparison,
+                source_lock,
+                v1_records,
+                arguments.v1_output,
+                v1_report,
+            )
+        print(report["source_competence_report_v2_id"])
+        return 0 if report["source_competence_pass"] or not arguments.require_pass else 3
+    report = load_cut3r_source_competence_v2_report(
+        comparison,
+        source_lock,
+        v2_lock,
+        records,
+        arguments.report,
+    )
+    if arguments.command == "verify-report":
+        print(report["source_competence_report_v2_id"])
+        return 0 if report["source_competence_pass"] or not arguments.require_pass else 3
+    mean_gate, identity_gate = source_competence_gates_v2(report)
+    print(
+        json.dumps(
+            {
+                "source_mean": mean_gate.to_dict(),
+                "identity_reliability": identity_gate.to_dict(),
+            },
+            sort_keys=True,
+            allow_nan=False,
+        )
+    )
+    return 0
+
+
+# Compatibility names used by the checked-in v2 tests and documentation.
+CUT3R_SOURCE_COMPETENCE_V2_PROPER_SCORE_SEMANTICS = PROPER_SCORE_SEMANTICS
+CUT3R_SOURCE_COMPETENCE_V2_RECORDS_SCHEMA = RECORDS_SCHEMA
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/prob4d/cut3r_source_competence_v2.py
+++ b/src/prob4d/cut3r_source_competence_v2.py
@@ -23,12 +23,12 @@ from ._cut3r_source_competence_v2_lock import (
     build_cut3r_source_competence_v2_lock,
     validate_cut3r_source_competence_v2_lock,
 )
+from ._cut3r_source_competence_v2_records import _normalize_v2_records
 from ._cut3r_source_competence_v2_report import (
     build_cut3r_source_competence_v2_report,
     source_competence_gates_v2,
     validate_cut3r_source_competence_v2_report,
 )
-from ._cut3r_source_competence_v2_records import _normalize_v2_records
 from .cut3r_comparison import load_cut3r_comparison_lock
 from .cut3r_source_competence import (
     _publish_json,

--- a/tests/test_cut3r_source_competence_v2.py
+++ b/tests/test_cut3r_source_competence_v2.py
@@ -1,0 +1,489 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from prob4d.cut3r_comparison import build_cut3r_comparison_lock
+from prob4d.cut3r_source_competence import build_cut3r_source_competence_lock
+from prob4d.cut3r_source_competence_v2 import (
+    CUT3R_SOURCE_COMPETENCE_V2_PROPER_SCORE_SEMANTICS,
+    CUT3R_SOURCE_COMPETENCE_V2_RECORDS_SCHEMA,
+    build_cut3r_source_competence_v2_lock,
+    build_cut3r_source_competence_v2_report,
+    source_competence_gates_v2,
+    validate_cut3r_source_competence_v2_report,
+    write_cut3r_source_competence_v2_lock,
+    write_cut3r_source_competence_v2_report,
+)
+
+
+def _case(case_id: str, digest_character: str) -> dict[str, object]:
+    return {
+        "case_id": case_id,
+        "input_video_sha256": digest_character * 64,
+        "input_video_byte_count": 100,
+        "frame_start": 0,
+        "frame_stop_exclusive": 2,
+        "evaluation_frame_start": 0,
+        "evaluation_frame_stop_exclusive": 2,
+    }
+
+
+def _comparison() -> dict[str, object]:
+    return build_cut3r_comparison_lock(
+        {
+            "protocol_name": "common-support-test-v2",
+            "provider_revision": "a" * 40,
+            "checkpoint_sha256": "b" * 64,
+            "prob4d_revision": "c" * 40,
+            "prob4d_distribution_sha256": "d" * 64,
+            "window_size": 2,
+            "overlap": 1,
+            "confidence_threshold": 1.0,
+            "storage_dtype": "float32",
+            "random_seeds": [7, 11],
+            "groups": [
+                {"group_id": "dev", "cases": [_case("dev-case", "1")]},
+                {"group_id": "cal", "cases": [_case("cal-case", "2")]},
+                {
+                    "group_id": "source-a",
+                    "cases": [_case("source-a-case", "3")],
+                },
+                {
+                    "group_id": "source-b",
+                    "cases": [_case("source-b-case", "4")],
+                },
+            ],
+            "group_roles": {
+                "development": ["dev"],
+                "calibration": ["cal"],
+                "source_evaluation": ["source-a", "source-b"],
+            },
+            "include_revisit_diagnostic": False,
+        }
+    )
+
+
+def _source_policy(**overrides: object) -> dict[str, object]:
+    result: dict[str, object] = {
+        "minimum_evaluable_groups": 2,
+        "maximum_technical_failures": 0,
+        "permitted_technical_failure_codes": [],
+        "maximum_mean_proper_score_delta": 0.0,
+        "maximum_mean_point_rmse_ratio": 1.0,
+        "maximum_mean_endpoint_rmse_ratio": 1.0,
+        "maximum_worst_group_point_rmse_ratio": 1.2,
+        "maximum_mean_absolute_drift_slope_m_per_frame": 0.01,
+        "maximum_mean_seam_rmse_m": 0.02,
+        "minimum_mean_quality_group_pass_fraction": 1.0,
+        "minimum_mean_association_precision": 0.7,
+        "minimum_mean_identity_retention": 0.7,
+        "minimum_mean_support_retention": 0.7,
+        "minimum_identity_group_pass_fraction": 1.0,
+    }
+    result.update(overrides)
+    return result
+
+
+def _source_lock(
+    comparison: dict[str, object],
+    **policy_overrides: object,
+) -> dict[str, object]:
+    return build_cut3r_source_competence_lock(
+        comparison,
+        {
+            "contrast_id": "prob4d-fusion-value",
+            "candidate_provider_manifest_id": "e" * 64,
+            "baseline_provider_manifest_id": "f" * 64,
+            "cohort_binding_id": "1" * 64,
+            "group_definition": "complete-object-v2-test",
+            "record_definition_sha256": "2" * 64,
+            "policy": _source_policy(**policy_overrides),
+        },
+    )
+
+
+def _paired_policy(**overrides: object) -> dict[str, object]:
+    result: dict[str, object] = {
+        "maximum_mean_seam_rmse_ratio": 1.0,
+        "maximum_worst_group_seam_rmse_ratio": 1.2,
+        "maximum_mean_absolute_drift_slope_ratio": 1.0,
+        "maximum_worst_group_absolute_drift_slope_ratio": 1.2,
+        "minimum_mean_association_precision_delta": -0.02,
+        "minimum_worst_group_association_precision_delta": -0.05,
+        "minimum_mean_identity_retention_delta": -0.02,
+        "minimum_worst_group_identity_retention_delta": -0.05,
+        "minimum_mean_support_retention_delta": -0.02,
+        "minimum_worst_group_support_retention_delta": -0.05,
+        "minimum_paired_quality_group_pass_fraction": 1.0,
+        "minimum_paired_identity_group_pass_fraction": 1.0,
+    }
+    result.update(overrides)
+    return result
+
+
+def _v2_lock(
+    comparison: dict[str, object],
+    source_lock: dict[str, object],
+    **paired_overrides: object,
+) -> dict[str, object]:
+    return build_cut3r_source_competence_v2_lock(
+        comparison,
+        source_lock,
+        {
+            "source_competence_policy": source_lock["policy"],
+            "common_support_definition_sha256": "3" * 64,
+            "proper_score_semantics": (
+                CUT3R_SOURCE_COMPETENCE_V2_PROPER_SCORE_SEMANTICS
+            ),
+            "paired_policy": _paired_policy(**paired_overrides),
+            "require_complete_source_roster": True,
+        },
+    )
+
+
+def _metric_support(frame: int) -> dict[str, object]:
+    return {
+        "point_support_sha256": ("4" if frame == 0 else "5") * 64,
+        "point_support_count": 8,
+        "endpoint_support_sha256": ("6" if frame == 0 else "7") * 64,
+        "endpoint_support_count": 1,
+        "proper_score_support_sha256": ("8" if frame == 0 else "9") * 64,
+        "proper_score_dimension": 24,
+        "proper_score_semantics": (
+            CUT3R_SOURCE_COMPETENCE_V2_PROPER_SCORE_SEMANTICS
+        ),
+        "seam_support_sha256": "a" * 64 if frame == 0 else None,
+        "seam_support_count": 4 if frame == 0 else 0,
+    }
+
+
+def _record(
+    group: str,
+    case: str,
+    frame: int,
+    seed: int,
+    arm: str,
+) -> dict[str, object]:
+    candidate = arm == "restarted-prob4d-fused"
+    return {
+        "group_id": group,
+        "case_id": case,
+        "frame_index": frame,
+        "random_seed": seed,
+        "arm_id": arm,
+        "point_error_m": 0.8 if candidate else 1.0,
+        "endpoint_error_m": 0.7 if candidate else 1.0,
+        "proper_score": 8.0 if candidate else 10.0,
+        "seam_error_m": 0.01 if frame == 0 else None,
+        "association_correct_count": 9 if candidate else 8,
+        "association_predicted_count": 10,
+        "identity_retained_count": 9 if candidate else 8,
+        "identity_reference_count": 10,
+        "support_retained_count": 9 if candidate else 8,
+        "support_reference_count": 10,
+        "metric_support": _metric_support(frame),
+    }
+
+
+def _records(
+    comparison: dict[str, object],
+    source_lock: dict[str, object],
+    v2_lock: dict[str, object],
+) -> dict[str, object]:
+    rows = []
+    for group, case in (
+        ("source-a", "source-a-case"),
+        ("source-b", "source-b-case"),
+    ):
+        for frame in range(2):
+            for seed in (7, 11):
+                for arm in ("restarted-prob4d-fused", "restarted-newest"):
+                    rows.append(_record(group, case, frame, seed, arm))
+    return {
+        "schema": CUT3R_SOURCE_COMPETENCE_V2_RECORDS_SCHEMA,
+        "schema_version": 2,
+        "comparison_lock_id": comparison["lock_id"],
+        "source_competence_lock_id": source_lock["source_competence_lock_id"],
+        "common_support_lock_id": v2_lock["common_support_lock_id"],
+        "record_definition_sha256": source_lock["record_definition_sha256"],
+        "common_support_definition_sha256": v2_lock[
+            "common_support_definition_sha256"
+        ],
+        "source_truth_used": True,
+        "target_payloads_opened": False,
+        "target_outcomes_opened": False,
+        "group_failures": [],
+        "records": rows,
+    }
+
+
+def _setup() -> tuple[
+    dict[str, object],
+    dict[str, object],
+    dict[str, object],
+    dict[str, object],
+]:
+    comparison = _comparison()
+    source_lock = _source_lock(comparison)
+    v2_lock = _v2_lock(comparison, source_lock)
+    return comparison, source_lock, v2_lock, _records(comparison, source_lock, v2_lock)
+
+
+def test_common_support_records_build_passing_paired_report() -> None:
+    comparison, source_lock, v2_lock, records = _setup()
+
+    report = build_cut3r_source_competence_v2_report(
+        comparison,
+        source_lock,
+        v2_lock,
+        records,
+    )
+
+    assert report["source_competence_pass"]
+    assert report["mean_quality_status"] == "pass"
+    assert report["identity_reliability_status"] == "pass"
+    assert report["aggregate"]["mean_seam_rmse_ratio"] == pytest.approx(1.0)
+    assert report["groups"][0]["candidate"]["association_precision"] == pytest.approx(
+        0.9
+    )
+    assert report["groups"][0]["baseline"]["association_precision"] == pytest.approx(
+        0.8
+    )
+    assert report["v1_report"]["source_competence_pass"]
+
+
+def test_point_support_mismatch_fails_before_scoring() -> None:
+    comparison, source_lock, v2_lock, records = _setup()
+    baseline = next(
+        row
+        for row in records["records"]
+        if row["arm_id"] == "restarted-newest"
+    )
+    baseline["metric_support"]["point_support_sha256"] = "b" * 64
+
+    with pytest.raises(ValueError, match="different exact metric support"):
+        build_cut3r_source_competence_v2_report(
+            comparison,
+            source_lock,
+            v2_lock,
+            records,
+        )
+
+
+def test_proper_score_dimension_mismatch_fails_before_scoring() -> None:
+    comparison, source_lock, v2_lock, records = _setup()
+    baseline = next(
+        row
+        for row in records["records"]
+        if row["arm_id"] == "restarted-newest"
+    )
+    baseline["metric_support"]["proper_score_dimension"] = 21
+
+    with pytest.raises(ValueError, match="different exact metric support"):
+        build_cut3r_source_competence_v2_report(
+            comparison,
+            source_lock,
+            v2_lock,
+            records,
+        )
+
+
+def test_arm_specific_proper_score_semantics_are_rejected() -> None:
+    comparison, source_lock, v2_lock, records = _setup()
+    records["records"][0]["metric_support"]["proper_score_semantics"] = (
+        "arm-specific-predicted-covariance-v1"
+    )
+
+    with pytest.raises(ValueError, match="arm-neutral fixed-scale semantics"):
+        build_cut3r_source_competence_v2_report(
+            comparison,
+            source_lock,
+            v2_lock,
+            records,
+        )
+
+
+def test_absent_seam_requires_zero_count_and_null_digest() -> None:
+    comparison, source_lock, v2_lock, records = _setup()
+    row = next(item for item in records["records"] if item["frame_index"] == 1)
+    row["metric_support"]["seam_support_sha256"] = "b" * 64
+
+    with pytest.raises(ValueError, match="zero count and null digest"):
+        build_cut3r_source_competence_v2_report(
+            comparison,
+            source_lock,
+            v2_lock,
+            records,
+        )
+
+
+def test_paired_seam_regression_fails_even_when_v1_absolute_gate_passes() -> None:
+    comparison, source_lock, v2_lock, records = _setup()
+    for row in records["records"]:
+        if row["arm_id"] == "restarted-prob4d-fused" and row["frame_index"] == 0:
+            row["seam_error_m"] = 0.019
+
+    report = build_cut3r_source_competence_v2_report(
+        comparison,
+        source_lock,
+        v2_lock,
+        records,
+    )
+
+    assert report["v1_report"]["mean_quality_status"] == "pass"
+    assert report["mean_quality_status"] == "fail"
+    assert "mean-seam-rmse-ratio-exceeded" in report["mean_quality_reasons"]
+    assert not report["source_competence_pass"]
+
+
+def test_paired_identity_regression_fails_after_mean_pass() -> None:
+    comparison, source_lock, v2_lock, records = _setup()
+    for row in records["records"]:
+        if row["arm_id"] == "restarted-prob4d-fused":
+            row["association_correct_count"] = 7
+            row["identity_retained_count"] = 7
+            row["support_retained_count"] = 7
+        else:
+            row["association_correct_count"] = 9
+            row["identity_retained_count"] = 9
+            row["support_retained_count"] = 9
+
+    report = build_cut3r_source_competence_v2_report(
+        comparison,
+        source_lock,
+        v2_lock,
+        records,
+    )
+
+    assert report["v1_report"]["identity_reliability_status"] == "pass"
+    assert report["mean_quality_status"] == "pass"
+    assert report["identity_reliability_status"] == "fail"
+    assert "mean-identity-retention-delta-below-minimum" in report[
+        "identity_reliability_reasons"
+    ]
+
+
+def test_complete_roster_lock_rejects_permissive_v1_policy() -> None:
+    comparison = _comparison()
+    source_lock = _source_lock(
+        comparison,
+        minimum_evaluable_groups=1,
+        maximum_technical_failures=1,
+        permitted_technical_failure_codes=["gpu-oom"],
+    )
+
+    with pytest.raises(ValueError, match="complete source roster requires"):
+        _v2_lock(comparison, source_lock)
+
+
+def test_target_opening_is_rejected() -> None:
+    comparison, source_lock, v2_lock, records = _setup()
+    records["target_outcomes_opened"] = True
+
+    with pytest.raises(ValueError, match="may not open target outcomes"):
+        build_cut3r_source_competence_v2_report(
+            comparison,
+            source_lock,
+            v2_lock,
+            records,
+        )
+
+
+def test_readiness_adapter_does_not_evaluate_identity_after_mean_failure() -> None:
+    comparison, source_lock, v2_lock, records = _setup()
+    for row in records["records"]:
+        if row["arm_id"] == "restarted-prob4d-fused" and row["frame_index"] == 0:
+            row["seam_error_m"] = 0.019
+    report = build_cut3r_source_competence_v2_report(
+        comparison,
+        source_lock,
+        v2_lock,
+        records,
+    )
+
+    mean_gate, identity_gate = source_competence_gates_v2(report)
+
+    assert mean_gate.status == "fail"
+    assert identity_gate.status == "not-evaluated"
+    assert identity_gate.evidence_id is None
+
+
+def test_readiness_adapter_rejects_report_identity_tampering() -> None:
+    comparison, source_lock, v2_lock, records = _setup()
+    report = build_cut3r_source_competence_v2_report(
+        comparison,
+        source_lock,
+        v2_lock,
+        records,
+    )
+    report["aggregate"]["mean_seam_rmse_ratio"] = 0.5
+
+    with pytest.raises(ValueError, match="content identity changed"):
+        source_competence_gates_v2(report)
+
+
+def test_report_replay_rejects_tampering() -> None:
+    comparison, source_lock, v2_lock, records = _setup()
+    report = build_cut3r_source_competence_v2_report(
+        comparison,
+        source_lock,
+        v2_lock,
+        records,
+    )
+    tampered = deepcopy(report)
+    tampered["aggregate"]["mean_seam_rmse_ratio"] = 0.5
+
+    with pytest.raises(ValueError, match="does not match the bound records"):
+        validate_cut3r_source_competence_v2_report(
+            comparison,
+            source_lock,
+            v2_lock,
+            records,
+            tampered,
+        )
+
+
+def test_identical_lock_and_report_publication_is_idempotent(tmp_path) -> None:
+    comparison, source_lock, v2_lock, records = _setup()
+    report = build_cut3r_source_competence_v2_report(
+        comparison,
+        source_lock,
+        v2_lock,
+        records,
+    )
+    lock_path = tmp_path / "common-support-lock.json"
+    report_path = tmp_path / "source-competence-v2.json"
+
+    write_cut3r_source_competence_v2_lock(
+        comparison,
+        source_lock,
+        lock_path,
+        v2_lock,
+    )
+    write_cut3r_source_competence_v2_lock(
+        comparison,
+        source_lock,
+        lock_path,
+        v2_lock,
+    )
+    write_cut3r_source_competence_v2_report(
+        comparison,
+        source_lock,
+        v2_lock,
+        records,
+        report_path,
+        report,
+    )
+    write_cut3r_source_competence_v2_report(
+        comparison,
+        source_lock,
+        v2_lock,
+        records,
+        report_path,
+        report,
+    )
+
+    assert lock_path.is_file()
+    assert report_path.is_file()


### PR DESCRIPTION
## Summary

Add an additive CUT3R source-competence v2 layer before the frozen Deform360 source execution:

- bind point, endpoint, proper-score, and seam support by exact canonical SHA-256 identity and count/dimension for every paired `(group, case, frame, seed)` record;
- reject candidate/baseline scoring on shifted, filtered, reordered, or otherwise different support before aggregation;
- require the source-mean proper score to use one arm-neutral fixed scale, leaving arm-specific covariance quality to the later covariance-localization gate;
- retain both-arm seam, drift, association precision, identity retention, and support retention, with paired group and aggregate decisions;
- embed and preserve the stable `SourceProviderCompetenceReportV1` result and hierarchical complete-group weighting;
- emit content-verified source-mean and identity/reliability readiness gates, leaving identity `not-evaluated` after a mean failure;
- retain valid negative reports before exit status 3; and
- freeze the Deform360 policy to all four source-evaluation object sessions with zero technical failures and no confirmation or target access.

## Frozen Deform360 boundary

The additive protocol keeps the existing CUT3R comparison, provider identity, camera panel, causal prefixes, windows, seeds, and source/confirmation split unchanged. It binds the four independent source-evaluation groups:

- `036-napkin-cloth-episode-0009`;
- `058-roll-napkin-episode-0001`;
- `152-slime-episode-0008`; and
- `198-kneepad-cloth-episode-0002`.

Frames, cameras, seeds, points, and support rows remain nested observations. The twelve confirmation object sessions remain closed.

## Paired policy

The checked-in Deform360 v2 policy requires:

- `4/4` evaluable source groups and zero technical failures;
- no mean point, endpoint, or arm-neutral fixed-scale proper-score regression;
- no mean seam or drift regression and at most 20% worst-group regression;
- mean association, identity, and support loss no worse than 0.02;
- worst-group loss no worse than 0.05; and
- at least `3/4` groups passing each paired endpoint family.

The common-support definition separately specifies canonical row identifiers and keeps full-reference deployment error and selective risk–coverage as diagnostics that cannot replace or rescue the primary common-support contrast.

## Exact-head validation

Final reviewed head: `f6903813c88bb739f5ad21948c08de8a3b67e438`.

The branch is two commits ahead of current `main`, zero behind, and changes exactly twelve intended paths. The second commit applies only Ruff's canonical import order.

All exact-head pull-request workflows pass:

- **Tests**: complete suites on Python 3.10, 3.11, 3.12, 3.13, and 3.14; the declared Python/NumPy runtime floor; repository, provider, release, public-API, and distribution contracts; wheel and source-distribution build/install smoke tests;
- **Fail-closed quality**: authoritative Ruff, documentation-surface validation, additive compatibility and CUT3R protocol replay, and strict MyPy;
- **Provider batch preflight**; and
- **Security scanning**: runtime dependency audit and CodeQL for Python and Actions.

Focused development validation also covered passing common-support replay, exact point/proper-score support mismatch rejection, arm-specific score-semantics rejection, seam-support consistency, a paired seam regression that v1 alone would admit, paired identity regressions, target-access rejection, valid-negative readiness order, content-ID tampering, strict report replay, and idempotent no-clobber publication.

## Scientific boundary

This PR does not execute CUT3R, read source residuals or scores, open confirmation or target payloads, fit a new provider/covariance model, change production estimator semantics, authorize BayesianPhysTwin or Causal4D use, establish deployment safety, or establish state of the art. It closes the last paired-support and endpoint-definition gap before the already-frozen source execution.

Refs #49