### PR TITLE
Admit exact CUT3R failure diagnostic for retry

### DIFF
--- a/.github/workflows/cut3r-exact-retry-v3-comment-dispatch.yml
+++ b/.github/workflows/cut3r-exact-retry-v3-comment-dispatch.yml
@@ -1,0 +1,149 @@
+name: Authorize exact CUT3R retry v3 from issue 49
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/cut3r-exact-retry-v3-comment-dispatch.yml"
+      - "CHANGELOG.d/cut3r-exact-retry-v3-dispatch.md"
+      - "docs/cut3r-exact-retry-v3-dispatch.md"
+      - "scripts/ci/cut3r_exact_retry_dispatch_v3.py"
+      - "tests/test_cut3r_exact_retry_dispatch_v3.py"
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cut3r-exact-retry-v3-comment-dispatch
+  cancel-in-progress: false
+
+env:
+  DISPATCH_COMMAND: /prob4d-dispatch-cut3r-source-freeze-v3 8b923e8cd67ca65f09312cffe305e36852f36fbb 8f3c9fba12f8a16895edce89d7a92e4806a43cb2f34b5a05faff71945809b63e
+  RETAINED_REQUEST_PATH: protocols/execution_requests/cut3r_deform360_source_freeze_v2.json
+  TARGET_WORKFLOW: cut3r-source-freeze-auto-v2.yml
+  HISTORICAL_EXECUTION_SHA: 8b923e8cd67ca65f09312cffe305e36852f36fbb
+  RETAINED_REQUEST_ID: 8f3c9fba12f8a16895edce89d7a92e4806a43cb2f34b5a05faff71945809b63e
+  PYTHONHASHSEED: "0"
+  PYTHONUNBUFFERED: "1"
+  PYTHONDONTWRITEBYTECODE: "1"
+
+jobs:
+  contract:
+    name: Exact retry-v3 contract
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Check out exact reviewed revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+          clean: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Validate v3 dispatch policy and historical authorization
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install -e ".[dev]"
+          python -m pip check
+          python -m ruff check \
+            scripts/ci/cut3r_exact_retry_dispatch_v3.py \
+            tests/test_cut3r_exact_retry_dispatch_v3.py
+          python -m ruff format --check \
+            scripts/ci/cut3r_exact_retry_dispatch_v3.py \
+            tests/test_cut3r_exact_retry_dispatch_v3.py
+          python -m pytest -q \
+            tests/test_cut3r_exact_retry_dispatch_v3.py \
+            tests/test_github_action_pins.py \
+            tests/test_trusted_self_hosted_validation_policy.py
+          python scripts/ci/cut3r_execution_preflight.py authorize-retry \
+            --repository . \
+            --request "$RETAINED_REQUEST_PATH" \
+            --current-revision "$(git rev-parse HEAD)" \
+            --execution-revision "$HISTORICAL_EXECUTION_SHA" \
+            --expected-request-id "$RETAINED_REQUEST_ID" \
+            > "$RUNNER_TEMP/cut3r-retry-v3-contract.json"
+
+  comment-dispatch:
+    name: Resolve or dispatch exact retained retry v3
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.number == 49 &&
+      github.actor == 'FlorianPfaff' &&
+      github.event.comment.user.login == 'FlorianPfaff' &&
+      github.event.comment.body == '/prob4d-dispatch-cut3r-source-freeze-v3 8b923e8cd67ca65f09312cffe305e36852f36fbb 8f3c9fba12f8a16895edce89d7a92e4806a43cb2f34b5a05faff71945809b63e'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: write
+      contents: read
+      issues: write
+    steps:
+      - name: Check out the exact default-branch event revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+          clean: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Reauthorize exact historical request and routed workflow
+        shell: bash
+        env:
+          EXPECTED_SHA: ${{ github.sha }}
+          EVENT_COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$EXPECTED_SHA"
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+          test "$EVENT_COMMENT_BODY" = "$DISPATCH_COMMAND"
+          grep -F \
+            "runs-on: [self-hosted, Linux, X64, nvidia-smi, data-prob4d-deform360-source-v1, prob4d-cut3r]" \
+            ".github/workflows/$TARGET_WORKFLOW" >/dev/null
+          python scripts/ci/cut3r_execution_preflight.py authorize-retry \
+            --repository . \
+            --request "$RETAINED_REQUEST_PATH" \
+            --current-revision "$EXPECTED_SHA" \
+            --execution-revision "$HISTORICAL_EXECUTION_SHA" \
+            --expected-request-id "$RETAINED_REQUEST_ID" \
+            > "$RUNNER_TEMP/cut3r-retry-v3-authorization.json"
+
+      - name: Publish accepted exact-command receipt
+        shell: bash
+        env:
+          API_URL: ${{ github.api_url }}
+          REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+          COMMAND_COMMENT_URL: ${{ github.event.comment.html_url }}
+          HELPER_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          python scripts/ci/cut3r_exact_retry_dispatch_v3.py accepted
+
+      - name: Resolve existing retry or dispatch exact v3 request
+        shell: bash
+        env:
+          API_URL: ${{ github.api_url }}
+          REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+          COMMAND_COMMENT_URL: ${{ github.event.comment.html_url }}
+          HELPER_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          python scripts/ci/cut3r_exact_retry_dispatch_v3.py dispatch

