### PR TITLE
Add installed-wheel cross-stack metamorphic invariants

### DIFF
--- a/.github/workflows/cross-stack-metamorphic.yml
+++ b/.github/workflows/cross-stack-metamorphic.yml
@@ -1,0 +1,127 @@
+name: Cross-stack metamorphic invariants
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/cross-stack-metamorphic.yml"
+      - "CHANGELOG.d/cross-stack-metamorphic-v1.md"
+      - "docs/cross-stack-metamorphic-v1.md"
+      - "integration_tests/test_three_repository_metamorphic_v1.py"
+      - "tests/test_cross_stack_metamorphic_workflow.py"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/cross-stack-metamorphic.yml"
+      - "CHANGELOG.d/cross-stack-metamorphic-v1.md"
+      - "docs/cross-stack-metamorphic-v1.md"
+      - "integration_tests/test_three_repository_metamorphic_v1.py"
+      - "tests/test_cross_stack_metamorphic_workflow.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cross-stack-metamorphic-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONUNBUFFERED: "1"
+  PROB4D_REQUIRE_CROSS_STACK_METAMORPHIC: "1"
+  BAYESIAN_PHYSTWIN_REF: c41974ad5583e2d426d12cf0afd3274b6a47d9b6
+  CAUSAL4D_REF: d5260f65fb3c7660a576ac4c8742190406247103
+
+jobs:
+  installed-wheel-metamorphic:
+    name: Installed-wheel metamorphic invariants
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Check out exact Prob4D revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: >-
+            ${{ github.event_name == 'pull_request' &&
+                github.event.pull_request.head.sha || github.sha }}
+          path: prob4d
+          persist-credentials: false
+          clean: true
+
+      - name: Check out exact BayesianPhysTwin revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: IPS-Stuttgart/BayesianPhysTwin
+          ref: ${{ env.BAYESIAN_PHYSTWIN_REF }}
+          path: bayesian-phystwin
+          persist-credentials: false
+          clean: true
+
+      - name: Check out exact Causal4D revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: IPS-Stuttgart/Causal4D
+          ref: ${{ env.CAUSAL4D_REF }}
+          path: causal4d
+          persist-credentials: false
+          clean: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: |
+            prob4d/pyproject.toml
+            bayesian-phystwin/pyproject.toml
+            causal4d/pyproject.toml
+
+      - name: Build and install exactly three wheels
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install build
+          mkdir -p "${RUNNER_TEMP}/wheelhouse"
+          python -m build --wheel --outdir "${RUNNER_TEMP}/wheelhouse" prob4d
+          python -m build --wheel --outdir "${RUNNER_TEMP}/wheelhouse" bayesian-phystwin
+          python -m build --wheel --outdir "${RUNNER_TEMP}/wheelhouse" causal4d
+          test "$(find "${RUNNER_TEMP}/wheelhouse" -maxdepth 1 -name '*.whl' | wc -l)" -eq 3
+          sha256sum "${RUNNER_TEMP}"/wheelhouse/*.whl | tee wheel-sha256.txt
+
+          python -m venv "${RUNNER_TEMP}/cross-stack-metamorphic"
+          python_bin="${RUNNER_TEMP}/cross-stack-metamorphic/bin/python"
+          "${python_bin}" -m pip install --upgrade pip
+          "${python_bin}" -m pip install pytest "${RUNNER_TEMP}"/wheelhouse/*.whl
+          "${python_bin}" -m pip check
+
+      - name: Run the isolated installed-wheel metamorphic suite
+        shell: bash
+        run: |
+          set -euo pipefail
+          run_root="${RUNNER_TEMP}/cross-stack-metamorphic-run"
+          mkdir -p "${run_root}"
+          cp \
+            prob4d/integration_tests/test_three_repository_metamorphic_v1.py \
+            "${run_root}/test_three_repository_metamorphic_v1.py"
+          cd "${run_root}"
+          env -u PYTHONPATH \
+            PYTHONNOUSERSITE=1 \
+            PROB4D_REQUIRE_CROSS_STACK_METAMORPHIC=1 \
+            "${RUNNER_TEMP}/cross-stack-metamorphic/bin/python" -I -m pytest \
+            -q \
+            --junitxml="${GITHUB_WORKSPACE}/cross-stack-metamorphic.xml" \
+            test_three_repository_metamorphic_v1.py \
+            2>&1 | tee "${GITHUB_WORKSPACE}/cross-stack-metamorphic.log"
+
+      - name: Upload metamorphic evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: cross-stack-metamorphic
+          path: |
+            cross-stack-metamorphic.log
+            cross-stack-metamorphic.xml
+            wheel-sha256.txt
+          if-no-files-found: error
+          retention-days: 30

--- a/CHANGELOG.d/cross-stack-metamorphic-v1.md
+++ b/CHANGELOG.d/cross-stack-metamorphic-v1.md
@@ -1,0 +1,3 @@
+- Add an installed-wheel three-repository metamorphic suite covering shared-root
+  basis invariance, coordinate and unit equivariance, observation-row
+  permutation, and exact zero-consumption fallback into Causal4D.

--- a/docs/cross-stack-metamorphic-v1.md
+++ b/docs/cross-stack-metamorphic-v1.md
@@ -1,0 +1,63 @@
+# Cross-stack metamorphic invariants v1
+
+This installed-wheel suite checks representation and coordinate invariants across
+the Prob4D, BayesianPhysTwin, and Causal4D package boundary. It uses the
+normative observation-contract vector published independently by all three
+packages and runs from three freshly built wheels with the source trees hidden
+from Python imports.
+
+## Invariants
+
+### Shared-root basis
+
+For any orthogonal matrix \(Q\), a covariance root may be replaced by \(UQ\)
+without changing the represented covariance:
+
+\[
+(UQ)(UQ)^\top = UU^\top.
+\]
+
+The suite rotates the shared low-rank root and requires the BayesianPhysTwin
+gauge-aware batch to retain the same innovation and full marginal observation
+covariance.
+
+### Coordinate frame and units
+
+For \(x' = Ax+t\), where \(A=sR\), the observation residual and covariance must
+transform as
+
+\[
+r' = Ar,\qquad \Sigma' = A\Sigma A^\top.
+\]
+
+The suite applies a rigid frame change together with metres-to-millimetres
+scaling. It transforms the observation belief, physical prediction, state and
+query Jacobians, and response scale, then checks the complete conditional plus
+shared covariance.
+
+### Observation ordering
+
+Permuting observation rows must only permute the innovation and corresponding
+\(3\times3\) covariance blocks. It must not change the represented Gaussian or
+silently treat the new order as new evidence.
+
+### Exact fallback
+
+A rejected BayesianPhysTwin candidate must deliver the unchanged baseline belief
+to Causal4D. The guarded handoff must consume zero Prob4D observation evidence,
+zero query covariance, and must reject attempts to alter any of those facts.
+
+## Workflow
+
+`.github/workflows/cross-stack-metamorphic.yml` checks out exact companion
+revisions, builds one wheel from each repository, installs only those wheels in
+a fresh environment, and runs the isolated suite with user and source-tree
+imports disabled. The retained JUnit report, log, and wheel SHA-256 manifest make
+the run auditable.
+
+## Evidence boundary
+
+Passing these tests establishes cross-package numerical and ownership
+invariants. It does not establish real-provider competence, calibration,
+BayesianPhysTwin physical benefit, Causal4D intervention benefit, deployment
+safety, or state of the art.

--- a/integration_tests/test_three_repository_metamorphic_v1.py
+++ b/integration_tests/test_three_repository_metamorphic_v1.py
@@ -1,0 +1,359 @@
+from __future__ import annotations
+
+import hashlib
+import os
+from dataclasses import replace
+from importlib import import_module
+from typing import Any
+
+import numpy as np
+import pytest
+from bayesian_phystwin.observation_belief import ObservationBeliefV1
+from bayesian_phystwin.observation_belief_gauge_adapter import (
+    build_gauge_aware_batch_from_observation_belief,
+)
+
+MODULE_NAMES = (
+    "prob4d.observation_contract_bundle",
+    "bayesian_phystwin.observation_contract_bundle",
+    "causal4d.observation_contract_bundle",
+)
+ROW_ARRAY_NAMES = (
+    "mean_xyz_m",
+    "frame_ids",
+    "entity_ids",
+    "view_indices",
+    "window_indices",
+    "correlation_group_ids",
+    "factor_group_ids",
+    "prior_reliability",
+    "association_probability",
+    "local_covariance_m2",
+    "low_rank_factor_m",
+)
+
+
+def _contract_vector() -> tuple[dict[str, Any], dict[str, np.ndarray]]:
+    modules = tuple(import_module(name) for name in MODULE_NAMES)
+    vectors = tuple(module.observation_contract_vector("minimal") for module in modules)
+    reference = vectors[0]
+
+    assert vectors[1].descriptor == reference.descriptor
+    assert vectors[2].descriptor == reference.descriptor
+    assert vectors[1].expected_artifact_id == reference.expected_artifact_id
+    assert vectors[2].expected_artifact_id == reference.expected_artifact_id
+
+    arrays = {name: np.asarray(value).copy() for name, value in reference.arrays.items()}
+    for vector in vectors[1:]:
+        assert tuple(sorted(vector.arrays)) == tuple(sorted(arrays))
+        for name, expected in arrays.items():
+            np.testing.assert_array_equal(vector.arrays[name], expected)
+    return dict(reference.descriptor), arrays
+
+
+def _belief(
+    *,
+    arrays_override: dict[str, np.ndarray] | None = None,
+    stream_id: str = "cross-stack-metamorphic",
+) -> ObservationBeliefV1:
+    descriptor, arrays = _contract_vector()
+    if arrays_override is not None:
+        arrays.update(
+            {name: np.asarray(value).copy() for name, value in arrays_override.items()}
+        )
+    return ObservationBeliefV1(
+        case_id=str(descriptor["case_id"]),
+        stream_id=stream_id,
+        causal_frame_stop=int(descriptor["causal_frame_stop"]),
+        view_names=tuple(descriptor["view_names"]),
+        window_names=tuple(descriptor["window_names"]),
+        factor_names=tuple(descriptor["factor_names"]),
+        source_repository="cross-stack/metamorphic-provider",
+        source_revision="a" * 40,
+        source_artifact_sha256="b" * 64,
+        declared_frame_ids=arrays["declared_frame_ids"],
+        mean_xyz_m=arrays["mean_xyz_m"],
+        frame_ids=arrays["frame_ids"],
+        entity_ids=arrays["entity_ids"],
+        view_indices=arrays["view_indices"],
+        window_indices=arrays["window_indices"],
+        correlation_group_ids=arrays["correlation_group_ids"],
+        factor_group_ids=arrays["factor_group_ids"],
+        prior_reliability=arrays["prior_reliability"],
+        association_probability=arrays["association_probability"],
+        local_covariance_m2=arrays["local_covariance_m2"],
+        low_rank_factor_m=arrays["low_rank_factor_m"],
+        group_ids=arrays["group_ids"],
+        group_prior_nominal_probability=arrays["group_prior_nominal_probability"],
+        group_composite_weight=arrays["group_composite_weight"],
+        metadata={"purpose": "installed-wheel-cross-stack-metamorphic-v1"},
+    )
+
+
+def _base_physical_prediction(belief: ObservationBeliefV1) -> np.ndarray:
+    residual = np.column_stack(
+        (
+            1.0e-3 * (belief.frame_ids + 1),
+            2.0e-3 * (belief.entity_ids + 1),
+            -1.5e-3 * (belief.window_indices + 1),
+        )
+    )
+    return belief.mean_xyz_m - residual
+
+
+def _base_state_jacobian(belief: ObservationBeliefV1) -> np.ndarray:
+    state = np.zeros((belief.observation_count, 3, 2), dtype=np.float64)
+    state[:, 0, 0] = 1.0
+    state[:, 1, 1] = 1.0
+    state[:, 2, 0] = 0.25
+    state[:, 2, 1] = -0.5
+    return state
+
+
+def _base_query_jacobian() -> np.ndarray:
+    query = np.zeros((2, 3, 2), dtype=np.float64)
+    query[0, 0, 0] = 1.0
+    query[0, 2, 1] = 0.25
+    query[1, 1, 1] = 1.0
+    query[1, 2, 0] = -0.5
+    return query
+
+
+def _adapter(
+    belief: ObservationBeliefV1,
+    *,
+    physical_prediction: np.ndarray | None = None,
+    linear_transform: np.ndarray | None = None,
+    response_scale_m: float = 0.1,
+):
+    state = _base_state_jacobian(belief)
+    query = _base_query_jacobian()
+    if linear_transform is not None:
+        transform = np.asarray(linear_transform, dtype=np.float64)
+        state = np.einsum("ij,njk->nik", transform, state)
+        query = np.einsum("ij,qjk->qik", transform, query)
+    return build_gauge_aware_batch_from_observation_belief(
+        belief,
+        physical_prediction_xyz_m=(
+            _base_physical_prediction(belief)
+            if physical_prediction is None
+            else physical_prediction
+        ),
+        state_jacobian=state,
+        query_state_jacobian=query,
+        physical_response_scale_m=response_scale_m,
+    )
+
+
+def _marginal_observation_covariance(batch: Any) -> np.ndarray:
+    count = len(batch.innovation_m)
+    covariance = np.zeros((3 * count, 3 * count), dtype=np.float64)
+    for index, block in enumerate(batch.observation_covariance_m2):
+        start = 3 * index
+        covariance[start : start + 3, start : start + 3] = block
+    gauge = batch.gauge_jacobian.reshape(3 * count, -1)
+    return covariance + gauge @ batch.gauge_prior_covariance @ gauge.T
+
+
+def test_shared_root_basis_rotation_is_invariant_across_installed_contracts() -> None:
+    belief = _belief()
+    reference = _adapter(belief).batch
+    angle = 0.731
+    orthogonal = np.array(
+        [
+            [np.cos(angle), -np.sin(angle)],
+            [np.sin(angle), np.cos(angle)],
+        ],
+        dtype=np.float64,
+    )
+    rotated_root = np.einsum(
+        "nij,jk->nik",
+        belief.low_rank_factor_m,
+        orthogonal,
+    )
+    rotated = _adapter(
+        _belief(
+            arrays_override={"low_rank_factor_m": rotated_root},
+            stream_id="cross-stack-metamorphic-root-rotation",
+        )
+    ).batch
+
+    np.testing.assert_allclose(rotated.innovation_m, reference.innovation_m, atol=0.0)
+    np.testing.assert_allclose(
+        _marginal_observation_covariance(rotated),
+        _marginal_observation_covariance(reference),
+        atol=1.0e-14,
+        rtol=1.0e-12,
+    )
+
+
+def test_global_frame_and_unit_change_is_equivariant() -> None:
+    belief = _belief()
+    prediction = _base_physical_prediction(belief)
+    reference = _adapter(belief, physical_prediction=prediction).batch
+
+    rotation = np.array(
+        [
+            [0.0, -1.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ],
+        dtype=np.float64,
+    )
+    scale = 1000.0
+    translation = np.array([250.0, -75.0, 10.0], dtype=np.float64)
+    linear = scale * rotation
+    transformed_belief = belief.transformed(
+        rotation=rotation,
+        translation_m=translation,
+        scale=scale,
+        stream_id="cross-stack-metamorphic-millimetres",
+    )
+    transformed_prediction = np.einsum(
+        "ij,nj->ni",
+        linear,
+        prediction,
+    ) + translation
+    transformed = _adapter(
+        transformed_belief,
+        physical_prediction=transformed_prediction,
+        linear_transform=linear,
+        response_scale_m=scale * 0.1,
+    ).batch
+
+    np.testing.assert_allclose(
+        transformed.innovation_m,
+        np.einsum("ij,nj->ni", linear, reference.innovation_m),
+        atol=1.0e-10,
+        rtol=1.0e-12,
+    )
+    row_transform = np.kron(
+        np.eye(belief.observation_count, dtype=np.float64),
+        linear,
+    )
+    expected_covariance = (
+        row_transform
+        @ _marginal_observation_covariance(reference)
+        @ row_transform.T
+    )
+    np.testing.assert_allclose(
+        _marginal_observation_covariance(transformed),
+        expected_covariance,
+        atol=1.0e-8,
+        rtol=1.0e-12,
+    )
+
+
+def test_observation_row_permutation_only_permutes_the_batch() -> None:
+    belief = _belief()
+    reference = _adapter(belief).batch
+    permutation = np.array([2, 0, 3, 1], dtype=np.int64)
+    overrides = {
+        name: np.asarray(getattr(belief, name))[permutation]
+        for name in ROW_ARRAY_NAMES
+    }
+    permuted = _adapter(
+        _belief(
+            arrays_override=overrides,
+            stream_id="cross-stack-metamorphic-row-permutation",
+        )
+    ).batch
+
+    np.testing.assert_allclose(
+        permuted.innovation_m,
+        reference.innovation_m[permutation],
+        atol=0.0,
+    )
+    flat_indices = np.concatenate(
+        [np.arange(3 * index, 3 * index + 3) for index in permutation]
+    )
+    expected_covariance = _marginal_observation_covariance(reference)[
+        np.ix_(flat_indices, flat_indices)
+    ]
+    np.testing.assert_allclose(
+        _marginal_observation_covariance(permuted),
+        expected_covariance,
+        atol=1.0e-14,
+        rtol=1.0e-12,
+    )
+
+
+def _sha256(label: str) -> str:
+    return hashlib.sha256(label.encode("utf-8")).hexdigest()
+
+
+def _guarded_handoff_type():
+    try:
+        module = import_module("causal4d.guarded_bpt_belief_handoff_v2")
+    except ModuleNotFoundError:
+        if os.environ.get("PROB4D_REQUIRE_CROSS_STACK_METAMORPHIC") == "1":
+            raise
+        pytest.skip("installed Causal4D revision predates guarded handoff v2")
+    return module.BayesianPhysTwinGuardedBeliefHandoffReceiptV2
+
+
+def _fallback_receipt():
+    receipt_type = _guarded_handoff_type()
+    baseline_bpt = _sha256("baseline-bpt")
+    baseline_causal = _sha256("baseline-causal4d")
+    return receipt_type(
+        protocol_id="cross-stack-metamorphic-v1",
+        case_id="fallback-case",
+        causal_frame_stop=12,
+        update_id=_sha256("update"),
+        admission_id=_sha256("admission"),
+        tree_block_result_id=_sha256("tree-block-result"),
+        observation_artifact_id=_sha256("observation"),
+        linearization_artifact_id=_sha256("linearization"),
+        provider_manifest_id=_sha256("provider-manifest"),
+        runtime_identity_id=_sha256("runtime"),
+        prob4d_source_repository="IPS-Stuttgart/Prob4D",
+        prob4d_runtime_revision="c" * 40,
+        runtime_revision_evidence_source="installed-wheel-build-identity",
+        candidate_construction_receipt_id=_sha256("candidate-construction"),
+        guarded_selection_receipt_id=_sha256("guarded-selection"),
+        guard_certificate_id=_sha256("guard-certificate"),
+        guard_decision_id=_sha256("guard-decision"),
+        selection_id=_sha256("selection"),
+        baseline_bpt_belief_id=baseline_bpt,
+        candidate_bpt_belief_id=_sha256("candidate-bpt"),
+        selected_bpt_belief_id=baseline_bpt,
+        baseline_causal4d_belief_id=baseline_causal,
+        delivered_causal4d_belief_id=baseline_causal,
+        update_inference_admissible=False,
+        selected_candidate=False,
+        exact_fallback=True,
+        evidence_consumed_count=0,
+        covariance_consumed_count=0,
+        covariance_result_id=None,
+        evidence_ledger_id=_sha256("evidence-ledger"),
+        raw_prob4d_reinterpreted=False,
+        metadata={"metamorphic_test": True},
+    )
+
+
+def test_exact_fallback_consumes_no_prob4d_evidence_or_query_covariance() -> None:
+    receipt = _fallback_receipt()
+
+    assert receipt.exact_fallback is True
+    assert receipt.selected_candidate is False
+    assert receipt.selected_bpt_belief_id == receipt.baseline_bpt_belief_id
+    assert (
+        receipt.delivered_causal4d_belief_id
+        == receipt.baseline_causal4d_belief_id
+    )
+    assert receipt.evidence_consumed_count == 0
+    assert receipt.covariance_consumed_count == 0
+    assert receipt.covariance_result_id is None
+
+    with pytest.raises(ValueError, match="zero observation evidence"):
+        replace(receipt, evidence_consumed_count=1)
+    with pytest.raises(ValueError, match="zero query covariance"):
+        replace(receipt, covariance_consumed_count=1)
+    with pytest.raises(ValueError, match="must not bind query covariance"):
+        replace(receipt, covariance_result_id=_sha256("forbidden-covariance"))
+    with pytest.raises(ValueError, match="changed the baseline Causal4D belief"):
+        replace(
+            receipt,
+            delivered_causal4d_belief_id=_sha256("changed-delivered-belief"),
+        )

--- a/tests/test_cross_stack_metamorphic_workflow.py
+++ b/tests/test_cross_stack_metamorphic_workflow.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "cross-stack-metamorphic.yml"
+BAYESIAN_PHYSTWIN_PIN = "c41974ad5583e2d426d12cf0afd3274b6a47d9b6"
+CAUSAL4D_PIN = "d5260f65fb3c7660a576ac4c8742190406247103"
+
+
+def test_cross_stack_workflow_is_hosted_read_only_and_exactly_pinned() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "runs-on: ubuntu-latest" in text
+    assert "self-hosted" not in text
+    assert "permissions:\n  contents: read" in text
+    assert "secrets." not in text
+    assert text.count("persist-credentials: false") == 3
+    assert f"BAYESIAN_PHYSTWIN_REF: {BAYESIAN_PHYSTWIN_PIN}" in text
+    assert f"CAUSAL4D_REF: {CAUSAL4D_PIN}" in text
+    assert "PROB4D_REQUIRE_CROSS_STACK_METAMORPHIC: \"1\"" in text
+    assert "actions/checkout@v" not in text
+    assert "actions/setup-python@v" not in text
+    assert "actions/upload-artifact@v" not in text
+
+
+def test_cross_stack_workflow_uses_only_installed_wheels() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert text.count("python -m build --wheel") == 3
+    assert "test \"$(find \"${RUNNER_TEMP}/wheelhouse\"" in text
+    assert "\"${python_bin}\" -m pip install pytest \"${RUNNER_TEMP}\"/wheelhouse/*.whl" in text
+    assert "PYTHONNOUSERSITE=1" in text
+    assert "env -u PYTHONPATH" in text
+    assert "\"${RUNNER_TEMP}/cross-stack-metamorphic/bin/python\" -I -m pytest" in text
+    assert "test_three_repository_metamorphic_v1.py" in text
+
+
+def test_cross_stack_workflow_retains_replayable_diagnostics() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "cross-stack-metamorphic.log" in text
+    assert "cross-stack-metamorphic.xml" in text
+    assert "wheel-sha256.txt" in text
+    assert "if-no-files-found: error" in text
+    assert "retention-days: 30" in text
+
+
+def test_cross_stack_paths_trigger_pull_request_and_push_runs() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    pull_request, remainder = text.split("  push:\n", maxsplit=1)
+    push, _ = remainder.split("  workflow_dispatch:\n", maxsplit=1)
+
+    for path_filter in (
+        '      - ".github/workflows/cross-stack-metamorphic.yml"',
+        '      - "integration_tests/test_three_repository_metamorphic_v1.py"',
+        '      - "tests/test_cross_stack_metamorphic_workflow.py"',
+    ):
+        assert path_filter in pull_request
+        assert path_filter in push
+        assert text.count(path_filter) == 2


### PR DESCRIPTION
## Summary

Add a dedicated hosted workflow and installed-wheel integration suite for four cross-repository invariants:

- orthogonal low-rank covariance-root basis changes preserve the represented observation Gaussian;
- global rigid-frame and metres-to-millimetres transformations propagate residuals and full conditional-plus-shared covariance equivariantly;
- observation-row permutation only permutes innovations and covariance blocks; and
- exact BayesianPhysTwin fallback into Causal4D consumes zero Prob4D evidence and zero query covariance, with deliberate violations failing closed.

The workflow checks out exact BayesianPhysTwin and Causal4D revisions, builds exactly three wheels, installs only those wheels in an isolated environment, hides source trees from Python imports, and retains JUnit, log, and wheel SHA-256 evidence.

## Validation

GitHub-hosted exact-head workflows are expected to cover repository tests, fail-closed quality, action-pin policy, security, packaging, and the new installed-wheel metamorphic job.

## Scientific boundary

This establishes numerical representation, coordinate, ordering, and exact-fallback invariants across the package boundary. It does not establish provider competence, uncertainty calibration, physical benefit, intervention benefit, deployment safety, or state of the art.