### PR TITLE
Record terminal CUT3R smoke result

### DIFF
--- a/CHANGELOG.d/cut3r-source-comparison-smoke-v1-2-result.md
+++ b/CHANGELOG.d/cut3r-source-comparison-smoke-v1-2-result.md
@@ -1,0 +1,1 @@
+- Preserve the one-shot CUT3R v1.2 smoke as a no-retry provider-inference failure, keep all truth and target boundaries closed, and remove decoded source frames from future technical-failure artifacts before publication.

--- a/docs/cut3r-source-comparison-smoke-v1-2-result.md
+++ b/docs/cut3r-source-comparison-smoke-v1-2-result.md
@@ -1,0 +1,40 @@
+# CUT3R source-comparison smoke v1.2 result
+
+The one registered distinct development smoke consumed its write-once attempt
+ledger and reached the CUT3R provider forward pass. The frozen model and
+checkpoint loaded, 58 causal source frames were decoded, and the first native
+continuous inference terminated with a CUDA device-side index assertion.
+
+The retained execution record reports:
+
+- 0 ordinary successes;
+- 1 retained technical failure;
+- 0 prediction products;
+- no source truth, candidate-reference contents, targets, BayesianPhysTwin, or
+  Causal4D access; and
+- no retry authorization.
+
+This is a real provider-runtime negative result, not an accuracy result. It
+closes the registered schema-v3 smoke and does not authorize the two frozen
+source shards.
+
+## Custody defect
+
+The independent artifact verifier then correctly rejected the retained case:
+the failure path had moved all 58 decoded PNG frames into the case directory.
+The source-only server tree remains quarantined and unmodified; it must not be
+published as an artifact. The compact metadata-only result is preserved at
+`evidence/cut3r-source-comparison-smoke-v1-2/summary.json`.
+
+The runner now removes its decoded-frame directory in a `finally` block before
+publishing either a success or a technical-failure manifest. This cleanup fix
+is prospective implementation hardening only. It does not reopen or retry the
+consumed smoke and does not convert the failed artifact into valid custody.
+
+## Claim boundary
+
+The result establishes that the repaired import path reaches actual CUT3R GPU
+inference, and that this frozen 58-frame invocation is not runtime-compatible
+with the pinned provider/checkpoint path. It establishes no provider competence,
+point accuracy, uncertainty calibration, transfer, or downstream physical-twin
+benefit.

--- a/evidence/cut3r-source-comparison-smoke-v1-2/summary.json
+++ b/evidence/cut3r-source-comparison-smoke-v1-2/summary.json
@@ -1,0 +1,56 @@
+{
+  "artifact_id": "c6577587b2b5f9dc92d408bb199fffbf710fa7b74bf271853e55a66c0edc81c9",
+  "attempt": {
+    "attempt_number": 1,
+    "ledger_file_sha256": "c315f73396b0d5557696e2326f10b9e4a5f1aee9d63c25479176a61b355e122c",
+    "ledger_record_id": "3ab151bf08d20bb460ee91d83b9decd0b22e0ffd7e933db483e429af850c3356",
+    "retry_authorized": false
+  },
+  "claim_boundary": "One registered development smoke only. This is provider-runtime and custody evidence, not source competence, accuracy, uncertainty, target transfer, BayesianPhysTwin, Causal4D, safety, or state-of-the-art evidence.",
+  "custody": {
+    "decoded_byte_count": 44036214,
+    "decoded_member_count": 58,
+    "decision": "failed-decoded-source-frames-retained",
+    "official_custody_receipt_written": false,
+    "publication_authorized": false,
+    "quarantined_source_tree_modified": false,
+    "verifier_error": "decoded source frame retained in case artifact: decoded/000000.png"
+  },
+  "execution": {
+    "case_id_sha256": "8ddd8b05edcd78515fc7c5647e2736060630e0932a59702495b2853a68f02fa7",
+    "cut3r_inference_executed": false,
+    "elapsed_seconds": 2.1263942389923614,
+    "failure_class": "RuntimeError",
+    "failure_summary": "CUDA error: device-side assert triggered",
+    "ordinary_success_count": 0,
+    "source_predictions_written": false,
+    "source_rgb_frames_decoded": true,
+    "terminal_stage": "provider-inference"
+  },
+  "information_boundary": {
+    "bayesian_phystwin_executed": false,
+    "candidate_reference_file_contents_opened": false,
+    "causal4d_executed": false,
+    "source_residuals_or_truth_opened": false,
+    "target_outcomes_opened": false,
+    "target_payloads_opened": false
+  },
+  "inputs": {
+    "checkpoint_sha256": "45f7e98a0a64dbeb54901ae2b878cd8cd125f20a4497316483f0bd6f109f8103",
+    "implementation_revision": "06f7a19c2016b291f85bf17634a515ffc4890ac1",
+    "plan_file_sha256": "172e725e3ecfe12dac7c0e402f01883dd92d6898179e89079f21f2b3c05e680c",
+    "plan_id": "1c74105994cb32885c8ab57af5a2d1feb296ce63c5e9a3fc39665fb2094bad3a",
+    "provider_revision": "8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf"
+  },
+  "raw_evidence": {
+    "case_artifact_id": "72244d724c21f942c1c0808b8e1beedda22bcce006c80cd20eff5cd1bb877986",
+    "case_manifest_file_sha256": "231b8c0eef6fd7911b7c20d7abe805509422673ca2b7f9f8ddc41204714c5d6c",
+    "quarantined_member_count": 59,
+    "shard_report_artifact_id": "920a3a92079dadf814e1f993413d93c3cfc56fb5a4971c609edcc1fdd31a82cd",
+    "shard_report_file_sha256": "c372a9da97bf78dcd4023340e9c90fb456c550c95eab1792f4966d6b021383c7"
+  },
+  "result": "retained-technical-failure-no-retry",
+  "schema": "prob4d.cut3r-source-comparison-smoke-result",
+  "schema_version": 2,
+  "source_shards_authorized": false
+}

