### PR TITLE
Harden legacy fixed-lag covariance reporting

### DIFF
--- a/CHANGELOG.d/fixed-lag-covariance-hardening.md
+++ b/CHANGELOG.d/fixed-lag-covariance-hardening.md
@@ -1,0 +1,5 @@
+Hardened the legacy fixed-lag gauge smoother's covariance reporting. Optimization
+damping now affects steps only; covariance is recomputed from the accepted final
+undamped Gauss--Newton Jacobian, and rank-deficient active gauge systems fail
+closed instead of receiving a silent pseudoinverse. The production marginalized
+joint-gauge observation path and frozen provider protocols are unchanged.

--- a/docs/marginalized-fixed-lag.md
+++ b/docs/marginalized-fixed-lag.md
@@ -26,6 +26,14 @@ solution. When every factor is admitted before either endpoint leaves the lag,
 increasing the lag approaches the corresponding batch solution; the regression
 suite checks exact chain-model marginals and full-batch parity.
 
+The legacy `FixedLagGaugeSmoother` remains available as a marginal-only control.
+Its optimization damping is not treated as posterior information: after the
+accepted final step, Prob4D recomputes the undamped Gauss--Newton Jacobian and
+forms covariance only when the complete active gauge state is observable. A
+rank-deficient active system now fails closed instead of silently returning a
+pseudoinverse covariance. The legacy path still discards cross-window covariance
+blocks and therefore must not be used as claim-bearing joint uncertainty.
+
 This change does not alter the production sequential `ObservationBeliefV1`
 contract. The fixed-lag export still contains block-diagonal historical marginals
 rather than one exact all-window covariance, so fixed-lag mode remains an

--- a/src/prob4d/gauge.py
+++ b/src/prob4d/gauge.py
@@ -360,6 +360,47 @@ def _whitener(covariance: FloatArray, floor: float = 1e-10) -> FloatArray:
     return (eigenvectors * (1.0 / np.sqrt(eigenvalues))) @ eigenvectors.T
 
 
