### PR TITLE
Add denominator-safe exact CUT3R recovery v2

### DIFF
--- a/CHANGELOG.d/cut3r-recurrent-state-recovery-v2.md
+++ b/CHANGELOG.d/cut3r-recurrent-state-recovery-v2.md
@@ -1,0 +1,14 @@
+Added an additive denominator-safe CUT3R recurrent-state recovery v2 report.
+Absolute Prob4D gain is now the primary mechanism endpoint, while the recovery
+fraction is secondary and is defined only when the uninterrupted-recurrence gap
+exceeds a prospectively frozen positive practical-separation floor. The
+content-addressed v2 specification records that source outcomes were still closed
+and target access forbidden when the analysis was frozen.
+
+The v2 analysis exactly enumerates the equal-complete-group empirical bootstrap
+through multinomial count vectors and exact ordered-resample multiplicities. It
+reports gain, denominator, and conditional recovery intervals; the exact valid-
+denominator probability; and leave-one-complete-group-out sign and eligibility
+sensitivity. It rejects non-finite derived statistics and preserves the existing
+v1 report and all frozen provider, source, target, BayesianPhysTwin, and Causal4D
+boundaries.

--- a/docs/cut3r-recurrent-state-recovery-v2.md
+++ b/docs/cut3r-recurrent-state-recovery-v2.md
@@ -1,0 +1,209 @@
+# CUT3R recurrent-state recovery v2
+
+`prob4d.cut3r_recurrent_state_recovery_v2` is an additive, source-only analysis
+of the same three frozen CUT3R arms used by the v1 report:
+
+| Role | Arm |
+| --- | --- |
+| Uninterrupted recurrent reference | `native-continuous` |
+| Restarted-window baseline | `restarted-newest` |
+| Prob4D treatment | `restarted-prob4d-fused` |
+
+It does not alter the provider, windowing, source roster, source-competence
+decisions, readiness order, target protocol, BayesianPhysTwin guard, or Causal4D
+handoff. Version 1 remains readable and reproducible. Version 2 exists because a
+ratio can become unstable even when every input artifact is valid.
+
+## Scientific question
+
+For each lower-is-better source metric, define the absolute Prob4D gain
+
+\[
+G = E_{\mathrm{restarted\mbox{-}newest}}
+    - E_{\mathrm{restarted\mbox{-}Prob4D}}
+\]
+
+and the recurrent-state gap
+
+\[
+D = E_{\mathrm{restarted\mbox{-}newest}}
+    - E_{\mathrm{native\mbox{-}continuous}}.
+\]
+
+The recovery fraction is
+
+\[
+R = \frac{G}{D}.
+\]
+
+Version 2 makes `G` the primary endpoint. `R` is secondary and is defined only
+when `D` exceeds the prospectively frozen practical-separation floor for that
+metric. This prevents an arbitrarily small positive denominator from producing
+an arbitrarily large but scientifically uninformative recovery fraction.
+
+The fraction is never clipped:
+
+- `R < 0` means Prob4D fusion is harmful relative to the restarted baseline;
+- `0 < R < 1` means partial recovery;
+- `R = 1` means the complete restart gap is closed;
+- `R > 1` means fused restarted windows outperform uninterrupted recurrence; and
+- `undefined-recurrence-gap-not-practically-separated` means the recurrent-state
+  gap is not large enough to support the ratio interpretation.
+
+Absolute gain, recurrent-state gap, and their intervals remain available even
+when the ratio is undefined.
+
+## Prospective specification
+
+The checked-in specification is
+[`protocols/cut3r_recurrent_state_recovery_v2.json`][v2-spec].
+It is content-addressed and freezes:
+
+- absolute Prob4D gain as the primary endpoint;
+- the recovery fraction as a denominator-gated secondary endpoint;
+- a 95% exact empirical-bootstrap interval;
+- a minimum valid-denominator probability of `0.8`;
+- exact enumeration for at most ten evaluable complete source groups;
+- strictly positive metric-specific recurrence-gap floors;
+- leave-one-complete-group-out sensitivity reporting;
+- `source_outcomes_opened_before_specification=false`; and
+- `target_access=forbidden`.
+
+The specification is additive analysis hardening frozen while the retained
+source-input job was still queued. It does not replace or mutate that exact
+execution request.
+
+The practical-separation floors are:
+
+| Metric | Frozen floor |
+| --- | ---: |
+| Point RMSE | `0.0001 m` (`0.1 mm`) |
+| Endpoint RMSE | `0.0001 m` (`0.1 mm`) |
+| Seam RMSE | `0.0001 m` (`0.1 mm`) |
+| Absolute drift slope | `0.00001 m/frame` (`0.01 mm/frame`) |
+| Fixed-scale proper score | `0.01` |
+
+These values are prospective interpretation floors, not accuracy, calibration,
+or sensor-resolution claims. Changing one after source outcomes are opened
+requires a new analysis version; the v2 artifact must not be rewritten.
+
+## Exact small-sample inference
+
+The v1 analysis uses a deterministic Monte Carlo group bootstrap. Version 2
+instead enumerates the exact equal-group empirical-bootstrap distribution.
+
+For `n` complete source groups, an ordered empirical-bootstrap sample contains
+`n` draws with replacement. Version 2 enumerates every multinomial count vector
+and weights it by its exact ordered-sample multiplicity
+
+\[
+\frac{n!}{\prod_i c_i!}.
+\]
+
+The multiplicities sum to `n**n`, which is checked at runtime. The number of
+count vectors is also checked against
+
+\[
+\binom{2n-1}{n-1}.
+\]
+
+For ten evaluable groups, this evaluates 92,378 count vectors representing all
+10,000,000,000 ordered resamples without pretending that 10,000 pseudorandom
+replicates provide 10,000 independent pieces of evidence.
+
+The report includes exact weighted nearest-rank intervals for:
+
+1. absolute Prob4D gain;
+2. the recurrent-state gap; and
+3. the recovery fraction, conditional on the recurrence gap exceeding its
+   frozen practical floor.
+
+It also records the exact ordered-resample count and probability for valid and
+invalid denominators. The recovery-fraction interval is withheld when that valid
+probability is below the frozen minimum, while the gain and denominator
+intervals remain reported.
+
+Frames, points, cameras, seeds, and tracks remain nested observations. Only
+complete source objects or acquisition sessions receive independent bootstrap
+mass.
+
+## Leave-one-group-out sensitivity
+
+For every metric, the report recomputes the equal-group aggregate after omitting
+each complete evaluable source group. It retains:
+
+- the complete omission table;
+- minimum and maximum absolute Prob4D gain;
+- whether the gain changes sign;
+- whether denominator eligibility changes; and
+- the range of defined recovery fractions.
+
+This is a sensitivity diagnostic, not an alternative selection rule. A sign
+reversal or denominator-status change is retained rather than used to choose a
+more favorable subset.
+
+## Evidence validation
+
+Version 2 consumes the same two complete
+`prob4d.cut3r-source-competence-report-v2` chains as version 1:
+
+1. `restarted-prob4d-fused` versus `restarted-newest`; and
+2. `native-continuous` versus `restarted-newest`.
+
+Before any v2 statistic is built, the existing strict v1 builder revalidates the
+comparison lock, both source-competence locks, both common-support locks, all
+canonical records, both reports, byte-identical restarted-window baseline rows,
+technical-failure evidence, cohort binding, and provider identities. The v2
+report binds the resulting validation-bridge report identity and then performs
+its own exact analysis.
+
+## Build, verify, and summarize
+
+After both common-support source reports exist:
+
+```bash
+prob4d prediction cut3r-recovery-v2 build \
+  outputs/cut3r/cut3r-comparison-lock.json \
+  outputs/cut3r/fusion/source-competence-lock.json \
+  outputs/cut3r/fusion/common-support-lock-v2.json \
+  outputs/cut3r/fusion/source-competence-records-v2.json \
+  outputs/cut3r/fusion/source-competence-v2.json \
+  outputs/cut3r/recurrence/source-competence-lock.json \
+  outputs/cut3r/recurrence/common-support-lock-v2.json \
+  outputs/cut3r/recurrence/source-competence-records-v2.json \
+  outputs/cut3r/recurrence/source-competence-v2.json \
+  protocols/cut3r_recurrent_state_recovery_v2.json \
+  --output outputs/cut3r/recurrent-state-recovery-v2.json
+```
+
+Rebuild every statistic and verify the retained bytes:
+
+```bash
+prob4d prediction cut3r-recovery-v2 verify \
+  outputs/cut3r/cut3r-comparison-lock.json \
+  outputs/cut3r/fusion/source-competence-lock.json \
+  outputs/cut3r/fusion/common-support-lock-v2.json \
+  outputs/cut3r/fusion/source-competence-records-v2.json \
+  outputs/cut3r/fusion/source-competence-v2.json \
+  outputs/cut3r/recurrence/source-competence-lock.json \
+  outputs/cut3r/recurrence/common-support-lock-v2.json \
+  outputs/cut3r/recurrence/source-competence-records-v2.json \
+  outputs/cut3r/recurrence/source-competence-v2.json \
+  protocols/cut3r_recurrent_state_recovery_v2.json \
+  outputs/cut3r/recurrent-state-recovery-v2.json
+```
+
+Use `summarize` with the same bound inputs and `--json` for a compact view that
+foregrounds absolute gain, its exact interval, denominator probability, the
+secondary recovery fraction, and leave-one-group-out sensitivity.
+
+## Claim boundary
+
+This is descriptive source mechanism evidence. It does not select a provider,
+repair a negative source gate, authorize target access, establish physical-query
+benefit in BayesianPhysTwin, establish counterfactual benefit in Causal4D,
+establish deployment safety, or establish state of the art. A negative,
+undefined, denominator-unstable, or leave-one-group-sensitive result remains a
+complete result and must not be retuned on the same opened source groups.
+
+[v2-spec]: ../protocols/cut3r_recurrent_state_recovery_v2.json

