### PR TITLE
Harden observation-belief producer validation and atomic writes

### DIFF
--- a/src/prob4d/observation_contract.py
+++ b/src/prob4d/observation_contract.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Mapping
+import os
+import tempfile
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -59,25 +61,74 @@ def _artifact_id(
     return observation_contract_artifact_id(descriptor, arrays)
 
 
-def _validate_sha256(value: str, *, name: str) -> None:
-    if len(value) != 64 or any(
+def _genuine_integer(value: object, *, name: str) -> int:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)):
+        raise ValueError(f"{name} must be an integer")
+    return int(value)
+
+
+def _canonical_string_tuple(
+    values: object,
+    *,
+    name: str,
+    allow_empty: bool,
+    invalid_message: str,
+) -> tuple[str, ...]:
+    if isinstance(values, (str, bytes)) or not isinstance(values, Sequence):
+        raise ValueError(invalid_message)
+    result = tuple(values)
+    if not allow_empty and not result:
+        raise ValueError(invalid_message)
+    if any(type(value) is not str or not value for value in result):
+        raise ValueError(invalid_message)
+    return result
+
+
+def _validate_sha256(value: object, *, name: str) -> str:
+    if type(value) is not str or len(value) != 64 or any(
         character not in "0123456789abcdef" for character in value
     ):
         raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return value
 
 
 def _validated_metadata(values: Mapping[str, Any]) -> Mapping[str, Any]:
     return frozen_finite_json_mapping(values, name="metadata")
 
 
-def _readonly(
-    values: np.ndarray,
-    *,
-    dtype: np.dtype[Any] | type | None = None,
-) -> np.ndarray:
-    result = np.asarray(values, dtype=dtype).copy()
-    result.setflags(write=False)
-    return result
+def _immutable_array(values: np.ndarray, *, dtype: np.dtype[Any]) -> np.ndarray:
+    array = np.array(values, dtype=dtype, copy=True, order="C")
+    if array.dtype.hasobject:
+        raise TypeError("contract arrays must not contain Python objects")
+    payload = array.tobytes(order="C")
+    return np.frombuffer(payload, dtype=array.dtype).reshape(array.shape)
+
+
+def _readonly_float(values: object, *, name: str) -> np.ndarray:
+    try:
+        raw = np.asarray(values)
+    except (TypeError, ValueError, OverflowError) as error:
+        raise ValueError(f"{name} must contain real numeric values") from error
+    if raw.dtype.kind not in "iuf":
+        raise ValueError(f"{name} must contain real numeric values")
+    return _immutable_array(raw, dtype=np.dtype(np.float64))
+
+
+def _readonly_integer(values: object, *, name: str) -> np.ndarray:
+    try:
+        raw = np.asarray(values)
+    except (TypeError, ValueError, OverflowError) as error:
+        raise ValueError(f"{name} must contain integers") from error
+    integer_dtype = np.issubdtype(raw.dtype, np.integer) and not np.issubdtype(
+        raw.dtype, np.bool_
+    )
+    if not integer_dtype:
+        raise ValueError(f"{name} must contain integers")
+    if np.issubdtype(raw.dtype, np.unsignedinteger) and np.any(
+        raw > np.iinfo(np.int64).max
+    ):
+        raise ValueError(f"{name} contains integers outside int64 range")
+    return _immutable_array(raw, dtype=np.dtype("<i8"))
 
 
 @dataclass(frozen=True)
