### PR TITLE
Route CUT3R source freezes by data and capability labels

### DIFF
--- a/.github/workflows/cut3r-source-freeze-auto-v2.yml
+++ b/.github/workflows/cut3r-source-freeze-auto-v2.yml
@@ -367,7 +367,7 @@ jobs:
     needs: [contract, authorize, preflight, announce]
     permissions:
       contents: read
-    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    runs-on: [self-hosted, Linux, X64, nvidia-smi, data-prob4d-deform360-source-v1, prob4d-cut3r]
     timeout-minutes: 180
     outputs:
       artifact_name: ${{ steps.freeze.outputs.artifact_name }}

--- a/.github/workflows/cut3r-source-freeze-execution.yml
+++ b/.github/workflows/cut3r-source-freeze-execution.yml
@@ -218,7 +218,7 @@ jobs:
     permissions:
       contents: read
     environment: trusted-self-hosted-validation
-    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    runs-on: [self-hosted, Linux, X64, nvidia-smi, data-prob4d-deform360-source-v1, prob4d-cut3r]
     timeout-minutes: 180
     outputs:
       artifact_name: ${{ steps.freeze.outputs.artifact_name }}

--- a/.github/workflows/trusted-self-hosted-validation.yml
+++ b/.github/workflows/trusted-self-hosted-validation.yml
@@ -122,7 +122,7 @@ jobs:
     name: Validate approved exact head on workstation2
     needs: authorize
     environment: trusted-self-hosted-validation
-    runs-on: [self-hosted, Linux, X64, nvidia-smi]
+    runs-on: [self-hosted, Linux, X64, nvidia-smi, data-prob4d-deform360-source-v1, prob4d-cut3r]
     timeout-minutes: 180
     steps:
       - name: Initialize isolated validation workspace

--- a/tests/test_trusted_self_hosted_validation_policy.py
+++ b/tests/test_trusted_self_hosted_validation_policy.py
@@ -7,6 +7,10 @@ WORKFLOW_ROOT = ROOT / ".github" / "workflows"
 TRUSTED_WORKFLOW = WORKFLOW_ROOT / "trusted-self-hosted-validation.yml"
 SOURCE_FREEZE_EXECUTION_WORKFLOW = WORKFLOW_ROOT / "cut3r-source-freeze-execution.yml"
 SOURCE_FREEZE_AUTO_V2_WORKFLOW = WORKFLOW_ROOT / "cut3r-source-freeze-auto-v2.yml"
