### PR TITLE
Harden retry-v3 pull-request checkout

### DIFF
--- a/.github/workflows/cut3r-exact-retry-v3-comment-dispatch.yml
+++ b/.github/workflows/cut3r-exact-retry-v3-comment-dispatch.yml
@@ -36,10 +36,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - name: Check out exact reviewed revision
+      - name: Check out reviewed merge candidate
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           persist-credentials: false
           clean: true

--- a/tests/test_cut3r_exact_retry_dispatch_v3.py
+++ b/tests/test_cut3r_exact_retry_dispatch_v3.py
@@ -209,12 +209,15 @@ def test_workflow_is_exact_actor_issue_and_default_branch_bound() -> None:
 
     assert "\n  issue_comment:\n    types: [created]" in text
     assert "pull_request_target:" not in text
+    assert "github.event.pull_request.head.sha" not in text
+    assert "allow-unsafe-pr-checkout" not in text
+    assert "Check out reviewed merge candidate" in text
     assert "github.event.issue.number == 49" in text
     assert "github.actor == 'FlorianPfaff'" in text
     assert "github.event.comment.user.login == 'FlorianPfaff'" in text
     assert f"github.event.comment.body == '{COMMAND}'" in text
     assert f"DISPATCH_COMMAND: {COMMAND}" in text
-    assert "ref: ${{ github.sha }}" in text
+    assert text.count("ref: ${{ github.sha }}") == 1
     assert "fetch-depth: 0" in text
     assert "persist-credentials: false" in text
     assert runs_on == ["runs-on: ubuntu-latest", "runs-on: ubuntu-latest"]


### PR DESCRIPTION
## Purpose

Follow up merged PR #304 by removing the explicit pull-request head-SHA checkout that triggered the CodeQL unsafe-checkout warning.

## Changes

- let `actions/checkout` use GitHub's standard `pull_request` merge candidate in the unprivileged contract job;
- retain the exact trusted default-branch `github.sha` checkout in the privileged issue-comment job;
- add regression assertions that forbid `pull_request_target`, explicit PR-head checkout, and unsafe-checkout overrides.

The workflow remains read-only on pull requests and the exact command, actor, issue, historical execution revision, retained request ID, target workflow, and runner routing are unchanged.