### PR TITLE
Add independent CUT3R source artifact custody gate

### DIFF
--- a/CHANGELOG.d/cut3r-source-comparison-custody.md
+++ b/CHANGELOG.d/cut3r-source-comparison-custody.md
@@ -1,0 +1,6 @@
+### Added
+
+- Add independent byte-level custody verification for retained CUT3R
+  source-comparison cases and shards, including exact resume validation and
+  fail-closed rejection of publishable artifacts that retain decoded source
+  frames.

--- a/docs/cut3r-source-comparison-custody.md
+++ b/docs/cut3r-source-comparison-custody.md
@@ -1,0 +1,49 @@
+# CUT3R source-comparison custody gate
+
+The frozen CUT3R executor writes one content-addressed case directory at a time
+and one shard report after all selected cases terminate. Before an output may be
+uploaded, aggregated, scored, or used to authorize another information stage,
+validate the retained bytes with the independent custody verifier:
+
+```bash
+python scripts/science/verify_cut3r_source_comparison_artifacts.py shard \
+  --output-root /path/to/source-comparison-output \
+  --report /path/to/source-comparison-output/shards/smoke-case.json \
+  --receipt /path/to/source-comparison-output/custody/smoke-case.json \
+  --expected-plan-id 0dbb6b3a46e2c895259fd5f4a4691c1d6d3c43b0e71774171bbfb3a20239953c
+```
+
+The default shard command requires every referenced case to be an ordinary
+success. `--allow-technical-failures` is available only for retaining a valid
+negative custody record; such a receipt does not satisfy the execution barrier.
+
+The verifier independently checks:
+
+- the case and shard content identities;
+- an exact, duplicate-free member roster;
+- every member SHA-256 and byte count;
+- regular-file and path-confinement semantics;
+- absence of symbolic links and undeclared files;
+- exact source/target and downstream-execution boundary flags;
+- agreement between shard counts and retained case statuses; and
+- absence of decoded source images from the publishable artifact.
+
+A previously existing case is not accepted merely because its manifest names the
+right plan and case. All bytes are rehashed. This closes the resume-integrity gap
+in which a stale, truncated, or externally modified case directory could
+otherwise be treated as complete.
+
+## Execution order
+
+1. Run exactly one frozen development smoke case.
+2. Require an ordinary-success custody receipt with zero decoded frames retained.
+3. Only then run the two frozen source shards.
+4. Validate each shard before publication.
+5. Aggregate or score only the case artifact IDs named by valid shard receipts.
+
+A custody receipt establishes byte integrity and information-boundary compliance
+only. It does not establish provider accuracy, source competence, covariance
+calibration, BayesianPhysTwin value, Causal4D value, deployment safety, or state
+of the art. A retained technical failure stops the source route unless the
+already frozen protocol explicitly authorizes a replacement; the custody
+verifier itself never grants such authorization.

