### PR TITLE
Make retained CUT3R retries exact and queue-bounded

### DIFF
--- a/.github/workflows/cut3r-source-freeze-auto-v2.yml
+++ b/.github/workflows/cut3r-source-freeze-auto-v2.yml
@@ -8,19 +8,33 @@ on:
       - "CHANGELOG.d/cut3r-source-freeze-auto-v2.md"
       - "docs/cut3r-source-freeze-auto-v2.md"
       - "protocols/execution_requests/cut3r_deform360_source_freeze_v2.json"
+      - "scripts/ci/cut3r_execution_preflight.py"
       - "scripts/science/run_cut3r_source_freeze_execution.py"
+      - "tests/test_cut3r_execution_preflight.py"
       - "tests/test_cut3r_source_freeze_execution_driver.py"
       - "tests/test_trusted_self_hosted_validation_policy.py"
   push:
     branches: [main]
     paths:
       - "protocols/execution_requests/cut3r_deform360_source_freeze_v2.json"
+  workflow_dispatch:
+    inputs:
+      execution_sha:
+        description: Exact historical merged-main SHA containing the retained request
+        required: true
+        type: string
+      request_id:
+        description: Exact 64-character retained source-freeze request ID
+        required: true
+        type: string
 
 permissions:
   contents: read
 
 concurrency:
-  group: cut3r-source-freeze-auto-v2-${{ github.ref }}-${{ github.sha }}
+  group: >-
+    cut3r-source-freeze-auto-v2-${{ github.event_name }}-${{
+    inputs.execution_sha || github.sha }}-${{ inputs.request_id || 'push' }}
   cancel-in-progress: false
 
 env:
@@ -63,34 +77,46 @@ jobs:
           python -m pip install -e ".[dev]"
           python -m pip check
           python -m ruff check \
+            scripts/ci/cut3r_execution_preflight.py \
             scripts/science/run_cut3r_source_freeze_execution.py \
+            tests/test_cut3r_execution_preflight.py \
             tests/test_cut3r_source_freeze_execution_driver.py \
             tests/test_trusted_self_hosted_validation_policy.py
           python -m ruff format --check \
+            scripts/ci/cut3r_execution_preflight.py \
             scripts/science/run_cut3r_source_freeze_execution.py \
+            tests/test_cut3r_execution_preflight.py \
             tests/test_cut3r_source_freeze_execution_driver.py \
             tests/test_trusted_self_hosted_validation_policy.py
           python -m pytest -q \
+            tests/test_cut3r_execution_preflight.py \
             tests/test_cut3r_source_freeze_execution_driver.py \
             tests/test_trusted_self_hosted_validation_policy.py \
             tests/test_github_action_pins.py
           python -m compileall -q \
+            scripts/ci/cut3r_execution_preflight.py \
             scripts/science/run_cut3r_source_freeze_execution.py \
             scripts/science/build_cut3r_deform360_source_freeze.py
 
   authorize:
     name: Authorize exact merged-main v2 request
-    if: github.event_name == 'push'
+    if: >-
+      github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     outputs:
-      head_sha: ${{ steps.request.outputs.head_sha }}
-      base_sha: ${{ steps.request.outputs.base_sha }}
-      request_id: ${{ steps.request.outputs.request_id }}
-      profile: ${{ steps.request.outputs.profile }}
-      authorization_mode: ${{ steps.request.outputs.authorization_mode }}
+      head_sha: ${{ steps.push_request.outputs.head_sha || steps.retry_request.outputs.head_sha }}
+      base_sha: ${{ steps.push_request.outputs.base_sha || steps.retry_request.outputs.base_sha }}
+      request_id: ${{ steps.push_request.outputs.request_id || steps.retry_request.outputs.request_id }}
+      profile: ${{ steps.push_request.outputs.profile || steps.retry_request.outputs.profile }}
+      authorization_mode: >-
+        ${{ steps.push_request.outputs.authorization_mode ||
+            steps.retry_request.outputs.authorization_mode }}
+      trigger_mode: >-
+        ${{ steps.push_request.outputs.trigger_mode ||
+            steps.retry_request.outputs.trigger_mode }}
     steps:
-      - name: Require an ordinary non-forced push to main
+      - name: Require an ordinary main push or a main-bound manual retry
         shell: bash
         env:
           EVENT_NAME: ${{ github.event_name }}
@@ -102,23 +128,33 @@ jobs:
           EXPECTED_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          test "$EVENT_NAME" = "push"
-          test "$EVENT_REF" = "refs/heads/main"
-          test "$EVENT_AFTER" = "$EXPECTED_SHA"
-          test "$EVENT_FORCED" = "false"
-          test "$EVENT_DELETED" = "false"
-          test "$EVENT_BEFORE" != "0000000000000000000000000000000000000000"
+          if [[ "$EVENT_NAME" == "push" ]]; then
+            test "$EVENT_REF" = "refs/heads/main"
+            test "$EVENT_AFTER" = "$EXPECTED_SHA"
+            test "$EVENT_FORCED" = "false"
+            test "$EVENT_DELETED" = "false"
+            test "$EVENT_BEFORE" != "0000000000000000000000000000000000000000"
+          elif [[ "$EVENT_NAME" == "workflow_dispatch" ]]; then
+            test "$EVENT_REF" = "refs/heads/main" || {
+              echo "exact retry must be dispatched from main" >&2
+              exit 1
+            }
+          else
+            echo "unsupported execution trigger" >&2
+            exit 1
+          fi
 
-      - name: Check out exact merged main revision
+      - name: Check out current merged main with complete ancestry
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.sha }}
-          fetch-depth: 2
+          fetch-depth: 0
           persist-credentials: false
           clean: true
 
-      - name: Verify immutable request and changed-path authorization
-        id: request
+      - name: Verify immutable push request and changed-path authorization
+        id: push_request
+        if: github.event_name == 'push'
         shell: bash
         env:
           EXPECTED_SHA: ${{ github.sha }}
@@ -137,12 +173,136 @@ jobs:
           {
             echo "head_sha=$EXPECTED_SHA"
             echo "base_sha=$BASE_SHA"
+            echo "trigger_mode=merged_main_push"
           } >> "$GITHUB_OUTPUT"