--- a/scripts/science/run_cut3r_source_comparison.py
+++ b/scripts/science/run_cut3r_source_comparison.py
@@ -483,7 +483,6 @@ def _execute_case(
             }
         _write_json_no_clobber(staging / "gauge_diagnostics.json", diagnostics)
         progress["source_predictions_written"] = True
-        shutil.rmtree(staging / "decoded")
     except Exception as error:
         status = "retained-technical-failure"
         failure = _safe_error(error, redactions)
@@ -491,6 +490,12 @@ def _execute_case(
             _safe_error(RuntimeError(traceback.format_exc()), redactions) + "\n",
             encoding="utf-8",
         )
+    finally:
+        decoded_root = staging / "decoded"
+        if decoded_root.is_symlink():
+            decoded_root.unlink()
+        elif decoded_root.exists():
+            shutil.rmtree(decoded_root)
     manifest = _publish_case_manifest(
         staging,
         plan=plan,
@@ -789,9 +794,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         "shard_index": args.shard_index,
         "shard_count": args.shard_count,
         "case_count": len(records),
-        "ordinary_success_count": sum(
-            record["status"] == "ordinary-success" for record in records
-        ),
+        "ordinary_success_count": sum(record["status"] == "ordinary-success" for record in records),
         "retained_technical_failure_count": sum(
             record["status"] == "retained-technical-failure" for record in records
         ),

--- a/tests/test_cut3r_source_comparison_execution.py
+++ b/tests/test_cut3r_source_comparison_execution.py
@@ -18,11 +18,15 @@ from prob4d.cut3r_source_comparison_execution import (
 from prob4d.cut3r_source_comparison_verifier import (
     content_id,
     path_identity_sha256,
+    validate_case_artifact,
     validate_shard_artifact,
     write_custody_receipt,
 )
 from prob4d.data import PredictionWindow
 from prob4d.sim3 import Sim3
+
+ROOT = Path(__file__).resolve().parents[1]
+V1_2_RESULT = ROOT / "evidence" / "cut3r-source-comparison-smoke-v1-2" / "summary.json"
 
 
 def _load_runner_module():
@@ -140,9 +144,23 @@ def test_native_product_preserves_point_mean_and_support() -> None:
     assert np.all(native.contributors[native.valid_mask] == 1)
 
 
-def test_cut3r_runtime_exposes_repository_and_internal_package(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_v1_2_smoke_result_is_content_bound_terminal_and_target_closed() -> None:
+    result = json.loads(V1_2_RESULT.read_text(encoding="utf-8"))
+    unsigned = dict(result)
+    artifact_id = unsigned.pop("artifact_id")
+
+    assert content_id(unsigned) == artifact_id
+    assert result["result"] == "retained-technical-failure-no-retry"
+    assert result["attempt"]["attempt_number"] == 1
+    assert result["attempt"]["retry_authorized"] is False
+    assert result["source_shards_authorized"] is False
+    assert result["execution"]["ordinary_success_count"] == 0
+    assert result["execution"]["source_predictions_written"] is False
+    assert result["custody"]["publication_authorized"] is False
+    assert not any(result["information_boundary"].values())
+
+
+def test_cut3r_runtime_exposes_repository_and_internal_package(tmp_path: Path, monkeypatch) -> None:
     module = _load_runner_module()
     checkout = tmp_path / "CUT3R"
     (checkout / "src").mkdir(parents=True)
@@ -188,6 +206,70 @@ def test_runtime_bootstrap_failure_is_retained_without_progress(tmp_path: Path) 
     assert (output / "cases/development-case/case_manifest.json").is_file()
 
 
+def test_provider_failure_after_decode_removes_source_frames(tmp_path: Path, monkeypatch) -> None:
+    module = _load_runner_module()
+    processed = tmp_path / "processed"
+    output = tmp_path / "output"
+    checkout = tmp_path / "CUT3R"
+    checkpoint = tmp_path / "model.pth"
+    processed.mkdir()
+    checkout.mkdir()
+    checkpoint.write_bytes(b"checkpoint")
+    video = processed / "video.mp4"
+    video.write_bytes(b"video")
+
+    class FailingRuntime:
+        def __init__(self) -> None:
+            self.checkout = checkout
+            self.checkpoint = checkpoint
+
+        def infer_to_direct_tree(self, frames: list[Path], output_root: Path) -> None:
+            assert len(frames) == 1
+            raise RuntimeError("provider inference failed")
+
+    def decode_frames(
+        source: Path,
+        decoded_root: Path,
+        *,
+        frame_start: int,
+        frame_stop_exclusive: int,
+    ) -> list[Path]:
+        assert source == video
+        assert (frame_start, frame_stop_exclusive) == (0, 1)
+        decoded_root.mkdir(parents=True)
+        frame = decoded_root / "000000.png"
+        frame.write_bytes(b"source-rgb")
+        return [frame]
+
+    monkeypatch.setattr(module, "_verify_video", lambda *_args: video)
+    monkeypatch.setattr(module, "_decode_frames", decode_frames)
+    case = {
+        "case_id": "development-case",
+        "group_id": "development-group",
+        "role": "development",
+        "frame_start": 0,
+        "frame_stop_exclusive": 1,
+    }
+
+    manifest = module._execute_case(
+        FailingRuntime(),
+        case=case,
+        plan={"plan_id": "a" * 64},
+        processed_root=processed,
+        output_root=output,
+        shard_index=0,
+    )
+
+    case_root = output / "cases" / "development-case"
+    assert manifest["status"] == "retained-technical-failure"
+    assert manifest["source_rgb_frames_decoded"] is True
+    assert manifest["cut3r_inference_executed"] is False
+    assert not (case_root / "decoded").exists()
+    assert [member["path"] for member in manifest["members"]] == ["failure_traceback.txt"]
+    validated = validate_case_artifact(case_root, expected_plan_id="a" * 64)
+    assert validated["artifact_id"] == manifest["artifact_id"]
+
+
 def test_amended_plan_selects_only_the_registered_replacement_smoke() -> None:
     module = _load_runner_module()
     plan = {
@@ -227,9 +309,7 @@ def _amended_gate_plan(output_root: Path, ledger: Path) -> dict[str, object]:
         "execution": {
             "smoke_policy": {
                 "registered_case_id": case_id,
-                "registered_case_id_sha256": hashlib.sha256(
-                    case_id.encode("utf-8")
-                ).hexdigest(),
+                "registered_case_id_sha256": hashlib.sha256(case_id.encode("utf-8")).hexdigest(),
                 "registered_output_root_path_sha256": path_identity_sha256(output_root),
                 "registered_attempt_ledger_path_sha256": path_identity_sha256(ledger),
             }


### PR DESCRIPTION
## Summary
- preserve the single registered schema-v3 CUT3R smoke as a no-retry provider-inference failure
- bind the ledger, plan, provider, checkpoint, case/report hashes, and closed information boundary in a compact result artifact
- remove decoded source frames in a `finally` block before future success or failure manifests are published

## Result boundary
The smoke loaded the frozen model, decoded 58 causal source frames, and entered the provider forward pass before a CUDA device-side index assertion. It produced zero predictions and opened no source truth, targets, BayesianPhysTwin, or Causal4D evidence. The original output tree remains quarantined and unmodified because its failed case retained decoded frames; no retry or source shard is authorized.

## Verification
- `1850 passed, 7 skipped`
- focused execution/custody tests: `18 passed`
- Ruff and format checks pass
- changed runner passes focused MyPy under Python 3.12
- `git diff --check` passes