### PR TITLE
Add fail-closed CUT3R native-RoPE runtime contract

### DIFF
--- a/CHANGELOG.d/cut3r-compiled-rope-runtime-contract.md
+++ b/CHANGELOG.d/cut3r-compiled-rope-runtime-contract.md
@@ -1,0 +1,1 @@
+- Add a fail-closed CUT3R compiled-RoPE runtime contract, content-bound receipt generator, and separately versioned successor runner. The terminal v1.2 smoke remains unchanged and non-retriable; this change does not constitute scientific evidence or authorize source/target access.

--- a/docs/cut3r-compiled-rope-runtime-contract.md
+++ b/docs/cut3r-compiled-rope-runtime-contract.md
@@ -1,0 +1,61 @@
+# CUT3R compiled-RoPE runtime contract
+
+## Purpose
+
+The terminal `cut3r-source-comparison-smoke-v1-2` result must not be retried. It entered CUT3R inference and terminated with a CUDA device-side assertion before writing a prediction. This contract defines a **new prospective provider-runtime identity** that fails closed unless the pinned CUT3R checkout imports its compiled CUDA RoPE kernel.
+
+CUT3R's installation instructions require building `src/croco/models/curope` with `python setup.py build_ext --inplace`. When that extension is unavailable, CUT3R permits a Python RoPE fallback. The fallback is not admissible for Prob4D provider qualification because the same failure signature has been reported upstream around its positional embedding lookup.
+
+The historical `run_cut3r_source_comparison.py` entry point is intentionally left unchanged. Any separately preregistered successor route must use `run_cut3r_source_comparison_native_rope.py`, so the terminal v1.2 implementation remains byte-for-byte attributable to its frozen result.
+
+## Contract
+
+`require_compiled_cut3r_rope()` is called before the delegated executor constructs `dust3r.model`. It requires all of the following:
+
+1. the native extension is importable;
+2. the imported module is a platform extension, not `curope.py`;
+3. the extension resides inside the pinned CUT3R `src/croco/models/curope` tree;
+4. it exposes the required `rope_2d` symbol;
+5. the extension binary and all relevant source members are hashed into a self-authenticating receipt.
+
+The receipt contains only checkout-relative paths. Its `artifact_id` must be frozen into any successor source-comparison plan together with the CUT3R revision, checkpoint digest, PyTorch/CUDA inventory, compiler identity, and Prob4D implementation revision.
+
+## Preparation
+
+From an installed Prob4D checkout:
+
+```bash
+python scripts/science/prepare_cut3r_runtime.py \
+  --cut3r-checkout /path/to/CUT3R \
+  --build \
+  --output /sealed/runtime/cut3r-compiled-rope-receipt.json
+```
+
+Run the provider process freshly after compilation. For a frozen receipt, repeat verification without `--build` and with `--expected-artifact-id`.
+
+A separately registered successor execution uses:
+
+```bash
+python scripts/science/run_cut3r_source_comparison_native_rope.py \
+  <the exact arguments frozen by the successor plan>
+```
+
+This entry point delegates to the established source-comparison executor only after replacing its runtime constructor with one that verifies and content-binds the native RoPE extension. It does not make the consumed v1.2 smoke executable again and does not itself authorize source or target access.
+
+## Admissible next experiment
+
+The successor route is not a retry of v1.2. It must use a new plan version and a fresh registered development case. Before opening any scientific outcomes:
+
+1. freeze the compiled-RoPE receipt and runtime inventory;
+2. run a technical-only CUT3R example capsule to establish forward-pass compatibility;
+3. discard example predictions and retain only stage/provenance evidence;
+4. prospectively register the fresh source-only cohort and exact continuous-versus-restarted comparison;
+5. permit target/BayesianPhysTwin/Causal4D execution only after ordinary source success and custody verification.
+
+The scientific endpoint should not be another isolated reconstruction score. The paper-strength experiment compares, on identical frames and provider weights:
+
+- native continuous CUT3R state;
+- restarted CUT3R windows with Prob4D gauge-aware probabilistic fusion;
+- exact BayesianPhysTwin fallback.
+
+Primary outcomes are downstream physical action error or regret, harmful accepted-update frequency with the already-frozen exact certificate, fallback rate, and support/identifiability diagnostics. Point error and calibration are mechanism diagnostics, not the headline claim.

