### PR TITLE
Publish retained CUT3R source-freeze locks through reviewed bytes

### DIFF
--- a/.github/workflows/cut3r-source-freeze-lock-publication.yml
+++ b/.github/workflows/cut3r-source-freeze-lock-publication.yml
@@ -1,0 +1,283 @@
+name: Publish retained CUT3R source-freeze locks
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/cut3r-source-freeze-lock-publication.yml"
+      - "CHANGELOG.d/cut3r-source-freeze-lock-publication.md"
+      - "docs/cut3r-source-freeze-lock-publication.md"
+      - "protocols/publication_requests/cut3r_deform360_source_freeze_v2.json"
+      - "scripts/science/publish_cut3r_source_freeze_lock.py"
+      - "tests/test_cut3r_source_freeze_lock_publication.py"
+  push:
+    branches: [main]
+    paths:
+      - "protocols/publication_requests/cut3r_deform360_source_freeze_v2.json"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cut3r-source-freeze-lock-publication-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONHASHSEED: "0"
+  PYTHONUNBUFFERED: "1"
+  REQUEST_PATH: protocols/publication_requests/cut3r_deform360_source_freeze_v2.json
+
+jobs:
+  contract:
+    name: Publication contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Check out exact reviewed revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: >-
+            ${{ github.event_name == 'pull_request' &&
+                github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+          clean: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Validate publication implementation
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install -e ".[dev]"
+          python -m pip check
+          python -m ruff check \
+            scripts/science/publish_cut3r_source_freeze_lock.py \
+            tests/test_cut3r_source_freeze_lock_publication.py
+          python -m ruff format --check \
+            scripts/science/publish_cut3r_source_freeze_lock.py \
+            tests/test_cut3r_source_freeze_lock_publication.py
+          python -m pytest -q \
+            tests/test_cut3r_source_freeze_lock_publication.py \
+            tests/test_github_action_pins.py
+          python -m compileall -q \
+            scripts/science/publish_cut3r_source_freeze_lock.py
+          python scripts/science/publish_cut3r_source_freeze_lock.py \
+            verify-request \
+            --request "$REQUEST_PATH"
+
+  publish:
+    name: Publish exact source-freeze bytes to a lock PR
+    if: github.event_name == 'push'
+    needs: contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      actions: read
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Require an ordinary push to main
+        shell: bash
+        env:
+          EVENT_REF: ${{ github.ref }}
+          EVENT_FORCED: ${{ github.event.forced }}
+          EVENT_DELETED: ${{ github.event.deleted }}
+        run: |
+          set -euo pipefail
+          test "$EVENT_REF" = "refs/heads/main"
+          test "$EVENT_FORCED" = "false"
+          test "$EVENT_DELETED" = "false"
+
+      - name: Check out exact merged revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: true
+          clean: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install the exact merged package
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install -e .
+          python -m pip check
+
+      - name: Discover, verify, and stage exact retained lock bytes
+        id: publish
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          workspace="${RUNNER_TEMP}/cut3r-source-freeze-publication-${GITHUB_RUN_ID}"
+          rm -rf -- "$workspace"
+          mkdir -p "$workspace"
+          python scripts/science/publish_cut3r_source_freeze_lock.py \
+            discover-and-publish \
+            --request "$REQUEST_PATH" \
+            --repository-root . \
+            --repository-name "$GITHUB_REPOSITORY" \
+            --api-url "$GITHUB_API_URL" \
+            --token "$GITHUB_TOKEN" \
+            --workspace "$workspace" \
+            --github-output "$GITHUB_OUTPUT" \
+            > publication-receipt.json
+          prob4d prediction cut3r-comparison verify \
+            protocols/locks/cut3r_deform360_comparison_lock_v2.json
+          prob4d prediction cut3r-comparison summarize \
+            protocols/locks/cut3r_deform360_comparison_lock_v2.json \
+            --json \
+            > /tmp/replayed-comparison-summary.json
+          cmp \
+            /tmp/replayed-comparison-summary.json \
+            protocols/locks/cut3r_deform360_comparison_summary_v2.json
+
+      - name: Create exact-byte publication branch
+        id: branch
+        shell: bash
+        env:
+          REQUEST_ID: 34eb4065a5be84ab6939595b38e53721d4555793a3d75eeb4cfc38170847b166
+          FREEZE_ARTIFACT_ID: ${{ steps.publish.outputs.freeze_artifact_id }}
+        run: |
+          set -euo pipefail
+          branch="evidence/cut3r-source-freeze-${FREEZE_ARTIFACT_ID:0:12}-${GITHUB_RUN_ID}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$branch"
+          git add \
+            protocols/locks/cut3r_deform360_source_freeze_v2.json \
+            protocols/locks/cut3r_deform360_comparison_spec_v2.json \
+            protocols/locks/cut3r_deform360_comparison_lock_v2.json \
+            protocols/locks/cut3r_deform360_comparison_summary_v2.json \
+            protocols/locks/cut3r_deform360_source_freeze_execution_v2.json \
+            protocols/locks/cut3r_deform360_source_freeze_publication_v2.json
+          git diff --cached --check
+          git commit -m "Publish retained CUT3R source-freeze locks"
+          git push --set-upstream origin "$branch"
+          echo "branch=$branch" >> "$GITHUB_OUTPUT"
+
+      - name: Open lock publication pull request
+        id: pr
+        shell: bash
+        env:
+          API_URL: ${{ github.api_url }}
+          REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+          HEAD_BRANCH: ${{ steps.branch.outputs.branch }}
+          ARTIFACT_ID: ${{ steps.publish.outputs.artifact_id }}
+          SOURCE_RUN_ID: ${{ steps.publish.outputs.run_id }}
+          FREEZE_ARTIFACT_ID: ${{ steps.publish.outputs.freeze_artifact_id }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from __future__ import annotations
+
+          import json
+          import os
+          import urllib.request
+
+          body = "\n".join(
+              (
+                  "## Retained evidence publication",
+                  "",
+                  "This PR publishes exact JSON bytes from the validated, target-closed "
+                  "CUT3R Deform360 source-freeze workflow artifact.",
+                  "",
+                  f"- source workflow run: `{os.environ['SOURCE_RUN_ID']}`",
+                  f"- Actions artifact ID: `{os.environ['ARTIFACT_ID']}`",
+                  f"- source-freeze artifact ID: `{os.environ['FREEZE_ARTIFACT_ID']}`",
+                  "- decision: `source-support-freeze-ready`",
+                  "- source groups: `10`",
+                  "- forbidden confirmation groups: `12`",
+                  "",
+                  "No CUT3R inference, source residual/truth, confirmation payload, "
+                  "target outcome, BayesianPhysTwin update, or Causal4D result is "
+                  "opened by this publication.",
+                  "",
+                  "Refs #49",
+              )
+          )
+          payload = json.dumps(
+              {
+                  "title": "Publish retained CUT3R source-freeze locks",
+                  "head": os.environ["HEAD_BRANCH"],
+                  "base": "main",
+                  "body": body,
+              }
+          ).encode("utf-8")
+          request = urllib.request.Request(
+              f"{os.environ['API_URL']}/repos/{os.environ['REPOSITORY']}/pulls",
+              data=payload,
+              method="POST",
+              headers={
+                  "Accept": "application/vnd.github+json",
+                  "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+                  "Content-Type": "application/json",
+                  "X-GitHub-Api-Version": "2022-11-28",
+              },
+          )
+          with urllib.request.urlopen(request, timeout=30) as response:
+              pull = json.load(response)
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"number={pull['number']}\n")
+              output.write(f"url={pull['html_url']}\n")
+          PY
+
+      - name: Record publication pointer on issue 49
+        shell: bash
+        env:
+          API_URL: ${{ github.api_url }}
+          REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          PR_URL: ${{ steps.pr.outputs.url }}
+          FREEZE_ARTIFACT_ID: ${{ steps.publish.outputs.freeze_artifact_id }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from __future__ import annotations
+
+          import json
+          import os
+          import urllib.request
+
+          body = "\n".join(
+              (
+                  "## Retained CUT3R source-freeze lock publication opened",
+                  "",
+                  f"- publication PR: {os.environ['PR_URL']}",
+                  f"- PR number: `#{os.environ['PR_NUMBER']}`",
+                  f"- source-freeze artifact ID: `{os.environ['FREEZE_ARTIFACT_ID']}`",
+                  "",
+                  "The PR contains exact retained lock bytes. The three-arm source "
+                  "comparison remains target-closed and starts only after those bytes "
+                  "are reviewed and merged.",
+              )
+          )
+          request = urllib.request.Request(
+              f"{os.environ['API_URL']}/repos/{os.environ['REPOSITORY']}/issues/49/comments",
+              data=json.dumps({"body": body}).encode("utf-8"),
+              method="POST",
+              headers={
+                  "Accept": "application/vnd.github+json",
+                  "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+                  "Content-Type": "application/json",
+                  "X-GitHub-Api-Version": "2022-11-28",
+              },
+          )
+          with urllib.request.urlopen(request, timeout=30):
+              pass
+          PY

--- a/CHANGELOG.d/cut3r-source-freeze-lock-publication.md
+++ b/CHANGELOG.d/cut3r-source-freeze-lock-publication.md
@@ -1,0 +1,13 @@
+### Added
+
+- Add a hosted, content-bound publication route that discovers the successful
+  retained CUT3R Deform360 source-freeze artifact, verifies all checksums and
+  target-closed decisions, and opens an exact-byte lock pull request.
+- Bind the source workflow run, Actions artifact, source-freeze artifact, and
+  every published JSON SHA-256 and byte count in a publication receipt.
+
+### Scientific boundary
+
+This is evidence-custody infrastructure. It does not execute CUT3R, open source
+outcomes or target payloads, fit uncertainty, run BayesianPhysTwin or Causal4D,
+or establish provider competence or state of the art.

--- a/docs/cut3r-source-freeze-lock-publication.md
+++ b/docs/cut3r-source-freeze-lock-publication.md
@@ -1,0 +1,54 @@
+# Retained CUT3R source-freeze lock publication
+
+The source-freeze workflow runs on protected retained storage and uploads one
+checksummed target-closed artifact. Claim-bearing source execution must consume
+reviewed repository bytes rather than a mutable Actions download. This publication
+stage converts the exact successful workflow payload into an ordinary lock pull
+request without recomputing any scientific value.
+
+## Request
+
+`protocols/publication_requests/cut3r_deform360_source_freeze_v2.json` binds:
+
+- source request ID
+  `34eb4065a5be84ab6939595b38e53721d4555793a3d75eeb4cfc38170847b166`;
+- the corresponding Actions artifact-name prefix;
+- the required `source-support-freeze-ready` decision;
+- ten source object-session groups;
+- twelve forbidden confirmation groups; and
+- the exact destination paths under `protocols/locks/`.
+
+The request keeps source RGB decoding, source residual/truth access, target
+payload access, and target outcome access false.
+
+## Artifact verification
+
+The hosted publication job lists nonexpired Actions artifacts and considers only
+names bound to the exact source request. For each candidate, it:
+
+1. downloads the ZIP through the GitHub Actions API;
+2. rejects path traversal and symbolic links;
+3. verifies every retained `SHA256SUMS` entry;
+4. requires one exact execution summary, source freeze, comparison specification,
+   comparison lock, and comparison summary;
+5. verifies the source request, decision, group counts, and target-closed flags;
+6. independently replays the comparison-lock validator and summary command; and
+7. copies the original JSON bytes without normalization or rewriting.
+
+A publication receipt binds the Actions artifact ID and source workflow run ID,
+the source-freeze artifact ID, and the SHA-256 and byte count of every published
+file.
+
+## Review boundary
+
+The workflow creates a normal pull request from a hosted runner. The retained
+comparison workflow may start only after this exact-byte PR passes ordinary
+repository review and is merged. The source-freeze publisher never runs on the
+self-hosted retained-data runner and never receives protected filesystem paths.
+
+## Scientific boundary
+
+Publication establishes custody and replayability only. It does not execute
+CUT3R, measure provider accuracy, fit uncertainty, open confirmation or target
+payloads, run BayesianPhysTwin, run Causal4D, authorize deployment, or establish
+state of the art.

--- a/protocols/publication_requests/cut3r_deform360_source_freeze_v2.json
+++ b/protocols/publication_requests/cut3r_deform360_source_freeze_v2.json
@@ -1,0 +1,23 @@
+{
+  "artifact_name_prefix": "cut3r-source-freeze-v2-34eb4065a5be-",
+  "claim_boundary": "This request publishes only the exact target-closed source-freeze and comparison-lock bytes produced by the retained CUT3R source-support workflow. It does not execute CUT3R, open source residuals or truth, open confirmation or target payloads, authorize BayesianPhysTwin or Causal4D, or establish provider competence.",
+  "forbidden_target_group_count": 12,
+  "issue_number": 49,
+  "output_paths": {
+    "comparison_lock": "protocols/locks/cut3r_deform360_comparison_lock_v2.json",
+    "comparison_spec": "protocols/locks/cut3r_deform360_comparison_spec_v2.json",
+    "comparison_summary": "protocols/locks/cut3r_deform360_comparison_summary_v2.json",
+    "execution_summary": "protocols/locks/cut3r_deform360_source_freeze_execution_v2.json",
+    "source_freeze": "protocols/locks/cut3r_deform360_source_freeze_v2.json"
+  },
+  "publication_request_id": "34eb4065a5be84ab6939595b38e53721d4555793a3d75eeb4cfc38170847b166",
+  "required_decision": "source-support-freeze-ready",
+  "schema": "prob4d.cut3r-source-freeze-publication-request",
+  "schema_version": 1,
+  "source_group_count": 10,
+  "source_request_id": "34eb4065a5be84ab6939595b38e53721d4555793a3d75eeb4cfc38170847b166",
+  "source_rgb_frames_decoded": false,
+  "source_residuals_or_truth_opened": false,
+  "target_outcomes_opened": false,
+  "target_payloads_opened": false
+}

--- a/scripts/science/publish_cut3r_source_freeze_lock.py
+++ b/scripts/science/publish_cut3r_source_freeze_lock.py
@@ -1,0 +1,464 @@
+#!/usr/bin/env python3
+"""Publish exact retained CUT3R source-freeze locks from a workflow artifact.
+
+The command discovers a nonexpired Actions artifact for the exact source request,
+verifies the uploaded checksum manifest and target-closed decision, then copies
+only the retained JSON bytes into their preregistered repository paths. It never
+executes CUT3R or opens source residuals, truth, confirmation, or target payloads.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import io
+import json
+import os
+import re
+import shutil
+import stat
+import tempfile
+import urllib.error
+import urllib.request
+import zipfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path, PurePosixPath
+from typing import Any, Final, cast
+
+REQUEST_SCHEMA: Final = "prob4d.cut3r-source-freeze-publication-request"
+REQUEST_VERSION: Final = 1
+RECEIPT_SCHEMA: Final = "prob4d.cut3r-source-freeze-publication-receipt"
+RECEIPT_VERSION: Final = 1
+EXPECTED_REQUEST_FIELDS: Final = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "publication_request_id",
+        "source_request_id",
+        "artifact_name_prefix",
+        "required_decision",
+        "source_group_count",
+        "forbidden_target_group_count",
+        "source_rgb_frames_decoded",
+        "source_residuals_or_truth_opened",
+        "target_payloads_opened",
+        "target_outcomes_opened",
+        "output_paths",
+        "claim_boundary",
+    }
+)
+OUTPUT_NAMES: Final = {
+    "source_freeze": "cut3r-deform360-source-freeze.json",
+    "comparison_spec": "cut3r-comparison-spec.json",
+    "comparison_lock": "cut3r-comparison-lock.json",
+    "comparison_summary": "cut3r-comparison-summary.json",
+    "execution_summary": "execution-summary.json",
+}
+FALSE_EXECUTION_FIELDS: Final = (
+    "source_rgb_frames_decoded",
+    "source_prediction_payloads_opened",
+    "source_residuals_or_truth_opened",
+    "target_payloads_opened",
+    "target_outcomes_opened",
+    "comparison_execution_authorized",
+)
+FALSE_FREEZE_BOUNDARY_FIELDS: Final = (
+    "source_rgb_frames_decoded",
+    "source_prediction_payloads_opened",
+    "source_residuals_or_truth_opened",
+    "source_future_geometry_opened",
+    "target_payloads_opened",
+    "target_outcomes_opened",
+    "downstream_physical_innovations_opened",
+)
+
+
+def _load_json(path: Path, *, name: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"failed to load {name} from {path}: {error}") from error
+    if type(value) is not dict or any(type(key) is not str for key in value):
+        raise ValueError(f"{name} must be a JSON object with exact string keys")
+    return cast(dict[str, Any], value)
+
+
+def _literal_string(value: object, *, name: str) -> str:
+    if type(value) is not str or not value or value != value.strip():
+        raise ValueError(f"{name} must be a nonempty exact string")
+    return value
+
+
+def _sha256_string(value: object, *, name: str) -> str:
+    result = _literal_string(value, name=name)
+    if re.fullmatch(r"[0-9a-f]{64}", result) is None:
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return result
+
+
+def _safe_repository_path(value: object, *, name: str) -> str:
+    text = _literal_string(value, name=name)
+    if "\\" in text:
+        raise ValueError(f"{name} must be a POSIX repository path")
+    path = PurePosixPath(text)
+    if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError(f"{name} must be a confined repository path")
+    if path.parts[:2] != ("protocols", "locks") or path.suffix != ".json":
+        raise ValueError(f"{name} must be a JSON path under protocols/locks")
+    return path.as_posix()
+
+
+def validate_request(path: Path) -> dict[str, Any]:
+    request = _load_json(path, name="source-freeze publication request")
+    if set(request) != EXPECTED_REQUEST_FIELDS:
+        missing = sorted(EXPECTED_REQUEST_FIELDS - set(request))
+        extra = sorted(set(request) - EXPECTED_REQUEST_FIELDS)
+        raise ValueError(
+            f"publication request fields changed; missing={missing}, extra={extra}"
+        )
+    if request["schema"] != REQUEST_SCHEMA or request["schema_version"] != REQUEST_VERSION:
+        raise ValueError("unsupported source-freeze publication request")
+    publication_id = _sha256_string(
+        request["publication_request_id"], name="publication_request_id"
+    )
+    source_id = _sha256_string(request["source_request_id"], name="source_request_id")
+    if publication_id != source_id:
+        raise ValueError("publication request must bind the exact source request ID")
+    prefix = _literal_string(request["artifact_name_prefix"], name="artifact_name_prefix")
+    if not prefix.startswith(f"cut3r-source-freeze-v2-{source_id[:12]}-"):
+        raise ValueError("artifact prefix does not bind the source request ID")
+    if request["required_decision"] != "source-support-freeze-ready":
+        raise ValueError("publication request must require the support-positive decision")
+    if request["source_group_count"] != 10:
+        raise ValueError("publication request source group count changed")
+    if request["forbidden_target_group_count"] != 12:
+        raise ValueError("publication request forbidden target count changed")
+    for name in (
+        "source_rgb_frames_decoded",
+        "source_residuals_or_truth_opened",
+        "target_payloads_opened",
+        "target_outcomes_opened",
+    ):
+        if request[name] is not False:
+            raise ValueError("publication request exceeds its target-closed boundary")
+    output_paths = request["output_paths"]
+    if type(output_paths) is not dict or set(output_paths) != set(OUTPUT_NAMES):
+        raise ValueError("publication output path inventory changed")
+    normalized = {
+        key: _safe_repository_path(value, name=f"output_paths.{key}")
+        for key, value in cast(dict[str, object], output_paths).items()
+    }
+    if len(set(normalized.values())) != len(normalized):
+        raise ValueError("publication output paths must be unique")
+    request["output_paths"] = normalized
+    _literal_string(request["claim_boundary"], name="claim_boundary")
+    return request
+
+
+def _request_json(url: str, *, token: str, accept: str) -> bytes:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": accept,
+            "Authorization": f"Bearer {token}",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "prob4d-source-freeze-publication-v1",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=60) as response:
+            return response.read()
+    except (urllib.error.URLError, TimeoutError) as error:
+        raise RuntimeError(f"GitHub request failed for {url}: {error}") from error
+
+
+def _list_artifacts(
+    *, api_url: str, repository: str, token: str, prefix: str
+) -> list[dict[str, Any]]:
+    matches: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        url = f"{api_url}/repos/{repository}/actions/artifacts?per_page=100&page={page}"
+        payload = json.loads(
+            _request_json(
+                url,
+                token=token,
+                accept="application/vnd.github+json",
+            )
+        )
+        artifacts = payload.get("artifacts")
+        if type(artifacts) is not list:
+            raise RuntimeError("GitHub artifact listing changed shape")
+        for artifact in artifacts:
+            if type(artifact) is not dict:
+                continue
+            name = artifact.get("name")
+            if (
+                type(name) is str
+                and name.startswith(prefix)
+                and artifact.get("expired") is False
+            ):
+                matches.append(cast(dict[str, Any], artifact))
+        if len(artifacts) < 100:
+            break
+        page += 1
+    matches.sort(
+        key=lambda item: (str(item.get("created_at", "")), int(item.get("id", 0))),
+        reverse=True,
+    )
+    return matches
+
+
+def _safe_extract_zip(payload: bytes, destination: Path) -> None:
+    with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+        for info in archive.infolist():
+            path = PurePosixPath(info.filename)
+            if path.is_absolute() or any(part in {"", ".", ".."} for part in path.parts):
+                raise ValueError("workflow artifact contains an unsafe path")
+            mode = info.external_attr >> 16
+            if stat.S_ISLNK(mode):
+                raise ValueError("workflow artifact contains a symbolic link")
+            target = destination.joinpath(*path.parts)
+            target.parent.mkdir(parents=True, exist_ok=True)
+            if info.is_dir():
+                target.mkdir(parents=True, exist_ok=True)
+            else:
+                with archive.open(info) as source, target.open("wb") as sink:
+                    shutil.copyfileobj(source, sink)
+
+
+def _verify_checksum_manifests(root: Path) -> None:
+    manifests = tuple(sorted(root.rglob("SHA256SUMS")))
+    if not manifests:
+        raise ValueError("workflow artifact has no SHA256SUMS manifest")
+    verified = 0
+    for manifest in manifests:
+        base = manifest.parent
+        lines = manifest.read_text(encoding="utf-8").splitlines()
+        for index, line in enumerate(lines):
+            if not line:
+                continue
+            match = re.fullmatch(r"([0-9a-f]{64})  (.+)", line)
+            if match is None:
+                raise ValueError(f"invalid checksum row {index + 1} in {manifest}")
+            expected, relative_text = match.groups()
+            relative = PurePosixPath(relative_text)
+            if relative.is_absolute() or any(
+                part in {"", ".", ".."} for part in relative.parts
+            ):
+                raise ValueError("checksum manifest contains an unsafe path")
+            candidate = base.joinpath(*relative.parts)
+            if candidate.name == "SHA256SUMS":
+                continue
+            if not candidate.is_file() or candidate.is_symlink():
+                raise ValueError(f"checksummed artifact member is missing: {relative_text}")
+            measured = hashlib.sha256(candidate.read_bytes()).hexdigest()
+            if measured != expected:
+                raise ValueError(f"artifact checksum mismatch for {relative_text}")
+            verified += 1
+    if verified == 0:
+        raise ValueError("workflow artifact checksum manifest verifies no members")
+
+
+def _unique_named_file(root: Path, name: str) -> Path:
+    matches = tuple(path for path in root.rglob(name) if path.is_file() and not path.is_symlink())
+    if len(matches) != 1:
+        raise ValueError(f"workflow artifact must contain exactly one {name}; found {len(matches)}")
+    return matches[0]
+
+
+def validate_artifact(
+    root: Path,
+    *,
+    request: Mapping[str, Any],
+) -> tuple[dict[str, Path], dict[str, Any]]:
+    _verify_checksum_manifests(root)
+    files = {
+        key: _unique_named_file(root, filename)
+        for key, filename in OUTPUT_NAMES.items()
+    }
+    execution = _load_json(files["execution_summary"], name="execution summary")
+    if execution.get("request_id") != request["source_request_id"]:
+        raise ValueError("execution summary is bound to a different source request")
+    if execution.get("decision") != request["required_decision"]:
+        raise ValueError("source-freeze artifact is not support positive")
+    if execution.get("source_group_count") != request["source_group_count"]:
+        raise ValueError("execution summary source group count changed")
+    if execution.get("forbidden_target_group_count") != request[
+        "forbidden_target_group_count"
+    ]:
+        raise ValueError("execution summary forbidden target count changed")
+    if any(execution.get(name) is not False for name in FALSE_EXECUTION_FIELDS):
+        raise ValueError("execution summary exceeds the target-closed boundary")
+
+    freeze = _load_json(files["source_freeze"], name="source-freeze artifact")
+    if freeze.get("decision") != request["required_decision"]:
+        raise ValueError("source-freeze artifact decision changed")
+    if freeze.get("source_group_count") != request["source_group_count"]:
+        raise ValueError("source-freeze artifact group count changed")
+    if freeze.get("forbidden_target_group_count") != request[
+        "forbidden_target_group_count"
+    ]:
+        raise ValueError("source-freeze artifact target count changed")
+    boundary = freeze.get("information_boundary")
+    if type(boundary) is not dict or any(
+        cast(dict[str, Any], boundary).get(name) is not False
+        for name in FALSE_FREEZE_BOUNDARY_FIELDS
+    ):
+        raise ValueError("source-freeze information boundary was exceeded")
+
+    for key in ("comparison_spec", "comparison_lock", "comparison_summary"):
+        _load_json(files[key], name=key.replace("_", " "))
+    return files, execution
+
+
+def _publish_exact_files(
+    *,
+    repository_root: Path,
+    request: Mapping[str, Any],
+    files: Mapping[str, Path],
+    artifact: Mapping[str, Any],
+    execution: Mapping[str, Any],
+) -> dict[str, Any]:
+    published: dict[str, dict[str, object]] = {}
+    output_paths = cast(dict[str, str], request["output_paths"])
+    for key, relative in output_paths.items():
+        destination = repository_root.joinpath(*PurePosixPath(relative).parts)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if destination.exists():
+            if destination.read_bytes() != files[key].read_bytes():
+                raise FileExistsError(f"refusing to replace different lock bytes: {relative}")
+        else:
+            destination.write_bytes(files[key].read_bytes())
+        published[key] = {
+            "path": relative,
+            "sha256": hashlib.sha256(destination.read_bytes()).hexdigest(),
+            "byte_count": destination.stat().st_size,
+        }
+    receipt = {
+        "schema": RECEIPT_SCHEMA,
+        "schema_version": RECEIPT_VERSION,
+        "publication_request_id": request["publication_request_id"],
+        "source_request_id": request["source_request_id"],
+        "source_workflow_artifact_id": int(artifact["id"]),
+        "source_workflow_artifact_name": artifact["name"],
+        "source_workflow_run_id": int(artifact["workflow_run"]["id"]),
+        "source_decision": execution["decision"],
+        "source_freeze_artifact_id": execution["freeze_artifact_id"],
+        "published": published,
+        "source_group_count": request["source_group_count"],
+        "forbidden_target_group_count": request["forbidden_target_group_count"],
+        "source_rgb_frames_decoded": False,
+        "source_residuals_or_truth_opened": False,
+        "target_payloads_opened": False,
+        "target_outcomes_opened": False,
+        "claim_boundary": request["claim_boundary"],
+    }
+    receipt_path = repository_root / "protocols/locks/cut3r_deform360_source_freeze_publication_v2.json"
+    encoded = (json.dumps(receipt, indent=2, sort_keys=True, allow_nan=False) + "\n").encode()
+    if receipt_path.exists() and receipt_path.read_bytes() != encoded:
+        raise FileExistsError("refusing to replace a different publication receipt")
+    receipt_path.parent.mkdir(parents=True, exist_ok=True)
+    receipt_path.write_bytes(encoded)
+    return receipt
+
+
+def discover_and_publish(args: argparse.Namespace) -> int:
+    request = validate_request(args.request.resolve())
+    token = _literal_string(args.token, name="GitHub token")
+    candidates = _list_artifacts(
+        api_url=args.api_url.rstrip("/"),
+        repository=args.repository_name,
+        token=token,
+        prefix=request["artifact_name_prefix"],
+    )
+    if not candidates:
+        raise RuntimeError("no nonexpired source-freeze workflow artifact matches the request")
+
+    selected: dict[str, Any] | None = None
+    selected_files: dict[str, Path] | None = None
+    selected_execution: dict[str, Any] | None = None
+    workspace = args.workspace.resolve()
+    workspace.mkdir(parents=True, exist_ok=True)
+    failures: list[str] = []
+    for artifact in candidates:
+        artifact_id = int(artifact["id"])
+        candidate_root = workspace / f"artifact-{artifact_id}"
+        candidate_root.mkdir(parents=True, exist_ok=False)
+        try:
+            payload = _request_json(
+                f"{args.api_url.rstrip('/')}/repos/{args.repository_name}/actions/artifacts/{artifact_id}/zip",
+                token=token,
+                accept="application/vnd.github+json",
+            )
+            _safe_extract_zip(payload, candidate_root)
+            files, execution = validate_artifact(candidate_root, request=request)
+        except (ValueError, RuntimeError, OSError, zipfile.BadZipFile) as error:
+            failures.append(f"artifact {artifact_id}: {error}")
+            continue
+        selected = artifact
+        selected_files = files
+        selected_execution = execution
+        break
+    if selected is None or selected_files is None or selected_execution is None:
+        raise RuntimeError(
+            "no candidate artifact passed validation: " + "; ".join(failures)
+        )
+
+    receipt = _publish_exact_files(
+        repository_root=args.repository_root.resolve(),
+        request=request,
+        files=selected_files,
+        artifact=selected,
+        execution=selected_execution,
+    )
+    if args.github_output is not None:
+        branch = f"evidence/cut3r-source-freeze-{str(receipt['source_freeze_artifact_id'])[:12]}"
+        with args.github_output.open("a", encoding="utf-8") as output:
+            output.write(f"branch={branch}\n")
+            output.write(f"artifact_id={receipt['source_workflow_artifact_id']}\n")
+            output.write(f"run_id={receipt['source_workflow_run_id']}\n")
+            output.write(f"freeze_artifact_id={receipt['source_freeze_artifact_id']}\n")
+    print(json.dumps(receipt, sort_keys=True, allow_nan=False))
+    return 0
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    verify = subparsers.add_parser("verify-request")
+    verify.add_argument("--request", type=Path, required=True)
+
+    publish = subparsers.add_parser("discover-and-publish")
+    publish.add_argument("--request", type=Path, required=True)
+    publish.add_argument("--repository-root", type=Path, required=True)
+    publish.add_argument("--repository-name", required=True)
+    publish.add_argument("--api-url", required=True)
+    publish.add_argument("--token", required=True)
+    publish.add_argument("--workspace", type=Path, required=True)
+    publish.add_argument("--github-output", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.command == "verify-request":
+        request = validate_request(args.request.resolve())
+        print(
+            json.dumps(
+                {
+                    "publication_request_id": request["publication_request_id"],
+                    "artifact_name_prefix": request["artifact_name_prefix"],
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+    if args.command == "discover-and-publish":
+        return discover_and_publish(args)
+    raise AssertionError("unreachable command")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cut3r_source_freeze_lock_publication.py
+++ b/tests/test_cut3r_source_freeze_lock_publication.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import zipfile
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/science/publish_cut3r_source_freeze_lock.py"
+REQUEST = (
+    ROOT
+    / "protocols/publication_requests/cut3r_deform360_source_freeze_v2.json"
+)
+
+
+def _module() -> ModuleType:
+    specification = importlib.util.spec_from_file_location(
+        "publish_cut3r_source_freeze_lock",
+        SCRIPT,
+    )
+    assert specification is not None
+    assert specification.loader is not None
+    module = importlib.util.module_from_spec(specification)
+    specification.loader.exec_module(module)
+    return module
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _artifact_fixture(root: Path) -> dict[str, object]:
+    evidence = root / "evidence"
+    payload = evidence / "cut3r-deform360-source-freeze"
+    execution = {
+        "request_id": (
+            "34eb4065a5be84ab6939595b38e53721d4555793a3d75eeb4cfc38170847b166"
+        ),
+        "decision": "source-support-freeze-ready",
+        "freeze_artifact_id": "a" * 64,
+        "source_group_count": 10,
+        "forbidden_target_group_count": 12,
+        "source_rgb_frames_decoded": False,
+        "source_prediction_payloads_opened": False,
+        "source_residuals_or_truth_opened": False,
+        "target_payloads_opened": False,
+        "target_outcomes_opened": False,
+        "comparison_execution_authorized": False,
+    }
+    freeze = {
+        "artifact_id": "a" * 64,
+        "decision": "source-support-freeze-ready",
+        "source_group_count": 10,
+        "forbidden_target_group_count": 12,
+        "information_boundary": {
+            "source_rgb_frames_decoded": False,
+            "source_prediction_payloads_opened": False,
+            "source_residuals_or_truth_opened": False,
+            "source_future_geometry_opened": False,
+            "target_payloads_opened": False,
+            "target_outcomes_opened": False,
+            "downstream_physical_innovations_opened": False,
+        },
+    }
+    _write_json(payload / "execution-summary.json", execution)
+    _write_json(payload / "cut3r-deform360-source-freeze.json", freeze)
+    _write_json(payload / "cut3r-comparison-spec.json", {"schema": "spec"})
+    _write_json(payload / "cut3r-comparison-lock.json", {"schema": "lock"})
+    _write_json(payload / "cut3r-comparison-summary.json", {"schema": "summary"})
+
+    rows = []
+    for path in sorted(evidence.rglob("*")):
+        if path.is_file():
+            digest = hashlib.sha256(path.read_bytes()).hexdigest()
+            rows.append(f"{digest}  {path.relative_to(evidence).as_posix()}")
+    (evidence / "SHA256SUMS").write_text("\n".join(rows) + "\n", encoding="utf-8")
+    return execution
+
+
+def test_checked_in_publication_request_is_target_closed() -> None:
+    module = _module()
+    request = module.validate_request(REQUEST)
+
+    assert request["source_group_count"] == 10
+    assert request["forbidden_target_group_count"] == 12
+    assert request["source_rgb_frames_decoded"] is False
+    assert request["source_residuals_or_truth_opened"] is False
+    assert request["target_payloads_opened"] is False
+    assert request["target_outcomes_opened"] is False
+    assert set(request["output_paths"]) == set(module.OUTPUT_NAMES)
+
+
+def test_artifact_validation_and_exact_publication(tmp_path: Path) -> None:
+    module = _module()
+    artifact_root = tmp_path / "artifact"
+    execution = _artifact_fixture(artifact_root)
+    request = module.validate_request(REQUEST)
+
+    files, measured_execution = module.validate_artifact(
+        artifact_root,
+        request=request,
+    )
+    assert measured_execution == execution
+
+    repository = tmp_path / "repository"
+    artifact = {
+        "id": 123,
+        "name": "cut3r-source-freeze-v2-34eb4065a5be-123-1",
+        "workflow_run": {"id": 456},
+    }
+    receipt = module._publish_exact_files(
+        repository_root=repository,
+        request=request,
+        files=files,
+        artifact=artifact,
+        execution=measured_execution,
+    )
+
+    assert receipt["source_workflow_artifact_id"] == 123
+    assert receipt["source_workflow_run_id"] == 456
+    for key, relative in request["output_paths"].items():
+        destination = repository / relative
+        assert destination.read_bytes() == files[key].read_bytes()
+
+
+def test_artifact_rejects_target_access(tmp_path: Path) -> None:
+    module = _module()
+    artifact_root = tmp_path / "artifact"
+    _artifact_fixture(artifact_root)
+    execution_path = next(artifact_root.rglob("execution-summary.json"))
+    execution = json.loads(execution_path.read_text(encoding="utf-8"))
+    execution["target_outcomes_opened"] = True
+    _write_json(execution_path, execution)
+
+    with pytest.raises(ValueError, match="checksum mismatch|target-closed"):
+        module.validate_artifact(
+            artifact_root,
+            request=module.validate_request(REQUEST),
+        )
+
+
+def test_safe_zip_extraction_rejects_escape(tmp_path: Path) -> None:
+    module = _module()
+    archive = tmp_path / "bad.zip"
+    with zipfile.ZipFile(archive, "w") as destination:
+        destination.writestr("../escape.txt", "bad")
+
+    with pytest.raises(ValueError, match="unsafe path"):
+        module._safe_extract_zip(archive.read_bytes(), tmp_path / "output")
+
+
+def test_publication_refuses_different_existing_lock(tmp_path: Path) -> None:
+    module = _module()
+    artifact_root = tmp_path / "artifact"
+    execution = _artifact_fixture(artifact_root)
+    request = module.validate_request(REQUEST)
+    files, _ = module.validate_artifact(artifact_root, request=request)
+    repository = tmp_path / "repository"
+    first_path = repository / request["output_paths"]["source_freeze"]
+    first_path.parent.mkdir(parents=True, exist_ok=True)
+    first_path.write_text("different\n", encoding="utf-8")
+
+    with pytest.raises(FileExistsError, match="different lock bytes"):
+        module._publish_exact_files(
+            repository_root=repository,
+            request=request,
+            files=files,
+            artifact={
+                "id": 1,
+                "name": "artifact",
+                "workflow_run": {"id": 2},
+            },
+            execution=execution,
+        )


### PR DESCRIPTION
## Summary

Add a hosted publication route for the successful target-closed CUT3R Deform360 source-freeze workflow artifact.

- bind the exact source request ID and Actions artifact prefix;
- discover only nonexpired artifacts for that request;
- reject unsafe ZIP members and verify every retained SHA-256 manifest row;
- require the support-positive decision, ten source groups, twelve forbidden confirmation groups, and all target-closed flags;
- independently replay the CUT3R comparison lock and summary;
- copy the original JSON bytes without normalization;
- bind source run, Actions artifact, freeze artifact, hashes, and byte counts in a publication receipt; and
- open a normal exact-byte lock PR before retained-data comparison execution.

## Scientific boundary

This PR does not execute CUT3R, open source residuals/truth or target payloads, fit uncertainty, run BayesianPhysTwin, run Causal4D, or claim provider competence. It advances only evidence custody for the already completed source-support pass.

Refs #49