--- a/docs/provider-evidence-status.md
+++ b/docs/provider-evidence-status.md
@@ -57,6 +57,8 @@ must not be retuned on the same opened target cohort.
 - [CUT3R source qualification runbook](cut3r-qualification-runbook.md)
 - [CUT3R recurrent-online provider](cut3r-online-provider.md)
 - [CUT3R native-versus-Prob4D comparison](cut3r-comparison.md)
+- [CUT3R recurrent-state recovery v1](cut3r-recurrent-state-recovery.md)
+- [Denominator-safe CUT3R recurrent-state recovery v2](cut3r-recurrent-state-recovery-v2.md)
 - [Provider readiness localization](provider-readiness-localization.md)
 - [Held-out provider promotion](heldout-provider-promotion.md)
 - [Material-identity stream](material-identity-stream.md)

--- a/protocols/cut3r_recurrent_state_recovery_v2.json
+++ b/protocols/cut3r_recurrent_state_recovery_v2.json
@@ -1,0 +1,29 @@
+{
+  "analysis_specification_id": "1e2f77a39a71410dd54e0eeb50da0765b8d6f5c79589777ea80c3ad8e6bfdbf7",
+  "claim_boundary": "This prospective specification was frozen before CUT3R source outcomes were opened. It authorizes only a descriptive source-only analysis of already registered three-arm evidence. It does not alter a provider, source gate, readiness decision, target protocol, BayesianPhysTwin guard, or Causal4D handoff, and target access remains forbidden.",
+  "confidence_level": 0.95,
+  "interval_method": "exact-multinomial-equal-group-bootstrap-nearest-rank-v1",
+  "leave_one_group_out": true,
+  "maximum_exact_group_count": 10,
+  "minimum_recurrence_gap_by_metric": {
+    "absolute_drift_slope_m_per_frame": 1e-05,
+    "endpoint_rmse_m": 0.0001,
+    "point_rmse_m": 0.0001,
+    "proper_score": 0.01,
+    "seam_rmse_m": 0.0001
+  },
+  "minimum_recurrence_gap_rationale_by_metric": {
+    "absolute_drift_slope_m_per_frame": "Prospective 0.01 mm/frame practical-separation floor for absolute drift slope.",
+    "endpoint_rmse_m": "Prospective 0.1 mm practical-separation floor for endpoint RMSE.",
+    "point_rmse_m": "Prospective 0.1 mm practical-separation floor for point RMSE.",
+    "proper_score": "Prospective 0.01 fixed-score practical-separation floor.",
+    "seam_rmse_m": "Prospective 0.1 mm practical-separation floor for seam RMSE."
+  },
+  "minimum_valid_denominator_probability": 0.8,
+  "primary_endpoint": "prob4d_gain",
+  "schema": "prob4d.cut3r-recurrent-state-recovery-specification",
+  "schema_version": 2,
+  "secondary_endpoint": "recovery_fraction_when_recurrence_gap_separated",
+  "source_outcomes_opened_before_specification": false,
+  "target_access": "forbidden"
+}