--- a/scripts/science/verify_cut3r_source_comparison_artifacts.py
+++ b/scripts/science/verify_cut3r_source_comparison_artifacts.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Validate retained CUT3R source-comparison cases and shard custody."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+from pathlib import Path
+
+from prob4d.cut3r_source_comparison_verifier import (
+    validate_case_artifact,
+    validate_shard_artifact,
+    write_custody_receipt,
+)
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    case_parser = subparsers.add_parser("case", help="validate one retained case")
+    case_parser.add_argument("--case-root", type=Path, required=True)
+    case_parser.add_argument("--expected-plan-id")
+    case_parser.add_argument("--require-success", action="store_true")
+
+    shard_parser = subparsers.add_parser(
+        "shard",
+        help="validate a shard report and every referenced case",
+    )
+    shard_parser.add_argument("--output-root", type=Path, required=True)
+    shard_parser.add_argument("--report", type=Path, required=True)
+    shard_parser.add_argument("--receipt", type=Path, required=True)
+    shard_parser.add_argument("--expected-plan-id")
+    shard_parser.add_argument(
+        "--allow-technical-failures",
+        action="store_true",
+        help="retain a valid negative custody receipt instead of requiring all cases to succeed",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.command == "case":
+        manifest = validate_case_artifact(
+            args.case_root,
+            expected_plan_id=args.expected_plan_id,
+            require_success=args.require_success,
+        )
+        print(
+            json.dumps(
+                {
+                    "artifact_id": manifest["artifact_id"],
+                    "case_id": manifest["case_id"],
+                    "plan_id": manifest["plan_id"],
+                    "status": manifest["status"],
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+
+    receipt = validate_shard_artifact(
+        args.output_root,
+        args.report,
+        expected_plan_id=args.expected_plan_id,
+        require_success=not args.allow_technical_failures,
+    )
+    write_custody_receipt(args.receipt, receipt)
+    print(
+        json.dumps(
+            {
+                "case_count": receipt["case_count"],
+                "decision": receipt["decision"],
+                "receipt_id": receipt["receipt_id"],
+                "retained_technical_failure_count": receipt[
+                    "retained_technical_failure_count"
+                ],
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/prob4d/cut3r_source_comparison_verifier.py
+++ b/src/prob4d/cut3r_source_comparison_verifier.py
@@ -1,0 +1,548 @@
+"""Independent custody validation for retained CUT3R source-comparison artifacts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import os
+import re
+import stat
+from collections.abc import Mapping, Sequence
+from pathlib import Path, PurePosixPath
+from typing import Any, Final, NoReturn, cast
+
+from ._atomic_file import atomic_write_bytes
+
+CASE_SCHEMA: Final = "prob4d.cut3r-source-comparison-case"
+CASE_SCHEMA_VERSION: Final = 1
+SHARD_SCHEMA: Final = "prob4d.cut3r-source-comparison-shard"
+SHARD_SCHEMA_VERSION: Final = 1
+CUSTODY_SCHEMA: Final = "prob4d.cut3r-source-comparison-custody"
+CUSTODY_SCHEMA_VERSION: Final = 1
+
+_SHA256_PATTERN: Final = re.compile(r"[0-9a-f]{64}")
+_ALLOWED_ROLES: Final = frozenset({"development", "calibration", "source_evaluation"})
+_ALLOWED_STATUSES: Final = frozenset({"ordinary-success", "retained-technical-failure"})
+_ALLOWED_SCOPES: Final = frozenset({"development-smoke", "frozen-source-shard"})
+_FORBIDDEN_IMAGE_SUFFIXES: Final = frozenset(
+    {".bmp", ".jpeg", ".jpg", ".png", ".tif", ".tiff", ".webp"}
+)
+_FALSE_CASE_BOUNDARIES: Final = (
+    "source_residuals_or_truth_opened",
+    "candidate_reference_file_contents_opened",
+    "target_payloads_opened",
+    "target_outcomes_opened",
+    "bayesian_phystwin_executed",
+    "causal4d_executed",
+)
+_PROGRESS_FIELDS: Final = (
+    "source_rgb_frames_decoded",
+    "cut3r_inference_executed",
+    "source_predictions_written",
+)
+_CASE_FIELDS: Final = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "plan_id",
+        "case_id",
+        "group_id",
+        "role",
+        "status",
+        "elapsed_seconds",
+        "failure",
+        "members",
+        *_PROGRESS_FIELDS,
+        *_FALSE_CASE_BOUNDARIES,
+        "artifact_id",
+    }
+)
+_MEMBER_FIELDS: Final = frozenset({"path", "sha256", "byte_count"})
+_FALSE_SHARD_BOUNDARIES: Final = (
+    "source_residuals_or_truth_opened",
+    "target_payloads_opened",
+    "target_outcomes_opened",
+)
+_SHARD_FIELDS: Final = frozenset(
+    {
+        "schema",
+        "schema_version",
+        "plan_id",
+        "scope",
+        "shard_index",
+        "shard_count",
+        "case_count",
+        "ordinary_success_count",
+        "retained_technical_failure_count",
+        "case_artifact_ids",
+        *_FALSE_SHARD_BOUNDARIES,
+        "artifact_id",
+    }
+)
+
+
+def _canonical_json_bytes(value: object) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def content_id(value: object) -> str:
+    """Return the canonical SHA-256 content identity used by the executor."""
+
+    return hashlib.sha256(_canonical_json_bytes(value)).hexdigest()
+
+
+def _require_sha256(value: object, *, name: str) -> str:
+    if type(value) is not str or _SHA256_PATTERN.fullmatch(value) is None:
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return value
+
+
+def _require_string(value: object, *, name: str) -> str:
+    if type(value) is not str or not value or value != value.strip():
+        raise ValueError(f"{name} must be a nonempty exact string")
+    return value
+
+
+def _require_integer(value: object, *, name: str, minimum: int = 0) -> int:
+    if type(value) is not int or value < minimum:
+        raise ValueError(f"{name} must be a genuine integer >= {minimum}")
+    return value
+
+
+def _require_boolean(value: object, *, name: str) -> bool:
+    if type(value) is not bool:
+        raise ValueError(f"{name} must be a genuine Boolean")
+    return value
+
+
+def _file_identity(metadata: os.stat_result) -> tuple[int, int, int, int]:
+    return (
+        metadata.st_dev,
+        metadata.st_ino,
+        metadata.st_size,
+        metadata.st_mtime_ns,
+    )
+
+
+def _read_regular_bytes(path: Path, *, name: str) -> bytes:
+    if path.is_symlink():
+        raise ValueError(f"{name} must not be a symbolic link")
+    try:
+        before = path.stat()
+    except OSError as error:
+        raise ValueError(f"failed to stat {name}: {error}") from error
+    if not stat.S_ISREG(before.st_mode):
+        raise ValueError(f"{name} must be a regular file")
+    try:
+        payload = path.read_bytes()
+        after = path.stat()
+    except OSError as error:
+        raise ValueError(f"failed to read {name}: {error}") from error
+    if _file_identity(before) != _file_identity(after):
+        raise ValueError(f"{name} changed while being read")
+    return payload
+
+
+def _file_digest(path: Path, *, name: str) -> tuple[str, int]:
+    if path.is_symlink():
+        raise ValueError(f"{name} must not be a symbolic link")
+    try:
+        before = path.stat()
+    except OSError as error:
+        raise ValueError(f"failed to stat {name}: {error}") from error
+    if not stat.S_ISREG(before.st_mode):
+        raise ValueError(f"{name} must be a regular file")
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as stream:
+            for block in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(block)
+        after = path.stat()
+    except OSError as error:
+        raise ValueError(f"failed to hash {name}: {error}") from error
+    if _file_identity(before) != _file_identity(after):
+        raise ValueError(f"{name} changed while being hashed")
+    return digest.hexdigest(), before.st_size
+
+
+def _load_json(path: Path, *, name: str) -> dict[str, Any]:
+    def reject_constant(value: str) -> NoReturn:
+        raise ValueError(f"{name} contains non-finite JSON constant {value!r}")
+
+    def unique_object(pairs: Sequence[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError(f"{name} repeats JSON key {key!r}")
+            result[key] = value
+        return result
+
+    raw = _read_regular_bytes(path, name=name)
+    try:
+        text = raw.decode("utf-8")
+        value = json.loads(
+            text,
+            parse_constant=reject_constant,
+            object_pairs_hook=unique_object,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"failed to parse {name}: {error}") from error
+    if type(value) is not dict:
+        raise ValueError(f"{name} must be a JSON object")
+    return cast(dict[str, Any], value)
+
+
+def _canonical_relative_path(value: object, *, name: str) -> PurePosixPath:
+    relative = _require_string(value, name=name)
+    if "\\" in relative:
+        raise ValueError(f"{name} must use POSIX separators")
+    path = PurePosixPath(relative)
+    if path.is_absolute() or not path.parts:
+        raise ValueError(f"{name} must be a canonical relative path")
+    if any(part in {"", ".", ".."} for part in path.parts):
+        raise ValueError(f"{name} must not contain empty, dot, or parent components")
+    if path.as_posix() != relative:
+        raise ValueError(f"{name} is not in canonical POSIX form")
+    return path
+
+
+def _scan_regular_files(root: Path) -> dict[str, Path]:
+    if root.is_symlink() or not root.is_dir():
+        raise ValueError("case artifact root must be a real directory")
+    resolved_root = root.resolve(strict=True)
+    result: dict[str, Path] = {}
+    for directory, directory_names, file_names in os.walk(
+        resolved_root,
+        topdown=True,
+        followlinks=False,
+    ):
+        current = Path(directory)
+        for child_name in directory_names:
+            child = current / child_name
+            if child.is_symlink():
+                raise ValueError(
+                    f"case artifact contains symbolic-link directory "
+                    f"{child.relative_to(resolved_root).as_posix()}"
+                )
+        for file_name in file_names:
+            path = current / file_name
+            if path.is_symlink():
+                raise ValueError(
+                    f"case artifact contains symbolic-link file "
+                    f"{path.relative_to(resolved_root).as_posix()}"
+                )
+            relative = path.relative_to(resolved_root).as_posix()
+            if relative == "case_manifest.json":
+                continue
+            if relative in result:
+                raise ValueError(f"case artifact repeats member {relative!r}")
+            result[relative] = path
+    return result
+
+
+def _validate_declared_members(
+    case_root: Path,
+    members_value: object,
+    *,
+    forbid_decoded_frames: bool,
+) -> list[dict[str, object]]:
+    if type(members_value) is not list or not members_value:
+        raise ValueError("case manifest members must be a nonempty JSON array")
+    declared: dict[str, tuple[str, int]] = {}
+    normalized: list[dict[str, object]] = []
+    for index, raw_member in enumerate(members_value):
+        if type(raw_member) is not dict:
+            raise ValueError(f"case member {index} must be a JSON object")
+        member = cast(dict[str, Any], raw_member)
+        if set(member) != _MEMBER_FIELDS:
+            raise ValueError(f"case member {index} has unexpected fields")
+        path = _canonical_relative_path(member["path"], name=f"members[{index}].path")
+        relative = path.as_posix()
+        if relative == "case_manifest.json":
+            raise ValueError("case_manifest.json must not declare itself as a member")
+        if relative in declared:
+            raise ValueError(f"case manifest repeats member {relative!r}")
+        if forbid_decoded_frames and (
+            path.parts[0] == "decoded" or path.suffix.lower() in _FORBIDDEN_IMAGE_SUFFIXES
+        ):
+            raise ValueError(f"decoded source frame retained in case artifact: {relative}")
+        digest = _require_sha256(
+            member["sha256"],
+            name=f"members[{index}].sha256",
+        )
+        byte_count = _require_integer(
+            member["byte_count"],
+            name=f"members[{index}].byte_count",
+        )
+        declared[relative] = (digest, byte_count)
+        normalized.append(
+            {"path": relative, "sha256": digest, "byte_count": byte_count}
+        )
+
+    actual = _scan_regular_files(case_root)
+    if set(actual) != set(declared):
+        missing = sorted(set(declared) - set(actual))
+        undeclared = sorted(set(actual) - set(declared))
+        raise ValueError(
+            "case member roster mismatch: "
+            f"missing={missing!r}, undeclared={undeclared!r}"
+        )
+    for relative, path in actual.items():
+        measured_digest, measured_size = _file_digest(
+            path,
+            name=f"case member {relative}",
+        )
+        expected_digest, expected_size = declared[relative]
+        if measured_digest != expected_digest:
+            raise ValueError(f"case member digest mismatch: {relative}")
+        if measured_size != expected_size:
+            raise ValueError(f"case member byte-count mismatch: {relative}")
+    return normalized
+
+
+def validate_case_artifact(
+    case_root: Path,
+    *,
+    expected_plan_id: str | None = None,
+    require_success: bool = False,
+    forbid_decoded_frames: bool = True,
+) -> dict[str, Any]:
+    """Validate one retained case and every byte named by its manifest."""
+
+    root = case_root.resolve(strict=True)
+    manifest = _load_json(root / "case_manifest.json", name="case manifest")
+    if set(manifest) != _CASE_FIELDS:
+        raise ValueError("case manifest has unexpected or missing fields")
+    if manifest.get("schema") != CASE_SCHEMA:
+        raise ValueError("unexpected case artifact schema")
+    if manifest.get("schema_version") != CASE_SCHEMA_VERSION:
+        raise ValueError("unsupported case artifact schema version")
+    plan_id = _require_sha256(manifest["plan_id"], name="case plan_id")
+    if expected_plan_id is not None and plan_id != _require_sha256(
+        expected_plan_id,
+        name="expected_plan_id",
+    ):
+        raise ValueError("case plan identity differs from the authorized plan")
+    case_id = _require_string(manifest["case_id"], name="case_id")
+    if case_id != root.name:
+        raise ValueError("case manifest identity differs from its directory name")
+    _require_string(manifest["group_id"], name="group_id")
+    role = _require_string(manifest["role"], name="role")
+    if role not in _ALLOWED_ROLES:
+        raise ValueError(f"unknown case role {role!r}")
+    status = _require_string(manifest["status"], name="status")
+    if status not in _ALLOWED_STATUSES:
+        raise ValueError(f"unknown case status {status!r}")
+    elapsed = manifest["elapsed_seconds"]
+    if (
+        isinstance(elapsed, bool)
+        or not isinstance(elapsed, (int, float))
+        or not math.isfinite(float(elapsed))
+        or float(elapsed) < 0.0
+    ):
+        raise ValueError("elapsed_seconds must be a finite nonnegative real value")
+    for field in _PROGRESS_FIELDS:
+        _require_boolean(manifest[field], name=field)
+    for field in _FALSE_CASE_BOUNDARIES:
+        if _require_boolean(manifest[field], name=field):
+            raise ValueError(f"case artifact exceeds information boundary: {field}")
+
+    failure = manifest["failure"]
+    if status == "ordinary-success":
+        if failure is not None:
+            raise ValueError("ordinary-success case must not retain a failure message")
+        if not all(cast(bool, manifest[field]) for field in _PROGRESS_FIELDS):
+            raise ValueError("ordinary-success case has an incomplete execution stage")
+    else:
+        if type(failure) is not str or not failure or failure != failure.strip():
+            raise ValueError("technical failure must retain one bounded exact message")
+        if len(failure) > 2000:
+            raise ValueError("technical failure message exceeds the retained bound")
+    if require_success and status != "ordinary-success":
+        raise ValueError("case artifact is not an ordinary success")
+
+    normalized_members = _validate_declared_members(
+        root,
+        manifest["members"],
+        forbid_decoded_frames=forbid_decoded_frames,
+    )
+    if normalized_members != manifest["members"]:
+        raise ValueError("case manifest members are not canonically ordered or typed")
+    recorded_id = _require_sha256(manifest["artifact_id"], name="case artifact_id")
+    unsigned = dict(manifest)
+    unsigned.pop("artifact_id")
+    if recorded_id != content_id(unsigned):
+        raise ValueError("case artifact content identity is invalid")
+    return manifest
+
+
+def _case_directories(output_root: Path) -> list[Path]:
+    cases_root = output_root / "cases"
+    if cases_root.is_symlink() or not cases_root.is_dir():
+        raise ValueError("output root has no real cases directory")
+    result: list[Path] = []
+    for child in sorted(cases_root.iterdir(), key=lambda item: item.name):
+        if child.is_symlink():
+            raise ValueError(f"cases directory contains symbolic link {child.name!r}")
+        if not child.is_dir():
+            raise ValueError(f"cases directory contains non-directory {child.name!r}")
+        result.append(child)
+    return result
+
+
+def validate_shard_artifact(
+    output_root: Path,
+    shard_report_path: Path,
+    *,
+    expected_plan_id: str | None = None,
+    require_success: bool = True,
+    forbid_decoded_frames: bool = True,
+) -> dict[str, Any]:
+    """Validate a shard report and the exact retained cases that it references."""
+
+    root = output_root.resolve(strict=True)
+    report = _load_json(shard_report_path.resolve(strict=True), name="shard report")
+    if set(report) != _SHARD_FIELDS:
+        raise ValueError("shard report has unexpected or missing fields")
+    if report.get("schema") != SHARD_SCHEMA:
+        raise ValueError("unexpected shard report schema")
+    if report.get("schema_version") != SHARD_SCHEMA_VERSION:
+        raise ValueError("unsupported shard report schema version")
+    plan_id = _require_sha256(report["plan_id"], name="shard plan_id")
+    if expected_plan_id is not None and plan_id != _require_sha256(
+        expected_plan_id,
+        name="expected_plan_id",
+    ):
+        raise ValueError("shard plan identity differs from the authorized plan")
+    scope = _require_string(report["scope"], name="scope")
+    if scope not in _ALLOWED_SCOPES:
+        raise ValueError(f"unknown shard scope {scope!r}")
+    shard_count = _require_integer(report["shard_count"], name="shard_count", minimum=1)
+    shard_index = _require_integer(report["shard_index"], name="shard_index")
+    if shard_index >= shard_count:
+        raise ValueError("shard_index must be smaller than shard_count")
+    case_count = _require_integer(report["case_count"], name="case_count", minimum=1)
+    success_count = _require_integer(
+        report["ordinary_success_count"],
+        name="ordinary_success_count",
+    )
+    failure_count = _require_integer(
+        report["retained_technical_failure_count"],
+        name="retained_technical_failure_count",
+    )
+    if success_count + failure_count != case_count:
+        raise ValueError("shard status counts do not sum to case_count")
+    if scope == "development-smoke" and case_count != 1:
+        raise ValueError("development smoke must contain exactly one case")
+    if scope == "frozen-source-shard" and case_count != 20:
+        raise ValueError("each frozen two-way source shard must contain exactly 20 cases")
+    for field in _FALSE_SHARD_BOUNDARIES:
+        if _require_boolean(report[field], name=field):
+            raise ValueError(f"shard report exceeds information boundary: {field}")
+
+    raw_ids = report["case_artifact_ids"]
+    if type(raw_ids) is not list or len(raw_ids) != case_count:
+        raise ValueError("case_artifact_ids must match case_count")
+    reported_ids = [
+        _require_sha256(value, name=f"case_artifact_ids[{index}]")
+        for index, value in enumerate(raw_ids)
+    ]
+    if len(set(reported_ids)) != len(reported_ids):
+        raise ValueError("shard report repeats a case artifact identity")
+
+    cases_by_id: dict[str, dict[str, Any]] = {}
+    for directory in _case_directories(root):
+        case = validate_case_artifact(
+            directory,
+            expected_plan_id=plan_id,
+            require_success=False,
+            forbid_decoded_frames=forbid_decoded_frames,
+        )
+        artifact_id = cast(str, case["artifact_id"])
+        if artifact_id in cases_by_id:
+            raise ValueError("two case directories share one artifact identity")
+        cases_by_id[artifact_id] = case
+    if any(artifact_id not in cases_by_id for artifact_id in reported_ids):
+        raise ValueError("shard report references a missing case artifact")
+    selected = [cases_by_id[artifact_id] for artifact_id in reported_ids]
+    measured_success = sum(case["status"] == "ordinary-success" for case in selected)
+    measured_failure = sum(
+        case["status"] == "retained-technical-failure" for case in selected
+    )
+    if (measured_success, measured_failure) != (success_count, failure_count):
+        raise ValueError("shard status counts differ from retained case manifests")
+    if scope == "development-smoke" and selected[0]["role"] != "development":
+        raise ValueError("development smoke references a non-development case")
+    if require_success and measured_failure:
+        raise ValueError("shard contains retained technical failures")
+
+    recorded_id = _require_sha256(report["artifact_id"], name="shard artifact_id")
+    unsigned_report = dict(report)
+    unsigned_report.pop("artifact_id")
+    if recorded_id != content_id(unsigned_report):
+        raise ValueError("shard report content identity is invalid")
+
+    receipt: dict[str, Any] = {
+        "schema": CUSTODY_SCHEMA,
+        "schema_version": CUSTODY_SCHEMA_VERSION,
+        "decision": "source-comparison-custody-valid",
+        "plan_id": plan_id,
+        "shard_report_artifact_id": recorded_id,
+        "scope": scope,
+        "shard_index": shard_index,
+        "shard_count": shard_count,
+        "case_count": case_count,
+        "ordinary_success_count": measured_success,
+        "retained_technical_failure_count": measured_failure,
+        "case_ids": sorted(cast(str, case["case_id"]) for case in selected),
+        "case_artifact_ids": sorted(reported_ids),
+        "decoded_source_frames_retained": False,
+        "source_residuals_or_truth_opened": False,
+        "target_payloads_opened": False,
+        "target_outcomes_opened": False,
+        "bayesian_phystwin_executed": False,
+        "causal4d_executed": False,
+    }
+    receipt["receipt_id"] = content_id(receipt)
+    return receipt
+
+
+def write_custody_receipt(path: Path, receipt: Mapping[str, Any]) -> None:
+    """Publish a validated receipt atomically without replacing different bytes."""
+
+    encoded = (
+        json.dumps(
+            receipt,
+            indent=2,
+            sort_keys=True,
+            ensure_ascii=False,
+            allow_nan=False,
+        ).encode("utf-8")
+        + b"\n"
+    )
+    try:
+        atomic_write_bytes(path, encoded, overwrite=False)
+    except FileExistsError:
+        if _read_regular_bytes(path, name="existing custody receipt") != encoded:
+            raise
+
+
+__all__ = [
+    "CASE_SCHEMA",
+    "CASE_SCHEMA_VERSION",
+    "CUSTODY_SCHEMA",
+    "CUSTODY_SCHEMA_VERSION",
+    "SHARD_SCHEMA",
+    "SHARD_SCHEMA_VERSION",
+    "content_id",
+    "validate_case_artifact",
+    "validate_shard_artifact",
+    "write_custody_receipt",
+]

--- a/tests/test_cut3r_source_comparison_verifier.py
+++ b/tests/test_cut3r_source_comparison_verifier.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from prob4d.cut3r_source_comparison_verifier import (
+    content_id,
+    validate_case_artifact,
+    validate_shard_artifact,
+    write_custody_receipt,
+)
+
+PLAN_ID = "a" * 64
+
+
+def _digest(payload: bytes) -> str:
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _write_manifest(case_root: Path, manifest: dict[str, object]) -> None:
+    unsigned = dict(manifest)
+    unsigned.pop("artifact_id", None)
+    manifest["artifact_id"] = content_id(unsigned)
+    (case_root / "case_manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _member_records(case_root: Path) -> list[dict[str, object]]:
+    result = []
+    for path in sorted(case_root.rglob("*")):
+        if not path.is_file() or path.name == "case_manifest.json":
+            continue
+        payload = path.read_bytes()
+        result.append(
+            {
+                "path": path.relative_to(case_root).as_posix(),
+                "sha256": _digest(payload),
+                "byte_count": len(payload),
+            }
+        )
+    return result
+
+
+def _case(
+    output_root: Path,
+    case_id: str = "case-00",
+    *,
+    role: str = "development",
+    status: str = "ordinary-success",
+) -> Path:
+    case_root = output_root / "cases" / case_id
+    member = case_root / "predictions" / "result.bin"
+    member.parent.mkdir(parents=True)
+    member.write_bytes(b"prediction")
+    failure: str | None = None
+    progress = {
+        "source_rgb_frames_decoded": True,
+        "cut3r_inference_executed": True,
+        "source_predictions_written": True,
+    }
+    if status == "retained-technical-failure":
+        failure = "RuntimeError: bounded synthetic failure"
+        progress["cut3r_inference_executed"] = False
+        progress["source_predictions_written"] = False
+    manifest: dict[str, object] = {
+        "schema": "prob4d.cut3r-source-comparison-case",
+        "schema_version": 1,
+        "plan_id": PLAN_ID,
+        "case_id": case_id,
+        "group_id": "group-00",
+        "role": role,
+        "status": status,
+        "elapsed_seconds": 1.25,
+        "failure": failure,
+        "members": _member_records(case_root),
+        **progress,
+        "source_residuals_or_truth_opened": False,
+        "candidate_reference_file_contents_opened": False,
+        "target_payloads_opened": False,
+        "target_outcomes_opened": False,
+        "bayesian_phystwin_executed": False,
+        "causal4d_executed": False,
+    }
+    _write_manifest(case_root, manifest)
+    return case_root
+
+
+def _shard_report(
+    output_root: Path,
+    case_manifest: dict[str, object],
+    *,
+    scope: str = "development-smoke",
+) -> Path:
+    success = int(case_manifest["status"] == "ordinary-success")
+    failure = int(case_manifest["status"] == "retained-technical-failure")
+    report: dict[str, object] = {
+        "schema": "prob4d.cut3r-source-comparison-shard",
+        "schema_version": 1,
+        "plan_id": PLAN_ID,
+        "scope": scope,
+        "shard_index": 0,
+        "shard_count": 2,
+        "case_count": 1,
+        "ordinary_success_count": success,
+        "retained_technical_failure_count": failure,
+        "case_artifact_ids": [case_manifest["artifact_id"]],
+        "source_residuals_or_truth_opened": False,
+        "target_payloads_opened": False,
+        "target_outcomes_opened": False,
+    }
+    report["artifact_id"] = content_id(report)
+    path = output_root / "shards" / "smoke.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def test_validates_complete_case_and_smoke_custody(tmp_path: Path) -> None:
+    case_root = _case(tmp_path)
+    case = validate_case_artifact(
+        case_root,
+        expected_plan_id=PLAN_ID,
+        require_success=True,
+    )
+    report = _shard_report(tmp_path, case)
+
+    receipt = validate_shard_artifact(
+        tmp_path,
+        report,
+        expected_plan_id=PLAN_ID,
+        require_success=True,
+    )
+    receipt_path = tmp_path / "custody" / "smoke.json"
+    write_custody_receipt(receipt_path, receipt)
+    write_custody_receipt(receipt_path, receipt)
+
+    assert receipt["decision"] == "source-comparison-custody-valid"
+    assert receipt["case_ids"] == ["case-00"]
+    assert receipt["decoded_source_frames_retained"] is False
+    assert receipt_path.is_file()
+
+
+def test_rejects_member_byte_tampering(tmp_path: Path) -> None:
+    case_root = _case(tmp_path)
+    (case_root / "predictions" / "result.bin").write_bytes(b"changed")
+
+    with pytest.raises(ValueError, match="digest mismatch"):
+        validate_case_artifact(case_root)
+
+
+def test_rejects_undeclared_members(tmp_path: Path) -> None:
+    case_root = _case(tmp_path)
+    (case_root / "unregistered.bin").write_bytes(b"unexpected")
+
+    with pytest.raises(ValueError, match="member roster mismatch"):
+        validate_case_artifact(case_root)
+
+
+def test_rejects_decoded_source_frames_even_when_declared(tmp_path: Path) -> None:
+    case_root = _case(tmp_path)
+    decoded = case_root / "decoded" / "000000.png"
+    decoded.parent.mkdir()
+    decoded.write_bytes(b"source-rgb")
+    manifest = json.loads((case_root / "case_manifest.json").read_text(encoding="utf-8"))
+    manifest["members"] = _member_records(case_root)
+    _write_manifest(case_root, manifest)
+
+    with pytest.raises(ValueError, match="decoded source frame retained"):
+        validate_case_artifact(case_root)
+
+
+def test_rejects_invalid_case_content_identity(tmp_path: Path) -> None:
+    case_root = _case(tmp_path)
+    manifest_path = case_root / "case_manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["artifact_id"] = "b" * 64
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="content identity"):
+        validate_case_artifact(case_root)
+
+
+def test_smoke_rejects_retained_technical_failure(tmp_path: Path) -> None:
+    case_root = _case(tmp_path, status="retained-technical-failure")
+    case = validate_case_artifact(case_root, require_success=False)
+    report = _shard_report(tmp_path, case)
+
+    with pytest.raises(ValueError, match="technical failures"):
+        validate_shard_artifact(tmp_path, report, require_success=True)
+
+    receipt = validate_shard_artifact(tmp_path, report, require_success=False)
+    assert receipt["retained_technical_failure_count"] == 1


### PR DESCRIPTION
## Purpose

Close the publication and resume-integrity gap around the newly merged frozen CUT3R source executor without changing its scientific method or execution plan.

## Changes

- independently recompute every case and shard content identity;
- require an exact, duplicate-free member roster and rehash every member byte;
- reject undeclared files, missing files, byte-count drift, symlinks, noncanonical paths, and boundary-field drift;
- reject publishable artifacts that retain decoded source images;
- validate previously existing case directories completely instead of accepting only matching `plan_id` and `case_id` fields;
- require one ordinary-success development smoke receipt before full-shard publication;
- distinguish a valid negative custody receipt from a receipt that satisfies the all-success execution barrier; and
- publish custody receipts atomically with exact-byte no-clobber semantics.

## Validation

The new module, CLI, and tests were syntax-checked before publication. Exact-head GitHub Actions are authoritative for Ruff, MyPy, Python 3.10–3.14, distribution, provider-preflight, and security validation.

## Scientific boundary

This PR changes no CUT3R revision, checkpoint, source or target roster, camera, frame interval, window schedule, random seed, Sim(3) estimator, covariance model, fusion rule, comparison arm, target-access rule, BayesianPhysTwin behavior, Causal4D behavior, or claim. It validates custody only and cannot turn implementation success into provider competence or downstream benefit.

Refs #49 and #321.