### PR TITLE
Freeze PointWorld–Flat'n'Fold source qualification

### DIFF
--- a/docs/pointworld-flatnfold-study.md
+++ b/docs/pointworld-flatnfold-study.md
@@ -1,0 +1,103 @@
+# PointWorld → Prob4D → BayesianPhysTwin on Flat'n'Fold
+
+## Purpose
+
+This branch starts the highest-value remaining Prob4D paper experiment: test whether a provider-agnostic, correlation-aware recursive belief improves a real action-conditioned 3-D world model and one frozen downstream BayesianPhysTwin query.
+
+The intended external provider is PointWorld (`NVlabs/PointWorld`) and the intended independent real cohort is the robot subset of Flat'n'Fold (`lipeng-zhuang521/flat-n-fold`). The experiment is deliberately separated from the terminal CUT3R attempt, the already-opened MotionCrafter/Deform360 cohorts, and the locked Causal4D physical-acquisition protocol.
+
+The present branch is **source qualification only**. No target outcome may be opened or used to choose a representation mapping, checkpoint, split, mask, exclusion, covariance treatment, or downstream query.
+
+The machine-readable lock is `protocols/pointworld-flatnfold-source-qualification-v1.json`.
+
+## Frozen public revisions
+
+The source-qualification protocol binds:
+
+- Prob4D: `d02f057671023ff586ebfc15c904dbb0a60f4425`;
+- BayesianPhysTwin: `b5f07d649ac2cd7dc6ca1aceb4004ff4803bddc8`;
+- PointWorld: `05484826dfef74cbe278a3974179a5a16705d35d`;
+- Flat'n'Fold code: `fa0d3d17ac827e7b5c43ec1ef7c0c38ad5e39340`.
+
+These source revisions are not a completed experiment lock. The exact PointWorld checkpoint bytes, runtime, Flat'n'Fold dataset bytes, garment roster, frame/action schedule, and downstream query still have to be bound before target access.
+
+## Why this experiment
+
+Prob4D already contains the methodological ingredients needed for a paper contribution: joint gauge uncertainty, cross-window covariance, covariance intersection, guarded multi-edge graph fusion, finite-sample source-cycle admission, sparse metric-anchor calibration, provider-neutral manifests, and exact fallback. Another covariance or planner component would add complexity without resolving the main empirical gap.
+
+The missing evidence is a fresh real provider and fresh physical object/session cohort showing that the same recursive belief machinery can wrap a different action-conditioned model and improve a downstream physical query.
+
+PointWorld is a materially different provider from MotionCrafter. Its released model predicts full-scene 3-D point flows from RGB-D observations and robot actions represented as 3-D point flows. Flat'n'Fold provides 887 robot demonstrations over 44 garments in eight categories, with three-camera RGB-D observations, camera calibration, Baxter action information, and point-cloud construction code.
+
+## Critical source-side representation gate
+
+This is the first issue that must be resolved before an adapter is authorized.
+
+Prob4D `PredictionWindow` v2 stores a dense `T × H × W × 3` point map and, when present, a dense scene-flow field on the same grid. The released PointWorld model instead predicts over `N_scene` seeded scene points: its dynamics output is shaped `B × T × N_scene × 3`, with a heteroscedastic log-variance output shaped `B × T × N_scene × 1`.
+
+Therefore we must **not** silently reshape or nearest-neighbor rasterize PointWorld output into a Prob4D image grid. One of the following must be established using source information only:
+
+1. a deterministic mapping from every PointWorld scene point back to a registered RGB-D grid location, preserving identity and without using future/target truth;
+2. a separately versioned sparse persistent-point provider contract in Prob4D, with explicit point identities, source lineage, dependence groups, and calibrated uncertainty semantics; or
+3. a valid negative result that this PointWorld version is not compatible with the current Prob4D claim.
+
+Target-truth nearest-neighbor mapping, target-tuned interpolation, and post-outcome removal of unsupported garments are prohibited.
+
+## Source-only qualification sequence
+
+Before provider residuals or target outcomes are opened:
+
+1. bind the exact PointWorld checkpoint SHA-256 and runtime environment;
+2. inventory the Flat'n'Fold robot data and bind the exact byte manifest;
+3. freeze complete physical garment identities as the top-level statistical units;
+4. verify camera timestamp coverage plus intrinsic and extrinsic identities;
+5. verify that Baxter action poses can be converted to PointWorld robot point-flow actions without target state;
+6. verify metric coordinate transformations using released calibration only;
+7. verify PointWorld scene-point identity semantics over the ten-frame prediction horizon;
+8. resolve the representation gate above;
+9. create an outcome-blind `ProviderSupportFeasibilityV1` request with all required streams and geometry support;
+10. stop if the support gate fails.
+
+The existing `prob4d.provider_support_feasibility` contract should be reused; no PointWorld-specific support framework is needed.
+
+## Later held-out study, only after qualification passes
+
+Use complete garment identity as the independent unit. Demonstrations/sessions are nested observations; frames, pixels, and points are not independent replicates.
+
+The primary provider comparison should remain small:
+
+1. raw/disjoint PointWorld;
+2. decoded uniform overlap fusion;
+3. Prob4D sequential full-joint spanning tree;
+4. conformal-guarded full-joint graph with exact tree fallback.
+
+Useful diagnostic controls include persistence, latest-window overwrite, naive precision fusion, and the unguarded graph.
+
+Provider endpoints should include long-horizon and terminal point/flow error, overlap seam or drift, proper score, 50/90/95% coverage, normalized NEES, covariance width, support/fallback accounting, and worst-garment performance. Inference should cluster at garment identity.
+
+## BayesianPhysTwin gate
+
+Freeze exactly one downstream physical query before target access. Compare:
+
+1. unchanged physical fallback;
+2. BayesianPhysTwin with raw PointWorld observations;
+3. BayesianPhysTwin with the selected Prob4D belief.
+
+Report query error/proper score, coverage and width, accepted/rejected/fallback counts, harmful accepted updates, and worst accepted regret. Rejected or unsupported observations must return the exact physical fallback.
+
+Provider competence and downstream value are separate conjunctive claims: neither may rescue failure of the other.
+
+## Causal4D boundary
+
+Do not modify the locked Causal4D physical protocol to enlarge this result. Causal4D can be described as a compatible later consumer, but the PointWorld/Flat'n'Fold study must stand on its own provider and BayesianPhysTwin evidence.
+
+## Completion states
+
+This source-qualification branch should close with exactly one of these outcomes:
+
+- **authorized:** PointWorld action, coordinate, point-identity, representation, and support semantics are frozen without target outcomes, permitting a new held-out protocol version;
+- **representation-negative:** the sparse PointWorld output cannot be mapped into a defensible Prob4D observation contract without target-dependent choices;
+- **support-negative:** the required Flat'n'Fold streams/geometry do not support the frozen provider version;
+- **runtime-negative:** the exact released PointWorld checkpoint cannot execute on the frozen source inventory.
+
+Any negative state is a complete result for this protocol. A later retry requires a new protocol version rather than rewriting this one.