--- a/src/prob4d/_cut3r_recovery_v2_exact.py
+++ b/src/prob4d/_cut3r_recovery_v2_exact.py
@@ -1,0 +1,296 @@
+"""Exact complete-group inference for CUT3R recurrent-state recovery v2."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterator, Mapping, Sequence
+from typing import Any, cast
+
+from ._cut3r_recovery_v2_spec import (
+    CUT3R_RECURRENT_STATE_RECOVERY_V2_INTERVAL_METHOD,
+)
+from .cut3r_recurrent_state_recovery import _mean
+
+
+def _count_vectors(total: int, length: int) -> Iterator[tuple[int, ...]]:
+    if length == 1:
+        yield (total,)
+        return
+    for first in range(total + 1):
+        for suffix in _count_vectors(total - first, length - 1):
+            yield (first, *suffix)
+
+
+def _multinomial_multiplicity(
+    counts: Sequence[int],
+    *,
+    factorials: Sequence[int],
+) -> int:
+    denominator = math.prod(factorials[count] for count in counts)
+    return factorials[sum(counts)] // denominator
+
+
+def _weighted_mean(values: Sequence[float], counts: Sequence[int]) -> float:
+    count = sum(counts)
+    if count <= 0 or len(values) != len(counts):
+        raise ValueError("weighted group mean requires matched nonempty inputs")
+    try:
+        result = math.fsum(
+            value * multiplicity
+            for value, multiplicity in zip(values, counts, strict=True)
+        ) / count
+    except OverflowError as error:
+        raise ValueError("weighted group mean overflowed") from error
+    if not math.isfinite(result):
+        raise ValueError("weighted group mean must remain finite")
+    return result
+
+
+def _finite_difference(left: float, right: float, *, name: str) -> float:
+    result = left - right
+    if not math.isfinite(result):
+        raise ValueError(f"{name} must remain finite")
+    return result
+
+
+def _triplet_v2(
+    native: float,
+    restarted: float,
+    fused: float,
+    *,
+    denominator_threshold: float,
+) -> dict[str, Any]:
+    prob4d_gain = _finite_difference(restarted, fused, name="Prob4D gain")
+    recurrence_gap = _finite_difference(restarted, native, name="recurrence gap")
+    if recurrence_gap > denominator_threshold:
+        recovery_fraction = prob4d_gain / recurrence_gap
+        if not math.isfinite(recovery_fraction):
+            raise ValueError("recovery fraction must remain finite")
+        status = "defined"
+    else:
+        recovery_fraction = None
+        status = "undefined-recurrence-gap-not-practically-separated"
+    return {
+        "native_continuous": native,
+        "restarted_newest": restarted,
+        "restarted_prob4d_fused": fused,
+        "prob4d_gain": prob4d_gain,
+        "recurrence_gap": recurrence_gap,
+        "minimum_recurrence_gap": denominator_threshold,
+        "recovery_fraction": recovery_fraction,
+        "status": status,
+    }
+
+
+def _weighted_nearest_rank(
+    weighted_values: Sequence[tuple[float, int]],
+    *,
+    total_weight: int,
+    probability: float,
+) -> float:
+    if total_weight <= 0 or not weighted_values:
+        raise ValueError("weighted quantile requires positive support")
+    rank = max(1, math.ceil(probability * total_weight))
+    cumulative = 0
+    for value, weight in sorted(weighted_values, key=lambda item: item[0]):
+        cumulative += weight
+        if cumulative >= rank:
+            return value
+    raise RuntimeError("weighted quantile support did not reach its total weight")
+
+
+def _weighted_interval(
+    weighted_values: Sequence[tuple[float, int]],
+    *,
+    total_weight: int,
+    confidence_level: float,
+) -> dict[str, Any]:
+    tail = (1.0 - confidence_level) / 2.0
+    return {
+        "method": CUT3R_RECURRENT_STATE_RECOVERY_V2_INTERVAL_METHOD,
+        "quantile_rule": "weighted-nearest-rank-ceiling-v1",
+        "confidence_level": confidence_level,
+        "support_ordered_resample_count": total_weight,
+        "lower": _weighted_nearest_rank(
+            weighted_values,
+            total_weight=total_weight,
+            probability=tail,
+        ),
+        "upper": _weighted_nearest_rank(
+            weighted_values,
+            total_weight=total_weight,
+            probability=1.0 - tail,
+        ),
+    }
+
+
+def _exact_group_bootstrap(
+    group_triplets: Sequence[tuple[float, float, float]],
+    *,
+    denominator_threshold: float,
+    confidence_level: float,
+    minimum_valid_denominator_probability: float,
+    maximum_exact_group_count: int,
+    point_status: str,
+) -> dict[str, Any]:
+    group_count = len(group_triplets)
+    if group_count < 2:
+        raise ValueError("v2 exact inference requires at least two evaluable groups")
+    if group_count > maximum_exact_group_count:
+        raise ValueError(
+            "evaluable group count exceeds the prospectively frozen exact limit"
+        )
+    factorials = [math.factorial(index) for index in range(group_count + 1)]
+    native_values = [item[0] for item in group_triplets]
+    restarted_values = [item[1] for item in group_triplets]
+    fused_values = [item[2] for item in group_triplets]
+    gain_values: list[tuple[float, int]] = []
+    gap_values: list[tuple[float, int]] = []
+    ratio_values: list[tuple[float, int]] = []
+    count_vector_count = 0
+    total_ordered_resamples = 0
+    valid_ordered_resamples = 0
+    for counts in _count_vectors(group_count, group_count):
+        multiplicity = _multinomial_multiplicity(counts, factorials=factorials)
+        count_vector_count += 1
+        total_ordered_resamples += multiplicity
+        native = _weighted_mean(native_values, counts)
+        restarted = _weighted_mean(restarted_values, counts)
+        fused = _weighted_mean(fused_values, counts)
+        triplet = _triplet_v2(
+            native,
+            restarted,
+            fused,
+            denominator_threshold=denominator_threshold,
+        )
+        gain_values.append((cast(float, triplet["prob4d_gain"]), multiplicity))
+        gap_values.append((cast(float, triplet["recurrence_gap"]), multiplicity))
+        if triplet["status"] == "defined":
+            ratio_values.append(
+                (cast(float, triplet["recovery_fraction"]), multiplicity)
+            )
+            valid_ordered_resamples += multiplicity
+
+    expected_ordered_resamples = group_count**group_count
+    expected_count_vectors = math.comb(2 * group_count - 1, group_count - 1)
+    if total_ordered_resamples != expected_ordered_resamples:
+        raise RuntimeError("exact bootstrap multiplicities do not sum to n**n")
+    if count_vector_count != expected_count_vectors:
+        raise RuntimeError("exact bootstrap count-vector enumeration is incomplete")
+    valid_probability = valid_ordered_resamples / total_ordered_resamples
+    if point_status != "defined":
+        ratio_interval: dict[str, Any] = {
+            "method": CUT3R_RECURRENT_STATE_RECOVERY_V2_INTERVAL_METHOD,
+            "interval_status": "not-applicable-point-denominator",
+            "lower": None,
+            "upper": None,
+        }
+    elif (
+        valid_ordered_resamples == 0
+        or valid_probability < minimum_valid_denominator_probability
+    ):
+        ratio_interval = {
+            "method": CUT3R_RECURRENT_STATE_RECOVERY_V2_INTERVAL_METHOD,
+            "interval_status": "insufficient-valid-denominator-probability",
+            "lower": None,
+            "upper": None,
+        }
+    else:
+        ratio_interval = {
+            **_weighted_interval(
+                ratio_values,
+                total_weight=valid_ordered_resamples,
+                confidence_level=confidence_level,
+            ),
+            "interval_status": "defined",
+            "conditioning": "recurrence-gap-above-frozen-practical-floor",
+        }
+    return {
+        "method": CUT3R_RECURRENT_STATE_RECOVERY_V2_INTERVAL_METHOD,
+        "group_count": group_count,
+        "count_vector_count": count_vector_count,
+        "ordered_resample_count": total_ordered_resamples,
+        "prob4d_gain_interval": _weighted_interval(
+            gain_values,
+            total_weight=total_ordered_resamples,
+            confidence_level=confidence_level,
+        ),
+        "recurrence_gap_interval": _weighted_interval(
+            gap_values,
+            total_weight=total_ordered_resamples,
+            confidence_level=confidence_level,
+        ),
+        "recovery_fraction_interval": ratio_interval,
+        "valid_denominator_ordered_resample_count": valid_ordered_resamples,
+        "invalid_denominator_ordered_resample_count": (
+            total_ordered_resamples - valid_ordered_resamples
+        ),
+        "valid_denominator_probability": valid_probability,
+        "minimum_valid_denominator_probability": (
+            minimum_valid_denominator_probability
+        ),
+        "minimum_recurrence_gap": denominator_threshold,
+    }
+
+
+def _leave_one_group_out(
+    group_ids: Sequence[str],
+    group_triplets: Sequence[tuple[float, float, float]],
+    *,
+    denominator_threshold: float,
+    point: Mapping[str, Any],
+) -> dict[str, Any]:
+    if len(group_ids) != len(group_triplets) or len(group_ids) < 2:
+        raise ValueError("leave-one-group-out requires matched groups and triplets")
+    rows: list[dict[str, Any]] = []
+    for omitted_index, omitted_group_id in enumerate(group_ids):
+        retained = [
+            triplet
+            for index, triplet in enumerate(group_triplets)
+            if index != omitted_index
+        ]
+        row = _triplet_v2(
+            _mean([item[0] for item in retained]),
+            _mean([item[1] for item in retained]),
+            _mean([item[2] for item in retained]),
+            denominator_threshold=denominator_threshold,
+        )
+        rows.append({"omitted_group_id": omitted_group_id, **row})
+    point_gain = cast(float, point["prob4d_gain"])
+    gains = [cast(float, row["prob4d_gain"]) for row in rows]
+    defined_recoveries = [
+        cast(float, row["recovery_fraction"])
+        for row in rows
+        if row["status"] == "defined"
+    ]
+    return {
+        "method": "leave-one-complete-source-group-out-v1",
+        "omission_count": len(rows),
+        "rows": rows,
+        "summary": {
+            "minimum_prob4d_gain": min(gains),
+            "maximum_prob4d_gain": max(gains),
+            "prob4d_gain_sign_reversal": any(
+                point_gain * gain < 0.0 for gain in gains
+            ),
+            "point_denominator_status": point["status"],
+            "denominator_status_changed": any(
+                row["status"] != point["status"] for row in rows
+            ),
+            "defined_recovery_count": len(defined_recoveries),
+            "minimum_defined_recovery_fraction": (
+                min(defined_recoveries) if defined_recoveries else None
+            ),
+            "maximum_defined_recovery_fraction": (
+                max(defined_recoveries) if defined_recoveries else None
+            ),
+        },
+    }
+
+
+__all__ = [
+    "_count_vectors",
+    "_exact_group_bootstrap",
+    "_leave_one_group_out",
+    "_triplet_v2",
+]

--- a/src/prob4d/_cut3r_recovery_v2_report.py
+++ b/src/prob4d/_cut3r_recovery_v2_report.py
@@ -1,0 +1,370 @@
+"""Content-addressed CUT3R recurrent-state recovery-v2 report."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, cast
+
+from ._cut3r_recovery_v2_exact import (
+    _exact_group_bootstrap,
+    _leave_one_group_out,
+    _triplet_v2,
+)
+from ._cut3r_recovery_v2_spec import (
+    CUT3R_RECURRENT_STATE_RECOVERY_V2_CLAIM_BOUNDARY,
+    CUT3R_RECURRENT_STATE_RECOVERY_V2_PRIMARY_ENDPOINT,
+    CUT3R_RECURRENT_STATE_RECOVERY_V2_SCHEMA,
+    CUT3R_RECURRENT_STATE_RECOVERY_V2_SECONDARY_ENDPOINT,
+    CUT3R_RECURRENT_STATE_RECOVERY_V2_VERSION,
+    validate_cut3r_recurrent_state_recovery_v2_specification,
+)
+from .cut3r_recurrent_state_recovery import (
+    CUT3R_RECURRENT_STATE_RECOVERY_ARMS,
+    CUT3R_RECURRENT_STATE_RECOVERY_METRICS,
+    _mean,
+    build_cut3r_recurrent_state_recovery_report,
+)
+from .cut3r_source_competence import (
+    _canonical_json,
+    _publish_json,
+    _record_id,
+    _strict_json,
+    _strict_mapping,
+)
+
+
+def _v1_bridge_specification(specification: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "bootstrap_seed": 0,
+        "bootstrap_replicates": 1,
+        "confidence_level": specification["confidence_level"],
+        "minimum_recurrence_gap_by_metric": specification[
+            "minimum_recurrence_gap_by_metric"
+        ],
+        "minimum_valid_bootstrap_fraction": 0.0,
+    }
+
+
+def _build_v2_from_validated_v1_report(
+    validated_v1_report: Mapping[str, Any],
+    specification: Mapping[str, Any],
+) -> dict[str, Any]:
+    group_rows = cast(Sequence[Mapping[str, Any]], validated_v1_report["groups"])
+    v2_group_rows: list[dict[str, Any]] = []
+    for row in group_rows:
+        if row["technical_failure_code"] is not None:
+            v2_group_rows.append(
+                {
+                    "group_id": row["group_id"],
+                    "technical_failure_code": row["technical_failure_code"],
+                    "metrics": None,
+                }
+            )
+            continue
+        source_metrics = cast(Mapping[str, Mapping[str, Any]], row["metrics"])
+        metrics: dict[str, Any] = {}
+        for metric in CUT3R_RECURRENT_STATE_RECOVERY_METRICS:
+            threshold = cast(
+                float,
+                cast(
+                    Mapping[str, Any],
+                    specification["minimum_recurrence_gap_by_metric"],
+                )[metric],
+            )
+            metric_values = source_metrics[metric]
+            metrics[metric] = _triplet_v2(
+                cast(float, metric_values["native_continuous"]),
+                cast(float, metric_values["restarted_newest"]),
+                cast(float, metric_values["restarted_prob4d_fused"]),
+                denominator_threshold=threshold,
+            )
+        v2_group_rows.append(
+            {
+                "group_id": row["group_id"],
+                "technical_failure_code": None,
+                "metrics": metrics,
+            }
+        )
+    evaluable_rows = [
+        row for row in v2_group_rows if row["technical_failure_code"] is None
+    ]
+    if len(evaluable_rows) < 2:
+        raise ValueError("v2 analysis requires at least two evaluable source groups")
+    maximum_exact_group_count = cast(int, specification["maximum_exact_group_count"])
+    if len(evaluable_rows) > maximum_exact_group_count:
+        raise ValueError(
+            "evaluable group count exceeds maximum_exact_group_count"
+        )
+    group_ids = [cast(str, row["group_id"]) for row in evaluable_rows]
+    aggregate: dict[str, Any] = {}
+    for metric in CUT3R_RECURRENT_STATE_RECOVERY_METRICS:
+        triplets = [
+            (
+                cast(float, cast(Mapping[str, Any], row["metrics"])[metric]["native_continuous"]),
+                cast(float, cast(Mapping[str, Any], row["metrics"])[metric]["restarted_newest"]),
+                cast(
+                    float,
+                    cast(Mapping[str, Any], row["metrics"])[metric][
+                        "restarted_prob4d_fused"
+                    ],
+                ),
+            )
+            for row in evaluable_rows
+        ]
+        threshold = cast(
+            float,
+            cast(Mapping[str, Any], specification["minimum_recurrence_gap_by_metric"])[
+                metric
+            ],
+        )
+        point = _triplet_v2(
+            _mean([item[0] for item in triplets]),
+            _mean([item[1] for item in triplets]),
+            _mean([item[2] for item in triplets]),
+            denominator_threshold=threshold,
+        )
+        point["exact_group_bootstrap"] = _exact_group_bootstrap(
+            triplets,
+            denominator_threshold=threshold,
+            confidence_level=cast(float, specification["confidence_level"]),
+            minimum_valid_denominator_probability=cast(
+                float,
+                specification["minimum_valid_denominator_probability"],
+            ),
+            maximum_exact_group_count=maximum_exact_group_count,
+            point_status=cast(str, point["status"]),
+        )
+        point["leave_one_group_out"] = _leave_one_group_out(
+            group_ids,
+            triplets,
+            denominator_threshold=threshold,
+            point=point,
+        )
+        aggregate[metric] = point
+
+    payload: dict[str, Any] = {
+        "schema": CUT3R_RECURRENT_STATE_RECOVERY_V2_SCHEMA,
+        "schema_version": CUT3R_RECURRENT_STATE_RECOVERY_V2_VERSION,
+        "comparison_lock_id": validated_v1_report["comparison_lock_id"],
+        "comparison_protocol_name": validated_v1_report[
+            "comparison_protocol_name"
+        ],
+        "group_unit": validated_v1_report["group_unit"],
+        "source_evaluation_group_ids": validated_v1_report[
+            "source_evaluation_group_ids"
+        ],
+        "group_count": validated_v1_report["group_count"],
+        "evaluable_group_count": validated_v1_report["evaluable_group_count"],
+        "technical_failure_count": validated_v1_report["technical_failure_count"],
+        "arms": dict(CUT3R_RECURRENT_STATE_RECOVERY_ARMS),
+        "evidence": {
+            **cast(Mapping[str, Any], validated_v1_report["evidence"]),
+            "v1_validation_bridge_report_id": validated_v1_report[
+                "recurrent_state_recovery_report_id"
+            ],
+        },
+        "metrics": list(CUT3R_RECURRENT_STATE_RECOVERY_METRICS),
+        "metric_direction": "lower-is-better",
+        "primary_endpoint": CUT3R_RECURRENT_STATE_RECOVERY_V2_PRIMARY_ENDPOINT,
+        "secondary_endpoint": CUT3R_RECURRENT_STATE_RECOVERY_V2_SECONDARY_ENDPOINT,
+        "recovery_definition": validated_v1_report["recovery_definition"],
+        "analysis_specification": dict(specification),
+        "groups": v2_group_rows,
+        "aggregate": aggregate,
+        "weighting": "equal-complete-source-group-mean-v1",
+        "exact_small_sample_inference": True,
+        "descriptive_only": True,
+        "source_access": "source-only",
+        "target_access": "forbidden",
+        "claim_boundary": CUT3R_RECURRENT_STATE_RECOVERY_V2_CLAIM_BOUNDARY,
+    }
+    payload["recurrent_state_recovery_v2_report_id"] = _record_id(payload)
+    return cast(dict[str, Any], json.loads(_canonical_json(payload)))
+
+
+def build_cut3r_recurrent_state_recovery_v2_report(
+    comparison_lock: Any,
+    fusion_source_competence_lock: Any,
+    fusion_common_support_lock: Any,
+    fusion_records: Any,
+    fusion_report: Any,
+    recurrence_source_competence_lock: Any,
+    recurrence_common_support_lock: Any,
+    recurrence_records: Any,
+    recurrence_report: Any,
+    analysis_specification: Any,
+) -> dict[str, Any]:
+    """Build a denominator-safe exact small-sample recovery report."""
+
+    specification = validate_cut3r_recurrent_state_recovery_v2_specification(
+        analysis_specification
+    )
+    validated_v1 = build_cut3r_recurrent_state_recovery_report(
+        comparison_lock,
+        fusion_source_competence_lock,
+        fusion_common_support_lock,
+        fusion_records,
+        fusion_report,
+        recurrence_source_competence_lock,
+        recurrence_common_support_lock,
+        recurrence_records,
+        recurrence_report,
+        _v1_bridge_specification(specification),
+    )
+    return _build_v2_from_validated_v1_report(validated_v1, specification)
+
+
+def validate_cut3r_recurrent_state_recovery_v2_report(
+    comparison_lock: Any,
+    fusion_source_competence_lock: Any,
+    fusion_common_support_lock: Any,
+    fusion_records: Any,
+    fusion_report: Any,
+    recurrence_source_competence_lock: Any,
+    recurrence_common_support_lock: Any,
+    recurrence_records: Any,
+    recurrence_report: Any,
+    analysis_specification: Any,
+    report: Any,
+) -> dict[str, Any]:
+    supplied = _strict_mapping(report, name="CUT3R recurrent-state recovery v2 report")
+    expected = build_cut3r_recurrent_state_recovery_v2_report(
+        comparison_lock,
+        fusion_source_competence_lock,
+        fusion_common_support_lock,
+        fusion_records,
+        fusion_report,
+        recurrence_source_competence_lock,
+        recurrence_common_support_lock,
+        recurrence_records,
+        recurrence_report,
+        analysis_specification,
+    )
+    if dict(supplied) != expected:
+        raise ValueError("v2 recovery report does not match bound evidence")
+    return expected
+
+
+def write_cut3r_recurrent_state_recovery_v2_report(
+    comparison_lock: Any,
+    fusion_source_competence_lock: Any,
+    fusion_common_support_lock: Any,
+    fusion_records: Any,
+    fusion_report: Any,
+    recurrence_source_competence_lock: Any,
+    recurrence_common_support_lock: Any,
+    recurrence_records: Any,
+    recurrence_report: Any,
+    analysis_specification: Any,
+    path: str | Path,
+    report: Mapping[str, Any],
+) -> dict[str, Any]:
+    payload = validate_cut3r_recurrent_state_recovery_v2_report(
+        comparison_lock,
+        fusion_source_competence_lock,
+        fusion_common_support_lock,
+        fusion_records,
+        fusion_report,
+        recurrence_source_competence_lock,
+        recurrence_common_support_lock,
+        recurrence_records,
+        recurrence_report,
+        analysis_specification,
+        report,
+    )
+    return _publish_json(
+        path,
+        payload,
+        load_existing=lambda existing: load_cut3r_recurrent_state_recovery_v2_report(
+            comparison_lock,
+            fusion_source_competence_lock,
+            fusion_common_support_lock,
+            fusion_records,
+            fusion_report,
+            recurrence_source_competence_lock,
+            recurrence_common_support_lock,
+            recurrence_records,
+            recurrence_report,
+            analysis_specification,
+            existing,
+        ),
+    )
+
+
+def load_cut3r_recurrent_state_recovery_v2_report(
+    comparison_lock: Any,
+    fusion_source_competence_lock: Any,
+    fusion_common_support_lock: Any,
+    fusion_records: Any,
+    fusion_report: Any,
+    recurrence_source_competence_lock: Any,
+    recurrence_common_support_lock: Any,
+    recurrence_records: Any,
+    recurrence_report: Any,
+    analysis_specification: Any,
+    path: str | Path,
+) -> dict[str, Any]:
+    return validate_cut3r_recurrent_state_recovery_v2_report(
+        comparison_lock,
+        fusion_source_competence_lock,
+        fusion_common_support_lock,
+        fusion_records,
+        fusion_report,
+        recurrence_source_competence_lock,
+        recurrence_common_support_lock,
+        recurrence_records,
+        recurrence_report,
+        analysis_specification,
+        _strict_json(path),
+    )
+
+
+def cut3r_recurrent_state_recovery_v2_summary(
+    report: Mapping[str, Any],
+) -> dict[str, Any]:
+    artifact = _strict_mapping(report, name="CUT3R recurrent-state recovery v2 report")
+    metrics = cast(Mapping[str, Mapping[str, Any]], artifact["aggregate"])
+    return {
+        "recurrent_state_recovery_v2_report_id": artifact[
+            "recurrent_state_recovery_v2_report_id"
+        ],
+        "comparison_lock_id": artifact["comparison_lock_id"],
+        "evaluable_group_count": artifact["evaluable_group_count"],
+        "technical_failure_count": artifact["technical_failure_count"],
+        "primary_endpoint": artifact["primary_endpoint"],
+        "secondary_endpoint": artifact["secondary_endpoint"],
+        "metrics": {
+            metric: {
+                "prob4d_gain": metrics[metric]["prob4d_gain"],
+                "prob4d_gain_interval": metrics[metric]["exact_group_bootstrap"][
+                    "prob4d_gain_interval"
+                ],
+                "recurrence_gap": metrics[metric]["recurrence_gap"],
+                "recovery_status": metrics[metric]["status"],
+                "recovery_fraction": metrics[metric]["recovery_fraction"],
+                "recovery_fraction_interval": metrics[metric][
+                    "exact_group_bootstrap"
+                ]["recovery_fraction_interval"],
+                "valid_denominator_probability": metrics[metric][
+                    "exact_group_bootstrap"
+                ]["valid_denominator_probability"],
+                "leave_one_group_out": metrics[metric]["leave_one_group_out"][
+                    "summary"
+                ],
+            }
+            for metric in CUT3R_RECURRENT_STATE_RECOVERY_METRICS
+        },
+        "descriptive_only": artifact["descriptive_only"],
+        "target_access": artifact["target_access"],
+    }
+
+
+__all__ = [
+    "build_cut3r_recurrent_state_recovery_v2_report",
+    "cut3r_recurrent_state_recovery_v2_summary",
+    "load_cut3r_recurrent_state_recovery_v2_report",
+    "validate_cut3r_recurrent_state_recovery_v2_report",
+    "write_cut3r_recurrent_state_recovery_v2_report",
+]

