### PR TITLE
Make joint gauge-dependence claims executable

### DIFF
--- a/CHANGELOG.d/joint-dependence-invariants.md
+++ b/CHANGELOG.d/joint-dependence-invariants.md
@@ -1,0 +1,1 @@
+Add executable scientific invariants for explicit-versus-collapsed Gaussian equivalence, the failure of rowwise marginal scoring under shared gauge dependence, physical-query cancellation/amplification, and structured-factor storage scaling. No estimator, provider, protocol, fallback, or retained result changes.

--- a/docs/joint-dependence-invariants.md
+++ b/docs/joint-dependence-invariants.md
@@ -1,0 +1,121 @@
+# Joint-dependence invariants
+
+Prob4D's central statistical object is not a collection of independent point
+covariances. For admitted observation rows, the linearized model is
+
+\[
+y = \mu + J_g\,\delta g + \varepsilon,
+\qquad
+\delta g \sim \mathcal N(0,\Sigma_g),
+\qquad
+\varepsilon \sim \mathcal N(0,R),
+\]
+
+where `R` is block diagonal conditional point uncertainty and the gauge latent
+`delta g` is shared by every row that depends on the same window-gauge tree.
+The resulting joint covariance is
+
+\[
+\Sigma_y = R + J_g\Sigma_gJ_g^\top.
+\]
+
+The tests in `tests/test_joint_dependence_invariants.py` make four consequences
+of this model executable.
+
+## 1. Explicit and collapsed Gaussian representations agree
+
+An affine transformation of jointly Gaussian variables is Gaussian. Therefore,
+marginalizing the explicit gauge latent gives exactly
+
+\[
+y \sim \mathcal N(\mu,\Sigma_y).
+\]
+
+A downstream estimator may consequently keep gauge errors as explicit nuisance
+variables or consume the correctly collapsed joint covariance. For the same
+mean, residual, conditional covariance, Jacobian, and gauge prior, both routes
+must produce the same inverse action, determinant, and Gaussian negative log
+likelihood.
+
+This is a representation equivalence, not permission to discard cross-row
+covariance. A collapsed artifact is equivalent only when it preserves the full
+joint covariance semantics required by the downstream query.
+
+## 2. Rowwise marginal proper scores are not joint proper scores
+
+Consider two scalar rows with independent conditional noise variance
+\(\sigma^2\) and one shared additive gauge error with variance \(\tau^2\):
+
+\[
+\Sigma =
+\begin{bmatrix}
+\sigma^2+\tau^2 & \tau^2\\
+\tau^2 & \sigma^2+\tau^2
+\end{bmatrix}.
+\]
+
+The common residual \([a,a]^\top\) and contrast residual \([a,-a]^\top\) have
+the same rowwise values and therefore receive identical sums of marginal
+Gaussian scores. Jointly, however, they lie in different eigendirections:
+
+- the common mode has variance \(\sigma^2+2\tau^2\);
+- the contrast mode has variance \(\sigma^2\).
+
+A joint score correctly treats the contrast as much less plausible when the
+conditional noise is small. Summing rowwise marginal scores erases precisely the
+dependence information that Prob4D is intended to preserve.
+
+## 3. Query covariance can cancel or amplify shared uncertainty
+
+For the same two-row model, the average query
+
+\[
+q_{+}=\tfrac12(y_1+y_2)
+\]
+
+retains the complete shared gauge variance, whereas the difference query
+
+\[
+q_{-}=y_1-y_2
+\]
+
+cancels it exactly. Their variances are
+
+\[
+\operatorname{Var}(q_+)=\tfrac12\sigma^2+\tau^2,
+\qquad
+\operatorname{Var}(q_-)=2\sigma^2.
+\]
+
+Consequently, a collection of per-row marginal covariance blocks is
+insufficient for physical queries spanning multiple rows. The query Jacobian
+must act on the complete conditional-plus-shared covariance model.
+
+## 4. Structured factor storage avoids dense quadratic growth
+
+A dense covariance for `M` three-dimensional rows requires storage proportional
+to \((3M)^2\). The covariance-root Woodbury backend retains one conditional
+`3 x 3` factor per row plus gauge-root and latent factors. With fixed shared
+latent rank, its cached storage grows linearly in `M`; the input factor stack is
+already owned separately. The causal tree backend similarly retains fixed-size
+row and seven-dimensional gauge blocks rather than a dense observation
+covariance.
+
+The executable storage invariant compares otherwise identical two-row and
+128-row stacks. It requires the structured-to-dense storage ratio to decrease
+with observation count and to remain below one percent for the registered
+128-row shared-rank example. This is a deterministic storage check, not a timing
+benchmark or a universal hardware-performance claim.
+
+## Ownership and claim boundary
+
+Prob4D owns the observation-space conditional covariance, shared gauge
+structure, exact joint Gaussian operations, and query projection. BayesianPhysTwin
+owns the physical residual or query Jacobian, update guard, identifiability test,
+and exact physical fallback. Causal4D consumes only an accepted BayesianPhysTwin
+belief and owns intervention inference.
+
+These invariants establish algebraic consistency and the necessity of retaining
+shared dependence. They do not establish real-provider competence, calibrated
+physical uncertainty, downstream physical benefit, Causal4D intervention
+benefit, deployment safety, or state of the art.

