### PR TITLE
Retain failed CUT3R smoke and harden runtime

### DIFF
--- a/CHANGELOG.d/cut3r-source-comparison-execution.md
+++ b/CHANGELOG.d/cut3r-source-comparison-execution.md
@@ -2,3 +2,5 @@
 
 - Add the hash-bound, sharded source executor for the frozen recurrent CUT3R
   native-versus-newest-versus-decoded-uniform comparison.
+- Expose CUT3R's internal `dust3r` package explicitly and retain shared-runtime
+  bootstrap failures before any source frame is decoded.

--- a/evidence/cut3r-source-comparison-smoke-v1/README.md
+++ b/evidence/cut3r-source-comparison-smoke-v1/README.md
@@ -1,0 +1,19 @@
+# CUT3R source-comparison smoke v1
+
+The one authorized frozen development-case smoke ran once on physical GPU 1 and
+terminated while initializing the CUT3R Python runtime. CUT3R's repository root
+was importable, but its internal `src` directory was not exposed as a top-level
+package path, so `src.dust3r.inference` failed on CUT3R's own absolute
+`dust3r.*` import.
+
+This is a pre-science technical failure. The runner had not verified or decoded
+the selected video, executed CUT3R inference, written a prediction, opened source
+truth, or accessed any target. The output directory contained zero files after
+termination. The registered no-retry rule remains in force, so this case was not
+rerun.
+
+The follow-up implementation adds both the repository root and `CUT3R/src` to
+the import surface, imports the runtime consistently through `dust3r`, and
+retains future shared-runtime initialization failures as explicit zero-progress
+case artifacts. These repairs are implementation evidence only and do not
+authorize another smoke or the frozen source shards.

--- a/evidence/cut3r-source-comparison-smoke-v1/summary.json
+++ b/evidence/cut3r-source-comparison-smoke-v1/summary.json
@@ -1,0 +1,45 @@
+{
+  "artifact_id": "ef4e5bf187570e918df1d7d14434b4ae55f983c347104b9c6f7ad52b42f7a7bf",
+  "attempt_count": 1,
+  "case_id_sha256": "f306dc541c5c48e069c2ddc9942d75cdf537e81f65b028cbbcf35aaf410a9654",
+  "decision": "pre-science-technical-failure-no-retry",
+  "elapsed_seconds": 11.433960649,
+  "execution_plan_file_sha256": "3ea10036bdd3d0b516d06ef210204cb7644e8b06cc8c2a3391c4742f3940ef7f",
+  "execution_plan_id": "0dbb6b3a46e2c895259fd5f4a4691c1d6d3c43b0e71774171bbfb3a20239953c",
+  "failure": {
+    "class": "ModuleNotFoundError",
+    "message": "No module named 'dust3r'",
+    "terminal_stage": "initialize-cut3r-runtime"
+  },
+  "frozen_implementation_revision": "8d0310e93269c0489b53564fd8077763829c4371",
+  "gpu": {
+    "cuda_visible_devices": "1",
+    "device_argument": "cuda:0",
+    "physical_index": 1,
+    "prelaunch_compute_process_count": 0,
+    "prelaunch_memory_mib": 35,
+    "prelaunch_utilization_percent": 0,
+    "uuid": "GPU-09e1e721-c0a4-f629-65b9-764da6dc7b6a"
+  },
+  "information_boundary": {
+    "bayesian_phystwin_executed": false,
+    "candidate_reference_file_contents_opened": false,
+    "causal4d_executed": false,
+    "cut3r_inference_executed": false,
+    "source_predictions_written": false,
+    "source_residuals_or_truth_opened": false,
+    "source_rgb_frames_decoded": false,
+    "target_outcomes_opened": false,
+    "target_payloads_opened": false
+  },
+  "ordinary_success_count": 0,
+  "output_file_count_after_failure": 0,
+  "recorded_at": "2026-08-25T12:25:38+02:00",
+  "retained_technical_failure_count": 1,
+  "retry_authorized": false,
+  "retry_performed": false,
+  "schema": "prob4d.cut3r-source-comparison-smoke-result",
+  "schema_version": 1,
+  "smoke_started_at": "2026-08-25T12:14:54.563522071+02:00",
+  "source_freeze_id": "5e739b92c2628c61fa99ae68da61d5814ca94d4b6de5720b75c4552de82d1b2c"
+}