+CUT3R_RUNNER_SELECTOR = (
+    "runs-on: [self-hosted, Linux, X64, nvidia-smi, "
+    "data-prob4d-deform360-source-v1, prob4d-cut3r]"
+)
 TRUSTED_SELF_HOSTED_WORKFLOWS = (
     TRUSTED_WORKFLOW,
     SOURCE_FREEZE_EXECUTION_WORKFLOW,
@@ -67,7 +71,7 @@ def test_trusted_workflow_is_manual_main_bound_and_exact_sha_authorized() -> Non
     assert "DISPATCH_REF: ${{ github.ref }}" in text
     assert "refs/heads/main" in text
     assert "environment: trusted-self-hosted-validation" in text
-    assert "runs-on: [self-hosted, Linux, X64, nvidia-smi, data-prob4d-deform360-source-v1, prob4d-cut3r]" in text
+    assert CUT3R_RUNNER_SELECTOR in text
     assert "[0-9a-f]{40}" in text
     assert "only same-repository pull requests are admitted" in text
     assert "pull request base must be main" in text
@@ -124,7 +128,7 @@ def test_source_freeze_execution_is_merged_main_bound_and_target_closed() -> Non
     assert "source_protocol_git_blob_sha" in text
     assert "execution request ID mismatch" in text
     assert "environment: trusted-self-hosted-validation" in text
-    assert "runs-on: [self-hosted, Linux, X64, nvidia-smi, data-prob4d-deform360-source-v1, prob4d-cut3r]" in text
+    assert CUT3R_RUNNER_SELECTOR in text
     assert "ref: ${{ needs.authorize.outputs.head_sha }}" in text
     assert "persist-credentials: false" in text
     assert "contents: write" not in text
@@ -170,7 +174,7 @@ def test_auto_v2_source_freeze_supports_exact_retry_and_bounded_queue() -> None:
     assert '--execution-revision "$EXECUTION_SHA"' in text
     assert '--expected-request-id "$EXPECTED_REQUEST_ID"' in text
     assert "ref: ${{ needs.authorize.outputs.head_sha }}" in text
-    assert "runs-on: [self-hosted, Linux, X64, nvidia-smi, data-prob4d-deform360-source-v1, prob4d-cut3r]" in text
+    assert CUT3R_RUNNER_SELECTOR in text
     assert "check-variables" in text
     assert "missing repository-variable names" in text
     assert "Bound self-hosted runner acceptance wait" in text

--- a/tests/test_trusted_self_hosted_validation_policy.py
+++ b/tests/test_trusted_self_hosted_validation_policy.py
@@ -67,7 +67,7 @@ def test_trusted_workflow_is_manual_main_bound_and_exact_sha_authorized() -> Non
     assert "DISPATCH_REF: ${{ github.ref }}" in text
     assert "refs/heads/main" in text
     assert "environment: trusted-self-hosted-validation" in text
-    assert "runs-on: [self-hosted, Linux, X64, nvidia-smi]" in text
+    assert "runs-on: [self-hosted, Linux, X64, nvidia-smi, data-prob4d-deform360-source-v1, prob4d-cut3r]" in text
     assert "[0-9a-f]{40}" in text
     assert "only same-repository pull requests are admitted" in text
     assert "pull request base must be main" in text
@@ -124,7 +124,7 @@ def test_source_freeze_execution_is_merged_main_bound_and_target_closed() -> Non
     assert "source_protocol_git_blob_sha" in text
     assert "execution request ID mismatch" in text
     assert "environment: trusted-self-hosted-validation" in text
-    assert "runs-on: [self-hosted, Linux, X64, nvidia-smi]" in text
+    assert "runs-on: [self-hosted, Linux, X64, nvidia-smi, data-prob4d-deform360-source-v1, prob4d-cut3r]" in text
     assert "ref: ${{ needs.authorize.outputs.head_sha }}" in text
     assert "persist-credentials: false" in text
     assert "contents: write" not in text
@@ -170,7 +170,7 @@ def test_auto_v2_source_freeze_supports_exact_retry_and_bounded_queue() -> None:
     assert '--execution-revision "$EXECUTION_SHA"' in text
     assert '--expected-request-id "$EXPECTED_REQUEST_ID"' in text
     assert "ref: ${{ needs.authorize.outputs.head_sha }}" in text
-    assert "runs-on: [self-hosted, Linux, X64, nvidia-smi]" in text
+    assert "runs-on: [self-hosted, Linux, X64, nvidia-smi, data-prob4d-deform360-source-v1, prob4d-cut3r]" in text
     assert "check-variables" in text
     assert "missing repository-variable names" in text
     assert "Bound self-hosted runner acceptance wait" in text

--- a/tests/test_trusted_self_hosted_validation_policy.py
+++ b/tests/test_trusted_self_hosted_validation_policy.py
@@ -9,7 +9,7 @@ SOURCE_FREEZE_EXECUTION_WORKFLOW = WORKFLOW_ROOT / "cut3r-source-freeze-executio
 SOURCE_FREEZE_AUTO_V2_WORKFLOW = WORKFLOW_ROOT / "cut3r-source-freeze-auto-v2.yml"
 CUT3R_RUNNER_SELECTOR = (
     "runs-on: [self-hosted, Linux, X64, nvidia-smi, "
-    "data-prob4d-deform360-source-v1, prob4d-cut3r]"
+    + "data-prob4d-deform360-source-v1, prob4d-cut3r]"
 )
 TRUSTED_SELF_HOSTED_WORKFLOWS = (
     TRUSTED_WORKFLOW,


### PR DESCRIPTION
## Summary

- require `data-prob4d-deform360-source-v1` on the three reviewed self-hosted execution jobs because workstation2 holds the retained Deform360 source data
- also require `prob4d-cut3r`, intentionally unassigned until a runner has the required CUT3R checkout and checkpoint
- leave every hosted authorization, configuration preflight, announcement, watchdog, and terminal-report job unchanged
- update the exact selector contract assertions

## Why both labels

All three self-hosted jobs validate `CUT3R_CHECKOUT`, `CUT3R_CHECKPOINT`, and `DEFORM360_PROCESSED_ROOT` before execution. Assigning only the existing data label would route them to workstation2 even though its CUT3R checkout/checkpoint capability is not currently present. The unassigned capability label keeps the workflow fail-closed in the queue until that dependency is genuinely provisioned.

## Validation

- each reviewed workflow contains exactly one self-hosted job and that selector alone changed
- branch comparison contains only the three selector lines and the three corresponding test assertions
- hosted prerequisite and reporting jobs retain `ubuntu-latest`
