### PR TITLE
Guard historical CUT3R cleanup path

### DIFF
--- a/.github/workflows/cut3r-source-freeze-auto-v2.yml
+++ b/.github/workflows/cut3r-source-freeze-auto-v2.yml
@@ -532,8 +532,12 @@ jobs:
             --workflow-run-id "$GITHUB_RUN_ID" \
             --workflow-run-attempt "$GITHUB_RUN_ATTEMPT"
 
-          /usr/bin/git -C "$execution_repository" restore \
-            --worktree -- src/prob4d.egg-info
+          if /usr/bin/git -C "$execution_repository" ls-files \
+            --error-unmatch -- src/prob4d.egg-info >/dev/null 2>&1
+          then
+            /usr/bin/git -C "$execution_repository" restore \
+              --worktree -- src/prob4d.egg-info
+          fi
           /usr/bin/git -C "$execution_repository" diff --exit-code
           test -z "$(/usr/bin/git -C "$execution_repository" status \
             --porcelain=v1 --untracked-files=no)"

--- a/CHANGELOG.d/cut3r-historical-egg-info-cleanup.md
+++ b/CHANGELOG.d/cut3r-historical-egg-info-cleanup.md
@@ -1,0 +1,1 @@
+Skip the historical CUT3R egg-info restore when that frozen revision does not track the path.

--- a/tests/test_trusted_self_hosted_validation_policy.py
+++ b/tests/test_trusted_self_hosted_validation_policy.py
@@ -200,6 +200,8 @@ def test_auto_v2_source_freeze_supports_exact_retry_and_bounded_queue() -> None:
     assert "scripts/science/run_cut3r_source_freeze_execution.py execute \\" in text
     assert '"$execution_repository/scripts/science' not in text
     assert "control_plane_sha=$CURRENT_CONTROL_PLANE_SHA" in text
+    assert "ls-files \\" in text
+    assert "--error-unmatch -- src/prob4d.egg-info" in text
     assert '/usr/bin/git worktree remove --force "$execution_repository"' in text
     assert CUT3R_AUTO_V2_RUNNER_SELECTOR in text
     assert 'test "$RUNNER_NAME" = "workstation2"' in text


### PR DESCRIPTION
## Summary

- restore `src/prob4d.egg-info` only when the authorized historical revision tracks it
- retain the existing clean-diff and worktree-removal checks
- add a workflow-policy regression for the guarded cleanup

## Retained evidence

Run `32828946794` successfully produced and uploaded the target-closed source-support artifact before this cleanup command failed. Artifact `9556012095` rehashes cleanly; builder status is 0, decision is `source-support-freeze-ready`, and every source-prediction/outcome/target boundary remains false. No scientific rerun is required.

## Verification

- 29 focused tests passed
- workflow YAML parsed successfully
- Ruff and focused MyPy passed
- `git diff --check` passed

Refs #49