--- a/protocols/pointworld-flatnfold-source-qualification-v1.json
+++ b/protocols/pointworld-flatnfold-source-qualification-v1.json
@@ -1,0 +1,120 @@
+{
+  "schema": "prob4d.pointworld-flatnfold-source-qualification",
+  "schema_version": 1,
+  "protocol_id": "prob4d-pointworld-flatnfold-source-qualification-v1",
+  "status": "SOURCE_QUALIFICATION_ONLY_TARGET_OUTCOMES_PROHIBITED",
+  "scientific_question": "Can the released PointWorld model be connected to Prob4D on Flat'n'Fold robot demonstrations with source-only coordinate, action, identity, and representation semantics strong enough to authorize a later garment-disjoint provider and BayesianPhysTwin study?",
+  "frozen_revisions": {
+    "prob4d_repository": "IPS-Stuttgart/Prob4D",
+    "prob4d_revision": "d02f057671023ff586ebfc15c904dbb0a60f4425",
+    "bayesian_phystwin_repository": "IPS-Stuttgart/BayesianPhysTwin",
+    "bayesian_phystwin_revision": "b5f07d649ac2cd7dc6ca1aceb4004ff4803bddc8",
+    "pointworld_repository": "NVlabs/PointWorld",
+    "pointworld_revision": "05484826dfef74cbe278a3974179a5a16705d35d",
+    "flatnfold_repository": "lipeng-zhuang521/flat-n-fold",
+    "flatnfold_revision": "fa0d3d17ac827e7b5c43ec1ef7c0c38ad5e39340"
+  },
+  "released_source_facts": {
+    "pointworld": {
+      "input": "partially observable RGB-D plus robot actions represented as 3D point flows",
+      "prediction": "full-scene 3D point flows",
+      "context_horizon_frames": 1,
+      "prediction_horizon_frames": 10,
+      "model_output_point_shape": "B,T,N_scene,3",
+      "model_output_log_variance_shape": "B,T,N_scene,1",
+      "released_scene_flow_checkpoints": [
+        "small-droid/model-best.pt",
+        "large-droid/model-best.pt",
+        "large-droid+behavior/model-best.pt"
+      ]
+    },
+    "flatnfold": {
+      "robot_demonstrations": 887,
+      "garments": 44,
+      "garment_categories": 8,
+      "observations": "RGB-D from three cameras with provided calibration",
+      "robot_action_origin": "Baxter base frame",
+      "pointcloud_support": "three-camera point-cloud construction code is released"
+    }
+  },
+  "critical_representation_gate": {
+    "prob4d_current_contract": "PredictionWindow v2 requires point_map and optional scene_flow on a dense T,H,W,3 grid",
+    "pointworld_released_contract": "PointWorld predicts flows for N_scene seeded scene points, not a native T,H,W image grid",
+    "target_access_before_resolution": false,
+    "permitted_resolution_paths": [
+      "prove a deterministic source-only mapping from PointWorld scene-point identities back to a registered dense RGB-D grid without interpolation chosen from target outcomes",
+      "introduce a separately versioned sparse persistent-point provider contract with explicit identity and dependence semantics, validated without target outcomes",
+      "declare this provider version infeasible for the present Prob4D claim"
+    ],
+    "forbidden_resolution_paths": [
+      "target-truth nearest-neighbor rasterization",
+      "target-outcome-tuned interpolation or masks",
+      "dropping unsupported target garments after outcome inspection"
+    ]
+  },
+  "source_only_qualification": {
+    "required_before_any_prediction_competence_result": [
+      "bind exact PointWorld checkpoint SHA-256 and runtime environment",
+      "bind exact Flat'n'Fold dataset byte manifest for the inventory/source cohort",
+      "freeze complete garment identities before provider residuals",
+      "verify three-camera timestamps and intrinsics/extrinsics",
+      "verify Baxter action pose semantics and construct PointWorld robot point-flow actions without target state",
+      "verify metric coordinate transform using released calibration only",
+      "verify point identity semantics over the ten-frame forecast horizon",
+      "resolve the critical representation gate",
+      "build a ProviderSupportFeasibilityV1 request before prediction payloads, residuals, or target outcomes are opened"
+    ],
+    "support_unit": "complete physical garment identity",
+    "nested_unit": "robot demonstration/session",
+    "non_independent_units": [
+      "frame",
+      "pixel",
+      "point"
+    ],
+    "admission_default": "all-streams",
+    "technical_failure_policy": "must be frozen before target access; unsupported cases remain in the denominator unless an exclusion code was preregistered"
+  },
+  "later_study_if_authorized": {
+    "provider_primary_arms": [
+      "pointworld_disjoint",
+      "decoded_uniform_overlap",
+      "prob4d_sequential_joint_spanning_tree",
+      "prob4d_conformal_guarded_full_joint_graph_exact_tree_fallback"
+    ],
+    "downstream_primary_arms": [
+      "bayesian_phystwin_physical_fallback",
+      "bayesian_phystwin_raw_pointworld",
+      "bayesian_phystwin_prob4d_belief"
+    ],
+    "provider_endpoints": [
+      "long_horizon_point_or_flow_error",
+      "terminal_error",
+      "seam_or_overlap_discontinuity",
+      "proper_score",
+      "coverage_50_90_95",
+      "normalized_nees",
+      "covariance_width",
+      "support_and_fallback_rate",
+      "worst_garment_performance"
+    ],
+    "downstream_endpoints": [
+      "frozen_physical_query_error",
+      "proper_score",
+      "coverage_and_width",
+      "accepted_rejected_fallback_counts",
+      "harmful_accepted_updates",
+      "worst_accepted_regret"
+    ],
+    "inference_unit": "garment_identity",
+    "no_rescue_rule": "provider competence and downstream benefit are separate conjunctive claims"
+  },
+  "stop_rules": [
+    "stop and retain a valid negative if PointWorld cannot execute on the frozen source roster",
+    "stop if action conversion is not semantically identifiable from released Flat'n'Fold information",
+    "stop if coordinate identity requires target truth",
+    "stop if persistent point identities or an outcome-blind dense mapping cannot be established",
+    "do not open target outcomes until source support and representation qualification pass",
+    "do not retune checkpoint, split, masks, representation mapping, or guard after target access"
+  ],
+  "claim_boundary": "This protocol freezes only a source-side feasibility and representation qualification. It establishes no PointWorld competence on Flat'n'Fold, no Prob4D accuracy or calibration gain, no BayesianPhysTwin benefit, no Causal4D benefit, and no deployment-safety claim."
+}