+
+      - name: Verify exact historical request retry
+        id: retry_request
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        env:
+          CURRENT_MAIN_SHA: ${{ github.sha }}
+          EXECUTION_SHA: ${{ inputs.execution_sha }}
+          EXPECTED_REQUEST_ID: ${{ inputs.request_id }}
+        run: |
+          set -euo pipefail
+          python scripts/ci/cut3r_execution_preflight.py authorize-retry \
+            --repository . \
+            --request "$REQUEST_PATH" \
+            --current-revision "$CURRENT_MAIN_SHA" \
+            --execution-revision "$EXECUTION_SHA" \
+            --expected-request-id "$EXPECTED_REQUEST_ID" \
+            --github-output "$GITHUB_OUTPUT"
+
+  preflight:
+    name: Check retained execution configuration
+    if: >-
+      success() &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    needs: [contract, authorize]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Check out current reviewed control-plane helper
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          clean: true
+
+      - name: Check repository-variable presence without publishing values
+        id: variables
+        continue-on-error: true
+        shell: bash
+        env:
+          BPT_CHECKOUT: ${{ vars.BPT_CHECKOUT }}
+          CUT3R_CHECKOUT: ${{ vars.CUT3R_CHECKOUT }}
+          CUT3R_CHECKPOINT: ${{ vars.CUT3R_CHECKPOINT }}
+          DEFORM360_PROCESSED_ROOT: ${{ vars.DEFORM360_PROCESSED_ROOT }}
+        run: |
+          set -euo pipefail
+          python scripts/ci/cut3r_execution_preflight.py check-variables \
+            --required-variable BPT_CHECKOUT \
+            --required-variable CUT3R_CHECKOUT \
+            --required-variable CUT3R_CHECKPOINT \
+            --required-variable DEFORM360_PROCESSED_ROOT \
+            --report "$RUNNER_TEMP/cut3r-variable-readiness.json" \
+            --github-output "$GITHUB_OUTPUT" \
+            --require-ready
+
+      - name: Publish bounded configuration blocker
+        if: steps.variables.outputs.ready != 'true'
+        shell: bash
+        env:
+          API_URL: ${{ github.api_url }}
+          REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+          REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
+          HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+          MISSING_VARIABLES: ${{ steps.variables.outputs.missing_variables_json }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from __future__ import annotations
+
+          import json
+          import os
+          import urllib.request
+
+          try:
+              missing = json.loads(os.environ.get("MISSING_VARIABLES") or "[]")
+          except json.JSONDecodeError:
+              missing = ["preflight-report-unavailable"]
+          if not isinstance(missing, list) or any(
+              not isinstance(value, str) for value in missing
+          ):
+              missing = ["preflight-report-unavailable"]
+          body = "\n".join(
+              (
+                  "## Retained CUT3R source-freeze configuration blocked",
+                  "",
+                  f"- request ID: `{os.environ['REQUEST_ID']}`",
+                  f"- exact execution revision: `{os.environ['HEAD_SHA']}`",
+                  f"- missing repository-variable names: `{json.dumps(missing)}`",
+                  f"- workflow run: {os.environ['RUN_URL']}",
+                  "",
+                  "No variable value or retained path is published. The self-hosted "
+                  "job was not queued, and no source, confirmation, target, "
+                  "BayesianPhysTwin, or Causal4D outcome was opened.",
+              )
+          )
+          request = urllib.request.Request(
+              f"{os.environ['API_URL']}/repos/{os.environ['REPOSITORY']}/issues/49/comments",
+              data=json.dumps({"body": body}).encode("utf-8"),
+              method="POST",
+              headers={
+                  "Accept": "application/vnd.github+json",
+                  "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+                  "Content-Type": "application/json",
+                  "X-GitHub-Api-Version": "2022-11-28",
+              },
+          )
+          with urllib.request.urlopen(request, timeout=30):
+              pass
+          PY
+
+      - name: Fail closed when retained configuration is incomplete
+        if: steps.variables.outputs.ready != 'true'
+        shell: bash
+        run: |
+          echo "retained CUT3R execution configuration is incomplete" >&2
+          exit 1
 
   announce:
     name: Publish queued run pointer
-    if: github.event_name == 'push'
-    needs: [contract, authorize]
+    if: >-
+      success() &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    needs: [contract, authorize, preflight]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -158,6 +318,7 @@ jobs:
           REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
           HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
           AUTHORIZATION_MODE: ${{ needs.authorize.outputs.authorization_mode }}
+          TRIGGER_MODE: ${{ needs.authorize.outputs.trigger_mode }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
@@ -175,6 +336,7 @@ jobs:
                   f"- request ID: `{os.environ['REQUEST_ID']}`",
                   f"- exact merged-main revision: `{os.environ['HEAD_SHA']}`",
                   f"- authorization: `{os.environ['AUTHORIZATION_MODE']}`",
+                  f"- trigger: `{os.environ['TRIGGER_MODE']}`",
                   f"- workflow run: {os.environ['RUN_URL']}",
                   "",
                   "The self-hosted job has a read-only repository token and receives "
@@ -199,8 +361,10 @@ jobs:
 
   execute:
     name: Freeze retained source inputs from trusted merged main
-    if: github.event_name == 'push'
-    needs: [contract, authorize, announce]
+    if: >-
+      success() &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    needs: [contract, authorize, preflight, announce]
     permissions:
       contents: read
     runs-on: [self-hosted, Linux, X64, nvidia-smi]
@@ -414,10 +578,147 @@ jobs:
           /usr/bin/git reset --hard HEAD
           /usr/bin/git clean -ffdx
 
+  watchdog:
+    name: Bound self-hosted runner acceptance wait
+    if: >-
+      success() &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    needs: [contract, authorize, preflight, announce]
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    permissions:
+      actions: write
+      contents: read
+      issues: write
+    steps:
+      - name: Cancel a run that no matching runner accepts within twenty minutes
+        shell: bash
+        env:
+          API_URL: ${{ github.api_url }}
+          REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
+          HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+          EXECUTE_JOB_NAME: Freeze retained source inputs from trusted merged main
+          RUNNER_ACCEPTANCE_TIMEOUT_SECONDS: "1200"
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from __future__ import annotations
+
+          import json
+          import os
+          import time
+          import urllib.request
+
+          api_url = os.environ["API_URL"]
+          repository = os.environ["REPOSITORY"]
+          token = os.environ["GITHUB_TOKEN"]
+          run_id = os.environ["RUN_ID"]
+          job_name = os.environ["EXECUTE_JOB_NAME"]
+          deadline = time.monotonic() + int(
+              os.environ["RUNNER_ACCEPTANCE_TIMEOUT_SECONDS"]
+          )
+          headers = {
+              "Accept": "application/vnd.github+json",
+              "Authorization": f"Bearer {token}",
+              "X-GitHub-Api-Version": "2022-11-28",
+          }
+
+          def job_status() -> str | None:
+              request = urllib.request.Request(
+                  f"{api_url}/repos/{repository}/actions/runs/{run_id}/jobs"
+                  "?filter=latest&per_page=100",
+                  headers=headers,
+              )
+              with urllib.request.urlopen(request, timeout=30) as response:
+                  payload = json.load(response)
+              jobs = payload.get("jobs")
+              if not isinstance(jobs, list):
+                  raise SystemExit("workflow jobs response is malformed")
+              matches = [
+                  job
+                  for job in jobs
+                  if isinstance(job, dict) and job.get("name") == job_name
+              ]
+              if len(matches) > 1:
+                  raise SystemExit("self-hosted execution job identity is ambiguous")
+              if not matches:
+                  return None
+              status = matches[0].get("status")
+              if status not in {
+                  "queued",
+                  "in_progress",
+                  "completed",
+                  "waiting",
+                  "pending",
+                  "requested",
+              }:
+                  raise SystemExit("self-hosted execution job status is unsupported")
+              return str(status)
+
+          while time.monotonic() < deadline:
+              status = job_status()
+              if status in {"in_progress", "completed"}:
+                  with open(
+                      os.environ["GITHUB_STEP_SUMMARY"],
+                      "a",
+                      encoding="utf-8",
+                  ) as summary:
+                      summary.write(
+                          "The retained self-hosted job was accepted before the "
+                          "bounded queue deadline.\n"
+                      )
+                  raise SystemExit(0)
+              time.sleep(15)
+
+          final_status = job_status()
+          if final_status in {"in_progress", "completed"}:
+              raise SystemExit(0)
+
+          body = "\n".join(
+              (
+                  "## Retained CUT3R source-freeze runner acceptance timeout",
+                  "",
+                  f"- request ID: `{os.environ['REQUEST_ID']}`",
+                  f"- exact execution revision: `{os.environ['HEAD_SHA']}`",
+                  f"- last observed execution-job status: `{final_status or 'not-listed'}`",
+                  f"- bounded acceptance window: `20 minutes`",
+                  f"- workflow run: {os.environ['RUN_URL']}",
+                  "",
+                  "The hosted controller canceled the run before an unavailable "
+                  "self-hosted queue could remain pending indefinitely. No source "
+                  "outcome, confirmation object, target payload, BayesianPhysTwin "
+                  "result, or Causal4D result is claimed by this receipt.",
+              )
+          )
+          comment = urllib.request.Request(
+              f"{api_url}/repos/{repository}/issues/49/comments",
+              data=json.dumps({"body": body}).encode("utf-8"),
+              method="POST",
+              headers={**headers, "Content-Type": "application/json"},
+          )
+          with urllib.request.urlopen(comment, timeout=30):
+              pass
+
+          cancel = urllib.request.Request(
+              f"{api_url}/repos/{repository}/actions/runs/{run_id}/cancel",
+              data=b"{}",
+              method="POST",
+              headers={**headers, "Content-Type": "application/json"},
+          )
+          with urllib.request.urlopen(cancel, timeout=30):
+              pass
+          PY
+
   report:
     name: Publish terminal v2 source-freeze receipt
-    if: ${{ always() && github.event_name == 'push' }}
-    needs: [authorize, execute]
+    if: >-
+      always() &&
+      (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
+    needs: [authorize, preflight, execute, watchdog]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -432,7 +733,10 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
           HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+          TRIGGER_MODE: ${{ needs.authorize.outputs.trigger_mode }}
+          PREFLIGHT_RESULT: ${{ needs.preflight.result }}
           EXECUTION_RESULT: ${{ needs.execute.result }}
+          WATCHDOG_RESULT: ${{ needs.watchdog.result }}
           DECISION: ${{ needs.execute.outputs.decision }}
           EXIT_STATUS: ${{ needs.execute.outputs.exit_status }}
           FREEZE_ARTIFACT_ID: ${{ needs.execute.outputs.freeze_artifact_id }}
@@ -455,9 +759,12 @@ jobs:
               (
                   "## Retained CUT3R source-freeze v2 terminal receipt",
                   "",
-                  f"- request ID: `{os.environ['REQUEST_ID']}`",
-                  f"- exact merged-main revision: `{os.environ['HEAD_SHA']}`",
+                  f"- request ID: `{os.environ.get('REQUEST_ID') or 'not-authorized'}`",
+                  f"- exact merged-main revision: `{os.environ.get('HEAD_SHA') or 'not-authorized'}`",
+                  f"- trigger: `{os.environ.get('TRIGGER_MODE') or 'not-authorized'}`",
+                  f"- configuration preflight: `{os.environ['PREFLIGHT_RESULT']}`",
                   f"- workflow result: `{os.environ['EXECUTION_RESULT']}`",
+                  f"- watchdog result: `{os.environ['WATCHDOG_RESULT']}`",
                   f"- source-freeze decision: `{decision}`",
                   f"- builder exit status: `{exit_status}`",
                   f"- freeze artifact ID: `{freeze_id}`",

--- a/CHANGELOG.d/cut3r-exact-retry-watchdog-tests.md
+++ b/CHANGELOG.d/cut3r-exact-retry-watchdog-tests.md
@@ -1,0 +1,4 @@
+### Tests
+
+- Cover the exact retained retry invocation and keep its historical execution SHA
+  and request ID synchronized with the checked-in target-closed request.

--- a/CHANGELOG.d/cut3r-exact-retry-watchdog.md
+++ b/CHANGELOG.d/cut3r-exact-retry-watchdog.md
@@ -1,0 +1,14 @@
+### Fixed
+
+- Preserve an exact, reviewable retry path for cancelled retained CUT3R
+  source-freeze requests instead of requiring a new scientific request or silently
+  executing newer development code.
+- Reject incomplete retained-runner configuration before privileged scheduling and
+  cancel a run when no matching GPU runner accepts the job within the bounded
+  queue window.
+
+### Scientific boundary
+
+This is execution-control hardening only. It changes no provider, checkpoint,
+cohort, prefix, support criterion, comparison arm, estimator, target-access state,
+or scientific claim.

--- a/CHANGELOG.d/cut3r-source-freeze-auto-v2.md
+++ b/CHANGELOG.d/cut3r-source-freeze-auto-v2.md
@@ -2,15 +2,26 @@
 
 - Add a content-addressed merged-main trigger for the retained CUT3R Deform360
   source-input freeze.
+- Add a main-only exact historical retry that requires the original 40-character
+  merged-main execution SHA and 64-character retained request ID, proves ancestry
+  and byte-identical request/protocol binding, and executes the historical code
+  rather than current development head.
+- Check required repository-variable names on a hosted runner without exposing
+  values or retained paths, and fail before scheduling privileged work when the
+  configuration is incomplete.
+- Bound self-hosted runner acceptance to 20 minutes; publish a target-closed issue
+  receipt and cancel the run when no matching runner accepts the job.
 - Run the self-hosted stage with a read-only repository token, publish queued and
   terminal issue receipts from hosted jobs, and retain either the registered
   support pass or support-negative decision.
-- Add an independently testable execution driver that sanitizes protected paths,
-  verifies the target-closed boundary, and creates the comparison lock only after
-  a source-support pass.
+- Add independently testable authorization and variable-readiness helpers plus
+  adversarial ancestry, byte-drift, identity, and redaction tests.
+- Keep the execution driver path-sanitized, target-closed, and able to create the
+  comparison lock only after a source-support pass.
 
 ### Scientific boundary
 
 This route changes no CUT3R, Prob4D, BayesianPhysTwin, or Causal4D method and
 opens no source outcome or target payload. It authorizes only the already frozen
-source-input support and identity stage.
+source-input support and identity stage. Configuration and queue-timeout receipts
+carry no scientific evidence.

--- a/docs/cut3r-exact-retry-invocation.md
+++ b/docs/cut3r-exact-retry-invocation.md
@@ -1,0 +1,21 @@
+# Exact retry invocation for the retained CUT3R source freeze
+
+After this change is merged, dispatch
+`Execute retained CUT3R source freeze automatically v2` from `main` with:
+
+```text
+execution_sha: 8b923e8cd67ca65f09312cffe305e36852f36fbb
+request_id: 8f3c9fba12f8a16895edce89d7a92e4806a43cb2f34b5a05faff71945809b63e
+```
+
+The workflow independently proves that the revision is historical merged main,
+that the retained request is byte-identical at the historical and current
+revisions, and that the registered protocol blob is unchanged. These literals are
+operational pointers to the cancelled zero-evidence request, not mutable defaults
+or a new scientific registration.
+
+Before dispatch, a matching `[self-hosted, Linux, X64, nvidia-smi]` runner should
+be online and the four required repository variables should be configured. The
+hosted preflight exposes variable names only. If no runner accepts the job within
+20 minutes, the run is cancelled with a target-closed receipt and can be retried
+with the same two literals.

--- a/docs/cut3r-source-freeze-auto-v2.md
+++ b/docs/cut3r-source-freeze-auto-v2.md
@@ -1,33 +1,80 @@
 # Automatic retained CUT3R source freeze v2
 
-This execution route runs the already registered Deform360 source-input freeze from
-one reviewed push to `main`. It exists because the linked GitHub capability cannot
-dispatch or approve the older protected-environment workflow. The scientific
-inputs are unchanged.
+This execution route runs the already registered Deform360 source-input freeze
+from reviewed `main`. The scientific inputs are unchanged. It supports both the
+original content-addressed push trigger and an exact manual retry of a cancelled
+historical merged-main execution.
 
 ## Authorization
 
-The trigger is the content-addressed request
+The retained request is
 
 ```text
 protocols/execution_requests/cut3r_deform360_source_freeze_v2.json
 ```
 
-The workflow accepts only an ordinary, non-forced push to `refs/heads/main`. It
-checks that the request file changed in that push, verifies its content identity,
-replays the exact source-protocol Git blob, and checks out the resulting merged
-revision by full SHA.
+### Original push route
 
-The self-hosted job has `contents: read` only. It receives no pull-request fields,
-no writable repository token, and no secret-valued command input. The merge into
-`main` is the authorization event; this v2 route deliberately does not use a
-GitHub Environment approval.
+An ordinary, non-forced push to `refs/heads/main` is accepted only when that push
+changes the request file. The workflow verifies its content identity, replays the
+exact source-protocol Git blob, and binds the resulting merged revision by full
+SHA.
+
+### Exact historical retry
+
+A maintainer may dispatch the workflow from `main` with:
+
+- the complete 40-character SHA of the historical merged-main execution; and
+- the complete 64-character retained request ID.
+
+The hosted authorization job proves that the historical revision is an ancestor
+of current `main`, that its request blob is byte-identical to the current retained
+request, that the request remains content-addressed and target-closed, that the
+historical source-protocol blob still matches the request, and that the reviewed
+execution driver exists at that revision. The self-hosted job then checks out and
+executes that historical revision rather than current development code.
+
+This retry therefore does not create a new request, silently advance the
+scientific implementation, or change the cohort, provider, checkpoint, prefix,
+support rule, or information order.
+
+## Hosted configuration preflight
+
+Before a self-hosted job is queued, a hosted job checks that these repository
+variable names are configured:
+
+```text
+BPT_CHECKOUT
+CUT3R_CHECKOUT
+CUT3R_CHECKPOINT
+DEFORM360_PROCESSED_ROOT
+```
+
+Only set/unset state is evaluated. Variable values and retained filesystem paths
+are never written to the report, logs, job summary, or issue comment. An
+incomplete configuration fails closed before the self-hosted job is scheduled.
+Actual path type, repository, checkpoint, and retained-input verification remains
+inside the read-only self-hosted job.
+
+## Bounded runner queue
+
+A hosted watchdog monitors the workflow's self-hosted execution job through the
+GitHub Actions jobs API. If no runner accepts the job within 20 minutes, the
+watchdog first publishes a target-closed timeout receipt to issue 49 and then
+cancels the workflow run. This prevents an unavailable runner from leaving the
+scientific request silently queued for many hours. It does not inspect runner
+host details, retained paths, provider inputs, or outcomes.
+
+The exact retry may be dispatched again after a matching
+`[self-hosted, Linux, X64, nvidia-smi]` runner is online. The same request ID and
+historical execution SHA must be supplied.
 
 ## Execution
 
-The workflow:
+The self-hosted job has `contents: read` only. It receives no pull-request fields,
+no writable repository token, and no secret-valued command input. The workflow:
 
-1. builds one wheel from the exact merged revision;
+1. builds one wheel from the exact authorized revision;
 2. installs that wheel in an isolated environment;
 3. verifies the retained CUT3R checkout, checkpoint, Deform360 processed source
    root, BayesianPhysTwin selection lock, protocol, wheel, and input sidecars;
@@ -38,7 +85,8 @@ The workflow:
    pass;
 7. sanitizes protected filesystem paths before publication;
 8. uploads checksummed evidence; and
-9. posts queued and terminal workflow pointers to issue 49 from hosted jobs.
+9. posts authorization, blocker, timeout, and terminal receipts to issue 49 from
+   hosted jobs.
 
 The v2 request supersedes the earlier request only because that run produced no
 observable terminal receipt. It does not change the ten source groups, twelve
@@ -52,3 +100,5 @@ truth, fit uncertainty, open confirmation or target payloads, run
 BayesianPhysTwin, or run Causal4D. A support-positive receipt authorizes only
 publication of the exact source-freeze and comparison-lock bytes. A
 support-negative receipt is the terminal result for this frozen source design.
+Configuration and runner-timeout receipts are operational negatives with zero
+scientific evidence.

--- a/scripts/ci/cut3r_execution_preflight.py
+++ b/scripts/ci/cut3r_execution_preflight.py
@@ -24,9 +24,7 @@ PROFILE: Final = "cut3r-deform360-source-freeze"
 AUTHORIZATION_MODE: Final = "merged-main-read-only-self-hosted-v1"
 READINESS_SCHEMA: Final = "prob4d.cut3r-source-freeze-variable-readiness"
 READINESS_VERSION: Final = 1
-REQUEST_PATH: Final = (
-    "protocols/execution_requests/cut3r_deform360_source_freeze_v2.json"
-)
+REQUEST_PATH: Final = "protocols/execution_requests/cut3r_deform360_source_freeze_v2.json"
 DRIVER_PATH: Final = "scripts/science/run_cut3r_source_freeze_execution.py"
 EXPECTED_REQUEST_FIELDS: Final = frozenset(
     {
@@ -86,17 +84,13 @@ def _content_id(value: object) -> str:
 
 def _lower_hex(value: object, *, name: str, length: int) -> str:
     if type(value) is not str or re.fullmatch(rf"[0-9a-f]{{{length}}}", value) is None:
-        raise ValueError(
-            f"{name} must be an exact lowercase {length}-character hexadecimal value"
-        )
+        raise ValueError(f"{name} must be an exact lowercase {length}-character hexadecimal value")
     return value
 
 
 def _variable_name(value: object) -> str:
     if type(value) is not str or re.fullmatch(r"[A-Z][A-Z0-9_]*", value) is None:
-        raise ValueError(
-            "required variable names must match [A-Z][A-Z0-9_]* exactly"
-        )
+        raise ValueError("required variable names must match [A-Z][A-Z0-9_]* exactly")
     return value
 
 
@@ -158,8 +152,7 @@ def _validate_request_identity(request: Mapping[str, Any]) -> str:
         missing = sorted(EXPECTED_REQUEST_FIELDS - set(request))
         extra = sorted(set(request) - EXPECTED_REQUEST_FIELDS)
         raise ValueError(
-            "source-freeze execution request fields changed; "
-            f"missing={missing}, extra={extra}"
+            f"source-freeze execution request fields changed; missing={missing}, extra={extra}"
         )
     if request.get("schema") != REQUEST_SCHEMA:
         raise ValueError("unexpected source-freeze execution-request schema")
@@ -170,9 +163,7 @@ def _validate_request_identity(request: Mapping[str, Any]) -> str:
     if request.get("authorization_mode") != AUTHORIZATION_MODE:
         raise ValueError("source-freeze authorization mode changed")
     if any(request.get(name) is not False for name in FALSE_BOUNDARY_FIELDS):
-        raise ValueError(
-            "source-freeze execution request exceeds its target-closed boundary"
-        )
+        raise ValueError("source-freeze execution request exceeds its target-closed boundary")
     request_id = _lower_hex(request.get("request_id"), name="request_id", length=64)
     identity = dict(request)
     identity.pop("request_id", None)

--- a/scripts/ci/cut3r_execution_preflight.py
+++ b/scripts/ci/cut3r_execution_preflight.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python3
+"""Target-closed authorization and environment checks for retained CUT3R runs.
+
+The helper has no provider, dataset, residual, truth, confirmation, or target I/O.
+It verifies that a manually retried execution uses the exact historical merged-main
+request bytes and reports only whether required repository-variable names are set.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final, cast
+
+REQUEST_SCHEMA: Final = "prob4d.cut3r-deform360-source-freeze-execution-request"
+REQUEST_VERSION: Final = 2
+PROFILE: Final = "cut3r-deform360-source-freeze"
+AUTHORIZATION_MODE: Final = "merged-main-read-only-self-hosted-v1"
+READINESS_SCHEMA: Final = "prob4d.cut3r-source-freeze-variable-readiness"
+READINESS_VERSION: Final = 1
+REQUEST_PATH: Final = (
+    "protocols/execution_requests/cut3r_deform360_source_freeze_v2.json"
+)
+DRIVER_PATH: Final = "scripts/science/run_cut3r_source_freeze_execution.py"
+EXPECTED_REQUEST_FIELDS: Final = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "request_id",
+        "issue_number",
+        "profile",
+        "authorization_mode",
+        "supersedes_request_id",
+        "source_protocol_path",
+        "source_protocol_git_blob_sha",
+        "source_group_count",
+        "forbidden_target_group_count",
+        "repository_write_token_on_self_hosted",
+        "environment_approval_required",
+        "source_rgb_frames_decoded",
+        "source_prediction_payloads_opened",
+        "source_residuals_or_truth_opened",
+        "target_payloads_opened",
+        "target_outcomes_opened",
+        "comparison_execution_authorized",
+        "claim_boundary",
+    }
+)
+FALSE_BOUNDARY_FIELDS: Final = (
+    "repository_write_token_on_self_hosted",
+    "environment_approval_required",
+    "source_rgb_frames_decoded",
+    "source_prediction_payloads_opened",
+    "source_residuals_or_truth_opened",
+    "target_payloads_opened",
+    "target_outcomes_opened",
+    "comparison_execution_authorized",
+)
+CLAIM_BOUNDARY: Final = (
+    "Operational authorization and repository-variable presence only. This helper "
+    "does not inspect retained paths, execute CUT3R, decode RGB, open source "
+    "residuals or truth, access confirmation or target payloads, run "
+    "BayesianPhysTwin or Causal4D, or establish a scientific result."
+)
+
+
+def _canonical_json_bytes(value: object) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _content_id(value: object) -> str:
+    return hashlib.sha256(_canonical_json_bytes(value)).hexdigest()
+
+
+def _lower_hex(value: object, *, name: str, length: int) -> str:
+    if type(value) is not str or re.fullmatch(rf"[0-9a-f]{{{length}}}", value) is None:
+        raise ValueError(
+            f"{name} must be an exact lowercase {length}-character hexadecimal value"
+        )
+    return value
+
+
+def _variable_name(value: object) -> str:
+    if type(value) is not str or re.fullmatch(r"[A-Z][A-Z0-9_]*", value) is None:
+        raise ValueError(
+            "required variable names must match [A-Z][A-Z0-9_]* exactly"
+        )
+    return value
+
+
+def _load_json_object(path: Path, *, name: str) -> dict[str, Any]:
+    if path.is_symlink() or not path.is_file():
+        raise ValueError(f"{name} must be an ordinary file")
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"failed to load {name}: {error}") from error
+    if type(value) is not dict or any(type(key) is not str for key in value):
+        raise ValueError(f"{name} must be a JSON object with exact string keys")
+    return cast(dict[str, Any], value)
+
+
+def _git_output(arguments: Sequence[str], *, repository: Path) -> str:
+    try:
+        return subprocess.run(
+            ["git", *arguments],
+            cwd=repository,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError) as error:
+        raise ValueError(f"git {' '.join(arguments)} failed") from error
+
+
+def _git_success(arguments: Sequence[str], *, repository: Path) -> bool:
+    try:
+        completed = subprocess.run(
+            ["git", *arguments],
+            cwd=repository,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError as error:
+        raise ValueError(f"git {' '.join(arguments)} failed") from error
+    if completed.returncode not in {0, 1}:
+        raise ValueError(f"git {' '.join(arguments)} failed")
+    return completed.returncode == 0
+
+
+def _relative_repository_path(path: Path, repository: Path, *, name: str) -> str:
+    resolved_repository = repository.resolve()
+    resolved = path.resolve()
+    try:
+        relative = resolved.relative_to(resolved_repository)
+    except ValueError as error:
+        raise ValueError(f"{name} must be inside the repository") from error
+    if path.is_symlink() or not path.is_file():
+        raise ValueError(f"{name} must be an ordinary repository file")
+    return relative.as_posix()
+
+
+def _validate_request_identity(request: Mapping[str, Any]) -> str:
+    if set(request) != EXPECTED_REQUEST_FIELDS:
+        missing = sorted(EXPECTED_REQUEST_FIELDS - set(request))
+        extra = sorted(set(request) - EXPECTED_REQUEST_FIELDS)
+        raise ValueError(
+            "source-freeze execution request fields changed; "
+            f"missing={missing}, extra={extra}"
+        )
+    if request.get("schema") != REQUEST_SCHEMA:
+        raise ValueError("unexpected source-freeze execution-request schema")
+    if request.get("schema_version") != REQUEST_VERSION:
+        raise ValueError("unsupported source-freeze execution-request version")
+    if request.get("profile") != PROFILE:
+        raise ValueError("source-freeze execution request names the wrong profile")
+    if request.get("authorization_mode") != AUTHORIZATION_MODE:
+        raise ValueError("source-freeze authorization mode changed")
+    if any(request.get(name) is not False for name in FALSE_BOUNDARY_FIELDS):
+        raise ValueError(
+            "source-freeze execution request exceeds its target-closed boundary"
+        )
+    request_id = _lower_hex(request.get("request_id"), name="request_id", length=64)
+    identity = dict(request)
+    identity.pop("request_id", None)
+    if _content_id(identity) != request_id:
+        raise ValueError("source-freeze execution request ID mismatch")
+    return request_id
+
+
+def authorize_retry(
+    *,
+    repository: Path,
+    request_path: Path,
+    current_revision: str,
+    execution_revision: str,
+    expected_request_id: str,
+) -> dict[str, str]:
+    """Authorize one exact historical merged-main retry without changing bytes."""
+
+    repository = repository.resolve()
+    if not (repository / ".git").exists():
+        raise ValueError("repository must be a Git checkout")
+    request_relative = _relative_repository_path(
+        request_path,
+        repository,
+        name="request",
+    )
+    if request_relative != REQUEST_PATH:
+        raise ValueError("retry request path changed")
+
+    current = _lower_hex(current_revision, name="current_revision", length=40)
+    execution = _lower_hex(execution_revision, name="execution_revision", length=40)
+    expected_id = _lower_hex(
+        expected_request_id,
+        name="expected_request_id",
+        length=64,
+    )
+    head = _lower_hex(
+        _git_output(["rev-parse", "HEAD"], repository=repository),
+        name="repository HEAD",
+        length=40,
+    )
+    if head != current:
+        raise ValueError("current workflow checkout differs from current_revision")
+    if _git_output(
+        ["status", "--porcelain=v1", "--untracked-files=all"],
+        repository=repository,
+    ):
+        raise ValueError("retry authorization checkout must be clean")
+    if not _git_success(
+        ["merge-base", "--is-ancestor", execution, current],
+        repository=repository,
+    ):
+        raise ValueError("execution_revision is not an ancestor of current main")
+
+    current_request_blob = _lower_hex(
+        _git_output(
+            ["rev-parse", f"{current}:{request_relative}"],
+            repository=repository,
+        ),
+        name="current request blob",
+        length=40,
+    )
+    execution_request_blob = _lower_hex(
+        _git_output(
+            ["rev-parse", f"{execution}:{request_relative}"],
+            repository=repository,
+        ),
+        name="execution request blob",
+        length=40,
+    )
+    if current_request_blob != execution_request_blob:
+        raise ValueError("historical and current execution-request bytes differ")
+
+    request = _load_json_object(request_path, name="source-freeze execution request")
+    request_id = _validate_request_identity(request)
+    if request_id != expected_id:
+        raise ValueError("workflow-dispatch request_id differs from retained request")
+
+    protocol_path = request.get("source_protocol_path")
+    if type(protocol_path) is not str or protocol_path.startswith("/"):
+        raise ValueError("source_protocol_path must be a repository-relative string")
+    expected_protocol_blob = _lower_hex(
+        request.get("source_protocol_git_blob_sha"),
+        name="source_protocol_git_blob_sha",
+        length=40,
+    )
+    historical_protocol_blob = _lower_hex(
+        _git_output(
+            ["rev-parse", f"{execution}:{protocol_path}"],
+            repository=repository,
+        ),
+        name="historical protocol blob",
+        length=40,
+    )
+    if historical_protocol_blob != expected_protocol_blob:
+        raise ValueError("historical protocol bytes differ from the retained request")
+    if not _git_success(
+        ["cat-file", "-e", f"{execution}:{DRIVER_PATH}"],
+        repository=repository,
+    ):
+        raise ValueError("historical execution revision lacks the reviewed driver")
+
+    ancestry = _git_output(
+        ["rev-list", "--parents", "-n", "1", execution],
+        repository=repository,
+    ).split()
+    if not ancestry or ancestry[0] != execution:
+        raise ValueError("failed to resolve the historical execution ancestry")
+    base_revision = _lower_hex(
+        ancestry[1] if len(ancestry) > 1 else execution,
+        name="execution base revision",
+        length=40,
+    )
+    return {
+        "head_sha": execution,
+        "base_sha": base_revision,
+        "request_id": request_id,
+        "profile": PROFILE,
+        "authorization_mode": AUTHORIZATION_MODE,
+        "trigger_mode": "workflow_dispatch_exact_retry",
+        "current_main_sha": current,
+    }
+
+
+def variable_readiness(
+    required_variables: Sequence[str],
+    *,
+    environment: Mapping[str, str],
+) -> dict[str, object]:
+    """Return a bounded presence-only report; variable values never enter it."""
+
+    names = tuple(sorted({_variable_name(value) for value in required_variables}))
+    if not names:
+        raise ValueError("at least one required variable name is required")
+    missing = tuple(name for name in names if not environment.get(name, "").strip())
+    return {
+        "schema": READINESS_SCHEMA,
+        "schema_version": READINESS_VERSION,
+        "required_variables": list(names),
+        "configured_variable_count": len(names) - len(missing),
+        "missing_variables": list(missing),
+        "ready": not missing,
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+
+
+def _write_json(path: Path, value: object) -> None:
+    if path.exists() and path.is_symlink():
+        raise ValueError("refusing to write readiness report through a symlink")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_github_output(path: Path, values: Mapping[str, object]) -> None:
+    with path.open("a", encoding="utf-8") as output:
+        for name, value in values.items():
+            if isinstance(value, bool):
+                encoded = "true" if value else "false"
+            elif isinstance(value, (list, dict)):
+                encoded = json.dumps(value, sort_keys=True, separators=(",", ":"))
+            else:
+                encoded = str(value)
+            if "\n" in encoded or "\r" in encoded:
+                raise ValueError(f"GitHub output {name!r} contains a newline")
+            output.write(f"{name}={encoded}\n")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    retry = subparsers.add_parser(
+        "authorize-retry",
+        help="authorize an exact historical merged-main source-freeze retry",
+    )
+    retry.add_argument("--repository", type=Path, required=True)
+    retry.add_argument("--request", type=Path, required=True)
+    retry.add_argument("--current-revision", required=True)
+    retry.add_argument("--execution-revision", required=True)
+    retry.add_argument("--expected-request-id", required=True)
+    retry.add_argument("--github-output", type=Path)
+
+    variables = subparsers.add_parser(
+        "check-variables",
+        help="check required repository-variable names without publishing values",
+    )
+    variables.add_argument("--required-variable", action="append", default=[])
+    variables.add_argument("--report", type=Path)
+    variables.add_argument("--github-output", type=Path)
+    variables.add_argument("--require-ready", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.command == "authorize-retry":
+        result = authorize_retry(
+            repository=args.repository,
+            request_path=args.request,
+            current_revision=args.current_revision,
+            execution_revision=args.execution_revision,
+            expected_request_id=args.expected_request_id,
+        )
+        if args.github_output is not None:
+            _write_github_output(args.github_output, result)
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return 0
+
+    report = variable_readiness(
+        args.required_variable,
+        environment=os.environ,
+    )
+    if args.report is not None:
+        _write_json(args.report, report)
+    if args.github_output is not None:
+        _write_github_output(
+            args.github_output,
+            {
+                "ready": report["ready"],
+                "configured_variable_count": report["configured_variable_count"],
+                "missing_variables_json": report["missing_variables"],
+            },
+        )
+    print(json.dumps(report, indent=2, sort_keys=True))
+    if args.require_ready and report["ready"] is not True:
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cut3r_exact_retry_invocation.py
+++ b/tests/test_cut3r_exact_retry_invocation.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCUMENT = ROOT / "docs" / "cut3r-exact-retry-invocation.md"
+REQUEST = (
+    ROOT
+    / "protocols"
+    / "execution_requests"
+    / "cut3r_deform360_source_freeze_v2.json"
+)
+
+
+def test_exact_retry_invocation_binds_the_retained_zero_evidence_request() -> None:
+    text = DOCUMENT.read_text(encoding="utf-8")
+    request = REQUEST.read_text(encoding="utf-8")
+
+    assert "8b923e8cd67ca65f09312cffe305e36852f36fbb" in text
+    assert "8f3c9fba12f8a16895edce89d7a92e4806a43cb2f34b5a05faff71945809b63e" in text
+    assert "8f3c9fba12f8a16895edce89d7a92e4806a43cb2f34b5a05faff71945809b63e" in request
+    assert "20 minutes" in text
+    assert "target-closed" in text

--- a/tests/test_cut3r_execution_preflight.py
+++ b/tests/test_cut3r_execution_preflight.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+import subprocess
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "ci" / "cut3r_execution_preflight.py"
+REQUEST_RELATIVE = Path(
+    "protocols/execution_requests/cut3r_deform360_source_freeze_v2.json"
+)
+PROTOCOL_RELATIVE = Path("protocols/cut3r_deform360_source_v1.json")
+DRIVER_RELATIVE = Path("scripts/science/run_cut3r_source_freeze_execution.py")
+
+
+def _module() -> ModuleType:
+    specification = importlib.util.spec_from_file_location(
+        "cut3r_execution_preflight",
+        SCRIPT,
+    )
+    assert specification is not None
+    assert specification.loader is not None
+    module = importlib.util.module_from_spec(specification)
+    specification.loader.exec_module(module)
+    return module
+
+
+def _run(*arguments: str, cwd: Path) -> str:
+    return subprocess.run(
+        ["git", *arguments],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _canonical_id(value: object) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def _request(protocol_blob: str) -> dict[str, object]:
+    request: dict[str, object] = {
+        "authorization_mode": "merged-main-read-only-self-hosted-v1",
+        "claim_boundary": "fixture target-closed request",
+        "comparison_execution_authorized": False,
+        "environment_approval_required": False,
+        "forbidden_target_group_count": 12,
+        "issue_number": 49,
+        "profile": "cut3r-deform360-source-freeze",
+        "repository_write_token_on_self_hosted": False,
+        "schema": "prob4d.cut3r-deform360-source-freeze-execution-request",
+        "schema_version": 2,
+        "source_group_count": 10,
+        "source_prediction_payloads_opened": False,
+        "source_protocol_git_blob_sha": protocol_blob,
+        "source_protocol_path": PROTOCOL_RELATIVE.as_posix(),
+        "source_residuals_or_truth_opened": False,
+        "source_rgb_frames_decoded": False,
+        "supersedes_request_id": "0" * 64,
+        "target_outcomes_opened": False,
+        "target_payloads_opened": False,
+    }
+    request["request_id"] = _canonical_id(request)
+    return request
+
+
+def _repository(tmp_path: Path) -> tuple[Path, str, str, str]:
+    repository = tmp_path / "repository"
+    repository.mkdir()
+    _run("init", "-q", "-b", "main", cwd=repository)
+    _run("config", "user.name", "Prob4D tests", cwd=repository)
+    _run("config", "user.email", "tests@example.invalid", cwd=repository)
+
+    protocol = repository / PROTOCOL_RELATIVE
+    protocol.parent.mkdir(parents=True)
+    protocol.write_text('{"schema":"fixture"}\n', encoding="utf-8")
+    driver = repository / DRIVER_RELATIVE
+    driver.parent.mkdir(parents=True)
+    driver.write_text("raise SystemExit(0)\n", encoding="utf-8")
+    protocol_blob = _run("hash-object", PROTOCOL_RELATIVE.as_posix(), cwd=repository)
+
+    request = _request(protocol_blob)
+    request_path = repository / REQUEST_RELATIVE
+    request_path.parent.mkdir(parents=True)
+    request_path.write_text(
+        json.dumps(request, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    _run("add", ".", cwd=repository)
+    _run("commit", "-qm", "historical request", cwd=repository)
+    historical = _run("rev-parse", "HEAD", cwd=repository)
+
+    (repository / "unrelated.txt").write_text("later main change\n", encoding="utf-8")
+    _run("add", "unrelated.txt", cwd=repository)
+    _run("commit", "-qm", "later main change", cwd=repository)
+    current = _run("rev-parse", "HEAD", cwd=repository)
+    return repository, historical, current, str(request["request_id"])
+
+
+def test_variable_readiness_reports_names_only() -> None:
+    module = _module()
+    secret_value = "/retained/private/path"
+
+    report = module.variable_readiness(
+        ["CUT3R_CHECKPOINT", "BPT_CHECKOUT", "CUT3R_CHECKPOINT"],
+        environment={
+            "BPT_CHECKOUT": secret_value,
+            "CUT3R_CHECKPOINT": "   ",
+        },
+    )
+
+    assert report["required_variables"] == ["BPT_CHECKOUT", "CUT3R_CHECKPOINT"]
+    assert report["configured_variable_count"] == 1
+    assert report["missing_variables"] == ["CUT3R_CHECKPOINT"]
+    assert report["ready"] is False
+    assert secret_value not in json.dumps(report)
+
+
+def test_variable_readiness_rejects_invalid_names() -> None:
+    module = _module()
+
+    with pytest.raises(ValueError, match="required variable names"):
+        module.variable_readiness(["bad-name"], environment={})
+    with pytest.raises(ValueError, match="at least one"):
+        module.variable_readiness([], environment={})
+
+
+def test_exact_historical_retry_is_authorized(tmp_path: Path) -> None:
+    module = _module()
+    repository, historical, current, request_id = _repository(tmp_path)
+
+    result = module.authorize_retry(
+        repository=repository,
+        request_path=repository / REQUEST_RELATIVE,
+        current_revision=current,
+        execution_revision=historical,
+        expected_request_id=request_id,
+    )
+
+    assert result["head_sha"] == historical
+    assert result["current_main_sha"] == current
+    assert result["request_id"] == request_id
+    assert result["trigger_mode"] == "workflow_dispatch_exact_retry"
+    assert result["profile"] == "cut3r-deform360-source-freeze"
+
+
+def test_retry_rejects_request_byte_drift(tmp_path: Path) -> None:
+    module = _module()
+    repository, historical, _, request_id = _repository(tmp_path)
+    request_path = repository / REQUEST_RELATIVE
+    request = json.loads(request_path.read_text(encoding="utf-8"))
+    request["claim_boundary"] = "changed current request"
+    identity = dict(request)
+    identity.pop("request_id")
+    request["request_id"] = _canonical_id(identity)
+    request_path.write_text(
+        json.dumps(request, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    _run("add", REQUEST_RELATIVE.as_posix(), cwd=repository)
+    _run("commit", "-qm", "change request", cwd=repository)
+    current = _run("rev-parse", "HEAD", cwd=repository)
+
+    with pytest.raises(ValueError, match="request bytes differ"):
+        module.authorize_retry(
+            repository=repository,
+            request_path=request_path,
+            current_revision=current,
+            execution_revision=historical,
+            expected_request_id=request_id,
+        )
+
+
+def test_retry_rejects_request_field_drift(tmp_path: Path) -> None:
+    module = _module()
+    repository, historical, _, request_id = _repository(tmp_path)
+    request_path = repository / REQUEST_RELATIVE
+    request = json.loads(request_path.read_text(encoding="utf-8"))
+    request["unexpected"] = "field"
+    identity = dict(request)
+    identity.pop("request_id")
+    request["request_id"] = _canonical_id(identity)
+    request_path.write_text(
+        json.dumps(request, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    _run("add", REQUEST_RELATIVE.as_posix(), cwd=repository)
+    _run("commit", "-qm", "add unexpected request field", cwd=repository)
+    current = _run("rev-parse", "HEAD", cwd=repository)
+
+    with pytest.raises(ValueError, match="request bytes differ"):
+        module.authorize_retry(
+            repository=repository,
+            request_path=request_path,
+            current_revision=current,
+            execution_revision=historical,
+            expected_request_id=request_id,
+        )
+
+
+def test_retry_rejects_nonancestor_revision(tmp_path: Path) -> None:
+    module = _module()
+    repository, _, current, request_id = _repository(tmp_path)
+    _run("checkout", "--orphan", "unrelated-history", cwd=repository)
+    _run("rm", "-rf", ".", cwd=repository)
+    (repository / "orphan.txt").write_text("unrelated\n", encoding="utf-8")
+    _run("add", "orphan.txt", cwd=repository)
+    _run("commit", "-qm", "unrelated history", cwd=repository)
+    unrelated = _run("rev-parse", "HEAD", cwd=repository)
+    _run("checkout", "main", cwd=repository)
+
+    with pytest.raises(ValueError, match="not an ancestor"):
+        module.authorize_retry(
+            repository=repository,
+            request_path=repository / REQUEST_RELATIVE,
+            current_revision=current,
+            execution_revision=unrelated,
+            expected_request_id=request_id,
+        )
+
+
+def test_check_variables_cli_returns_registered_not_ready_status(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _module()
+    report_path = tmp_path / "readiness.json"
+    output_path = tmp_path / "github-output.txt"
+    monkeypatch.setenv("BPT_CHECKOUT", "/configured")
+    monkeypatch.delenv("CUT3R_CHECKPOINT", raising=False)
+
+    status = module.main(
+        [
+            "check-variables",
+            "--required-variable",
+            "BPT_CHECKOUT",
+            "--required-variable",
+            "CUT3R_CHECKPOINT",
+            "--report",
+            os.fspath(report_path),
+            "--github-output",
+            os.fspath(output_path),
+            "--require-ready",
+        ]
+    )
+
+    assert status == 3
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["missing_variables"] == ["CUT3R_CHECKPOINT"]
+    outputs = output_path.read_text(encoding="utf-8")
+    assert "ready=false" in outputs
+    assert 'missing_variables_json=["CUT3R_CHECKPOINT"]' in outputs

--- a/tests/test_cut3r_execution_preflight.py
+++ b/tests/test_cut3r_execution_preflight.py
@@ -12,9 +12,7 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "ci" / "cut3r_execution_preflight.py"
-REQUEST_RELATIVE = Path(
-    "protocols/execution_requests/cut3r_deform360_source_freeze_v2.json"
-)
+REQUEST_RELATIVE = Path("protocols/execution_requests/cut3r_deform360_source_freeze_v2.json")
 PROTOCOL_RELATIVE = Path("protocols/cut3r_deform360_source_v1.json")
 DRIVER_RELATIVE = Path("scripts/science/run_cut3r_source_freeze_execution.py")
 

--- a/tests/test_trusted_self_hosted_validation_policy.py
+++ b/tests/test_trusted_self_hosted_validation_policy.py
@@ -20,7 +20,10 @@ REMOVED_TEMPORARY_WORKFLOWS = (
 
 
 def _workflow_files() -> tuple[Path, ...]:
-    return tuple(sorted(WORKFLOW_ROOT.glob("*.yml")) + sorted(WORKFLOW_ROOT.glob("*.yaml")))
+    return tuple(
+        sorted(WORKFLOW_ROOT.glob("*.yml"))
+        + sorted(WORKFLOW_ROOT.glob("*.yaml"))
+    )
 
 
 def _uses_self_hosted_runner(text: str) -> bool:
@@ -36,7 +39,9 @@ def _uses_self_hosted_runner(text: str) -> bool:
             continuation_stripped = continuation.lstrip()
             if not continuation_stripped:
                 continue
-            continuation_indentation = len(continuation) - len(continuation_stripped)
+            continuation_indentation = len(continuation) - len(
+                continuation_stripped
+            )
             if continuation_indentation <= indentation:
                 break
             if "self-hosted" in continuation:
@@ -116,7 +121,9 @@ def test_source_freeze_execution_is_merged_main_bound_and_target_closed() -> Non
 
     assert "\n  push:" in text
     assert "branches: [main]" in text
-    assert ("protocols/execution_requests/cut3r_deform360_source_freeze_v1.json") in text
+    assert (
+        "protocols/execution_requests/cut3r_deform360_source_freeze_v1.json"
+    ) in text
     assert "pull_request_target:" not in text
     assert "github.event_name == 'push'" in text
     assert 'test "$EVENT_REF" = "refs/heads/main"' in text
@@ -153,28 +160,45 @@ def test_source_freeze_execution_keeps_write_permission_off_self_hosted_job() ->
     assert "runs-on: ubuntu-latest" in report
 
 
-def test_auto_v2_source_freeze_is_exact_main_bound_and_read_only() -> None:
+def test_auto_v2_source_freeze_supports_exact_retry_and_bounded_queue() -> None:
     text = SOURCE_FREEZE_AUTO_V2_WORKFLOW.read_text(encoding="utf-8")
 
     assert "\n  push:" in text
+    assert "\n  workflow_dispatch:" in text
+    assert "execution_sha:" in text
+    assert "request_id:" in text
     assert "branches: [main]" in text
     assert "pull_request_target:" not in text
-    assert "if: github.event_name == 'push'" in text
     assert 'test "$EVENT_REF" = "refs/heads/main"' in text
     assert 'test "$EVENT_AFTER" = "$EXPECTED_SHA"' in text
     assert 'test "$EVENT_FORCED" = "false"' in text
     assert 'test "$EVENT_DELETED" = "false"' in text
+    assert "authorize-retry" in text
+    assert "--execution-revision \"$EXECUTION_SHA\"" in text
+    assert "--expected-request-id \"$EXPECTED_REQUEST_ID\"" in text
     assert "ref: ${{ needs.authorize.outputs.head_sha }}" in text
     assert "runs-on: [self-hosted, Linux, X64, nvidia-smi]" in text
+    assert "check-variables" in text
+    assert "missing repository-variable names" in text
+    assert "Bound self-hosted runner acceptance wait" in text
+    assert "RUNNER_ACCEPTANCE_TIMEOUT_SECONDS: \"1200\"" in text
+    assert "/actions/runs/{run_id}/jobs" in text
+    assert "/actions/runs/{run_id}/cancel" in text
+    assert "actions: write" in text
 
     execute_start = text.index("\n  execute:")
+    watchdog_start = text.index("\n  watchdog:")
     report_start = text.index("\n  report:")
-    execute = text[execute_start:report_start]
+    execute = text[execute_start:watchdog_start]
+    watchdog = text[watchdog_start:report_start]
     report = text[report_start:]
 
-    assert "if: github.event_name == 'push'" in execute
+    assert "success() &&" in execute
+    assert "github.event_name == 'workflow_dispatch'" in execute
+    assert "needs: [contract, authorize, preflight, announce]" in execute
     assert "permissions:\n      contents: read" in execute
     assert "issues: write" not in execute
+    assert "actions: write" not in execute
     assert "contents: write" not in execute
     assert "pull-requests: write" not in execute
     assert "persist-credentials: false" in execute
@@ -182,6 +206,13 @@ def test_auto_v2_source_freeze_is_exact_main_bound_and_read_only() -> None:
     assert "repository_write_token_on_self_hosted=false" in execute
     assert "environment_approval_required=false" in execute
     assert "git push" not in execute
+
+    assert "runs-on: ubuntu-latest" in watchdog
+    assert "actions: write" in watchdog
+    assert "issues: write" in watchdog
+    assert "runner acceptance timeout" in watchdog
+    assert "always() &&" in report
+    assert "github.event_name == 'workflow_dispatch'" in report
     assert "runs-on: ubuntu-latest" in report
     assert "issues: write" in report
 

--- a/tests/test_trusted_self_hosted_validation_policy.py
+++ b/tests/test_trusted_self_hosted_validation_policy.py
@@ -20,10 +20,7 @@ REMOVED_TEMPORARY_WORKFLOWS = (
 
 
 def _workflow_files() -> tuple[Path, ...]:
-    return tuple(
-        sorted(WORKFLOW_ROOT.glob("*.yml"))
-        + sorted(WORKFLOW_ROOT.glob("*.yaml"))
-    )
+    return tuple(sorted(WORKFLOW_ROOT.glob("*.yml")) + sorted(WORKFLOW_ROOT.glob("*.yaml")))
 
 
 def _uses_self_hosted_runner(text: str) -> bool:
@@ -39,9 +36,7 @@ def _uses_self_hosted_runner(text: str) -> bool:
             continuation_stripped = continuation.lstrip()
             if not continuation_stripped:
                 continue
-            continuation_indentation = len(continuation) - len(
-                continuation_stripped
-            )
+            continuation_indentation = len(continuation) - len(continuation_stripped)
             if continuation_indentation <= indentation:
                 break
             if "self-hosted" in continuation:
@@ -121,9 +116,7 @@ def test_source_freeze_execution_is_merged_main_bound_and_target_closed() -> Non
 
     assert "\n  push:" in text
     assert "branches: [main]" in text
-    assert (
-        "protocols/execution_requests/cut3r_deform360_source_freeze_v1.json"
-    ) in text
+    assert ("protocols/execution_requests/cut3r_deform360_source_freeze_v1.json") in text
     assert "pull_request_target:" not in text
     assert "github.event_name == 'push'" in text
     assert 'test "$EVENT_REF" = "refs/heads/main"' in text
@@ -174,14 +167,14 @@ def test_auto_v2_source_freeze_supports_exact_retry_and_bounded_queue() -> None:
     assert 'test "$EVENT_FORCED" = "false"' in text
     assert 'test "$EVENT_DELETED" = "false"' in text
     assert "authorize-retry" in text
-    assert "--execution-revision \"$EXECUTION_SHA\"" in text
-    assert "--expected-request-id \"$EXPECTED_REQUEST_ID\"" in text
+    assert '--execution-revision "$EXECUTION_SHA"' in text
+    assert '--expected-request-id "$EXPECTED_REQUEST_ID"' in text
     assert "ref: ${{ needs.authorize.outputs.head_sha }}" in text
     assert "runs-on: [self-hosted, Linux, X64, nvidia-smi]" in text
     assert "check-variables" in text
     assert "missing repository-variable names" in text
     assert "Bound self-hosted runner acceptance wait" in text
-    assert "RUNNER_ACCEPTANCE_TIMEOUT_SECONDS: \"1200\"" in text
+    assert 'RUNNER_ACCEPTANCE_TIMEOUT_SECONDS: "1200"' in text
     assert "/actions/runs/{run_id}/jobs" in text
     assert "/actions/runs/{run_id}/cancel" in text
     assert "actions: write" in text


### PR DESCRIPTION
## Summary

- add a `main`-only manual retry for the cancelled retained CUT3R source-freeze request;
- prove the requested historical revision is merged-main ancestry and carries byte-identical request and protocol bindings;
- execute the exact historical authorized revision rather than silently using newer development code;
- check required repository-variable names on a hosted runner without exposing values or retained paths;
- fail before privileged scheduling when configuration is incomplete;
- bound self-hosted runner acceptance to 20 minutes, post a target-closed receipt, and cancel an unaccepted run;
- add ancestry, request-drift, identity, redaction, workflow-policy, and exact-invocation tests;
- document the exact retry literals for the earlier zero-evidence cancelled request.

## Validation

Focused local validation before opening covered the new helper and policy path. Authoritative exact-head GitHub Actions are the merge gate. The initial CI run found only canonical Ruff formatting differences; those were repaired on the branch. Current exact-head quality, CUT3R contract, provider-preflight, and automatic-v2 workflow lanes are green while the full Python matrix and security scan finish.

## Scientific boundary

This changes execution control only. It changes no CUT3R, Prob4D, BayesianPhysTwin, or Causal4D estimator; no provider revision, checkpoint, cohort, camera panel, prefix, support threshold, comparison arm, fallback, or target-access rule; and no scientific claim. Configuration and queue-timeout receipts contain zero scientific evidence. The source-input freeze remains unable to decode RGB, open source residuals or truth, access confirmation or target payloads, or run downstream BayesianPhysTwin/Causal4D inference.