### PR TITLE
Add three-arm CUT3R recurrent-state recovery evidence

### DIFF
--- a/CHANGELOG.d/cut3r-recurrent-state-recovery.md
+++ b/CHANGELOG.d/cut3r-recurrent-state-recovery.md
@@ -1,0 +1,5 @@
+Added a content-addressed three-arm CUT3R recurrent-state recovery report. It
+combines the frozen fusion-value and recurrence-value common-support evidence,
+requires byte-identical restarted-window baseline rows, reports per-group and
+equal-group recovery fractions with deterministic paired bootstrap intervals,
+and remains source-only and non-selective.

--- a/docs/cut3r-recurrent-state-recovery.md
+++ b/docs/cut3r-recurrent-state-recovery.md
@@ -1,0 +1,154 @@
+# CUT3R recurrent-state recovery
+
+`prob4d.cut3r_recurrent_state_recovery` adds a source-only, report-only analysis to
+the frozen CUT3R comparison. It answers a specific mechanism question:
+
+> How much of the error caused by restarting CUT3R for every causal window is
+> recovered by Prob4D fusion of those same restarted windows?
+
+The analysis does not introduce a new estimator, select a candidate, change a
+readiness gate, or authorize target access.
+
+## Three frozen arms
+
+The report combines the two claim-eligible contrasts already registered by the
+CUT3R comparison lock:
+
+| Role | Arm |
+| --- | --- |
+| Uninterrupted recurrent reference | `native-continuous` |
+| Restarted-window baseline | `restarted-newest` |
+| Prob4D treatment | `restarted-prob4d-fused` |
+
+For every lower-is-better metric \(E\), the descriptive recovery fraction is
+
+\[
+\operatorname{Recovery}(E)=
+\frac{E_{\mathrm{restarted\mbox{-}newest}}-
+      E_{\mathrm{restarted\mbox{-}Prob4D}}}
+     {E_{\mathrm{restarted\mbox{-}newest}}-
+      E_{\mathrm{native\mbox{-}continuous}}}.
+\]
+
+Interpretation:
+
+- `0`: Prob4D recovers none of the restart penalty;
+- `1`: Prob4D closes the entire gap to uninterrupted recurrence;
+- between `0` and `1`: partial recovery;
+- above `1`: fused restarted windows outperform uninterrupted recurrence;
+- below `0`: fusion is harmful; and
+- `undefined-native-not-better`: uninterrupted recurrence does not provide a
+  positive denominator beyond the frozen metric-specific tolerance.
+
+The report retains the numerator and denominator. It never clips the fraction.
+
+## Evidence prerequisites
+
+The command consumes two complete
+`prob4d.cut3r-source-competence-report-v2` evidence chains:
+
+1. `restarted-prob4d-fused` versus `restarted-newest`; and
+2. `native-continuous` versus `restarted-newest`.
+
+Before computing any statistic, it verifies all bound locks, records, and reports
+through their existing strict loaders. It then requires:
+
+- the canonical registered contrast in each source-competence lock;
+- identical cohort binding, group definition, and restarted-newest provider
+  manifest identity;
+- identical technical-failure evidence;
+- byte-identical normalized `restarted-newest` rows across both contrasts; and
+- equal restarted-newest aggregate metrics in every evaluable group.
+
+Each v2 contrast already proves exact candidate/baseline metric-support identity.
+The byte-identical common baseline therefore establishes transitive common support
+for all three arms on every evaluable group. A changed support hash, row, score,
+reference count, or baseline value fails closed.
+
+## Reported metrics
+
+The source report covers:
+
+- point RMSE;
+- endpoint RMSE;
+- arm-neutral fixed-scale proper score;
+- seam RMSE; and
+- absolute drift slope.
+
+It reports the three arm values, Prob4D gain, recurrent-state gap, recovery
+fraction, and status for every complete object/session group and for the
+equal-group aggregate.
+
+## Uncertainty interval
+
+Aggregate intervals use deterministic paired bootstrap resampling of complete
+source groups. Frames, seeds, cameras, points, and tracks remain nested
+observations and are never resampled as independent evidence units.
+
+The implementation uses `sha256-counter-equal-group-bootstrap-v1`, so the same
+bound evidence and analysis specification reproduce identical resamples without
+relying on process-global random state. Replicates whose recurrence denominator
+does not exceed the metric-specific frozen minimum gap are retained as invalid
+denominator counts rather than silently divided. The interval is withheld when
+the valid-replicate fraction is below the frozen minimum.
+
+## Frozen analysis specification
+
+A prospective source-only specification is provided at
+`protocols/cut3r_recurrent_state_recovery_v1.json`. It freezes:
+
+- bootstrap seed;
+- bootstrap replicate count;
+- confidence level;
+- a dimensionally appropriate minimum recurrence gap for every metric; and
+- the minimum fraction of valid bootstrap denominators.
+
+The specification is embedded in and authenticated by the report identity.
+
+## Build, verify, and summarize
+
+After both common-support v2 reports exist:
+
+```bash
+prob4d prediction cut3r-recovery build \
+  outputs/cut3r/cut3r-comparison-lock.json \
+  outputs/cut3r/fusion/source-competence-lock.json \
+  outputs/cut3r/fusion/common-support-lock-v2.json \
+  outputs/cut3r/fusion/source-competence-records-v2.json \
+  outputs/cut3r/fusion/source-competence-v2.json \
+  outputs/cut3r/recurrence/source-competence-lock.json \
+  outputs/cut3r/recurrence/common-support-lock-v2.json \
+  outputs/cut3r/recurrence/source-competence-records-v2.json \
+  outputs/cut3r/recurrence/source-competence-v2.json \
+  protocols/cut3r_recurrent_state_recovery_v1.json \
+  --output outputs/cut3r/recurrent-state-recovery-v1.json
+```
+
+Independently rebuild the report from all bound evidence:
+
+```bash
+prob4d prediction cut3r-recovery verify \
+  outputs/cut3r/cut3r-comparison-lock.json \
+  outputs/cut3r/fusion/source-competence-lock.json \
+  outputs/cut3r/fusion/common-support-lock-v2.json \
+  outputs/cut3r/fusion/source-competence-records-v2.json \
+  outputs/cut3r/fusion/source-competence-v2.json \
+  outputs/cut3r/recurrence/source-competence-lock.json \
+  outputs/cut3r/recurrence/common-support-lock-v2.json \
+  outputs/cut3r/recurrence/source-competence-records-v2.json \
+  outputs/cut3r/recurrence/source-competence-v2.json \
+  protocols/cut3r_recurrent_state_recovery_v1.json \
+  outputs/cut3r/recurrent-state-recovery-v1.json
+```
+
+Use `summarize` with the same arguments and `--json` for a compact machine-readable
+view.
+
+## Claim boundary
+
+This report is descriptive source mechanism evidence. A positive recovery
+fraction does not establish held-out provider competence, BayesianPhysTwin
+physical-query benefit, Causal4D intervention benefit, deployment safety, or
+state of the art. A negative or undefined result remains informative because it
+separates irrecoverable recurrent information from useful restarted-window
+fusion without changing the frozen target protocol.