+def _full_rank_gauss_newton_covariance(
+    residual_function: Callable[[FloatArray], FloatArray],
+    vector: FloatArray,
+    *,
+    name: str,
+) -> FloatArray:
+    """Return final undamped covariance or fail closed on an unobservable state."""
+
+    jacobian = _numerical_jacobian(residual_function, vector)
+    if not np.all(np.isfinite(jacobian)):
+        raise ValueError(f"{name} Jacobian must be finite")
+    _, singular_values, right_vectors_transpose = np.linalg.svd(
+        jacobian,
+        full_matrices=False,
+    )
+    largest_singular_value = (
+        float(singular_values[0]) if singular_values.size else 0.0
+    )
+    rank_tolerance = (
+        np.finfo(np.float64).eps
+        * max(jacobian.shape)
+        * largest_singular_value
+    )
+    rank = int(np.count_nonzero(singular_values > rank_tolerance))
+    dimension = int(vector.size)
+    if rank != dimension:
+        raise ValueError(
+            f"{name} is rank-deficient ({rank}/{dimension}); "
+            "legacy fixed-lag covariance requires a fully observable active state"
+        )
+    inverse_squared = 1.0 / np.square(singular_values)
+    covariance = (right_vectors_transpose.T * inverse_squared) @ right_vectors_transpose
+    covariance = 0.5 * (covariance + covariance.T)
+    return validated_covariance_psd(
+        covariance,
+        name=f"{name} covariance",
+        shape=(dimension, dimension),
+        readonly=False,
+    )
+
+
 _ComposeWithCovariance = Callable[
     [Sim3, FloatArray, Sim3, FloatArray],
     tuple[Sim3, FloatArray],
@@ -487,7 +528,14 @@ def constraint_cost(
 
 
 class FixedLagGaugeSmoother:
-    """Rolling nonlinear least-squares smoother over recent ``Sim(3)`` gauges."""
+    """Legacy marginal-only fixed-lag smoother over recent ``Sim(3)`` gauges.
+
+    Damping is used only to compute optimization steps. Covariance is recomputed
+    from the undamped Jacobian at the accepted final state and fails closed when
+    that active state is not fully observable. Cross-window covariance blocks are
+    still discarded; claim-bearing joint uncertainty should use the marginalized
+    fixed-lag or joint-gauge posterior paths.
+    """
 
     def __init__(
         self,
@@ -499,6 +547,12 @@ class FixedLagGaugeSmoother:
     ) -> None:
         if lag < 2:
             raise ValueError("fixed-lag smoother requires lag >= 2")
+        if max_iterations < 1:
+            raise ValueError("max_iterations must be positive")
+        if not np.isfinite(damping) or damping < 0.0:
+            raise ValueError("damping must be finite and non-negative")
+        if not np.isfinite(tolerance) or tolerance <= 0.0:
+            raise ValueError("tolerance must be finite and positive")
         self.lag = lag
         self.max_iterations = max_iterations
         self.damping = damping
@@ -596,16 +650,18 @@ class FixedLagGaugeSmoother:
                 return np.concatenate(residual_parts)
 
             vector = initial_vector
-            hessian = np.eye(vector.size)
             for _ in range(self.max_iterations):
                 residual = residual_vector(vector)
                 jacobian = _numerical_jacobian(residual_vector, vector)
-                hessian = jacobian.T @ jacobian + self.damping * np.eye(vector.size)
+                damped_hessian = (
+                    jacobian.T @ jacobian
+                    + self.damping * np.eye(vector.size)
+                )
                 gradient = jacobian.T @ residual
                 try:
-                    increment = -np.linalg.solve(hessian, gradient)
+                    increment = -np.linalg.solve(damped_hessian, gradient)
                 except np.linalg.LinAlgError:
-                    increment = -np.linalg.lstsq(hessian, gradient, rcond=None)[0]
+                    increment = -np.linalg.lstsq(damped_hessian, gradient, rcond=None)[0]
                 if np.linalg.norm(increment) < self.tolerance:
                     break
                 current_cost = float(residual @ residual)
@@ -621,7 +677,11 @@ class FixedLagGaugeSmoother:
                     break
 
             optimized = unpack(vector)
-            joint_covariance = np.linalg.pinv(hessian, rcond=1e-10)
+            joint_covariance = _full_rank_gauss_newton_covariance(
+                residual_vector,
+                vector,
+                name="fixed-lag active gauge posterior",
+            )
             for index, window_id in enumerate(active_ids):
                 state[window_id] = optimized[window_id]
                 block = joint_covariance[7 * index : 7 * (index + 1), 7 * index : 7 * (index + 1)]

--- a/tests/test_gauge.py
+++ b/tests/test_gauge.py
@@ -1,8 +1,11 @@
 import numpy as np
+import pytest
 
 from prob4d.gauge import (
     FixedLagGaugeSmoother,
+    GaugeAnchor,
     GaugeCovarianceCalibration,
+    GaugeEstimate,
     RelativeGaugeConstraint,
     ScaleAnchor,
     SequentialGaugeEstimator,
@@ -94,6 +97,59 @@ def test_sparse_scale_anchor_reduces_chain_scale_drift() -> None:
 
     final_error = abs(np.log(smoothed["w2"].global_from_local.scale))
     assert final_error < initial_error * 0.2
+
+
+def test_fixed_lag_covariance_uses_final_undamped_information() -> None:
+    anchor_covariance = np.diag([0.04, 0.03, 0.02, 0.01, 0.05, 0.06, 0.07])
+    initial = {
+        window_id: GaugeEstimate(window_id, Sim3.identity(), np.eye(7))
+        for window_id in ("w0", "w1")
+    }
+
+    smoothed = FixedLagGaugeSmoother(lag=2, damping=1e6).smooth(
+        ["w0", "w1"],
+        initial,
+        [],
+        gauge_anchors=[GaugeAnchor("w1", Sim3.identity(), anchor_covariance)],
+    )
+
+    np.testing.assert_allclose(
+        smoothed["w1"].covariance,
+        anchor_covariance,
+        rtol=2e-5,
+        atol=1e-10,
+    )
+
+
+def test_fixed_lag_covariance_fails_closed_when_active_state_is_rank_deficient() -> None:
+    initial = {
+        window_id: GaugeEstimate(window_id, Sim3.identity(), np.eye(7))
+        for window_id in ("w0", "w1")
+    }
+
+    with pytest.raises(ValueError, match="rank-deficient"):
+        FixedLagGaugeSmoother(lag=2).smooth(
+            ["w0", "w1"],
+            initial,
+            [],
+            scale_anchors=[ScaleAnchor("w1", 1.0, 0.1)],
+        )
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"max_iterations": 0}, "max_iterations"),
+        ({"damping": -1.0}, "damping"),
+        ({"tolerance": 0.0}, "tolerance"),
+    ],
+)
+def test_fixed_lag_rejects_invalid_numerical_settings(
+    kwargs: dict[str, float],
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        FixedLagGaugeSmoother(**kwargs)
 
 
 def test_gauge_covariance_calibration_fits_blockwise_inflation() -> None:


### PR DESCRIPTION
## Summary

- recompute the legacy fixed-lag covariance from the undamped Gauss–Newton Jacobian at the accepted final state;
- keep Levenberg-style damping confined to optimization steps instead of treating it as posterior information;
- fail closed when the active gauge state is rank deficient rather than silently returning a pseudoinverse covariance;
- validate numerical constructor settings;
- add regression tests for damping independence, rank-deficiency rejection, and invalid settings; and
- document that the legacy path remains marginal-only while production observation export continues to use the marginalized joint-gauge path.

## Scientific and protocol boundary

This is a numerical correctness hardening of a legacy reconstruction control. It does not alter the frozen CUT3R source/confirmation/target rosters, provider identities, readiness order, source outcomes, target authorization, BayesianPhysTwin guard, Causal4D handoff, or any scientific result. No source residual, truth, confirmation, target, or physical-query outcome was opened.

The queued retained CUT3R source-freeze execution and draft #288 remain independent prerequisites for issue #49.

## Validation intent

The full repository quality, Python-version, packaging, provider-contract, security, and frozen-protocol workflows should run unchanged. The focused tests prove that a very large optimizer damping value does not shrink posterior covariance and that an underdetermined active gauge system is rejected explicitly.

Tracks #49 without completing its provider-competence gate.