### PR TITLE
Bind retained CUT3R source-freeze identity

### DIFF
--- a/CHANGELOG.d/cut3r-source-freeze-id-binding.md
+++ b/CHANGELOG.d/cut3r-source-freeze-id-binding.md
@@ -1,0 +1,1 @@
+Bind retained CUT3R source-freeze execution summaries to the builder's verified content-addressed `source_freeze_id`.

--- a/scripts/science/run_cut3r_source_freeze_execution.py
+++ b/scripts/science/run_cut3r_source_freeze_execution.py
@@ -106,6 +106,19 @@ def _lower_hex(value: object, *, name: str, length: int) -> str:
     return value
 
 
+def _source_freeze_id(freeze: Mapping[str, Any]) -> str:
+    source_freeze_id = _lower_hex(
+        freeze.get("source_freeze_id"),
+        name="source-freeze source_freeze_id",
+        length=64,
+    )
+    identity = dict(freeze)
+    identity.pop("source_freeze_id")
+    if _sha256_json(identity) != source_freeze_id:
+        raise ValueError("source-freeze source_freeze_id mismatch")
+    return source_freeze_id
+
+
 def _literal_string(value: object, *, name: str) -> str:
     if type(value) is not str or not value or value != value.strip():
         raise ValueError(f"{name} must be a nonempty exact string")
@@ -429,11 +442,7 @@ def execute(args: argparse.Namespace) -> int:
         f"cut3r-source-freeze-v2-{request_id[:12]}-"
         f"{args.workflow_run_id}-{args.workflow_run_attempt}"
     )
-    freeze_artifact_id = _lower_hex(
-        freeze.get("artifact_id"),
-        name="source-freeze artifact_id",
-        length=64,
-    )
+    freeze_artifact_id = _source_freeze_id(freeze)
     summary = {
         "schema": SUMMARY_SCHEMA,
         "schema_version": SUMMARY_VERSION,

--- a/tests/test_cut3r_source_freeze_execution_driver.py
+++ b/tests/test_cut3r_source_freeze_execution_driver.py
@@ -140,3 +140,25 @@ def test_log_sanitization_prefers_longer_paths() -> None:
     )
 
     assert sanitized == "<CHECKPOINT> <CUT3R>"
+
+
+def test_driver_binds_the_builders_content_addressed_source_freeze_id() -> None:
+    module = _driver()
+    freeze: dict[str, object] = {
+        "schema": "prob4d.cut3r-deform360-source-freeze",
+        "decision": "source-support-freeze-ready",
+    }
+    source_freeze_id = _canonical_id(freeze)
+    freeze["source_freeze_id"] = source_freeze_id
+
+    assert module._source_freeze_id(freeze) == source_freeze_id
+
+    obsolete_alias = dict(freeze)
+    obsolete_alias["artifact_id"] = obsolete_alias.pop("source_freeze_id")
+    with pytest.raises(ValueError, match="source_freeze_id must be"):
+        module._source_freeze_id(obsolete_alias)
+
+    drifted = dict(freeze)
+    drifted["decision"] = "changed-after-identification"
+    with pytest.raises(ValueError, match="source_freeze_id mismatch"):
+        module._source_freeze_id(drifted)


### PR DESCRIPTION
## Summary

- consume the builder's canonical `source_freeze_id` instead of the obsolete `artifact_id` field
- recompute and verify the source-freeze content digest before publication
- retain `freeze_artifact_id` only as the execution-summary publication alias
- add regressions for the canonical field, obsolete-field rejection, and content drift

## Retained evidence

Run `32821877298`, attempt 2, completed the frozen 40-case source-support builder with decision `source-support-freeze-ready`. The retained artifact is `9554790547` (`cut3r-source-freeze-v2-failed-32821877298-2`, SHA-256 `cc053e468cdf1e2e7ec188358f3246402ec9204e9d1e2e460a8b0bd331523319`). The driver failed only afterward because it looked for `artifact_id`; the builder emitted canonical `source_freeze_id` `dbd5e6cc160e28a3379c09e3814185a8ec9f89c1cdba7f6e31825e7f5f773cc0`.

This changes no CUT3R provider, checkpoint, cohort, camera, prefix, seed, threshold, comparison arm, or outcome boundary.

## Verification

- focused tests: 18 passed
- Ruff check and format: pass
- MyPy: pass
- py_compile: pass
- `git diff --check`: pass
- exact retained-artifact identity replay: pass

Refs #49