--- a/protocols/cut3r_recurrent_state_recovery_v1.json
+++ b/protocols/cut3r_recurrent_state_recovery_v1.json
@@ -1,0 +1,13 @@
+{
+  "bootstrap_replicates": 10000,
+  "bootstrap_seed": 20260823,
+  "confidence_level": 0.95,
+  "minimum_recurrence_gap_by_metric": {
+    "absolute_drift_slope_m_per_frame": 0.0,
+    "endpoint_rmse_m": 0.0,
+    "point_rmse_m": 0.0,
+    "proper_score": 0.0,
+    "seam_rmse_m": 0.0
+  },
+  "minimum_valid_bootstrap_fraction": 0.8
+}

--- a/src/prob4d/cut3r_recurrent_state_recovery.py
+++ b/src/prob4d/cut3r_recurrent_state_recovery.py
@@ -189,7 +189,7 @@ def _bootstrap_index(
     material = (
         f"{CUT3R_RECURRENT_STATE_RECOVERY_BOOTSTRAP}:"
         f"{seed}:{replicate}:{position}:{group_count}"
-    ).encode("utf-8")
+    ).encode()
     return int.from_bytes(hashlib.sha256(material).digest(), "big") % group_count
 
 

--- a/src/prob4d/cut3r_recurrent_state_recovery.py
+++ b/src/prob4d/cut3r_recurrent_state_recovery.py
@@ -1,0 +1,823 @@
+"""Quantify how much CUT3R recurrent-state loss is recovered by Prob4D fusion.
+
+The report combines two independently validated, source-only common-support
+competence reports: Prob4D-fused restarted windows versus the restarted-newest
+baseline, and native continuous recurrence versus the same restarted-newest
+baseline. It requires the canonical restarted-newest rows to be byte-identical
+across both contrasts before computing any descriptive recovery statistic.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final, cast
+
+from ._cut3r_source_competence_v2_records import _normalize_v2_records
+from .cut3r_comparison import (
+    CUT3R_COMPARISON_GROUP_UNIT,
+    load_cut3r_comparison_lock,
+    validate_cut3r_comparison_lock,
+)
+from .cut3r_source_competence import (
+    _canonical_json,
+    _exact_keys,
+    _publish_json,
+    _record_id,
+    _strict_integer,
+    _strict_json,
+    _strict_mapping,
+    load_cut3r_source_competence_lock,
+    validate_cut3r_source_competence_lock,
+)
+from .cut3r_source_competence_v2 import (
+    load_cut3r_source_competence_v2_lock,
+    load_cut3r_source_competence_v2_report,
+    validate_cut3r_source_competence_v2_report,
+)
+
+CUT3R_RECURRENT_STATE_RECOVERY_SCHEMA: Final = (
+    "prob4d.cut3r-recurrent-state-recovery"
+)
+CUT3R_RECURRENT_STATE_RECOVERY_VERSION: Final = 1
+CUT3R_RECURRENT_STATE_RECOVERY_CLAIM_BOUNDARY: Final = (
+    "This source-only report is a descriptive mechanism analysis of three frozen "
+    "CUT3R arms. It does not select a candidate, alter a readiness gate, authorize "
+    "target access, establish BayesianPhysTwin or Causal4D benefit, establish "
+    "deployment safety, or establish state of the art. Recovery is undefined when "
+    "native continuous recurrence does not outperform the restarted-newest baseline."
+)
+CUT3R_RECURRENT_STATE_RECOVERY_METRICS: Final[tuple[str, ...]] = (
+    "point_rmse_m",
+    "endpoint_rmse_m",
+    "proper_score",
+    "seam_rmse_m",
+    "absolute_drift_slope_m_per_frame",
+)
+CUT3R_RECURRENT_STATE_RECOVERY_ARMS: Final = {
+    "native_continuous": "native-continuous",
+    "restarted_newest": "restarted-newest",
+    "restarted_prob4d_fused": "restarted-prob4d-fused",
+}
+CUT3R_RECURRENT_STATE_RECOVERY_BOOTSTRAP: Final = (
+    "sha256-counter-equal-group-bootstrap-v1"
+)
+
+_SPEC_FIELDS: Final = frozenset(
+    {
+        "bootstrap_seed",
+        "bootstrap_replicates",
+        "confidence_level",
+        "minimum_recurrence_gap_by_metric",
+        "minimum_valid_bootstrap_fraction",
+    }
+)
+
+
+def _finite_float(
+    value: Any,
+    *,
+    name: str,
+    minimum: float | None = None,
+    maximum: float | None = None,
+    maximum_inclusive: bool = True,
+) -> float:
+    if type(value) not in {int, float}:
+        raise ValueError(f"{name} must be a genuine finite number")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"{name} must be finite")
+    if minimum is not None and result < minimum:
+        raise ValueError(f"{name} must be >= {minimum}")
+    if maximum is not None:
+        invalid = result > maximum if maximum_inclusive else result >= maximum
+        if invalid:
+            relation = "<=" if maximum_inclusive else "<"
+            raise ValueError(f"{name} must be {relation} {maximum}")
+    return result
+
+
+def _analysis_specification(value: Any) -> dict[str, Any]:
+    specification = _strict_mapping(
+        value,
+        name="CUT3R recurrent-state recovery specification",
+    )
+    _exact_keys(
+        specification,
+        _SPEC_FIELDS,
+        name="CUT3R recurrent-state recovery specification",
+    )
+    confidence_level = _finite_float(
+        specification["confidence_level"],
+        name="confidence_level",
+        minimum=0.0,
+        maximum=1.0,
+        maximum_inclusive=False,
+    )
+    if confidence_level <= 0.0:
+        raise ValueError("confidence_level must be > 0")
+    minimum_valid_fraction = _finite_float(
+        specification["minimum_valid_bootstrap_fraction"],
+        name="minimum_valid_bootstrap_fraction",
+        minimum=0.0,
+        maximum=1.0,
+    )
+    gaps = _strict_mapping(
+        specification["minimum_recurrence_gap_by_metric"],
+        name="minimum_recurrence_gap_by_metric",
+    )
+    _exact_keys(
+        gaps,
+        set(CUT3R_RECURRENT_STATE_RECOVERY_METRICS),
+        name="minimum_recurrence_gap_by_metric",
+    )
+    return {
+        "bootstrap_seed": _strict_integer(
+            specification["bootstrap_seed"],
+            name="bootstrap_seed",
+        ),
+        "bootstrap_replicates": _strict_integer(
+            specification["bootstrap_replicates"],
+            name="bootstrap_replicates",
+            minimum=1,
+        ),
+        "confidence_level": confidence_level,
+        "minimum_recurrence_gap_by_metric": {
+            metric: _finite_float(
+                gaps[metric],
+                name=f"minimum_recurrence_gap_by_metric.{metric}",
+                minimum=0.0,
+            )
+            for metric in CUT3R_RECURRENT_STATE_RECOVERY_METRICS
+        },
+        "minimum_valid_bootstrap_fraction": minimum_valid_fraction,
+    }
+
+
+def _mean(values: Sequence[float]) -> float:
+    if not values:
+        raise ValueError("cannot average an empty sequence")
+    return math.fsum(values) / len(values)
+
+
+def _percentile(values: Sequence[float], probability: float) -> float:
+    if not values:
+        raise ValueError("cannot compute a percentile of an empty sequence")
+    if not 0.0 <= probability <= 1.0:
+        raise ValueError("percentile probability must lie in [0, 1]")
+    ordered = sorted(values)
+    position = probability * (len(ordered) - 1)
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    weight = position - lower
+    return ordered[lower] * (1.0 - weight) + ordered[upper] * weight
+
+
+def _bootstrap_index(
+    *,
+    seed: int,
+    replicate: int,
+    position: int,
+    group_count: int,
+) -> int:
+    material = (
+        f"{CUT3R_RECURRENT_STATE_RECOVERY_BOOTSTRAP}:"
+        f"{seed}:{replicate}:{position}:{group_count}"
+    ).encode("utf-8")
+    return int.from_bytes(hashlib.sha256(material).digest(), "big") % group_count
+
+
+def _triplet(
+    native: float,
+    restarted: float,
+    fused: float,
+    *,
+    denominator_tolerance: float,
+) -> dict[str, Any]:
+    prob4d_gain = restarted - fused
+    recurrence_gap = restarted - native
+    if recurrence_gap > denominator_tolerance:
+        return {
+            "native_continuous": native,
+            "restarted_newest": restarted,
+            "restarted_prob4d_fused": fused,
+            "prob4d_gain": prob4d_gain,
+            "recurrence_gap": recurrence_gap,
+            "recovery_fraction": prob4d_gain / recurrence_gap,
+            "status": "defined",
+        }
+    return {
+        "native_continuous": native,
+        "restarted_newest": restarted,
+        "restarted_prob4d_fused": fused,
+        "prob4d_gain": prob4d_gain,
+        "recurrence_gap": recurrence_gap,
+        "recovery_fraction": None,
+        "status": "undefined-native-not-better",
+    }
+
+
+def _bootstrap_interval(
+    group_triplets: Sequence[tuple[float, float, float]],
+    *,
+    specification: Mapping[str, Any],
+    point_status: str,
+) -> dict[str, Any]:
+    replicates = cast(int, specification["bootstrap_replicates"])
+    seed = cast(int, specification["bootstrap_seed"])
+    tolerance = cast(float, specification["minimum_recurrence_gap"])
+    confidence_level = cast(float, specification["confidence_level"])
+    minimum_valid_fraction = cast(
+        float,
+        specification["minimum_valid_bootstrap_fraction"],
+    )
+    group_count = len(group_triplets)
+    ratios: list[float] = []
+    for replicate in range(replicates):
+        selected = [
+            group_triplets[
+                _bootstrap_index(
+                    seed=seed,
+                    replicate=replicate,
+                    position=position,
+                    group_count=group_count,
+                )
+            ]
+            for position in range(group_count)
+        ]
+        native = _mean([item[0] for item in selected])
+        restarted = _mean([item[1] for item in selected])
+        fused = _mean([item[2] for item in selected])
+        recurrence_gap = restarted - native
+        if recurrence_gap > tolerance:
+            ratios.append((restarted - fused) / recurrence_gap)
+    valid_count = len(ratios)
+    valid_fraction = valid_count / replicates
+    invalid_count = replicates - valid_count
+    if point_status != "defined":
+        interval_status = "not-applicable"
+        lower = None
+        upper = None
+    elif valid_count == 0 or valid_fraction < minimum_valid_fraction:
+        interval_status = "insufficient-valid-bootstrap-denominators"
+        lower = None
+        upper = None
+    else:
+        tail = (1.0 - confidence_level) / 2.0
+        interval_status = "defined"
+        lower = _percentile(ratios, tail)
+        upper = _percentile(ratios, 1.0 - tail)
+    return {
+        "method": CUT3R_RECURRENT_STATE_RECOVERY_BOOTSTRAP,
+        "replicate_count": replicates,
+        "valid_replicate_count": valid_count,
+        "invalid_replicate_count": invalid_count,
+        "valid_replicate_fraction": valid_fraction,
+        "minimum_valid_replicate_fraction": minimum_valid_fraction,
+        "confidence_level": confidence_level,
+        "interval_status": interval_status,
+        "lower": lower,
+        "upper": upper,
+    }
+
+
+def _contrast(
+    source_lock: Mapping[str, Any],
+    *,
+    contrast_id: str,
+    treatment: str,
+    control: str,
+    name: str,
+) -> None:
+    contrast = cast(Mapping[str, Any], source_lock["contrast"])
+    expected = {
+        "contrast_id": contrast_id,
+        "treatment_arm": treatment,
+        "control_arm": control,
+        "claim_eligible": True,
+        "enabled": True,
+    }
+    if contrast != expected:
+        raise ValueError(f"{name} must use the canonical {contrast_id!r} contrast")
+
+
+def _baseline_rows(records: Mapping[str, Any]) -> list[dict[str, Any]]:
+    rows = [
+        cast(dict[str, Any], row)
+        for row in cast(list[dict[str, Any]], records["records"])
+        if row["arm_id"] == CUT3R_RECURRENT_STATE_RECOVERY_ARMS["restarted_newest"]
+    ]
+    return sorted(
+        rows,
+        key=lambda row: (
+            row["group_id"],
+            row["case_id"],
+            row["frame_index"],
+            row["random_seed"],
+        ),
+    )
+
+
+def _group_lookup(report: Mapping[str, Any], *, name: str) -> dict[str, Mapping[str, Any]]:
+    raw_groups = report["groups"]
+    if type(raw_groups) is not list:
+        raise ValueError(f"{name}.groups must be a JSON array")
+    result: dict[str, Mapping[str, Any]] = {}
+    for index, raw_group in enumerate(raw_groups):
+        group = _strict_mapping(raw_group, name=f"{name}.groups[{index}]")
+        group_id = group.get("group_id")
+        if type(group_id) is not str or not group_id:
+            raise ValueError(f"{name}.groups[{index}].group_id is invalid")
+        if group_id in result:
+            raise ValueError(f"{name} repeats group_id {group_id!r}")
+        result[group_id] = group
+    return result
+
+
+def build_cut3r_recurrent_state_recovery_report(
+    comparison_lock: Any,
+    fusion_source_competence_lock: Any,
+    fusion_common_support_lock: Any,
+    fusion_records: Any,
+    fusion_report: Any,
+    recurrence_source_competence_lock: Any,
+    recurrence_common_support_lock: Any,
+    recurrence_records: Any,
+    recurrence_report: Any,
+    analysis_specification: Any,
+) -> dict[str, Any]:
+    """Build a content-addressed three-arm recurrent-state recovery report."""
+
+    comparison = validate_cut3r_comparison_lock(comparison_lock)
+    specification = _analysis_specification(analysis_specification)
+    fusion_source = validate_cut3r_source_competence_lock(
+        comparison,
+        fusion_source_competence_lock,
+    )
+    recurrence_source = validate_cut3r_source_competence_lock(
+        comparison,
+        recurrence_source_competence_lock,
+    )
+    _contrast(
+        fusion_source,
+        contrast_id="prob4d-fusion-value",
+        treatment=CUT3R_RECURRENT_STATE_RECOVERY_ARMS["restarted_prob4d_fused"],
+        control=CUT3R_RECURRENT_STATE_RECOVERY_ARMS["restarted_newest"],
+        name="fusion source competence lock",
+    )
+    _contrast(
+        recurrence_source,
+        contrast_id="provider-recurrence-value",
+        treatment=CUT3R_RECURRENT_STATE_RECOVERY_ARMS["native_continuous"],
+        control=CUT3R_RECURRENT_STATE_RECOVERY_ARMS["restarted_newest"],
+        name="recurrence source competence lock",
+    )
+    for field in ("cohort_binding_id", "group_definition", "baseline_provider_manifest_id"):
+        if fusion_source[field] != recurrence_source[field]:
+            raise ValueError(f"the two contrasts use different {field}")
+    fusion = validate_cut3r_source_competence_v2_report(
+        comparison,
+        fusion_source,
+        fusion_common_support_lock,
+        fusion_records,
+        fusion_report,
+    )
+    recurrence = validate_cut3r_source_competence_v2_report(
+        comparison,
+        recurrence_source,
+        recurrence_common_support_lock,
+        recurrence_records,
+        recurrence_report,
+    )
+    normalized_fusion_records, _ = _normalize_v2_records(
+        comparison,
+        fusion_source,
+        fusion_common_support_lock,
+        fusion_records,
+    )
+    normalized_recurrence_records, _ = _normalize_v2_records(
+        comparison,
+        recurrence_source,
+        recurrence_common_support_lock,
+        recurrence_records,
+    )
+    if normalized_fusion_records["group_failures"] != normalized_recurrence_records[
+        "group_failures"
+    ]:
+        raise ValueError("the two contrasts use different technical-failure evidence")
+    if _baseline_rows(normalized_fusion_records) != _baseline_rows(
+        normalized_recurrence_records
+    ):
+        raise ValueError(
+            "the two contrasts do not use byte-identical restarted-newest rows"
+        )
+
+    source_group_ids = list(comparison["group_roles"]["source_evaluation"])
+    fusion_groups = _group_lookup(fusion, name="fusion_report")
+    recurrence_groups = _group_lookup(recurrence, name="recurrence_report")
+    if list(fusion_groups) != source_group_ids or list(recurrence_groups) != source_group_ids:
+        raise ValueError("source report group order changed from the comparison lock")
+
+    group_rows: list[dict[str, Any]] = []
+    evaluable_triplets: dict[str, list[tuple[float, float, float]]] = {
+        metric: [] for metric in CUT3R_RECURRENT_STATE_RECOVERY_METRICS
+    }
+    for group_id in source_group_ids:
+        fusion_group = fusion_groups[group_id]
+        recurrence_group = recurrence_groups[group_id]
+        fusion_failure = fusion_group["technical_failure_code"]
+        recurrence_failure = recurrence_group["technical_failure_code"]
+        if fusion_failure != recurrence_failure:
+            raise ValueError(f"group {group_id!r} has contrast-specific technical failure")
+        if fusion_failure is not None:
+            group_rows.append(
+                {
+                    "group_id": group_id,
+                    "technical_failure_code": fusion_failure,
+                    "metrics": None,
+                }
+            )
+            continue
+        fusion_baseline = cast(Mapping[str, Any], fusion_group["baseline"])
+        recurrence_baseline = cast(Mapping[str, Any], recurrence_group["baseline"])
+        if fusion_baseline != recurrence_baseline:
+            raise ValueError(
+                f"group {group_id!r} has different restarted-newest aggregate metrics"
+            )
+        fused = cast(Mapping[str, Any], fusion_group["candidate"])
+        native = cast(Mapping[str, Any], recurrence_group["candidate"])
+        metrics: dict[str, Any] = {}
+        for metric in CUT3R_RECURRENT_STATE_RECOVERY_METRICS:
+            native_value = _finite_float(native[metric], name=f"{group_id}.{metric}.native")
+            restarted_value = _finite_float(
+                fusion_baseline[metric],
+                name=f"{group_id}.{metric}.restarted",
+            )
+            fused_value = _finite_float(fused[metric], name=f"{group_id}.{metric}.fused")
+            metrics[metric] = _triplet(
+                native_value,
+                restarted_value,
+                fused_value,
+                denominator_tolerance=specification[
+                    "minimum_recurrence_gap_by_metric"
+                ][metric],
+            )
+            evaluable_triplets[metric].append(
+                (native_value, restarted_value, fused_value)
+            )
+        group_rows.append(
+            {
+                "group_id": group_id,
+                "technical_failure_code": None,
+                "metrics": metrics,
+            }
+        )
+
+    evaluable_group_count = sum(
+        row["technical_failure_code"] is None for row in group_rows
+    )
+    if evaluable_group_count == 0:
+        raise ValueError("recurrent-state recovery requires at least one evaluable group")
+    aggregate: dict[str, Any] = {}
+    for metric in CUT3R_RECURRENT_STATE_RECOVERY_METRICS:
+        triplets = evaluable_triplets[metric]
+        point = _triplet(
+            _mean([item[0] for item in triplets]),
+            _mean([item[1] for item in triplets]),
+            _mean([item[2] for item in triplets]),
+            denominator_tolerance=specification[
+                "minimum_recurrence_gap_by_metric"
+            ][metric],
+        )
+        bootstrap_specification = {
+            **specification,
+            "minimum_recurrence_gap": specification[
+                "minimum_recurrence_gap_by_metric"
+            ][metric],
+        }
+        point["bootstrap_interval"] = _bootstrap_interval(
+            triplets,
+            specification=bootstrap_specification,
+            point_status=cast(str, point["status"]),
+        )
+        aggregate[metric] = point
+
+    payload: dict[str, Any] = {
+        "schema": CUT3R_RECURRENT_STATE_RECOVERY_SCHEMA,
+        "schema_version": CUT3R_RECURRENT_STATE_RECOVERY_VERSION,
+        "comparison_lock_id": comparison["lock_id"],
+        "comparison_protocol_name": comparison["protocol_name"],
+        "group_unit": CUT3R_COMPARISON_GROUP_UNIT,
+        "source_evaluation_group_ids": source_group_ids,
+        "group_count": len(source_group_ids),
+        "evaluable_group_count": evaluable_group_count,
+        "technical_failure_count": len(source_group_ids) - evaluable_group_count,
+        "arms": dict(CUT3R_RECURRENT_STATE_RECOVERY_ARMS),
+        "evidence": {
+            "fusion_source_competence_report_v2_id": fusion[
+                "source_competence_report_v2_id"
+            ],
+            "fusion_common_support_lock_id": fusion["common_support_lock_id"],
+            "fusion_records_id": fusion["records_id"],
+            "recurrence_source_competence_report_v2_id": recurrence[
+                "source_competence_report_v2_id"
+            ],
+            "recurrence_common_support_lock_id": recurrence[
+                "common_support_lock_id"
+            ],
+            "recurrence_records_id": recurrence["records_id"],
+            "restarted_newest_provider_manifest_id": fusion_source[
+                "baseline_provider_manifest_id"
+            ],
+            "byte_identical_restarted_newest_rows": True,
+            "common_three_arm_metric_support_for_evaluable_groups": True,
+        },
+        "metrics": list(CUT3R_RECURRENT_STATE_RECOVERY_METRICS),
+        "metric_direction": "lower-is-better",
+        "recovery_definition": (
+            "(restarted-newest - restarted-prob4d-fused) / "
+            "(restarted-newest - native-continuous)"
+        ),
+        "analysis_specification": specification,
+        "groups": group_rows,
+        "aggregate": aggregate,
+        "weighting": "equal-complete-source-group-mean-v1",
+        "descriptive_only": True,
+        "source_access": "source-only",
+        "target_access": "forbidden",
+        "claim_boundary": CUT3R_RECURRENT_STATE_RECOVERY_CLAIM_BOUNDARY,
+    }
+    payload["recurrent_state_recovery_report_id"] = _record_id(payload)
+    return cast(dict[str, Any], json.loads(_canonical_json(payload)))
+
+
+def validate_cut3r_recurrent_state_recovery_report(
+    comparison_lock: Any,
+    fusion_source_competence_lock: Any,
+    fusion_common_support_lock: Any,
+    fusion_records: Any,
+    fusion_report: Any,
+    recurrence_source_competence_lock: Any,
+    recurrence_common_support_lock: Any,
+    recurrence_records: Any,
+    recurrence_report: Any,
+    analysis_specification: Any,
+    report: Any,
+) -> dict[str, Any]:
+    supplied = _strict_mapping(report, name="CUT3R recurrent-state recovery report")
+    expected = build_cut3r_recurrent_state_recovery_report(
+        comparison_lock,
+        fusion_source_competence_lock,
+        fusion_common_support_lock,
+        fusion_records,
+        fusion_report,
+        recurrence_source_competence_lock,
+        recurrence_common_support_lock,
+        recurrence_records,
+        recurrence_report,
+        analysis_specification,
+    )
+    if supplied != expected:
+        raise ValueError("recurrent-state recovery report does not match bound evidence")
+    return expected
+
+
+def write_cut3r_recurrent_state_recovery_report(
+    comparison_lock: Any,
+    fusion_source_competence_lock: Any,
+    fusion_common_support_lock: Any,
+    fusion_records: Any,
+    fusion_report: Any,
+    recurrence_source_competence_lock: Any,
+    recurrence_common_support_lock: Any,
+    recurrence_records: Any,
+    recurrence_report: Any,
+    analysis_specification: Any,
+    path: str | Path,
+    report: Mapping[str, Any],
+) -> dict[str, Any]:
+    payload = validate_cut3r_recurrent_state_recovery_report(
+        comparison_lock,
+        fusion_source_competence_lock,
+        fusion_common_support_lock,
+        fusion_records,
+        fusion_report,
+        recurrence_source_competence_lock,
+        recurrence_common_support_lock,
+        recurrence_records,
+        recurrence_report,
+        analysis_specification,
+        report,
+    )
+    return _publish_json(
+        path,
+        payload,
+        load_existing=lambda existing: load_cut3r_recurrent_state_recovery_report(
+            comparison_lock,
+            fusion_source_competence_lock,
+            fusion_common_support_lock,
+            fusion_records,
+            fusion_report,
+            recurrence_source_competence_lock,
+            recurrence_common_support_lock,
+            recurrence_records,
+            recurrence_report,
+            analysis_specification,
+            existing,
+        ),
+    )
+
+
+def load_cut3r_recurrent_state_recovery_report(
+    comparison_lock: Any,
+    fusion_source_competence_lock: Any,
+    fusion_common_support_lock: Any,
+    fusion_records: Any,
+    fusion_report: Any,
+    recurrence_source_competence_lock: Any,
+    recurrence_common_support_lock: Any,
+    recurrence_records: Any,
+    recurrence_report: Any,
+    analysis_specification: Any,
+    path: str | Path,
+) -> dict[str, Any]:
+    return validate_cut3r_recurrent_state_recovery_report(
+        comparison_lock,
+        fusion_source_competence_lock,
+        fusion_common_support_lock,
+        fusion_records,
+        fusion_report,
+        recurrence_source_competence_lock,
+        recurrence_common_support_lock,
+        recurrence_records,
+        recurrence_report,
+        analysis_specification,
+        _strict_json(path),
+    )
+
+
+def cut3r_recurrent_state_recovery_summary(report: Mapping[str, Any]) -> dict[str, Any]:
+    artifact = _strict_mapping(report, name="CUT3R recurrent-state recovery report")
+    metrics = cast(Mapping[str, Mapping[str, Any]], artifact["aggregate"])
+    return {
+        "recurrent_state_recovery_report_id": artifact[
+            "recurrent_state_recovery_report_id"
+        ],
+        "comparison_lock_id": artifact["comparison_lock_id"],
+        "group_count": artifact["group_count"],
+        "evaluable_group_count": artifact["evaluable_group_count"],
+        "technical_failure_count": artifact["technical_failure_count"],
+        "recovery": {
+            metric: {
+                "status": metrics[metric]["status"],
+                "recovery_fraction": metrics[metric]["recovery_fraction"],
+                "bootstrap_interval": metrics[metric]["bootstrap_interval"],
+            }
+            for metric in CUT3R_RECURRENT_STATE_RECOVERY_METRICS
+        },
+        "descriptive_only": artifact["descriptive_only"],
+        "target_access": artifact["target_access"],
+    }
+
+
+def _add_bound_evidence_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("comparison_lock")
+    parser.add_argument("fusion_source_competence_lock")
+    parser.add_argument("fusion_common_support_lock")
+    parser.add_argument("fusion_records")
+    parser.add_argument("fusion_report")
+    parser.add_argument("recurrence_source_competence_lock")
+    parser.add_argument("recurrence_common_support_lock")
+    parser.add_argument("recurrence_records")
+    parser.add_argument("recurrence_report")
+    parser.add_argument("analysis_specification")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="prob4d prediction cut3r-recovery",
+        description=__doc__,
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+    build = commands.add_parser("build", help="build the bound recovery report")
+    _add_bound_evidence_arguments(build)
+    build.add_argument("--output", required=True)
+    verify = commands.add_parser("verify", help="rebuild and verify a recovery report")
+    _add_bound_evidence_arguments(verify)
+    verify.add_argument("report")
+    summarize = commands.add_parser("summarize", help="summarize a verified report")
+    _add_bound_evidence_arguments(summarize)
+    summarize.add_argument("report")
+    summarize.add_argument("--json", action="store_true")
+    return parser
+
+
+def _load_bound_inputs(arguments: argparse.Namespace) -> tuple[Any, ...]:
+    comparison = load_cut3r_comparison_lock(arguments.comparison_lock)
+    fusion_source = load_cut3r_source_competence_lock(
+        comparison,
+        arguments.fusion_source_competence_lock,
+    )
+    fusion_support = load_cut3r_source_competence_v2_lock(
+        comparison,
+        fusion_source,
+        arguments.fusion_common_support_lock,
+    )
+    fusion_records = _strict_json(arguments.fusion_records)
+    fusion_report = load_cut3r_source_competence_v2_report(
+        comparison,
+        fusion_source,
+        fusion_support,
+        fusion_records,
+        arguments.fusion_report,
+    )
+    recurrence_source = load_cut3r_source_competence_lock(
+        comparison,
+        arguments.recurrence_source_competence_lock,
+    )
+    recurrence_support = load_cut3r_source_competence_v2_lock(
+        comparison,
+        recurrence_source,
+        arguments.recurrence_common_support_lock,
+    )
+    recurrence_records = _strict_json(arguments.recurrence_records)
+    recurrence_report = load_cut3r_source_competence_v2_report(
+        comparison,
+        recurrence_source,
+        recurrence_support,
+        recurrence_records,
+        arguments.recurrence_report,
+    )
+    specification = _strict_json(arguments.analysis_specification)
+    return (
+        comparison,
+        fusion_source,
+        fusion_support,
+        fusion_records,
+        fusion_report,
+        recurrence_source,
+        recurrence_support,
+        recurrence_records,
+        recurrence_report,
+        specification,
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _parser().parse_args(list(argv) if argv is not None else None)
+    inputs = _load_bound_inputs(arguments)
+    if arguments.command == "build":
+        report = build_cut3r_recurrent_state_recovery_report(*inputs)
+        write_cut3r_recurrent_state_recovery_report(
+            *inputs,
+            arguments.output,
+            report,
+        )
+        print(report["recurrent_state_recovery_report_id"])
+        return 0
+    report = load_cut3r_recurrent_state_recovery_report(
+        *inputs,
+        arguments.report,
+    )
+    if arguments.command == "verify":
+        print(report["recurrent_state_recovery_report_id"])
+        return 0
+    summary = cut3r_recurrent_state_recovery_summary(report)
+    if arguments.json:
+        print(json.dumps(summary, sort_keys=True, indent=2, allow_nan=False))
+    else:
+        print(f"report_id: {summary['recurrent_state_recovery_report_id']}")
+        print(f"evaluable groups: {summary['evaluable_group_count']}")
+        for metric, result in summary["recovery"].items():
+            print(
+                f"{metric}: {result['status']} "
+                f"recovery={result['recovery_fraction']}"
+            )
+        print(f"target access: {summary['target_access']}")
+    return 0
+
+
+__all__ = [
+    "CUT3R_RECURRENT_STATE_RECOVERY_ARMS",
+    "CUT3R_RECURRENT_STATE_RECOVERY_BOOTSTRAP",
+    "CUT3R_RECURRENT_STATE_RECOVERY_CLAIM_BOUNDARY",
+    "CUT3R_RECURRENT_STATE_RECOVERY_METRICS",
+    "CUT3R_RECURRENT_STATE_RECOVERY_SCHEMA",
+    "CUT3R_RECURRENT_STATE_RECOVERY_VERSION",
+    "build_cut3r_recurrent_state_recovery_report",
+    "cut3r_recurrent_state_recovery_summary",
+    "load_cut3r_recurrent_state_recovery_report",
+    "main",
+    "validate_cut3r_recurrent_state_recovery_report",
+    "write_cut3r_recurrent_state_recovery_report",
+]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/prob4d/prediction_cli.py
+++ b/src/prob4d/prediction_cli.py
@@ -48,6 +48,10 @@ def _help_parser() -> argparse.ArgumentParser:
         help="aggregate complete paired CUT3R source records into competence evidence",
     )
     subparsers.add_parser(
+        "cut3r-recovery",
+        help="quantify how much recurrent-state loss Prob4D fusion recovers",
+    )
+    subparsers.add_parser(
         "compatibility",
         help="build or compare additive semantic-compatibility manifests",
     )
@@ -106,6 +110,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         from .cut3r_source_competence import main as cut3r_source_competence_main
 
         return int(cut3r_source_competence_main(arguments[1:]))
+    if arguments[0] == "cut3r-recovery":
+        from .cut3r_recurrent_state_recovery import main as cut3r_recovery_main
+
+        return int(cut3r_recovery_main(arguments[1:]))
     if arguments[0] == "compatibility":
         from .semantic_compatibility import main as compatibility_main
 

--- a/tests/test_cut3r_recurrent_state_recovery.py
+++ b/tests/test_cut3r_recurrent_state_recovery.py
@@ -1,0 +1,397 @@
+from __future__ import annotations
+
+from copy import deepcopy
+
+import pytest
+
+from prob4d.cut3r_comparison import build_cut3r_comparison_lock
+from prob4d.cut3r_recurrent_state_recovery import (
+    build_cut3r_recurrent_state_recovery_report,
+)
+from prob4d.cut3r_source_competence import build_cut3r_source_competence_lock
+from prob4d.cut3r_source_competence_v2 import (
+    CUT3R_SOURCE_COMPETENCE_V2_PROPER_SCORE_SEMANTICS,
+    CUT3R_SOURCE_COMPETENCE_V2_RECORDS_SCHEMA,
+    build_cut3r_source_competence_v2_lock,
+    build_cut3r_source_competence_v2_report,
+)
+from prob4d.prediction_cli import main as prediction_main
+
+
+def _case(case_id: str, digest_character: str) -> dict[str, object]:
+    return {
+        "case_id": case_id,
+        "input_video_sha256": digest_character * 64,
+        "input_video_byte_count": 100,
+        "frame_start": 0,
+        "frame_stop_exclusive": 2,
+        "evaluation_frame_start": 0,
+        "evaluation_frame_stop_exclusive": 2,
+    }
+
+
+def _comparison() -> dict[str, object]:
+    return build_cut3r_comparison_lock(
+        {
+            "protocol_name": "recurrent-state-recovery-test-v1",
+            "provider_revision": "a" * 40,
+            "checkpoint_sha256": "b" * 64,
+            "prob4d_revision": "c" * 40,
+            "prob4d_distribution_sha256": "d" * 64,
+            "window_size": 2,
+            "overlap": 1,
+            "confidence_threshold": 1.0,
+            "storage_dtype": "float32",
+            "random_seeds": [7, 11],
+            "groups": [
+                {"group_id": "dev", "cases": [_case("dev-case", "1")]},
+                {"group_id": "cal", "cases": [_case("cal-case", "2")]},
+                {
+                    "group_id": "source-a",
+                    "cases": [_case("source-a-case", "3")],
+                },
+                {
+                    "group_id": "source-b",
+                    "cases": [_case("source-b-case", "4")],
+                },
+            ],
+            "group_roles": {
+                "development": ["dev"],
+                "calibration": ["cal"],
+                "source_evaluation": ["source-a", "source-b"],
+            },
+            "include_revisit_diagnostic": False,
+        }
+    )
+
+
+def _source_policy() -> dict[str, object]:
+    return {
+        "minimum_evaluable_groups": 2,
+        "maximum_technical_failures": 0,
+        "permitted_technical_failure_codes": [],
+        "maximum_mean_proper_score_delta": 0.0,
+        "maximum_mean_point_rmse_ratio": 1.0,
+        "maximum_mean_endpoint_rmse_ratio": 1.0,
+        "maximum_worst_group_point_rmse_ratio": 1.2,
+        "maximum_mean_absolute_drift_slope_m_per_frame": 2.0,
+        "maximum_mean_seam_rmse_m": 2.0,
+        "minimum_mean_quality_group_pass_fraction": 1.0,
+        "minimum_mean_association_precision": 0.5,
+        "minimum_mean_identity_retention": 0.5,
+        "minimum_mean_support_retention": 0.5,
+        "minimum_identity_group_pass_fraction": 1.0,
+    }
+
+
+def _source_lock(
+    comparison: dict[str, object],
+    *,
+    contrast_id: str,
+    digest_character: str,
+) -> dict[str, object]:
+    return build_cut3r_source_competence_lock(
+        comparison,
+        {
+            "contrast_id": contrast_id,
+            "candidate_provider_manifest_id": digest_character * 64,
+            "baseline_provider_manifest_id": "f" * 64,
+            "cohort_binding_id": "1" * 64,
+            "group_definition": "complete-object-recovery-test",
+            "record_definition_sha256": (
+                "2" if contrast_id == "prob4d-fusion-value" else "3"
+            )
+            * 64,
+            "policy": _source_policy(),
+        },
+    )
+
+
+def _paired_policy() -> dict[str, object]:
+    return {
+        "maximum_mean_seam_rmse_ratio": 1.0,
+        "maximum_worst_group_seam_rmse_ratio": 1.2,
+        "maximum_mean_absolute_drift_slope_ratio": 1.0,
+        "maximum_worst_group_absolute_drift_slope_ratio": 1.2,
+        "minimum_mean_association_precision_delta": -0.02,
+        "minimum_worst_group_association_precision_delta": -0.05,
+        "minimum_mean_identity_retention_delta": -0.02,
+        "minimum_worst_group_identity_retention_delta": -0.05,
+        "minimum_mean_support_retention_delta": -0.02,
+        "minimum_worst_group_support_retention_delta": -0.05,
+        "minimum_paired_quality_group_pass_fraction": 1.0,
+        "minimum_paired_identity_group_pass_fraction": 1.0,
+    }
+
+
+def _v2_lock(
+    comparison: dict[str, object],
+    source_lock: dict[str, object],
+    digest_character: str,
+) -> dict[str, object]:
+    return build_cut3r_source_competence_v2_lock(
+        comparison,
+        source_lock,
+        {
+            "source_competence_policy": source_lock["policy"],
+            "common_support_definition_sha256": digest_character * 64,
+            "proper_score_semantics": (
+                CUT3R_SOURCE_COMPETENCE_V2_PROPER_SCORE_SEMANTICS
+            ),
+            "paired_policy": _paired_policy(),
+            "require_complete_source_roster": True,
+        },
+    )
+
+
+def _metric_support(frame: int) -> dict[str, object]:
+    return {
+        "point_support_sha256": ("4" if frame == 0 else "5") * 64,
+        "point_support_count": 8,
+        "endpoint_support_sha256": ("6" if frame == 0 else "7") * 64,
+        "endpoint_support_count": 1,
+        "proper_score_support_sha256": ("8" if frame == 0 else "9") * 64,
+        "proper_score_dimension": 24,
+        "proper_score_semantics": (
+            CUT3R_SOURCE_COMPETENCE_V2_PROPER_SCORE_SEMANTICS
+        ),
+        "seam_support_sha256": "a" * 64 if frame == 0 else None,
+        "seam_support_count": 4 if frame == 0 else 0,
+    }
+
+
+def _arm_values(arm: str, frame: int) -> tuple[float, float, float, float | None, int]:
+    if arm == "restarted-newest":
+        return (
+            1.0 if frame == 0 else 2.0,
+            1.0,
+            10.0,
+            1.0 if frame == 0 else None,
+            8,
+        )
+    if arm == "restarted-prob4d-fused":
+        return (
+            1.0 if frame == 0 else 1.7,
+            0.8,
+            8.0,
+            0.8 if frame == 0 else None,
+            9,
+        )
+    if arm == "native-continuous":
+        return (
+            1.0 if frame == 0 else 1.4,
+            0.6,
+            6.0,
+            0.6 if frame == 0 else None,
+            9,
+        )
+    raise AssertionError(arm)
+
+
+def _record(
+    group: str,
+    case: str,
+    frame: int,
+    seed: int,
+    arm: str,
+) -> dict[str, object]:
+    point, endpoint, score, seam, retained = _arm_values(arm, frame)
+    return {
+        "group_id": group,
+        "case_id": case,
+        "frame_index": frame,
+        "random_seed": seed,
+        "arm_id": arm,
+        "point_error_m": point,
+        "endpoint_error_m": endpoint,
+        "proper_score": score,
+        "seam_error_m": seam,
+        "association_correct_count": retained,
+        "association_predicted_count": 10,
+        "identity_retained_count": retained,
+        "identity_reference_count": 10,
+        "support_retained_count": retained,
+        "support_reference_count": 10,
+        "metric_support": _metric_support(frame),
+    }
+
+
+def _records(
+    comparison: dict[str, object],
+    source_lock: dict[str, object],
+    v2_lock: dict[str, object],
+    *,
+    candidate_arm: str,
+) -> dict[str, object]:
+    rows = []
+    for group, case in (
+        ("source-a", "source-a-case"),
+        ("source-b", "source-b-case"),
+    ):
+        for frame in range(2):
+            for seed in (7, 11):
+                for arm in (candidate_arm, "restarted-newest"):
+                    rows.append(_record(group, case, frame, seed, arm))
+    return {
+        "schema": CUT3R_SOURCE_COMPETENCE_V2_RECORDS_SCHEMA,
+        "schema_version": 2,
+        "comparison_lock_id": comparison["lock_id"],
+        "source_competence_lock_id": source_lock["source_competence_lock_id"],
+        "common_support_lock_id": v2_lock["common_support_lock_id"],
+        "record_definition_sha256": source_lock["record_definition_sha256"],
+        "common_support_definition_sha256": v2_lock[
+            "common_support_definition_sha256"
+        ],
+        "source_truth_used": True,
+        "target_payloads_opened": False,
+        "target_outcomes_opened": False,
+        "group_failures": [],
+        "records": rows,
+    }
+
+
+def _setup() -> tuple[object, ...]:
+    comparison = _comparison()
+    fusion_source = _source_lock(
+        comparison,
+        contrast_id="prob4d-fusion-value",
+        digest_character="e",
+    )
+    recurrence_source = _source_lock(
+        comparison,
+        contrast_id="provider-recurrence-value",
+        digest_character="d",
+    )
+    fusion_support = _v2_lock(comparison, fusion_source, "b")
+    recurrence_support = _v2_lock(comparison, recurrence_source, "c")
+    fusion_records = _records(
+        comparison,
+        fusion_source,
+        fusion_support,
+        candidate_arm="restarted-prob4d-fused",
+    )
+    recurrence_records = _records(
+        comparison,
+        recurrence_source,
+        recurrence_support,
+        candidate_arm="native-continuous",
+    )
+    fusion_report = build_cut3r_source_competence_v2_report(
+        comparison,
+        fusion_source,
+        fusion_support,
+        fusion_records,
+    )
+    recurrence_report = build_cut3r_source_competence_v2_report(
+        comparison,
+        recurrence_source,
+        recurrence_support,
+        recurrence_records,
+    )
+    specification = {
+        "bootstrap_seed": 20260823,
+        "bootstrap_replicates": 200,
+        "confidence_level": 0.95,
+        "minimum_recurrence_gap_by_metric": {
+            "point_rmse_m": 1e-12,
+            "endpoint_rmse_m": 1e-12,
+            "proper_score": 1e-12,
+            "seam_rmse_m": 1e-12,
+            "absolute_drift_slope_m_per_frame": 1e-12,
+        },
+        "minimum_valid_bootstrap_fraction": 0.8,
+    }
+    return (
+        comparison,
+        fusion_source,
+        fusion_support,
+        fusion_records,
+        fusion_report,
+        recurrence_source,
+        recurrence_support,
+        recurrence_records,
+        recurrence_report,
+        specification,
+    )
+
+
+def test_recovery_report_quantifies_three_arm_mechanism() -> None:
+    report = build_cut3r_recurrent_state_recovery_report(*_setup())
+
+    assert report["evidence"]["byte_identical_restarted_newest_rows"]
+    assert report["evidence"][
+        "common_three_arm_metric_support_for_evaluable_groups"
+    ]
+    for metric in (
+        "endpoint_rmse_m",
+        "proper_score",
+        "seam_rmse_m",
+        "absolute_drift_slope_m_per_frame",
+    ):
+        result = report["aggregate"][metric]
+        assert result["status"] == "defined"
+        assert result["recovery_fraction"] == pytest.approx(0.5)
+        assert result["bootstrap_interval"]["lower"] == pytest.approx(0.5)
+        assert result["bootstrap_interval"]["upper"] == pytest.approx(0.5)
+    assert 0.0 < report["aggregate"]["point_rmse_m"]["recovery_fraction"] < 1.0
+    assert report["target_access"] == "forbidden"
+    assert report["descriptive_only"]
+
+
+def test_recovery_report_is_deterministic() -> None:
+    inputs = _setup()
+    assert build_cut3r_recurrent_state_recovery_report(
+        *inputs
+    ) == build_cut3r_recurrent_state_recovery_report(*inputs)
+
+
+def test_recovery_rejects_different_restarted_newest_rows() -> None:
+    inputs = list(_setup())
+    recurrence_records = deepcopy(inputs[7])
+    newest = next(
+        row
+        for row in recurrence_records["records"]
+        if row["arm_id"] == "restarted-newest"
+    )
+    newest["proper_score"] = 10.1
+    inputs[7] = recurrence_records
+    inputs[8] = build_cut3r_source_competence_v2_report(
+        inputs[0],
+        inputs[5],
+        inputs[6],
+        recurrence_records,
+    )
+
+    with pytest.raises(ValueError, match="byte-identical restarted-newest rows"):
+        build_cut3r_recurrent_state_recovery_report(*inputs)
+
+
+def test_recovery_is_undefined_when_native_does_not_outperform_restart() -> None:
+    inputs = list(_setup())
+    recurrence_records = deepcopy(inputs[7])
+    for row in recurrence_records["records"]:
+        if row["arm_id"] == "native-continuous":
+            row["endpoint_error_m"] = 1.2
+    inputs[7] = recurrence_records
+    inputs[8] = build_cut3r_source_competence_v2_report(
+        inputs[0],
+        inputs[5],
+        inputs[6],
+        recurrence_records,
+    )
+
+    report = build_cut3r_recurrent_state_recovery_report(*inputs)
+    endpoint = report["aggregate"]["endpoint_rmse_m"]
+    assert endpoint["status"] == "undefined-native-not-better"
+    assert endpoint["recovery_fraction"] is None
+    assert endpoint["bootstrap_interval"]["interval_status"] == "not-applicable"
+
+
+def test_prediction_cli_dispatches_cut3r_recovery_help(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as caught:
+        prediction_main(["cut3r-recovery", "--help"])
+
+    assert caught.value.code == 0
+    assert "recurrent-state" in capsys.readouterr().out


### PR DESCRIPTION
## Summary

- add a content-addressed source-only report for the three frozen CUT3R arms;
- quantify the fraction of restart-induced error recovered by Prob4D fusion;
- prove transitive three-arm common support through identical canonical `restarted-newest` rows;
- retain negative and undefined-denominator outcomes without clipping;
- add deterministic equal-group bootstrap intervals with invalid-denominator accounting; and
- freeze a prospective analysis specification and expose build/verify/summarize CLI commands.

## Scientific boundary

This is a descriptive mechanism report only. It does not select a candidate, change readiness gates, authorize target access, or claim BayesianPhysTwin/Causal4D benefit.

## Validation

Final reviewed head: `eac8d4ccfbbe891b22f9610a4f6e716a70e6445c`.

All exact-head pull-request workflows pass:

- complete suites on Python 3.10, 3.11, 3.12, 3.13, and 3.14;
- the declared Python/NumPy runtime floor;
- wheel and source-distribution builds plus isolated installed-artifact CLI smoke tests;
- fail-closed Ruff, formatting, strict MyPy, documentation-surface, and protocol checks;
- provider batch preflight, generic provider import, provider-neutral executable runtime, VGGT boundary, and CUT3R direct-point-map fidelity; and
- CodeQL and runtime dependency security scanning.

Focused tests cover the intended 50% recovery case, baseline-row mismatch rejection, deterministic report construction, undefined native-not-better denominators, and grouped CLI dispatch.

## Resolved prerequisite

PR #287 repaired the inherited source-freeze v2 request identities and reviewed self-hosted-workflow policy and is merged into `main` at `8b923e8cd67ca65f09312cffe305e36852f36fbb`. This branch contains that repair and is zero commits behind `main`.

Refs #49