### PR TITLE
Make gauge calibration diagnostics observability-aware

### DIFF
--- a/CHANGELOG.d/gauge-covariance-support-diagnostics.md
+++ b/CHANGELOG.d/gauge-covariance-support-diagnostics.md
@@ -1,0 +1,1 @@
+Harden ablation gauge-consistency reporting by replacing silent pseudoinverse-only NEES evaluation with explicit covariance rank, nullspace-error, support-consistency, and rank-normalized diagnostics. Provider estimation, exports, frozen protocols, and scientific results are unchanged.

--- a/docs/gauge-covariance-support-diagnostics.md
+++ b/docs/gauge-covariance-support-diagnostics.md
@@ -1,0 +1,58 @@
+# Gauge covariance support diagnostics
+
+A positive-semidefinite gauge covariance may be singular because a gauge is
+partly deterministic, anchored, or unobservable. A Moore--Penrose pseudoinverse
+alone is insufficient for evaluating its error: any error component in the
+covariance nullspace receives zero quadratic cost and can therefore make an
+invalid estimate look well calibrated.
+
+Prob4D now evaluates each gauge error with
+`covariance_support_diagnostic`:
+
+```python
+from prob4d.diagnostics.covariance_support import (
+    covariance_support_diagnostic,
+)
+
+result = covariance_support_diagnostic(error, covariance)
+```
+
+The diagnostic validates the covariance as symmetric positive semidefinite
+without adding jitter, defines its observable range with a scale-aware
+eigenvalue threshold, and decomposes the error into observable and nullspace
+components. It reports:
+
+- covariance dimension and numerical rank;
+- the observable Moore--Penrose quadratic;
+- that quadratic divided by the effective rank;
+- the covariance-nullspace error norm;
+- the declared support tolerance; and
+- whether the complete error lies in covariance support.
+
+The observable quadratic is a valid NEES-style statistic only when
+`support_consistent` is true. A nonzero nullspace error is a model or reporting
+failure, not a low-uncertainty success.
+
+## Ablation output
+
+The historical `gauge_mean_normalized_squared_error` field remains available as
+the mean observable quadratic. Ablation reports now add:
+
+- `gauge_mean_rank_normalized_squared_error`;
+- `gauge_mean_covariance_rank`;
+- `gauge_minimum_covariance_rank`;
+- `gauge_support_violation_count`;
+- `gauge_maximum_nullspace_error_norm`; and
+- `gauge_all_errors_in_covariance_support`.
+
+Do not interpret the historical mean quadratic as a calibration statistic when
+`gauge_support_violation_count` is nonzero. Rank-normalized values exclude
+rank-zero deterministic gauges; the support fields still test those gauges and
+will expose any incompatible error.
+
+## Scope
+
+This change hardens non-claim-bearing gauge diagnostics and synthetic or
+manifest ablation reporting. It does not alter provider selection, gauge
+estimation, covariance export, the frozen CUT3R protocol, BayesianPhysTwin
+admission, exact fallback, or any scientific result.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ module = [
     "prob4d._observation_gaussian_woodbury",
     "prob4d._provider_portfolio_model",
     "prob4d.api.v2",
+    "prob4d.diagnostics.covariance_support",
     "prob4d.observation_gaussian_operator",
     "prob4d.provider_portfolio",
     "prob4d.public_api_manifest",

--- a/src/prob4d/diagnostics/covariance_support.py
+++ b/src/prob4d/diagnostics/covariance_support.py
@@ -1,0 +1,129 @@
+"""Observability-aware diagnostics for errors under positive-semidefinite covariance."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .._scientific_scalars import require_finite_real
+from ..covariance import validated_covariance_psd
+
+FloatArray = NDArray[np.floating]
+
+
+@dataclass(frozen=True)
+class CovarianceSupportDiagnostic:
+    """Decompose one error into observable and covariance-nullspace components.
+
+    ``observable_normalized_squared_error`` is the Moore--Penrose quadratic on
+    the covariance range. It is a valid NEES-style statistic only when
+    ``support_consistent`` is true. The explicit support fields prevent a
+    nullspace error from being silently assigned zero cost.
+    """
+
+    dimension: int
+    rank: int
+    observable_normalized_squared_error: float
+    rank_normalized_observable_squared_error: float
+    error_norm: float
+    nullspace_error_norm: float
+    support_tolerance: float
+    support_consistent: bool
+    eigenvalue_threshold: float
+    minimum_eigenvalue: float
+    maximum_eigenvalue: float
+
+
+def covariance_support_diagnostic(
+    error: FloatArray,
+    covariance: FloatArray,
+    *,
+    rank_relative_tolerance: float = 1e-10,
+    rank_absolute_tolerance: float = 0.0,
+    support_relative_tolerance: float = 1e-9,
+    support_absolute_tolerance: float = 1e-12,
+) -> CovarianceSupportDiagnostic:
+    """Evaluate an error without hiding covariance-nullspace inconsistency.
+
+    The covariance is validated as symmetric positive semidefinite without
+    adding jitter. Eigenvalues above the declared scale-aware threshold define
+    the observable range. The residual component outside that range is reported
+    explicitly and compared with a scale-aware support tolerance.
+    """
+
+    vector = np.asarray(error, dtype=np.float64)
+    if vector.ndim != 1 or vector.size == 0:
+        raise ValueError("error must be a nonempty vector")
+    if not np.all(np.isfinite(vector)):
+        raise ValueError("error must be finite")
+
+    rank_relative_tolerance = require_finite_real(
+        rank_relative_tolerance,
+        name="rank_relative_tolerance",
+        minimum=0.0,
+    )
+    rank_absolute_tolerance = require_finite_real(
+        rank_absolute_tolerance,
+        name="rank_absolute_tolerance",
+        minimum=0.0,
+    )
+    support_relative_tolerance = require_finite_real(
+        support_relative_tolerance,
+        name="support_relative_tolerance",
+        minimum=0.0,
+    )
+    support_absolute_tolerance = require_finite_real(
+        support_absolute_tolerance,
+        name="support_absolute_tolerance",
+        minimum=0.0,
+    )
+
+    validated = validated_covariance_psd(
+        covariance,
+        name="diagnostic covariance",
+        shape=(vector.size, vector.size),
+        readonly=False,
+    )
+    eigenvalues, eigenvectors = np.linalg.eigh(validated)
+    minimum_eigenvalue = float(np.min(eigenvalues))
+    maximum_eigenvalue = float(np.max(eigenvalues))
+    eigenvalue_threshold = (
+        rank_absolute_tolerance + rank_relative_tolerance * maximum_eigenvalue
+    )
+    observable = eigenvalues > eigenvalue_threshold
+    rank = int(np.count_nonzero(observable))
+
+    coordinates = eigenvectors.T @ vector
+    if rank:
+        observable_normalized_squared_error = float(
+            np.sum(coordinates[observable] ** 2 / eigenvalues[observable])
+        )
+        rank_normalized = observable_normalized_squared_error / rank
+    else:
+        observable_normalized_squared_error = 0.0
+        rank_normalized = 0.0
+
+    nullspace_error_norm = float(np.linalg.norm(coordinates[~observable]))
+    error_norm = float(np.linalg.norm(vector))
+    support_tolerance = (
+        support_absolute_tolerance + support_relative_tolerance * error_norm
+    )
+
+    return CovarianceSupportDiagnostic(
+        dimension=int(vector.size),
+        rank=rank,
+        observable_normalized_squared_error=observable_normalized_squared_error,
+        rank_normalized_observable_squared_error=float(rank_normalized),
+        error_norm=error_norm,
+        nullspace_error_norm=nullspace_error_norm,
+        support_tolerance=float(support_tolerance),
+        support_consistent=bool(nullspace_error_norm <= support_tolerance),
+        eigenvalue_threshold=float(eigenvalue_threshold),
+        minimum_eigenvalue=minimum_eigenvalue,
+        maximum_eigenvalue=maximum_eigenvalue,
+    )
+
+
+__all__ = ["CovarianceSupportDiagnostic", "covariance_support_diagnostic"]

--- a/src/prob4d/experiments.py
+++ b/src/prob4d/experiments.py
@@ -12,6 +12,7 @@ from typing import Any
 import numpy as np
 
 from .alignment import WindowAlignment, align_windows, estimate_sim3_robust
+from .diagnostics.covariance_support import covariance_support_diagnostic
 from .fusion import FusedSequence, fuse_windows
 from .gauge import (
     FixedLagGaugeSmoother,
@@ -38,6 +39,12 @@ class GaugeMetrics:
     rotation_rmse: float
     translation_rmse: float
     mean_normalized_squared_error: float
+    mean_rank_normalized_squared_error: float
+    mean_covariance_rank: float
+    minimum_covariance_rank: int
+    support_violation_count: int
+    maximum_nullspace_error_norm: float
+    all_errors_in_covariance_support: bool
 
 
 @dataclass(frozen=True)
@@ -122,19 +129,40 @@ def _gauge_metrics(
     truth: dict[str, Sim3],
 ) -> GaugeMetrics:
     errors: list[np.ndarray] = []
-    normalized_squared_errors: list[float] = []
+    diagnostics = []
     for window_id, estimate in estimates.items():
         error = truth[window_id].inverse().compose(estimate.global_from_local).as_vector()
         errors.append(error)
-        covariance = 0.5 * (estimate.covariance + estimate.covariance.T)
-        inverse = np.linalg.pinv(covariance, rcond=1e-10)
-        normalized_squared_errors.append(float(error @ inverse @ error))
+        diagnostics.append(covariance_support_diagnostic(error, estimate.covariance))
+
     stacked = np.stack(errors)
+    normalized_squared_errors = [
+        diagnostic.observable_normalized_squared_error for diagnostic in diagnostics
+    ]
+    rank_normalized_errors = [
+        diagnostic.rank_normalized_observable_squared_error
+        for diagnostic in diagnostics
+        if diagnostic.rank > 0
+    ]
+    ranks = [diagnostic.rank for diagnostic in diagnostics]
+    support_violation_count = sum(
+        not diagnostic.support_consistent for diagnostic in diagnostics
+    )
     return GaugeMetrics(
         log_scale_rmse=float(np.sqrt(np.mean(stacked[:, 0] ** 2))),
         rotation_rmse=float(np.sqrt(np.mean(np.sum(stacked[:, 1:4] ** 2, axis=1)))),
         translation_rmse=float(np.sqrt(np.mean(np.sum(stacked[:, 4:7] ** 2, axis=1)))),
         mean_normalized_squared_error=float(np.mean(normalized_squared_errors)),
+        mean_rank_normalized_squared_error=(
+            float(np.mean(rank_normalized_errors)) if rank_normalized_errors else 0.0
+        ),
+        mean_covariance_rank=float(np.mean(ranks)),
+        minimum_covariance_rank=min(ranks),
+        support_violation_count=int(support_violation_count),
+        maximum_nullspace_error_norm=max(
+            diagnostic.nullspace_error_norm for diagnostic in diagnostics
+        ),
+        all_errors_in_covariance_support=support_violation_count == 0,
     )
 
 
@@ -663,6 +691,8 @@ def _write_results(
         "endpoint_point_rmse",
         "coverage_95",
         "mean_mahalanobis_squared",
+        "gauge_mean_rank_normalized_squared_error",
+        "gauge_support_violation_count",
     ]
     header = "| " + " | ".join(columns) + " |"
     divider = "| " + " | ".join("---" for _ in columns) + " |"

--- a/tests/test_covariance_support_diagnostic.py
+++ b/tests/test_covariance_support_diagnostic.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from prob4d.diagnostics.covariance_support import covariance_support_diagnostic
+
+
+def test_full_rank_diagnostic_matches_standard_nees() -> None:
+    diagnostic = covariance_support_diagnostic(
+        np.array([2.0, 3.0]),
+        np.diag([4.0, 9.0]),
+    )
+
+    assert diagnostic.dimension == 2
+    assert diagnostic.rank == 2
+    assert diagnostic.observable_normalized_squared_error == pytest.approx(2.0)
+    assert diagnostic.rank_normalized_observable_squared_error == pytest.approx(1.0)
+    assert diagnostic.nullspace_error_norm == pytest.approx(0.0)
+    assert diagnostic.support_consistent
+
+
+def test_singular_covariance_is_valid_when_error_lies_in_its_range() -> None:
+    diagnostic = covariance_support_diagnostic(
+        np.array([2.0, 0.0]),
+        np.diag([4.0, 0.0]),
+    )
+
+    assert diagnostic.rank == 1
+    assert diagnostic.observable_normalized_squared_error == pytest.approx(1.0)
+    assert diagnostic.rank_normalized_observable_squared_error == pytest.approx(1.0)
+    assert diagnostic.nullspace_error_norm == pytest.approx(0.0)
+    assert diagnostic.support_consistent
+
+
+def test_nullspace_error_is_reported_instead_of_silently_zero_weighted() -> None:
+    diagnostic = covariance_support_diagnostic(
+        np.array([2.0, 0.25]),
+        np.diag([4.0, 0.0]),
+    )
+
+    assert diagnostic.rank == 1
+    assert diagnostic.observable_normalized_squared_error == pytest.approx(1.0)
+    assert diagnostic.nullspace_error_norm == pytest.approx(0.25)
+    assert not diagnostic.support_consistent
+
+
+def test_zero_covariance_accepts_only_numerically_zero_error() -> None:
+    zero = covariance_support_diagnostic(np.zeros(3), np.zeros((3, 3)))
+    nonzero = covariance_support_diagnostic(
+        np.array([0.0, 0.0, 1e-4]),
+        np.zeros((3, 3)),
+    )
+
+    assert zero.rank == 0
+    assert zero.observable_normalized_squared_error == 0.0
+    assert zero.support_consistent
+    assert nonzero.rank == 0
+    assert not nonzero.support_consistent
+    assert nonzero.nullspace_error_norm == pytest.approx(1e-4)
+
+
+def test_invalid_covariance_fails_closed() -> None:
+    with pytest.raises(ValueError, match="positive semidefinite"):
+        covariance_support_diagnostic(
+            np.ones(2),
+            np.diag([1.0, -1e-3]),
+        )
+
+    with pytest.raises(ValueError, match="symmetric"):
+        covariance_support_diagnostic(
+            np.ones(2),
+            np.array([[1.0, 0.5], [0.0, 1.0]]),
+        )

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -1,6 +1,12 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
 from test_io import write_problem_bundle
 
-from prob4d.experiments import run_manifest_ablation, run_synthetic_ablation
+from prob4d.experiments import _gauge_metrics, run_manifest_ablation, run_synthetic_ablation
+from prob4d.gauge import GaugeEstimate
+from prob4d.sim3 import Sim3
 from prob4d.synthetic import make_synthetic_problem
 
 
@@ -24,6 +30,26 @@ def test_synthetic_ablation_covers_all_requested_variants() -> None:
     assert calibration.count > 0
     assert rows[3].sequence_metrics.coverage_95 <= rows[4].sequence_metrics.coverage_95
     assert rows[-1].gauge_metrics is not None
+
+
+def test_gauge_metrics_do_not_hide_error_in_covariance_nullspace() -> None:
+    covariance = np.diag([1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 0.0])
+    estimates = {
+        "window-a": GaugeEstimate(
+            window_id="window-a",
+            global_from_local=Sim3(translation=np.array([0.0, 0.0, 0.25])),
+            covariance=covariance,
+        )
+    }
+    truth = {"window-a": Sim3.identity()}
+
+    metrics = _gauge_metrics(estimates, truth)
+
+    assert metrics.mean_normalized_squared_error == pytest.approx(0.0)
+    assert metrics.minimum_covariance_rank == 6
+    assert metrics.support_violation_count == 1
+    assert metrics.maximum_nullspace_error_norm == pytest.approx(0.25)
+    assert not metrics.all_errors_in_covariance_support
 
 
 def test_manifest_ablation_uses_held_out_calibration_and_exact_baselines(tmp_path) -> None:


### PR DESCRIPTION
## Summary

- replace pseudoinverse-only gauge NEES reporting with an explicit covariance-support decomposition
- report effective rank, rank-normalized observable NEES, covariance-nullspace error, and support violations
- retain the historical observable quadratic for compatibility, but make its validity conditional and visible
- add focused full-rank, singular-range, nullspace-error, zero-covariance, asymmetric, and indefinite regressions
- expose the new diagnostics in ablation JSON/CSV and the compact Markdown table

## Why

A Moore–Penrose pseudoinverse silently assigns zero cost to an error in a covariance nullspace. That can make a deterministic or unobservable direction look calibrated even when the estimate contradicts it. The new diagnostic preserves the observable quadratic while separately testing whether the complete error lies in covariance support.

## Scientific boundary

This changes non-claim-bearing diagnostics only. It does not alter gauge estimation, covariance export, provider selection, the queued/frozen CUT3R execution, BayesianPhysTwin admission or fallback, Causal4D handoff, data-access boundaries, or any retained result.

## Validation

The PR adds focused unit tests and leaves the full repository quality, packaging, provider-contract, security, and compatibility matrices to the exact-head CI workflows.