--- a/CHANGELOG.d/cut3r-exact-retry-v3-dispatch.md
+++ b/CHANGELOG.d/cut3r-exact-retry-v3-dispatch.md
@@ -1,0 +1,1 @@
+- Add a v3 exact CUT3R retry dispatcher that admits only the registered 3,106-byte failure-diagnostic artifact from the historical zero-result run. It binds the artifact ID, digest, size, run, retained-data job, and step outcomes; rejects any additional or changed artifact; prevents duplicate target dispatches; and leaves every scientific input and outcome boundary unchanged.

--- a/docs/cut3r-exact-retry-v3-dispatch.md
+++ b/docs/cut3r-exact-retry-v3-dispatch.md
@@ -1,0 +1,73 @@
+# Exact retained CUT3R retry v3
+
+The original retained CUT3R source-freeze run reached the trusted GPU runner but
+failed before provider execution. Its registered terminal decision was
+`workflow-failed-before-decision`: no source-freeze result, CUT3R prediction,
+source residual, truth, confirmation payload, target payload, BayesianPhysTwin
+result, or Causal4D result was produced.
+
+The run nevertheless retained one small Actions artifact because the protected
+workflow deliberately uploads diagnostics after a failed self-hosted job. The
+artifact contains only environment, host, and request-verification records. A
+blanket requirement that the old run have zero Actions artifacts therefore
+rejected a scientifically empty failure for the wrong reason.
+
+## Exact admitted diagnostic
+
+The v3 dispatcher admits only this immutable artifact:
+
+```text
+artifact ID: 9532584642
+name: cut3r-source-freeze-v2-failed-32621813949-2
+size: 3106 bytes
+SHA-256: a7805e079ccb367d56634c62bb91a79fdac71babaa69c233e485135b9243a0a0
+run: 32621813949
+historical revision: 8b923e8cd67ca65f09312cffe305e36852f36fbb
+```
+
+It also binds the failed retained-data job `97376973894` and the exact outcomes
+of the workspace, checkout, wheel-build, source-freeze, upload, and cleanup
+steps. Any additional artifact, result-like artifact, changed digest, changed
+size, changed workflow/run/job identity, successful source-freeze job, or step
+outcome drift fails closed.
+
+This is narrower than allowing arbitrary failure artifacts. It is an exact
+custody exception for one already inspected diagnostic bundle.
+
+## Exact command
+
+After the workflow is merged to `main`, only this exact comment by
+`FlorianPfaff` on issue 49 is admitted:
+
+```text
+/prob4d-dispatch-cut3r-source-freeze-v3 8b923e8cd67ca65f09312cffe305e36852f36fbb 8f3c9fba12f8a16895edce89d7a92e4806a43cb2f34b5a05faff71945809b63e
+```
+
+The GitHub-hosted dispatcher checks out the exact default-branch event revision,
+replays the existing historical retry authorization, verifies the routed
+retained-data/CUT3R runner labels, and resolves any already-created target retry
+before dispatching. Repeated commands cannot create duplicate target executions.
+
+## Next operational gate
+
+The current target workflow performs a hosted set/unset preflight for:
+
+```text
+BPT_CHECKOUT
+CUT3R_CHECKOUT
+CUT3R_CHECKPOINT
+DEFORM360_PROCESSED_ROOT
+```
+
+Only their names and readiness state may be published. If any variable remains
+unset, the target workflow stops before queueing the self-hosted job and opens no
+retained input. If all are configured, the exact historical request is queued on
+the routed runner and remains bounded by its runner-acceptance watchdog.
+
+## Scientific boundary
+
+This correction changes no provider, checkpoint, source cohort, camera panel,
+prefix, support rule, comparison arm, covariance rule, target roster, or
+analysis. It authorizes no source or target outcome. Scientific evidence begins
+only when the separately protected target workflow emits its registered terminal
+source-freeze artifact and decision.

--- a/scripts/ci/cut3r_exact_retry_dispatch_v3.py
+++ b/scripts/ci/cut3r_exact_retry_dispatch_v3.py
@@ -15,9 +15,7 @@ ISSUE_NUMBER = 49
 TARGET_WORKFLOW = "cut3r-source-freeze-auto-v2.yml"
 TARGET_REF = "main"
 HISTORICAL_EXECUTION_SHA = "8b923e8cd67ca65f09312cffe305e36852f36fbb"
-RETAINED_REQUEST_ID = (
-    "8f3c9fba12f8a16895edce89d7a92e4806a43cb2f34b5a05faff71945809b63e"
-)
+RETAINED_REQUEST_ID = "8f3c9fba12f8a16895edce89d7a92e4806a43cb2f34b5a05faff71945809b63e"
 SUPERSEDED_RUN_ID = 32621813949
 SUPERSEDED_EXECUTE_JOB_ID = 97376973894
 RETRY_WINDOW_START_UTC = "2026-08-24T18:12:05Z"