--- a/src/prob4d/_cut3r_recovery_v2_spec.py
+++ b/src/prob4d/_cut3r_recovery_v2_spec.py
@@ -7,8 +7,8 @@ from pathlib import Path
 from typing import Any, Final, cast
 
 from .cut3r_recurrent_state_recovery import (
-    _finite_float,
     CUT3R_RECURRENT_STATE_RECOVERY_METRICS,
+    _finite_float,
 )
 from .cut3r_source_competence import (
     _canonical_json,
@@ -18,7 +18,6 @@ from .cut3r_source_competence import (
     _strict_json,
     _strict_mapping,
 )
-
 
 CUT3R_RECURRENT_STATE_RECOVERY_V2_SCHEMA: Final = (
     "prob4d.cut3r-recurrent-state-recovery-v2"

--- a/src/prob4d/_cut3r_recovery_v2_spec.py
+++ b/src/prob4d/_cut3r_recovery_v2_spec.py
@@ -1,0 +1,255 @@
+"""Prospective denominator-safe CUT3R recovery-v2 specification."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Final, cast
+
+from .cut3r_recurrent_state_recovery import (
+    CUT3R_RECURRENT_STATE_RECOVERY_METRICS,
+    _finite_float,
+)
+from .cut3r_source_competence import (
+    _canonical_json,
+    _exact_keys,
+    _record_id,
+    _strict_integer,
+    _strict_json,
+    _strict_mapping,
+)
+
+
+CUT3R_RECURRENT_STATE_RECOVERY_V2_SCHEMA: Final = (
+    "prob4d.cut3r-recurrent-state-recovery-v2"
+)
+CUT3R_RECURRENT_STATE_RECOVERY_V2_VERSION: Final = 2
+CUT3R_RECURRENT_STATE_RECOVERY_V2_SPEC_SCHEMA: Final = (
+    "prob4d.cut3r-recurrent-state-recovery-specification"
+)
+CUT3R_RECURRENT_STATE_RECOVERY_V2_SPEC_VERSION: Final = 2
+CUT3R_RECURRENT_STATE_RECOVERY_V2_INTERVAL_METHOD: Final = (
+    "exact-multinomial-equal-group-bootstrap-nearest-rank-v1"
+)
+CUT3R_RECURRENT_STATE_RECOVERY_V2_PRIMARY_ENDPOINT: Final = "prob4d_gain"
+CUT3R_RECURRENT_STATE_RECOVERY_V2_SECONDARY_ENDPOINT: Final = (
+    "recovery_fraction_when_recurrence_gap_separated"
+)
+CUT3R_RECURRENT_STATE_RECOVERY_V2_SPEC_CLAIM_BOUNDARY: Final = (
+    "This prospective specification was frozen before CUT3R source outcomes were "
+    "opened. It authorizes only a descriptive source-only analysis of already "
+    "registered three-arm evidence. It does not alter a provider, source gate, "
+    "readiness decision, target protocol, BayesianPhysTwin guard, or Causal4D "
+    "handoff, and target access remains forbidden."
+)
+CUT3R_RECURRENT_STATE_RECOVERY_V2_CLAIM_BOUNDARY: Final = (
+    "This source-only report is a descriptive three-arm mechanism analysis. "
+    "Absolute Prob4D gain is primary. The recovery fraction is secondary and is "
+    "reported only when the recurrent-state gap exceeds the prospectively frozen "
+    "metric-specific practical-separation floor. Exact group-bootstrap and "
+    "leave-one-group-out diagnostics do not select a candidate, alter readiness "
+    "gates, authorize target access, establish BayesianPhysTwin or Causal4D "
+    "benefit, establish deployment safety, or establish state of the art."
+)
+
+_SPEC_PAYLOAD_FIELDS: Final = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "primary_endpoint",
+        "secondary_endpoint",
+        "interval_method",
+        "confidence_level",
+        "minimum_valid_denominator_probability",
+        "maximum_exact_group_count",
+        "minimum_recurrence_gap_by_metric",
+        "minimum_recurrence_gap_rationale_by_metric",
+        "leave_one_group_out",
+        "source_outcomes_opened_before_specification",
+        "target_access",
+        "claim_boundary",
+    }
+)
+_SPEC_FIELDS: Final = _SPEC_PAYLOAD_FIELDS | {"analysis_specification_id"}
+
+
+def _nonempty_string(value: Any, *, name: str) -> str:
+    if type(value) is not str or not value or value != value.strip():
+        raise ValueError(
+            f"{name} must be a nonempty exact string without surrounding whitespace"
+        )
+    return cast(str, value)
+
+
+def _normalized_specification_payload(value: Any) -> dict[str, Any]:
+    specification = _strict_mapping(
+        value,
+        name="CUT3R recurrent-state recovery v2 specification",
+    )
+    _exact_keys(
+        specification,
+        _SPEC_PAYLOAD_FIELDS,
+        name="CUT3R recurrent-state recovery v2 specification",
+    )
+    if specification["schema"] != CUT3R_RECURRENT_STATE_RECOVERY_V2_SPEC_SCHEMA:
+        raise ValueError("unexpected CUT3R recurrent-state recovery v2 spec schema")
+    schema_version = _strict_integer(
+        specification["schema_version"],
+        name="schema_version",
+        minimum=1,
+    )
+    if schema_version != CUT3R_RECURRENT_STATE_RECOVERY_V2_SPEC_VERSION:
+        raise ValueError("unexpected CUT3R recurrent-state recovery v2 spec version")
+    if (
+        specification["primary_endpoint"]
+        != CUT3R_RECURRENT_STATE_RECOVERY_V2_PRIMARY_ENDPOINT
+    ):
+        raise ValueError("v2 primary endpoint must be absolute Prob4D gain")
+    if (
+        specification["secondary_endpoint"]
+        != CUT3R_RECURRENT_STATE_RECOVERY_V2_SECONDARY_ENDPOINT
+    ):
+        raise ValueError("v2 secondary endpoint must be denominator-safe recovery")
+    if (
+        specification["interval_method"]
+        != CUT3R_RECURRENT_STATE_RECOVERY_V2_INTERVAL_METHOD
+    ):
+        raise ValueError("unexpected v2 exact interval method")
+    confidence_level = _finite_float(
+        specification["confidence_level"],
+        name="confidence_level",
+        minimum=0.0,
+        maximum=1.0,
+        maximum_inclusive=False,
+    )
+    if confidence_level <= 0.0:
+        raise ValueError("confidence_level must be > 0")
+    minimum_valid_probability = _finite_float(
+        specification["minimum_valid_denominator_probability"],
+        name="minimum_valid_denominator_probability",
+        minimum=0.0,
+        maximum=1.0,
+    )
+    if minimum_valid_probability <= 0.0:
+        raise ValueError("minimum_valid_denominator_probability must be > 0")
+    maximum_exact_group_count = _strict_integer(
+        specification["maximum_exact_group_count"],
+        name="maximum_exact_group_count",
+        minimum=2,
+    )
+    if maximum_exact_group_count > 10:
+        raise ValueError("maximum_exact_group_count must be <= 10")
+    if specification["leave_one_group_out"] is not True:
+        raise ValueError("leave_one_group_out must be true")
+    if specification["source_outcomes_opened_before_specification"] is not False:
+        raise ValueError(
+            "source_outcomes_opened_before_specification must be false"
+        )
+    if specification["target_access"] != "forbidden":
+        raise ValueError("target_access must remain forbidden")
+    if (
+        specification["claim_boundary"]
+        != CUT3R_RECURRENT_STATE_RECOVERY_V2_SPEC_CLAIM_BOUNDARY
+    ):
+        raise ValueError("unexpected v2 specification claim boundary")
+
+    gaps = _strict_mapping(
+        specification["minimum_recurrence_gap_by_metric"],
+        name="minimum_recurrence_gap_by_metric",
+    )
+    rationales = _strict_mapping(
+        specification["minimum_recurrence_gap_rationale_by_metric"],
+        name="minimum_recurrence_gap_rationale_by_metric",
+    )
+    metric_fields = set(CUT3R_RECURRENT_STATE_RECOVERY_METRICS)
+    _exact_keys(gaps, metric_fields, name="minimum_recurrence_gap_by_metric")
+    _exact_keys(
+        rationales,
+        metric_fields,
+        name="minimum_recurrence_gap_rationale_by_metric",
+    )
+    normalized_gaps: dict[str, float] = {}
+    normalized_rationales: dict[str, str] = {}
+    for metric in CUT3R_RECURRENT_STATE_RECOVERY_METRICS:
+        gap = _finite_float(
+            gaps[metric],
+            name=f"minimum_recurrence_gap_by_metric.{metric}",
+            minimum=0.0,
+        )
+        if gap <= 0.0:
+            raise ValueError(
+                f"minimum_recurrence_gap_by_metric.{metric} must be strictly positive"
+            )
+        normalized_gaps[metric] = gap
+        normalized_rationales[metric] = _nonempty_string(
+            rationales[metric],
+            name=f"minimum_recurrence_gap_rationale_by_metric.{metric}",
+        )
+
+    return {
+        "schema": CUT3R_RECURRENT_STATE_RECOVERY_V2_SPEC_SCHEMA,
+        "schema_version": CUT3R_RECURRENT_STATE_RECOVERY_V2_SPEC_VERSION,
+        "primary_endpoint": CUT3R_RECURRENT_STATE_RECOVERY_V2_PRIMARY_ENDPOINT,
+        "secondary_endpoint": CUT3R_RECURRENT_STATE_RECOVERY_V2_SECONDARY_ENDPOINT,
+        "interval_method": CUT3R_RECURRENT_STATE_RECOVERY_V2_INTERVAL_METHOD,
+        "confidence_level": confidence_level,
+        "minimum_valid_denominator_probability": minimum_valid_probability,
+        "maximum_exact_group_count": maximum_exact_group_count,
+        "minimum_recurrence_gap_by_metric": normalized_gaps,
+        "minimum_recurrence_gap_rationale_by_metric": normalized_rationales,
+        "leave_one_group_out": True,
+        "source_outcomes_opened_before_specification": False,
+        "target_access": "forbidden",
+        "claim_boundary": CUT3R_RECURRENT_STATE_RECOVERY_V2_SPEC_CLAIM_BOUNDARY,
+    }
+
+
+def build_cut3r_recurrent_state_recovery_v2_specification(value: Any) -> dict[str, Any]:
+    """Build a content-addressed prospective v2 analysis specification."""
+
+    payload = _normalized_specification_payload(value)
+    payload["analysis_specification_id"] = _record_id(payload)
+    return cast(dict[str, Any], json.loads(_canonical_json(payload)))
+
+
+def validate_cut3r_recurrent_state_recovery_v2_specification(
+    value: Any,
+) -> dict[str, Any]:
+    """Validate a content-addressed prospective v2 analysis specification."""
+
+    supplied = _strict_mapping(
+        value,
+        name="CUT3R recurrent-state recovery v2 specification",
+    )
+    _exact_keys(
+        supplied,
+        _SPEC_FIELDS,
+        name="CUT3R recurrent-state recovery v2 specification",
+    )
+    payload = {key: supplied[key] for key in _SPEC_PAYLOAD_FIELDS}
+    expected = build_cut3r_recurrent_state_recovery_v2_specification(payload)
+    if dict(supplied) != expected:
+        raise ValueError("CUT3R recurrent-state recovery v2 specification is invalid")
+    return expected
+
+
+def load_cut3r_recurrent_state_recovery_v2_specification(
+    path: str | Path,
+) -> dict[str, Any]:
+    return validate_cut3r_recurrent_state_recovery_v2_specification(_strict_json(path))
+
+
+__all__ = [
+    "CUT3R_RECURRENT_STATE_RECOVERY_V2_CLAIM_BOUNDARY",
+    "CUT3R_RECURRENT_STATE_RECOVERY_V2_INTERVAL_METHOD",
+    "CUT3R_RECURRENT_STATE_RECOVERY_V2_PRIMARY_ENDPOINT",
+    "CUT3R_RECURRENT_STATE_RECOVERY_V2_SCHEMA",
+    "CUT3R_RECURRENT_STATE_RECOVERY_V2_SECONDARY_ENDPOINT",
+    "CUT3R_RECURRENT_STATE_RECOVERY_V2_SPEC_CLAIM_BOUNDARY",
+    "CUT3R_RECURRENT_STATE_RECOVERY_V2_SPEC_SCHEMA",
+    "CUT3R_RECURRENT_STATE_RECOVERY_V2_SPEC_VERSION",
+    "CUT3R_RECURRENT_STATE_RECOVERY_V2_VERSION",
+    "build_cut3r_recurrent_state_recovery_v2_specification",
+    "load_cut3r_recurrent_state_recovery_v2_specification",
+    "validate_cut3r_recurrent_state_recovery_v2_specification",
+]

--- a/src/prob4d/_cut3r_recovery_v2_spec.py
+++ b/src/prob4d/_cut3r_recovery_v2_spec.py
@@ -7,8 +7,8 @@ from pathlib import Path
 from typing import Any, Final, cast
 
 from .cut3r_recurrent_state_recovery import (
-    CUT3R_RECURRENT_STATE_RECOVERY_METRICS,
     _finite_float,
+    CUT3R_RECURRENT_STATE_RECOVERY_METRICS,
 )
 from .cut3r_source_competence import (
     _canonical_json,

--- a/src/prob4d/cut3r_recurrent_state_recovery_v2.py
+++ b/src/prob4d/cut3r_recurrent_state_recovery_v2.py
@@ -6,14 +6,7 @@ import argparse
 import json
 from collections.abc import Sequence
 
-from ._cut3r_recovery_v2_exact import (
-    _count_vectors,
-    _exact_group_bootstrap,
-    _leave_one_group_out,
-    _triplet_v2,
-)
 from ._cut3r_recovery_v2_report import (
-    _build_v2_from_validated_v1_report,
     build_cut3r_recurrent_state_recovery_v2_report,
     cut3r_recurrent_state_recovery_v2_summary,
     load_cut3r_recurrent_state_recovery_v2_report,
@@ -35,7 +28,6 @@ from ._cut3r_recovery_v2_spec import (
     validate_cut3r_recurrent_state_recovery_v2_specification,
 )
 from .cut3r_recurrent_state_recovery import (
-    CUT3R_RECURRENT_STATE_RECOVERY_METRICS,
     _add_bound_evidence_arguments,
     _load_bound_inputs,
 )
@@ -105,7 +97,6 @@ __all__ = [
     "CUT3R_RECURRENT_STATE_RECOVERY_V2_SPEC_SCHEMA",
     "CUT3R_RECURRENT_STATE_RECOVERY_V2_SPEC_VERSION",
     "CUT3R_RECURRENT_STATE_RECOVERY_V2_VERSION",
-    "_build_v2_from_validated_v1_report",
     "build_cut3r_recurrent_state_recovery_v2_report",
     "build_cut3r_recurrent_state_recovery_v2_specification",
     "cut3r_recurrent_state_recovery_v2_summary",

--- a/src/prob4d/cut3r_recurrent_state_recovery_v2.py
+++ b/src/prob4d/cut3r_recurrent_state_recovery_v2.py
@@ -1,0 +1,122 @@
+"""Denominator-safe exact small-sample CUT3R recurrent-state recovery analysis."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+
+from ._cut3r_recovery_v2_exact import (
+    _count_vectors,
+    _exact_group_bootstrap,
+    _leave_one_group_out,
+    _triplet_v2,
+)
+from ._cut3r_recovery_v2_report import (
+    _build_v2_from_validated_v1_report,
+    build_cut3r_recurrent_state_recovery_v2_report,
+    cut3r_recurrent_state_recovery_v2_summary,
+    load_cut3r_recurrent_state_recovery_v2_report,
+    validate_cut3r_recurrent_state_recovery_v2_report,
+    write_cut3r_recurrent_state_recovery_v2_report,
+)
+from ._cut3r_recovery_v2_spec import (
+    CUT3R_RECURRENT_STATE_RECOVERY_V2_CLAIM_BOUNDARY,
+    CUT3R_RECURRENT_STATE_RECOVERY_V2_INTERVAL_METHOD,
+    CUT3R_RECURRENT_STATE_RECOVERY_V2_PRIMARY_ENDPOINT,
+    CUT3R_RECURRENT_STATE_RECOVERY_V2_SCHEMA,
+    CUT3R_RECURRENT_STATE_RECOVERY_V2_SECONDARY_ENDPOINT,
+    CUT3R_RECURRENT_STATE_RECOVERY_V2_SPEC_CLAIM_BOUNDARY,
+    CUT3R_RECURRENT_STATE_RECOVERY_V2_SPEC_SCHEMA,
+    CUT3R_RECURRENT_STATE_RECOVERY_V2_SPEC_VERSION,
+    CUT3R_RECURRENT_STATE_RECOVERY_V2_VERSION,
+    build_cut3r_recurrent_state_recovery_v2_specification,
+    load_cut3r_recurrent_state_recovery_v2_specification,
+    validate_cut3r_recurrent_state_recovery_v2_specification,
+)
+from .cut3r_recurrent_state_recovery import (
+    CUT3R_RECURRENT_STATE_RECOVERY_METRICS,
+    _add_bound_evidence_arguments,
+    _load_bound_inputs,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="prob4d prediction cut3r-recovery-v2",
+        description=__doc__,
+    )
+    commands = parser.add_subparsers(dest="command", required=True)
+    build = commands.add_parser("build", help="build the bound v2 recovery report")
+    _add_bound_evidence_arguments(build)
+    build.add_argument("--output", required=True)
+    verify = commands.add_parser("verify", help="rebuild and verify a v2 report")
+    _add_bound_evidence_arguments(verify)
+    verify.add_argument("report")
+    summarize = commands.add_parser("summarize", help="summarize a verified v2 report")
+    _add_bound_evidence_arguments(summarize)
+    summarize.add_argument("report")
+    summarize.add_argument("--json", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _parser().parse_args(list(argv) if argv is not None else None)
+    inputs = _load_bound_inputs(arguments)
+    if arguments.command == "build":
+        report = build_cut3r_recurrent_state_recovery_v2_report(*inputs)
+        write_cut3r_recurrent_state_recovery_v2_report(
+            *inputs,
+            arguments.output,
+            report,
+        )
+        print(report["recurrent_state_recovery_v2_report_id"])
+        return 0
+    report = load_cut3r_recurrent_state_recovery_v2_report(
+        *inputs,
+        arguments.report,
+    )
+    if arguments.command == "verify":
+        print(report["recurrent_state_recovery_v2_report_id"])
+        return 0
+    summary = cut3r_recurrent_state_recovery_v2_summary(report)
+    if arguments.json:
+        print(json.dumps(summary, sort_keys=True, indent=2, allow_nan=False))
+    else:
+        print(f"report_id: {summary['recurrent_state_recovery_v2_report_id']}")
+        print(f"evaluable groups: {summary['evaluable_group_count']}")
+        for metric, result in summary["metrics"].items():
+            print(
+                f"{metric}: gain={result['prob4d_gain']} "
+                f"recovery={result['recovery_status']} "
+                f"fraction={result['recovery_fraction']}"
+            )
+        print(f"target access: {summary['target_access']}")
+    return 0
+
+
+__all__ = [
+    "CUT3R_RECURRENT_STATE_RECOVERY_V2_CLAIM_BOUNDARY",
+    "CUT3R_RECURRENT_STATE_RECOVERY_V2_INTERVAL_METHOD",
+    "CUT3R_RECURRENT_STATE_RECOVERY_V2_PRIMARY_ENDPOINT",
+    "CUT3R_RECURRENT_STATE_RECOVERY_V2_SCHEMA",
+    "CUT3R_RECURRENT_STATE_RECOVERY_V2_SECONDARY_ENDPOINT",
+    "CUT3R_RECURRENT_STATE_RECOVERY_V2_SPEC_CLAIM_BOUNDARY",
+    "CUT3R_RECURRENT_STATE_RECOVERY_V2_SPEC_SCHEMA",
+    "CUT3R_RECURRENT_STATE_RECOVERY_V2_SPEC_VERSION",
+    "CUT3R_RECURRENT_STATE_RECOVERY_V2_VERSION",
+    "_build_v2_from_validated_v1_report",
+    "build_cut3r_recurrent_state_recovery_v2_report",
+    "build_cut3r_recurrent_state_recovery_v2_specification",
+    "cut3r_recurrent_state_recovery_v2_summary",
+    "load_cut3r_recurrent_state_recovery_v2_report",
+    "load_cut3r_recurrent_state_recovery_v2_specification",
+    "main",
+    "validate_cut3r_recurrent_state_recovery_v2_report",
+    "validate_cut3r_recurrent_state_recovery_v2_specification",
+    "write_cut3r_recurrent_state_recovery_v2_report",
+]
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/prob4d/prediction_cli.py
+++ b/src/prob4d/prediction_cli.py
@@ -52,6 +52,10 @@ def _help_parser() -> argparse.ArgumentParser:
         help="quantify how much recurrent-state loss Prob4D fusion recovers",
     )
     subparsers.add_parser(
+        "cut3r-recovery-v2",
+        help="run denominator-safe exact group inference for recurrent-state recovery",
+    )
+    subparsers.add_parser(
         "compatibility",
         help="build or compare additive semantic-compatibility manifests",
     )
@@ -114,6 +118,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         from .cut3r_recurrent_state_recovery import main as cut3r_recovery_main
 
         return int(cut3r_recovery_main(arguments[1:]))
+    if arguments[0] == "cut3r-recovery-v2":
+        from .cut3r_recurrent_state_recovery_v2 import main as cut3r_recovery_v2_main
+
+        return int(cut3r_recovery_v2_main(arguments[1:]))
     if arguments[0] == "compatibility":
         from .semantic_compatibility import main as compatibility_main
 

--- a/tests/test_cut3r_recurrent_state_recovery_v2.py
+++ b/tests/test_cut3r_recurrent_state_recovery_v2.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from prob4d.cut3r_recurrent_state_recovery_v2 import (
+    _build_v2_from_validated_v1_report,
+    _exact_group_bootstrap,
+    _leave_one_group_out,
+    _triplet_v2,
+    build_cut3r_recurrent_state_recovery_v2_specification,
+    load_cut3r_recurrent_state_recovery_v2_specification,
+)
+from prob4d.prediction_cli import main as prediction_main
+
+
+_SPECIFICATION_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "protocols"
+    / "cut3r_recurrent_state_recovery_v2.json"
+)
+_METRICS = (
+    "point_rmse_m",
+    "endpoint_rmse_m",
+    "proper_score",
+    "seam_rmse_m",
+    "absolute_drift_slope_m_per_frame",
+)
+
+
+def _metric_values(native: float, restarted: float, fused: float) -> dict[str, object]:
+    return {
+        "native_continuous": native,
+        "restarted_newest": restarted,
+        "restarted_prob4d_fused": fused,
+        "prob4d_gain": restarted - fused,
+        "recurrence_gap": restarted - native,
+        "recovery_fraction": (restarted - fused) / (restarted - native),
+        "status": "defined",
+    }
+
+
+def _validated_v1_report() -> dict[str, object]:
+    groups = [
+        {
+            "group_id": group_id,
+            "technical_failure_code": None,
+            "metrics": {
+                metric: _metric_values(0.6, 1.0, 0.8) for metric in _METRICS
+            },
+        }
+        for group_id in ("source-a", "source-b")
+    ]
+    return {
+        "comparison_lock_id": "a" * 64,
+        "comparison_protocol_name": "v2-unit-test",
+        "group_unit": "complete-object-or-acquisition-session",
+        "source_evaluation_group_ids": ["source-a", "source-b"],
+        "group_count": 2,
+        "evaluable_group_count": 2,
+        "technical_failure_count": 0,
+        "evidence": {
+            "fusion_source_competence_report_v2_id": "b" * 64,
+            "recurrence_source_competence_report_v2_id": "c" * 64,
+            "byte_identical_restarted_newest_rows": True,
+        },
+        "recovery_definition": (
+            "(restarted-newest - restarted-prob4d-fused) / "
+            "(restarted-newest - native-continuous)"
+        ),
+        "groups": groups,
+        "recurrent_state_recovery_report_id": "d" * 64,
+    }
+
+
+def test_checked_in_v2_specification_is_content_addressed_and_positive() -> None:
+    specification = load_cut3r_recurrent_state_recovery_v2_specification(
+        _SPECIFICATION_PATH
+    )
+
+    assert len(specification["analysis_specification_id"]) == 64
+    assert specification["maximum_exact_group_count"] == 10
+    assert specification["leave_one_group_out"] is True
+    assert specification["source_outcomes_opened_before_specification"] is False
+    assert specification["target_access"] == "forbidden"
+    assert all(
+        value > 0.0
+        for value in specification["minimum_recurrence_gap_by_metric"].values()
+    )
+
+
+def test_v2_specification_rejects_zero_recurrence_gap_floor() -> None:
+    raw = json.loads(_SPECIFICATION_PATH.read_text(encoding="utf-8"))
+    raw.pop("analysis_specification_id")
+    raw["minimum_recurrence_gap_by_metric"]["endpoint_rmse_m"] = 0.0
+
+    with pytest.raises(ValueError, match="strictly positive"):
+        build_cut3r_recurrent_state_recovery_v2_specification(raw)
+
+
+def test_exact_group_bootstrap_enumerates_all_ordered_resamples() -> None:
+    result = _exact_group_bootstrap(
+        [(0.6, 1.0, 0.8), (0.6, 1.0, 0.8)],
+        denominator_threshold=1e-4,
+        confidence_level=0.95,
+        minimum_valid_denominator_probability=0.8,
+        maximum_exact_group_count=10,
+        point_status="defined",
+    )
+
+    assert result["count_vector_count"] == 3
+    assert result["ordered_resample_count"] == 4
+    assert result["valid_denominator_probability"] == 1.0
+    assert result["prob4d_gain_interval"]["lower"] == pytest.approx(0.2)
+    assert result["prob4d_gain_interval"]["upper"] == pytest.approx(0.2)
+    assert result["recovery_fraction_interval"]["lower"] == pytest.approx(0.5)
+    assert result["recovery_fraction_interval"]["upper"] == pytest.approx(0.5)
+
+
+def test_exact_group_bootstrap_covers_the_frozen_ten_group_limit() -> None:
+    result = _exact_group_bootstrap(
+        [(0.6, 1.0, 0.8)] * 10,
+        denominator_threshold=1e-4,
+        confidence_level=0.95,
+        minimum_valid_denominator_probability=0.8,
+        maximum_exact_group_count=10,
+        point_status="defined",
+    )
+
+    assert result["count_vector_count"] == 92378
+    assert result["ordered_resample_count"] == 10**10
+    assert result["valid_denominator_probability"] == 1.0
+
+
+def test_ratio_interval_is_withheld_when_denominator_support_is_unstable() -> None:
+    result = _exact_group_bootstrap(
+        [(0.5, 1.0, 0.8), (1.2, 1.0, 0.8)],
+        denominator_threshold=1e-4,
+        confidence_level=0.95,
+        minimum_valid_denominator_probability=0.8,
+        maximum_exact_group_count=10,
+        point_status="defined",
+    )
+
+    assert result["valid_denominator_probability"] == pytest.approx(0.75)
+    assert (
+        result["recovery_fraction_interval"]["interval_status"]
+        == "insufficient-valid-denominator-probability"
+    )
+    assert result["recovery_fraction_interval"]["lower"] is None
+    assert result["prob4d_gain_interval"]["lower"] is not None
+    assert result["recurrence_gap_interval"]["lower"] is not None
+
+
+def test_recovery_is_undefined_below_practical_separation_floor() -> None:
+    result = _triplet_v2(
+        0.99995,
+        1.0,
+        0.8,
+        denominator_threshold=1e-4,
+    )
+
+    assert result["status"] == (
+        "undefined-recurrence-gap-not-practically-separated"
+    )
+    assert result["recovery_fraction"] is None
+    assert result["prob4d_gain"] == pytest.approx(0.2)
+
+
+def test_nonfinite_derived_gain_fails_closed() -> None:
+    with pytest.raises(ValueError, match="Prob4D gain must remain finite"):
+        _triplet_v2(
+            0.0,
+            1e308,
+            -1e308,
+            denominator_threshold=1.0,
+        )
+
+
+def test_leave_one_group_out_reports_gain_sign_reversal() -> None:
+    point = _triplet_v2(0.6, 1.0, 0.8, denominator_threshold=1e-4)
+    result = _leave_one_group_out(
+        ["source-a", "source-b"],
+        [(0.6, 1.0, 0.5), (0.6, 1.0, 1.1)],
+        denominator_threshold=1e-4,
+        point=point,
+    )
+
+    assert result["summary"]["prob4d_gain_sign_reversal"] is True
+    assert result["summary"]["minimum_prob4d_gain"] == pytest.approx(-0.1)
+    assert result["summary"]["maximum_prob4d_gain"] == pytest.approx(0.5)
+
+
+def test_v2_payload_foregrounds_gain_and_is_deterministic() -> None:
+    specification = load_cut3r_recurrent_state_recovery_v2_specification(
+        _SPECIFICATION_PATH
+    )
+    validated_v1 = _validated_v1_report()
+
+    first = _build_v2_from_validated_v1_report(validated_v1, specification)
+    second = _build_v2_from_validated_v1_report(validated_v1, specification)
+
+    assert first == second
+    assert first["primary_endpoint"] == "prob4d_gain"
+    assert first["exact_small_sample_inference"] is True
+    assert len(first["recurrent_state_recovery_v2_report_id"]) == 64
+    endpoint = first["aggregate"]["endpoint_rmse_m"]
+    assert endpoint["prob4d_gain"] == pytest.approx(0.2)
+    assert endpoint["recovery_fraction"] == pytest.approx(0.5)
+    assert endpoint["exact_group_bootstrap"]["ordered_resample_count"] == 4
+
+
+def test_prediction_cli_dispatches_cut3r_recovery_v2_help(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as caught:
+        prediction_main(["cut3r-recovery-v2", "--help"])
+
+    assert caught.value.code == 0
+    assert "denominator-safe" in capsys.readouterr().out.lower()

--- a/tests/test_cut3r_recurrent_state_recovery_v2.py
+++ b/tests/test_cut3r_recurrent_state_recovery_v2.py
@@ -19,7 +19,6 @@ from prob4d._cut3r_recovery_v2_spec import (
 )
 from prob4d.prediction_cli import main as prediction_main
 
-
 _SPECIFICATION_PATH = (
     Path(__file__).resolve().parents[1]
     / "protocols"

--- a/tests/test_cut3r_recurrent_state_recovery_v2.py
+++ b/tests/test_cut3r_recurrent_state_recovery_v2.py
@@ -5,11 +5,15 @@ from pathlib import Path
 
 import pytest
 
-from prob4d.cut3r_recurrent_state_recovery_v2 import (
-    _build_v2_from_validated_v1_report,
+from prob4d._cut3r_recovery_v2_exact import (
     _exact_group_bootstrap,
     _leave_one_group_out,
     _triplet_v2,
+)
+from prob4d._cut3r_recovery_v2_report import (
+    _build_v2_from_validated_v1_report,
+)
+from prob4d._cut3r_recovery_v2_spec import (
     build_cut3r_recurrent_state_recovery_v2_specification,
     load_cut3r_recurrent_state_recovery_v2_specification,
 )


### PR DESCRIPTION
## Summary

- preserve the existing recurrent-state recovery v1 report and add an additive v2 analysis;
- make absolute Prob4D gain the primary mechanism endpoint;
- report the recovery fraction only when the recurrent-state gap exceeds a prospectively frozen, strictly positive metric-specific practical-separation floor;
- freeze a content-addressed v2 specification while CUT3R source outcomes remain closed and target access remains forbidden;
- enumerate the exact equal-complete-group empirical bootstrap through multinomial count vectors and exact ordered-resample multiplicities;
- report exact gain and denominator intervals, a conditional recovery interval, exact valid-denominator probability, and leave-one-complete-group-out sensitivity;
- reject non-finite derived gain, gap, and ratio values; and
- expose `prob4d prediction cut3r-recovery-v2` with build, verify, and summarize routes.

For the frozen ten-group source design, v2 evaluates 92,378 multinomial count vectors representing all `10**10` ordered empirical-bootstrap resamples. It does not treat frames, points, cameras, seeds, or tracks as independent evidence.

## Prospective analysis boundary

Issue #49 and workflow run `32621813949` still show only the target-closed source-input freeze waiting for the trusted self-hosted runner. No CUT3R source prediction, residual, source truth, confirmation payload, target payload/outcome, BayesianPhysTwin result, or Causal4D result was opened before the v2 specification was frozen.

The practical-separation floors are interpretation thresholds, not sensor-resolution, calibration, or accuracy claims:

- point, endpoint, and seam RMSE: `0.1 mm`;
- absolute drift slope: `0.01 mm/frame`; and
- fixed-scale proper score: `0.01`.

Changing them after source outcomes are opened requires a new analysis version. This PR does not modify the provider, comparison arms, source or target roster, source competence decisions, readiness order, BayesianPhysTwin guard, or Causal4D handoff.

## Validation

- all changed Python files compile;
- 10 focused v2 tests pass in an isolated import harness, including exact two- and ten-group enumeration, unstable-denominator withholding, positive-floor enforcement, non-finite rejection, leave-one-group-out sign reversal, deterministic content identity, and CLI dispatch;
- the checked-in specification reproduces content ID `1e2f77a39a71410dd54e0eeb50da0765b8d6f5c79589777ea80c3ad8e6bfdbf7`.

The repository's complete Python 3.10–3.14, runtime-floor, wheel/sdist, Ruff, MyPy, documentation, provider, and security workflows remain authoritative.

## Scientific boundary

This is descriptive source-only mechanism analysis. A positive result does not establish held-out provider competence, BayesianPhysTwin physical-query benefit, Causal4D intervention benefit, deployment safety, or state of the art. A negative, undefined, denominator-unstable, or leave-one-group-sensitive result remains complete evidence and must not be retuned on the same opened source groups.

Refs #49