--- a/scripts/science/prepare_cut3r_runtime.py
+++ b/scripts/science/prepare_cut3r_runtime.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Build or verify CUT3R's native RoPE kernel and emit an immutable receipt."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from prob4d.cut3r_runtime_contract import require_compiled_cut3r_rope
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cut3r-checkout", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--build",
+        action="store_true",
+        help="Run CUT3R's pinned curope setup.py before verification.",
+    )
+    parser.add_argument(
+        "--expected-artifact-id",
+        help="Fail unless the verified receipt matches this frozen artifact ID.",
+    )
+    return parser
+
+
+def _write_no_clobber(path: Path, payload: dict[str, object]) -> None:
+    encoded = json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with path.open("x", encoding="utf-8", newline="\n") as stream:
+            stream.write(encoded)
+    except FileExistsError:
+        if path.read_text(encoding="utf-8") != encoded:
+            raise
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    checkout = args.cut3r_checkout.expanduser().resolve(strict=True)
+    curope_root = checkout / "src/croco/models/curope"
+
+    if args.build:
+        subprocess.run(
+            [sys.executable, "setup.py", "build_ext", "--inplace"],
+            cwd=curope_root,
+            check=True,
+        )
+
+    receipt = require_compiled_cut3r_rope(checkout)
+    if (
+        args.expected_artifact_id is not None
+        and receipt["artifact_id"] != args.expected_artifact_id
+    ):
+        raise SystemExit(
+            "verified CUT3R runtime receipt differs from the frozen artifact ID"
+        )
+    _write_no_clobber(args.output, receipt)
+    print(receipt["artifact_id"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/science/run_cut3r_source_comparison_native_rope.py
+++ b/scripts/science/run_cut3r_source_comparison_native_rope.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Run a separately versioned CUT3R source comparison with native RoPE enforced."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+
+import run_cut3r_source_comparison as legacy
+
+from prob4d.cut3r_runtime_contract import require_compiled_cut3r_rope
+
+
+class _NativeRopeCut3RRuntime(legacy._Cut3RRuntime):
+    """Legacy executor runtime with an additional native-RoPE admission gate."""
+
+    def __init__(self, checkout: Path, checkpoint: Path, *, device: str) -> None:
+        self.runtime_receipt = require_compiled_cut3r_rope(checkout)
+        super().__init__(checkout, checkpoint, device=device)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Delegate to the frozen executor after replacing only its runtime constructor."""
+
+    legacy._Cut3RRuntime = _NativeRopeCut3RRuntime
+    return legacy.main(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/prob4d/cut3r_runtime_contract.py
+++ b/src/prob4d/cut3r_runtime_contract.py
@@ -1,0 +1,217 @@
+"""Fail-closed attestation for CUT3R's native CUDA RoPE implementation."""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import importlib.machinery
+import json
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+CUT3R_RUNTIME_CONTRACT_SCHEMA = "prob4d.cut3r-runtime-contract"
+CUT3R_RUNTIME_CONTRACT_VERSION = 1
+
+_CROCO_ROOT = Path("src/croco")
+_CUROPE_ROOT = _CROCO_ROOT / "models/curope"
+_REQUIRED_SOURCE_MEMBERS = (
+    _CUROPE_ROOT / "__init__.py",
+    _CUROPE_ROOT / "curope2d.py",
+    _CUROPE_ROOT / "curope.cpp",
+    _CUROPE_ROOT / "kernels.cu",
+    _CUROPE_ROOT / "setup.py",
+    _CROCO_ROOT / "models/pos_embed.py",
+)
+
+
+class Cut3RRuntimeContractError(RuntimeError):
+    """Raised when CUT3R cannot prove use of its native RoPE implementation."""
+
+
+def _canonical_json(value: object) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _checkout_member(checkout: Path, relative: Path, *, label: str) -> Path:
+    candidate = checkout / relative
+    cursor = checkout
+    for part in relative.parts:
+        cursor = cursor / part
+        if cursor.is_symlink():
+            raise Cut3RRuntimeContractError(
+                f"{label} traverses a symbolic link: {relative.as_posix()}"
+            )
+    try:
+        resolved = candidate.resolve(strict=True)
+    except FileNotFoundError as error:
+        raise Cut3RRuntimeContractError(
+            f"required {label} is missing: {relative.as_posix()}"
+        ) from error
+    try:
+        resolved.relative_to(checkout)
+    except ValueError as error:
+        raise Cut3RRuntimeContractError(
+            f"{label} escapes the pinned CUT3R checkout: {relative.as_posix()}"
+        ) from error
+    if not resolved.is_file():
+        raise Cut3RRuntimeContractError(
+            f"required {label} is not a regular file: {relative.as_posix()}"
+        )
+    return resolved
+
+
+def _native_extension_path(module: object, *, checkout: Path, curope_root: Path) -> Path:
+    raw_path = getattr(module, "__file__", None)
+    if not isinstance(raw_path, str) or not raw_path:
+        raise Cut3RRuntimeContractError(
+            "CUT3R RoPE kernel module does not expose a filesystem identity"
+        )
+    unresolved = Path(raw_path)
+    if unresolved.is_symlink():
+        raise Cut3RRuntimeContractError("CUT3R RoPE extension must not be a symbolic link")
+    try:
+        extension = unresolved.resolve(strict=True)
+    except FileNotFoundError as error:
+        raise Cut3RRuntimeContractError(
+            "CUT3R RoPE kernel module points to a missing extension file"
+        ) from error
+    if not extension.is_file():
+        raise Cut3RRuntimeContractError(
+            "CUT3R RoPE kernel module is not backed by a regular file"
+        )
+    if not any(
+        extension.name.endswith(suffix)
+        for suffix in importlib.machinery.EXTENSION_SUFFIXES
+    ):
+        raise Cut3RRuntimeContractError(
+            "CUT3R resolved the Python RoPE fallback instead of a native extension"
+        )
+    try:
+        extension.relative_to(curope_root)
+    except ValueError as error:
+        try:
+            reported = extension.relative_to(checkout).as_posix()
+        except ValueError:
+            reported = "<outside-cut3r-checkout>"
+        raise Cut3RRuntimeContractError(
+            "CUT3R RoPE extension is outside the pinned curope source tree: "
+            f"{reported}"
+        ) from error
+    return extension
+
+
+def _source_records(checkout: Path) -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    for relative in _REQUIRED_SOURCE_MEMBERS:
+        source = _checkout_member(checkout, relative, label="CUT3R RoPE source member")
+        records.append(
+            {
+                "relative_path": relative.as_posix(),
+                "sha256": _sha256(source),
+                "byte_count": int(source.stat().st_size),
+            }
+        )
+    return records
+
+
+def require_compiled_cut3r_rope(checkout: Path) -> dict[str, Any]:
+    """Require CUT3R's compiled RoPE kernel and return a content-bound receipt.
+
+    This function is intentionally called before importing ``dust3r.model``. CUT3R
+    otherwise silently permits a Python RoPE fallback, which is not an admissible
+    runtime for the provider comparison.
+    """
+
+    try:
+        resolved_checkout = checkout.expanduser().resolve(strict=True)
+    except FileNotFoundError as error:
+        raise Cut3RRuntimeContractError("CUT3R checkout does not exist") from error
+    if not resolved_checkout.is_dir():
+        raise Cut3RRuntimeContractError("CUT3R checkout is not a directory")
+
+    croco_root = resolved_checkout / _CROCO_ROOT
+    curope_root = resolved_checkout / _CUROPE_ROOT
+    if not croco_root.is_dir() or not curope_root.is_dir():
+        raise Cut3RRuntimeContractError(
+            "CUT3R checkout is missing src/croco/models/curope"
+        )
+
+    croco_path = str(croco_root)
+    while croco_path in sys.path:
+        sys.path.remove(croco_path)
+    sys.path.insert(0, croco_path)
+    importlib.invalidate_caches()
+
+    try:
+        curope2d = importlib.import_module("models.curope.curope2d")
+    except Exception as error:
+        raise Cut3RRuntimeContractError(
+            "CUT3R native RoPE is unavailable. Build the pinned checkout from "
+            "src/croco/models/curope with 'python setup.py build_ext --inplace', "
+            "then start a fresh Python process. The Python fallback is forbidden "
+            "for provider qualification."
+        ) from error
+
+    kernels = getattr(curope2d, "_kernels", None)
+    if kernels is None:
+        raise Cut3RRuntimeContractError(
+            "CUT3R curope2d did not expose its native kernel module"
+        )
+    extension = _native_extension_path(
+        kernels,
+        checkout=resolved_checkout,
+        curope_root=curope_root,
+    )
+    if not callable(getattr(kernels, "rope_2d", None)):
+        raise Cut3RRuntimeContractError(
+            "CUT3R RoPE extension does not expose the required rope_2d symbol"
+        )
+
+    receipt: dict[str, Any] = {
+        "schema": CUT3R_RUNTIME_CONTRACT_SCHEMA,
+        "schema_version": CUT3R_RUNTIME_CONTRACT_VERSION,
+        "status": "native-rope-verified",
+        "import_target": "models.curope.curope2d._kernels",
+        "extension": {
+            "relative_path": extension.relative_to(resolved_checkout).as_posix(),
+            "sha256": _sha256(extension),
+            "byte_count": int(extension.stat().st_size),
+        },
+        "sources": _source_records(resolved_checkout),
+    }
+    receipt["artifact_id"] = hashlib.sha256(_canonical_json(receipt)).hexdigest()
+    return receipt
+
+
+def validate_cut3r_runtime_receipt(receipt: Mapping[str, object]) -> None:
+    """Validate the self-authenticating structure of a runtime receipt."""
+
+    unsigned = dict(receipt)
+    artifact_id = unsigned.pop("artifact_id", None)
+    if not isinstance(artifact_id, str) or len(artifact_id) != 64:
+        raise Cut3RRuntimeContractError("runtime receipt has no canonical artifact ID")
+    if receipt.get("schema") != CUT3R_RUNTIME_CONTRACT_SCHEMA:
+        raise Cut3RRuntimeContractError("runtime receipt schema is unsupported")
+    if receipt.get("schema_version") != CUT3R_RUNTIME_CONTRACT_VERSION:
+        raise Cut3RRuntimeContractError("runtime receipt version is unsupported")
+    if receipt.get("status") != "native-rope-verified":
+        raise Cut3RRuntimeContractError("runtime receipt does not attest native RoPE")
+    expected = hashlib.sha256(_canonical_json(unsigned)).hexdigest()
+    if artifact_id != expected:
+        raise Cut3RRuntimeContractError("runtime receipt artifact ID is invalid")

--- a/tests/test_cut3r_runtime_contract.py
+++ b/tests/test_cut3r_runtime_contract.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import hashlib
+import importlib
+import importlib.machinery
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from prob4d import cut3r_runtime_contract as contract
+
+_SOURCE_MEMBERS = (
+    "src/croco/models/curope/__init__.py",
+    "src/croco/models/curope/curope2d.py",
+    "src/croco/models/curope/curope.cpp",
+    "src/croco/models/curope/kernels.cu",
+    "src/croco/models/curope/setup.py",
+    "src/croco/models/pos_embed.py",
+)
+
+
+def _checkout(tmp_path: Path) -> tuple[Path, Path]:
+    checkout = tmp_path / "CUT3R"
+    for relative in _SOURCE_MEMBERS:
+        path = checkout / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"source:{relative}\n", encoding="utf-8")
+    suffix = importlib.machinery.EXTENSION_SUFFIXES[0]
+    extension = checkout / "src/croco/models/curope" / f"curope{suffix}"
+    extension.write_bytes(b"compiled-curope")
+    return checkout, extension
+
+
+def _install_fake_import(monkeypatch: pytest.MonkeyPatch, extension: Path) -> None:
+    kernels = SimpleNamespace(__file__=str(extension), rope_2d=lambda *_args: None)
+    curope2d = SimpleNamespace(_kernels=kernels)
+    monkeypatch.setattr(importlib, "import_module", lambda _name: curope2d)
+
+
+def _canonical_json(value: object) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def test_native_runtime_receipt_is_content_bound_and_path_redacted(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checkout, extension = _checkout(tmp_path)
+    _install_fake_import(monkeypatch, extension)
+
+    first = contract.require_compiled_cut3r_rope(checkout)
+    second = contract.require_compiled_cut3r_rope(checkout)
+
+    assert first == second
+    assert first["status"] == "native-rope-verified"
+    assert first["extension"]["relative_path"].startswith(
+        "src/croco/models/curope/curope"
+    )
+    assert str(checkout) not in json.dumps(first, sort_keys=True)
+    unsigned = dict(first)
+    artifact_id = unsigned.pop("artifact_id")
+    assert artifact_id == hashlib.sha256(_canonical_json(unsigned)).hexdigest()
+    contract.validate_cut3r_runtime_receipt(first)
+
+
+def test_python_fallback_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checkout, _ = _checkout(tmp_path)
+    fallback = checkout / "src/croco/models/curope/curope.py"
+    fallback.write_text("def rope_2d(*args): pass\n", encoding="utf-8")
+    _install_fake_import(monkeypatch, fallback)
+
+    with pytest.raises(
+        contract.Cut3RRuntimeContractError,
+        match="Python RoPE fallback",
+    ):
+        contract.require_compiled_cut3r_rope(checkout)
+
+
+def test_out_of_tree_native_extension_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checkout, _ = _checkout(tmp_path)
+    suffix = importlib.machinery.EXTENSION_SUFFIXES[0]
+    external = tmp_path / f"curope{suffix}"
+    external.write_bytes(b"external-extension")
+    _install_fake_import(monkeypatch, external)
+
+    with pytest.raises(
+        contract.Cut3RRuntimeContractError,
+        match="outside the pinned curope source tree",
+    ):
+        contract.require_compiled_cut3r_rope(checkout)
+
+
+def test_missing_bound_source_member_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checkout, extension = _checkout(tmp_path)
+    (checkout / "src/croco/models/curope/kernels.cu").unlink()
+    _install_fake_import(monkeypatch, extension)
+
+    with pytest.raises(
+        contract.Cut3RRuntimeContractError,
+        match="required CUT3R RoPE source member is missing",
+    ):
+        contract.require_compiled_cut3r_rope(checkout)
+
+
+def test_tampered_receipt_is_rejected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checkout, extension = _checkout(tmp_path)
+    _install_fake_import(monkeypatch, extension)
+    receipt = contract.require_compiled_cut3r_rope(checkout)
+    receipt["extension"]["byte_count"] += 1
+
+    with pytest.raises(
+        contract.Cut3RRuntimeContractError,
+        match="artifact ID is invalid",
+    ):
+        contract.validate_cut3r_runtime_receipt(receipt)


### PR DESCRIPTION
## Summary

Add a separately versioned CUT3R provider-runtime boundary that fails closed unless the pinned checkout is using its compiled CUDA RoPE implementation.

This PR intentionally leaves the terminal `cut3r-source-comparison-smoke-v1-2` executor unchanged. The historical v1.2 attempt remains consumed and non-retriable.

### Changes

- add `prob4d.cut3r_runtime_contract` to verify the native extension, reject the Python fallback/out-of-tree modules, bind source and extension hashes, and emit a self-authenticating receipt;
- add `scripts/science/prepare_cut3r_runtime.py` to build/verify the pinned extension and freeze its artifact ID;
- add `scripts/science/run_cut3r_source_comparison_native_rope.py` as the separately versioned successor runner;
- add fail-closed unit tests for fallback, provenance, missing-source and receipt-tamper cases;
- document the prospective experiment and information boundary.

## Scientific boundary

This is runtime qualification infrastructure, not provider-competence evidence. It does not authorize a retry of v1.2, source truth, target access, BayesianPhysTwin execution, or Causal4D execution. Any successor study needs a new preregistered plan, fresh development case, frozen compiled-RoPE receipt/runtime identity, and ordinary source success before downstream access.

## Intended next step

After CI, run a technical-only CUT3R example capsule on the pinned runtime, then register a fresh source-only continuous-vs-restarted comparison. The paper-strength endpoint remains downstream guarded physical-twin decision value rather than another isolated reconstruction score.