### PR TITLE
Separate CUT3R retry control and science revisions

### DIFF
--- a/.github/workflows/cut3r-source-freeze-auto-v2.yml
+++ b/.github/workflows/cut3r-source-freeze-auto-v2.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - ".github/workflows/cut3r-source-freeze-auto-v2.yml"
       - "CHANGELOG.d/cut3r-source-freeze-auto-v2.md"
+      - "CHANGELOG.d/cut3r-current-control-plane-retry.md"
       - "docs/cut3r-source-freeze-auto-v2.md"
       - "protocols/execution_requests/cut3r_deform360_source_freeze_v2.json"
       - "scripts/ci/cut3r_execution_preflight.py"
@@ -408,26 +409,35 @@ jobs:
             echo "TMPDIR=$root/tmp"
           } >> "$GITHUB_ENV"
 
-      - name: Check out only the authorized merged revision
+      - name: Check out current control-plane revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.authorize.outputs.head_sha }}
+          ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
           clean: true
 
-      - name: Verify exact clean checkout
+      - name: Materialize and verify the authorized execution checkout
         shell: bash
         env:
+          CURRENT_CONTROL_PLANE_SHA: ${{ github.sha }}
           EXPECTED_HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
           EXPECTED_REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
         run: |
           set -euo pipefail
-          test "$(/usr/bin/git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
+          test "$(/usr/bin/git rev-parse HEAD)" = "$CURRENT_CONTROL_PLANE_SHA"
           test -z "$(/usr/bin/git status --porcelain=v1 --untracked-files=all)"
+          root="${{ steps.workspace.outputs.root }}"
+          execution_repository="$root/execution-repository"
+          test ! -e "$execution_repository"
+          /usr/bin/git worktree add --detach "$execution_repository" "$EXPECTED_HEAD_SHA"
+          test "$(/usr/bin/git -C "$execution_repository" rev-parse HEAD)" = \
+            "$EXPECTED_HEAD_SHA"
+          test -z "$(/usr/bin/git -C "$execution_repository" status \
+            --porcelain=v1 --untracked-files=all)"
           /usr/bin/python3 scripts/science/run_cut3r_source_freeze_execution.py verify-request \
-            --repository . \
-            --request "$REQUEST_PATH" \
+            --repository "$execution_repository" \
+            --request "$execution_repository/$REQUEST_PATH" \
             --expected-revision "$EXPECTED_HEAD_SHA" \
             > "${{ steps.workspace.outputs.root }}/evidence/request-verification.json"
           grep -F "$EXPECTED_REQUEST_ID" \
@@ -453,7 +463,12 @@ jobs:
             "build==1.3.0"
           wheel_dir="$root/wheelhouse"
           /usr/bin/mkdir -p "$wheel_dir"
-          "$build_python" -m build --wheel --outdir "$wheel_dir"
+          execution_repository="$root/execution-repository"
+          test -f "$execution_repository/.git"
+          "$build_python" -m build \
+            --wheel \
+            --outdir "$wheel_dir" \
+            "$execution_repository"
           mapfile -t wheels < <(find "$wheel_dir" -maxdepth 1 -type f -name '*.whl' | sort)
           test "${#wheels[@]}" -eq 1
           python -m venv "$root/run-venv"
@@ -494,6 +509,7 @@ jobs:
           test -f "$WHEEL_PATH"
 
           root="${{ steps.workspace.outputs.root }}"
+          execution_repository="$root/execution-repository"
           output="$root/evidence/cut3r-deform360-source-freeze"
           selection="$BPT_CHECKOUT/protocols/locks/deform360_official_hub_visuotactile_v1_selection.json"
           test -f "$selection"
@@ -504,8 +520,8 @@ jobs:
           GIT_CONFIG_VALUE_0="$cut3r_checkout" \
           "$root/run-venv/bin/python" \
             scripts/science/run_cut3r_source_freeze_execution.py execute \
-            --repository . \
-            --request "$REQUEST_PATH" \
+            --repository "$execution_repository" \
+            --request "$execution_repository/$REQUEST_PATH" \
             --expected-revision "$EXPECTED_HEAD_SHA" \
             --selection "$selection" \
             --processed-root "$DEFORM360_PROCESSED_ROOT" \