### PR DESCRIPTION
## Purpose

Start the fresh-provider path for #49 without opening target outcomes.

This PR freezes a source-only qualification protocol for a proposed PointWorld -> Prob4D -> BayesianPhysTwin study on garment-disjoint Flat'n'Fold robot demonstrations.

Closes no scientific claim. Tracks execution in #333.

## What is added

- `protocols/pointworld-flatnfold-source-qualification-v1.json`
  - binds current Prob4D, BayesianPhysTwin, PointWorld, and Flat'n'Fold source revisions;
  - records released PointWorld and Flat'n'Fold source facts;
  - freezes the source-only qualification sequence and stop rules;
  - prohibits target-outcome access before support and representation semantics are resolved.
- `docs/pointworld-flatnfold-study.md`
  - explains the paper motivation, later held-out provider/BayesianPhysTwin arms, inference unit, and Causal4D boundary.

## Critical finding before adapter work

The released PointWorld model predicts seeded scene-point flows on `B x T x N_scene x 3` and a `B x T x N_scene x 1` log-variance field. Current Prob4D `PredictionWindow` v2 is a dense `T x H x W x 3` contract.

Therefore this PR intentionally does **not** add a fake dense adapter. Before target access, #333 must establish one of:

1. a deterministic source-only mapping from PointWorld scene-point identities back to a registered RGB-D grid;
2. a separately versioned sparse persistent-point provider contract with explicit identities, lineage, dependence, and uncertainty semantics; or
3. a retained representation-negative result for this provider version.

Target-truth nearest-neighbor rasterization, target-tuned interpolation/masks, and post-outcome removal of unsupported garments are explicitly forbidden.

## Information boundary

No Flat'n'Fold target outcome, provider residual, covariance result, BayesianPhysTwin innovation, or Causal4D outcome was used to create this protocol. The exact PointWorld checkpoint bytes, runtime, Flat'n'Fold dataset byte manifest, garment roster, frame/action schedule, and downstream query remain to be frozen during source qualification.

## Validation

Documentation/protocol-only change. The branch is exactly two added files on top of `d02f057671023ff586ebfc15c904dbb0a60f4425`; no estimator, provider, or production semantics change.