### PR TITLE
Fix CUT3R camera-ray and depth semantics

### DIFF
--- a/CHANGELOG.d/cut3r-camera-geometry.md
+++ b/CHANGELOG.d/cut3r-camera-geometry.md
@@ -1,0 +1,17 @@
+### Fixed
+
+- The recurrent-online CUT3R importer now preserves camera-origin unit viewing
+  rays in the sequence-local frame instead of forcing downstream covariance code
+  to infer rays from the arbitrary common-frame origin.
+- Added a fail-closed camera-relative depth model that recovers one camera centre
+  per frame from the imported points and rays and uses translation-invariant
+  camera-to-point range for anisotropic uncertainty.
+- CUT3R dense-memory limits now include the retained ray field, while manifest
+  metadata reports legacy point/mask/index bytes, ray bytes, and their total
+  separately.
+
+### Scientific boundary
+
+This corrects provider geometry and uncertainty-coordinate semantics. It opens no
+source residual, target outcome, calibration, BayesianPhysTwin update, or
+Causal4D result and does not establish provider competence or downstream benefit.

--- a/docs/cut3r-online-provider.md
+++ b/docs/cut3r-online-provider.md
@@ -46,7 +46,68 @@ For depth `z` at pixel `(u, v)`, the adapter backprojects the pixel with the
 stored intrinsics and applies the camera-to-common-frame pose. Invalid depth,
 non-finite confidence, nonpositive depth, and confidence below the frozen
 threshold are excluded from the canonical support mask. The confidence threshold
-is a support rule, not calibrated source reliability.
+is a support rule, not calibrated source reliability. The exact confidence files
+remain part of the source-bundle identity and must be retained for any later
+source-only reliability or heteroscedastic-covariance study.
+
+## Camera-ray and depth semantics
+
+A point in the CUT3R common frame is
+
+```text
+p_common = R_camera_to_common (z K^-1 [u, v, 1]) + t_camera_to_common.
+```
+
+The corresponding viewing direction is not generally
+`p_common / ||p_common||`, because the common-frame origin is arbitrary and the
+camera translation can be nonzero. The adapter therefore exports the true unit
+ray
+
+```text
+r_common =
+    normalize(R_camera_to_common K^-1 [u, v, 1]).
+```
+
+Camera translation changes the common-frame point but not this direction. The
+portable prediction window records these vectors as `ray_directions`, the
+provider payload declares `has_ray_directions=true`, and the manifest uses the
+provider-neutral ray semantic
+`camera-ray-unit-vector`. Its metadata binds the stricter frame declaration
+
+```text
+camera-origin-unit-rays-in-sequence-local-frame-v1
+```
+
+so downstream code cannot reinterpret the vectors as common-origin directions
+or replace them with a world-origin fallback.
+
+Depth-conditioned covariance must likewise use camera-relative range rather than
+`||p_common||`. `prob4d.cut3r_camera_geometry` recovers one camera centre per
+frame from the common-frame points and rays and supplies
+`CameraRelativeDepthDisagreementModel`. Its range and anisotropic covariance are
+invariant to a rigid translation of the complete common frame. Recovery fails
+closed when rays are absent, geometrically inconsistent, or too degenerate to
+identify a camera centre.
+
+```python
+from prob4d.cut3r_camera_geometry import (
+    CameraRelativeDepthDisagreementModel,
+    recover_camera_relative_geometry,
+)
+from prob4d.data import PredictionWindow
+
+window = PredictionWindow.from_npz(
+    "outputs/provider/payloads/sequence-cut3r-online.npz",
+    dense_storage_dtype="float32",
+)
+geometry = recover_camera_relative_geometry(window)
+model = CameraRelativeDepthDisagreementModel()
+conditional_covariance = model.predict(window)
+```
+
+This model is an additive source-side correction. It does not by itself promote
+CUT3R, replace the ordered provider-readiness gates, or establish calibrated
+target uncertainty.
 
 ## Import
 
@@ -70,12 +131,13 @@ The importer:
 2. hashes every depth, confidence, and camera member while checking that it does
    not change during reading;
 3. rechecks the complete source tree after canonical loading;
-4. writes one immutable versioned `PredictionWindow` payload;
+4. writes one immutable versioned `PredictionWindow` payload containing the
+   common-frame point map, support mask, and true common-frame camera rays;
 5. records frame `i` as depending on the complete source prefix ending at
    `i + 1` exclusively;
 6. binds the CUT3R code revision, checkpoint, input video, source bundle, the
-   complete adapter implementation-set digest, threshold, and output payload into
-   content identities; and
+   complete adapter implementation-set digest, threshold, ray semantics, and
+   output payload into content identities; and
 7. immediately reopens and verifies the published provider manifest.
 
 The canonical coordinate declaration is `sequence-local-sim3`. Even when an
@@ -85,12 +147,13 @@ claim without an independently calibrated metric anchor.
 ## Bounded-memory canonicalization
 
 The adapter reads depth and confidence members through read-only NumPy memory
-maps, reconstructs one frame at a time, and writes the canonical point map and
-support mask into temporary NPY memory maps. It no longer retains a Python list
-of every reconstructed frame, performs a sequence-wide dense `stack`, or asks the
-ordinary `PredictionWindow` constructor to copy the complete sequence before NPZ
-publication. The portable NPZ schema and provider-manifest semantics are
-unchanged.
+maps, reconstructs one frame at a time, and writes the canonical point map,
+camera rays, and support mask into temporary NPY memory maps. It does not retain
+a Python list of every reconstructed frame, perform a sequence-wide dense
+`stack`, or ask the ordinary `PredictionWindow` constructor to copy the complete
+sequence before NPZ publication. The existing portable NPZ schema already
+supports optional ray directions, so no prediction-window schema migration is
+required.
 
 Imports fail closed before large allocations when any configured budget is
 exceeded. The defaults are:
@@ -100,25 +163,25 @@ exceeded. The defaults are:
 - `--max-width 4096`;
 - `--max-source-bytes 137438953472` (128 GiB); and
 - `--max-dense-bytes 137438953472` (128 GiB of uncompressed frame indices,
-  point-map values, and support-mask values).
+  point-map values, camera-ray values, and support-mask values).
 
 Use smaller values in automated ingestion environments. Raising a limit only
 permits a larger import; it does not alter the reconstructed values, confidence
 threshold, causal lineage, statistical dependence declarations, or scientific
