### PR TITLE
[Superseded by #325] Authorize one zero-progress CUT3R comparison smoke replacement

### DIFF
--- a/.github/workflows/cut3r-source-comparison-smoke-retry-v2.yml
+++ b/.github/workflows/cut3r-source-comparison-smoke-retry-v2.yml
@@ -1,0 +1,713 @@
+name: Run one exact CUT3R source-comparison smoke replacement v2
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/cut3r-source-comparison-smoke-retry-v2.yml"
+      - "CHANGELOG.d/cut3r-source-comparison-smoke-retry-v2.md"
+      - "docs/cut3r-source-comparison-smoke-retry-v2.md"
+      - "protocols/execution_requests/cut3r_source_comparison_smoke_retry_v2.json"
+      - "scripts/ci/cut3r_source_comparison_smoke_retry_v2.py"
+      - "scripts/science/run_cut3r_source_comparison.py"
+      - "scripts/science/verify_cut3r_source_comparison_artifacts.py"
+      - "src/prob4d/cut3r_source_comparison_plan.py"
+      - "src/prob4d/cut3r_source_comparison_verifier.py"
+      - "tests/test_cut3r_source_comparison_smoke_retry_v2.py"
+      - "tests/test_trusted_self_hosted_validation_policy.py"
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cut3r-source-comparison-smoke-retry-v2
+  cancel-in-progress: false
+
+env:
+  AUTHORIZATION_PATH: protocols/execution_requests/cut3r_source_comparison_smoke_retry_v2.json
+  FIRST_SMOKE_SUMMARY_PATH: evidence/cut3r-source-comparison-smoke-v1/summary.json
+  HISTORICAL_PLAN_PATH: protocols/execution_requests/cut3r_deform360_source_comparison_execution_v1.json
+  PREFLIGHT_PATH: protocols/locks/cut3r_deform360_source_comparison_preflight_v1.json
+  HELPER_PATH: scripts/ci/cut3r_source_comparison_smoke_retry_v2.py
+  AUTHORIZATION_ID: efa8ef5040f268c41c02a9ea7789272d565e36dd655beccb04cfc2b3d588477a
+  FIRST_SMOKE_ARTIFACT_ID: ef4e5bf187570e918df1d7d14434b4ae55f983c347104b9c6f7ad52b42f7a7bf
+  SOURCE_FREEZE_ID: 5e739b92c2628c61fa99ae68da61d5814ca94d4b6de5720b75c4552de82d1b2c
+  SMOKE_CASE_ID: 031-cotton-cloth-episode-0000-brics-odroid-010_cam0
+  EXPECTED_PROVIDER_REVISION: 8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf
+  EXPECTED_CHECKPOINT_SHA256: 45f7e98a0a64dbeb54901ae2b878cd8cd125f20a4497316483f0bd6f109f8103
+  DISPATCH_COMMAND: >-
+    /prob4d-run-cut3r-source-comparison-smoke-retry-v2
+    efa8ef5040f268c41c02a9ea7789272d565e36dd655beccb04cfc2b3d588477a
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONHASHSEED: "0"
+  PYTHONUNBUFFERED: "1"
+  PYTHONDONTWRITEBYTECODE: "1"
+  OMP_NUM_THREADS: "1"
+  OPENBLAS_NUM_THREADS: "1"
+  MKL_NUM_THREADS: "1"
+  NUMEXPR_NUM_THREADS: "1"
+
+jobs:
+  contract:
+    name: Exact zero-progress smoke replacement contract
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out reviewed pull-request merge candidate
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          clean: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Validate authorization, policy, formatting, and custody code
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install -e ".[dev]"
+          python -m pip check
+          python -m ruff check \
+            "$HELPER_PATH" \
+            tests/test_cut3r_source_comparison_smoke_retry_v2.py \
+            tests/test_trusted_self_hosted_validation_policy.py
+          python -m ruff format --check \
+            "$HELPER_PATH" \
+            tests/test_cut3r_source_comparison_smoke_retry_v2.py \
+            tests/test_trusted_self_hosted_validation_policy.py
+          python -m compileall -q "$HELPER_PATH"
+          python "$HELPER_PATH" validate \
+            --repository . \
+            --authorization "$AUTHORIZATION_PATH" \
+            --first-summary "$FIRST_SMOKE_SUMMARY_PATH"
+          python -m pytest -q \
+            tests/test_cut3r_source_comparison_smoke_retry_v2.py \
+            tests/test_cut3r_source_comparison_execution.py \
+            tests/test_cut3r_source_comparison_verifier.py \
+            tests/test_trusted_self_hosted_validation_policy.py \
+            tests/test_github_action_pins.py
+
+  authorize:
+    name: Authorize one exact replacement from issue 49
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.number == 49 &&
+      github.actor == 'FlorianPfaff' &&
+      github.event.comment.user.login == 'FlorianPfaff' &&
+      github.event.comment.body ==
+        '/prob4d-run-cut3r-source-comparison-smoke-retry-v2
+        efa8ef5040f268c41c02a9ea7789272d565e36dd655beccb04cfc2b3d588477a'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      issues: write
+    outputs:
+      control_plane_sha: ${{ steps.identity.outputs.control_plane_sha }}
+    steps:
+      - name: Check out exact default-branch event revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+          clean: true
+
+      - name: Validate exact authorization and merged control plane
+        id: identity
+        shell: bash
+        env:
+          EVENT_REF: ${{ github.ref }}
+          EVENT_SHA: ${{ github.sha }}
+          EVENT_COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          set -euo pipefail
+          test "$EVENT_REF" = "refs/heads/main"
+          test "$(git rev-parse HEAD)" = "$EVENT_SHA"
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+          test "$EVENT_COMMENT_BODY" = "$DISPATCH_COMMAND"
+          python "$HELPER_PATH" validate \
+            --repository . \
+            --authorization "$AUTHORIZATION_PATH" \
+            --first-summary "$FIRST_SMOKE_SUMMARY_PATH"
+          echo "control_plane_sha=$EVENT_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Reject a second accepted replacement and publish acceptance
+        shell: bash
+        env:
+          API_URL: ${{ github.api_url }}
+          REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+          COMMAND_COMMENT_ID: ${{ github.event.comment.id }}
+          COMMAND_COMMENT_URL: ${{ github.event.comment.html_url }}
+          CONTROL_PLANE_SHA: ${{ steps.identity.outputs.control_plane_sha }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from __future__ import annotations
+
+          import json
+          import os
+          import urllib.request
+
+          marker = "## CUT3R source-comparison smoke replacement accepted"
+          api_url = os.environ["API_URL"]
+          repository = os.environ["REPOSITORY"]
+          token = os.environ["GITHUB_TOKEN"]
+          headers = {
+              "Accept": "application/vnd.github+json",
+              "Authorization": f"Bearer {token}",
+              "X-GitHub-Api-Version": "2022-11-28",
+          }
+          page = 1
+          while True:
+              request = urllib.request.Request(
+                  f"{api_url}/repos/{repository}/issues/49/comments"
+                  f"?per_page=100&page={page}",
+                  headers=headers,
+              )
+              with urllib.request.urlopen(request, timeout=30) as response:
+                  comments = json.load(response)
+              if not isinstance(comments, list):
+                  raise SystemExit("issue-comment response is malformed")
+              for comment in comments:
+                  body = comment.get("body") if isinstance(comment, dict) else None
+                  if (
+                      isinstance(body, str)
+                      and marker in body
+                      and os.environ["AUTHORIZATION_ID"] in body
+                  ):
+                      raise SystemExit("the exact replacement was already accepted")
+              if len(comments) < 100:
+                  break
+              page += 1
+
+          body = "\n".join(
+              (
+                  marker,
+                  "",
+                  f"- authorization ID: `{os.environ['AUTHORIZATION_ID']}`",
+                  f"- first smoke artifact ID: `{os.environ['FIRST_SMOKE_ARTIFACT_ID']}`",
+                  f"- source-freeze ID: `{os.environ['SOURCE_FREEZE_ID']}`",
+                  f"- control-plane SHA: `{os.environ['CONTROL_PLANE_SHA']}`",
+                  f"- command comment ID: `{os.environ['COMMAND_COMMENT_ID']}`",
+                  f"- command comment: {os.environ['COMMAND_COMMENT_URL']}",
+                  f"- workflow run: {os.environ['RUN_URL']}",
+                  "",
+                  "Exactly one replacement development smoke is authorized. "
+                  "The first smoke decoded no source frame, executed no CUT3R "
+                  "inference, and wrote no prediction. Full source shards, source "
+                  "truth or residuals, targets, BayesianPhysTwin, and Causal4D "
+                  "remain unauthorized.",
+              )
+          )
+          request = urllib.request.Request(
+              f"{api_url}/repos/{repository}/issues/49/comments",
+              data=json.dumps({"body": body}).encode("utf-8"),
+              method="POST",
+              headers={**headers, "Content-Type": "application/json"},
+          )
+          with urllib.request.urlopen(request, timeout=30):
+              pass
+          PY
+
+  smoke:
+    name: Execute one retained development smoke on workstation2
+    if: >-
+      github.event_name == 'issue_comment' &&
+      needs.authorize.result == 'success'
+    needs: [authorize]
+    runs-on: [self-hosted, host-workstation2]
+    timeout-minutes: 180
+    permissions:
+      actions: read
+      contents: read
+      issues: read
+    outputs:
+      decision: ${{ steps.summary.outputs.decision }}
+      plan_id: ${{ steps.summary.outputs.plan_id }}
+      case_artifact_id: ${{ steps.summary.outputs.case_artifact_id }}
+      custody_receipt_id: ${{ steps.summary.outputs.custody_receipt_id }}
+      summary_artifact_id: ${{ steps.summary.outputs.summary_artifact_id }}
+      smoke_exit_status: ${{ steps.summary.outputs.smoke_exit_status }}
+    steps:
+      - name: Bind the sole retained GPU runner
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$RUNNER_NAME" = "workstation2"
+          test "$RUNNER_OS" = "Linux"
+          test "$RUNNER_ARCH" = "X64"
+          command -v nvidia-smi >/dev/null 2>&1
+          nvidia-smi -i 1 --query-gpu=index,uuid --format=csv,noheader
+
+      - name: Initialize isolated read-only execution workspace
+        id: workspace
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${RUNNER_TEMP}/prob4d-cut3r-source-comparison-smoke-retry-v2-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          expected="${RUNNER_TEMP}/prob4d-cut3r-source-comparison-smoke-retry-v2-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          test "$root" = "$expected"
+          /usr/bin/rm -rf -- "$root"
+          /usr/bin/mkdir -p \
+            "$root/home" \
+            "$root/cache" \
+            "$root/tmp" \
+            "$root/evidence" \
+            "$root/output"
+          echo "root=$root" >> "$GITHUB_OUTPUT"
+          {
+            echo "HOME=$root/home"
+            echo "XDG_CACHE_HOME=$root/cache"
+            echo "TMPDIR=$root/tmp"
+          } >> "$GITHUB_ENV"
+
+      - name: Check out only the authorized merged control plane
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.authorize.outputs.control_plane_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+          clean: true
+
+      - name: Reject a duplicate retained attempt
+        shell: bash
+        env:
+          API_URL: ${{ github.api_url }}
+          REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+          CONTROL_PLANE_SHA: ${{ needs.authorize.outputs.control_plane_sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$CONTROL_PLANE_SHA"
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+          python - <<'PY'
+          from __future__ import annotations
+
+          import json
+          import os
+          import urllib.request
+
+          api_url = os.environ["API_URL"]
+          repository = os.environ["REPOSITORY"]
+          token = os.environ["GITHUB_TOKEN"]
+          headers = {
+              "Accept": "application/vnd.github+json",
+              "Authorization": f"Bearer {token}",
+              "X-GitHub-Api-Version": "2022-11-28",
+          }
+          request = urllib.request.Request(
+              f"{api_url}/repos/{repository}/actions/runs/"
+              f"{os.environ['GITHUB_RUN_ID']}/artifacts?per_page=100",
+              headers=headers,
+          )
+          with urllib.request.urlopen(request, timeout=30) as response:
+              payload = json.load(response)
+          artifacts = payload.get("artifacts") if isinstance(payload, dict) else None
+          if not isinstance(artifacts, list):
+              raise SystemExit("workflow artifact response is malformed")
+          if any(
+              isinstance(item, dict)
+              and str(item.get("name", "")).startswith(
+                  "cut3r-source-comparison-smoke-retry-v2-"
+              )
+              for item in artifacts
+          ):
+              raise SystemExit("a retained replacement artifact already exists")
+
+          marker = "## CUT3R source-comparison smoke replacement terminal"
+          page = 1
+          while True:
+              request = urllib.request.Request(
+                  f"{api_url}/repos/{repository}/issues/49/comments"
+                  f"?per_page=100&page={page}",
+                  headers=headers,
+              )
+              with urllib.request.urlopen(request, timeout=30) as response:
+                  comments = json.load(response)
+              if not isinstance(comments, list):
+                  raise SystemExit("issue-comment response is malformed")
+              for comment in comments:
+                  body = comment.get("body") if isinstance(comment, dict) else None
+                  if (
+                      isinstance(body, str)
+                      and marker in body
+                      and os.environ["AUTHORIZATION_ID"] in body
+                  ):
+                      raise SystemExit("a terminal replacement receipt already exists")
+              if len(comments) < 100:
+                  break
+              page += 1
+          PY
+
+      - name: Verify frozen paths, provider bytes, and exact compatible runtime
+        id: runtime
+        shell: bash
+        env:
+          CUT3R_CHECKOUT_VALUE: ${{ vars.CUT3R_CHECKOUT }}
+          CUT3R_CHECKPOINT_VALUE: ${{ vars.CUT3R_CHECKPOINT }}
+          DEFORM360_PROCESSED_ROOT_VALUE: ${{ vars.DEFORM360_PROCESSED_ROOT }}
+          CUT3R_PYTHON_VALUE: ${{ vars.CUT3R_PYTHON }}
+        run: |
+          set -euo pipefail
+          for value in \
+            "$CUT3R_CHECKOUT_VALUE" \
+            "$CUT3R_CHECKPOINT_VALUE" \
+            "$DEFORM360_PROCESSED_ROOT_VALUE"
+          do
+            test -n "$value"
+          done
+          cut3r=$(/usr/bin/realpath -e -- "$CUT3R_CHECKOUT_VALUE")
+          checkpoint=$(/usr/bin/realpath -e -- "$CUT3R_CHECKPOINT_VALUE")
+          processed=$(/usr/bin/realpath -e -- "$DEFORM360_PROCESSED_ROOT_VALUE")
+          test -d "$cut3r/.git"
+          test -f "$checkpoint"
+          test -d "$processed"
+          test "$(/usr/bin/git -c safe.directory="$cut3r" -C "$cut3r" rev-parse HEAD)" = \
+            "$EXPECTED_PROVIDER_REVISION"
+          test -z "$(/usr/bin/git -c safe.directory="$cut3r" -C "$cut3r" status \
+            --porcelain=v1 --untracked-files=all)"
+          test "$(sha256sum "$checkpoint" | cut -d' ' -f1)" = \
+            "$EXPECTED_CHECKPOINT_SHA256"
+
+          mapfile -t candidates < <(
+            {
+              test -n "$CUT3R_PYTHON_VALUE" && printf '%s\n' "$CUT3R_PYTHON_VALUE"
+              printf '%s\n' \
+                "$cut3r/.venv/bin/python" \
+                "$cut3r/venv/bin/python" \
+                "$cut3r/../.venv/bin/python" \
+                "/home/github-runner/miniconda3/envs/cut3r/bin/python" \
+                "/home/github-runner/anaconda3/envs/cut3r/bin/python" \
+                "/opt/conda/envs/cut3r/bin/python"
+              command -v python || true
+              command -v python3 || true
+              if command -v conda >/dev/null 2>&1; then
+                conda env list --json 2>/dev/null \
+                  | /usr/bin/python3 -c \
+                    'import json,sys; [print(p + "/bin/python") for p in json.load(sys.stdin).get("envs", [])]'
+              fi
+            } | awk 'NF && !seen[$0]++'
+          )
+
+          selected=""
+          for candidate in "${candidates[@]}"
+          do
+            test -x "$candidate" || continue
+            if CUDA_VISIBLE_DEVICES=1 "$candidate" - "$cut3r" "$checkpoint" <<'PY'
+          from __future__ import annotations
+
+          import importlib.metadata
+          import os
+          from pathlib import Path
+          import sys
+
+          checkout = Path(sys.argv[1]).resolve(strict=True)
+          checkpoint = Path(sys.argv[2]).resolve(strict=True)
+          expected = {
+              "numpy": "1.26.4",
+              "opencv-python": "4.11.0.86",
+              "pillow": "10.3.0",
+              "torch": "2.5.1+cu121",
+              "torchvision": "0.20.1+cu121",
+          }
+          if ".".join(str(item) for item in sys.version_info[:3]) != "3.11.15":
+              raise SystemExit(1)
+          if Path(sys.executable).name != "python":
+              raise SystemExit(1)
+          for package, version in expected.items():
+              if importlib.metadata.version(package) != version:
+                  raise SystemExit(1)
+          for path in (checkout, checkout / "src"):
+              sys.path.insert(0, os.fspath(path))
+          from add_ckpt_path import add_path_to_dust3r
+
+          add_path_to_dust3r(os.fspath(checkpoint))
+          import cv2  # noqa: F401
+          import demo  # noqa: F401
+          import dust3r.inference  # noqa: F401
+          import dust3r.model  # noqa: F401
+          import PIL  # noqa: F401
+          import torch
+          import torchvision  # noqa: F401
+
+          if not torch.cuda.is_available() or torch.version.cuda != "12.1":
+              raise SystemExit(1)
+          if torch.cuda.device_count() != 1:
+              raise SystemExit(1)
+          PY
+            then
+              selected=$(/usr/bin/realpath -e -- "$candidate")
+              break
+            fi
+          done
+          test -n "$selected" || {
+            echo "no exact frozen CUT3R Python runtime was found" >&2
+            exit 2
+          }
+          {
+            echo "CUT3R_CANONICAL=$cut3r"
+            echo "CHECKPOINT_CANONICAL=$checkpoint"
+            echo "PROCESSED_CANONICAL=$processed"
+            echo "RUNTIME_PYTHON=$selected"
+            echo "PYTHONPATH=$GITHUB_WORKSPACE/src"
+            echo "CUDA_VISIBLE_DEVICES=1"
+            echo "CUDA_DEVICE_ORDER=PCI_BUS_ID"
+            echo "GIT_CONFIG_COUNT=1"
+            echo "GIT_CONFIG_KEY_0=safe.directory"
+            echo "GIT_CONFIG_VALUE_0=$cut3r"
+          } >> "$GITHUB_ENV"
+          echo "python=$selected" >> "$GITHUB_OUTPUT"
+
+      - name: Build and bind the repaired outcome-blind execution plan
+        shell: bash
+        env:
+          CONTROL_PLANE_SHA: ${{ needs.authorize.outputs.control_plane_sha }}
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          generated="$root/evidence/execution-plan.generated.json"
+          repaired="$root/evidence/execution-plan.repaired.json"
+          "$RUNTIME_PYTHON" \
+            scripts/science/build_cut3r_source_comparison_execution_plan.py \
+            --repository . \
+            --preflight "$PREFLIGHT_PATH" \
+            --cut3r-checkout "$CUT3R_CANONICAL" \
+            --checkpoint "$CHECKPOINT_CANONICAL" \
+            --output "$generated"
+          "$RUNTIME_PYTHON" "$HELPER_PATH" adapt-plan \
+            --repository . \
+            --authorization "$AUTHORIZATION_PATH" \
+            --first-summary "$FIRST_SMOKE_SUMMARY_PATH" \
+            --historical-plan "$HISTORICAL_PLAN_PATH" \
+            --generated-plan "$generated" \
+            --output "$repaired"
+          test "$(git rev-parse HEAD)" = "$CONTROL_PLANE_SHA"
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+
+      - name: Execute one exact replacement smoke
+        id: execute
+        shell: bash
+        continue-on-error: true
+        run: |
+          set +e
+          root="${{ steps.workspace.outputs.root }}"
+          plan="$root/evidence/execution-plan.repaired.json"
+          "$RUNTIME_PYTHON" scripts/science/run_cut3r_source_comparison.py \
+            --repository . \
+            --plan "$plan" \
+            --processed-root "$PROCESSED_CANONICAL" \
+            --cut3r-checkout "$CUT3R_CANONICAL" \
+            --checkpoint "$CHECKPOINT_CANONICAL" \
+            --output-root "$root/output" \
+            --device cuda:0 \
+            --shard-index 0 \
+            --shard-count 2 \
+            --smoke-case-id "$SMOKE_CASE_ID" \
+            > "$root/evidence/smoke-stdout.json" \
+            2> "$root/evidence/smoke-stderr.txt"
+          status=$?
+          set -e
+          echo "exit_status=$status" >> "$GITHUB_OUTPUT"
+          test "$status" -eq 0 || test "$status" -eq 3
+
+      - name: Validate every retained byte and publish custody
+        id: summary
+        if: steps.execute.outputs.exit_status == '0' || steps.execute.outputs.exit_status == '3'
+        shell: bash
+        env:
+          CONTROL_PLANE_SHA: ${{ needs.authorize.outputs.control_plane_sha }}
+          SMOKE_EXIT_STATUS: ${{ steps.execute.outputs.exit_status }}
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          plan="$root/evidence/execution-plan.repaired.json"
+          report="$root/output/shards/smoke-${SMOKE_CASE_ID}.json"
+          receipt="$root/evidence/custody-receipt.json"
+          case_root="$root/output/cases/$SMOKE_CASE_ID"
+          plan_id=$("$RUNTIME_PYTHON" - "$plan" <<'PY'
+          import json
+          import sys
+
+          print(json.load(open(sys.argv[1], encoding="utf-8"))["plan_id"])
+          PY
+          )
+          "$RUNTIME_PYTHON" \
+            scripts/science/verify_cut3r_source_comparison_artifacts.py shard \
+            --output-root "$root/output" \
+            --report "$report" \
+            --receipt "$receipt" \
+            --expected-plan-id "$plan_id" \
+            --allow-technical-failures
+          "$RUNTIME_PYTHON" "$HELPER_PATH" summarize \
+            --authorization "$AUTHORIZATION_PATH" \
+            --plan "$plan" \
+            --output-root "$root/output" \
+            --shard-report "$report" \
+            --custody-receipt "$receipt" \
+            --case-root "$case_root" \
+            --smoke-exit-status "$SMOKE_EXIT_STATUS" \
+            --workflow-run-id "$GITHUB_RUN_ID" \
+            --workflow-run-attempt "$GITHUB_RUN_ATTEMPT" \
+            --control-plane-sha "$CONTROL_PLANE_SHA" \
+            --output "$root/evidence/replacement-summary.json" \
+            --github-output "$GITHUB_OUTPUT"
+
+      - name: Record bounded execution environment
+        if: always() && steps.workspace.outcome == 'success'
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          {
+            echo "repository=${GITHUB_REPOSITORY}"
+            echo "control_plane_sha=${{ needs.authorize.outputs.control_plane_sha }}"
+            echo "authorization_id=$AUTHORIZATION_ID"
+            echo "source_freeze_id=$SOURCE_FREEZE_ID"
+            echo "runner_name=$RUNNER_NAME"
+            echo "runner_os=$RUNNER_OS"
+            echo "runner_arch=$RUNNER_ARCH"
+            echo "physical_gpu_index=1"
+            test -n "${RUNTIME_PYTHON:-}" && "$RUNTIME_PYTHON" --version || true
+          } > "$root/evidence/environment.txt"
+          {
+            /usr/bin/uname -a
+            nvidia-smi -i 1
+          } > "$root/evidence/host.txt" 2>&1
+          /usr/bin/python3 - "$root/evidence" <<'PY'
+          from __future__ import annotations
+
+          import hashlib
+          from pathlib import Path
+          import sys
+
+          root = Path(sys.argv[1])
+          lines = []
+          for path in sorted(root.rglob("*")):
+              if path.is_file() and path.name != "SHA256SUMS":
+                  digest = hashlib.sha256(path.read_bytes()).hexdigest()
+                  lines.append(f"{digest}  {path.relative_to(root).as_posix()}")
+          (root / "SHA256SUMS").write_text(
+              "\n".join(lines) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Upload retained replacement evidence
+        if: always() && steps.workspace.outcome == 'success'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: cut3r-source-comparison-smoke-retry-v2-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ steps.workspace.outputs.root }}/evidence/
+            ${{ steps.workspace.outputs.root }}/output/
+          if-no-files-found: error
+          retention-days: 30
+          compression-level: 6
+
+      - name: Remove isolated workspace and checkout residue
+        if: always() && steps.workspace.outcome == 'success'
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          expected="${RUNNER_TEMP}/prob4d-cut3r-source-comparison-smoke-retry-v2-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          test "$root" = "$expected"
+          /usr/bin/rm -rf -- "$root"
+          /usr/bin/git reset --hard HEAD
+          /usr/bin/git clean -ffdx
+
+      - name: Fail closed unless the replacement is an ordinary success
+        if: always()
+        shell: bash
+        env:
+          RETAINED_DECISION: ${{ steps.summary.outputs.decision }}
+          SMOKE_EXIT_STATUS: ${{ steps.execute.outputs.exit_status }}
+        run: |
+          set -euo pipefail
+          test "$SMOKE_EXIT_STATUS" = "0"
+          test "$RETAINED_DECISION" = "ordinary-success-development-smoke"
+
+  report:
+    name: Publish terminal replacement receipt
+    if: >-
+      always() &&
+      github.event_name == 'issue_comment' &&
+      needs.authorize.result == 'success'
+    needs: [authorize, smoke]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Comment exact terminal status on issue 49
+        shell: bash
+        env:
+          API_URL: ${{ github.api_url }}
+          REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+          CONTROL_PLANE_SHA: ${{ needs.authorize.outputs.control_plane_sha }}
+          SMOKE_JOB_RESULT: ${{ needs.smoke.result }}
+          DECISION: ${{ needs.smoke.outputs.decision }}
+          PLAN_ID: ${{ needs.smoke.outputs.plan_id }}
+          CASE_ARTIFACT_ID: ${{ needs.smoke.outputs.case_artifact_id }}
+          CUSTODY_RECEIPT_ID: ${{ needs.smoke.outputs.custody_receipt_id }}
+          SUMMARY_ARTIFACT_ID: ${{ needs.smoke.outputs.summary_artifact_id }}
+          SMOKE_EXIT_STATUS: ${{ needs.smoke.outputs.smoke_exit_status }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from __future__ import annotations
+
+          import json
+          import os
+          import urllib.request
+
+          decision = os.environ.get("DECISION") or "workflow-failed-before-retained-decision"
+          body = "\n".join(
+              (
+                  "## CUT3R source-comparison smoke replacement terminal",
+                  "",
+                  f"- authorization ID: `{os.environ['AUTHORIZATION_ID']}`",
+                  f"- control-plane SHA: `{os.environ['CONTROL_PLANE_SHA']}`",
+                  f"- smoke job result: `{os.environ['SMOKE_JOB_RESULT']}`",
+                  f"- retained decision: `{decision}`",
+                  f"- smoke exit status: `{os.environ.get('SMOKE_EXIT_STATUS') or 'not-produced'}`",
+                  f"- plan ID: `{os.environ.get('PLAN_ID') or 'not-produced'}`",
+                  f"- case artifact ID: `{os.environ.get('CASE_ARTIFACT_ID') or 'not-produced'}`",
+                  f"- custody receipt ID: `{os.environ.get('CUSTODY_RECEIPT_ID') or 'not-produced'}`",
+                  f"- summary artifact ID: `{os.environ.get('SUMMARY_ARTIFACT_ID') or 'not-produced'}`",
+                  f"- workflow run: {os.environ['RUN_URL']}",
+                  "",
+                  "This receipt covers one development smoke only. Source truth "
+                  "and residuals, target payloads and outcomes, BayesianPhysTwin, "
+                  "and Causal4D remained closed.",
+              )
+          )
+          request = urllib.request.Request(
+              f"{os.environ['API_URL']}/repos/{os.environ['REPOSITORY']}/issues/49/comments",
+              data=json.dumps({"body": body}).encode("utf-8"),
+              method="POST",
+              headers={
+                  "Accept": "application/vnd.github+json",
+                  "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+                  "Content-Type": "application/json",
+                  "X-GitHub-Api-Version": "2022-11-28",
+              },
+          )
+          with urllib.request.urlopen(request, timeout=30):
+              pass
+          PY

--- a/.github/workflows/cut3r-source-comparison-smoke-retry-v2.yml
+++ b/.github/workflows/cut3r-source-comparison-smoke-retry-v2.yml
@@ -103,9 +103,7 @@ jobs:
       github.event.issue.number == 49 &&
       github.actor == 'FlorianPfaff' &&
       github.event.comment.user.login == 'FlorianPfaff' &&
-      github.event.comment.body ==
-        '/prob4d-run-cut3r-source-comparison-smoke-retry-v2
-        efa8ef5040f268c41c02a9ea7789272d565e36dd655beccb04cfc2b3d588477a'
+      github.event.comment.body == '/prob4d-run-cut3r-source-comparison-smoke-retry-v2 efa8ef5040f268c41c02a9ea7789272d565e36dd655beccb04cfc2b3d588477a'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/CHANGELOG.d/cut3r-source-comparison-smoke-retry-v2.md
+++ b/CHANGELOG.d/cut3r-source-comparison-smoke-retry-v2.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Authorize one content-addressed replacement of the zero-progress CUT3R
+  development smoke, bind the repaired `dust3r` callable identity, and retain an
+  independent source-artifact custody receipt without opening source outcomes or
+  targets.

--- a/docs/cut3r-source-comparison-smoke-retry-v2.md
+++ b/docs/cut3r-source-comparison-smoke-retry-v2.md
@@ -1,0 +1,39 @@
+# CUT3R source-comparison smoke replacement v2
+
+The first authorized development smoke for the frozen CUT3R source comparison
+terminated while initializing CUT3R's Python runtime. Its retained artifact
+`ef4e5bf187570e918df1d7d14434b4ae55f983c347104b9c6f7ad52b42f7a7bf`
+records that no source frame was decoded, no CUT3R inference was executed, no
+prediction was written, and no source truth, target data, BayesianPhysTwin, or
+Causal4D result was opened.
+
+This protocol permits exactly one replacement smoke on the same frozen
+development case. It is justified only by that zero-progress state. The
+replacement:
+
+- keeps source-freeze ID
+  `5e739b92c2628c61fa99ae68da61d5814ca94d4b6de5720b75c4552de82d1b2c`;
+- keeps CUT3R revision
+  `8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf` and checkpoint bytes unchanged;
+- keeps the 40-case roster, windows, seeds, alignment, covariance, fusion,
+  comparator, and information boundary unchanged;
+- corrects only the recorded/imported callable from
+  `src.dust3r.inference.inference` to `dust3r.inference.inference`;
+- requires the exact Python/CUDA package inventory retained by the first smoke;
+- executes on physical GPU 1 of the labelled `workstation2` runner; and
+- independently rehashes every retained case byte and emits a custody receipt.
+
+The GitHub issue command is accepted only once. A second command, a rerun after a
+terminal receipt, or a run with an existing replacement artifact fails before
+source decoding. The self-hosted job has read-only Actions, contents, and issue
+permissions.
+
+An ordinary-success replacement smoke permits preparation of the separately
+reviewed two-shard source execution. It does not itself authorize those shards.
+A retained technical failure is terminal for this replacement route and may not
+be silently retried.
+
+Neither outcome opens source residuals or truth, confirmation or target
+payloads, BayesianPhysTwin, or Causal4D. The result is implementation and custody
+evidence only, not provider competence, downstream benefit, deployment safety,
+or a state-of-the-art claim.

--- a/protocols/execution_requests/cut3r_source_comparison_smoke_retry_v2.json
+++ b/protocols/execution_requests/cut3r_source_comparison_smoke_retry_v2.json
@@ -1,0 +1,61 @@
+{
+  "authorization": {
+    "bayesian_phystwin_authorized": false,
+    "causal4d_authorized": false,
+    "full_source_shards_authorized": false,
+    "maximum_replacement_attempts": 1,
+    "source_truth_or_residuals_authorized": false,
+    "target_access_authorized": false
+  },
+  "authorization_id": "efa8ef5040f268c41c02a9ea7789272d565e36dd655beccb04cfc2b3d588477a",
+  "claim_boundary": "This authorization permits one replacement development smoke only because the first smoke terminated before source RGB decode, CUT3R inference, or prediction publication. It does not authorize the frozen source shards, source truth or residual access, target access, BayesianPhysTwin, Causal4D, deployment, or state-of-the-art claims.",
+  "decision": "one-exact-zero-progress-smoke-replacement-authorized",
+  "first_smoke": {
+    "artifact_id": "ef4e5bf187570e918df1d7d14434b4ae55f983c347104b9c6f7ad52b42f7a7bf",
+    "attempt_count": 1,
+    "case_id": "031-cotton-cloth-episode-0000-brics-odroid-010_cam0",
+    "case_id_sha256": "f306dc541c5c48e069c2ddc9942d75cdf537e81f65b028cbbcf35aaf410a9654",
+    "failure": {
+      "class": "ModuleNotFoundError",
+      "message": "No module named 'dust3r'",
+      "terminal_stage": "initialize-cut3r-runtime"
+    },
+    "implementation_revision": "8d0310e93269c0489b53564fd8077763829c4371",
+    "ordinary_success_count": 0,
+    "output_file_count_after_failure": 0,
+    "plan_id": "0dbb6b3a46e2c895259fd5f4a4691c1d6d3c43b0e71774171bbfb3a20239953c",
+    "retained_technical_failure_count": 1,
+    "zero_progress": {
+      "bayesian_phystwin_executed": false,
+      "candidate_reference_file_contents_opened": false,
+      "causal4d_executed": false,
+      "cut3r_inference_executed": false,
+      "source_predictions_written": false,
+      "source_residuals_or_truth_opened": false,
+      "source_rgb_frames_decoded": false,
+      "target_outcomes_opened": false,
+      "target_payloads_opened": false
+    }
+  },
+  "frozen_scientific_inputs": {
+    "checkpoint_sha256": "45f7e98a0a64dbeb54901ae2b878cd8cd125f20a4497316483f0bd6f109f8103",
+    "device_argument": "cuda:0",
+    "physical_gpu_index": 1,
+    "preflight_artifact_id": "1baad7f8786592363c9e26acf3e5b30e6fb652c6441e32818aeeff676edf2827",
+    "provider_revision": "8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf",
+    "replacement_smoke_case_id": "031-cotton-cloth-episode-0000-brics-odroid-010_cam0",
+    "source_freeze_id": "5e739b92c2628c61fa99ae68da61d5814ca94d4b6de5720b75c4552de82d1b2c"
+  },
+  "required_control_plane": {
+    "custody_gate_commit": "d787e2a3ba345581969993dabf07393e542f4f4e",
+    "provider_callable": "dust3r.inference.inference",
+    "runner_labels": [
+      "self-hosted",
+      "host-workstation2"
+    ],
+    "runner_name": "workstation2",
+    "runtime_fix_commit": "9b6b5dae325b71a1399b6cbb967740f81e3529a1"
+  },
+  "schema": "prob4d.cut3r-source-comparison-smoke-retry-authorization",
+  "schema_version": 1
+}

--- a/scripts/ci/cut3r_source_comparison_smoke_retry_v2.py
+++ b/scripts/ci/cut3r_source_comparison_smoke_retry_v2.py
@@ -1,0 +1,605 @@
+#!/usr/bin/env python3
+"""Authorize and summarize one exact zero-progress CUT3R smoke replacement."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, NoReturn, cast
+
+AUTHORIZATION_SCHEMA = "prob4d.cut3r-source-comparison-smoke-retry-authorization"
+AUTHORIZATION_VERSION = 1
+AUTHORIZATION_DECISION = "one-exact-zero-progress-smoke-replacement-authorized"
+FIRST_SUMMARY_SCHEMA = "prob4d.cut3r-source-comparison-smoke-result"
+FIRST_SUMMARY_VERSION = 1
+FIRST_SUMMARY_DECISION = "pre-science-technical-failure-no-retry"
+HISTORICAL_CALLABLE = "src.dust3r.inference.inference"
+REPAIRED_CALLABLE = "dust3r.inference.inference"
+_SHA256 = re.compile(r"[0-9a-f]{64}")
+_REVISION = re.compile(r"[0-9a-f]{40}")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    validate = subparsers.add_parser("validate", help="validate the exact authorization")
+    validate.add_argument("--repository", type=Path, required=True)
+    validate.add_argument("--authorization", type=Path, required=True)
+    validate.add_argument("--first-summary", type=Path, required=True)
+
+    adapt = subparsers.add_parser(
+        "adapt-plan",
+        help="bind the repaired callable to one newly built outcome-blind plan",
+    )
+    adapt.add_argument("--repository", type=Path, required=True)
+    adapt.add_argument("--authorization", type=Path, required=True)
+    adapt.add_argument("--first-summary", type=Path, required=True)
+    adapt.add_argument("--historical-plan", type=Path, required=True)
+    adapt.add_argument("--generated-plan", type=Path, required=True)
+    adapt.add_argument("--output", type=Path, required=True)
+
+    summarize = subparsers.add_parser(
+        "summarize",
+        help="validate one retained replacement smoke and publish a bounded summary",
+    )
+    summarize.add_argument("--authorization", type=Path, required=True)
+    summarize.add_argument("--plan", type=Path, required=True)
+    summarize.add_argument("--output-root", type=Path, required=True)
+    summarize.add_argument("--shard-report", type=Path, required=True)
+    summarize.add_argument("--custody-receipt", type=Path, required=True)
+    summarize.add_argument("--case-root", type=Path, required=True)
+    summarize.add_argument("--smoke-exit-status", type=int, required=True)
+    summarize.add_argument("--workflow-run-id", required=True)
+    summarize.add_argument("--workflow-run-attempt", required=True)
+    summarize.add_argument("--control-plane-sha", required=True)
+    summarize.add_argument("--output", type=Path, required=True)
+    summarize.add_argument("--github-output", type=Path)
+    return parser
+
+
+def _canonical_json(value: object) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _content_id(value: object) -> str:
+    return hashlib.sha256(_canonical_json(value)).hexdigest()
+
+
+def _load_json(path: Path, *, name: str) -> dict[str, Any]:
+    def reject_constant(value: str) -> NoReturn:
+        raise ValueError(f"{name} contains non-finite JSON constant {value!r}")
+
+    def unique_object(pairs: Sequence[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise ValueError(f"{name} repeats JSON key {key!r}")
+            result[key] = value
+        return result
+
+    try:
+        value = json.loads(
+            path.read_text(encoding="utf-8"),
+            parse_constant=reject_constant,
+            object_pairs_hook=unique_object,
+        )
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"failed to load {name}: {error}") from error
+    if type(value) is not dict:
+        raise ValueError(f"{name} must be a JSON object")
+    return cast(dict[str, Any], value)
+
+
+def _require_sha256(value: object, *, name: str) -> str:
+    if type(value) is not str or _SHA256.fullmatch(value) is None:
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return value
+
+
+def _require_revision(value: object, *, name: str) -> str:
+    if type(value) is not str or _REVISION.fullmatch(value) is None:
+        raise ValueError(f"{name} must be an exact lowercase Git revision")
+    return value
+
+
+def _git(repository: Path, *arguments: str) -> str:
+    result = subprocess.run(
+        ("git", "-C", os.fspath(repository), *arguments),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def _require_ancestor(repository: Path, ancestor: str, descendant: str) -> None:
+    subprocess.run(
+        (
+            "git",
+            "-C",
+            os.fspath(repository),
+            "merge-base",
+            "--is-ancestor",
+            ancestor,
+            descendant,
+        ),
+        check=True,
+        capture_output=True,
+    )
+
+
+def validate_authorization(
+    *,
+    repository: Path,
+    authorization_path: Path,
+    first_summary_path: Path,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Validate the one-shot authorization against the retained first smoke."""
+
+    repository = repository.resolve(strict=True)
+    authorization = _load_json(
+        authorization_path.resolve(strict=True),
+        name="smoke replacement authorization",
+    )
+    first_summary = _load_json(
+        first_summary_path.resolve(strict=True),
+        name="retained first smoke summary",
+    )
+    if authorization.get("schema") != AUTHORIZATION_SCHEMA:
+        raise ValueError("unsupported smoke replacement authorization schema")
+    if authorization.get("schema_version") != AUTHORIZATION_VERSION:
+        raise ValueError("unsupported smoke replacement authorization version")
+    if authorization.get("decision") != AUTHORIZATION_DECISION:
+        raise ValueError("smoke replacement is not authorized")
+    authorization_id = _require_sha256(
+        authorization.get("authorization_id"),
+        name="authorization_id",
+    )
+    unsigned = dict(authorization)
+    unsigned.pop("authorization_id")
+    if authorization_id != _content_id(unsigned):
+        raise ValueError("smoke replacement authorization identity is invalid")
+
+    if first_summary.get("schema") != FIRST_SUMMARY_SCHEMA:
+        raise ValueError("unexpected first smoke summary schema")
+    if first_summary.get("schema_version") != FIRST_SUMMARY_VERSION:
+        raise ValueError("unexpected first smoke summary version")
+    if first_summary.get("decision") != FIRST_SUMMARY_DECISION:
+        raise ValueError("first smoke was not the registered no-retry technical failure")
+
+    expected = cast(Mapping[str, Any], authorization["first_smoke"])
+    root_mapping = {
+        "artifact_id": "artifact_id",
+        "plan_id": "execution_plan_id",
+        "case_id_sha256": "case_id_sha256",
+        "implementation_revision": "frozen_implementation_revision",
+        "attempt_count": "attempt_count",
+        "ordinary_success_count": "ordinary_success_count",
+        "retained_technical_failure_count": "retained_technical_failure_count",
+        "output_file_count_after_failure": "output_file_count_after_failure",
+    }
+    for expected_name, summary_name in root_mapping.items():
+        if first_summary.get(summary_name) != expected.get(expected_name):
+            raise ValueError(f"first smoke field changed: {summary_name}")
+
+    first_case_id = cast(str, expected["case_id"])
+    measured_case_hash = hashlib.sha256(first_case_id.encode("utf-8")).hexdigest()
+    if measured_case_hash != expected["case_id_sha256"]:
+        raise ValueError("authorized smoke case identity is internally inconsistent")
+    failure = cast(Mapping[str, Any], expected["failure"])
+    if first_summary.get("failure") != failure:
+        raise ValueError("first smoke failure diagnosis changed")
+    boundary = first_summary.get("information_boundary")
+    if type(boundary) is not dict:
+        raise ValueError("first smoke information boundary is missing")
+    for field, expected_value in cast(
+        Mapping[str, bool],
+        expected["zero_progress"],
+    ).items():
+        if boundary.get(field) is not expected_value:
+            raise ValueError(f"first smoke exceeded zero-progress boundary: {field}")
+    if first_summary.get("retry_authorized") is not False:
+        raise ValueError("first smoke summary was mutated to authorize a retry")
+    if first_summary.get("retry_performed") is not False:
+        raise ValueError("first smoke summary was mutated to claim a retry")
+
+    frozen = cast(Mapping[str, Any], authorization["frozen_scientific_inputs"])
+    if first_summary.get("source_freeze_id") != frozen["source_freeze_id"]:
+        raise ValueError("first smoke source-freeze identity changed")
+    if frozen["replacement_smoke_case_id"] != first_case_id:
+        raise ValueError("replacement smoke case differs from the zero-progress case")
+    control = cast(Mapping[str, Any], authorization["required_control_plane"])
+    if control.get("provider_callable") != REPAIRED_CALLABLE:
+        raise ValueError("authorization does not bind the repaired CUT3R callable")
+    if control.get("runner_name") != "workstation2":
+        raise ValueError("authorization does not bind workstation2")
+    if control.get("runner_labels") != ["self-hosted", "host-workstation2"]:
+        raise ValueError("authorization runner labels changed")
+    limits = cast(Mapping[str, Any], authorization["authorization"])
+    if limits.get("maximum_replacement_attempts") != 1:
+        raise ValueError("authorization is not limited to one replacement")
+    for field in (
+        "full_source_shards_authorized",
+        "source_truth_or_residuals_authorized",
+        "target_access_authorized",
+        "bayesian_phystwin_authorized",
+        "causal4d_authorized",
+    ):
+        if limits.get(field) is not False:
+            raise ValueError(f"authorization exceeds the smoke boundary: {field}")
+
+    head = _require_revision(_git(repository, "rev-parse", "HEAD"), name="repository HEAD")
+    _require_ancestor(
+        repository,
+        _require_revision(control["runtime_fix_commit"], name="runtime_fix_commit"),
+        head,
+    )
+    _require_ancestor(
+        repository,
+        _require_revision(control["custody_gate_commit"], name="custody_gate_commit"),
+        head,
+    )
+    return authorization, first_summary
+
+
+def _verify_content_identity(value: Mapping[str, Any], *, id_field: str, name: str) -> None:
+    recorded = _require_sha256(value.get(id_field), name=f"{name} {id_field}")
+    unsigned = dict(value)
+    unsigned.pop(id_field)
+    if recorded != _content_id(unsigned):
+        raise ValueError(f"{name} content identity is invalid")
+
+
+def adapt_plan(
+    *,
+    repository: Path,
+    authorization_path: Path,
+    first_summary_path: Path,
+    historical_plan_path: Path,
+    generated_plan_path: Path,
+    output_path: Path,
+) -> dict[str, Any]:
+    """Create the exact repaired plan before any replacement smoke data are opened."""
+
+    authorization, _ = validate_authorization(
+        repository=repository,
+        authorization_path=authorization_path,
+        first_summary_path=first_summary_path,
+    )
+    historical = _load_json(
+        historical_plan_path.resolve(strict=True),
+        name="historical source-comparison plan",
+    )
+    generated = _load_json(
+        generated_plan_path.resolve(strict=True),
+        name="newly generated source-comparison plan",
+    )
+    _verify_content_identity(historical, id_field="plan_id", name="historical plan")
+    _verify_content_identity(generated, id_field="plan_id", name="generated plan")
+
+    first = cast(Mapping[str, Any], authorization["first_smoke"])
+    frozen = cast(Mapping[str, Any], authorization["frozen_scientific_inputs"])
+    if historical["plan_id"] != first["plan_id"]:
+        raise ValueError("historical plan differs from the retained first smoke")
+    if historical["source_freeze_id"] != frozen["source_freeze_id"]:
+        raise ValueError("historical plan source-freeze identity changed")
+    if generated["source_freeze_id"] != frozen["source_freeze_id"]:
+        raise ValueError("generated plan source-freeze identity changed")
+    if historical["preflight_artifact_id"] != frozen["preflight_artifact_id"]:
+        raise ValueError("historical preflight identity changed")
+    if generated["preflight_artifact_id"] != frozen["preflight_artifact_id"]:
+        raise ValueError("generated preflight identity changed")
+
+    stable_fields = (
+        "schema",
+        "schema_version",
+        "decision",
+        "comparison_lock_id",
+        "method",
+        "execution",
+        "cases",
+        "information_boundary",
+        "claim_boundary",
+    )
+    for field in stable_fields:
+        if generated.get(field) != historical.get(field):
+            raise ValueError(f"replacement plan changed frozen scientific field: {field}")
+
+    historical_provider = dict(cast(Mapping[str, Any], historical["provider"]))
+    generated_provider = dict(cast(Mapping[str, Any], generated["provider"]))
+    if historical_provider.pop("callable") != HISTORICAL_CALLABLE:
+        raise ValueError("historical plan no longer records its original callable")
+    generated_callable = generated_provider.pop("callable")
+    if generated_callable not in {HISTORICAL_CALLABLE, REPAIRED_CALLABLE}:
+        raise ValueError("generated plan records an unsupported provider callable")
+    if generated_provider != historical_provider:
+        raise ValueError("replacement plan changed frozen provider inputs")
+    generated["provider"]["callable"] = REPAIRED_CALLABLE
+
+    if generated.get("runtime") != historical.get("runtime"):
+        raise ValueError("replacement smoke runtime differs from the first smoke runtime")
+    historical_implementation = cast(Mapping[str, Any], historical["implementation"])
+    generated_implementation = cast(Mapping[str, Any], generated["implementation"])
+    if historical_implementation.get("revision") != first["implementation_revision"]:
+        raise ValueError("historical implementation revision changed")
+    head = _require_revision(
+        _git(repository.resolve(strict=True), "rev-parse", "HEAD"),
+        name="repository HEAD",
+    )
+    if generated_implementation.get("revision") != head:
+        raise ValueError("generated plan does not bind the exact control-plane revision")
+    old_hashes = cast(Mapping[str, str], historical_implementation["source_file_sha256"])
+    new_hashes = cast(Mapping[str, str], generated_implementation["source_file_sha256"])
+    if set(old_hashes) != set(new_hashes):
+        raise ValueError("replacement implementation file roster changed")
+    changed = sorted(path for path in old_hashes if old_hashes[path] != new_hashes[path])
+    if changed != ["scripts/science/run_cut3r_source_comparison.py"]:
+        raise ValueError(f"unexpected replacement implementation changes: {changed!r}")
+
+    authorization_id = cast(str, authorization["authorization_id"])
+    generated["replacement_smoke_authorization_id"] = authorization_id
+    generated["provenance_repair"] = {
+        "first_smoke_artifact_id": first["artifact_id"],
+        "first_smoke_plan_id": first["plan_id"],
+        "from_provider_callable": HISTORICAL_CALLABLE,
+        "to_provider_callable": REPAIRED_CALLABLE,
+        "runtime_fix_commit": authorization["required_control_plane"]["runtime_fix_commit"],
+        "custody_gate_commit": authorization["required_control_plane"]["custody_gate_commit"],
+        "scientific_method_changed": False,
+        "provider_or_checkpoint_changed": False,
+        "source_or_target_roster_changed": False,
+    }
+    generated.pop("plan_id")
+    generated["plan_id"] = _content_id(generated)
+    output = output_path.resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    encoded = (
+        json.dumps(generated, indent=2, sort_keys=True, allow_nan=False).encode("utf-8")
+        + b"\n"
+    )
+    if output.exists() and output.read_bytes() != encoded:
+        raise FileExistsError("different repaired execution plan already exists")
+    output.write_bytes(encoded)
+    return generated
+
+
+def _write_github_output(path: Path | None, values: Mapping[str, object]) -> None:
+    if path is None:
+        return
+    with path.open("a", encoding="utf-8") as stream:
+        for key, value in values.items():
+            text = str(value)
+            if "\n" in text or "\r" in text:
+                raise ValueError(f"GitHub output {key!r} is not a scalar")
+            stream.write(f"{key}={text}\n")
+
+
+def summarize(
+    *,
+    authorization_path: Path,
+    plan_path: Path,
+    output_root: Path,
+    shard_report_path: Path,
+    custody_receipt_path: Path,
+    case_root: Path,
+    smoke_exit_status: int,
+    workflow_run_id: str,
+    workflow_run_attempt: str,
+    control_plane_sha: str,
+    output_path: Path,
+    github_output: Path | None,
+) -> dict[str, Any]:
+    """Bind one custody-validated replacement result without interpreting outcomes."""
+
+    authorization = _load_json(
+        authorization_path.resolve(strict=True),
+        name="smoke replacement authorization",
+    )
+    plan = _load_json(plan_path.resolve(strict=True), name="repaired execution plan")
+    report = _load_json(shard_report_path.resolve(strict=True), name="smoke shard report")
+    receipt = _load_json(
+        custody_receipt_path.resolve(strict=True),
+        name="smoke custody receipt",
+    )
+    case = _load_json(
+        (case_root.resolve(strict=True) / "case_manifest.json"),
+        name="smoke case manifest",
+    )
+    _verify_content_identity(plan, id_field="plan_id", name="repaired plan")
+    _verify_content_identity(report, id_field="artifact_id", name="smoke report")
+    _verify_content_identity(case, id_field="artifact_id", name="smoke case")
+
+    authorization_id = _require_sha256(
+        authorization.get("authorization_id"),
+        name="authorization_id",
+    )
+    if plan.get("replacement_smoke_authorization_id") != authorization_id:
+        raise ValueError("repaired plan is not bound to the one-shot authorization")
+    frozen = cast(Mapping[str, Any], authorization["frozen_scientific_inputs"])
+    case_id = cast(str, frozen["replacement_smoke_case_id"])
+    if case.get("case_id") != case_id or case_root.name != case_id:
+        raise ValueError("replacement smoke case identity changed")
+    plan_id = _require_sha256(plan.get("plan_id"), name="plan_id")
+    if report.get("plan_id") != plan_id or case.get("plan_id") != plan_id:
+        raise ValueError("replacement smoke artifacts do not share one plan identity")
+    if report.get("scope") != "development-smoke":
+        raise ValueError("replacement execution is not a development smoke")
+    if report.get("case_count") != 1:
+        raise ValueError("replacement smoke did not contain exactly one case")
+    if receipt.get("decision") != "source-comparison-custody-valid":
+        raise ValueError("replacement smoke custody did not validate")
+    if receipt.get("plan_id") != plan_id:
+        raise ValueError("custody receipt plan identity changed")
+    if receipt.get("case_ids") != [case_id]:
+        raise ValueError("custody receipt case identity changed")
+    if receipt.get("case_artifact_ids") != [case["artifact_id"]]:
+        raise ValueError("custody receipt case artifact identity changed")
+    for field in (
+        "source_residuals_or_truth_opened",
+        "target_payloads_opened",
+        "target_outcomes_opened",
+        "bayesian_phystwin_executed",
+        "causal4d_executed",
+    ):
+        if receipt.get(field) is not False:
+            raise ValueError(f"replacement smoke custody exceeded boundary: {field}")
+    if receipt.get("decoded_source_frames_retained") is not False:
+        raise ValueError("replacement smoke retained decoded source frames")
+
+    status = case.get("status")
+    if status == "ordinary-success":
+        expected_exit = 0
+        decision = "ordinary-success-development-smoke"
+        if report.get("ordinary_success_count") != 1:
+            raise ValueError("successful smoke report has the wrong success count")
+        if report.get("retained_technical_failure_count") != 0:
+            raise ValueError("successful smoke report retains a technical failure")
+    elif status == "retained-technical-failure":
+        expected_exit = 3
+        decision = "retained-technical-failure-no-further-retry"
+        if report.get("ordinary_success_count") != 0:
+            raise ValueError("failed smoke report has the wrong success count")
+        if report.get("retained_technical_failure_count") != 1:
+            raise ValueError("failed smoke report has the wrong failure count")
+    else:
+        raise ValueError("replacement smoke has an unsupported status")
+    if smoke_exit_status != expected_exit:
+        raise ValueError("replacement smoke process status differs from retained evidence")
+
+    summary: dict[str, Any] = {
+        "schema": "prob4d.cut3r-source-comparison-smoke-retry-result",
+        "schema_version": 1,
+        "decision": decision,
+        "authorization_id": authorization_id,
+        "control_plane_sha": _require_revision(
+            control_plane_sha,
+            name="control_plane_sha",
+        ),
+        "workflow_run_id": str(workflow_run_id),
+        "workflow_run_attempt": str(workflow_run_attempt),
+        "plan_id": plan_id,
+        "source_freeze_id": frozen["source_freeze_id"],
+        "case_id": case_id,
+        "case_artifact_id": case["artifact_id"],
+        "shard_report_artifact_id": report["artifact_id"],
+        "custody_receipt_id": receipt["receipt_id"],
+        "smoke_exit_status": smoke_exit_status,
+        "ordinary_success_count": report["ordinary_success_count"],
+        "retained_technical_failure_count": report[
+            "retained_technical_failure_count"
+        ],
+        "source_rgb_frames_decoded": case["source_rgb_frames_decoded"],
+        "cut3r_inference_executed": case["cut3r_inference_executed"],
+        "source_predictions_written": case["source_predictions_written"],
+        "decoded_source_frames_retained": False,
+        "source_residuals_or_truth_opened": False,
+        "target_payloads_opened": False,
+        "target_outcomes_opened": False,
+        "bayesian_phystwin_executed": False,
+        "causal4d_executed": False,
+        "full_source_shards_authorized": status == "ordinary-success",
+    }
+    summary["artifact_id"] = _content_id(summary)
+    output = output_path.resolve()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    encoded = (
+        json.dumps(summary, indent=2, sort_keys=True, allow_nan=False).encode("utf-8")
+        + b"\n"
+    )
+    if output.exists() and output.read_bytes() != encoded:
+        raise FileExistsError("different replacement summary already exists")
+    output.write_bytes(encoded)
+    _write_github_output(
+        github_output,
+        {
+            "decision": decision,
+            "plan_id": plan_id,
+            "case_artifact_id": case["artifact_id"],
+            "custody_receipt_id": receipt["receipt_id"],
+            "summary_artifact_id": summary["artifact_id"],
+            "smoke_exit_status": smoke_exit_status,
+        },
+    )
+    return summary
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.command == "validate":
+        authorization, _ = validate_authorization(
+            repository=args.repository,
+            authorization_path=args.authorization,
+            first_summary_path=args.first_summary,
+        )
+        print(
+            json.dumps(
+                {
+                    "authorization_id": authorization["authorization_id"],
+                    "decision": authorization["decision"],
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+    if args.command == "adapt-plan":
+        plan = adapt_plan(
+            repository=args.repository,
+            authorization_path=args.authorization,
+            first_summary_path=args.first_summary,
+            historical_plan_path=args.historical_plan,
+            generated_plan_path=args.generated_plan,
+            output_path=args.output,
+        )
+        print(
+            json.dumps(
+                {
+                    "decision": plan["decision"],
+                    "plan_id": plan["plan_id"],
+                    "provider_callable": plan["provider"]["callable"],
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+    summary = summarize(
+        authorization_path=args.authorization,
+        plan_path=args.plan,
+        output_root=args.output_root,
+        shard_report_path=args.shard_report,
+        custody_receipt_path=args.custody_receipt,
+        case_root=args.case_root,
+        smoke_exit_status=args.smoke_exit_status,
+        workflow_run_id=args.workflow_run_id,
+        workflow_run_attempt=args.workflow_run_attempt,
+        control_plane_sha=args.control_plane_sha,
+        output_path=args.output,
+        github_output=args.github_output,
+    )
+    print(
+        json.dumps(
+            {
+                "artifact_id": summary["artifact_id"],
+                "decision": summary["decision"],
+                "plan_id": summary["plan_id"],
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cut3r_source_comparison_smoke_retry_v2.py
+++ b/tests/test_cut3r_source_comparison_smoke_retry_v2.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+ROOT = Path(__file__).resolve().parents[1]
+AUTHORIZATION = (
+    ROOT
+    / "protocols"
+    / "execution_requests"
+    / "cut3r_source_comparison_smoke_retry_v2.json"
+)
+FIRST_SUMMARY = ROOT / "evidence" / "cut3r-source-comparison-smoke-v1" / "summary.json"
+HELPER = ROOT / "scripts" / "ci" / "cut3r_source_comparison_smoke_retry_v2.py"
+WORKFLOW = (
+    ROOT
+    / ".github"
+    / "workflows"
+    / "cut3r-source-comparison-smoke-retry-v2.yml"
+)
+
+
+def _canonical_json(value: object) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _load(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    assert type(value) is dict
+    return cast(dict[str, Any], value)
+
+
+def test_authorization_is_content_addressed_and_one_shot() -> None:
+    authorization = _load(AUTHORIZATION)
+    recorded = authorization.pop("authorization_id")
+    assert recorded == hashlib.sha256(_canonical_json(authorization)).hexdigest()
+    assert authorization["schema"] == (
+        "prob4d.cut3r-source-comparison-smoke-retry-authorization"
+    )
+    assert authorization["schema_version"] == 1
+    assert authorization["decision"] == (
+        "one-exact-zero-progress-smoke-replacement-authorized"
+    )
+    limits = authorization["authorization"]
+    assert limits == {
+        "bayesian_phystwin_authorized": False,
+        "causal4d_authorized": False,
+        "full_source_shards_authorized": False,
+        "maximum_replacement_attempts": 1,
+        "source_truth_or_residuals_authorized": False,
+        "target_access_authorized": False,
+    }
+
+
+def test_authorization_matches_the_retained_zero_progress_failure() -> None:
+    authorization = _load(AUTHORIZATION)
+    summary = _load(FIRST_SUMMARY)
+    first = authorization["first_smoke"]
+    assert summary["artifact_id"] == first["artifact_id"]
+    assert summary["execution_plan_id"] == first["plan_id"]
+    assert summary["frozen_implementation_revision"] == first["implementation_revision"]
+    assert summary["attempt_count"] == 1
+    assert summary["ordinary_success_count"] == 0
+    assert summary["retained_technical_failure_count"] == 1
+    assert summary["output_file_count_after_failure"] == 0
+    assert summary["failure"] == first["failure"]
+    assert summary["retry_authorized"] is False
+    assert summary["retry_performed"] is False
+    for field, value in first["zero_progress"].items():
+        assert summary["information_boundary"][field] is value
+
+
+def test_helper_replays_the_exact_authorization() -> None:
+    subprocess.run(
+        (
+            sys.executable,
+            str(HELPER),
+            "validate",
+            "--repository",
+            str(ROOT),
+            "--authorization",
+            str(AUTHORIZATION),
+            "--first-summary",
+            str(FIRST_SUMMARY),
+        ),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_workflow_is_hosted_authorized_and_read_only_on_workstation2() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "\n  pull_request:" in text
+    assert "\n  issue_comment:" in text
+    assert "pull_request_target:" not in text
+    assert "github.event.issue.number == 49" in text
+    assert "github.actor == 'FlorianPfaff'" in text
+    assert "github.event.comment.user.login == 'FlorianPfaff'" in text
+    assert "runs-on: [self-hosted, host-workstation2]" in text
+    assert 'test "$RUNNER_NAME" = "workstation2"' in text
+    assert 'test "$RUNNER_OS" = "Linux"' in text
+    assert 'test "$RUNNER_ARCH" = "X64"' in text
+    assert "physical_gpu_index=1" in text
+    assert "CUDA_VISIBLE_DEVICES=1" in text
+    assert "permissions:\n      actions: read\n      contents: read\n      issues: read" in text
+    assert "contents: write" not in text
+    assert "git push" not in text
+    assert "sudo " not in text
+    assert "safe.directory=*" not in text
+    assert "persist-credentials: false" in text
+
+
+def test_workflow_binds_plan_custody_and_information_boundary() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "adapt-plan" in text
+    assert "dust3r.inference.inference" not in text
+    assert "verify_cut3r_source_comparison_artifacts.py shard" in text
+    assert "--allow-technical-failures" in text
+    assert "ordinary-success-development-smoke" in text
+    assert "full source shards" in text
+    assert "BayesianPhysTwin" in text
+    assert "Causal4D" in text
+    assert "Reject a duplicate retained attempt" in text
+    assert "a retained replacement artifact already exists" in text
+    assert "a terminal replacement receipt already exists" in text

--- a/tests/test_trusted_self_hosted_validation_policy.py
+++ b/tests/test_trusted_self_hosted_validation_policy.py
@@ -8,6 +8,9 @@ TRUSTED_WORKFLOW = WORKFLOW_ROOT / "trusted-self-hosted-validation.yml"
 SOURCE_FREEZE_EXECUTION_WORKFLOW = WORKFLOW_ROOT / "cut3r-source-freeze-execution.yml"
 SOURCE_FREEZE_AUTO_V2_WORKFLOW = WORKFLOW_ROOT / "cut3r-source-freeze-auto-v2.yml"
 CUT3R_CHECKOUT_TRUST_RERUN_WORKFLOW = WORKFLOW_ROOT / "cut3r-checkout-trust-rerun-v1.yml"
+CUT3R_SOURCE_COMPARISON_SMOKE_RETRY_V2_WORKFLOW = (
+    WORKFLOW_ROOT / "cut3r-source-comparison-smoke-retry-v2.yml"
+)
 CUT3R_RUNNER_SELECTOR = (
     "runs-on: [self-hosted, Linux, X64, nvidia-smi, "
     + "data-prob4d-deform360-source-v1, prob4d-cut3r]"
@@ -18,6 +21,7 @@ TRUSTED_SELF_HOSTED_WORKFLOWS = (
     SOURCE_FREEZE_EXECUTION_WORKFLOW,
     SOURCE_FREEZE_AUTO_V2_WORKFLOW,
     CUT3R_CHECKOUT_TRUST_RERUN_WORKFLOW,
+    CUT3R_SOURCE_COMPARISON_SMOKE_RETRY_V2_WORKFLOW,
 )
 REMOVED_TEMPORARY_WORKFLOWS = (
     WORKFLOW_ROOT / "issue-49-protected-cohort-inventory.yml",


### PR DESCRIPTION
## Superseded

Closed without merge because PR #325 landed first with the more complete prospective v2 execution route. It already binds the exact zero-information predecessor, localizes the `dust3r` import repair, generates a new content-addressed plan before source access, requires development-smoke custody, and conditionally executes both frozen source shards while preserving the target-closed boundary.

The v2 command was accepted on issue #49 and workflow run `32841781121` is the sole admitted execution. This PR produced no workflow dispatch, source decode, CUT3R inference, source outcome access, target access, BayesianPhysTwin result, or Causal4D result.

Refs #49, #325