### PR TITLE
Add observable-subspace Sim(3) gauge factors

### DIFF
--- a/CHANGELOG.d/observable-gauge-subspace.md
+++ b/CHANGELOG.d/observable-gauge-subspace.md
@@ -1,0 +1,4 @@
+- Add an experimental centroid-normalized observable-subspace Sim(3) factor and a
+  frozen DLO-like study showing that rank-six gauge information can improve observed
+  and off-support geometry without fabricating certainty in the unobservable twist
+  direction.

--- a/docs/observable-gauge-subspace.md
+++ b/docs/observable-gauge-subspace.md
@@ -1,0 +1,180 @@
+# Observable-subspace Sim(3) gauge factors
+
+Status: **experimental scientific kernel**. This path is not admitted to the
+claim-bearing provider-v2 export.
+
+## Motivation
+
+Prob4D currently estimates a full seven-dimensional relative Sim(3) gauge from
+an overlap and rejects the alignment when its Gauss--Newton information has rank
+below seven. That is a sound fail-closed policy for a covariance-only interface,
+but it discards useful information in geometries that are only *partially*
+observable.
+
+A deformable linear object is the canonical case. Corresponding centerline
+points determine scale, centroid translation, and two rotational directions, but
+they do not determine twist around the transformed centerline. Rejecting the
+whole overlap loses six valid directions. Adding a numerical ridge has the
+opposite failure: it turns an arbitrary representative twist into fabricated
+measurement information.
+
+The experimental kernel in `prob4d.observable_gauge` instead returns a
+rank-deficient Gaussian information factor. A full-rank prior supplies the
+missing direction, so the posterior remains complete without pretending that
+the visual overlap measured twist.
+
+## Origin-invariant local chart
+
+Let the fitted transform be \(\widehat T\), the weighted source centroid be
+\(\bar x\), the transformed centroid be \(\bar y=\widehat T(\bar x)\), and the
+weighted RMS radius be \(\rho\). The local coordinate is
+
+\[
+\boldsymbol\zeta =
+[\delta\ell,\;\delta\boldsymbol\phi^\top,\;
+ \delta\boldsymbol\tau^\top]^\top,
+\]
+
+where log-scale and left rotation act around \(\bar y\), and
+\(\delta\boldsymbol\tau\) is centroid translation normalized by \(\rho\). For a
+fitted centered point \(\boldsymbol q_i=\widehat T(\boldsymbol x_i)-\bar y\), the
+first-order point Jacobian is
+
+\[
+\boldsymbol J_i =
+\begin{bmatrix}
+\boldsymbol q_i & -[\boldsymbol q_i]_\times & \rho\boldsymbol I_3
+\end{bmatrix}.
+\]
+
+Centering removes dependence on the arbitrary coordinate origin. Normalizing
+centroid translation by \(\rho\) also avoids comparing raw translation units to
+log-scale and rotation units when the observability spectrum is thresholded.
+The weighted geometry information is
+
+\[
+\boldsymbol H = \sum_i w_i\boldsymbol J_i^\top\boldsymbol J_i.
+\]
+
+With eigendecomposition
+\(\boldsymbol H=\boldsymbol U\operatorname{diag}(\lambda_i)\boldsymbol U^\top\),
+only directions satisfying
+\(\lambda_i/\lambda_{\max}\geq\epsilon_{\mathrm{obs}}\) are retained. The IID
+factor information is
+
+\[
+\boldsymbol\Lambda_{\mathrm{obs}} =
+\boldsymbol U_r
+\operatorname{diag}(\lambda_1/\widehat\sigma^2,\ldots,
+                    \lambda_r/\widehat\sigma^2)
+\boldsymbol U_r^\top.
+\]
+
+The module also supports a cluster-robust sandwich covariance restricted to the
+same observable subspace.
+
+## Fusion with a complete prior
+
+For a full-rank local prior
+\(\mathcal N(\boldsymbol\mu^-,\boldsymbol P^-)\), the factor is centered at the
+fitted chart origin and gives
+
+\[
+\boldsymbol P^+ =
+\left[(\boldsymbol P^-)^{-1}+\boldsymbol\Lambda_{\mathrm{obs}}\right]^{-1},
+\qquad
+\boldsymbol\mu^+ =
+\boldsymbol P^+(\boldsymbol P^-)^{-1}\boldsymbol\mu^-.
+\]
+
+A nullspace direction receives no direct information. It can still change when
+the prior correlates it with observed directions, which is the correct Bayesian
+behavior; an isotropic prior leaves it exactly unchanged. Existing Prob4D gauge
+priors in standard `Sim3.as_vector()` coordinates can be transported through
+`CentroidGaugeChart.transport_vector_gaussian` and fused with
+`ObservableGaugeFactor.fuse_vector_gaussian`.
+
+## Frozen controlled result
+
+The checked-in study uses 1,000 independent DLO-like trials with 48 collinear
+correspondences, 10 mm point noise, and a 0.6 rad true twist that cannot be seen
+from the centerline. Three methods are compared:
+
+1. exact physical-prior fallback, representing the current rank-rejection path;
+2. the rank-six observable-subspace factor; and
+3. an intentionally invalid full-rank control that assigns the missing direction
+   the weakest observable precision.
+
+| Method | Centerline RMSE | Probe RMSE | 90% coverage | Normalized NEES | Harmful trials |
+|---|---:|---:|---:|---:|---:|
+| Exact prior fallback | 94.246 mm | 100.475 mm | 90.7% | 0.980 | -- |
+| Observable subspace | **1.955 mm** | **17.764 mm** | 88.0% | 1.028 | **0.0%** |
+| Full-rank completion control | 1.956 mm | 93.843 mm | 0.0% | 10611.347 | 43.7% |
+
+The observable factor improves centerline RMSE by 97.93% and off-axis probe RMSE
+by 82.32% relative to fallback while retaining calibrated full-state uncertainty.
+The full-rank completion looks equally good on the observed centerline but is
+catastrophically overconfident and harmful on 437 of 1,000 off-axis trials. This
+is precisely the distinction that point-only reconstruction metrics miss.
+
+Reproduce the result with
+
+```bash
+PYTHONPATH=src python -m prob4d.observable_gauge_study \
+  --output evidence/observable-gauge-control-v1/result.json
+```
+
+## Relationship to prior work
+
+Localizability-aware ICP methods such as X-ICP and LP-ICP already diagnose weak
+SE(3) directions and constrain or preserve their updates. ICP covariance work
+also shows that registration uncertainty cannot be reduced safely to a generic
+closed-form covariance. The paper contribution should therefore not be framed
+as the discovery of geometric degeneracy.
+
+The defensible extension is narrower and specific to this stack:
+
+- a centroid-normalized **Sim(3)** information factor rather than a hard pose
+  update;
+- exact retention of a rank-deficient gauge likelihood from learned overlapping
+  4D windows;
+- fusion with a complete correlated gauge prior rather than arbitrary damping;
+- propagation toward point covariance and a guarded Bayesian physical-twin
+  candidate; and
+- decision-relevant evaluation that exposes harm outside the observed support.
+
+Relevant context includes:
+
+- T. Tuna et al., *X-ICP: Localizability-Aware LiDAR Registration for Robust
+  Localization in Extreme Environments*, 2022, arXiv:2211.16335.
+- H. Yue et al., *LP-ICP: General Localizability-Aware Point Cloud Registration
+  for Robust Localization in Extreme Unstructured Environments*, 2025,
+  arXiv:2501.02580.
+- D. Landry et al., *CELLO-3D: Estimating the Covariance of ICP in the Real
+  World*, 2018, arXiv:1810.01470.
+- T. Ding et al., *LASER: Layer-wise Scale Alignment for Training-Free Streaming
+  4D Reconstruction*, CVPR 2026.
+- M. Kim et al., *GP-4DGS: Probabilistic 4D Gaussian Splatting from Monocular
+  Video via Variational Gaussian Processes*, CVPR 2026.
+
+## Claim boundary and promotion path
+
+The current result is controlled mechanism evidence only. It does **not** show
+real-provider competence, target calibration, BayesianPhysTwin benefit, or
+Causal4D benefit. The existing claim-bearing provider-v2 path remains unchanged.
+
+A paper-bearing promotion requires a prospective protocol with these stages:
+
+1. freeze the observability threshold on source/calibration sequences;
+2. audit the rank spectrum on a fresh real provider without opening target
+   outcomes;
+3. transport the existing complete gauge prior into the centroid chart and form
+   complete posterior candidates;
+4. evaluate point means, full covariance, off-support physical queries, accepted
+   update harm, and exact fallback on held-out targets; and
+5. expose the posterior to Causal4D only after the BayesianPhysTwin guard passes.
+
+This should be developed as a Prob4D-focused companion contribution. The bounded
+BayesianPhysTwin paper should absorb it only after a fresh real-provider result
+shows a material gain; otherwise the current paper remains cleaner and stronger
+without it.

