### PR TITLE
Bind legacy CUT3R freeze receipts to canonical identity

### DIFF
--- a/.github/workflows/cut3r-source-freeze-execution.yml
+++ b/.github/workflows/cut3r-source-freeze-execution.yml
@@ -413,8 +413,10 @@ jobs:
             "$run_venv/bin/python" - <<'PY'
           from __future__ import annotations
 
+          import hashlib
           import json
           import os
+          import re
           from pathlib import Path
 
           output = Path(os.environ["OUTPUT_DIR"])
@@ -437,6 +439,24 @@ jobs:
               raise SystemExit("source freeze does not contain exactly ten groups")
           if freeze["forbidden_target_group_count"] != 12:
               raise SystemExit("source freeze does not retain all forbidden targets")
+
+          source_freeze_id = freeze["source_freeze_id"]
+          if not isinstance(source_freeze_id, str) or re.fullmatch(
+              r"[0-9a-f]{64}", source_freeze_id
+          ) is None:
+              raise SystemExit("source_freeze_id must be an exact lowercase SHA-256 digest")
+          identity = dict(freeze)
+          identity.pop("source_freeze_id")
+          canonical = json.dumps(
+              identity,
+              sort_keys=True,
+              separators=(",", ":"),
+              ensure_ascii=False,
+              allow_nan=False,
+          ).encode("utf-8")
+          expected_source_freeze_id = hashlib.sha256(canonical).hexdigest()
+          if source_freeze_id != expected_source_freeze_id:
+              raise SystemExit("source_freeze_id does not bind the canonical freeze record")
 
           specification = output / "cut3r-comparison-spec.json"
           lock = output / "cut3r-comparison-lock.json"
@@ -462,7 +482,7 @@ jobs:
               "workflow_run_attempt": int(os.environ["RUN_ATTEMPT"]),
               "exit_status": status,
               "decision": decision,
-              "freeze_artifact_id": freeze["artifact_id"],
+              "freeze_artifact_id": source_freeze_id,
               "source_group_count": freeze["source_group_count"],
               "forbidden_target_group_count": freeze["forbidden_target_group_count"],
               "target_payloads_opened": False,
@@ -481,7 +501,7 @@ jobs:
               stream.write(f"artifact_name={artifact_name}\n")
               stream.write(f"decision={decision}\n")
               stream.write(f"exit_status={status}\n")
-              stream.write(f"freeze_artifact_id={freeze['artifact_id']}\n")
+              stream.write(f"freeze_artifact_id={source_freeze_id}\n")
           PY
 
           /usr/bin/git restore --worktree -- src/prob4d.egg-info

--- a/CHANGELOG.d/cut3r-source-freeze-execution.md
+++ b/CHANGELOG.d/cut3r-source-freeze-execution.md
@@ -7,6 +7,8 @@
   roster.
 - Publish a compact issue pointer from a separate hosted job while keeping
   write-capable tokens off the self-hosted runner.
+- Consume the builder's canonical `source_freeze_id`, rederive it from the exact
+  freeze record, and reject obsolete `artifact_id` aliases or post-seal drift.
 
 ### Scientific boundary
 

--- a/tests/test_trusted_self_hosted_validation_policy.py
+++ b/tests/test_trusted_self_hosted_validation_policy.py
@@ -160,6 +160,21 @@ def test_source_freeze_execution_keeps_write_permission_off_self_hosted_job() ->
     assert "runs-on: ubuntu-latest" in report
 
 
+def test_source_freeze_execution_binds_the_builders_canonical_identity() -> None:
+    text = SOURCE_FREEZE_EXECUTION_WORKFLOW.read_text(encoding="utf-8")
+    execute_start = text.index("\n  execute:")
+    report_start = text.index("\n  report:")
+    execute = text[execute_start:report_start]
+
+    assert 'freeze["artifact_id"]' not in execute
+    assert "freeze['artifact_id']" not in execute
+    assert 'freeze["source_freeze_id"]' in execute
+    assert 'identity.pop("source_freeze_id")' in execute
+    assert "hashlib.sha256(canonical).hexdigest()" in execute
+    assert '"freeze_artifact_id": source_freeze_id' in execute
+    assert "freeze_artifact_id={source_freeze_id}" in execute
+
+
 def test_auto_v2_source_freeze_supports_exact_retry_and_bounded_queue() -> None:
     text = SOURCE_FREEZE_AUTO_V2_WORKFLOW.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary
- consume the source-freeze builder's canonical source_freeze_id in the retained v1 workflow
- recompute the exact canonical JSON SHA-256 before publishing the receipt
- reject the obsolete artifact_id alias and add a hosted policy regression

## Verification
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python3 -m pytest tests/test_trusted_self_hosted_validation_policy.py -q (11 passed)
- python3 -m ruff check tests/test_trusted_self_hosted_validation_policy.py
- parsed the workflow with PyYAML
- git diff --check

This changes only the receipt/control-plane binding. It does not alter the retained scientific request or access target/confirmation data.