-readiness decision. The manifest records the actual source-member and dense-array
-byte counts together with `canonicalization_backend="frame-streamed-npy-memmap-v1"`.
+readiness decision. The manifest separately records the historical
+point/mask/index byte count, the camera-ray byte count, and their total.
 
 ## Scientific progression
 
-A valid import proves byte-level interoperability and declared causal lineage
-only. The next order is:
+A valid import proves byte-level interoperability, declared causal lineage, and
+correct camera-origin ray geometry only. The next order is:
 
 1. freeze and run provider support feasibility before opening source residuals;
 2. evaluate source mean quality and identity competence by complete physical
    object or acquisition session;
 3. localize gauge/dependence and conditional point-covariance failures;
-4. fit reliability or uncertainty only when the corresponding source gate
-   authorizes it; and
+4. use camera-relative range and retained source confidence only if the ordered
+   source gates authorize uncertainty or reliability development; and
 5. permit one held-out target evaluation only after the complete fresh-provider
    readiness decision passes.
 

--- a/src/prob4d/_cut3r_limits.py
+++ b/src/prob4d/_cut3r_limits.py
@@ -155,9 +155,7 @@ def _dense_vector_byte_count(
     width: int,
     storage_dtype: DenseStorageDType,
 ) -> int:
-    dense_itemsize = np.dtype(
-        np.float32 if storage_dtype == "float32" else np.float64
-    ).itemsize
+    dense_itemsize = np.dtype(np.float32 if storage_dtype == "float32" else np.float64).itemsize
     return frame_count * height * width * 3 * dense_itemsize
 
 

