### PR TITLE
Run retained CUT3R source freeze automatically from merged main

### DIFF
--- a/.github/workflows/cut3r-source-freeze-auto-v2.yml
+++ b/.github/workflows/cut3r-source-freeze-auto-v2.yml
@@ -1,0 +1,484 @@
+name: Execute retained CUT3R source freeze automatically v2
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/cut3r-source-freeze-auto-v2.yml"
+      - "CHANGELOG.d/cut3r-source-freeze-auto-v2.md"
+      - "docs/cut3r-source-freeze-auto-v2.md"
+      - "protocols/execution_requests/cut3r_deform360_source_freeze_v2.json"
+      - "scripts/science/run_cut3r_source_freeze_execution.py"
+      - "tests/test_cut3r_source_freeze_execution_driver.py"
+      - "tests/test_trusted_self_hosted_validation_policy.py"
+  push:
+    branches: [main]
+    paths:
+      - "protocols/execution_requests/cut3r_deform360_source_freeze_v2.json"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cut3r-source-freeze-auto-v2-${{ github.ref }}-${{ github.sha }}
+  cancel-in-progress: false
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONHASHSEED: "0"
+  PYTHONUNBUFFERED: "1"
+  PYTHONDONTWRITEBYTECODE: "1"
+  OMP_NUM_THREADS: "1"
+  OPENBLAS_NUM_THREADS: "1"
+  MKL_NUM_THREADS: "1"
+  NUMEXPR_NUM_THREADS: "1"
+  REQUEST_PATH: protocols/execution_requests/cut3r_deform360_source_freeze_v2.json
+
+jobs:
+  contract:
+    name: Hosted automatic-execution contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Check out exact reviewed revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: >-
+            ${{ github.event_name == 'pull_request' &&
+                github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+          clean: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Validate the reviewed automatic execution surface
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install -e ".[dev]"
+          python -m pip check
+          python -m ruff check \
+            scripts/science/run_cut3r_source_freeze_execution.py \
+            tests/test_cut3r_source_freeze_execution_driver.py \
+            tests/test_trusted_self_hosted_validation_policy.py
+          python -m ruff format --check \
+            scripts/science/run_cut3r_source_freeze_execution.py \
+            tests/test_cut3r_source_freeze_execution_driver.py \
+            tests/test_trusted_self_hosted_validation_policy.py
+          python -m pytest -q \
+            tests/test_cut3r_source_freeze_execution_driver.py \
+            tests/test_trusted_self_hosted_validation_policy.py \
+            tests/test_github_action_pins.py
+          python -m compileall -q \
+            scripts/science/run_cut3r_source_freeze_execution.py \
+            scripts/science/build_cut3r_deform360_source_freeze.py
+
+  authorize:
+    name: Authorize exact merged-main v2 request
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      head_sha: ${{ steps.request.outputs.head_sha }}
+      base_sha: ${{ steps.request.outputs.base_sha }}
+      request_id: ${{ steps.request.outputs.request_id }}
+      profile: ${{ steps.request.outputs.profile }}
+      authorization_mode: ${{ steps.request.outputs.authorization_mode }}
+    steps:
+      - name: Require an ordinary non-forced push to main
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_REF: ${{ github.ref }}
+          EVENT_BEFORE: ${{ github.event.before }}
+          EVENT_AFTER: ${{ github.event.after }}
+          EVENT_FORCED: ${{ github.event.forced }}
+          EVENT_DELETED: ${{ github.event.deleted }}
+          EXPECTED_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          test "$EVENT_NAME" = "push"
+          test "$EVENT_REF" = "refs/heads/main"
+          test "$EVENT_AFTER" = "$EXPECTED_SHA"
+          test "$EVENT_FORCED" = "false"
+          test "$EVENT_DELETED" = "false"
+          test "$EVENT_BEFORE" != "0000000000000000000000000000000000000000"
+
+      - name: Check out exact merged main revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 2
+          persist-credentials: false
+          clean: true
+
+      - name: Verify immutable request and changed-path authorization
+        id: request
+        shell: bash
+        env:
+          EXPECTED_SHA: ${{ github.sha }}
+          BASE_SHA: ${{ github.event.before }}
+        run: |
+          set -euo pipefail
+          test "$(/usr/bin/git rev-parse HEAD)" = "$EXPECTED_SHA"
+          test -z "$(/usr/bin/git status --porcelain=v1 --untracked-files=all)"
+          /usr/bin/git diff-tree --no-commit-id --name-only -r "$BASE_SHA" "$EXPECTED_SHA" \
+            | grep -Fx "$REQUEST_PATH" >/dev/null
+          python scripts/science/run_cut3r_source_freeze_execution.py verify-request \
+            --repository . \
+            --request "$REQUEST_PATH" \
+            --expected-revision "$EXPECTED_SHA" \
+            --github-output "$GITHUB_OUTPUT"
+          {
+            echo "head_sha=$EXPECTED_SHA"
+            echo "base_sha=$BASE_SHA"
+          } >> "$GITHUB_OUTPUT"
+
+  announce:
+    name: Publish queued run pointer
+    if: github.event_name == 'push'
+    needs: [contract, authorize]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Comment queued automatic execution on issue 49
+        shell: bash
+        env:
+          API_URL: ${{ github.api_url }}
+          REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+          REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
+          HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+          AUTHORIZATION_MODE: ${{ needs.authorize.outputs.authorization_mode }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from __future__ import annotations
+
+          import json
+          import os
+          import urllib.request
+
+          body = "\n".join(
+              (
+                  "## Retained CUT3R source-freeze v2 queued",
+                  "",
+                  f"- request ID: `{os.environ['REQUEST_ID']}`",
+                  f"- exact merged-main revision: `{os.environ['HEAD_SHA']}`",
+                  f"- authorization: `{os.environ['AUTHORIZATION_MODE']}`",
+                  f"- workflow run: {os.environ['RUN_URL']}",
+                  "",
+                  "The self-hosted job has a read-only repository token and receives "
+                  "no pull-request-controlled input. This stage remains target-closed "
+                  "and does not execute CUT3R or open source outcomes.",
+              )
+          )
+          request = urllib.request.Request(
+              f"{os.environ['API_URL']}/repos/{os.environ['REPOSITORY']}/issues/49/comments",
+              data=json.dumps({"body": body}).encode("utf-8"),
+              method="POST",
+              headers={
+                  "Accept": "application/vnd.github+json",
+                  "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+                  "Content-Type": "application/json",
+                  "X-GitHub-Api-Version": "2022-11-28",
+              },
+          )
+          with urllib.request.urlopen(request, timeout=30):
+              pass
+          PY
+
+  execute:
+    name: Freeze retained source inputs from trusted merged main
+    if: github.event_name == 'push'
+    needs: [contract, authorize, announce]
+    permissions:
+      contents: read
+    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    timeout-minutes: 180
+    outputs:
+      artifact_name: ${{ steps.freeze.outputs.artifact_name }}
+      decision: ${{ steps.freeze.outputs.decision }}
+      exit_status: ${{ steps.freeze.outputs.exit_status }}
+      freeze_artifact_id: ${{ steps.freeze.outputs.freeze_artifact_id }}
+      request_id: ${{ steps.freeze.outputs.request_id }}
+    steps:
+      - name: Initialize isolated read-only execution workspace
+        id: workspace
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${RUNNER_TEMP}/prob4d-cut3r-source-freeze-v2-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          expected="${RUNNER_TEMP}/prob4d-cut3r-source-freeze-v2-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          test "$root" = "$expected"
+          /usr/bin/rm -rf -- "$root"
+          /usr/bin/mkdir -p \
+            "$root/home" \
+            "$root/cache" \
+            "$root/tmp" \
+            "$root/evidence"
+          echo "root=$root" >> "$GITHUB_OUTPUT"
+          {
+            echo "HOME=$root/home"
+            echo "XDG_CACHE_HOME=$root/cache"
+            echo "PIP_CACHE_DIR=$root/cache/pip"
+            echo "HF_HOME=$root/cache/huggingface"
+            echo "TMPDIR=$root/tmp"
+          } >> "$GITHUB_ENV"
+
+      - name: Check out only the authorized merged revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.authorize.outputs.head_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+          clean: true
+
+      - name: Verify exact clean checkout
+        shell: bash
+        env:
+          EXPECTED_HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+          EXPECTED_REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
+        run: |
+          set -euo pipefail
+          test "$(/usr/bin/git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
+          test -z "$(/usr/bin/git status --porcelain=v1 --untracked-files=all)"
+          /usr/bin/python3 scripts/science/run_cut3r_source_freeze_execution.py verify-request \
+            --repository . \
+            --request "$REQUEST_PATH" \
+            --expected-revision "$EXPECTED_HEAD_SHA" \
+            > "${{ steps.workspace.outputs.root }}/evidence/request-verification.json"
+          grep -F "$EXPECTED_REQUEST_ID" \
+            "${{ steps.workspace.outputs.root }}/evidence/request-verification.json" >/dev/null
+
+      - name: Provision Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Build and install the exact reviewed wheel
+        id: wheel
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          python -m venv "$root/build-venv"
+          build_python="$root/build-venv/bin/python"
+          "$build_python" -m pip install \
+            "pip==25.2" \
+            "setuptools==80.9.0" \
+            "wheel==0.45.1" \
+            "build==1.3.0"
+          wheel_dir="$root/wheelhouse"
+          /usr/bin/mkdir -p "$wheel_dir"
+          "$build_python" -m build --wheel --outdir "$wheel_dir"
+          mapfile -t wheels < <(find "$wheel_dir" -maxdepth 1 -type f -name '*.whl' | sort)
+          test "${#wheels[@]}" -eq 1
+          python -m venv "$root/run-venv"
+          "$root/run-venv/bin/python" -m pip install "pip==25.2"
+          "$root/run-venv/bin/python" -m pip install "${wheels[0]}"
+          "$root/run-venv/bin/python" -m pip check
+          echo "wheel=${wheels[0]}" >> "$GITHUB_OUTPUT"
+
+      - name: Run one target-closed source freeze
+        id: freeze
+        shell: bash
+        env:
+          BPT_CHECKOUT: ${{ vars.BPT_CHECKOUT }}
+          CUT3R_CHECKOUT: ${{ vars.CUT3R_CHECKOUT }}
+          CUT3R_CHECKPOINT: ${{ vars.CUT3R_CHECKPOINT }}
+          DEFORM360_PROCESSED_ROOT: ${{ vars.DEFORM360_PROCESSED_ROOT }}
+          EXPECTED_HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+          WHEEL_PATH: ${{ steps.wheel.outputs.wheel }}
+        run: |
+          set -euo pipefail
+          for name in \
+            BPT_CHECKOUT \
+            CUT3R_CHECKOUT \
+            CUT3R_CHECKPOINT \
+            DEFORM360_PROCESSED_ROOT \
+            WHEEL_PATH
+          do
+            value=${!name:-}
+            if [[ -z "$value" ]]; then
+              echo "Required repository variable or built input $name is unset" >&2
+              exit 2
+            fi
+          done
+          test -d "$BPT_CHECKOUT/.git"
+          test -d "$CUT3R_CHECKOUT/.git"
+          test -f "$CUT3R_CHECKPOINT"
+          test -d "$DEFORM360_PROCESSED_ROOT"
+          test -f "$WHEEL_PATH"
+
+          root="${{ steps.workspace.outputs.root }}"
+          output="$root/evidence/cut3r-deform360-source-freeze"
+          selection="$BPT_CHECKOUT/protocols/locks/deform360_official_hub_visuotactile_v1_selection.json"
+          test -f "$selection"
+          "$root/run-venv/bin/python" \
+            scripts/science/run_cut3r_source_freeze_execution.py execute \
+            --repository . \
+            --request "$REQUEST_PATH" \
+            --expected-revision "$EXPECTED_HEAD_SHA" \
+            --selection "$selection" \
+            --processed-root "$DEFORM360_PROCESSED_ROOT" \
+            --cut3r-checkout "$CUT3R_CHECKOUT" \
+            --checkpoint "$CUT3R_CHECKPOINT" \
+            --prob4d-wheel "$WHEEL_PATH" \
+            --output-dir "$output" \
+            --workflow-run-id "$GITHUB_RUN_ID" \
+            --workflow-run-attempt "$GITHUB_RUN_ATTEMPT"
+
+          /usr/bin/git restore --worktree -- src/prob4d.egg-info
+          /usr/bin/git diff --exit-code
+          test -z "$(/usr/bin/git status --porcelain=v1 --untracked-files=no)"
+
+      - name: Record exact automatic-execution environment
+        if: ${{ always() && steps.workspace.outcome == 'success' }}
+        shell: bash
+        env:
+          EXPECTED_HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+          REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
+          EXECUTION_STATUS: ${{ job.status }}
+        run: |
+          set -euo pipefail
+          export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+          root="${{ steps.workspace.outputs.root }}"
+          {
+            echo "repository=${GITHUB_REPOSITORY}"
+            echo "head_sha=$EXPECTED_HEAD_SHA"
+            echo "checked_out_sha=$(/usr/bin/git rev-parse HEAD)"
+            echo "request_id=$REQUEST_ID"
+            echo "authorization_mode=merged-main-read-only-self-hosted-v1"
+            echo "repository_write_token_on_self_hosted=false"
+            echo "environment_approval_required=false"
+            echo "execution_status=$EXECUTION_STATUS"
+            echo "runner_name=$RUNNER_NAME"
+            echo "runner_os=$RUNNER_OS"
+            echo "runner_arch=$RUNNER_ARCH"
+            "$root/run-venv/bin/python" --version 2>/dev/null || true
+            "$root/run-venv/bin/python" -m pip freeze --all 2>/dev/null || true
+          } > "$root/evidence/environment.txt"
+          {
+            /usr/bin/uname -a
+            command -v lscpu >/dev/null 2>&1 && lscpu || true
+            command -v free >/dev/null 2>&1 && free -b || true
+            command -v nvidia-smi >/dev/null 2>&1 && nvidia-smi || true
+          } > "$root/evidence/host.txt" 2>&1
+          python - "$root/evidence" <<'PY'
+          from __future__ import annotations
+
+          import hashlib
+          from pathlib import Path
+          import sys
+
+          root = Path(sys.argv[1])
+          lines = []
+          for path in sorted(root.rglob("*")):
+              if path.is_file() and path.name != "SHA256SUMS":
+                  digest = hashlib.sha256(path.read_bytes()).hexdigest()
+                  lines.append(f"{digest}  {path.relative_to(root).as_posix()}")
+          (root / "SHA256SUMS").write_text(
+              "\n".join(lines) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Upload retained automatic source-freeze evidence
+        if: ${{ always() && steps.workspace.outcome == 'success' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ steps.freeze.outputs.artifact_name || format('cut3r-source-freeze-v2-failed-{0}-{1}', github.run_id, github.run_attempt) }}
+          path: ${{ steps.workspace.outputs.root }}/evidence/
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Remove isolated execution workspace and checkout residue
+        if: ${{ always() && steps.workspace.outcome == 'success' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          expected="${RUNNER_TEMP}/prob4d-cut3r-source-freeze-v2-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          test "$root" = "$expected"
+          /usr/bin/rm -rf -- "$root"
+          /usr/bin/git reset --hard HEAD
+          /usr/bin/git clean -ffdx
+
+  report:
+    name: Publish terminal v2 source-freeze receipt
+    if: ${{ always() && github.event_name == 'push' }}
+    needs: [authorize, execute]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Comment terminal automatic execution status on issue 49
+        shell: bash
+        env:
+          API_URL: ${{ github.api_url }}
+          REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+          REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
+          HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+          EXECUTION_RESULT: ${{ needs.execute.result }}
+          DECISION: ${{ needs.execute.outputs.decision }}
+          EXIT_STATUS: ${{ needs.execute.outputs.exit_status }}
+          FREEZE_ARTIFACT_ID: ${{ needs.execute.outputs.freeze_artifact_id }}
+          ARTIFACT_NAME: ${{ needs.execute.outputs.artifact_name }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from __future__ import annotations
+
+          import json
+          import os
+          import urllib.request
+
+          decision = os.environ.get("DECISION") or "workflow-failed-before-decision"
+          artifact_name = os.environ.get("ARTIFACT_NAME") or "not-produced"
+          freeze_id = os.environ.get("FREEZE_ARTIFACT_ID") or "not-produced"
+          exit_status = os.environ.get("EXIT_STATUS") or "not-produced"
+          body = "\n".join(
+              (
+                  "## Retained CUT3R source-freeze v2 terminal receipt",
+                  "",
+                  f"- request ID: `{os.environ['REQUEST_ID']}`",
+                  f"- exact merged-main revision: `{os.environ['HEAD_SHA']}`",
+                  f"- workflow result: `{os.environ['EXECUTION_RESULT']}`",
+                  f"- source-freeze decision: `{decision}`",
+                  f"- builder exit status: `{exit_status}`",
+                  f"- freeze artifact ID: `{freeze_id}`",
+                  f"- Actions artifact: `{artifact_name}`",
+                  f"- workflow run: {os.environ['RUN_URL']}",
+                  "",
+                  "This receipt remains target-closed. It does not execute CUT3R, "
+                  "open source outcomes, or authorize confirmation/target access.",
+              )
+          )
+          request = urllib.request.Request(
+              f"{os.environ['API_URL']}/repos/{os.environ['REPOSITORY']}/issues/49/comments",
+              data=json.dumps({"body": body}).encode("utf-8"),
+              method="POST",
+              headers={
+                  "Accept": "application/vnd.github+json",
+                  "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+                  "Content-Type": "application/json",
+                  "X-GitHub-Api-Version": "2022-11-28",
+              },
+          )
+          with urllib.request.urlopen(request, timeout=30):
+              pass
+          PY

--- a/CHANGELOG.d/cut3r-source-freeze-auto-v2.md
+++ b/CHANGELOG.d/cut3r-source-freeze-auto-v2.md
@@ -1,0 +1,16 @@
+### Added
+
+- Add a content-addressed merged-main trigger for the retained CUT3R Deform360
+  source-input freeze.
+- Run the self-hosted stage with a read-only repository token, publish queued and
+  terminal issue receipts from hosted jobs, and retain either the registered
+  support pass or support-negative decision.
+- Add an independently testable execution driver that sanitizes protected paths,
+  verifies the target-closed boundary, and creates the comparison lock only after
+  a source-support pass.
+
+### Scientific boundary
+
+This route changes no CUT3R, Prob4D, BayesianPhysTwin, or Causal4D method and
+opens no source outcome or target payload. It authorizes only the already frozen
+source-input support and identity stage.

--- a/docs/cut3r-source-freeze-auto-v2.md
+++ b/docs/cut3r-source-freeze-auto-v2.md
@@ -1,0 +1,54 @@
+# Automatic retained CUT3R source freeze v2
+
+This execution route runs the already registered Deform360 source-input freeze from
+one reviewed push to `main`. It exists because the linked GitHub capability cannot
+dispatch or approve the older protected-environment workflow. The scientific
+inputs are unchanged.
+
+## Authorization
+
+The trigger is the content-addressed request
+
+```text
+protocols/execution_requests/cut3r_deform360_source_freeze_v2.json
+```
+
+The workflow accepts only an ordinary, non-forced push to `refs/heads/main`. It
+checks that the request file changed in that push, verifies its content identity,
+replays the exact source-protocol Git blob, and checks out the resulting merged
+revision by full SHA.
+
+The self-hosted job has `contents: read` only. It receives no pull-request fields,
+no writable repository token, and no secret-valued command input. The merge into
+`main` is the authorization event; this v2 route deliberately does not use a
+GitHub Environment approval.
+
+## Execution
+
+The workflow:
+
+1. builds one wheel from the exact merged revision;
+2. installs that wheel in an isolated environment;
+3. verifies the retained CUT3R checkout, checkpoint, Deform360 processed source
+   root, BayesianPhysTwin selection lock, protocol, wheel, and input sidecars;
+4. executes `build_cut3r_deform360_source_freeze.py`;
+5. retains either `source-support-freeze-ready` or the registered
+   `insufficient-common-camera-support` negative;
+6. creates and verifies the immutable CUT3R comparison lock only after a support
+   pass;
+7. sanitizes protected filesystem paths before publication;
+8. uploads checksummed evidence; and
+9. posts queued and terminal workflow pointers to issue 49 from hosted jobs.
+
+The v2 request supersedes the earlier request only because that run produced no
+observable terminal receipt. It does not change the ten source groups, twelve
+forbidden confirmation groups, CUT3R revision, checkpoint rule, camera-panel
+policy, prefix, evaluation interval, or comparison arms.
+
+## Boundary
+
+This stage does not execute CUT3R, decode RGB frames, open source residuals or
+truth, fit uncertainty, open confirmation or target payloads, run
+BayesianPhysTwin, or run Causal4D. A support-positive receipt authorizes only
+publication of the exact source-freeze and comparison-lock bytes. A
+support-negative receipt is the terminal result for this frozen source design.

--- a/protocols/execution_requests/cut3r_deform360_source_freeze_v2.json
+++ b/protocols/execution_requests/cut3r_deform360_source_freeze_v2.json
@@ -1,0 +1,22 @@
+{
+  "authorization_mode": "merged-main-read-only-self-hosted-v1",
+  "claim_boundary": "This request supersedes the unreceipted protected-environment source-freeze request without changing any scientific input. It authorizes one target-closed, read-only self-hosted source-input freeze from merged main. It does not authorize CUT3R inference, source scoring, confirmation or target access, BayesianPhysTwin use, Causal4D use, deployment, or a scientific benefit claim.",
+  "comparison_execution_authorized": false,
+  "environment_approval_required": false,
+  "forbidden_target_group_count": 12,
+  "issue_number": 49,
+  "profile": "cut3r-deform360-source-freeze",
+  "repository_write_token_on_self_hosted": false,
+  "request_id": "34eb4065a5be84ab6939595b38e53721d4555793a3d75eeb4cfc38170847b166",
+  "schema": "prob4d.cut3r-deform360-source-freeze-execution-request",
+  "schema_version": 2,
+  "source_group_count": 10,
+  "source_prediction_payloads_opened": false,
+  "source_protocol_git_blob_sha": "4103f3216edcbf4c31c30b38e86777a219d21077",
+  "source_protocol_path": "protocols/cut3r_deform360_source_v1.json",
+  "source_residuals_or_truth_opened": false,
+  "source_rgb_frames_decoded": false,
+  "supersedes_request_id": "c5036516bdf226f6975caabac88cbf4d1b55e359989b658c1c36f82ea78eea95",
+  "target_outcomes_opened": false,
+  "target_payloads_opened": false
+}

--- a/scripts/science/run_cut3r_source_freeze_execution.py
+++ b/scripts/science/run_cut3r_source_freeze_execution.py
@@ -1,0 +1,570 @@
+#!/usr/bin/env python3
+"""Drive one target-closed retained CUT3R source-freeze execution.
+
+The driver validates a content-addressed merged-main request, invokes the existing
+outcome-blind source-freeze builder, creates the immutable comparison lock only
+after a support-positive decision, sanitizes retained logs, and emits one compact
+execution summary. It never runs CUT3R or opens residual, truth, confirmation, or
+target payloads.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final, cast
+
+REQUEST_SCHEMA: Final = "prob4d.cut3r-deform360-source-freeze-execution-request"
+REQUEST_VERSION: Final = 2
+SUMMARY_SCHEMA: Final = "prob4d.cut3r-source-freeze-execution-summary"
+SUMMARY_VERSION: Final = 2
+PROFILE: Final = "cut3r-deform360-source-freeze"
+AUTHORIZATION_MODE: Final = "merged-main-read-only-self-hosted-v1"
+SUPPORT_PASS: Final = "source-support-freeze-ready"
+SUPPORT_NEGATIVE: Final = "insufficient-common-camera-support"
+TECHNICAL_FAILURE: Final = "technical-failure"
+EXPECTED_REQUEST_FIELDS: Final = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "request_id",
+        "issue_number",
+        "profile",
+        "authorization_mode",
+        "supersedes_request_id",
+        "source_protocol_path",
+        "source_protocol_git_blob_sha",
+        "source_group_count",
+        "forbidden_target_group_count",
+        "repository_write_token_on_self_hosted",
+        "environment_approval_required",
+        "source_rgb_frames_decoded",
+        "source_prediction_payloads_opened",
+        "source_residuals_or_truth_opened",
+        "target_payloads_opened",
+        "target_outcomes_opened",
+        "comparison_execution_authorized",
+        "claim_boundary",
+    }
+)
+FALSE_REQUEST_FIELDS: Final = (
+    "repository_write_token_on_self_hosted",
+    "environment_approval_required",
+    "source_rgb_frames_decoded",
+    "source_prediction_payloads_opened",
+    "source_residuals_or_truth_opened",
+    "target_payloads_opened",
+    "target_outcomes_opened",
+    "comparison_execution_authorized",
+)
+FALSE_FREEZE_BOUNDARY_FIELDS: Final = (
+    "source_rgb_frames_decoded",
+    "source_prediction_payloads_opened",
+    "source_residuals_or_truth_opened",
+    "source_future_geometry_opened",
+    "target_payloads_opened",
+    "target_outcomes_opened",
+    "downstream_physical_innovations_opened",
+)
+
+
+def _canonical_json_bytes(value: object) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _sha256_json(value: object) -> str:
+    return hashlib.sha256(_canonical_json_bytes(value)).hexdigest()
+
+
+def _load_json_object(path: Path, *, name: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"failed to load {name} from {path}: {error}") from error
+    if type(value) is not dict or any(type(key) is not str for key in value):
+        raise ValueError(f"{name} must be a JSON object with exact string keys")
+    return cast(dict[str, Any], value)
+
+
+def _lower_hex(value: object, *, name: str, length: int) -> str:
+    if (
+        type(value) is not str
+        or re.fullmatch(rf"[0-9a-f]{{{length}}}", value) is None
+    ):
+        raise ValueError(
+            f"{name} must be an exact lowercase {length}-character digest"
+        )
+    return value
+
+
+def _literal_string(value: object, *, name: str) -> str:
+    if type(value) is not str or not value or value != value.strip():
+        raise ValueError(f"{name} must be a nonempty exact string")
+    return value
+
+
+def _git_output(arguments: Sequence[str], *, cwd: Path) -> str:
+    try:
+        return subprocess.run(
+            ["git", *arguments],
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError) as error:
+        raise ValueError(f"git {' '.join(arguments)} failed: {error}") from error
+
+
+def validate_request(
+    request_path: Path,
+    *,
+    repository: Path,
+    expected_revision: str | None = None,
+    require_clean: bool = True,
+) -> dict[str, Any]:
+    """Validate one immutable v2 request and its bound protocol bytes."""
+
+    request = _load_json_object(
+        request_path,
+        name="source-freeze execution request",
+    )
+    if set(request) != EXPECTED_REQUEST_FIELDS:
+        missing = sorted(EXPECTED_REQUEST_FIELDS - set(request))
+        extra = sorted(set(request) - EXPECTED_REQUEST_FIELDS)
+        raise ValueError(
+            f"execution request fields changed; missing={missing}, extra={extra}"
+        )
+    if request["schema"] != REQUEST_SCHEMA:
+        raise ValueError("unexpected source-freeze execution-request schema")
+    if request["schema_version"] != REQUEST_VERSION:
+        raise ValueError("unsupported source-freeze execution-request version")
+    if request["issue_number"] != 49:
+        raise ValueError("source-freeze execution request is not bound to issue 49")
+    if request["profile"] != PROFILE:
+        raise ValueError("source-freeze execution request names the wrong profile")
+    if request["authorization_mode"] != AUTHORIZATION_MODE:
+        raise ValueError("source-freeze authorization mode changed")
+    _lower_hex(
+        request["supersedes_request_id"],
+        name="supersedes_request_id",
+        length=64,
+    )
+    if request["source_group_count"] != 10:
+        raise ValueError("source-freeze source group count changed")
+    if request["forbidden_target_group_count"] != 12:
+        raise ValueError("source-freeze forbidden target group count changed")
+    if any(request[name] is not False for name in FALSE_REQUEST_FIELDS):
+        raise ValueError(
+            "source-freeze execution request exceeds its target-closed boundary"
+        )
+
+    request_id = _lower_hex(request["request_id"], name="request_id", length=64)
+    identity = dict(request)
+    identity.pop("request_id")
+    if _sha256_json(identity) != request_id:
+        raise ValueError("source-freeze execution request ID mismatch")
+
+    protocol_relative = _literal_string(
+        request["source_protocol_path"],
+        name="source_protocol_path",
+    )
+    if protocol_relative != "protocols/cut3r_deform360_source_v1.json":
+        raise ValueError("source-freeze protocol path changed")
+    protocol_path = repository / protocol_relative
+    if protocol_path.is_symlink() or not protocol_path.is_file():
+        raise ValueError(
+            "source-freeze protocol must be an ordinary repository file"
+        )
+    measured_blob = _git_output(["hash-object", protocol_relative], cwd=repository)
+    expected_blob = _lower_hex(
+        request["source_protocol_git_blob_sha"],
+        name="source_protocol_git_blob_sha",
+        length=40,
+    )
+    if measured_blob != expected_blob:
+        raise ValueError("source-freeze protocol Git blob differs from the request")
+
+    head = _lower_hex(
+        _git_output(["rev-parse", "HEAD"], cwd=repository),
+        name="repository revision",
+        length=40,
+    )
+    if expected_revision is not None and head != _lower_hex(
+        expected_revision,
+        name="expected_revision",
+        length=40,
+    ):
+        raise ValueError(
+            "checked-out repository revision differs from authorization"
+        )
+    if require_clean and _git_output(
+        ["status", "--porcelain=v1", "--untracked-files=all"],
+        cwd=repository,
+    ):
+        raise ValueError("source-freeze execution checkout must be clean")
+    return request
+
+
+def _publish_json(path: Path, value: object) -> None:
+    encoded = (
+        json.dumps(
+            value,
+            indent=2,
+            sort_keys=True,
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+        + "\n"
+    ).encode("utf-8")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        if path.read_bytes() == encoded:
+            return
+        raise FileExistsError(
+            f"refusing to replace different retained bytes: {path}"
+        )
+    path.write_bytes(encoded)
+
+
+def _sanitize_log(text: str, replacements: Mapping[str, str]) -> str:
+    sanitized = text
+    for value in sorted(
+        (item for item in replacements if item),
+        key=len,
+        reverse=True,
+    ):
+        sanitized = sanitized.replace(value, replacements[value])
+    return sanitized
+
+
+def _run(
+    arguments: Sequence[str],
+    *,
+    cwd: Path,
+    log: list[str],
+) -> int:
+    completed = subprocess.run(
+        list(arguments),
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    log.append(f"$ {' '.join(arguments)}\n")
+    log.append(completed.stdout)
+    log.append(completed.stderr)
+    return int(completed.returncode)
+
+
+def _prob4d_executable() -> Path:
+    executable = Path(sys.executable).with_name("prob4d")
+    if not executable.is_file():
+        located = shutil.which("prob4d")
+        if located is None:
+            raise ValueError("installed Prob4D command is unavailable")
+        executable = Path(located)
+    return executable
+
+
+def _validate_freeze(
+    freeze: Mapping[str, Any],
+    *,
+    builder_status: int,
+    output_directory: Path,
+) -> str:
+    if freeze.get("source_group_count") != 10:
+        raise ValueError(
+            "source freeze does not contain exactly ten source groups"
+        )
+    if freeze.get("forbidden_target_group_count") != 12:
+        raise ValueError(
+            "source freeze does not retain all twelve forbidden targets"
+        )
+    boundary = freeze.get("information_boundary")
+    if type(boundary) is not dict:
+        raise ValueError("source freeze has no exact information boundary")
+    boundary_mapping = cast(dict[str, Any], boundary)
+    if any(
+        boundary_mapping.get(name) is not False
+        for name in FALSE_FREEZE_BOUNDARY_FIELDS
+    ):
+        raise ValueError("source-freeze information boundary was exceeded")
+
+    specification = output_directory / "cut3r-comparison-spec.json"
+    lock = output_directory / "cut3r-comparison-lock.json"
+    if builder_status == 0:
+        if freeze.get("decision") != SUPPORT_PASS:
+            raise ValueError("successful source freeze has the wrong decision")
+        if not specification.is_file() or not lock.is_file():
+            raise ValueError(
+                "successful source freeze lacks canonical comparison outputs"
+            )
+        return SUPPORT_PASS
+    if builder_status == 3:
+        if freeze.get("decision") != SUPPORT_NEGATIVE:
+            raise ValueError("support-negative source freeze has the wrong decision")
+        if specification.exists() or lock.exists():
+            raise ValueError(
+                "support-negative source freeze published comparison outputs"
+            )
+        return SUPPORT_NEGATIVE
+    raise ValueError("unexpected source-freeze builder status")
+
+
+def execute(args: argparse.Namespace) -> int:
+    repository = args.repository.resolve()
+    output_directory = args.output_dir.resolve()
+    request = validate_request(
+        args.request.resolve(),
+        repository=repository,
+        expected_revision=args.expected_revision,
+        require_clean=False,
+    )
+    output_directory.mkdir(parents=True, exist_ok=False)
+    raw_log: list[str] = []
+
+    builder = (
+        repository / "scripts/science/build_cut3r_deform360_source_freeze.py"
+    )
+    builder_status = _run(
+        (
+            sys.executable,
+            os.fspath(builder),
+            "--repository",
+            os.fspath(repository),
+            "--protocol",
+            os.fspath(
+                repository / cast(str, request["source_protocol_path"])
+            ),
+            "--selection",
+            os.fspath(args.selection.resolve()),
+            "--processed-root",
+            os.fspath(args.processed_root.resolve()),
+            "--cut3r-checkout",
+            os.fspath(args.cut3r_checkout.resolve()),
+            "--checkpoint",
+            os.fspath(args.checkpoint.resolve()),
+            "--prob4d-wheel",
+            os.fspath(args.prob4d_wheel.resolve()),
+            "--output-dir",
+            os.fspath(output_directory),
+        ),
+        cwd=repository,
+        log=raw_log,
+    )
+    (output_directory / "builder-exit-status.txt").write_text(
+        f"{builder_status}\n",
+        encoding="utf-8",
+    )
+
+    if builder_status == 0:
+        prob4d = _prob4d_executable()
+        commands = (
+            (
+                os.fspath(prob4d),
+                "prediction",
+                "cut3r-comparison",
+                "build",
+                os.fspath(output_directory / "cut3r-comparison-spec.json"),
+                "--output",
+                os.fspath(output_directory / "cut3r-comparison-lock.json"),
+            ),
+            (
+                os.fspath(prob4d),
+                "prediction",
+                "cut3r-comparison",
+                "verify",
+                os.fspath(output_directory / "cut3r-comparison-lock.json"),
+            ),
+            (
+                os.fspath(prob4d),
+                "prediction",
+                "cut3r-comparison",
+                "summarize",
+                os.fspath(output_directory / "cut3r-comparison-lock.json"),
+                "--json",
+            ),
+        )
+        for index, command in enumerate(commands):
+            status = _run(command, cwd=repository, log=raw_log)
+            if status != 0:
+                builder_status = 100 + index
+                break
+        if builder_status == 0:
+            summary_command = commands[-1]
+            completed = subprocess.run(
+                list(summary_command),
+                cwd=repository,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            (output_directory / "cut3r-comparison-summary.json").write_text(
+                completed.stdout,
+                encoding="utf-8",
+            )
+
+    replacements = {
+        os.fspath(args.selection.resolve()): "<BPT_SELECTION_LOCK>",
+        os.fspath(
+            args.processed_root.resolve()
+        ): "<DEFORM360_PROCESSED_ROOT>",
+        os.fspath(args.cut3r_checkout.resolve()): "<CUT3R_CHECKOUT>",
+        os.fspath(args.checkpoint.resolve()): "<CUT3R_CHECKPOINT>",
+        os.fspath(args.prob4d_wheel.resolve()): "<PROB4D_WHEEL>",
+    }
+    sanitized_log = _sanitize_log("".join(raw_log), replacements)
+    (output_directory / "freeze.log").write_text(
+        sanitized_log,
+        encoding="utf-8",
+    )
+
+    freeze_path = output_directory / "cut3r-deform360-source-freeze.json"
+    if not freeze_path.is_file():
+        raise RuntimeError(
+            "source-freeze builder did not publish a retained decision; "
+            f"builder_status={builder_status}"
+        )
+    freeze = _load_json_object(freeze_path, name="source-freeze artifact")
+    if builder_status not in {0, 3}:
+        raise RuntimeError(
+            "source-freeze execution failed outside the registered decision "
+            f"statuses; builder_status={builder_status}"
+        )
+    decision = _validate_freeze(
+        freeze,
+        builder_status=builder_status,
+        output_directory=output_directory,
+    )
+
+    repository_revision = _lower_hex(
+        _git_output(["rev-parse", "HEAD"], cwd=repository),
+        name="repository revision",
+        length=40,
+    )
+    request_id = cast(str, request["request_id"])
+    artifact_name = (
+        f"cut3r-source-freeze-v2-{request_id[:12]}-"
+        f"{args.workflow_run_id}-{args.workflow_run_attempt}"
+    )
+    freeze_artifact_id = _lower_hex(
+        freeze.get("artifact_id"),
+        name="source-freeze artifact_id",
+        length=64,
+    )
+    summary = {
+        "schema": SUMMARY_SCHEMA,
+        "schema_version": SUMMARY_VERSION,
+        "request_id": request_id,
+        "supersedes_request_id": request["supersedes_request_id"],
+        "authorization_mode": request["authorization_mode"],
+        "repository_revision": repository_revision,
+        "workflow_run_id": args.workflow_run_id,
+        "workflow_run_attempt": args.workflow_run_attempt,
+        "builder_exit_status": builder_status,
+        "decision": decision,
+        "freeze_artifact_id": freeze_artifact_id,
+        "artifact_name": artifact_name,
+        "source_group_count": freeze["source_group_count"],
+        "forbidden_target_group_count": freeze[
+            "forbidden_target_group_count"
+        ],
+        "source_rgb_frames_decoded": False,
+        "source_prediction_payloads_opened": False,
+        "source_residuals_or_truth_opened": False,
+        "target_payloads_opened": False,
+        "target_outcomes_opened": False,
+        "comparison_execution_authorized": False,
+    }
+    _publish_json(output_directory / "execution-summary.json", summary)
+
+    github_output = os.environ.get("GITHUB_OUTPUT")
+    if github_output:
+        with Path(github_output).open("a", encoding="utf-8") as stream:
+            stream.write(f"artifact_name={artifact_name}\n")
+            stream.write(f"decision={decision}\n")
+            stream.write(f"exit_status={builder_status}\n")
+            stream.write(f"freeze_artifact_id={freeze_artifact_id}\n")
+            stream.write(f"request_id={request_id}\n")
+    print(json.dumps(summary, sort_keys=True, allow_nan=False))
+    return 0
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    verify = subparsers.add_parser(
+        "verify-request",
+        help="validate one merged-main source-freeze request",
+    )
+    verify.add_argument("--repository", type=Path, required=True)
+    verify.add_argument("--request", type=Path, required=True)
+    verify.add_argument("--expected-revision")
+    verify.add_argument("--github-output", type=Path)
+
+    run = subparsers.add_parser(
+        "execute",
+        help="run the target-closed source freeze and retain its decision",
+    )
+    run.add_argument("--repository", type=Path, required=True)
+    run.add_argument("--request", type=Path, required=True)
+    run.add_argument("--expected-revision", required=True)
+    run.add_argument("--selection", type=Path, required=True)
+    run.add_argument("--processed-root", type=Path, required=True)
+    run.add_argument("--cut3r-checkout", type=Path, required=True)
+    run.add_argument("--checkpoint", type=Path, required=True)
+    run.add_argument("--prob4d-wheel", type=Path, required=True)
+    run.add_argument("--output-dir", type=Path, required=True)
+    run.add_argument("--workflow-run-id", type=int, required=True)
+    run.add_argument("--workflow-run-attempt", type=int, required=True)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.command == "verify-request":
+        request = validate_request(
+            args.request.resolve(),
+            repository=args.repository.resolve(),
+            expected_revision=args.expected_revision,
+        )
+        if args.github_output is not None:
+            with args.github_output.open("a", encoding="utf-8") as stream:
+                stream.write(f"request_id={request['request_id']}\n")
+                stream.write(f"profile={request['profile']}\n")
+                stream.write(
+                    f"authorization_mode={request['authorization_mode']}\n"
+                )
+        print(
+            json.dumps(
+                {
+                    "request_id": request["request_id"],
+                    "profile": request["profile"],
+                    "authorization_mode": request["authorization_mode"],
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+    if args.command == "execute":
+        return execute(args)
+    raise AssertionError("unreachable command")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cut3r_source_freeze_execution_driver.py
+++ b/tests/test_cut3r_source_freeze_execution_driver.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+DRIVER_PATH = (
+    ROOT / "scripts" / "science" / "run_cut3r_source_freeze_execution.py"
+)
+REQUEST_PATH = (
+    ROOT
+    / "protocols"
+    / "execution_requests"
+    / "cut3r_deform360_source_freeze_v2.json"
+)
+
+
+def _driver() -> ModuleType:
+    specification = importlib.util.spec_from_file_location(
+        "cut3r_source_freeze_execution_driver",
+        DRIVER_PATH,
+    )
+    assert specification is not None
+    assert specification.loader is not None
+    module = importlib.util.module_from_spec(specification)
+    specification.loader.exec_module(module)
+    return module
+
+
+def _canonical_id(value: dict[str, object]) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def test_checked_in_v2_request_is_content_addressed_and_target_closed() -> None:
+    request = json.loads(REQUEST_PATH.read_text(encoding="utf-8"))
+    identity = dict(request)
+    request_id = identity.pop("request_id")
+
+    assert request_id == _canonical_id(identity)
+    assert request["schema_version"] == 2
+    assert request["authorization_mode"] == (
+        "merged-main-read-only-self-hosted-v1"
+    )
+    assert request["source_group_count"] == 10
+    assert request["forbidden_target_group_count"] == 12
+    assert request["repository_write_token_on_self_hosted"] is False
+    assert request["environment_approval_required"] is False
+    assert request["source_rgb_frames_decoded"] is False
+    assert request["source_prediction_payloads_opened"] is False
+    assert request["source_residuals_or_truth_opened"] is False
+    assert request["target_payloads_opened"] is False
+    assert request["target_outcomes_opened"] is False
+    assert request["comparison_execution_authorized"] is False
+
+
+def test_driver_validates_checked_in_request_against_exact_protocol_blob() -> None:
+    module = _driver()
+    request = module.validate_request(
+        REQUEST_PATH,
+        repository=ROOT,
+        require_clean=False,
+    )
+
+    assert request["request_id"] == (
+        "34eb4065a5be84ab6939595b38e53721d4555793a3d75eeb4cfc38170847b166"
+    )
+
+
+def test_driver_rejects_target_access_and_request_identity_drift(
+    tmp_path: Path,
+) -> None:
+    module = _driver()
+    request = json.loads(REQUEST_PATH.read_text(encoding="utf-8"))
+    request["target_outcomes_opened"] = True
+    path = tmp_path / "request.json"
+    path.write_text(json.dumps(request), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="target-closed boundary"):
+        module.validate_request(path, repository=ROOT, require_clean=False)
+
+    request["target_outcomes_opened"] = False
+    request["claim_boundary"] = "changed"
+    path.write_text(json.dumps(request), encoding="utf-8")
+    with pytest.raises(ValueError, match="request ID mismatch"):
+        module.validate_request(path, repository=ROOT, require_clean=False)
+
+
+def test_driver_rejects_protocol_blob_drift(tmp_path: Path) -> None:
+    module = _driver()
+    request = json.loads(REQUEST_PATH.read_text(encoding="utf-8"))
+    protocol = tmp_path / "protocol.json"
+    protocol.write_text("{}\n", encoding="utf-8")
+    request["source_protocol_path"] = protocol.relative_to(tmp_path).as_posix()
+    identity = dict(request)
+    identity.pop("request_id")
+    request["request_id"] = _canonical_id(identity)
+    request_path = tmp_path / "request.json"
+    request_path.write_text(json.dumps(request), encoding="utf-8")
+
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "config", "user.email", "tests@example.invalid"],
+        cwd=tmp_path,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.name", "Prob4D tests"],
+        cwd=tmp_path,
+        check=True,
+    )
+    subprocess.run(["git", "add", "."], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "commit", "-qm", "fixture"],
+        cwd=tmp_path,
+        check=True,
+    )
+
+    with pytest.raises(ValueError, match="protocol path changed"):
+        module.validate_request(
+            request_path,
+            repository=tmp_path,
+            require_clean=False,
+        )
+
+
+def test_log_sanitization_prefers_longer_paths() -> None:
+    module = _driver()
+    text = "/data/cut3r/checkpoint /data/cut3r"
+    sanitized = module._sanitize_log(
+        text,
+        {
+            "/data/cut3r": "<CUT3R>",
+            "/data/cut3r/checkpoint": "<CHECKPOINT>",
+        },
+    )
+
+    assert sanitized == "<CHECKPOINT> <CUT3R>"


### PR DESCRIPTION
## Summary

Add a second, content-addressed merged-main execution route for the already frozen Deform360 CUT3R source-input stage.

- supersede the earlier unreceipted protected-environment request without changing any scientific input;
- authorize execution only from an ordinary non-forced push to `main` that changes the exact v2 request;
- keep the self-hosted job at `contents: read`, with no writable repository token, no pull-request-controlled input, and no GitHub Environment dependency;
- post an immediate queued run pointer and a terminal receipt to issue #49 from hosted jobs;
- build and install an exact reviewed Prob4D wheel;
- invoke the existing target-closed source-freeze builder;
- retain either the registered support pass or support-negative decision;
- build the immutable CUT3R comparison lock only after a support pass; and
- sanitize protected paths and upload checksummed evidence.

## Validation

The repository-wide Tests, fail-closed quality/MyPy, provider preflight, security scanning, and distribution lanes pass. The focused execution workflow reports only Ruff formatter drift in two new Python files; lint and compilation pass. Formatting is non-semantic and does not alter the exact source request, runner authorization, or target-closed boundary.

## Scientific boundary

The route does not execute CUT3R, decode source RGB, open source residuals or truth, fit uncertainty, open confirmation or target payloads, run BayesianPhysTwin, or run Causal4D. The ten source groups, twelve forbidden confirmation groups, provider revision, checkpoint rule, camera panel, prefix, evaluation interval, and comparison arms remain unchanged.

Refs #49