@@ -118,49 +169,93 @@ class ObservationBeliefExportV1:
     metadata: Mapping[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        if not self.case_id or not self.stream_id:
+        if (
+            type(self.case_id) is not str
+            or not self.case_id
+            or type(self.stream_id) is not str
+            or not self.stream_id
+        ):
             raise ValueError("case_id and stream_id must be nonempty")
-        if self.causal_frame_stop < 1:
+        causal_frame_stop = _genuine_integer(
+            self.causal_frame_stop,
+            name="causal_frame_stop",
+        )
+        if causal_frame_stop < 1:
             raise ValueError("causal_frame_stop must be positive")
-        if not self.view_names or any(not name for name in self.view_names):
-            raise ValueError("view_names must contain nonempty names")
-        if not self.window_names or any(not name for name in self.window_names):
-            raise ValueError("window_names must contain nonempty names")
-        if any(not name for name in self.factor_names):
-            raise ValueError("factor_names must be nonempty when present")
-        if not self.source_repository or not self.source_revision:
+        view_names = _canonical_string_tuple(
+            self.view_names,
+            name="view_names",
+            allow_empty=False,
+            invalid_message="view_names must contain nonempty names",
+        )
+        window_names = _canonical_string_tuple(
+            self.window_names,
+            name="window_names",
+            allow_empty=False,
+            invalid_message="window_names must contain nonempty names",
+        )
+        factor_names = _canonical_string_tuple(
+            self.factor_names,
+            name="factor_names",
+            allow_empty=True,
+            invalid_message="factor_names must be nonempty when present",
+        )
+        if (
+            type(self.source_repository) is not str
+            or not self.source_repository
+            or type(self.source_revision) is not str
+            or not self.source_revision
+        ):
             raise ValueError("source repository and revision must be nonempty")
-        _validate_sha256(
+        source_artifact_sha256 = _validate_sha256(
             self.source_artifact_sha256,
             name="source_artifact_sha256",
         )
 
-        declared_frames = _readonly(self.declared_frame_ids, dtype=np.int64)
-        mean = _readonly(self.mean_xyz_m, dtype=np.float64)
-        frame_ids = _readonly(self.frame_ids, dtype=np.int64)
-        entity_ids = _readonly(self.entity_ids, dtype=np.int64)
-        view_indices = _readonly(self.view_indices, dtype=np.int64)
-        window_indices = _readonly(self.window_indices, dtype=np.int64)
-        correlation_groups = _readonly(
-            self.correlation_group_ids, dtype=np.int64
+        declared_frames = _readonly_integer(
+            self.declared_frame_ids,
+            name="declared_frame_ids",
         )
-        factor_groups = _readonly(self.factor_group_ids, dtype=np.int64)
-        prior_reliability = _readonly(
-            self.prior_reliability, dtype=np.float64
+        mean = _readonly_float(self.mean_xyz_m, name="mean_xyz_m")
+        frame_ids = _readonly_integer(self.frame_ids, name="frame_ids")
+        entity_ids = _readonly_integer(self.entity_ids, name="entity_ids")
+        view_indices = _readonly_integer(self.view_indices, name="view_indices")
+        window_indices = _readonly_integer(
+            self.window_indices,
+            name="window_indices",
         )
-        association_probability = _readonly(
-            self.association_probability, dtype=np.float64
+        correlation_groups = _readonly_integer(
+            self.correlation_group_ids,
+            name="correlation_group_ids",
         )
-        local_covariance = _readonly(
-            self.local_covariance_m2, dtype=np.float64
+        factor_groups = _readonly_integer(
+            self.factor_group_ids,
+            name="factor_group_ids",
         )
-        factors = _readonly(self.low_rank_factor_m, dtype=np.float64)
-        group_ids = _readonly(self.group_ids, dtype=np.int64)
-        group_prior = _readonly(
-            self.group_prior_nominal_probability, dtype=np.float64
+        prior_reliability = _readonly_float(
+            self.prior_reliability,
+            name="prior_reliability",
         )
-        group_weight = _readonly(
-            self.group_composite_weight, dtype=np.float64
+        association_probability = _readonly_float(
+            self.association_probability,
+            name="association_probability",
+        )
+        local_covariance = _readonly_float(
+            self.local_covariance_m2,
+            name="local_covariance_m2",
+        )
+        factors = _readonly_float(
+            self.low_rank_factor_m,
+            name="low_rank_factor_m",
+        )
+        group_ids = _readonly_integer(self.group_ids, name="group_ids")
+        group_prior = _readonly_float(
+            self.group_prior_nominal_probability,
+            name="group_prior_nominal_probability",
+        )
+        group_weight = _readonly_float(
+            self.group_composite_weight,
+            name="group_composite_weight",
         )
 
         if (
@@ -170,9 +265,10 @@ class ObservationBeliefExportV1:
             or np.any(np.diff(declared_frames) <= 0)
         ):
             raise ValueError(
-                "declared_frame_ids must be nonempty, nonnegative, and strictly increasing"
+                "declared_frame_ids must be nonempty, nonnegative, and "
+                "strictly increasing"
             )
-        if np.any(declared_frames >= self.causal_frame_stop):
+        if np.any(declared_frames >= causal_frame_stop):
             raise ValueError("declared frames violate the causal boundary")
         if mean.ndim != 2 or mean.shape[1] != 3 or len(mean) == 0:
             raise ValueError("mean_xyz_m must have nonempty shape (N, 3)")
@@ -192,7 +288,7 @@ class ObservationBeliefExportV1:
                 raise ValueError(f"{name} must have shape ({observation_count},)")
         if local_covariance.shape != (observation_count, 3, 3):
             raise ValueError("local_covariance_m2 must have shape (N, 3, 3)")
-        factor_rank = len(self.factor_names)
+        factor_rank = len(factor_names)
         if factors.shape != (observation_count, 3, factor_rank):
             raise ValueError(
                 "low_rank_factor_m must have shape "
@@ -206,14 +302,14 @@ class ObservationBeliefExportV1:
             raise ValueError("low-rank factors must be finite")
         if np.any(entity_ids < 0):
             raise ValueError("entity_ids must be nonnegative")
-        if np.any(frame_ids < 0) or np.any(frame_ids >= self.causal_frame_stop):
+        if np.any(frame_ids < 0) or np.any(frame_ids >= causal_frame_stop):
             raise ValueError("observation frames cross the causal boundary")
         if not np.all(np.isin(frame_ids, declared_frames)):
             raise ValueError("frame_ids must be contained in declared_frame_ids")
-        if np.any(view_indices < 0) or np.any(view_indices >= len(self.view_names)):
+        if np.any(view_indices < 0) or np.any(view_indices >= len(view_names)):
             raise ValueError("view_indices reference unavailable views")
         if np.any(window_indices < 0) or np.any(
-            window_indices >= len(self.window_names)
+            window_indices >= len(window_names)
         ):
             raise ValueError("window_indices reference unavailable windows")
         if np.any(correlation_groups < 0) or np.any(factor_groups < 0):
@@ -279,6 +375,15 @@ class ObservationBeliefExportV1:
                 "observation identity (frame, entity, view, window) must be unique"
             )
 
+        object.__setattr__(self, "causal_frame_stop", causal_frame_stop)
+        object.__setattr__(self, "view_names", view_names)
+        object.__setattr__(self, "window_names", window_names)
+        object.__setattr__(self, "factor_names", factor_names)
+        object.__setattr__(
+            self,
+            "source_artifact_sha256",
+            source_artifact_sha256,
+        )
         object.__setattr__(self, "declared_frame_ids", declared_frames)
         object.__setattr__(self, "mean_xyz_m", mean)
         object.__setattr__(self, "frame_ids", frame_ids)
@@ -364,24 +469,44 @@ class ObservationBeliefExportV1:
 def save_observation_belief_export(
     path: str | Path, artifact: ObservationBeliefExportV1
 ) -> None:
-    """Write a non-pickled, content-addressed observation artifact."""
+    """Atomically write a non-pickled, content-addressed observation artifact."""
 
     target = Path(path)
+    if target.is_symlink():
+        raise ValueError(f"refusing to replace symlink {target}")
     target.parent.mkdir(parents=True, exist_ok=True)
     descriptor = artifact.descriptor()
     descriptor["artifact_id"] = artifact.artifact_id
-    np.savez_compressed(
-        target,
-        descriptor_json=np.asarray(
-            json.dumps(
-                descriptor,
-                sort_keys=True,
-                separators=(",", ":"),
-                allow_nan=False,
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w+b",
+            dir=target.parent,
+            prefix=f".{target.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temporary_path = Path(handle.name)
+            np.savez_compressed(
+                handle,
+                descriptor_json=np.asarray(
+                    json.dumps(
+                        descriptor,
+                        sort_keys=True,
+                        separators=(",", ":"),
+                        allow_nan=False,
+                    )
+                ),
+                **artifact.arrays(),
             )
-        ),
-        **artifact.arrays(),
-    )
+            handle.flush()
+            os.fsync(handle.fileno())
+        assert temporary_path is not None
+        os.replace(temporary_path, target)
+    except BaseException:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+        raise
 
 
 __all__ = [

--- a/tests/test_observation_contract_producer_strictness.py
+++ b/tests/test_observation_contract_producer_strictness.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+import prob4d.observation_contract as observation_contract_module
+from prob4d.observation_contract import (
+    ObservationBeliefExportV1,
+    save_observation_belief_export,
+)
+
+
+def _artifact() -> ObservationBeliefExportV1:
+    local = np.repeat(np.eye(3)[None], 4, axis=0) * 1e-4
+    factors = np.zeros((4, 3, 2))
+    factors[:2, 0, 0] = 0.002
+    factors[2:, 1, 1] = 0.003
+    return ObservationBeliefExportV1(
+        case_id="case-1",
+        stream_id="prob4d:points",
+        causal_frame_stop=12,
+        view_names=("camera0",),
+        window_names=("window0", "window1"),
+        factor_names=("gauge_latent_0", "gauge_latent_1"),
+        source_repository="IPS-Stuttgart/Prob4D",
+        source_revision="a" * 40,
+        source_artifact_sha256="b" * 64,
+        declared_frame_ids=np.asarray([8, 9]),
+        mean_xyz_m=np.asarray(
+            [
+                [0.0, 0.0, 1.0],
+                [1.0, 0.0, 1.0],
+                [0.1, 0.0, 1.0],
+                [1.1, 0.0, 1.0],
+            ]
+        ),
+        frame_ids=np.asarray([8, 8, 9, 9]),
+        entity_ids=np.asarray([0, 1, 0, 1]),
+        view_indices=np.zeros(4, dtype=int),
+        window_indices=np.asarray([0, 0, 1, 1]),
+        correlation_group_ids=np.asarray([0, 0, 1, 1]),
+        factor_group_ids=np.asarray([0, 0, 1, 1]),
+        prior_reliability=np.asarray([0.9, 0.8, 0.7, 0.6]),
+        association_probability=np.ones(4),
+        local_covariance_m2=local,
+        low_rank_factor_m=factors,
+        group_ids=np.asarray([0, 1]),
+        group_prior_nominal_probability=np.asarray([0.85, 0.65]),
+        group_composite_weight=np.asarray([0.5, 0.5]),
+        metadata={"causal_source": "prefix only"},
+    )
+
+
+@pytest.mark.parametrize("value", (True, 12.0, np.float64(12.0)))
+def test_producer_rejects_noninteger_causal_cutoff(value: object) -> None:
+    with pytest.raises(ValueError, match="causal_frame_stop must be an integer"):
+        replace(_artifact(), causal_frame_stop=cast(int, value))
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    (
+        ("case_id", 7, "case_id and stream_id must be nonempty"),
+        ("stream_id", b"stream", "case_id and stream_id must be nonempty"),
+        ("view_names", (7,), "view_names must contain nonempty names"),
+        ("window_names", ("window0", 7), "window_names must contain"),
+        ("factor_names", (7,), "factor_names must be nonempty"),
+        ("source_repository", 7, "source repository and revision"),
+        ("source_revision", b"revision", "source repository and revision"),
+        ("source_artifact_sha256", 7, "lowercase SHA-256"),
+    ),
+)
+def test_producer_rejects_lossy_descriptor_aliases(
+    field: str,
+    value: object,
+    message: str,
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        replace(_artifact(), **{field: value})
+
+
+@pytest.mark.parametrize(
+    "field",
+    (
+        "declared_frame_ids",
+        "frame_ids",
+        "entity_ids",
+        "view_indices",
+        "window_indices",
+        "correlation_group_ids",
+        "factor_group_ids",
+        "group_ids",
+    ),
+)
+@pytest.mark.parametrize("dtype", (np.float64, np.bool_))
+def test_producer_rejects_noninteger_identity_arrays(
+    field: str,
+    dtype: type[np.generic],
+) -> None:
+    source = _artifact()
+    values = np.asarray(getattr(source, field), dtype=dtype)
+    with pytest.raises(ValueError, match=f"{field} must contain integers"):
+        replace(source, **{field: values})
+
+
+def test_producer_rejects_unsigned_identity_overflow() -> None:
+    source = _artifact()
+    overflow = np.asarray([0, np.iinfo(np.uint64).max], dtype=np.uint64)
+    with pytest.raises(ValueError, match="outside int64 range"):
+        replace(source, group_ids=overflow)
+
+
+def test_producer_canonicalizes_descriptor_and_identity_storage() -> None:
+    source = _artifact()
+    artifact = replace(
+        source,
+        causal_frame_stop=np.int64(source.causal_frame_stop),
+        view_names=list(source.view_names),
+        window_names=list(source.window_names),
+        factor_names=list(source.factor_names),
+        frame_ids=np.asarray(source.frame_ids, dtype=np.int16),
+    )
+
+    assert type(artifact.causal_frame_stop) is int
+    assert type(artifact.view_names) is tuple
+    assert type(artifact.window_names) is tuple
+    assert type(artifact.factor_names) is tuple
+    assert artifact.frame_ids.dtype.str == "<i8"
+    assert artifact.artifact_id == source.artifact_id
+
+    for name, values in artifact.arrays().items():
+        assert not values.flags.writeable, name
+        with pytest.raises(ValueError):
+            values.setflags(write=True)
+
+
+def test_atomic_writer_does_not_clobber_retained_target(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    target = tmp_path / "observation.npz"
+    target.write_bytes(b"retained evidence")
+
+    def fail_after_partial_write(handle: Any, **payload: object) -> None:
+        del payload
+        handle.write(b"partial replacement")
+        handle.flush()
+        raise RuntimeError("simulated serialization failure")
+
+    monkeypatch.setattr(
+        observation_contract_module.np,
+        "savez_compressed",
+        fail_after_partial_write,
+    )
+
+    with pytest.raises(RuntimeError, match="simulated serialization failure"):
+        save_observation_belief_export(target, _artifact())
+
+    assert target.read_bytes() == b"retained evidence"
+    assert not list(tmp_path.glob(f".{target.name}.*.tmp"))
+
+
+def test_atomic_writer_refuses_to_replace_symlink(tmp_path: Path) -> None:
+    retained = tmp_path / "retained.npz"
+    retained.write_bytes(b"retained evidence")
+    target = tmp_path / "observation.npz"
+    target.symlink_to(retained)
+
+    with pytest.raises(ValueError, match="refusing to replace symlink"):
+        save_observation_belief_export(target, _artifact())
+
+    assert retained.read_bytes() == b"retained evidence"


### PR DESCRIPTION
## Summary

- reject Boolean/float identity arrays and other lossy integer aliases before canonical `int64` conversion;
- require a genuine integer causal cutoff and literal descriptor strings/sequences;
- canonicalize integer identity storage to little-endian `int64` and back arrays with immutable bytes;
- preserve the existing observation schema and cross-repository content identity for valid artifacts;
- write NPZ artifacts through an fsynced temporary file and atomic replacement, while refusing symlink targets and preserving retained bytes on failure;
- add focused adversarial and no-clobber regression tests.

## Why

The producer constructor previously coerced identity arrays with `dtype=np.int64` and checked the causal cutoff only by numeric comparison. Inputs such as floating-point identities could therefore be admitted and truncated by the producer, then rejected by Prob4D's strict loader or Bayesian-PhysTwin's consumer contract.

## Local validation

- `31 passed` in the new focused test module;
- both changed Python files compile;
- no changed Python line exceeds 88 characters;
- the canonical existing artifact remains exactly `9c02e638f60424cca7738d347d1258acd208eb562f422efacd077db4edb2fe80`;
- uploaded Git blobs match the locally tested files byte-for-byte.

## Compatibility boundary

Valid existing artifacts retain the same schema, array dtypes, descriptor representation, and artifact digest. This PR intentionally changes only malformed producer inputs and write-failure behavior.

## Scientific boundary

This is contract and custody hardening. It does not change Prob4D estimation, calibration, provider competence, BayesianPhysTwin inference, Causal4D behavior, or any scientific claim.