--- a/src/prob4d/_cut3r_limits.py
+++ b/src/prob4d/_cut3r_limits.py
@@ -92,7 +92,9 @@ def _unproject_world_points(
     intrinsics: np.ndarray,
     *,
     confidence_threshold: float,
-) -> tuple[np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Return common-frame points, true camera rays, and the support mask."""
+
     _validate_camera(pose, intrinsics)
 
     depth64 = np.asarray(depth, dtype=np.float64)
@@ -117,11 +119,46 @@ def _unproject_world_points(
         ).T.reshape(height, width, 3)
     except np.linalg.LinAlgError as error:
         raise ValueError("CUT3R camera intrinsics must be nonsingular") from error
+
+    camera_ray_norms = np.linalg.norm(camera_rays, axis=-1, keepdims=True)
+    if np.any(camera_ray_norms <= np.finfo(np.float64).eps):
+        raise ValueError("CUT3R intrinsics produced a zero viewing ray")
+    camera_ray_directions = camera_rays / camera_ray_norms
+
+    rotation = pose[:3, :3]
     camera_points = camera_rays * depth64[..., None]
-    world = np.einsum("ij,hwj->hwi", pose[:3, :3], camera_points) + pose[:3, 3]
+    world = np.einsum("ij,hwj->hwi", rotation, camera_points) + pose[:3, 3]
+    world_ray_directions = np.einsum(
+        "ij,hwj->hwi",
+        rotation,
+        camera_ray_directions,
+    )
+    world_ray_norms = np.linalg.norm(
+        world_ray_directions,
+        axis=-1,
+        keepdims=True,
+    )
+    if np.any(world_ray_norms <= np.finfo(np.float64).eps):
+        raise ValueError("CUT3R camera pose produced a zero common-frame ray")
+    world_ray_directions /= world_ray_norms
+
     valid &= np.all(np.isfinite(world), axis=-1)
+    valid &= np.all(np.isfinite(world_ray_directions), axis=-1)
     world[~valid] = 0.0
-    return world, valid
+    world_ray_directions[~valid] = 0.0
+    return world, world_ray_directions, valid
+
+
+def _dense_vector_byte_count(
+    frame_count: int,
+    height: int,
+    width: int,
+    storage_dtype: DenseStorageDType,
+) -> int:
+    dense_itemsize = np.dtype(
+        np.float32 if storage_dtype == "float32" else np.float64
+    ).itemsize
+    return frame_count * height * width * 3 * dense_itemsize
 
 
 def _dense_array_byte_count(
@@ -130,8 +167,12 @@ def _dense_array_byte_count(
     width: int,
     storage_dtype: DenseStorageDType,
 ) -> int:
-    dense_itemsize = np.dtype(np.float32 if storage_dtype == "float32" else np.float64).itemsize
-    point_bytes = frame_count * height * width * 3 * dense_itemsize
+    point_bytes = _dense_vector_byte_count(
+        frame_count,
+        height,
+        width,
+        storage_dtype,
+    )
     mask_bytes = frame_count * height * width * np.dtype(bool).itemsize
     frame_index_bytes = frame_count * np.dtype(np.int64).itemsize
     return point_bytes + mask_bytes + frame_index_bytes

--- a/src/prob4d/_cut3r_window.py
+++ b/src/prob4d/_cut3r_window.py
@@ -15,6 +15,7 @@ from ._atomic_file import publish_temporary_file
 from ._cut3r_limits import (
     Cut3RImportLimits,
     _dense_array_byte_count,
+    _dense_vector_byte_count,
     _unproject_world_points,
     _validated_grid_shape,
 )
@@ -60,6 +61,7 @@ def _canonical_window(
         tuple[_SourceMemberDescriptor, ...],
         int,
         int,
+        int,
     ]
 ]:
     depth_members, confidence_members, camera_members = _validated_source_members(root)
@@ -75,6 +77,7 @@ def _canonical_window(
 
     workspace = Path(tempfile.mkdtemp(prefix=".prob4d-cut3r-import."))
     point_writer: np.memmap | None = None
+    ray_writer: np.memmap | None = None
     mask_writer: np.memmap | None = None
     frame_writer: np.memmap | None = None
     read_only_maps: list[np.ndarray] = []
@@ -82,9 +85,11 @@ def _canonical_window(
         descriptors: list[_SourceMemberDescriptor] = []
         shape: tuple[int, int] | None = None
         dense_bytes = 0
+        ray_bytes = 0
         any_valid = False
         dense_dtype = np.float32 if storage_dtype == "float32" else np.float64
         point_path = workspace / "point_map.npy"
+        ray_path = workspace / "ray_directions.npy"
         mask_path = workspace / "valid_mask.npy"
         frame_path = workspace / "frame_indices.npy"
 
@@ -109,14 +114,27 @@ def _canonical_window(
                         shape[1],
                         storage_dtype,
                     )
-                    if dense_bytes > limits.max_dense_bytes:
+                    ray_bytes = _dense_vector_byte_count(
+                        frame_count,
+                        shape[0],
+                        shape[1],
+                        storage_dtype,
+                    )
+                    total_dense_bytes = dense_bytes + ray_bytes
+                    if total_dense_bytes > limits.max_dense_bytes:
                         raise ValueError(
                             "CUT3R dense array byte count "
-                            f"{dense_bytes} exceeds max_dense_bytes="
+                            f"{total_dense_bytes} exceeds max_dense_bytes="
                             f"{limits.max_dense_bytes}"
                         )
                     point_writer = np.lib.format.open_memmap(
                         point_path,
+                        mode="w+",
+                        dtype=dense_dtype,
+                        shape=(frame_count, shape[0], shape[1], 3),
+                    )
+                    ray_writer = np.lib.format.open_memmap(
+                        ray_path,
                         mode="w+",
                         dtype=dense_dtype,
                         shape=(frame_count, shape[0], shape[1], 3),
@@ -140,7 +158,7 @@ def _canonical_window(
                     )
 
                 pose, intrinsics, camera_descriptor = _load_camera(camera_members[index])
-                world, valid = _unproject_world_points(
+                world, world_rays, valid = _unproject_world_points(
                     depth,
                     confidence,
                     pose,
@@ -148,8 +166,10 @@ def _canonical_window(
                     confidence_threshold=confidence_threshold,
                 )
                 assert point_writer is not None
+                assert ray_writer is not None
                 assert mask_writer is not None
                 point_writer[index] = world
+                ray_writer[index] = world_rays
                 mask_writer[index] = valid
                 any_valid = any_valid or bool(np.any(valid))
                 descriptors.extend((depth_descriptor, confidence_descriptor, camera_descriptor))
@@ -161,12 +181,14 @@ def _canonical_window(
             raise ValueError("CUT3R output contains no point above the frozen support threshold")
         assert shape is not None
         assert point_writer is not None
+        assert ray_writer is not None
         assert mask_writer is not None
         assert frame_writer is not None
-        for active_writer in (point_writer, mask_writer, frame_writer):
+        for active_writer in (point_writer, ray_writer, mask_writer, frame_writer):
             active_writer.flush()
             _close_memmap(active_writer)
         point_writer = None
+        ray_writer = None
         mask_writer = None
         frame_writer = None
 
@@ -179,18 +201,31 @@ def _canonical_window(
 
         frame_indices = _load_read_only_npy(frame_path, name="frame indices")
         point_map = _load_read_only_npy(point_path, name="point map")
+        ray_directions = _load_read_only_npy(ray_path, name="ray directions")
         valid_mask = _load_read_only_npy(mask_path, name="valid mask")
-        read_only_maps.extend((frame_indices, point_map, valid_mask))
+        read_only_maps.extend((frame_indices, point_map, ray_directions, valid_mask))
         window = MMapPredictionWindow(
             window_id=window_id,
             frame_indices=frame_indices,
             point_map=point_map,
             valid_mask=valid_mask,
+            ray_directions=ray_directions,
             dense_storage_dtype=storage_dtype,
         )
-        yield window, tuple(descriptors), described_source_bytes, dense_bytes
+        yield (
+            window,
+            tuple(descriptors),
+            described_source_bytes,
+            dense_bytes,
+            ray_bytes,
+        )
     finally:
-        for pending_writer in (point_writer, mask_writer, frame_writer):
+        for pending_writer in (
+            point_writer,
+            ray_writer,
+            mask_writer,
+            frame_writer,
+        ):
             if pending_writer is not None:
                 _close_memmap(pending_writer)
         for value in read_only_maps:
@@ -199,6 +234,16 @@ def _canonical_window(
 
 
 def _windows_equal(first: PredictionWindow, second: PredictionWindow) -> bool:
+    rays_equal = (
+        first.ray_directions is not None
+        and second.ray_directions is not None
+        and np.allclose(
+            first.ray_directions,
+            second.ray_directions,
+            atol=5e-7,
+            rtol=5e-7,
+        )
+    )
     return (
         first.window_id == second.window_id
         and first.dense_storage_dtype == second.dense_storage_dtype
@@ -207,8 +252,7 @@ def _windows_equal(first: PredictionWindow, second: PredictionWindow) -> bool:
         and np.array_equal(first.valid_mask, second.valid_mask)
         and first.scene_flow is None
         and second.scene_flow is None
-        and first.ray_directions is None
-        and second.ray_directions is None
+        and rays_equal
     )
 
 

--- a/src/prob4d/cut3r_camera_geometry.py
+++ b/src/prob4d/cut3r_camera_geometry.py
@@ -1,0 +1,371 @@
+"""Translation-invariant camera geometry for CUT3R prediction windows.
+
+CUT3R stores points in one sequence-local common frame.  A viewing ray therefore
+must originate at the frame's camera centre, not at the arbitrary common-frame
+origin.  This module recovers each camera centre from the common-frame points and
+unit rays and uses the resulting camera-relative ranges for depth-aware
+uncertainty.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+
+import numpy as np
+
+from ._scientific_scalars import require_finite_real, require_genuine_integer
+from .data import PredictionWindow
+from .uncertainty import (
+    DepthDisagreementModel,
+    DisagreementEvidence,
+    StructuredCovariance,
+)
+
+CUT3R_CAMERA_GEOMETRY_SEMANTICS: Final = (
+    "common-frame-points-plus-camera-origin-unit-rays-v1"
+)
+CUT3R_CAMERA_GEOMETRY_CLAIM_BOUNDARY: Final = (
+    "Camera-centre recovery and translation-invariant range propagation establish "
+    "geometric semantics only. They do not establish CUT3R provider competence, "
+    "uncertainty calibration, BayesianPhysTwin benefit, Causal4D intervention "
+    "benefit, deployment safety, or state of the art."
+)
+
+
+def _immutable_float64(value: object) -> np.ndarray:
+    array = np.ascontiguousarray(value, dtype=np.float64)
+    payload = array.tobytes(order="C")
+    return np.frombuffer(payload, dtype=np.float64).reshape(array.shape)
+
+
+@dataclass(frozen=True, slots=True)
+class CameraRelativeGeometryV1:
+    """Recovered camera centres and ranges for one prediction window."""
+
+    camera_centers_local: np.ndarray
+    range_local: np.ndarray
+    frame_condition_numbers: tuple[float, ...]
+    frame_max_perpendicular_residual_local: tuple[float, ...]
+
+    def __post_init__(self) -> None:
+        centers = np.asarray(self.camera_centers_local, dtype=np.float64)
+        ranges = np.asarray(self.range_local, dtype=np.float64)
+        if centers.ndim != 2 or centers.shape[1] != 3 or centers.shape[0] == 0:
+            raise ValueError("camera_centers_local must have nonempty shape (T, 3)")
+        if ranges.ndim != 3 or ranges.shape[0] != centers.shape[0]:
+            raise ValueError("range_local must have shape (T, H, W)")
+        if not np.all(np.isfinite(centers)) or not np.all(np.isfinite(ranges)):
+            raise ValueError("camera-relative geometry must be finite")
+        if np.any(ranges < 0.0):
+            raise ValueError("camera-relative ranges must be non-negative")
+        frame_count = centers.shape[0]
+        if len(self.frame_condition_numbers) != frame_count or len(
+            self.frame_max_perpendicular_residual_local
+        ) != frame_count:
+            raise ValueError("camera-relative frame diagnostics changed length")
+        conditions = tuple(
+            require_finite_real(
+                value,
+                name=f"frame_condition_numbers[{index}]",
+                minimum=1.0,
+            )
+            for index, value in enumerate(self.frame_condition_numbers)
+        )
+        residuals = tuple(
+            require_finite_real(
+                value,
+                name=f"frame_max_perpendicular_residual_local[{index}]",
+                minimum=0.0,
+            )
+            for index, value in enumerate(
+                self.frame_max_perpendicular_residual_local
+            )
+        )
+        object.__setattr__(self, "camera_centers_local", _immutable_float64(centers))
+        object.__setattr__(self, "range_local", _immutable_float64(ranges))
+        object.__setattr__(self, "frame_condition_numbers", conditions)
+        object.__setattr__(
+            self,
+            "frame_max_perpendicular_residual_local",
+            residuals,
+        )
+
+    @property
+    def frame_count(self) -> int:
+        return int(self.camera_centers_local.shape[0])
+
+    @property
+    def maximum_condition_number(self) -> float:
+        return max(self.frame_condition_numbers)
+
+    @property
+    def maximum_perpendicular_residual_local(self) -> float:
+        return max(self.frame_max_perpendicular_residual_local)
+
+    def summary(self) -> dict[str, object]:
+        return {
+            "semantics": CUT3R_CAMERA_GEOMETRY_SEMANTICS,
+            "frame_count": self.frame_count,
+            "maximum_condition_number": self.maximum_condition_number,
+            "maximum_perpendicular_residual_local": (
+                self.maximum_perpendicular_residual_local
+            ),
+            "claim_boundary": CUT3R_CAMERA_GEOMETRY_CLAIM_BOUNDARY,
+        }
+
+
+def _recover_frame_camera_geometry(
+    points: np.ndarray,
+    rays: np.ndarray,
+    *,
+    absolute_tolerance_local: float,
+    relative_tolerance: float,
+    maximum_condition_number: float,
+) -> tuple[np.ndarray, np.ndarray, float, float]:
+    if points.ndim != 2 or points.shape[1] != 3 or rays.shape != points.shape:
+        raise ValueError("camera geometry rows must have matching shape (N, 3)")
+    if points.shape[0] < 3:
+        raise ValueError("camera-centre recovery requires at least three valid rays")
+    if not np.all(np.isfinite(points)) or not np.all(np.isfinite(rays)):
+        raise ValueError("camera geometry rows must be finite")
+
+    ray_norms = np.linalg.norm(rays, axis=1)
+    if not np.allclose(ray_norms, 1.0, atol=1e-7, rtol=1e-6):
+        raise ValueError("camera geometry requires normalized viewing rays")
+    unit_rays = rays / ray_norms[:, None]
+
+    row_count = float(points.shape[0])
+    normal_matrix = row_count * np.eye(3) - unit_rays.T @ unit_rays
+    normal_matrix = 0.5 * (normal_matrix + normal_matrix.T)
+    eigenvalues = np.linalg.eigvalsh(normal_matrix)
+    largest = float(eigenvalues[-1])
+    smallest = float(eigenvalues[0])
+    if largest <= 0.0 or smallest <= 0.0:
+        raise ValueError("camera rays do not identify a finite camera centre")
+    condition_number = largest / smallest
+    if condition_number > maximum_condition_number:
+        raise ValueError(
+            "camera-centre recovery is ill-conditioned: "
+            f"condition_number={condition_number:.6g}, "
+            f"maximum={maximum_condition_number:.6g}"
+        )
+
+    # Solve in coordinates centred on the observed points.  The exact least-squares
+    # problem is translation equivariant; centring also avoids subtracting large
+    # common-frame offsets when the sequence origin is far from the camera.
+    point_reference = np.mean(points, axis=0)
+    centered_points = points - point_reference
+    ray_point_projection = np.einsum(
+        "ni,ni->n",
+        unit_rays,
+        centered_points,
+        optimize=True,
+    )
+    right_hand_side = np.sum(
+        centered_points - unit_rays * ray_point_projection[:, None],
+        axis=0,
+    )
+    try:
+        camera_offset = np.linalg.solve(normal_matrix, right_hand_side)
+    except np.linalg.LinAlgError as error:
+        raise ValueError("camera centre could not be recovered from points and rays") from error
+    camera_center = point_reference + camera_offset
+
+    displacement = points - camera_center
+    ranges = np.einsum(
+        "ni,ni->n",
+        displacement,
+        unit_rays,
+        optimize=True,
+    )
+    range_scale = max(float(np.max(np.abs(ranges))), np.finfo(np.float64).tiny)
+    positive_tolerance = absolute_tolerance_local + relative_tolerance * range_scale
+    if np.any(ranges <= -positive_tolerance):
+        raise ValueError("camera rays point away from one or more valid CUT3R points")
+    ranges = np.maximum(ranges, 0.0)
+
+    perpendicular = displacement - ranges[:, None] * unit_rays
+    maximum_residual = float(np.max(np.linalg.norm(perpendicular, axis=1)))
+    allowed_residual = absolute_tolerance_local + relative_tolerance * range_scale
+    if maximum_residual > allowed_residual:
+        raise ValueError(
+            "common-frame points and camera rays are geometrically inconsistent: "
+            f"maximum_perpendicular_residual={maximum_residual:.6g}, "
+            f"allowed={allowed_residual:.6g}"
+        )
+    return camera_center, ranges, condition_number, maximum_residual
+
+
+def recover_camera_relative_geometry(
+    window: PredictionWindow,
+    *,
+    absolute_tolerance_local: float = 1e-5,
+    relative_tolerance: float = 1e-5,
+    maximum_condition_number: float = 1e12,
+    minimum_valid_rays_per_frame: int = 3,
+) -> CameraRelativeGeometryV1:
+    """Recover camera centres and ranges without using the common-frame origin."""
+
+    absolute_tolerance = require_finite_real(
+        absolute_tolerance_local,
+        name="absolute_tolerance_local",
+        minimum=0.0,
+    )
+    relative = require_finite_real(
+        relative_tolerance,
+        name="relative_tolerance",
+        minimum=0.0,
+    )
+    maximum_condition = require_finite_real(
+        maximum_condition_number,
+        name="maximum_condition_number",
+        minimum=1.0,
+    )
+    minimum_rays = require_genuine_integer(
+        minimum_valid_rays_per_frame,
+        name="minimum_valid_rays_per_frame",
+        minimum=3,
+    )
+    if window.ray_directions is None:
+        raise ValueError(
+            "camera-relative depth requires explicit camera-origin ray_directions"
+        )
+
+    points = np.asarray(window.point_map, dtype=np.float64)
+    valid = np.asarray(window.valid_mask, dtype=bool)
+    rays = np.asarray(window.rays(dtype=np.float64), dtype=np.float64)
+    if points.ndim != 4 or points.shape[-1] != 3:
+        raise ValueError("prediction window points must have shape (T, H, W, 3)")
+    if valid.shape != points.shape[:-1] or rays.shape != points.shape:
+        raise ValueError("prediction window geometry arrays changed shape")
+
+    centers = np.empty((points.shape[0], 3), dtype=np.float64)
+    ranges = np.zeros(valid.shape, dtype=np.float64)
+    condition_numbers: list[float] = []
+    maximum_residuals: list[float] = []
+    for frame_index in range(points.shape[0]):
+        frame_valid = valid[frame_index]
+        valid_count = int(np.count_nonzero(frame_valid))
+        if valid_count < minimum_rays:
+            raise ValueError(
+                "camera-centre recovery has insufficient valid rays in frame "
+                f"{frame_index}: count={valid_count}, minimum={minimum_rays}"
+            )
+        (
+            center,
+            frame_ranges,
+            condition_number,
+            maximum_residual,
+        ) = _recover_frame_camera_geometry(
+            points[frame_index][frame_valid],
+            rays[frame_index][frame_valid],
+            absolute_tolerance_local=absolute_tolerance,
+            relative_tolerance=relative,
+            maximum_condition_number=maximum_condition,
+        )
+        centers[frame_index] = center
+        ranges[frame_index][frame_valid] = frame_ranges
+        condition_numbers.append(condition_number)
+        maximum_residuals.append(maximum_residual)
+
+    return CameraRelativeGeometryV1(
+        camera_centers_local=centers,
+        range_local=ranges,
+        frame_condition_numbers=tuple(condition_numbers),
+        frame_max_perpendicular_residual_local=tuple(maximum_residuals),
+    )
+
+
+@dataclass(frozen=True)
+class CameraRelativeDepthDisagreementModel(DepthDisagreementModel):
+    """Depth-disagreement model using recovered camera-relative range."""
+
+    geometry_absolute_tolerance_local: float = 1e-5
+    geometry_relative_tolerance: float = 1e-5
+    geometry_maximum_condition_number: float = 1e12
+    geometry_minimum_valid_rays_per_frame: int = 3
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        object.__setattr__(
+            self,
+            "geometry_absolute_tolerance_local",
+            require_finite_real(
+                self.geometry_absolute_tolerance_local,
+                name="geometry_absolute_tolerance_local",
+                minimum=0.0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "geometry_relative_tolerance",
+            require_finite_real(
+                self.geometry_relative_tolerance,
+                name="geometry_relative_tolerance",
+                minimum=0.0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "geometry_maximum_condition_number",
+            require_finite_real(
+                self.geometry_maximum_condition_number,
+                name="geometry_maximum_condition_number",
+                minimum=1.0,
+            ),
+        )
+        object.__setattr__(
+            self,
+            "geometry_minimum_valid_rays_per_frame",
+            require_genuine_integer(
+                self.geometry_minimum_valid_rays_per_frame,
+                name="geometry_minimum_valid_rays_per_frame",
+                minimum=3,
+            ),
+        )
+
+    def recover_geometry(
+        self,
+        window: PredictionWindow,
+    ) -> CameraRelativeGeometryV1:
+        return recover_camera_relative_geometry(
+            window,
+            absolute_tolerance_local=self.geometry_absolute_tolerance_local,
+            relative_tolerance=self.geometry_relative_tolerance,
+            maximum_condition_number=self.geometry_maximum_condition_number,
+            minimum_valid_rays_per_frame=(
+                self.geometry_minimum_valid_rays_per_frame
+            ),
+        )
+
+    def predict(
+        self,
+        window: PredictionWindow,
+        evidence: DisagreementEvidence | None = None,
+    ) -> StructuredCovariance:
+        geometry = self.recover_geometry(window)
+        depth_squared = np.square(geometry.range_local)
+        parallel = self.parallel_floor + self.parallel_depth_coefficient * depth_squared
+        lateral = self.lateral_floor + self.lateral_depth_coefficient * depth_squared
+        if evidence is not None:
+            if evidence.count.shape != window.shape:
+                raise ValueError("disagreement evidence shape does not match window")
+            parallel += 0.5 * self.disagreement_gain * evidence.parallel_mean
+            lateral += 0.5 * self.disagreement_gain * evidence.lateral_mean
+        parallel *= self.parallel_scale
+        lateral *= self.lateral_scale
+        return StructuredCovariance(
+            ray_directions=window.rays(),
+            parallel_variance=np.maximum(parallel, np.finfo(np.float64).eps),
+            lateral_variance=np.maximum(lateral, np.finfo(np.float64).eps),
+        )
+
+
+__all__ = [
+    "CUT3R_CAMERA_GEOMETRY_CLAIM_BOUNDARY",
+    "CUT3R_CAMERA_GEOMETRY_SEMANTICS",
+    "CameraRelativeDepthDisagreementModel",
+    "CameraRelativeGeometryV1",
+    "recover_camera_relative_geometry",
+]

--- a/src/prob4d/cut3r_provider_adapter.py
+++ b/src/prob4d/cut3r_provider_adapter.py
@@ -35,7 +35,11 @@ from .prediction_provider_manifest import (
 
 CUT3R_OFFICIAL_REPOSITORY: Final = "CUT3R/CUT3R"
 CUT3R_ONLINE_SOURCE_LAYOUT: Final = "cut3r-demo-recurrent-depth-conf-camera-v1"
-_ADAPTER_DOMAIN: Final = "prob4d.cut3r-online-provider-adapter.v1"
+CUT3R_CAMERA_RAY_SEMANTICS: Final = "camera-ray-unit-vector"
+CUT3R_CAMERA_RAY_FRAME_SEMANTICS: Final = (
+    "camera-origin-unit-rays-in-sequence-local-frame-v1"
+)
+_ADAPTER_DOMAIN: Final = "prob4d.cut3r-online-provider-adapter.v2"
 _MODEL_SET_DOMAIN: Final = "prob4d.cut3r-online-model-set.v1"
 _SOURCE_BUNDLE_DOMAIN: Final = "prob4d.cut3r-online-source-bundle.v1"
 _RUN_DOMAIN: Final = "prob4d.cut3r-online-run.v1"
@@ -105,7 +109,13 @@ def import_cut3r_online_prediction_manifest(
         confidence_threshold=threshold,
         storage_dtype=storage_dtype,
         limits=effective_limits,
-    ) as (window, source_members, source_member_bytes, dense_array_bytes):
+    ) as (
+        window,
+        source_members,
+        source_member_bytes,
+        dense_array_bytes,
+        ray_direction_array_bytes,
+    ):
         _verify_source_descriptors(source, source_members)
 
         loader_id = _adapter_implementation_sha256()
@@ -138,6 +148,8 @@ def import_cut3r_online_prediction_manifest(
                 "execution_mode": "recurrent-online",
                 "revisit_count": 1,
                 "global_alignment": False,
+                "ray_semantics": CUT3R_CAMERA_RAY_SEMANTICS,
+                "ray_frame_semantics": CUT3R_CAMERA_RAY_FRAME_SEMANTICS,
             },
         )
         stochastic_member_id = _record_id(
@@ -164,7 +176,7 @@ def import_cut3r_online_prediction_manifest(
             ),
             dense_storage_dtype=storage_dtype,
             has_scene_flow=False,
-            has_ray_directions=False,
+            has_ray_directions=True,
             frame_lineage=tuple(
                 PredictionFrameLineageV1(
                     output_frame_id=int(frame_id),
@@ -186,7 +198,7 @@ def import_cut3r_online_prediction_manifest(
             coordinate_semantics="sequence-local-sim3",
             point_semantics="dense-point-map",
             flow_semantics="absent",
-            ray_semantics="absent",
+            ray_semantics=CUT3R_CAMERA_RAY_SEMANTICS,
             payloads=(payload,),
             metadata={
                 "source_adapter": _ADAPTER_DOMAIN,
@@ -196,6 +208,10 @@ def import_cut3r_online_prediction_manifest(
                 "source_member_count": len(source_members),
                 "source_member_total_bytes": source_member_bytes,
                 "dense_array_byte_count": dense_array_bytes,
+                "ray_direction_array_byte_count": ray_direction_array_bytes,
+                "total_dense_array_byte_count": (
+                    dense_array_bytes + ray_direction_array_bytes
+                ),
                 "canonicalization_backend": "frame-streamed-npy-memmap-v1",
                 "sequence_wide_dense_stack_avoided": True,
                 "input_video_sha256": video_sha256,
@@ -207,6 +223,14 @@ def import_cut3r_online_prediction_manifest(
                 "global_alignment": False,
                 "confidence_threshold": threshold,
                 "confidence_is_support_not_reliability": True,
+                "camera_ray_frame_semantics": CUT3R_CAMERA_RAY_FRAME_SEMANTICS,
+                "camera_ray_derivation": "normalize(R_camera_to_common K^-1 [u,v,1])",
+                "camera_ray_translation_invariant": True,
+                "world_origin_ray_fallback_allowed": False,
+                "camera_relative_depth_model": (
+                    "prob4d.cut3r_camera_geometry."
+                    "CameraRelativeDepthDisagreementModel"
+                ),
                 "metric_scale_claimed": False,
                 "uses_truth": False,
                 "uses_downstream_physical_innovation": False,
@@ -226,6 +250,8 @@ def main(argv: Sequence[str] | None = None) -> int:
 
 
 __all__ = [
+    "CUT3R_CAMERA_RAY_FRAME_SEMANTICS",
+    "CUT3R_CAMERA_RAY_SEMANTICS",
     "CUT3R_OFFICIAL_REPOSITORY",
     "CUT3R_ONLINE_SOURCE_LAYOUT",
     "Cut3RImportLimits",

--- a/src/prob4d/cut3r_provider_adapter.py
+++ b/src/prob4d/cut3r_provider_adapter.py
@@ -36,9 +36,7 @@ from .prediction_provider_manifest import (
 CUT3R_OFFICIAL_REPOSITORY: Final = "CUT3R/CUT3R"
 CUT3R_ONLINE_SOURCE_LAYOUT: Final = "cut3r-demo-recurrent-depth-conf-camera-v1"
 CUT3R_CAMERA_RAY_SEMANTICS: Final = "camera-ray-unit-vector"
-CUT3R_CAMERA_RAY_FRAME_SEMANTICS: Final = (
-    "camera-origin-unit-rays-in-sequence-local-frame-v1"
-)
+CUT3R_CAMERA_RAY_FRAME_SEMANTICS: Final = "camera-origin-unit-rays-in-sequence-local-frame-v1"
 _ADAPTER_DOMAIN: Final = "prob4d.cut3r-online-provider-adapter.v2"
 _MODEL_SET_DOMAIN: Final = "prob4d.cut3r-online-model-set.v1"
 _SOURCE_BUNDLE_DOMAIN: Final = "prob4d.cut3r-online-source-bundle.v1"
@@ -209,9 +207,7 @@ def import_cut3r_online_prediction_manifest(
                 "source_member_total_bytes": source_member_bytes,
                 "dense_array_byte_count": dense_array_bytes,
                 "ray_direction_array_byte_count": ray_direction_array_bytes,
-                "total_dense_array_byte_count": (
-                    dense_array_bytes + ray_direction_array_bytes
-                ),
+                "total_dense_array_byte_count": (dense_array_bytes + ray_direction_array_bytes),
                 "canonicalization_backend": "frame-streamed-npy-memmap-v1",
                 "sequence_wide_dense_stack_avoided": True,
                 "input_video_sha256": video_sha256,
@@ -228,8 +224,7 @@ def import_cut3r_online_prediction_manifest(
                 "camera_ray_translation_invariant": True,
                 "world_origin_ray_fallback_allowed": False,
                 "camera_relative_depth_model": (
-                    "prob4d.cut3r_camera_geometry."
-                    "CameraRelativeDepthDisagreementModel"
+                    "prob4d.cut3r_camera_geometry.CameraRelativeDepthDisagreementModel"
                 ),
                 "metric_scale_claimed": False,
                 "uses_truth": False,

--- a/tests/test_cut3r_camera_geometry.py
+++ b/tests/test_cut3r_camera_geometry.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from prob4d.cut3r_camera_geometry import (
+    CameraRelativeDepthDisagreementModel,
+    recover_camera_relative_geometry,
+)
+from prob4d.cut3r_provider_adapter import (
+    CUT3R_CAMERA_RAY_FRAME_SEMANTICS,
+    CUT3R_CAMERA_RAY_SEMANTICS,
+    import_cut3r_online_prediction_manifest,
+)
+from prob4d.data import PredictionWindow
+from prob4d.uncertainty import DepthDisagreementModel
+
+
+def _normalized(values: np.ndarray) -> np.ndarray:
+    return values / np.linalg.norm(values, axis=-1, keepdims=True)
+
+
+def _geometry_window(
+    camera_center: np.ndarray,
+    *,
+    translation: np.ndarray | None = None,
+) -> PredictionWindow:
+    rays = _normalized(
+        np.asarray(
+            [
+                [-0.25, -0.25, 1.0],
+                [0.25, -0.25, 1.0],
+                [-0.25, 0.25, 1.0],
+                [0.25, 0.25, 1.0],
+            ],
+            dtype=np.float64,
+        )
+    )
+    ranges = np.asarray([2.0, 3.0, 4.0, 5.0], dtype=np.float64)
+    offset = np.zeros(3) if translation is None else np.asarray(translation)
+    points = camera_center + offset + ranges[:, None] * rays
+    return PredictionWindow(
+        window_id="cut3r-online",
+        frame_indices=np.asarray([0], dtype=np.int64),
+        point_map=points.reshape(1, 2, 2, 3),
+        valid_mask=np.ones((1, 2, 2), dtype=bool),
+        ray_directions=rays.reshape(1, 2, 2, 3),
+        dense_storage_dtype="float64",
+    )
+
+
+def _write_cut3r_frame(
+    root: Path,
+    index: int,
+    *,
+    translation: np.ndarray,
+) -> None:
+    stem = f"{index:06d}"
+    (root / "depth").mkdir(parents=True, exist_ok=True)
+    (root / "conf").mkdir(parents=True, exist_ok=True)
+    (root / "camera").mkdir(parents=True, exist_ok=True)
+    depth = np.asarray([[1.0, 2.0], [3.0, 4.0]], dtype=np.float32)
+    confidence = np.full((2, 2), 3.0, dtype=np.float32)
+    pose = np.eye(4, dtype=np.float64)
+    pose[:3, 3] = translation
+    intrinsics = np.asarray(
+        [[2.0, 0.0, 0.5], [0.0, 2.0, 0.5], [0.0, 0.0, 1.0]],
+        dtype=np.float64,
+    )
+    np.save(root / "depth" / f"{stem}.npy", depth)
+    np.save(root / "conf" / f"{stem}.npy", confidence)
+    np.savez_compressed(
+        root / "camera" / f"{stem}.npz",
+        pose=pose,
+        intrinsics=intrinsics,
+    )
+
+
+def test_camera_relative_geometry_recovers_centres_and_ranges() -> None:
+    camera_center = np.asarray([10.0, -3.0, 2.0])
+    window = _geometry_window(camera_center)
+
+    geometry = recover_camera_relative_geometry(window)
+
+    np.testing.assert_allclose(
+        geometry.camera_centers_local,
+        camera_center[None, :],
+        atol=1e-12,
+        rtol=1e-12,
+    )
+    np.testing.assert_allclose(
+        geometry.range_local,
+        np.asarray([[[2.0, 3.0], [4.0, 5.0]]]),
+        atol=1e-12,
+        rtol=1e-12,
+    )
+    assert geometry.maximum_perpendicular_residual_local < 1e-12
+    assert geometry.summary()["semantics"].endswith("-v1")
+
+
+def test_camera_relative_covariance_is_common_frame_translation_invariant() -> None:
+    camera_center = np.asarray([1.0, 2.0, 3.0])
+    translated = np.asarray([100.0, -40.0, 25.0])
+    first = _geometry_window(camera_center)
+    second = _geometry_window(camera_center, translation=translated)
+    model = CameraRelativeDepthDisagreementModel(
+        parallel_floor=0.1,
+        parallel_depth_coefficient=0.2,
+        lateral_floor=0.05,
+        lateral_depth_coefficient=0.1,
+    )
+
+    first_covariance = model.predict(first)
+    second_covariance = model.predict(second)
+
+    np.testing.assert_allclose(
+        first_covariance.parallel_variance,
+        second_covariance.parallel_variance,
+        atol=1e-12,
+        rtol=1e-12,
+    )
+    np.testing.assert_allclose(
+        first_covariance.lateral_variance,
+        second_covariance.lateral_variance,
+        atol=1e-12,
+        rtol=1e-12,
+    )
+    np.testing.assert_allclose(
+        first_covariance.ray_directions,
+        second_covariance.ray_directions,
+        atol=1e-12,
+        rtol=1e-12,
+    )
+
+    legacy_first = DepthDisagreementModel(
+        parallel_floor=0.1,
+        parallel_depth_coefficient=0.2,
+        lateral_floor=0.05,
+        lateral_depth_coefficient=0.1,
+    ).predict(first)
+    legacy_second = DepthDisagreementModel(
+        parallel_floor=0.1,
+        parallel_depth_coefficient=0.2,
+        lateral_floor=0.05,
+        lateral_depth_coefficient=0.1,
+    ).predict(second)
+    assert not np.allclose(
+        legacy_first.parallel_variance,
+        legacy_second.parallel_variance,
+    )
+
+
+def test_camera_relative_geometry_fails_closed_without_explicit_rays() -> None:
+    with_rays = _geometry_window(np.asarray([1.0, 2.0, 3.0]))
+    without_rays = PredictionWindow(
+        window_id=with_rays.window_id,
+        frame_indices=with_rays.frame_indices,
+        point_map=with_rays.point_map,
+        valid_mask=with_rays.valid_mask,
+        dense_storage_dtype="float64",
+    )
+
+    with pytest.raises(ValueError, match="explicit camera-origin ray_directions"):
+        recover_camera_relative_geometry(without_rays)
+
+
+def test_cut3r_import_preserves_true_camera_rays(tmp_path: Path) -> None:
+    source = tmp_path / "cut3r"
+    _write_cut3r_frame(
+        source,
+        0,
+        translation=np.asarray([10.0, -4.0, 2.0]),
+    )
+    output = tmp_path / "bundle" / "provider.json"
+
+    manifest = import_cut3r_online_prediction_manifest(
+        source,
+        output,
+        sequence_id="sequence-a",
+        cut3r_revision="a" * 40,
+        checkpoint_sha256="b" * 64,
+        input_video_sha256="c" * 64,
+        input_video_byte_count=1234,
+        confidence_threshold=1.5,
+    )
+
+    payload = manifest.payloads[0]
+    assert payload.has_ray_directions is True
+    assert manifest.ray_semantics == CUT3R_CAMERA_RAY_SEMANTICS
+    assert (
+        manifest.metadata["camera_ray_frame_semantics"]
+        == CUT3R_CAMERA_RAY_FRAME_SEMANTICS
+    )
+    assert manifest.metadata["camera_ray_translation_invariant"] is True
+    assert manifest.metadata["world_origin_ray_fallback_allowed"] is False
+    assert manifest.metadata["dense_array_byte_count"] == 60
+    assert manifest.metadata["ray_direction_array_byte_count"] == 48
+    assert manifest.metadata["total_dense_array_byte_count"] == 108
+
+    window = PredictionWindow.from_npz(
+        output.parent / payload.path,
+        dense_storage_dtype="float32",
+    )
+    assert window.ray_directions is not None
+    expected_ray = _normalized(np.asarray([-0.25, -0.25, 1.0]))
+    np.testing.assert_allclose(
+        window.ray_directions[0, 0, 0],
+        expected_ray,
+        atol=1e-6,
+        rtol=1e-6,
+    )
+    world_origin_direction = _normalized(window.point_map[0, 0, 0])
+    assert not np.allclose(
+        window.ray_directions[0, 0, 0],
+        world_origin_direction,
+    )
+
+    geometry = recover_camera_relative_geometry(window)
+    np.testing.assert_allclose(
+        geometry.camera_centers_local[0],
+        np.asarray([10.0, -4.0, 2.0]),
+        atol=2e-5,
+        rtol=2e-5,
+    )


### PR DESCRIPTION
## Summary

- preserve the true camera-origin unit ray for every recurrent-online CUT3R point instead of leaving downstream code to normalize points about the arbitrary sequence-common origin;
- include the retained ray field in bounded-memory canonicalization and bind its semantics and byte accounting into the provider identity;
- add `CameraRelativeDepthDisagreementModel`, which recovers one camera centre per frame from common-frame points and rays and uses camera-to-point range for anisotropic covariance;
- fail closed on absent, inconsistent, or geometrically degenerate ray fields;
- add import, camera-centre recovery, and common-frame translation-invariance regressions; and
- document the corrected geometry and the remaining provider-readiness boundary.

## Defect corrected

For a translated camera, the current fallback direction

```text
p_common / ||p_common||
```

is not the viewing ray. The correct direction is

```text
normalize(R_camera_to_common K^-1 [u,v,1]).
```

Likewise, `||p_common||` is not camera-relative depth and changes when the arbitrary common-frame origin is translated. A scalar covariance calibration cannot repair the resulting rotated anisotropy or origin-dependent depth feature.

## Validation added

- exact recovery of camera centres and camera-relative ranges;
- invariance of the new covariance model under a rigid translation of the complete common frame;
- explicit demonstration that the legacy common-origin depth proxy is not invariant;
- fail-closed behavior when camera-origin rays are absent; and
- an end-to-end CUT3R import check with a translated camera, manifest semantics, memory accounting, and payload reload.

## Scientific boundary

This is a provider-geometry and uncertainty-coordinate correction. It opens no source residual, target outcome, calibration, BayesianPhysTwin update, or Causal4D result. The next scientific action remains the frozen CUT3R source qualification under issue #49; provider competence and downstream benefit are not claimed here.

Advances #49 without closing it.