@@ -516,14 +532,17 @@ jobs:
             --workflow-run-id "$GITHUB_RUN_ID" \
             --workflow-run-attempt "$GITHUB_RUN_ATTEMPT"
 
-          /usr/bin/git restore --worktree -- src/prob4d.egg-info
-          /usr/bin/git diff --exit-code
-          test -z "$(/usr/bin/git status --porcelain=v1 --untracked-files=no)"
+          /usr/bin/git -C "$execution_repository" restore \
+            --worktree -- src/prob4d.egg-info
+          /usr/bin/git -C "$execution_repository" diff --exit-code
+          test -z "$(/usr/bin/git -C "$execution_repository" status \
+            --porcelain=v1 --untracked-files=no)"
 
       - name: Record exact automatic-execution environment
         if: ${{ always() && steps.workspace.outcome == 'success' }}
         shell: bash
         env:
+          CURRENT_CONTROL_PLANE_SHA: ${{ github.sha }}
           EXPECTED_HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
           REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
           EXECUTION_STATUS: ${{ job.status }}
@@ -531,10 +550,13 @@ jobs:
           set -euo pipefail
           export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
           root="${{ steps.workspace.outputs.root }}"
+          execution_repository="$root/execution-repository"
           {
             echo "repository=${GITHUB_REPOSITORY}"
+            echo "control_plane_sha=$CURRENT_CONTROL_PLANE_SHA"
             echo "head_sha=$EXPECTED_HEAD_SHA"
-            echo "checked_out_sha=$(/usr/bin/git rev-parse HEAD)"
+            echo "checked_out_sha=$(/usr/bin/git -C \
+              "$execution_repository" rev-parse HEAD)"
             echo "request_id=$REQUEST_ID"
             echo "authorization_mode=merged-main-read-only-self-hosted-v1"
             echo "repository_write_token_on_self_hosted=false"
@@ -588,6 +610,12 @@ jobs:
           root="${{ steps.workspace.outputs.root }}"
           expected="${RUNNER_TEMP}/prob4d-cut3r-source-freeze-v2-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           test "$root" = "$expected"
+          execution_repository="$root/execution-repository"
+          test "$execution_repository" = "$root/execution-repository"
+          if [[ -e "$execution_repository" ]]; then
+            /usr/bin/git worktree remove --force "$execution_repository"
+          fi
+          /usr/bin/git worktree prune
           /usr/bin/rm -rf -- "$root"
           /usr/bin/git reset --hard HEAD
           /usr/bin/git clean -ffdx

--- a/CHANGELOG.d/cut3r-current-control-plane-retry.md
+++ b/CHANGELOG.d/cut3r-current-control-plane-retry.md
@@ -1,0 +1,1 @@
+Use current merged-main CUT3R custody code with an isolated historical scientific checkout during exact retries.

--- a/docs/cut3r-source-freeze-auto-v2.md
+++ b/docs/cut3r-source-freeze-auto-v2.md
@@ -31,12 +31,19 @@ The hosted authorization job proves that the historical revision is an ancestor
 of current `main`, that its request blob is byte-identical to the current retained
 request, that the request remains content-addressed and target-closed, that the
 historical source-protocol blob still matches the request, and that the reviewed
-execution driver exists at that revision. The self-hosted job then checks out and
-executes that historical revision rather than current development code.
+execution driver exists at that revision. The self-hosted job keeps the current
+merged-main checkout as a read-only control plane and materializes the authorized
+historical revision in an isolated detached worktree. It builds the scientific
+wheel from that historical worktree and validates the historical request and
+protocol there. Only the current control-plane driver performs custody and
+publication orchestration; it receives no permission to change scientific input
+bytes.
 
-This retry therefore does not create a new request, silently advance the
-scientific implementation, or change the cohort, provider, checkpoint, prefix,
-support rule, or information order.
+This separation permits a reviewed post-execution custody repair without
+silently advancing the scientific implementation. The retry does not create a
+new request or change the cohort, provider, checkpoint, prefix, support rule,
+package wheel, or information order. Both the control-plane and historical
+execution SHAs are recorded in retained evidence.
 
 ## Hosted configuration preflight
 
@@ -74,18 +81,19 @@ historical execution SHA must be supplied.
 The self-hosted job has `contents: read` only. It receives no pull-request fields,
 no writable repository token, and no secret-valued command input. The workflow:
 
-1. builds one wheel from the exact authorized revision;
-2. installs that wheel in an isolated environment;
-3. verifies the retained CUT3R checkout, checkpoint, Deform360 processed source
+1. materializes the exact authorized revision in an isolated detached worktree;
+2. builds one wheel from that historical scientific revision;
+3. installs that wheel in an isolated environment;
+4. verifies the retained CUT3R checkout, checkpoint, Deform360 processed source
    root, BayesianPhysTwin selection lock, protocol, wheel, and input sidecars;
-4. executes `build_cut3r_deform360_source_freeze.py`;
-5. retains either `source-support-freeze-ready` or the registered
+5. executes `build_cut3r_deform360_source_freeze.py`;
+6. retains either `source-support-freeze-ready` or the registered
    `insufficient-common-camera-support` negative;
-6. creates and verifies the immutable CUT3R comparison lock only after a support
+7. creates and verifies the immutable CUT3R comparison lock only after a support
    pass;
-7. sanitizes protected filesystem paths before publication;
-8. uploads checksummed evidence; and
-9. posts authorization, blocker, timeout, and terminal receipts to issue 49 from
+8. sanitizes protected filesystem paths before publication;
+9. uploads checksummed evidence; and
+10. posts authorization, blocker, timeout, and terminal receipts to issue 49 from
    hosted jobs.
 
 The v2 request supersedes the earlier request only because that run produced no

--- a/tests/test_trusted_self_hosted_validation_policy.py
+++ b/tests/test_trusted_self_hosted_validation_policy.py
@@ -176,7 +176,16 @@ def test_auto_v2_source_freeze_supports_exact_retry_and_bounded_queue() -> None:
     assert "authorize-retry" in text
     assert '--execution-revision "$EXECUTION_SHA"' in text
     assert '--expected-request-id "$EXPECTED_REQUEST_ID"' in text
-    assert "ref: ${{ needs.authorize.outputs.head_sha }}" in text
+    assert "ref: ${{ github.sha }}" in text
+    assert ('git worktree add --detach "$execution_repository" "$EXPECTED_HEAD_SHA"') in text
+    assert '--repository "$execution_repository"' in text
+    assert '--request "$execution_repository/$REQUEST_PATH"' in text
+    assert '"$build_python" -m build \\' in text
+    assert '"$execution_repository"' in text
+    assert "scripts/science/run_cut3r_source_freeze_execution.py execute \\" in text
+    assert '"$execution_repository/scripts/science' not in text
+    assert "control_plane_sha=$CURRENT_CONTROL_PLANE_SHA" in text
+    assert '/usr/bin/git worktree remove --force "$execution_repository"' in text
     assert CUT3R_AUTO_V2_RUNNER_SELECTOR in text
     assert 'test "$RUNNER_NAME" = "workstation2"' in text
     assert 'test "$RUNNER_OS" = "Linux"' in text


### PR DESCRIPTION
## Summary

- keep current merged main as the read-only custody/control-plane checkout
- materialize the authorized historical scientific revision in an isolated detached worktree
- build and install the Prob4D wheel from that historical worktree
- validate and execute the historical request/protocol through the repaired current driver
- retain both control-plane and scientific revisions in evidence and remove the worktree during cleanup

## Why

The support-positive run `32821877298`, attempt 2, completed the 40-case source builder but failed after the freeze because the historical driver expected obsolete `artifact_id` instead of canonical `source_freeze_id`. PR #316 fixes that custody bug. The existing exact-retry route nevertheless checked out the historical driver too, so rerunning it would reproduce the same post-freeze failure. This PR separates operational custody code from frozen scientific bytes without changing the request, protocol, wheel source revision, cohort, provider, checkpoint, camera panel, prefix, seed, threshold, or information boundary.

## Verification

- 43 focused workflow/driver/preflight tests passed
- Ruff and focused MyPy passed
- workflow YAML parsed successfully
- `git diff --check` passed
- full-history smoke verified the exact historical request/protocol under the current repaired driver

No CUT3R inference, source residual/truth, confirmation payload, target payload, BayesianPhysTwin result, or Causal4D result was opened.

Refs #49