### PR TITLE
Repair CUT3R source-freeze request and workflow contracts

### DIFF
--- a/.github/workflows/cut3r-source-freeze-lock-publication.yml
+++ b/.github/workflows/cut3r-source-freeze-lock-publication.yml
@@ -149,7 +149,6 @@ jobs:
         id: branch
         shell: bash
         env:
-          REQUEST_ID: 34eb4065a5be84ab6939595b38e53721d4555793a3d75eeb4cfc38170847b166
           FREEZE_ARTIFACT_ID: ${{ steps.publish.outputs.freeze_artifact_id }}
         run: |
           set -euo pipefail

--- a/CHANGELOG.d/cut3r-source-freeze-contract-repair.md
+++ b/CHANGELOG.d/cut3r-source-freeze-contract-repair.md
@@ -1,0 +1,15 @@
+### Fixed
+
+- Rotate the content-addressed CUT3R source-freeze v2 request identity after the
+  issue binding was added, and propagate that identity through the exact-byte
+  publication request and artifact prefix.
+- Restore the publication request's strict schema by removing an unsupported
+  duplicate issue field.
+- Register the automatic v2 source-freeze workflow as a reviewed self-hosted
+  workflow and assert its exact-main, read-only, no-secret execution boundary.
+
+### Scientific boundary
+
+This repair changes evidence identity and workflow validation only. It does not
+change the source cohort, CUT3R inputs, comparison arms, target-access boundary,
+BayesianPhysTwin or Causal4D methods, or any scientific outcome.

--- a/docs/cut3r-source-freeze-lock-publication.md
+++ b/docs/cut3r-source-freeze-lock-publication.md
@@ -11,7 +11,7 @@ request without recomputing any scientific value.
 `protocols/publication_requests/cut3r_deform360_source_freeze_v2.json` binds:
 
 - source request ID
-  `34eb4065a5be84ab6939595b38e53721d4555793a3d75eeb4cfc38170847b166`;
+  `8f3c9fba12f8a16895edce89d7a92e4806a43cb2f34b5a05faff71945809b63e`;
 - the corresponding Actions artifact-name prefix;
 - the required `source-support-freeze-ready` decision;
 - ten source object-session groups;

--- a/protocols/execution_requests/cut3r_deform360_source_freeze_v2.json
+++ b/protocols/execution_requests/cut3r_deform360_source_freeze_v2.json
@@ -7,7 +7,7 @@
   "issue_number": 49,
   "profile": "cut3r-deform360-source-freeze",
   "repository_write_token_on_self_hosted": false,
-  "request_id": "34eb4065a5be84ab6939595b38e53721d4555793a3d75eeb4cfc38170847b166",
+  "request_id": "8f3c9fba12f8a16895edce89d7a92e4806a43cb2f34b5a05faff71945809b63e",
   "schema": "prob4d.cut3r-deform360-source-freeze-execution-request",
   "schema_version": 2,
   "source_group_count": 10,