--- a/docs/scientific-kernel.md
+++ b/docs/scientific-kernel.md
@@ -185,5 +185,6 @@ The current highest-priority execution is the
 - [Provider API v2](provider-v2.md)
 - [Unfused observation-factor bundle](observation-factor-bundle.md)
 - [Structured observation covariance queries](observation-covariance-queries.md)
+- [Executable joint-dependence invariants](joint-dependence-invariants.md)
 - [Analytic gauge propagation](analytic-gauge-propagation.md)
 - [Provider readiness localization](provider-readiness-localization.md)

--- a/tests/test_joint_dependence_invariants.py
+++ b/tests/test_joint_dependence_invariants.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from prob4d.api.v2 import (
+    StackedObservationFactors,
+    build_observation_gaussian_operator,
+    project_observation_covariance,
+)
+
+_CONDITIONAL_X_VARIANCE = 0.25
+_SHARED_GAUGE_VARIANCE = 0.75
+
+
+def _shared_gauge_stack(observation_count: int) -> StackedObservationFactors:
+    if observation_count < 1:
+        raise ValueError("observation_count must be positive")
+
+    conditional_row = np.diag([_CONDITIONAL_X_VARIANCE, 1.0, 1.0])
+    conditional = np.repeat(conditional_row[None, :, :], observation_count, axis=0)
+    gauge_jacobian = np.zeros((observation_count, 3, 7), dtype=np.float64)
+    gauge_jacobian[:, 0, 0] = 1.0
+    gauge_prior = np.zeros((7, 7), dtype=np.float64)
+    gauge_prior[0, 0] = _SHARED_GAUGE_VARIANCE
+    gauge_row_covariance = np.asarray(
+        [jacobian @ gauge_prior @ jacobian.T for jacobian in gauge_jacobian]
+    )
+    marginal = conditional + gauge_row_covariance
+
+    return StackedObservationFactors(
+        world_mean_m=np.zeros((observation_count, 3), dtype=np.float64),
+        conditional_world_covariance_m2=conditional,
+        marginal_world_covariance_m2=marginal,
+        gauge_jacobian=gauge_jacobian,
+        gauge_prior_covariance=gauge_prior,
+        association_probability=np.ones(observation_count),
+        prior_reliability=np.ones(observation_count),
+        prior_nominal_probability=np.ones(observation_count),
+        composite_weight=np.ones(observation_count),
+        point_ids=np.arange(1, observation_count + 1, dtype=np.int64),
+        frame_indices=np.arange(observation_count, dtype=np.int64),
+        view_ids=tuple("camera" for _ in range(observation_count)),
+        factor_ids=tuple(f"factor-{index}" for index in range(observation_count)),
+        correlation_group_ids=tuple("shared-provider" for _ in range(observation_count)),
+        gauge_ids=("shared-gauge",),
+        causal_frame_stop=observation_count,
+    )
+
+
+def _dense_covariance(stacked: StackedObservationFactors) -> np.ndarray:
+    count = len(stacked.world_mean_m)
+    conditional = np.zeros((3 * count, 3 * count), dtype=np.float64)
+    for index, block in enumerate(stacked.conditional_world_covariance_m2):
+        conditional[3 * index : 3 * index + 3, 3 * index : 3 * index + 3] = block
+    jacobian = np.asarray(stacked.gauge_jacobian).reshape(3 * count, -1)
+    return conditional + jacobian @ stacked.gauge_prior_covariance @ jacobian.T
+
+
+def _dense_gaussian_nll(residual: np.ndarray, covariance: np.ndarray) -> float:
+    flattened = residual.reshape(-1)
+    sign, log_determinant = np.linalg.slogdet(covariance)
+    assert sign == 1.0
+    quadratic = float(flattened @ np.linalg.solve(covariance, flattened))
+    return 0.5 * (
+        flattened.size * math.log(2.0 * math.pi) + log_determinant + quadratic
+    )
+
+
+def _rowwise_marginal_nll(
+    residual: np.ndarray,
+    marginal_covariance: np.ndarray,
+) -> float:
+    total = 0.0
+    for row, covariance in zip(residual, marginal_covariance, strict=True):
+        sign, log_determinant = np.linalg.slogdet(covariance)
+        assert sign == 1.0
+        quadratic = float(row @ np.linalg.solve(covariance, row))
+        total += 0.5 * (3 * math.log(2.0 * math.pi) + log_determinant + quadratic)
+    return total
+
+
+def test_explicit_shared_latent_matches_collapsed_joint_gaussian() -> None:
+    stacked = _shared_gauge_stack(2)
+    residual = np.asarray(
+        [[0.7, -0.2, 0.1], [-0.4, 0.3, -0.1]],
+        dtype=np.float64,
+    )
+    dense_covariance = _dense_covariance(stacked)
+
+    structured = build_observation_gaussian_operator(stacked).gaussian_nll(residual)
+    collapsed = _dense_gaussian_nll(residual, dense_covariance)
+
+    assert structured == pytest.approx(collapsed, abs=1e-12, rel=1e-12)
+
+
+def test_rowwise_marginal_scores_discard_the_shared_dependence_direction() -> None:
+    stacked = _shared_gauge_stack(2)
+    common_mode = np.zeros((2, 3), dtype=np.float64)
+    common_mode[:, 0] = 1.0
+    contrast_mode = np.zeros((2, 3), dtype=np.float64)
+    contrast_mode[:, 0] = np.asarray([1.0, -1.0])
+
+    rowwise_common = _rowwise_marginal_nll(
+        common_mode,
+        stacked.marginal_world_covariance_m2,
+    )
+    rowwise_contrast = _rowwise_marginal_nll(
+        contrast_mode,
+        stacked.marginal_world_covariance_m2,
+    )
+    operator = build_observation_gaussian_operator(stacked)
+    joint_common = operator.gaussian_nll(common_mode)
+    joint_contrast = operator.gaussian_nll(contrast_mode)
+
+    assert rowwise_common == pytest.approx(rowwise_contrast)
+    assert joint_common < rowwise_common < joint_contrast
+    assert joint_contrast - joint_common > 3.0
+
+
+def test_physical_queries_preserve_shared_mode_cancellation_and_amplification() -> None:
+    stacked = _shared_gauge_stack(2)
+    query = np.asarray(
+        [
+            [[0.5, 0.0, 0.0], [0.5, 0.0, 0.0]],
+            [[1.0, 0.0, 0.0], [-1.0, 0.0, 0.0]],
+        ],
+        dtype=np.float64,
+    )
+
+    projected = project_observation_covariance(stacked, query)
+
+    np.testing.assert_allclose(
+        projected.conditional_covariance,
+        np.diag([0.5 * _CONDITIONAL_X_VARIANCE, 2.0 * _CONDITIONAL_X_VARIANCE]),
+        atol=1e-12,
+        rtol=1e-12,
+    )
+    np.testing.assert_allclose(
+        projected.gauge_covariance,
+        np.diag([_SHARED_GAUGE_VARIANCE, 0.0]),
+        atol=1e-12,
+        rtol=1e-12,
+    )
+    np.testing.assert_allclose(
+        projected.marginal_covariance,
+        projected.conditional_covariance + projected.gauge_covariance,
+        atol=1e-12,
+        rtol=1e-12,
+    )
+
+
+def test_structured_factor_storage_scales_subquadratically_in_observation_count() -> None:
+    small = build_observation_gaussian_operator(_shared_gauge_stack(2))
+    large = build_observation_gaussian_operator(_shared_gauge_stack(128))
+
+    assert large.factor_storage_nbytes > small.factor_storage_nbytes
+    assert large.factor_storage_ratio_to_dense < small.factor_storage_ratio_to_dense
+    assert large.factor_storage_ratio_to_dense < 0.01


### PR DESCRIPTION
## Summary

- verify explicit shared-gauge latent and correctly collapsed joint Gaussian representations produce the same likelihood
- provide a two-row counterexample where rowwise marginal scores cannot distinguish common and contrast residuals, while the joint score correctly does
- verify physical-query covariance retains shared uncertainty for an average query and cancels it for a difference query
- verify structured factor storage grows subquadratically and remains below 1% of dense covariance storage in the registered 128-row fixed-rank example
- document the corresponding propositions and link them from the scientific kernel

## Why

The central Prob4D contribution is preservation of shared cross-row gauge dependence, not generic per-point uncertainty. These regressions turn that argument into exact, reviewable invariants and protect against future implementations that accidentally collapse to rowwise marginal semantics.

## Scientific boundary

This PR establishes algebraic and storage invariants only. It changes no estimator, provider, covariance model, calibration, selection rule, fallback, CUT3R protocol, data-access boundary, or retained result. It does not establish real-provider competence or downstream physical or causal benefit.

## Validation

The new tests use the public `prob4d.api.v2` Gaussian operator and query projection, with independent dense NumPy references and analytically registered expected query variances. The complete exact-head CI matrix remains authoritative.