--- a/evidence/observable-gauge-control-v1/README.md
+++ b/evidence/observable-gauge-control-v1/README.md
@@ -1,0 +1,15 @@
+# Observable-gauge controlled mechanism v1
+
+This directory contains the frozen 1,000-trial DLO-like mechanism result for
+`prob4d.observable_gauge`.
+
+Generate it from the repository root with:
+
+```bash
+PYTHONPATH=src python -m prob4d.observable_gauge_study \
+  --output evidence/observable-gauge-control-v1/result.json
+```
+
+The result is controlled synthetic evidence. It is not a claim-bearing provider
+artifact and does not establish real-provider, BayesianPhysTwin, or Causal4D
+benefit.

--- a/evidence/observable-gauge-control-v1/result.json
+++ b/evidence/observable-gauge-control-v1/result.json
@@ -1,0 +1,70 @@
+{
+  "claim_boundary": "controlled DLO-like gauge-observability mechanism only; not real-provider competence, downstream physical benefit, or deployment calibration",
+  "config": {
+    "line_half_extent_m": 1.0,
+    "nullspace_precision_ratio": 1.0,
+    "observation_sigma_m": 0.01,
+    "points_per_line": 48,
+    "prior_centroid_translation_std": 0.1,
+    "prior_log_scale_std": 0.06,
+    "prior_rotation_std_rad": 0.14,
+    "probe_radius_m": 0.25,
+    "rank_threshold": 1e-08,
+    "seed": 20260827,
+    "trials": 1000,
+    "truth_scale": 1.1,
+    "truth_twist_rad": 0.6
+  },
+  "criteria": {
+    "all_trials_rank_six": true,
+    "completion_is_more_harmful_than_subspace": true,
+    "completion_is_undercovered": true,
+    "observable_coverage_is_calibrated": true,
+    "observable_nll_improves": true,
+    "observable_probe_rmse_improves": true,
+    "observable_support_rmse_improves_at_least_50pct": true
+  },
+  "decision": "pass",
+  "geometry": {
+    "current_full_covariance_alignment_accepts_rank_deficient_geometry": false,
+    "expected_observable_rank": 6,
+    "mean_unobservable_truth_magnitude_rad": 0.5999931351611657,
+    "rank_counts": {
+      "6": 1000
+    }
+  },
+  "methods": {
+    "exact_physical_prior_fallback": {
+      "empirical_90pct_coverage": 0.907,
+      "mean_gaussian_nll": -5.75528120008018,
+      "mean_local_standard_deviation": 0.11489125293076063,
+      "mean_probe_rmse_mm": 100.47478800812233,
+      "mean_support_rmse_mm": 94.24599488685435,
+      "normalized_nees": 0.9804724663850798
+    },
+    "isotropic_nullspace_completion_control": {
+      "empirical_90pct_coverage": 0.0,
+      "harmful_probe_fraction": 0.437,
+      "mean_gaussian_nll": 37103.341080424216,
+      "mean_local_standard_deviation": 0.0022133127405227974,
+      "mean_probe_rmse_mm": 93.84292343598571,
+      "mean_support_rmse_mm": 1.9555302441809117,
+      "normalized_nees": 10611.347030845327,
+      "probe_rmse_improvement_fraction": 0.06600526065902723,
+      "support_rmse_improvement_fraction": 0.979250786767877
+    },
+    "observable_subspace_factor": {
+      "empirical_90pct_coverage": 0.88,
+      "harmful_probe_fraction": 0.0,
+      "mean_gaussian_nll": -28.62612707940606,
+      "mean_local_standard_deviation": 0.0529548350731917,
+      "mean_probe_rmse_mm": 17.76403321718713,
+      "mean_support_rmse_mm": 1.9554049881790552,
+      "normalized_nees": 1.0281393703277517,
+      "probe_rmse_improvement_fraction": 0.8231990973123418,
+      "support_rmse_improvement_fraction": 0.9792521158005008
+    }
+  },
+  "schema": "prob4d.observable-gauge-study",
+  "schema_version": 1
+}