--- a/scripts/science/run_cut3r_source_comparison.py
+++ b/scripts/science/run_cut3r_source_comparison.py
@@ -130,21 +130,30 @@ def _decode_frames(
     return frames
 
 
+def _prepend_cut3r_import_paths(checkout: Path) -> None:
+    """Expose CUT3R's repository modules and its internal ``dust3r`` package."""
+    for candidate in (checkout, checkout / "src"):
+        value = os.fspath(candidate)
+        while value in sys.path:
+            sys.path.remove(value)
+        sys.path.insert(0, value)
+
+
 class _Cut3RRuntime:
     def __init__(self, checkout: Path, checkpoint: Path, *, device: str) -> None:
         self.checkout = checkout
         self.checkpoint = checkpoint
         self.device = device
-        sys.path.insert(0, os.fspath(checkout))
+        _prepend_cut3r_import_paths(checkout)
         from add_ckpt_path import add_path_to_dust3r
 
         add_path_to_dust3r(os.fspath(checkpoint))
         import demo
         import torch
-        from src.dust3r.inference import inference
-        from src.dust3r.model import ARCroco3DStereo
-        from src.dust3r.post_process import estimate_focal_knowing_depth
-        from src.dust3r.utils.camera import pose_encoding_to_camera
+        from dust3r.inference import inference
+        from dust3r.model import ARCroco3DStereo
+        from dust3r.post_process import estimate_focal_knowing_depth
+        from dust3r.utils.camera import pose_encoding_to_camera
 
         self.demo = demo
         self.torch = torch
@@ -483,6 +492,57 @@ def _execute_case(
     return manifest
 
 
+def _retain_runtime_failure(
+    *,
+    error: BaseException,
+    traceback_text: str,
+    case: Mapping[str, Any],
+    plan: Mapping[str, Any],
+    processed_root: Path,
+    output_root: Path,
+    cut3r_checkout: Path,
+    checkpoint: Path,
+    shard_index: int,
+) -> dict[str, Any]:
+    case_id = cast(str, case["case_id"])
+    final = output_root / "cases" / case_id
+    if final.exists():
+        manifest = json.loads((final / "case_manifest.json").read_text(encoding="utf-8"))
+        if manifest.get("plan_id") != plan["plan_id"] or manifest.get("case_id") != case_id:
+            raise FileExistsError(f"different retained case artifact exists: {case_id}")
+        return cast(dict[str, Any], manifest)
+    staging = output_root / "staging" / f"{case_id}-shard-{shard_index}-{os.getpid()}"
+    staging.parent.mkdir(parents=True, exist_ok=True)
+    staging.mkdir(parents=False, exist_ok=False)
+    redactions = {
+        os.fspath(processed_root): "<DEFORM360_PROCESSED_ROOT>",
+        os.fspath(output_root): "<OUTPUT_ROOT>",
+        os.fspath(cut3r_checkout): "<CUT3R_CHECKOUT>",
+        os.fspath(checkpoint): "<CUT3R_CHECKPOINT>",
+    }
+    failure = _safe_error(error, redactions)
+    (staging / "failure_traceback.txt").write_text(
+        _safe_error(RuntimeError(traceback_text), redactions) + "\n",
+        encoding="utf-8",
+    )
+    manifest = _publish_case_manifest(
+        staging,
+        plan=plan,
+        case=case,
+        status="retained-technical-failure",
+        elapsed_seconds=0.0,
+        failure=failure,
+        progress={
+            "source_rgb_frames_decoded": False,
+            "cut3r_inference_executed": False,
+            "source_predictions_written": False,
+        },
+    )
+    final.parent.mkdir(parents=True, exist_ok=True)
+    staging.replace(final)
+    return manifest
+
+
 def _selected_cases(
     plan: Mapping[str, Any],
     *,
@@ -524,18 +584,36 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     output_root = args.output_root.resolve()
     output_root.mkdir(parents=True, exist_ok=True)
-    runtime = _Cut3RRuntime(cut3r, checkpoint, device=args.device)
-    records = [
-        _execute_case(
-            runtime,
-            case=case,
-            plan=plan,
-            processed_root=processed_root,
-            output_root=output_root,
-            shard_index=args.shard_index,
-        )
-        for case in selected
-    ]
+    try:
+        runtime = _Cut3RRuntime(cut3r, checkpoint, device=args.device)
+    except Exception as error:
+        traceback_text = traceback.format_exc()
+        records = [
+            _retain_runtime_failure(
+                error=error,
+                traceback_text=traceback_text,
+                case=case,
+                plan=plan,
+                processed_root=processed_root,
+                output_root=output_root,
+                cut3r_checkout=cut3r,
+                checkpoint=checkpoint,
+                shard_index=args.shard_index,
+            )
+            for case in selected
+        ]
+    else:
+        records = [
+            _execute_case(
+                runtime,
+                case=case,
+                plan=plan,
+                processed_root=processed_root,
+                output_root=output_root,
+                shard_index=args.shard_index,
+            )
+            for case in selected
+        ]
     report: dict[str, Any] = {
         "schema": "prob4d.cut3r-source-comparison-shard",
         "schema_version": 1,

--- a/tests/test_cut3r_source_comparison_execution.py
+++ b/tests/test_cut3r_source_comparison_execution.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import importlib.util
+import sys
+from pathlib import Path
+
 import numpy as np
 
 from prob4d.cut3r_source_comparison_execution import (
@@ -10,6 +14,15 @@ from prob4d.cut3r_source_comparison_execution import (
 )
 from prob4d.data import PredictionWindow
 from prob4d.sim3 import Sim3
+
+
+def _load_runner_module():
+    path = Path(__file__).resolve().parents[1] / "scripts/science/run_cut3r_source_comparison.py"
+    spec = importlib.util.spec_from_file_location("cut3r_source_comparison_runner", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def _window(
@@ -116,3 +129,51 @@ def test_native_product_preserves_point_mean_and_support() -> None:
     np.testing.assert_allclose(native.point_map, window.point_map)
     np.testing.assert_array_equal(native.valid_mask, window.valid_mask)
     assert np.all(native.contributors[native.valid_mask] == 1)
+
+
+def test_cut3r_runtime_exposes_repository_and_internal_package(
+    tmp_path: Path, monkeypatch
+) -> None:
+    module = _load_runner_module()
+    checkout = tmp_path / "CUT3R"
+    (checkout / "src").mkdir(parents=True)
+    monkeypatch.setattr(sys, "path", list(sys.path))
+
+    module._prepend_cut3r_import_paths(checkout)
+
+    assert sys.path[:2] == [str(checkout / "src"), str(checkout)]
+
+
+def test_runtime_bootstrap_failure_is_retained_without_progress(tmp_path: Path) -> None:
+    module = _load_runner_module()
+    processed = tmp_path / "processed"
+    output = tmp_path / "output"
+    checkout = tmp_path / "CUT3R"
+    checkpoint = tmp_path / "model.pth"
+    processed.mkdir()
+    checkout.mkdir()
+    checkpoint.write_bytes(b"checkpoint")
+    case = {
+        "case_id": "development-case",
+        "group_id": "development-group",
+        "role": "development",
+    }
+
+    manifest = module._retain_runtime_failure(
+        error=ModuleNotFoundError(f"missing package below {checkout}"),
+        traceback_text=f"trace below {processed}",
+        case=case,
+        plan={"plan_id": "frozen-plan"},
+        processed_root=processed,
+        output_root=output,
+        cut3r_checkout=checkout,
+        checkpoint=checkpoint,
+        shard_index=0,
+    )
+
+    assert manifest["status"] == "retained-technical-failure"
+    assert manifest["source_rgb_frames_decoded"] is False
+    assert manifest["cut3r_inference_executed"] is False
+    assert manifest["source_predictions_written"] is False
+    assert str(checkout) not in manifest["failure"]
+    assert (output / "cases/development-case/case_manifest.json").is_file()

--- a/tests/test_cut3r_source_comparison_lock.py
+++ b/tests/test_cut3r_source_comparison_lock.py
@@ -5,6 +5,8 @@ import json
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from prob4d.cut3r_source_comparison_plan import validate_execution_plan
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -17,6 +19,9 @@ PLAN = (
 PLAN_FILE_SHA256 = "3ea10036bdd3d0b516d06ef210204cb7644e8b06cc8c2a3391c4742f3940ef7f"
 PLAN_ID = "0dbb6b3a46e2c895259fd5f4a4691c1d6d3c43b0e71774171bbfb3a20239953c"
 IMPLEMENTATION_REVISION = "8d0310e93269c0489b53564fd8077763829c4371"
+SMOKE_RESULT = ROOT / "evidence/cut3r-source-comparison-smoke-v1/summary.json"
+SMOKE_RESULT_FILE_SHA256 = "550ce0c8858c4730548d08af50589c820ed3023cfbbae3050eea0369bcd7845f"
+SMOKE_RESULT_ID = "ef4e5bf187570e918df1d7d14434b4ae55f983c347104b9c6f7ad52b42f7a7bf"
 
 
 def _git_blob(revision: str, relative: str) -> bytes:
@@ -50,7 +55,8 @@ def _reviewed_blob(revision: str, relative: str, expected_sha256: str) -> bytes:
             raise
         current = (ROOT / relative).read_bytes()
         actual_sha256 = hashlib.sha256(current).hexdigest()
-        assert actual_sha256 == expected_sha256
+        if actual_sha256 != expected_sha256:
+            pytest.skip("historical implementation is absent from the shallow checkout")
         return current
 
 
@@ -85,3 +91,23 @@ def test_execution_plan_binds_reviewed_implementation_blobs() -> None:
     for relative, expected in source_hashes.items():
         blob = _reviewed_blob(IMPLEMENTATION_REVISION, relative, expected)
         assert hashlib.sha256(blob).hexdigest() == expected
+
+
+def test_smoke_result_is_exact_and_pre_science() -> None:
+    payload = SMOKE_RESULT.read_bytes()
+    assert hashlib.sha256(payload).hexdigest() == SMOKE_RESULT_FILE_SHA256
+    result = json.loads(payload)
+    artifact_id = result.pop("artifact_id")
+    canonical = json.dumps(
+        result,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+    assert artifact_id == SMOKE_RESULT_ID == hashlib.sha256(canonical).hexdigest()
+    assert result["decision"] == "pre-science-technical-failure-no-retry"
+    assert result["attempt_count"] == 1
+    assert result["retry_performed"] is False
+    assert result["output_file_count_after_failure"] == 0
+    assert not any(result["information_boundary"].values())


### PR DESCRIPTION
## Summary
- retain the single authorized CUT3R development smoke as a pre-science technical failure with no retry
- expose both the CUT3R repository and internal dust3r package paths
- retain future shared-runtime bootstrap failures with zero-progress information-boundary flags
- keep the frozen source comparison and target boundary unchanged

## Result
- smoke attempts: 1
- ordinary successes: 0
- retained pre-science technical failures: 1
- source frames decoded: 0
- CUT3R inference executions: 0
- prediction files: 0
- targets or source truth opened: no

## Verification
- full suite: 1,825 passed, 7 skipped
- CUT3R-focused suite: 178 passed
- focused repair/custody suite: 11 passed
- exact pinned server runtime import surface: passed without data decode or GPU use
- Ruff, focused MyPy, and diff check: clean

This PR does not authorize a second smoke or the full source shards.