--- a/protocols/publication_requests/cut3r_deform360_source_freeze_v2.json
+++ b/protocols/publication_requests/cut3r_deform360_source_freeze_v2.json
@@ -1,8 +1,7 @@
 {
-  "artifact_name_prefix": "cut3r-source-freeze-v2-34eb4065a5be-",
+  "artifact_name_prefix": "cut3r-source-freeze-v2-8f3c9fba12f8-",
   "claim_boundary": "This request publishes only the exact target-closed source-freeze and comparison-lock bytes produced by the retained CUT3R source-support workflow. It does not execute CUT3R, open source residuals or truth, open confirmation or target payloads, authorize BayesianPhysTwin or Causal4D, or establish provider competence.",
   "forbidden_target_group_count": 12,
-  "issue_number": 49,
   "output_paths": {
     "comparison_lock": "protocols/locks/cut3r_deform360_comparison_lock_v2.json",
     "comparison_spec": "protocols/locks/cut3r_deform360_comparison_spec_v2.json",
@@ -10,12 +9,12 @@
     "execution_summary": "protocols/locks/cut3r_deform360_source_freeze_execution_v2.json",
     "source_freeze": "protocols/locks/cut3r_deform360_source_freeze_v2.json"
   },
-  "publication_request_id": "34eb4065a5be84ab6939595b38e53721d4555793a3d75eeb4cfc38170847b166",
+  "publication_request_id": "8f3c9fba12f8a16895edce89d7a92e4806a43cb2f34b5a05faff71945809b63e",
   "required_decision": "source-support-freeze-ready",
   "schema": "prob4d.cut3r-source-freeze-publication-request",
   "schema_version": 1,
   "source_group_count": 10,
-  "source_request_id": "34eb4065a5be84ab6939595b38e53721d4555793a3d75eeb4cfc38170847b166",
+  "source_request_id": "8f3c9fba12f8a16895edce89d7a92e4806a43cb2f34b5a05faff71945809b63e",
   "source_rgb_frames_decoded": false,
   "source_residuals_or_truth_opened": false,
   "target_outcomes_opened": false,

--- a/scripts/science/publish_cut3r_source_freeze_lock.py
+++ b/scripts/science/publish_cut3r_source_freeze_lock.py
@@ -10,15 +10,12 @@ executes CUT3R or opens source residuals, truth, confirmation, or target payload
 from __future__ import annotations
 
 import argparse
-import base64
 import hashlib
 import io
 import json
-import os
 import re
 import shutil
 import stat
-import tempfile
 import urllib.error
 import urllib.request
 import zipfile
@@ -355,7 +352,10 @@ def _publish_exact_files(
         "target_outcomes_opened": False,
         "claim_boundary": request["claim_boundary"],
     }
-    receipt_path = repository_root / "protocols/locks/cut3r_deform360_source_freeze_publication_v2.json"
+    receipt_path = (
+        repository_root
+        / "protocols/locks/cut3r_deform360_source_freeze_publication_v2.json"
+    )
     encoded = (json.dumps(receipt, indent=2, sort_keys=True, allow_nan=False) + "\n").encode()
     if receipt_path.exists() and receipt_path.read_bytes() != encoded:
         raise FileExistsError("refusing to replace a different publication receipt")

--- a/scripts/science/run_cut3r_source_freeze_execution.py
+++ b/scripts/science/run_cut3r_source_freeze_execution.py
@@ -101,13 +101,8 @@ def _load_json_object(path: Path, *, name: str) -> dict[str, Any]:
 
 
 def _lower_hex(value: object, *, name: str, length: int) -> str:
-    if (
-        type(value) is not str
-        or re.fullmatch(rf"[0-9a-f]{{{length}}}", value) is None
-    ):
-        raise ValueError(
-            f"{name} must be an exact lowercase {length}-character digest"
-        )
+    if type(value) is not str or re.fullmatch(rf"[0-9a-f]{{{length}}}", value) is None:
+        raise ValueError(f"{name} must be an exact lowercase {length}-character digest")
     return value
 
 
@@ -146,9 +141,7 @@ def validate_request(
     if set(request) != EXPECTED_REQUEST_FIELDS:
         missing = sorted(EXPECTED_REQUEST_FIELDS - set(request))
         extra = sorted(set(request) - EXPECTED_REQUEST_FIELDS)
-        raise ValueError(
-            f"execution request fields changed; missing={missing}, extra={extra}"
-        )
+        raise ValueError(f"execution request fields changed; missing={missing}, extra={extra}")
     if request["schema"] != REQUEST_SCHEMA:
         raise ValueError("unexpected source-freeze execution-request schema")
     if request["schema_version"] != REQUEST_VERSION:
@@ -169,9 +162,7 @@ def validate_request(
     if request["forbidden_target_group_count"] != 12:
         raise ValueError("source-freeze forbidden target group count changed")
     if any(request[name] is not False for name in FALSE_REQUEST_FIELDS):
-        raise ValueError(
-            "source-freeze execution request exceeds its target-closed boundary"
-        )
+        raise ValueError("source-freeze execution request exceeds its target-closed boundary")
 
     request_id = _lower_hex(request["request_id"], name="request_id", length=64)
     identity = dict(request)
@@ -187,9 +178,7 @@ def validate_request(
         raise ValueError("source-freeze protocol path changed")
     protocol_path = repository / protocol_relative
     if protocol_path.is_symlink() or not protocol_path.is_file():
-        raise ValueError(
-            "source-freeze protocol must be an ordinary repository file"
-        )
+        raise ValueError("source-freeze protocol must be an ordinary repository file")
     measured_blob = _git_output(["hash-object", protocol_relative], cwd=repository)
     expected_blob = _lower_hex(
         request["source_protocol_git_blob_sha"],
@@ -209,9 +198,7 @@ def validate_request(
         name="expected_revision",
         length=40,
     ):
-        raise ValueError(
-            "checked-out repository revision differs from authorization"
-        )
+        raise ValueError("checked-out repository revision differs from authorization")
     if require_clean and _git_output(
         ["status", "--porcelain=v1", "--untracked-files=all"],
         cwd=repository,
@@ -235,9 +222,7 @@ def _publish_json(path: Path, value: object) -> None:
     if path.exists():
         if path.read_bytes() == encoded:
             return
-        raise FileExistsError(
-            f"refusing to replace different retained bytes: {path}"
-        )
+        raise FileExistsError(f"refusing to replace different retained bytes: {path}")
     path.write_bytes(encoded)
 
 
@@ -287,21 +272,14 @@ def _validate_freeze(
     output_directory: Path,
 ) -> str:
     if freeze.get("source_group_count") != 10:
-        raise ValueError(
-            "source freeze does not contain exactly ten source groups"
-        )
+        raise ValueError("source freeze does not contain exactly ten source groups")
     if freeze.get("forbidden_target_group_count") != 12:
-        raise ValueError(
-            "source freeze does not retain all twelve forbidden targets"
-        )
+        raise ValueError("source freeze does not retain all twelve forbidden targets")
     boundary = freeze.get("information_boundary")
     if type(boundary) is not dict:
         raise ValueError("source freeze has no exact information boundary")
     boundary_mapping = cast(dict[str, Any], boundary)
-    if any(
-        boundary_mapping.get(name) is not False
-        for name in FALSE_FREEZE_BOUNDARY_FIELDS
-    ):
+    if any(boundary_mapping.get(name) is not False for name in FALSE_FREEZE_BOUNDARY_FIELDS):
         raise ValueError("source-freeze information boundary was exceeded")
 
     specification = output_directory / "cut3r-comparison-spec.json"
@@ -310,17 +288,13 @@ def _validate_freeze(
         if freeze.get("decision") != SUPPORT_PASS:
             raise ValueError("successful source freeze has the wrong decision")
         if not specification.is_file() or not lock.is_file():
-            raise ValueError(
-                "successful source freeze lacks canonical comparison outputs"
-            )
+            raise ValueError("successful source freeze lacks canonical comparison outputs")
         return SUPPORT_PASS
     if builder_status == 3:
         if freeze.get("decision") != SUPPORT_NEGATIVE:
             raise ValueError("support-negative source freeze has the wrong decision")
         if specification.exists() or lock.exists():
-            raise ValueError(
-                "support-negative source freeze published comparison outputs"
-            )
+            raise ValueError("support-negative source freeze published comparison outputs")
         return SUPPORT_NEGATIVE
     raise ValueError("unexpected source-freeze builder status")
 
@@ -337,9 +311,7 @@ def execute(args: argparse.Namespace) -> int:
     output_directory.mkdir(parents=True, exist_ok=False)
     raw_log: list[str] = []
 
-    builder = (
-        repository / "scripts/science/build_cut3r_deform360_source_freeze.py"
-    )
+    builder = repository / "scripts/science/build_cut3r_deform360_source_freeze.py"
     builder_status = _run(
         (
             sys.executable,
@@ -347,9 +319,7 @@ def execute(args: argparse.Namespace) -> int:
             "--repository",
             os.fspath(repository),
             "--protocol",
-            os.fspath(
-                repository / cast(str, request["source_protocol_path"])
-            ),
+            os.fspath(repository / cast(str, request["source_protocol_path"])),
             "--selection",
             os.fspath(args.selection.resolve()),
             "--processed-root",
@@ -420,9 +390,7 @@ def execute(args: argparse.Namespace) -> int:
 
     replacements = {
         os.fspath(args.selection.resolve()): "<BPT_SELECTION_LOCK>",
-        os.fspath(
-            args.processed_root.resolve()
-        ): "<DEFORM360_PROCESSED_ROOT>",
+        os.fspath(args.processed_root.resolve()): "<DEFORM360_PROCESSED_ROOT>",
         os.fspath(args.cut3r_checkout.resolve()): "<CUT3R_CHECKOUT>",
         os.fspath(args.checkpoint.resolve()): "<CUT3R_CHECKPOINT>",
         os.fspath(args.prob4d_wheel.resolve()): "<PROB4D_WHEEL>",
@@ -480,9 +448,7 @@ def execute(args: argparse.Namespace) -> int:
         "freeze_artifact_id": freeze_artifact_id,
         "artifact_name": artifact_name,
         "source_group_count": freeze["source_group_count"],
-        "forbidden_target_group_count": freeze[
-            "forbidden_target_group_count"
-        ],
+        "forbidden_target_group_count": freeze["forbidden_target_group_count"],
         "source_rgb_frames_decoded": False,
         "source_prediction_payloads_opened": False,
         "source_residuals_or_truth_opened": False,
@@ -547,9 +513,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             with args.github_output.open("a", encoding="utf-8") as stream:
                 stream.write(f"request_id={request['request_id']}\n")
                 stream.write(f"profile={request['profile']}\n")
-                stream.write(
-                    f"authorization_mode={request['authorization_mode']}\n"
-                )
+                stream.write(f"authorization_mode={request['authorization_mode']}\n")
         print(
             json.dumps(
                 {

--- a/tests/test_cut3r_source_freeze_execution_driver.py
+++ b/tests/test_cut3r_source_freeze_execution_driver.py
@@ -41,7 +41,7 @@ def _canonical_id(value: dict[str, object]) -> str:
             separators=(",", ":"),
             ensure_ascii=False,
             allow_nan=False,
-        ).encode("utf-8")
+        ).encode()
     ).hexdigest()
 
 
@@ -76,7 +76,7 @@ def test_driver_validates_checked_in_request_against_exact_protocol_blob() -> No
     )
 
     assert request["request_id"] == (
-        "34eb4065a5be84ab6939595b38e53721d4555793a3d75eeb4cfc38170847b166"
+        "8f3c9fba12f8a16895edce89d7a92e4806a43cb2f34b5a05faff71945809b63e"
     )
 
 

--- a/tests/test_cut3r_source_freeze_execution_driver.py
+++ b/tests/test_cut3r_source_freeze_execution_driver.py
@@ -10,15 +10,8 @@ from types import ModuleType
 import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
-DRIVER_PATH = (
-    ROOT / "scripts" / "science" / "run_cut3r_source_freeze_execution.py"
-)
-REQUEST_PATH = (
-    ROOT
-    / "protocols"
-    / "execution_requests"
-    / "cut3r_deform360_source_freeze_v2.json"
-)
+DRIVER_PATH = ROOT / "scripts" / "science" / "run_cut3r_source_freeze_execution.py"
+REQUEST_PATH = ROOT / "protocols" / "execution_requests" / "cut3r_deform360_source_freeze_v2.json"
 
 
 def _driver() -> ModuleType:
@@ -52,9 +45,7 @@ def test_checked_in_v2_request_is_content_addressed_and_target_closed() -> None:
 
     assert request_id == _canonical_id(identity)
     assert request["schema_version"] == 2
-    assert request["authorization_mode"] == (
-        "merged-main-read-only-self-hosted-v1"
-    )
+    assert request["authorization_mode"] == ("merged-main-read-only-self-hosted-v1")
     assert request["source_group_count"] == 10
     assert request["forbidden_target_group_count"] == 12
     assert request["repository_write_token_on_self_hosted"] is False

--- a/tests/test_cut3r_source_freeze_lock_publication.py
+++ b/tests/test_cut3r_source_freeze_lock_publication.py
@@ -10,10 +10,15 @@ from types import ModuleType
 import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
-SCRIPT = ROOT / "scripts/science/publish_cut3r_source_freeze_lock.py"
+SCRIPT = ROOT / "scripts" / "science" / "publish_cut3r_source_freeze_lock.py"
 REQUEST = (
     ROOT
-    / "protocols/publication_requests/cut3r_deform360_source_freeze_v2.json"
+    / "protocols"
+    / "publication_requests"
+    / "cut3r_deform360_source_freeze_v2.json"
+)
+SOURCE_REQUEST_ID = (
+    "8f3c9fba12f8a16895edce89d7a92e4806a43cb2f34b5a05faff71945809b63e"
 )
 
 
@@ -41,9 +46,7 @@ def _artifact_fixture(root: Path) -> dict[str, object]:
     evidence = root / "evidence"
     payload = evidence / "cut3r-deform360-source-freeze"
     execution = {
-        "request_id": (
-            "34eb4065a5be84ab6939595b38e53721d4555793a3d75eeb4cfc38170847b166"
-        ),
+        "request_id": SOURCE_REQUEST_ID,
         "decision": "source-support-freeze-ready",
         "freeze_artifact_id": "a" * 64,
         "source_group_count": 10,
@@ -89,6 +92,12 @@ def test_checked_in_publication_request_is_target_closed() -> None:
     module = _module()
     request = module.validate_request(REQUEST)
 
+    assert request["publication_request_id"] == SOURCE_REQUEST_ID
+    assert request["source_request_id"] == SOURCE_REQUEST_ID
+    assert request["artifact_name_prefix"].startswith(
+        "cut3r-source-freeze-v2-8f3c9fba12f8-"
+    )
+    assert "issue_number" not in request
     assert request["source_group_count"] == 10
     assert request["forbidden_target_group_count"] == 12
     assert request["source_rgb_frames_decoded"] is False
@@ -113,7 +122,7 @@ def test_artifact_validation_and_exact_publication(tmp_path: Path) -> None:
     repository = tmp_path / "repository"
     artifact = {
         "id": 123,
-        "name": "cut3r-source-freeze-v2-34eb4065a5be-123-1",
+        "name": "cut3r-source-freeze-v2-8f3c9fba12f8-123-1",
         "workflow_run": {"id": 456},
     }
     receipt = module._publish_exact_files(

--- a/tests/test_trusted_self_hosted_validation_policy.py
+++ b/tests/test_trusted_self_hosted_validation_policy.py
@@ -6,9 +6,11 @@ ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW_ROOT = ROOT / ".github" / "workflows"
 TRUSTED_WORKFLOW = WORKFLOW_ROOT / "trusted-self-hosted-validation.yml"
 SOURCE_FREEZE_EXECUTION_WORKFLOW = WORKFLOW_ROOT / "cut3r-source-freeze-execution.yml"
+SOURCE_FREEZE_AUTO_V2_WORKFLOW = WORKFLOW_ROOT / "cut3r-source-freeze-auto-v2.yml"
 TRUSTED_SELF_HOSTED_WORKFLOWS = (
     TRUSTED_WORKFLOW,
     SOURCE_FREEZE_EXECUTION_WORKFLOW,
+    SOURCE_FREEZE_AUTO_V2_WORKFLOW,
 )
 REMOVED_TEMPORARY_WORKFLOWS = (
     WORKFLOW_ROOT / "issue-49-protected-cohort-inventory.yml",
@@ -149,6 +151,39 @@ def test_source_freeze_execution_keeps_write_permission_off_self_hosted_job() ->
     assert "contents: write" not in execute
     assert "permissions:\n      contents: read\n      issues: write" in report
     assert "runs-on: ubuntu-latest" in report
+
+
+def test_auto_v2_source_freeze_is_exact_main_bound_and_read_only() -> None:
+    text = SOURCE_FREEZE_AUTO_V2_WORKFLOW.read_text(encoding="utf-8")
+
+    assert "\n  push:" in text
+    assert "branches: [main]" in text
+    assert "pull_request_target:" not in text
+    assert "if: github.event_name == 'push'" in text
+    assert 'test "$EVENT_REF" = "refs/heads/main"' in text
+    assert 'test "$EVENT_AFTER" = "$EXPECTED_SHA"' in text
+    assert 'test "$EVENT_FORCED" = "false"' in text
+    assert 'test "$EVENT_DELETED" = "false"' in text
+    assert "ref: ${{ needs.authorize.outputs.head_sha }}" in text
+    assert "runs-on: [self-hosted, Linux, X64, nvidia-smi]" in text
+
+    execute_start = text.index("\n  execute:")
+    report_start = text.index("\n  report:")
+    execute = text[execute_start:report_start]
+    report = text[report_start:]
+
+    assert "if: github.event_name == 'push'" in execute
+    assert "permissions:\n      contents: read" in execute
+    assert "issues: write" not in execute
+    assert "contents: write" not in execute
+    assert "pull-requests: write" not in execute
+    assert "persist-credentials: false" in execute
+    assert "secrets." not in execute
+    assert "repository_write_token_on_self_hosted=false" in execute
+    assert "environment_approval_required=false" in execute
+    assert "git push" not in execute
+    assert "runs-on: ubuntu-latest" in report
+    assert "issues: write" in report
 
 
 def test_full_validation_tracks_the_05_cleanup_surface() -> None:


### PR DESCRIPTION
## Summary

Repair the merged CUT3R source-freeze v2 evidence contracts that currently make the repository test matrix fail.

- rotate the execution request ID to the canonical digest after `issue_number` was added;
- propagate the new source request identity into the exact-byte publication request and artifact prefix;
- remove the unsupported duplicate `issue_number` field from the strict publication-request schema;
- remove a stale, unused hard-coded request ID from the publication workflow;
- register `cut3r-source-freeze-auto-v2.yml` as a reviewed self-hosted workflow; and
- add explicit tests for its exact-main, read-only, no-secret execution boundary.

## Why this is separate

This is a prerequisite contract repair for #286. Keeping it separate prevents the recurrent-state recovery feature from absorbing unrelated evidence-custody and workflow-security changes.

## Scientific boundary

No source cohort, CUT3R input, comparison arm, target-access rule, BayesianPhysTwin method, Causal4D method, or scientific outcome changes. The patch repairs content identity, publication validation, and workflow policy only.

## Validation target

The patch directly addresses all seven baseline failures observed in the full Python matrix:

- two stale execution-request identity failures;
- four publication-request schema/fixture failures; and
- one trusted self-hosted workflow allowlist failure.

Refs #49
Depends-on: none
Follow-up: #286