@@ -25,9 +23,7 @@ FAILURE_ARTIFACT = {
     "id": 9532584642,
     "name": "cut3r-source-freeze-v2-failed-32621813949-2",
     "size_in_bytes": 3106,
-    "digest": (
-        "sha256:a7805e079ccb367d56634c62bb91a79fdac71babaa69c233e485135b9243a0a0"
-    ),
+    "digest": ("sha256:a7805e079ccb367d56634c62bb91a79fdac71babaa69c233e485135b9243a0a0"),
     "expired": False,
 }
 
@@ -63,10 +59,7 @@ def _require_exact_fields(
     for key, expected_value in expected.items():
         actual_value = actual.get(key)
         if actual_value != expected_value:
-            _fail(
-                f"{label} {key} mismatch: "
-                f"{actual_value!r} != {expected_value!r}"
-            )
+            _fail(f"{label} {key} mismatch: {actual_value!r} != {expected_value!r}")
 
 
 def validate_superseded_run(
@@ -98,8 +91,7 @@ def validate_superseded_run(
         row
         for row in job_rows
         if isinstance(row, dict)
-        and row.get("name")
-        == "Freeze retained source inputs from trusted merged main"
+        and row.get("name") == "Freeze retained source inputs from trusted merged main"
     ]
     if len(execute_jobs) != 1:
         _fail("expected exactly one superseded retained source-freeze job")
@@ -192,9 +184,7 @@ def select_relevant_runs(payload: Any) -> list[JsonObject]:
         response.get("workflow_runs"),
         label="target workflow runs.workflow_runs",
     )
-    window_start = datetime.fromisoformat(
-        RETRY_WINDOW_START_UTC.replace("Z", "+00:00")
-    )
+    window_start = datetime.fromisoformat(RETRY_WINDOW_START_UTC.replace("Z", "+00:00"))
     selected: list[JsonObject] = []
     for value in rows:
         if not isinstance(value, dict):
@@ -219,9 +209,7 @@ def select_relevant_runs(payload: Any) -> list[JsonObject]:
 class GitHubClient:
     def __init__(self, *, api_url: str, repository: str, token: str) -> None:
         if repository != EXPECTED_REPOSITORY:
-            _fail(
-                f"repository mismatch: {repository!r} != {EXPECTED_REPOSITORY!r}"
-            )
+            _fail(f"repository mismatch: {repository!r} != {EXPECTED_REPOSITORY!r}")
         if not token:
             _fail("GITHUB_TOKEN is empty")
         self.api_url = api_url.rstrip("/")
@@ -252,10 +240,7 @@ class GitHubClient:
                 body = response.read()
         except urllib.error.HTTPError as error:
             detail = error.read().decode("utf-8", errors="replace")
-            _fail(
-                f"GitHub API {method} {path} failed with "
-                f"{error.code}: {detail}"
-            )
+            _fail(f"GitHub API {method} {path} failed with {error.code}: {detail}")
         return None if not body else json.loads(body)
 
     def post_comment(self, body: str) -> None:
@@ -350,9 +335,7 @@ def resolve_or_dispatch() -> None:
     )
 
     before_ids = {
-        int(row["id"])
-        for row in client.relevant_runs()
-        if isinstance(row.get("id"), int)
+        int(row["id"]) for row in client.relevant_runs() if isinstance(row.get("id"), int)
     }
     client.request_json(
         "POST",

--- a/scripts/ci/cut3r_exact_retry_dispatch_v3.py
+++ b/scripts/ci/cut3r_exact_retry_dispatch_v3.py
@@ -1,0 +1,450 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime
+from typing import Any, NoReturn
+
+EXPECTED_REPOSITORY = "IPS-Stuttgart/Prob4D"
+ISSUE_NUMBER = 49
+TARGET_WORKFLOW = "cut3r-source-freeze-auto-v2.yml"
+TARGET_REF = "main"
+HISTORICAL_EXECUTION_SHA = "8b923e8cd67ca65f09312cffe305e36852f36fbb"
+RETAINED_REQUEST_ID = (
+    "8f3c9fba12f8a16895edce89d7a92e4806a43cb2f34b5a05faff71945809b63e"
+)
+SUPERSEDED_RUN_ID = 32621813949
+SUPERSEDED_EXECUTE_JOB_ID = 97376973894
+RETRY_WINDOW_START_UTC = "2026-08-24T18:12:05Z"
+FAILURE_ARTIFACT = {
+    "id": 9532584642,
+    "name": "cut3r-source-freeze-v2-failed-32621813949-2",
+    "size_in_bytes": 3106,
+    "digest": (
+        "sha256:a7805e079ccb367d56634c62bb91a79fdac71babaa69c233e485135b9243a0a0"
+    ),
+    "expired": False,
+}
+
+JsonObject = dict[str, Any]
+
+
+class DispatchError(RuntimeError):
+    """Fail-closed exact-retry dispatch error."""
+
+
+def _fail(message: str) -> NoReturn:
+    raise DispatchError(message)
+
+
+def _require_object(value: Any, *, label: str) -> JsonObject:
+    if not isinstance(value, dict):
+        _fail(f"{label} is not a JSON object")
+    return value
+
+
+def _require_list(value: Any, *, label: str) -> list[Any]:
+    if not isinstance(value, list):
+        _fail(f"{label} is not a JSON list")
+    return value
+
+
+def _require_exact_fields(
+    actual: JsonObject,
+    expected: JsonObject,
+    *,
+    label: str,
+) -> None:
+    for key, expected_value in expected.items():
+        actual_value = actual.get(key)
+        if actual_value != expected_value:
+            _fail(
+                f"{label} {key} mismatch: "
+                f"{actual_value!r} != {expected_value!r}"
+            )
+
+
+def validate_superseded_run(
+    run_payload: Any,
+    jobs_payload: Any,
+    artifacts_payload: Any,
+) -> JsonObject:
+    """Validate the exact terminal failure and its diagnostic-only artifact."""
+
+    run = _require_object(run_payload, label="superseded run")
+    _require_exact_fields(
+        run,
+        {
+            "id": SUPERSEDED_RUN_ID,
+            "name": "Execute retained CUT3R source freeze automatically v2",
+            "path": ".github/workflows/cut3r-source-freeze-auto-v2.yml",
+            "head_sha": HISTORICAL_EXECUTION_SHA,
+            "head_branch": "main",
+            "event": "push",
+            "status": "completed",
+            "conclusion": "failure",
+        },
+        label="superseded run",
+    )
+
+    jobs = _require_object(jobs_payload, label="superseded jobs")
+    job_rows = _require_list(jobs.get("jobs"), label="superseded jobs.jobs")
+    execute_jobs = [
+        row
+        for row in job_rows
+        if isinstance(row, dict)
+        and row.get("name")
+        == "Freeze retained source inputs from trusted merged main"
+    ]
+    if len(execute_jobs) != 1:
+        _fail("expected exactly one superseded retained source-freeze job")
+    execute_job = _require_object(execute_jobs[0], label="superseded execute job")
+    _require_exact_fields(
+        execute_job,
+        {
+            "id": SUPERSEDED_EXECUTE_JOB_ID,
+            "run_id": SUPERSEDED_RUN_ID,
+            "status": "completed",
+            "conclusion": "failure",
+        },
+        label="superseded execute job",
+    )
+
+    step_rows = _require_list(
+        execute_job.get("steps"),
+        label="superseded execute job.steps",
+    )
+    steps_by_name = {
+        str(row.get("name")): row
+        for row in step_rows
+        if isinstance(row, dict) and isinstance(row.get("name"), str)
+    }
+    expected_steps = {
+        "Initialize isolated read-only execution workspace": "success",
+        "Check out only the authorized merged revision": "success",
+        "Verify exact clean checkout": "success",
+        "Provision Python 3.12": "success",
+        "Build and install the exact reviewed wheel": "success",
+        "Run one target-closed source freeze": "failure",
+        "Upload retained automatic source-freeze evidence": "success",
+        "Remove isolated execution workspace and checkout residue": "success",
+    }
+    for step_name, expected_conclusion in expected_steps.items():
+        step = _require_object(
+            steps_by_name.get(step_name),
+            label=f"superseded step {step_name!r}",
+        )
+        _require_exact_fields(
+            step,
+            {
+                "status": "completed",
+                "conclusion": expected_conclusion,
+            },
+            label=f"superseded step {step_name!r}",
+        )
+
+    artifacts = _require_object(
+        artifacts_payload,
+        label="superseded artifacts",
+    )
+    artifact_rows = _require_list(
+        artifacts.get("artifacts"),
+        label="superseded artifacts.artifacts",
+    )
+    total_count = artifacts.get("total_count", len(artifact_rows))
+    if total_count != 1 or len(artifact_rows) != 1:
+        _fail("superseded run has an unexpected artifact count")
+    artifact = _require_object(
+        artifact_rows[0],
+        label="superseded failure artifact",
+    )
+    _require_exact_fields(
+        artifact,
+        FAILURE_ARTIFACT,
+        label="superseded failure artifact",
+    )
+    workflow_run = _require_object(
+        artifact.get("workflow_run"),
+        label="superseded failure artifact.workflow_run",
+    )
+    _require_exact_fields(
+        workflow_run,
+        {
+            "id": SUPERSEDED_RUN_ID,
+            "repository_id": 1295794737,
+            "head_repository_id": 1295794737,
+            "head_branch": "main",
+            "head_sha": HISTORICAL_EXECUTION_SHA,
+        },
+        label="superseded failure artifact.workflow_run",
+    )
+    return artifact
+
+
+def select_relevant_runs(payload: Any) -> list[JsonObject]:
+    response = _require_object(payload, label="target workflow runs")
+    rows = _require_list(
+        response.get("workflow_runs"),
+        label="target workflow runs.workflow_runs",
+    )
+    window_start = datetime.fromisoformat(
+        RETRY_WINDOW_START_UTC.replace("Z", "+00:00")
+    )
+    selected: list[JsonObject] = []
+    for value in rows:
+        if not isinstance(value, dict):
+            continue
+        created_raw = value.get("created_at")
+        if not isinstance(created_raw, str):
+            continue
+        created = datetime.fromisoformat(created_raw.replace("Z", "+00:00"))
+        if (
+            value.get("event") == "workflow_dispatch"
+            and value.get("head_branch") == TARGET_REF
+            and created >= window_start
+        ):
+            selected.append(value)
+    return sorted(
+        selected,
+        key=lambda row: (str(row.get("created_at")), int(row.get("id", 0))),
+        reverse=True,
+    )
+
+
+class GitHubClient:
+    def __init__(self, *, api_url: str, repository: str, token: str) -> None:
+        if repository != EXPECTED_REPOSITORY:
+            _fail(
+                f"repository mismatch: {repository!r} != {EXPECTED_REPOSITORY!r}"
+            )
+        if not token:
+            _fail("GITHUB_TOKEN is empty")
+        self.api_url = api_url.rstrip("/")
+        self.repository = repository
+        self.token = token
+
+    def request_json(
+        self,
+        method: str,
+        path: str,
+        payload: JsonObject | None = None,
+    ) -> Any:
+        data = None if payload is None else json.dumps(payload).encode("utf-8")
+        request = urllib.request.Request(
+            f"{self.api_url}{path}",
+            data=data,
+            method=method,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self.token}",
+                "Content-Type": "application/json",
+                "User-Agent": "prob4d-cut3r-exact-retry-dispatch-v3",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                body = response.read()
+        except urllib.error.HTTPError as error:
+            detail = error.read().decode("utf-8", errors="replace")
+            _fail(
+                f"GitHub API {method} {path} failed with "
+                f"{error.code}: {detail}"
+            )
+        return None if not body else json.loads(body)
+
+    def post_comment(self, body: str) -> None:
+        self.request_json(
+            "POST",
+            f"/repos/{self.repository}/issues/{ISSUE_NUMBER}/comments",
+            {"body": body},
+        )
+
+    @property
+    def encoded_target_workflow(self) -> str:
+        return urllib.parse.quote(TARGET_WORKFLOW, safe="")
+
+    @property
+    def target_runs_path(self) -> str:
+        return (
+            f"/repos/{self.repository}/actions/workflows/"
+            f"{self.encoded_target_workflow}/runs"
+            f"?event=workflow_dispatch&branch={TARGET_REF}&per_page=50"
+        )
+
+    def relevant_runs(self) -> list[JsonObject]:
+        return select_relevant_runs(self.request_json("GET", self.target_runs_path))
+
+
+def _client_from_environment() -> GitHubClient:
+    return GitHubClient(
+        api_url=os.environ["API_URL"],
+        repository=os.environ["REPOSITORY"],
+        token=os.environ["GITHUB_TOKEN"],
+    )
+
+
+def publish_accepted_receipt() -> None:
+    client = _client_from_environment()
+    client.post_comment(
+        "\n".join(
+            (
+                "## Exact CUT3R retry-v3 command accepted",
+                "",
+                f"- historical execution revision: `{HISTORICAL_EXECUTION_SHA}`",
+                f"- retained request ID: `{RETAINED_REQUEST_ID}`",
+                f"- command comment: {os.environ['COMMAND_COMMENT_URL']}",
+                f"- helper workflow: {os.environ['HELPER_RUN_URL']}",
+                "",
+                "The hosted helper admits only the exact registered diagnostic "
+                "failure artifact and first resolves any existing target retry. "
+                "No retained path or scientific outcome is opened.",
+            )
+        )
+    )
+
+
+def resolve_or_dispatch() -> None:
+    client = _client_from_environment()
+    existing = client.relevant_runs()
+    if existing:
+        run = existing[0]
+        client.post_comment(
+            "\n".join(
+                (
+                    "## Existing CUT3R retry resolved by v3 dispatcher",
+                    "",
+                    f"- workflow run: {run.get('html_url')}",
+                    f"- run ID: `{run.get('id')}`",
+                    f"- status: `{run.get('status')}`",
+                    f"- conclusion: `{run.get('conclusion')}`",
+                    f"- created at: `{run.get('created_at')}`",
+                    f"- command comment: {os.environ['COMMAND_COMMENT_URL']}",
+                    f"- resolver workflow: {os.environ['HELPER_RUN_URL']}",
+                    "",
+                    "No duplicate target retry was dispatched and no outcome was opened.",
+                )
+            )
+        )
+        return
+
+    run_path = f"/repos/{client.repository}/actions/runs/{SUPERSEDED_RUN_ID}"
+    run_payload = client.request_json("GET", run_path)
+    jobs_payload = client.request_json(
+        "GET",
+        f"{run_path}/jobs?per_page=100",
+    )
+    artifacts_payload = client.request_json(
+        "GET",
+        f"{run_path}/artifacts?per_page=100",
+    )
+    admitted_artifact = validate_superseded_run(
+        run_payload,
+        jobs_payload,
+        artifacts_payload,
+    )
+
+    before_ids = {
+        int(row["id"])
+        for row in client.relevant_runs()
+        if isinstance(row.get("id"), int)
+    }
+    client.request_json(
+        "POST",
+        (
+            f"/repos/{client.repository}/actions/workflows/"
+            f"{client.encoded_target_workflow}/dispatches"
+        ),
+        {
+            "ref": TARGET_REF,
+            "inputs": {
+                "execution_sha": HISTORICAL_EXECUTION_SHA,
+                "request_id": RETAINED_REQUEST_ID,
+            },
+        },
+    )
+
+    discovered: JsonObject | None = None
+    for _ in range(30):
+        time.sleep(2)
+        for row in client.relevant_runs():
+            run_id = row.get("id")
+            if isinstance(run_id, int) and run_id not in before_ids:
+                discovered = row
+                break
+        if discovered is not None:
+            break
+
+    if discovered is None:
+        client.post_comment(
+            "\n".join(
+                (
+                    "## Exact CUT3R retry-v3 dispatch not yet discoverable",
+                    "",
+                    f"- historical execution revision: `{HISTORICAL_EXECUTION_SHA}`",
+                    f"- retained request ID: `{RETAINED_REQUEST_ID}`",
+                    f"- admitted diagnostic artifact ID: `{admitted_artifact['id']}`",
+                    f"- helper workflow: {os.environ['HELPER_RUN_URL']}",
+                    "",
+                    "GitHub accepted the workflow dispatch, but the target run did "
+                    "not appear during the bounded discovery interval. No outcome "
+                    "was opened.",
+                )
+            )
+        )
+        _fail("accepted target workflow dispatch was not discoverable")
+
+    client.post_comment(
+        "\n".join(
+            (
+                "## Exact retained CUT3R source-freeze retry dispatched by v3",
+                "",
+                f"- workflow run: {discovered.get('html_url')}",
+                f"- run ID: `{discovered.get('id')}`",
+                f"- status: `{discovered.get('status')}`",
+                f"- historical execution revision: `{HISTORICAL_EXECUTION_SHA}`",
+                f"- retained request ID: `{RETAINED_REQUEST_ID}`",
+                f"- admitted diagnostic artifact ID: `{admitted_artifact['id']}`",
+                f"- admitted artifact digest: `{admitted_artifact['digest']}`",
+                f"- command comment: {os.environ['COMMAND_COMMENT_URL']}",
+                f"- dispatcher workflow: {os.environ['HELPER_RUN_URL']}",
+                "",
+                "The target workflow independently repeats exact authorization, "
+                "checks retained-variable presence before queueing, uses the routed "
+                "retained-data/CUT3R labels, and remains target-closed.",
+            )
+        )
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Dispatch the exact retained CUT3R source-freeze retry v3."
+    )
+    parser.add_argument(
+        "phase",
+        choices=("accepted", "dispatch"),
+        help="Publish the accepted receipt or resolve/dispatch the target run.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        if args.phase == "accepted":
+            publish_accepted_receipt()
+        else:
+            resolve_or_dispatch()
+    except DispatchError as error:
+        raise SystemExit(str(error)) from error
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cut3r_exact_retry_dispatch_v3.py
+++ b/tests/test_cut3r_exact_retry_dispatch_v3.py
@@ -1,0 +1,262 @@
+from __future__ import annotations
+
+import importlib.util
+from copy import deepcopy
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "ci" / "cut3r_exact_retry_dispatch_v3.py"
+WORKFLOW = (
+    ROOT
+    / ".github"
+    / "workflows"
+    / "cut3r-exact-retry-v3-comment-dispatch.yml"
+)
+HISTORICAL_EXECUTION_SHA = "8b923e8cd67ca65f09312cffe305e36852f36fbb"
+RETAINED_REQUEST_ID = (
+    "8f3c9fba12f8a16895edce89d7a92e4806a43cb2f34b5a05faff71945809b63e"
+)
+COMMAND = (
+    "/prob4d-dispatch-cut3r-source-freeze-v3 "
+    f"{HISTORICAL_EXECUTION_SHA} {RETAINED_REQUEST_ID}"
+)
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "cut3r_exact_retry_dispatch_v3",
+        SCRIPT,
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _valid_run() -> dict[str, object]:
+    return {
+        "id": 32621813949,
+        "name": "Execute retained CUT3R source freeze automatically v2",
+        "path": ".github/workflows/cut3r-source-freeze-auto-v2.yml",
+        "head_sha": HISTORICAL_EXECUTION_SHA,
+        "head_branch": "main",
+        "event": "push",
+        "status": "completed",
+        "conclusion": "failure",
+    }
+
+
+def _valid_jobs() -> dict[str, object]:
+    step_conclusions = {
+        "Initialize isolated read-only execution workspace": "success",
+        "Check out only the authorized merged revision": "success",
+        "Verify exact clean checkout": "success",
+        "Provision Python 3.12": "success",
+        "Build and install the exact reviewed wheel": "success",
+        "Run one target-closed source freeze": "failure",
+        "Upload retained automatic source-freeze evidence": "success",
+        "Remove isolated execution workspace and checkout residue": "success",
+    }
+    return {
+        "jobs": [
+            {
+                "id": 97376973894,
+                "name": "Freeze retained source inputs from trusted merged main",
+                "run_id": 32621813949,
+                "status": "completed",
+                "conclusion": "failure",
+                "steps": [
+                    {
+                        "name": name,
+                        "status": "completed",
+                        "conclusion": conclusion,
+                    }
+                    for name, conclusion in step_conclusions.items()
+                ],
+            }
+        ]
+    }
+
+
+def _valid_artifacts() -> dict[str, object]:
+    return {
+        "total_count": 1,
+        "artifacts": [
+            {
+                "id": 9532584642,
+                "name": "cut3r-source-freeze-v2-failed-32621813949-2",
+                "size_in_bytes": 3106,
+                "digest": (
+                    "sha256:a7805e079ccb367d56634c62bb91a79f"
+                    "dac71babaa69c233e485135b9243a0a0"
+                ),
+                "expired": False,
+                "workflow_run": {
+                    "id": 32621813949,
+                    "repository_id": 1295794737,
+                    "head_repository_id": 1295794737,
+                    "head_branch": "main",
+                    "head_sha": HISTORICAL_EXECUTION_SHA,
+                },
+            }
+        ],
+    }
+
+
+def test_exact_failure_diagnostic_is_admitted() -> None:
+    module = _load_module()
+
+    admitted = module.validate_superseded_run(
+        _valid_run(),
+        _valid_jobs(),
+        _valid_artifacts(),
+    )
+
+    assert admitted["id"] == 9532584642
+    assert admitted["size_in_bytes"] == 3106
+    assert admitted["name"].startswith("cut3r-source-freeze-v2-failed-")
+
+
+def test_result_or_additional_artifact_is_rejected() -> None:
+    module = _load_module()
+    artifacts = _valid_artifacts()
+    rows = artifacts["artifacts"]
+    assert isinstance(rows, list)
+    rows.append(
+        {
+            "id": 999,
+            "name": "cut3r-deform360-source-freeze-result",
+            "size_in_bytes": 100,
+            "digest": "sha256:unexpected",
+            "expired": False,
+        }
+    )
+    artifacts["total_count"] = 2
+
+    with pytest.raises(
+        module.DispatchError,
+        match="unexpected artifact count",
+    ):
+        module.validate_superseded_run(
+            _valid_run(),
+            _valid_jobs(),
+            artifacts,
+        )
+
+
+def test_failure_artifact_digest_drift_is_rejected() -> None:
+    module = _load_module()
+    artifacts = _valid_artifacts()
+    rows = artifacts["artifacts"]
+    assert isinstance(rows, list)
+    artifact = rows[0]
+    assert isinstance(artifact, dict)
+    artifact["digest"] = "sha256:drift"
+
+    with pytest.raises(module.DispatchError, match="digest mismatch"):
+        module.validate_superseded_run(
+            _valid_run(),
+            _valid_jobs(),
+            artifacts,
+        )
+
+
+def test_successful_scientific_job_is_rejected() -> None:
+    module = _load_module()
+    jobs = _valid_jobs()
+    rows = jobs["jobs"]
+    assert isinstance(rows, list)
+    execute_job = rows[0]
+    assert isinstance(execute_job, dict)
+    execute_job["conclusion"] = "success"
+
+    with pytest.raises(module.DispatchError, match="conclusion mismatch"):
+        module.validate_superseded_run(
+            _valid_run(),
+            jobs,
+            _valid_artifacts(),
+        )
+
+
+def test_relevant_run_selection_is_target_workflow_dispatch_only() -> None:
+    module = _load_module()
+    payload = {
+        "workflow_runs": [
+            {
+                "id": 3,
+                "event": "workflow_dispatch",
+                "head_branch": "main",
+                "created_at": "2026-08-24T18:30:00Z",
+            },
+            {
+                "id": 2,
+                "event": "push",
+                "head_branch": "main",
+                "created_at": "2026-08-24T18:31:00Z",
+            },
+            {
+                "id": 1,
+                "event": "workflow_dispatch",
+                "head_branch": "other",
+                "created_at": "2026-08-24T18:32:00Z",
+            },
+        ]
+    }
+
+    selected = module.select_relevant_runs(payload)
+
+    assert [row["id"] for row in selected] == [3]
+
+
+def test_workflow_is_exact_actor_issue_and_default_branch_bound() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    runs_on = [
+        line.strip()
+        for line in text.splitlines()
+        if line.lstrip().startswith("runs-on:")
+    ]
+
+    assert "\n  issue_comment:\n    types: [created]" in text
+    assert "pull_request_target:" not in text
+    assert "github.event.issue.number == 49" in text
+    assert "github.actor == 'FlorianPfaff'" in text
+    assert "github.event.comment.user.login == 'FlorianPfaff'" in text
+    assert f"github.event.comment.body == '{COMMAND}'" in text
+    assert f"DISPATCH_COMMAND: {COMMAND}" in text
+    assert "ref: ${{ github.sha }}" in text
+    assert "fetch-depth: 0" in text
+    assert "persist-credentials: false" in text
+    assert runs_on == ["runs-on: ubuntu-latest", "runs-on: ubuntu-latest"]
+
+
+def test_workflow_reauthorizes_and_uses_routed_target() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "authorize-retry" in text
+    assert '--execution-revision "$HISTORICAL_EXECUTION_SHA"' in text
+    assert '--expected-request-id "$RETAINED_REQUEST_ID"' in text
+    assert (
+        "runs-on: [self-hosted, Linux, X64, nvidia-smi, "
+        "data-prob4d-deform360-source-v1, prob4d-cut3r]"
+    ) in text
+    assert "cut3r_exact_retry_dispatch_v3.py accepted" in text
+    assert "cut3r_exact_retry_dispatch_v3.py dispatch" in text
+    assert "actions: write" in text
+    assert "issues: write" in text
+    assert "contents: read" in text
+
+
+def test_validation_does_not_mutate_inputs() -> None:
+    module = _load_module()
+    run = _valid_run()
+    jobs = _valid_jobs()
+    artifacts = _valid_artifacts()
+    before = deepcopy((run, jobs, artifacts))
+
+    module.validate_superseded_run(run, jobs, artifacts)
+
+    assert (run, jobs, artifacts) == before

--- a/tests/test_cut3r_exact_retry_dispatch_v3.py
+++ b/tests/test_cut3r_exact_retry_dispatch_v3.py
@@ -9,19 +9,11 @@ import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts" / "ci" / "cut3r_exact_retry_dispatch_v3.py"
-WORKFLOW = (
-    ROOT
-    / ".github"
-    / "workflows"
-    / "cut3r-exact-retry-v3-comment-dispatch.yml"
-)
+WORKFLOW = ROOT / ".github" / "workflows" / "cut3r-exact-retry-v3-comment-dispatch.yml"
 HISTORICAL_EXECUTION_SHA = "8b923e8cd67ca65f09312cffe305e36852f36fbb"
-RETAINED_REQUEST_ID = (
-    "8f3c9fba12f8a16895edce89d7a92e4806a43cb2f34b5a05faff71945809b63e"
-)
+RETAINED_REQUEST_ID = "8f3c9fba12f8a16895edce89d7a92e4806a43cb2f34b5a05faff71945809b63e"
 COMMAND = (
-    "/prob4d-dispatch-cut3r-source-freeze-v3 "
-    f"{HISTORICAL_EXECUTION_SHA} {RETAINED_REQUEST_ID}"
+    f"/prob4d-dispatch-cut3r-source-freeze-v3 {HISTORICAL_EXECUTION_SHA} {RETAINED_REQUEST_ID}"
 )
 
 
@@ -91,8 +83,7 @@ def _valid_artifacts() -> dict[str, object]:
                 "name": "cut3r-source-freeze-v2-failed-32621813949-2",
                 "size_in_bytes": 3106,
                 "digest": (
-                    "sha256:a7805e079ccb367d56634c62bb91a79f"
-                    "dac71babaa69c233e485135b9243a0a0"
+                    "sha256:a7805e079ccb367d56634c62bb91a79fdac71babaa69c233e485135b9243a0a0"
                 ),
                 "expired": False,
                 "workflow_run": {
@@ -214,11 +205,7 @@ def test_relevant_run_selection_is_target_workflow_dispatch_only() -> None:
 
 def test_workflow_is_exact_actor_issue_and_default_branch_bound() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
-    runs_on = [
-        line.strip()
-        for line in text.splitlines()
-        if line.lstrip().startswith("runs-on:")
-    ]
+    runs_on = [line.strip() for line in text.splitlines() if line.lstrip().startswith("runs-on:")]
 
     assert "\n  issue_comment:\n    types: [created]" in text
     assert "pull_request_target:" not in text


### PR DESCRIPTION
## Purpose

Correct the v2 retry helper’s over-broad assumption that a scientifically empty failed workflow must have zero GitHub Actions artifacts.

The historical retained-data job produced no CUT3R prediction, source-freeze result, residual, truth, confirmation payload, target payload, BayesianPhysTwin result, or Causal4D result. It did retain the workflow’s expected 3,106-byte failure-diagnostic bundle containing environment, host, and request-verification records.

## Changes

- add a v3 exact-command dispatcher;
- bind the historical run, retained-data job, and critical step conclusions;
- admit only artifact `9532584642`, with its exact name, size, SHA-256, run identity, repository identity, and historical revision;
- reject every additional, result-like, expired, changed, or identity-drifted artifact;
- resolve any existing target retry before dispatching;
- keep the current target workflow’s hosted repository-variable preflight and routed runner labels;
- add focused adversarial tests and documentation.

## Scientific boundary

No provider, checkpoint, source cohort, camera panel, prefix, support criterion, comparison arm, covariance rule, target roster, or analysis changes. This PR authorizes no source or target outcome. The separately protected target workflow remains the sole owner of retained-data execution and terminal source-support evidence.

Refs #49