--- a/src/prob4d/observable_gauge.py
+++ b/src/prob4d/observable_gauge.py
@@ -1,0 +1,657 @@
+"""Observability-aware Gaussian factors for partially constrained Sim(3) gauges.
+
+The stable alignment path rejects rank-deficient overlap geometry.  This
+experimental kernel retains only the observable subspace in an origin-invariant,
+centroid-normalized local chart.  A downstream Gaussian prior supplies the
+unobservable directions instead of a numerical ridge pretending that the visual
+factor measured them.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .alignment import AlignmentNonConvergenceError, _normalized_transform_step, _weighted_umeyama
+from .sim3 import Sim3, skew, so3_exp, so3_log
+
+FloatArray = NDArray[np.floating]
+IntArray = NDArray[np.integer]
+
+IID_OBSERVABLE_INFORMATION = "iid_observable_information_v1"
+CLUSTER_OBSERVABLE_INFORMATION = "cluster_observable_information_v1"
+
+
+def _readonly(value: FloatArray, *, shape: tuple[int, ...], name: str) -> FloatArray:
+    array = np.asarray(value, dtype=np.float64).copy()
+    if array.shape != shape:
+        raise ValueError(f"{name} must have shape {shape}")
+    if not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} must be finite")
+    array.setflags(write=False)
+    return array
+
+
+def _finite_positive(value: float, *, name: str, allow_zero: bool = False) -> float:
+    numeric = float(value)
+    if not np.isfinite(numeric) or (numeric < 0.0 if allow_zero else numeric <= 0.0):
+        relation = "nonnegative" if allow_zero else "positive"
+        raise ValueError(f"{name} must be finite and {relation}")
+    return numeric
+
+
+def _integer(value: int, *, name: str, minimum: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, (int, np.integer)):
+        raise TypeError(f"{name} must be an integer")
+    result = int(value)
+    if result < minimum:
+        raise ValueError(f"{name} must be at least {minimum}")
+    return result
+
+
+def _symmetric_positive_definite(value: FloatArray, *, size: int, name: str) -> FloatArray:
+    array = _readonly(value, shape=(size, size), name=name).copy()
+    symmetric = 0.5 * (array + array.T)
+    if not np.allclose(array, symmetric, atol=1e-12, rtol=1e-10):
+        raise ValueError(f"{name} must be symmetric")
+    eigenvalues = np.linalg.eigvalsh(symmetric)
+    if float(eigenvalues[0]) <= 0.0:
+        raise ValueError(f"{name} must be positive definite")
+    symmetric.setflags(write=False)
+    return symmetric
+
+
+def _canonicalize_basis_signs(basis: FloatArray) -> FloatArray:
+    result = np.asarray(basis, dtype=np.float64).copy()
+    for column in range(result.shape[1]):
+        nonzero = np.flatnonzero(np.abs(result[:, column]) > 1e-12)
+        if nonzero.size and result[int(nonzero[0]), column] < 0.0:
+            result[:, column] *= -1.0
+    return result
+
+
+@dataclass(frozen=True)
+class CentroidGaugeChart:
+    """Dimensionless local Sim(3) chart around a fitted transform.
+
+    Coordinates are ``[log scale, left rotation(3), centroid translation / rho]``.
+    Scale and rotation act around the weighted source centroid, while translation
+    moves the transformed centroid.  ``rho`` is the fitted RMS cloud radius.
+    """
+
+    linearization: Sim3
+    source_centroid: FloatArray
+    cloud_scale: float
+
+    def __post_init__(self) -> None:
+        centroid = _readonly(
+            self.source_centroid,
+            shape=(3,),
+            name="source_centroid",
+        )
+        cloud_scale = _finite_positive(self.cloud_scale, name="cloud_scale")
+        object.__setattr__(self, "source_centroid", centroid)
+        object.__setattr__(self, "cloud_scale", cloud_scale)
+
+    @property
+    def reference_centroid(self) -> FloatArray:
+        center = np.asarray(
+            self.linearization.transform_points(self.source_centroid),
+            dtype=np.float64,
+        )
+        center.setflags(write=False)
+        return center
+
+    def to_local(self, transform: Sim3) -> FloatArray:
+        """Map a nearby transform to the chart coordinates."""
+
+        log_scale = np.log(transform.scale / self.linearization.scale)
+        left_rotation = transform.rotation @ self.linearization.rotation.T
+        rotation = so3_log(left_rotation)
+        center_delta = (
+            transform.transform_points(self.source_centroid) - self.reference_centroid
+        ) / self.cloud_scale
+        return np.concatenate(([log_scale], rotation, center_delta))
+
+    def from_local(self, local: FloatArray) -> Sim3:
+        """Map chart coordinates to a Sim(3) transform."""
+
+        coordinates = _readonly(local, shape=(7,), name="local")
+        scale = float(np.exp(coordinates[0]) * self.linearization.scale)
+        rotation = so3_exp(coordinates[1:4]) @ self.linearization.rotation
+        center = self.reference_centroid + self.cloud_scale * coordinates[4:7]
+        translation = center - scale * (rotation @ self.source_centroid)
+        return Sim3(scale=scale, rotation=rotation, translation=translation)
+
+    def vector_to_local_jacobian(
+        self,
+        transform: Sim3,
+        *,
+        relative_step: float = 1e-6,
+    ) -> FloatArray:
+        """Linearize standard ``Sim3.as_vector`` coordinates into this chart."""
+
+        step_scale = _finite_positive(relative_step, name="relative_step")
+        vector = transform.as_vector()
+        if float(np.linalg.norm(vector[1:4])) >= np.pi - 1e-5:
+            raise ValueError("vector covariance transport reaches the SO(3) branch cut")
+        baseline = self.to_local(transform)
+        if float(np.linalg.norm(baseline[1:4])) >= np.pi - 1e-5:
+            raise ValueError("local covariance transport reaches the SO(3) branch cut")
+        jacobian = np.empty((7, 7), dtype=np.float64)
+        for index in range(7):
+            step = step_scale * max(1.0, abs(float(vector[index])))
+            perturbed = vector.copy()
+            perturbed[index] += step
+            mapped = self.to_local(Sim3.from_vector(perturbed))
+            jacobian[:, index] = (mapped - baseline) / step
+        if not np.all(np.isfinite(jacobian)):
+            raise ValueError("vector-to-local covariance Jacobian must be finite")
+        jacobian.setflags(write=False)
+        return jacobian
+
+    def transport_vector_gaussian(
+        self,
+        mean: Sim3,
+        covariance_vector: FloatArray,
+    ) -> GaugeGaussianPosterior:
+        """Transport a standard seven-vector Gaussian into the local chart."""
+
+        covariance = _symmetric_positive_definite(
+            covariance_vector,
+            size=7,
+            name="covariance_vector",
+        )
+        jacobian = self.vector_to_local_jacobian(mean)
+        local_covariance = jacobian @ covariance @ jacobian.T
+        local_covariance = 0.5 * (local_covariance + local_covariance.T)
+        return GaugeGaussianPosterior(
+            chart=self,
+            mean_local=self.to_local(mean),
+            covariance_local=local_covariance,
+        )
+
+
+@dataclass(frozen=True)
+class GaugeGaussianPosterior:
+    """Gaussian posterior in one :class:`CentroidGaugeChart`."""
+
+    chart: CentroidGaugeChart
+    mean_local: FloatArray
+    covariance_local: FloatArray
+
+    def __post_init__(self) -> None:
+        mean = _readonly(self.mean_local, shape=(7,), name="mean_local")
+        covariance = _symmetric_positive_definite(
+            self.covariance_local,
+            size=7,
+            name="covariance_local",
+        )
+        object.__setattr__(self, "mean_local", mean)
+        object.__setattr__(self, "covariance_local", covariance)
+
+    @property
+    def mean_transform(self) -> Sim3:
+        return self.chart.from_local(self.mean_local)
+
+
+@dataclass(frozen=True)
+class ObservableGaugeFactor:
+    """A Gaussian factor carrying information only in an observable subspace."""
+
+    chart: CentroidGaugeChart
+    observable_basis: FloatArray
+    nullspace_basis: FloatArray
+    observable_information: FloatArray
+    normalized_geometry_spectrum: FloatArray
+    rank_threshold: float
+    residual_rms: float
+    residual_variance: float
+    inlier_fraction: float
+    num_correspondences: int
+    covariance_method: str
+    num_covariance_clusters: int = 0
+
+    def __post_init__(self) -> None:
+        observable = np.asarray(self.observable_basis, dtype=np.float64).copy()
+        nullspace = np.asarray(self.nullspace_basis, dtype=np.float64).copy()
+        if observable.ndim != 2 or observable.shape[0] != 7 or observable.shape[1] < 1:
+            raise ValueError("observable_basis must have shape (7, rank) with rank positive")
+        rank = int(observable.shape[1])
+        if rank > 7:
+            raise ValueError("observable rank must not exceed seven")
+        if nullspace.shape != (7, 7 - rank):
+            raise ValueError("nullspace_basis must have shape (7, 7-rank)")
+        combined = np.concatenate((observable, nullspace), axis=1)
+        if not np.allclose(combined.T @ combined, np.eye(7), atol=1e-9, rtol=1e-9):
+            raise ValueError("observable and nullspace bases must form an orthonormal basis")
+        information = _symmetric_positive_definite(
+            self.observable_information,
+            size=rank,
+            name="observable_information",
+        )
+        spectrum = _readonly(
+            self.normalized_geometry_spectrum,
+            shape=(7,),
+            name="normalized_geometry_spectrum",
+        )
+        if np.any(spectrum < 0.0) or np.any(np.diff(spectrum) > 1e-12):
+            raise ValueError("normalized_geometry_spectrum must be nonnegative and descending")
+        if not np.isclose(spectrum[0], 1.0, atol=1e-10, rtol=1e-10):
+            raise ValueError("normalized_geometry_spectrum must start at one")
+        rank_threshold = _finite_positive(self.rank_threshold, name="rank_threshold")
+        residual_rms = _finite_positive(
+            self.residual_rms,
+            name="residual_rms",
+            allow_zero=True,
+        )
+        residual_variance = _finite_positive(
+            self.residual_variance,
+            name="residual_variance",
+        )
+        inlier_fraction = float(self.inlier_fraction)
+        if not np.isfinite(inlier_fraction) or not 0.0 <= inlier_fraction <= 1.0:
+            raise ValueError("inlier_fraction must lie in [0, 1]")
+        correspondences = _integer(
+            self.num_correspondences,
+            name="num_correspondences",
+            minimum=4,
+        )
+        clusters = _integer(
+            self.num_covariance_clusters,
+            name="num_covariance_clusters",
+            minimum=0,
+        )
+        if not self.covariance_method:
+            raise ValueError("covariance_method must be nonempty")
+        observable.setflags(write=False)
+        nullspace.setflags(write=False)
+        object.__setattr__(self, "observable_basis", observable)
+        object.__setattr__(self, "nullspace_basis", nullspace)
+        object.__setattr__(self, "observable_information", information)
+        object.__setattr__(self, "normalized_geometry_spectrum", spectrum)
+        object.__setattr__(self, "rank_threshold", rank_threshold)
+        object.__setattr__(self, "residual_rms", residual_rms)
+        object.__setattr__(self, "residual_variance", residual_variance)
+        object.__setattr__(self, "inlier_fraction", inlier_fraction)
+        object.__setattr__(self, "num_correspondences", correspondences)
+        object.__setattr__(self, "num_covariance_clusters", clusters)
+
+    @property
+    def rank(self) -> int:
+        return int(self.observable_basis.shape[1])
+
+    @property
+    def information_matrix(self) -> FloatArray:
+        matrix = self.observable_basis @ self.observable_information @ self.observable_basis.T
+        matrix = 0.5 * (matrix + matrix.T)
+        matrix.setflags(write=False)
+        return matrix
+
+    @property
+    def observable_covariance(self) -> FloatArray:
+        covariance = np.linalg.solve(
+            self.observable_information,
+            np.eye(self.rank),
+        )
+        covariance = 0.5 * (covariance + covariance.T)
+        covariance.setflags(write=False)
+        return covariance
+
+    def quadratic_cost_local(self, local: FloatArray) -> float:
+        coordinates = _readonly(local, shape=(7,), name="local")
+        projected = self.observable_basis.T @ coordinates
+        return 0.5 * float(projected @ self.observable_information @ projected)
+
+    def quadratic_cost(self, transform: Sim3) -> float:
+        return self.quadratic_cost_local(self.chart.to_local(transform))
+
+    def fuse_local_gaussian(
+        self,
+        prior_mean_local: FloatArray,
+        prior_covariance_local: FloatArray,
+    ) -> GaugeGaussianPosterior:
+        """Fuse the factor with a full-rank Gaussian prior in the same chart."""
+
+        prior_mean = _readonly(prior_mean_local, shape=(7,), name="prior_mean_local")
+        prior_covariance = _symmetric_positive_definite(
+            prior_covariance_local,
+            size=7,
+            name="prior_covariance_local",
+        )
+        prior_information = np.linalg.solve(prior_covariance, np.eye(7))
+        posterior_information = prior_information + self.information_matrix
+        posterior_covariance = np.linalg.solve(posterior_information, np.eye(7))
+        posterior_covariance = 0.5 * (posterior_covariance + posterior_covariance.T)
+        posterior_mean = posterior_covariance @ (prior_information @ prior_mean)
+        return GaugeGaussianPosterior(
+            chart=self.chart,
+            mean_local=posterior_mean,
+            covariance_local=posterior_covariance,
+        )
+
+    def fuse_transform_gaussian(
+        self,
+        prior_mean: Sim3,
+        prior_covariance_local: FloatArray,
+    ) -> GaugeGaussianPosterior:
+        return self.fuse_local_gaussian(
+            self.chart.to_local(prior_mean),
+            prior_covariance_local,
+        )
+
+    def fuse_vector_gaussian(
+        self,
+        prior_mean: Sim3,
+        prior_covariance_vector: FloatArray,
+    ) -> GaugeGaussianPosterior:
+        """Transport and fuse an existing standard-coordinate gauge prior."""
+
+        transported = self.chart.transport_vector_gaussian(
+            prior_mean,
+            prior_covariance_vector,
+        )
+        return self.fuse_local_gaussian(
+            transported.mean_local,
+            transported.covariance_local,
+        )
+
+
+def _prepare_inputs(
+    source: FloatArray,
+    target: FloatArray,
+    weights: FloatArray | None,
+    covariance_cluster_ids: IntArray | None,
+) -> tuple[FloatArray, FloatArray, FloatArray, IntArray | None]:
+    source_array = np.asarray(source, dtype=np.float64)
+    target_array = np.asarray(target, dtype=np.float64)
+    if (
+        source_array.shape != target_array.shape
+        or source_array.ndim != 2
+        or source_array.shape[1] != 3
+    ):
+        raise ValueError("source and target must both have shape (N, 3)")
+    if source_array.shape[0] < 4:
+        raise ValueError("at least four correspondences are required")
+    finite = np.all(np.isfinite(source_array), axis=1) & np.all(
+        np.isfinite(target_array), axis=1
+    )
+    source_array = source_array[finite]
+    target_array = target_array[finite]
+    if source_array.shape[0] < 4:
+        raise ValueError("at least four finite correspondences are required")
+    if weights is None:
+        base_weights = np.ones(source_array.shape[0], dtype=np.float64)
+    else:
+        supplied = np.asarray(weights, dtype=np.float64)
+        if supplied.shape != finite.shape:
+            raise ValueError("weights must have shape (N,)")
+        base_weights = supplied[finite]
+        if np.any(base_weights < 0.0) or not np.all(np.isfinite(base_weights)):
+            raise ValueError("weights must be finite and nonnegative")
+    if float(np.sum(base_weights)) <= np.finfo(np.float64).eps:
+        raise ValueError("alignment weights have zero total mass")
+    clusters: IntArray | None = None
+    if covariance_cluster_ids is not None:
+        supplied_clusters = np.asarray(covariance_cluster_ids)
+        if supplied_clusters.shape != finite.shape:
+            raise ValueError("covariance_cluster_ids must have shape (N,)")
+        clusters = supplied_clusters[finite]
+    return source_array, target_array, base_weights, clusters
+
+
+def _robust_fit(
+    source: FloatArray,
+    target: FloatArray,
+    base_weights: FloatArray,
+    *,
+    max_iterations: int,
+    huber_multiplier: float,
+    tolerance: float,
+) -> tuple[Sim3, FloatArray, float]:
+    iterations = _integer(max_iterations, name="max_iterations", minimum=2)
+    multiplier = _finite_positive(huber_multiplier, name="huber_multiplier")
+    convergence_tolerance = _finite_positive(tolerance, name="tolerance")
+    robust_weights = base_weights.copy()
+    previous_transform: Sim3 | None = None
+    cutoff = np.inf
+    transform = Sim3.identity()
+    transform_delta = np.inf
+    relative_weight_delta = np.inf
+    converged = False
+    for _ in range(iterations):
+        fit_weights = robust_weights
+        transform = _weighted_umeyama(source, target, fit_weights)
+        residual_norms = np.linalg.norm(
+            target - transform.transform_points(source),
+            axis=1,
+        )
+        median = float(np.median(residual_norms))
+        mad = float(np.median(np.abs(residual_norms - median)))
+        robust_scale = max(1.4826 * mad, np.finfo(np.float64).eps)
+        cutoff = max(median + multiplier * robust_scale, np.finfo(np.float64).eps)
+        huber_weights = np.minimum(1.0, cutoff / np.maximum(residual_norms, cutoff))
+        next_weights = base_weights * huber_weights
+        transform_delta = (
+            np.inf
+            if previous_transform is None
+            else _normalized_transform_step(
+                source,
+                base_weights,
+                previous_transform,
+                transform,
+            )
+        )
+        weight_norm = max(float(np.linalg.norm(fit_weights)), np.finfo(np.float64).eps)
+        relative_weight_delta = float(
+            np.linalg.norm(next_weights - fit_weights) / weight_norm
+        )
+        if previous_transform is not None and transform_delta < convergence_tolerance:
+            robust_weights = fit_weights
+            converged = True
+            break
+        previous_transform = transform
+        robust_weights = next_weights
+    if not converged:
+        raise AlignmentNonConvergenceError(
+            max_iterations=iterations,
+            transform_delta=transform_delta,
+            relative_weight_delta=relative_weight_delta,
+        )
+    return transform, robust_weights, cutoff
+
+
+def _intrinsic_information(
+    source: FloatArray,
+    target: FloatArray,
+    weights: FloatArray,
+    transform: Sim3,
+    *,
+    cluster_ids: IntArray | None,
+) -> tuple[
+    CentroidGaugeChart,
+    FloatArray,
+    FloatArray,
+    FloatArray | None,
+    int,
+]:
+    active_mask = weights > 1e-3
+    active = int(np.count_nonzero(active_mask))
+    if active < 4:
+        raise ValueError("fewer than four correspondences retain positive robust weight")
+    weight_sum = float(np.sum(weights))
+    source_centroid = np.sum(weights[:, None] * source, axis=0) / weight_sum
+    transformed = transform.transform_points(source)
+    reference_centroid = transform.transform_points(source_centroid)
+    centered = transformed - reference_centroid
+    cloud_scale = float(
+        np.sqrt(np.sum(weights * np.sum(centered**2, axis=1)) / weight_sum)
+    )
+    if cloud_scale <= np.finfo(np.float64).eps:
+        raise ValueError("source correspondences have no spatial extent")
+    chart = CentroidGaugeChart(
+        linearization=transform,
+        source_centroid=source_centroid,
+        cloud_scale=cloud_scale,
+    )
+    residuals = target - transformed
+    information = np.zeros((7, 7), dtype=np.float64)
+    cluster_inverse: IntArray | None = None
+    cluster_scores: FloatArray | None = None
+    num_clusters = 0
+    if cluster_ids is not None:
+        clusters = np.asarray(cluster_ids)
+        if clusters.shape != (source.shape[0],):
+            raise ValueError("covariance_cluster_ids must have shape (N,)")
+        _, compact = np.unique(clusters[active_mask], return_inverse=True)
+        num_clusters = int(np.max(compact) + 1) if compact.size else 0
+        cluster_inverse = np.full(source.shape[0], -1, dtype=np.int64)
+        cluster_inverse[active_mask] = compact
+        cluster_scores = np.zeros((num_clusters, 7), dtype=np.float64)
+    identity = np.eye(3)
+    for index, (point, residual, weight) in enumerate(
+        zip(centered, residuals, weights, strict=True)
+    ):
+        jacobian = np.empty((3, 7), dtype=np.float64)
+        jacobian[:, 0] = point
+        jacobian[:, 1:4] = -skew(point)
+        jacobian[:, 4:7] = cloud_scale * identity
+        information += float(weight) * jacobian.T @ jacobian
+        if cluster_scores is not None and active_mask[index]:
+            cluster_scores[cluster_inverse[index]] += float(weight) * jacobian.T @ residual
+    return chart, residuals, information, cluster_scores, num_clusters
+
+
+def estimate_observable_sim3_factor(
+    source: FloatArray,
+    target: FloatArray,
+    *,
+    weights: FloatArray | None = None,
+    covariance_cluster_ids: IntArray | None = None,
+    max_iterations: int = 64,
+    huber_multiplier: float = 2.5,
+    tolerance: float = 1e-8,
+    rank_threshold: float = 1e-8,
+    residual_variance_floor: float = 1e-12,
+) -> ObservableGaugeFactor:
+    """Fit a robust Sim(3) representative and retain its observable information.
+
+    ``rank_threshold`` applies to the descending geometry spectrum after the
+    centroid-normalized chart has removed origin and mixed translation-scale
+    effects.  It is a scientific observability threshold, not a ridge.  Directions
+    below it remain in the factor nullspace and must be supplied by a prior or
+    exact fallback downstream.
+    """
+
+    relative_threshold = _finite_positive(rank_threshold, name="rank_threshold")
+    if relative_threshold >= 1.0:
+        raise ValueError("rank_threshold must be smaller than one")
+    variance_floor = _finite_positive(
+        residual_variance_floor,
+        name="residual_variance_floor",
+    )
+    source_array, target_array, base_weights, clusters = _prepare_inputs(
+        source,
+        target,
+        weights,
+        covariance_cluster_ids,
+    )
+    transform, robust_weights, cutoff = _robust_fit(
+        source_array,
+        target_array,
+        base_weights,
+        max_iterations=max_iterations,
+        huber_multiplier=huber_multiplier,
+        tolerance=tolerance,
+    )
+    chart, residuals, geometry_information, cluster_scores, num_clusters = (
+        _intrinsic_information(
+            source_array,
+            target_array,
+            robust_weights,
+            transform,
+            cluster_ids=clusters,
+        )
+    )
+    eigenvalues, eigenvectors = np.linalg.eigh(
+        0.5 * (geometry_information + geometry_information.T)
+    )
+    order = np.argsort(eigenvalues)[::-1]
+    eigenvalues = np.maximum(eigenvalues[order], 0.0)
+    eigenvectors = eigenvectors[:, order]
+    maximum = float(eigenvalues[0])
+    if maximum <= np.finfo(np.float64).eps:
+        raise ValueError("alignment geometry carries no observable gauge information")
+    normalized_spectrum = eigenvalues / maximum
+    rank = int(np.count_nonzero(normalized_spectrum >= relative_threshold))
+    if rank < 1:
+        raise ValueError("rank_threshold removes every gauge direction")
+    observable_basis = _canonicalize_basis_signs(eigenvectors[:, :rank])
+    nullspace_basis = _canonicalize_basis_signs(eigenvectors[:, rank:])
+    active = int(np.count_nonzero(robust_weights > 1e-3))
+    weighted_squared_error = float(np.sum(robust_weights[:, None] * residuals**2))
+    degrees_of_freedom = max(1, 3 * active - rank)
+    residual_variance = max(weighted_squared_error / degrees_of_freedom, variance_floor)
+    if cluster_scores is None:
+        observable_information = np.diag(eigenvalues[:rank] / residual_variance)
+        method = IID_OBSERVABLE_INFORMATION
+    else:
+        if num_clusters <= rank:
+            raise ValueError(
+                "cluster-robust observable covariance requires more active clusters "
+                "than observable gauge dimensions"
+            )
+        meat = cluster_scores.T @ cluster_scores
+        reduced_meat = observable_basis.T @ meat @ observable_basis
+        inverse_geometry = np.diag(1.0 / eigenvalues[:rank])
+        correction = (num_clusters / (num_clusters - 1)) * (
+            (active - 1) / max(active - rank, 1)
+        )
+        reduced_covariance = (
+            correction * inverse_geometry @ reduced_meat @ inverse_geometry
+        )
+        reduced_covariance = 0.5 * (reduced_covariance + reduced_covariance.T)
+        covariance_eigenvalues, covariance_eigenvectors = np.linalg.eigh(
+            reduced_covariance
+        )
+        covariance_floor = max(
+            float(np.max(np.abs(covariance_eigenvalues), initial=0.0)) * 1e-12,
+            np.finfo(np.float64).eps,
+        )
+        reduced_covariance = (
+            covariance_eigenvectors
+            * np.maximum(covariance_eigenvalues, covariance_floor)
+        ) @ covariance_eigenvectors.T
+        observable_information = np.linalg.solve(
+            reduced_covariance,
+            np.eye(rank),
+        )
+        method = CLUSTER_OBSERVABLE_INFORMATION
+    residual_norms = np.linalg.norm(residuals, axis=1)
+    weight_sum = max(float(np.sum(robust_weights)), np.finfo(np.float64).eps)
+    return ObservableGaugeFactor(
+        chart=chart,
+        observable_basis=observable_basis,
+        nullspace_basis=nullspace_basis,
+        observable_information=observable_information,
+        normalized_geometry_spectrum=normalized_spectrum,
+        rank_threshold=relative_threshold,
+        residual_rms=float(np.sqrt(np.sum(robust_weights * residual_norms**2) / weight_sum)),
+        residual_variance=residual_variance,
+        inlier_fraction=float(np.mean(residual_norms <= cutoff)),
+        num_correspondences=int(source_array.shape[0]),
+        covariance_method=method,
+        num_covariance_clusters=num_clusters,
+    )
+
+
+__all__ = [
+    "CLUSTER_OBSERVABLE_INFORMATION",
+    "IID_OBSERVABLE_INFORMATION",
+    "CentroidGaugeChart",
+    "GaugeGaussianPosterior",
+    "ObservableGaugeFactor",
+    "estimate_observable_sim3_factor",
+]

--- a/src/prob4d/observable_gauge_study.py
+++ b/src/prob4d/observable_gauge_study.py
@@ -213,10 +213,12 @@ def _aggregate(
 
 
 def run_observable_gauge_study(
-    config: ObservableGaugeStudyConfig = ObservableGaugeStudyConfig(),
+    config: ObservableGaugeStudyConfig | None = None,
 ) -> dict[str, Any]:
     """Run the frozen controlled mechanism study."""
 
+    if config is None:
+        config = ObservableGaugeStudyConfig()
     config.validate()
     generator = np.random.default_rng(config.seed)
     source = _source_line(config)

--- a/src/prob4d/observable_gauge_study.py
+++ b/src/prob4d/observable_gauge_study.py
@@ -1,0 +1,363 @@
+"""Controlled DLO-like study for observability-aware Sim(3) gauge factors.
+
+The synthetic overlap is a one-dimensional centerline.  It constrains six of the
+seven similarity-gauge directions and leaves twist around the transformed line
+unobservable.  Complete object/session trials are the Monte Carlo units.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from .observable_gauge import GaugeGaussianPosterior, estimate_observable_sim3_factor
+from .sim3 import Sim3, so3_exp
+
+_SCHEMA = "prob4d.observable-gauge-study"
+_SCHEMA_VERSION = 1
+_CHI2_7_90 = 12.017036623780532
+
+
+@dataclass(frozen=True)
+class ObservableGaugeStudyConfig:
+    seed: int = 20_260_827
+    trials: int = 1_000
+    points_per_line: int = 48
+    observation_sigma_m: float = 0.01
+    line_half_extent_m: float = 1.0
+    probe_radius_m: float = 0.25
+    truth_scale: float = 1.1
+    truth_twist_rad: float = 0.6
+    rank_threshold: float = 1e-8
+    nullspace_precision_ratio: float = 1.0
+    prior_log_scale_std: float = 0.06
+    prior_rotation_std_rad: float = 0.14
+    prior_centroid_translation_std: float = 0.10
+
+    def validate(self) -> None:
+        for name in ("seed", "trials", "points_per_line"):
+            value = getattr(self, name)
+            if isinstance(value, bool) or not isinstance(value, int):
+                raise TypeError(f"{name} must be an integer")
+        if self.seed < 0:
+            raise ValueError("seed must be nonnegative")
+        if self.trials < 20:
+            raise ValueError("trials must be at least 20")
+        if self.points_per_line < 8:
+            raise ValueError("points_per_line must be at least eight")
+        positive = (
+            "observation_sigma_m",
+            "line_half_extent_m",
+            "probe_radius_m",
+            "truth_scale",
+            "rank_threshold",
+            "nullspace_precision_ratio",
+            "prior_log_scale_std",
+            "prior_rotation_std_rad",
+            "prior_centroid_translation_std",
+        )
+        for name in positive:
+            value = float(getattr(self, name))
+            if not np.isfinite(value) or value <= 0.0:
+                raise ValueError(f"{name} must be finite and positive")
+        if self.rank_threshold >= 1.0:
+            raise ValueError("rank_threshold must be smaller than one")
+        if not np.isfinite(self.truth_twist_rad):
+            raise ValueError("truth_twist_rad must be finite")
+
+
+@dataclass(frozen=True)
+class _MethodTrial:
+    support_rmse_m: float
+    probe_rmse_m: float
+    nll: float
+    nees: float
+    mean_std_local: float
+
+
+def _source_line(config: ObservableGaugeStudyConfig) -> np.ndarray:
+    coordinate = np.linspace(
+        -config.line_half_extent_m,
+        config.line_half_extent_m,
+        config.points_per_line,
+    )
+    return np.column_stack((coordinate, np.zeros_like(coordinate), np.zeros_like(coordinate)))
+
+
+def _probe_tube(config: ObservableGaugeStudyConfig) -> np.ndarray:
+    coordinate = np.linspace(
+        -config.line_half_extent_m,
+        config.line_half_extent_m,
+        max(8, config.points_per_line // 2),
+    )
+    angles = np.linspace(0.0, 2.0 * np.pi, 8, endpoint=False)
+    points = []
+    for position in coordinate:
+        for angle in angles:
+            points.append(
+                [
+                    position,
+                    config.probe_radius_m * np.cos(angle),
+                    config.probe_radius_m * np.sin(angle),
+                ]
+            )
+    return np.asarray(points, dtype=np.float64)
+
+
+def _truth_transform(config: ObservableGaugeStudyConfig) -> Sim3:
+    base_rotation = so3_exp(np.array([0.0, 0.25, -0.15]))
+    unobservable_twist = so3_exp(np.array([config.truth_twist_rad, 0.0, 0.0]))
+    return Sim3(
+        scale=config.truth_scale,
+        rotation=base_rotation @ unobservable_twist,
+        translation=np.array([0.20, -0.10, 0.05]),
+    )
+
+
+def _prior_covariance(config: ObservableGaugeStudyConfig) -> np.ndarray:
+    standard_deviations = np.array(
+        [
+            config.prior_log_scale_std,
+            config.prior_rotation_std_rad,
+            config.prior_rotation_std_rad,
+            config.prior_rotation_std_rad,
+            config.prior_centroid_translation_std,
+            config.prior_centroid_translation_std,
+            config.prior_centroid_translation_std,
+        ]
+    )
+    return np.diag(standard_deviations**2)
+
+
+def _fuse_information(
+    chart,
+    prior_mean: np.ndarray,
+    prior_covariance: np.ndarray,
+    factor_information: np.ndarray,
+) -> GaugeGaussianPosterior:
+    prior_information = np.linalg.solve(prior_covariance, np.eye(7))
+    posterior_information = prior_information + factor_information
+    posterior_covariance = np.linalg.solve(posterior_information, np.eye(7))
+    posterior_covariance = 0.5 * (posterior_covariance + posterior_covariance.T)
+    posterior_mean = posterior_covariance @ (prior_information @ prior_mean)
+    return GaugeGaussianPosterior(
+        chart=chart,
+        mean_local=posterior_mean,
+        covariance_local=posterior_covariance,
+    )
+
+
+def _trial_metrics(
+    posterior: GaugeGaussianPosterior,
+    truth_local: np.ndarray,
+    truth: Sim3,
+    source: np.ndarray,
+    probes: np.ndarray,
+) -> _MethodTrial:
+    mean_transform = posterior.mean_transform
+    support_error = mean_transform.transform_points(source) - truth.transform_points(source)
+    probe_error = mean_transform.transform_points(probes) - truth.transform_points(probes)
+    delta = truth_local - posterior.mean_local
+    precision_delta = np.linalg.solve(posterior.covariance_local, delta)
+    nees = float(delta @ precision_delta)
+    sign, logdet = np.linalg.slogdet(posterior.covariance_local)
+    if sign <= 0.0:
+        raise ValueError("posterior covariance must have positive determinant")
+    nll = 0.5 * (7.0 * np.log(2.0 * np.pi) + logdet + nees)
+    return _MethodTrial(
+        support_rmse_m=float(np.sqrt(np.mean(support_error**2))),
+        probe_rmse_m=float(np.sqrt(np.mean(probe_error**2))),
+        nll=float(nll),
+        nees=nees,
+        mean_std_local=float(np.sqrt(np.trace(posterior.covariance_local) / 7.0)),
+    )
+
+
+def _aggregate(
+    trials: list[_MethodTrial],
+    fallback: list[_MethodTrial] | None = None,
+) -> dict[str, Any]:
+    support = np.asarray([trial.support_rmse_m for trial in trials])
+    probe = np.asarray([trial.probe_rmse_m for trial in trials])
+    nll = np.asarray([trial.nll for trial in trials])
+    nees = np.asarray([trial.nees for trial in trials])
+    width = np.asarray([trial.mean_std_local for trial in trials])
+    result: dict[str, Any] = {
+        "mean_support_rmse_mm": float(1_000.0 * np.mean(support)),
+        "mean_probe_rmse_mm": float(1_000.0 * np.mean(probe)),
+        "mean_gaussian_nll": float(np.mean(nll)),
+        "normalized_nees": float(np.mean(nees) / 7.0),
+        "empirical_90pct_coverage": float(np.mean(nees <= _CHI2_7_90)),
+        "mean_local_standard_deviation": float(np.mean(width)),
+    }
+    if fallback is not None:
+        fallback_support = np.asarray([trial.support_rmse_m for trial in fallback])
+        fallback_probe = np.asarray([trial.probe_rmse_m for trial in fallback])
+        result.update(
+            {
+                "support_rmse_improvement_fraction": float(
+                    1.0 - np.mean(support) / np.mean(fallback_support)
+                ),
+                "probe_rmse_improvement_fraction": float(
+                    1.0 - np.mean(probe) / np.mean(fallback_probe)
+                ),
+                "harmful_probe_fraction": float(np.mean(probe > fallback_probe)),
+            }
+        )
+    return result
+
+
+def run_observable_gauge_study(
+    config: ObservableGaugeStudyConfig = ObservableGaugeStudyConfig(),
+) -> dict[str, Any]:
+    """Run the frozen controlled mechanism study."""
+
+    config.validate()
+    generator = np.random.default_rng(config.seed)
+    source = _source_line(config)
+    probes = _probe_tube(config)
+    truth = _truth_transform(config)
+    prior_covariance = _prior_covariance(config)
+    fallback_trials: list[_MethodTrial] = []
+    observable_trials: list[_MethodTrial] = []
+    completion_trials: list[_MethodTrial] = []
+    ranks: list[int] = []
+    nullspace_truth_magnitudes: list[float] = []
+
+    for _ in range(config.trials):
+        target = truth.transform_points(source) + generator.normal(
+            scale=config.observation_sigma_m,
+            size=source.shape,
+        )
+        factor = estimate_observable_sim3_factor(
+            source,
+            target,
+            rank_threshold=config.rank_threshold,
+        )
+        ranks.append(factor.rank)
+        truth_local = factor.chart.to_local(truth)
+        prior_mean = truth_local + generator.multivariate_normal(
+            np.zeros(7),
+            prior_covariance,
+        )
+        nullspace_truth_magnitudes.append(
+            float(np.linalg.norm(factor.nullspace_basis.T @ truth_local))
+        )
+        fallback = GaugeGaussianPosterior(
+            chart=factor.chart,
+            mean_local=prior_mean,
+            covariance_local=prior_covariance,
+        )
+        observable = factor.fuse_local_gaussian(prior_mean, prior_covariance)
+        weakest_observable_precision = float(
+            np.min(np.linalg.eigvalsh(factor.observable_information))
+        )
+        completed_information = factor.information_matrix.copy()
+        if factor.nullspace_basis.shape[1]:
+            completed_information += (
+                config.nullspace_precision_ratio
+                * weakest_observable_precision
+                * factor.nullspace_basis
+                @ factor.nullspace_basis.T
+            )
+        completion = _fuse_information(
+            factor.chart,
+            prior_mean,
+            prior_covariance,
+            completed_information,
+        )
+        fallback_trials.append(
+            _trial_metrics(fallback, truth_local, truth, source, probes)
+        )
+        observable_trials.append(
+            _trial_metrics(observable, truth_local, truth, source, probes)
+        )
+        completion_trials.append(
+            _trial_metrics(completion, truth_local, truth, source, probes)
+        )
+
+    fallback_result = _aggregate(fallback_trials)
+    observable_result = _aggregate(observable_trials, fallback_trials)
+    completion_result = _aggregate(completion_trials, fallback_trials)
+    rank_counts = {
+        str(rank): int(np.count_nonzero(np.asarray(ranks) == rank))
+        for rank in sorted(set(ranks))
+    }
+    criteria = {
+        "all_trials_rank_six": rank_counts == {"6": config.trials},
+        "observable_support_rmse_improves_at_least_50pct": (
+            observable_result["support_rmse_improvement_fraction"] >= 0.50
+        ),
+        "observable_probe_rmse_improves": (
+            observable_result["probe_rmse_improvement_fraction"] > 0.0
+        ),
+        "observable_nll_improves": (
+            observable_result["mean_gaussian_nll"] < fallback_result["mean_gaussian_nll"]
+        ),
+        "observable_coverage_is_calibrated": (
+            0.86 <= observable_result["empirical_90pct_coverage"] <= 0.94
+        ),
+        "completion_is_more_harmful_than_subspace": (
+            completion_result["harmful_probe_fraction"]
+            >= observable_result["harmful_probe_fraction"] + 0.25
+        ),
+        "completion_is_undercovered": (
+            completion_result["empirical_90pct_coverage"] <= 0.50
+        ),
+    }
+    return {
+        "schema": _SCHEMA,
+        "schema_version": _SCHEMA_VERSION,
+        "claim_boundary": (
+            "controlled DLO-like gauge-observability mechanism only; not real-provider "
+            "competence, downstream physical benefit, or deployment calibration"
+        ),
+        "config": asdict(config),
+        "geometry": {
+            "expected_observable_rank": 6,
+            "rank_counts": rank_counts,
+            "mean_unobservable_truth_magnitude_rad": float(
+                np.mean(nullspace_truth_magnitudes)
+            ),
+            "current_full_covariance_alignment_accepts_rank_deficient_geometry": False,
+        },
+        "methods": {
+            "exact_physical_prior_fallback": fallback_result,
+            "observable_subspace_factor": observable_result,
+            "isotropic_nullspace_completion_control": completion_result,
+        },
+        "criteria": criteria,
+        "decision": "pass" if all(criteria.values()) else "fail",
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m prob4d.observable_gauge_study",
+        description="run the controlled DLO-like observable-gauge study",
+    )
+    parser.add_argument("--output", type=Path)
+    parser.add_argument("--trials", type=int, default=ObservableGaugeStudyConfig.trials)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = _build_parser().parse_args(argv)
+    config = ObservableGaugeStudyConfig(trials=arguments.trials)
+    result = run_observable_gauge_study(config)
+    rendered = json.dumps(result, indent=2, sort_keys=True) + "\n"
+    if arguments.output is None:
+        print(rendered, end="")
+    else:
+        arguments.output.parent.mkdir(parents=True, exist_ok=True)
+        arguments.output.write_text(rendered, encoding="utf-8")
+    return 0 if result["decision"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_observable_gauge.py
+++ b/tests/test_observable_gauge.py
@@ -1,0 +1,162 @@
+import numpy as np
+
+from prob4d.observable_gauge import (
+    CLUSTER_OBSERVABLE_INFORMATION,
+    IID_OBSERVABLE_INFORMATION,
+    estimate_observable_sim3_factor,
+)
+from prob4d.observable_gauge_study import (
+    ObservableGaugeStudyConfig,
+    run_observable_gauge_study,
+)
+from prob4d.sim3 import Sim3, so3_exp
+
+
+def _line_case(seed: int = 4):
+    generator = np.random.default_rng(seed)
+    coordinate = np.linspace(-1.0, 1.0, 48)
+    source = np.column_stack((coordinate, np.zeros_like(coordinate), np.zeros_like(coordinate)))
+    base_rotation = so3_exp(np.array([0.0, 0.25, -0.15]))
+    truth = Sim3(
+        scale=1.1,
+        rotation=base_rotation @ so3_exp(np.array([0.6, 0.0, 0.0])),
+        translation=np.array([0.2, -0.1, 0.05]),
+    )
+    target = truth.transform_points(source) + generator.normal(scale=0.01, size=source.shape)
+    return source, target, truth
+
+
+def test_centroid_chart_round_trip() -> None:
+    source, target, _ = _line_case()
+    factor = estimate_observable_sim3_factor(source, target)
+    local = np.array([0.02, 0.03, -0.01, 0.04, 0.1, -0.2, 0.05])
+
+    recovered = factor.chart.to_local(factor.chart.from_local(local))
+
+    np.testing.assert_allclose(recovered, local, atol=1e-10, rtol=1e-10)
+
+
+def test_collinear_overlap_retains_six_dimensional_information() -> None:
+    source, target, truth = _line_case()
+
+    factor = estimate_observable_sim3_factor(source, target)
+
+    assert factor.rank == 6
+    assert factor.nullspace_basis.shape == (7, 1)
+    assert factor.covariance_method == IID_OBSERVABLE_INFORMATION
+    np.testing.assert_allclose(factor.normalized_geometry_spectrum[:6], 1.0, atol=1e-12)
+    assert factor.normalized_geometry_spectrum[6] < 1e-12
+    null_direction = factor.nullspace_basis[:, 0]
+    assert factor.quadratic_cost_local(0.5 * null_direction) < 1e-18
+    truth_local = factor.chart.to_local(truth)
+    assert abs(float(null_direction @ truth_local)) > 0.5
+
+
+def test_standard_sim3_covariance_transports_into_intrinsic_chart() -> None:
+    source, target, truth = _line_case()
+    factor = estimate_observable_sim3_factor(source, target)
+    covariance_vector = np.diag(
+        np.array([0.03, 0.04, 0.05, 0.06, 0.02, 0.03, 0.04]) ** 2
+    )
+
+    transported = factor.chart.transport_vector_gaussian(truth, covariance_vector)
+    fused = factor.fuse_vector_gaussian(truth, covariance_vector)
+
+    np.testing.assert_allclose(
+        transported.mean_transform.rotation,
+        truth.rotation,
+        atol=1e-10,
+    )
+    np.testing.assert_allclose(
+        transported.mean_transform.translation, truth.translation, atol=1e-10
+    )
+    assert np.all(np.linalg.eigvalsh(transported.covariance_local) > 0.0)
+    assert np.trace(fused.covariance_local) < np.trace(transported.covariance_local)
+
+
+def test_gaussian_prior_supplies_only_the_missing_direction() -> None:
+    source, target, _ = _line_case()
+    factor = estimate_observable_sim3_factor(source, target)
+    null_direction = factor.nullspace_basis[:, 0]
+    prior_covariance = 0.04 * np.eye(7)
+    prior_mean = 0.3 * null_direction
+
+    posterior = factor.fuse_local_gaussian(prior_mean, prior_covariance)
+
+    np.testing.assert_allclose(
+        null_direction @ posterior.mean_local,
+        0.3,
+        atol=1e-10,
+        rtol=1e-10,
+    )
+    np.testing.assert_allclose(
+        null_direction @ posterior.covariance_local @ null_direction,
+        0.04,
+        atol=1e-10,
+        rtol=1e-10,
+    )
+    observable_variance = np.diag(
+        factor.observable_basis.T
+        @ posterior.covariance_local
+        @ factor.observable_basis
+    )
+    assert np.all(observable_variance < 0.04)
+
+
+def test_generic_three_dimensional_overlap_is_full_rank() -> None:
+    generator = np.random.default_rng(10)
+    source = generator.normal(size=(200, 3))
+    truth = Sim3(
+        scale=0.9,
+        rotation=so3_exp(np.array([0.1, -0.2, 0.05])),
+        translation=np.array([0.4, -0.2, 0.1]),
+    )
+    target = truth.transform_points(source) + generator.normal(scale=0.005, size=source.shape)
+
+    factor = estimate_observable_sim3_factor(source, target)
+
+    assert factor.rank == 7
+    assert factor.nullspace_basis.shape == (7, 0)
+    np.testing.assert_allclose(
+        factor.chart.linearization.transform_points(source),
+        truth.transform_points(source),
+        atol=3e-3,
+    )
+
+
+def test_cluster_robust_factor_stays_within_observable_subspace() -> None:
+    generator = np.random.default_rng(22)
+    points_per_cluster = 10
+    clusters = np.repeat(np.arange(20), points_per_cluster)
+    source = generator.normal(size=(clusters.size, 3))
+    truth = Sim3(
+        scale=1.05,
+        rotation=so3_exp(np.array([0.08, -0.04, 0.03])),
+        translation=np.array([0.2, -0.1, 0.05]),
+    )
+    shared_error = generator.normal(scale=0.01, size=(20, 3))
+    target = truth.transform_points(source) + shared_error[clusters]
+    target += generator.normal(scale=0.001, size=source.shape)
+
+    factor = estimate_observable_sim3_factor(
+        source,
+        target,
+        covariance_cluster_ids=clusters,
+    )
+
+    assert factor.rank == 7
+    assert factor.covariance_method == CLUSTER_OBSERVABLE_INFORMATION
+    assert factor.num_covariance_clusters == 20
+    assert np.all(np.linalg.eigvalsh(factor.observable_information) > 0.0)
+
+
+def test_controlled_dlo_mechanism_is_decisive() -> None:
+    result = run_observable_gauge_study(ObservableGaugeStudyConfig(trials=100))
+    observable = result["methods"]["observable_subspace_factor"]
+    completion = result["methods"]["isotropic_nullspace_completion_control"]
+
+    assert result["geometry"]["rank_counts"] == {"6": 100}
+    assert observable["support_rmse_improvement_fraction"] > 0.95
+    assert observable["probe_rmse_improvement_fraction"] > 0.70
+    assert observable["harmful_probe_fraction"] == 0.0
+    assert completion["empirical_90pct_coverage"] < 0.10


### PR DESCRIPTION
## Motivation

Prob4D's current covariance-only overlap alignment fails closed whenever the seven-dimensional Sim(3) information is rank deficient. That is safe, but it discards valid partial information. A DLO-like centerline overlap is the canonical case: six gauge directions are observable while twist about the transformed line is not.

This PR adds an **experimental** information-factor path that retains only the observable subspace instead of either rejecting the whole overlap or fabricating nullspace precision with a ridge.

## Method

- centroid-normalized, origin-invariant local Sim(3) chart;
- explicit observable and nullspace bases from the normalized geometry spectrum;
- IID or cluster-robust covariance restricted to the observable subspace;
- fusion with a complete Gaussian prior, including transport from existing `Sim3.as_vector()` covariance;
- no change to the stable alignment or claim-bearing provider-v2 export path.

## Controlled evidence

Frozen 1,000-trial DLO-like study, 48 collinear correspondences, 10 mm point noise, and 0.6 rad unobservable twist:

| Method | Centerline RMSE | Off-axis probe RMSE | 90% coverage | Normalized NEES | Harmful trials |
|---|---:|---:|---:|---:|---:|
| Exact prior fallback | 94.246 mm | 100.475 mm | 90.7% | 0.980 | — |
| Observable subspace | **1.955 mm** | **17.764 mm** | 88.0% | 1.028 | **0.0%** |
| Invalid full-rank completion | 1.956 mm | 93.843 mm | 0.0% | 10611.347 | 43.7% |

The observable factor improves observed-support RMSE by 97.93% and off-support probe RMSE by 82.32% relative to fallback. The invalid completion demonstrates why centerline-only error is insufficient: it appears equally accurate on the observed support but becomes catastrophically overconfident and harmful off support.

## Verification

```bash
python -m pytest tests/test_observable_gauge.py
PYTHONPATH=src python -m prob4d.observable_gauge_study \
  --output evidence/observable-gauge-control-v1/result.json
```

Seven focused tests pass locally, including the rank-six DLO case, full-rank 3D parity, nullspace-preserving fusion, standard-coordinate covariance transport, cluster-robust information, and the controlled decision gate.

## Scientific boundary

This is controlled mechanism evidence, not a real-provider, BayesianPhysTwin, Causal4D, deployment, or state-of-the-art result. Localizability-aware ICP already studies weak pose directions; the candidate contribution here is the narrower probabilistic Sim(3) gauge-factor treatment for learned 4D windows and its prospective propagation into guarded physical-twin revision. Promotion requires a frozen fresh-provider and held-out downstream protocol described in `docs/observable-gauge-subspace.md`.
