### PR TITLE
Add persistent PointWorld sparse prediction contract

### DIFF
--- a/.github/workflows/pointworld-persistent-point.yml
+++ b/.github/workflows/pointworld-persistent-point.yml
@@ -1,0 +1,84 @@
+name: PointWorld persistent-point contract
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/pointworld-persistent-point.yml"
+      - "docs/persistent-point-prediction.md"
+      - "docs/pointworld-flatnfold-study.md"
+      - "protocols/pointworld-flatnfold-source-qualification-v1.json"
+      - "src/prob4d/persistent_point_prediction.py"
+      - "src/prob4d/pointworld_sparse_adapter.py"
+      - "src/prob4d/prediction_cli.py"
+      - "tests/test_cli.py"
+      - "tests/test_persistent_point_prediction.py"
+      - "tests/test_pointworld_sparse_adapter.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pointworld-persistent-point-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONUNBUFFERED: "1"
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out exact reviewed source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install lightweight development environment
+        run: |
+          python -m pip install -e ".[dev]" "numpy>=1.24,<2.3"
+          python -m pip check
+
+      - name: Lint and format focused sources
+        run: |
+          python -m ruff check \
+            src/prob4d/persistent_point_prediction.py \
+            src/prob4d/pointworld_sparse_adapter.py \
+            src/prob4d/prediction_cli.py \
+            tests/test_cli.py \
+            tests/test_persistent_point_prediction.py \
+            tests/test_pointworld_sparse_adapter.py
+          python -m ruff format --check --diff \
+            src/prob4d/persistent_point_prediction.py \
+            src/prob4d/pointworld_sparse_adapter.py \
+            src/prob4d/prediction_cli.py \
+            tests/test_cli.py \
+            tests/test_persistent_point_prediction.py \
+            tests/test_pointworld_sparse_adapter.py
+
+      - name: Type-check focused sources
+        run: |
+          python -m mypy \
+            src/prob4d/persistent_point_prediction.py \
+            src/prob4d/pointworld_sparse_adapter.py
+
+      - name: Run focused contracts
+        run: |
+          python -m pytest -q \
+            tests/test_cli.py \
+            tests/test_persistent_point_prediction.py \
+            tests/test_pointworld_sparse_adapter.py
+
+      - name: Compile and smoke-test installed command
+        run: |
+          python -m compileall -q src/prob4d
+          prob4d prediction import-pointworld-sparse --help

--- a/docs/persistent-point-prediction.md
+++ b/docs/persistent-point-prediction.md
@@ -1,0 +1,111 @@
+# Persistent sparse point-prediction windows
+
+`prob4d.persistent_point_prediction` defines a strict, versioned payload for
+providers whose output is a set of point trajectories rather than a dense image
+grid.
+
+The first consumer is PointWorld. Its released data pipeline samples scene
+points at time zero and applies the same selected indices to every later
+timestep. Its model then predicts one absolute trajectory for each retained
+source point. Preserving those identities is more faithful than rasterizing the
+output into `PredictionWindow`'s dense `T x H x W` grid.
+
+## Contract
+
+`PersistentPointPredictionWindow` retains:
+
+- strictly increasing absolute output-frame indices;
+- strictly increasing non-negative point IDs;
+- absolute point positions with shape `T x N x 3`;
+- one `T x N` validity mask;
+- the number of context frames;
+- fixed point-identity and trajectory semantics; and
+- optional provider uncertainty with shape `T x N x 1` or `T x N x 3`.
+
+Every retained point must be valid in the first context frame. The same point ID
+therefore denotes the same seeded material/sample point throughout one window.
+The identity scope is deliberately **window-local**. Cross-window association is
+a separate scientific problem and is not invented by this archive.
+
+The archive schema is:
+
+```text
+prob4d.persistent-point-prediction-window-npz
+```
+
+version `1`. It rejects missing or additional members, dtype drift, duplicate or
+reordered point IDs, non-finite values, ambiguous uncertainty semantics, and
+non-Boolean masks. Loaded arrays use immutable byte-backed storage.
+
+## PointWorld export
+
+The source-only adapter accepts a strict runtime snapshot with schema:
+
+```text
+prob4d.pointworld-persistent-point-source-npz
+```
+
+version `1`, containing:
+
+```text
+schema_name
+schema_version
+frame_indices          int64, shape (T,)
+scene_flows            float32/float64, shape (T,N,3) or (1,T,N,3)
+scene_exists           bool, shape (T,N) or (1,T,N)
+log_var                float32/float64, shape (T,N,1|3) or batched equivalent
+context_frame_count    int64 scalar
+point_ids              optional int64, shape (N,)
+```
+
+Run:
+
+```bash
+prob4d prediction import-pointworld-sparse \
+  pointworld-source-window-0000.npz \
+  persistent-window-0000.npz \
+  --window-id pointworld-window-0000 \
+  --storage-dtype float32
+```
+
+The adapter removes only source-frame padding, sorts explicit point IDs while
+reordering all trajectory fields identically, writes a no-clobber canonical
+archive, reloads it, and checks exact array equality.
+
+## Uncertainty boundary
+
+PointWorld's released `log_var` is trained in its normalized relative-displacement
+space. The adapter retains it under the explicit semantic label:
+
+```text
+pointworld-normalized-relative-log-variance-v1
+```
+
+This value is **not** called metric covariance, predictive coverage, or a
+calibrated likelihood. A later source/calibration-only study must bind the exact
+normalization statistics and determine whether the raw quantity supports a
+calibrated conditional covariance. Until then, it is an identity-bound provider
+uncertainty feature only.
+
+## What this resolves
+
+For the PointWorld–Flat'n'Fold source qualification, this contract resolves the
+representation choice without target outcomes:
+
+- no target-truth nearest-neighbor rasterization;
+- no target-tuned interpolation or masks;
+- no loss of within-window point identity; and
+- no reinterpretation of PointWorld's raw log variance.
+
+It does not yet establish:
+
+- executable PointWorld support on the Flat'n'Fold inventory;
+- Baxter-action conversion;
+- metric coordinate consistency;
+- cross-window point association;
+- recursive fusion benefit;
+- provider calibration;
+- BayesianPhysTwin benefit; or
+- Causal4D benefit.
+
+Those remain separate source-qualification and held-out gates.

--- a/docs/pointworld-flatnfold-study.md
+++ b/docs/pointworld-flatnfold-study.md
@@ -2,13 +2,21 @@
 
 ## Purpose
 
-This branch starts the highest-value remaining Prob4D paper experiment: test whether a provider-agnostic, correlation-aware recursive belief improves a real action-conditioned 3-D world model and one frozen downstream BayesianPhysTwin query.
+This branch starts the highest-value remaining Prob4D paper experiment: test whether a
+provider-agnostic, correlation-aware recursive belief improves a real action-conditioned 3-D
+world model and one frozen downstream BayesianPhysTwin query.
 
-The intended external provider is PointWorld (`NVlabs/PointWorld`) and the intended independent real cohort is the robot subset of Flat'n'Fold (`lipeng-zhuang521/flat-n-fold`). The experiment is deliberately separated from the terminal CUT3R attempt, the already-opened MotionCrafter/Deform360 cohorts, and the locked Causal4D physical-acquisition protocol.
+The intended external provider is PointWorld (`NVlabs/PointWorld`) and the intended independent
+real cohort is the robot subset of Flat'n'Fold (`lipeng-zhuang521/flat-n-fold`). The experiment is
+deliberately separated from the terminal CUT3R attempt, the already-opened
+MotionCrafter/Deform360 cohorts, and the locked Causal4D physical-acquisition protocol.
 
-The present branch is **source qualification only**. No target outcome may be opened or used to choose a representation mapping, checkpoint, split, mask, exclusion, covariance treatment, or downstream query.
+The present branch is **source qualification only**. No target outcome may be opened or used to
+choose a representation mapping, checkpoint, split, mask, exclusion, covariance treatment, or
+downstream query.
 
-The machine-readable lock is `protocols/pointworld-flatnfold-source-qualification-v1.json`.
+The machine-readable lock is
+`protocols/pointworld-flatnfold-source-qualification-v1.json`.
 
 ## Frozen public revisions
 
@@ -19,29 +27,58 @@ The source-qualification protocol binds:
 - PointWorld: `05484826dfef74cbe278a3974179a5a16705d35d`;
 - Flat'n'Fold code: `fa0d3d17ac827e7b5c43ec1ef7c0c38ad5e39340`.
 
-These source revisions are not a completed experiment lock. The exact PointWorld checkpoint bytes, runtime, Flat'n'Fold dataset bytes, garment roster, frame/action schedule, and downstream query still have to be bound before target access.
+These source revisions are not a completed experiment lock. The exact PointWorld checkpoint
+bytes, runtime, Flat'n'Fold dataset bytes, garment roster, frame/action schedule, and downstream
+query still have to be bound before target access.
 
 ## Why this experiment
 
-Prob4D already contains the methodological ingredients needed for a paper contribution: joint gauge uncertainty, cross-window covariance, covariance intersection, guarded multi-edge graph fusion, finite-sample source-cycle admission, sparse metric-anchor calibration, provider-neutral manifests, and exact fallback. Another covariance or planner component would add complexity without resolving the main empirical gap.
+Prob4D already contains the methodological ingredients needed for a paper contribution: joint
+gauge uncertainty, cross-window covariance, covariance intersection, guarded multi-edge graph
+fusion, finite-sample source-cycle admission, sparse metric-anchor calibration, provider-neutral
+manifests, and exact fallback. Another covariance or planner component would add complexity
+without resolving the main empirical gap.
 
-The missing evidence is a fresh real provider and fresh physical object/session cohort showing that the same recursive belief machinery can wrap a different action-conditioned model and improve a downstream physical query.
+The missing evidence is a fresh real provider and fresh physical object/session cohort showing
+that the same recursive belief machinery can wrap a different action-conditioned model and
+improve a downstream physical query.
 
-PointWorld is a materially different provider from MotionCrafter. Its released model predicts full-scene 3-D point flows from RGB-D observations and robot actions represented as 3-D point flows. Flat'n'Fold provides 887 robot demonstrations over 44 garments in eight categories, with three-camera RGB-D observations, camera calibration, Baxter action information, and point-cloud construction code.
+PointWorld is a materially different provider from MotionCrafter. Its released model predicts
+full-scene 3-D point flows from RGB-D observations and robot actions represented as 3-D point
+flows. Flat'n'Fold provides 887 robot demonstrations over 44 garments in eight categories, with
+three-camera RGB-D observations, camera calibration, Baxter action information, and point-cloud
+construction code.
 
-## Critical source-side representation gate
+## Representation decision
 
-This is the first issue that must be resolved before an adapter is authorized.
+The source-only representation question is resolved in favor of a sparse persistent-point
+contract.
 
-Prob4D `PredictionWindow` v2 stores a dense `T × H × W × 3` point map and, when present, a dense scene-flow field on the same grid. The released PointWorld model instead predicts over `N_scene` seeded scene points: its dynamics output is shaped `B × T × N_scene × 3`, with a heteroscedastic log-variance output shaped `B × T × N_scene × 1`.
+PointWorld's released test pipeline performs scene-point sampling only at time zero and applies
+the selected indices to every timestep. Its model outputs one absolute trajectory for each
+retained source point as `scene_coord0 + predicted_relative_displacement`. The same
+`N_scene` index therefore has a defensible within-window identity over the one-frame context and
+ten-frame forecast horizon.
 
-Therefore we must **not** silently reshape or nearest-neighbor rasterize PointWorld output into a Prob4D image grid. One of the following must be established using source information only:
+Prob4D must not reshape or nearest-neighbor rasterize this output into the dense
+`PredictionWindow` `T x H x W x 3` grid. This branch instead adds:
 
-1. a deterministic mapping from every PointWorld scene point back to a registered RGB-D grid location, preserving identity and without using future/target truth;
-2. a separately versioned sparse persistent-point provider contract in Prob4D, with explicit point identities, source lineage, dependence groups, and calibrated uncertainty semantics; or
-3. a valid negative result that this PointWorld version is not compatible with the current Prob4D claim.
+- `PersistentPointPredictionWindow`, a strict versioned `T x N x 3` archive;
+- immutable frame and point identities;
+- a context-frame count and explicit trajectory semantics;
+- optional provider uncertainty with named, uninterpreted semantics; and
+- `prob4d prediction import-pointworld-sparse`, a strict no-clobber export route.
 
-Target-truth nearest-neighbor mapping, target-tuned interpolation, and post-outcome removal of unsupported garments are prohibited.
+The implementation and exact source snapshot format are documented in
+`docs/persistent-point-prediction.md`.
+
+PointWorld's released log variance remains labelled
+`pointworld-normalized-relative-log-variance-v1`. It is not treated as metric covariance or a
+calibrated likelihood.
+
+This resolves only the payload representation. Cross-window association, action conversion,
+metric coordinate identity, source support, covariance calibration, recursive fusion, and
+downstream value remain unopened questions.
 
 ## Source-only qualification sequence
 
@@ -51,18 +88,23 @@ Before provider residuals or target outcomes are opened:
 2. inventory the Flat'n'Fold robot data and bind the exact byte manifest;
 3. freeze complete physical garment identities as the top-level statistical units;
 4. verify camera timestamp coverage plus intrinsic and extrinsic identities;
-5. verify that Baxter action poses can be converted to PointWorld robot point-flow actions without target state;
+5. verify that Baxter action poses can be converted to PointWorld robot point-flow actions
+   without target state;
 6. verify metric coordinate transformations using released calibration only;
-7. verify PointWorld scene-point identity semantics over the ten-frame prediction horizon;
-8. resolve the representation gate above;
-9. create an outcome-blind `ProviderSupportFeasibilityV1` request with all required streams and geometry support;
-10. stop if the support gate fails.
+7. execute PointWorld on source-only windows and verify that the exported point order follows the
+   released persistent-index semantics;
+8. export and replay strict persistent-point snapshots;
+9. create an outcome-blind `ProviderSupportFeasibilityV1` request with all required streams and
+   geometry support;
+10. stop if the runtime, action, coordinate, archive, or support gate fails.
 
-The existing `prob4d.provider_support_feasibility` contract should be reused; no PointWorld-specific support framework is needed.
+The existing `prob4d.provider_support_feasibility` contract should be reused; no PointWorld-specific
+support framework is needed.
 
 ## Later held-out study, only after qualification passes
 
-Use complete garment identity as the independent unit. Demonstrations/sessions are nested observations; frames, pixels, and points are not independent replicates.
+Use complete garment identity as the independent unit. Demonstrations/sessions are nested
+observations; frames, pixels, and points are not independent replicates.
 
 The primary provider comparison should remain small:
 
@@ -71,9 +113,12 @@ The primary provider comparison should remain small:
 3. Prob4D sequential full-joint spanning tree;
 4. conformal-guarded full-joint graph with exact tree fallback.
 
-Useful diagnostic controls include persistence, latest-window overwrite, naive precision fusion, and the unguarded graph.
+Useful diagnostic controls include persistence, latest-window overwrite, naive precision fusion,
+and the unguarded graph.
 
-Provider endpoints should include long-horizon and terminal point/flow error, overlap seam or drift, proper score, 50/90/95% coverage, normalized NEES, covariance width, support/fallback accounting, and worst-garment performance. Inference should cluster at garment identity.
+Provider endpoints should include long-horizon and terminal point/flow error, overlap seam or
+drift, proper score, 50/90/95% coverage, normalized NEES, covariance width, support/fallback
+accounting, and worst-garment performance. Inference should cluster at garment identity.
 
 ## BayesianPhysTwin gate
 
@@ -83,21 +128,31 @@ Freeze exactly one downstream physical query before target access. Compare:
 2. BayesianPhysTwin with raw PointWorld observations;
 3. BayesianPhysTwin with the selected Prob4D belief.
 
-Report query error/proper score, coverage and width, accepted/rejected/fallback counts, harmful accepted updates, and worst accepted regret. Rejected or unsupported observations must return the exact physical fallback.
+Report query error/proper score, coverage and width, accepted/rejected/fallback counts, harmful
+accepted updates, and worst accepted regret. Rejected or unsupported observations must return the
+exact physical fallback.
 
-Provider competence and downstream value are separate conjunctive claims: neither may rescue failure of the other.
+Provider competence and downstream value are separate conjunctive claims: neither may rescue
+failure of the other.
 
 ## Causal4D boundary
 
-Do not modify the locked Causal4D physical protocol to enlarge this result. Causal4D can be described as a compatible later consumer, but the PointWorld/Flat'n'Fold study must stand on its own provider and BayesianPhysTwin evidence.
+Do not modify the locked Causal4D physical protocol to enlarge this result. Causal4D can be
+described as a compatible later consumer, but the PointWorld/Flat'n'Fold study must stand on its
+own provider and BayesianPhysTwin evidence.
 
 ## Completion states
 
 This source-qualification branch should close with exactly one of these outcomes:
 
-- **authorized:** PointWorld action, coordinate, point-identity, representation, and support semantics are frozen without target outcomes, permitting a new held-out protocol version;
-- **representation-negative:** the sparse PointWorld output cannot be mapped into a defensible Prob4D observation contract without target-dependent choices;
-- **support-negative:** the required Flat'n'Fold streams/geometry do not support the frozen provider version;
-- **runtime-negative:** the exact released PointWorld checkpoint cannot execute on the frozen source inventory.
+- **authorized:** PointWorld action, coordinate, persistent-point archive, and support semantics
+  are frozen without target outcomes, permitting a new held-out protocol version;
+- **representation-negative:** runtime output does not satisfy the released persistent-index
+  semantics or cannot be exported without target-dependent choices;
+- **support-negative:** the required Flat'n'Fold streams/geometry do not support the frozen
+  provider version;
+- **runtime-negative:** the exact released PointWorld checkpoint cannot execute on the frozen
+  source inventory.
 
-Any negative state is a complete result for this protocol. A later retry requires a new protocol version rather than rewriting this one.
+Any negative state is a complete result for this protocol. A later retry requires a new protocol
+version rather than rewriting this one.

--- a/protocols/pointworld-flatnfold-source-qualification-v1.json
+++ b/protocols/pointworld-flatnfold-source-qualification-v1.json
@@ -17,11 +17,13 @@
   "released_source_facts": {
     "pointworld": {
       "input": "partially observable RGB-D plus robot actions represented as 3D point flows",
-      "prediction": "full-scene 3D point flows",
+      "prediction": "full-scene 3D point trajectories/flows",
       "context_horizon_frames": 1,
       "prediction_horizon_frames": 10,
       "model_output_point_shape": "B,T,N_scene,3",
       "model_output_log_variance_shape": "B,T,N_scene,1",
+      "point_identity_fact": "released grid sampling selects scene indices at t=0 and applies the same indices to all timesteps; deterministic test subsampling also applies one sorted index set to all scene fields",
+      "absolute_trajectory_fact": "released model exports scene_flows as scene_coord0 plus predicted relative displacement",
       "released_scene_flow_checkpoints": [
         "small-droid/model-best.pt",
         "large-droid/model-best.pt",
@@ -38,19 +40,28 @@
     }
   },
   "critical_representation_gate": {
-    "prob4d_current_contract": "PredictionWindow v2 requires point_map and optional scene_flow on a dense T,H,W,3 grid",
-    "pointworld_released_contract": "PointWorld predicts flows for N_scene seeded scene points, not a native T,H,W image grid",
-    "target_access_before_resolution": false,
-    "permitted_resolution_paths": [
-      "prove a deterministic source-only mapping from PointWorld scene-point identities back to a registered dense RGB-D grid without interpolation chosen from target outcomes",
-      "introduce a separately versioned sparse persistent-point provider contract with explicit identity and dependence semantics, validated without target outcomes",
-      "declare this provider version infeasible for the present Prob4D claim"
-    ],
+    "prob4d_dense_contract": "PredictionWindow v2 requires point_map and optional scene_flow on a dense T,H,W,3 grid",
+    "pointworld_released_contract": "PointWorld predicts persistent trajectories for N_scene points sampled at the first timestep",
+    "resolution_status": "SPARSE_PERSISTENT_POINT_CONTRACT_IMPLEMENTED_SOURCE_EXECUTION_PENDING",
+    "selected_resolution_path": "separately versioned sparse persistent-point provider payload with explicit within-window point identity, frame identity, context count, trajectory semantics, validity, and raw uncertainty semantics",
+    "implementation": {
+      "archive_module": "src/prob4d/persistent_point_prediction.py",
+      "adapter_module": "src/prob4d/pointworld_sparse_adapter.py",
+      "archive_schema": "prob4d.persistent-point-prediction-window-npz",
+      "archive_schema_version": 1,
+      "source_snapshot_schema": "prob4d.pointworld-persistent-point-source-npz",
+      "source_snapshot_schema_version": 1,
+      "cli": "prob4d prediction import-pointworld-sparse",
+      "uncertainty_semantics": "pointworld-normalized-relative-log-variance-v1"
+    },
+    "target_access_before_runtime_verification": false,
     "forbidden_resolution_paths": [
       "target-truth nearest-neighbor rasterization",
       "target-outcome-tuned interpolation or masks",
-      "dropping unsupported target garments after outcome inspection"
-    ]
+      "dropping unsupported target garments after outcome inspection",
+      "calling PointWorld raw log variance calibrated metric covariance"
+    ],
+    "remaining_gate": "execute the exact released PointWorld checkpoint on source-only Flat'n'Fold inventory windows and verify that runtime arrays, actions, coordinates, and point order satisfy the frozen sparse contract"
   },
   "source_only_qualification": {
     "required_before_any_prediction_competence_result": [
@@ -60,8 +71,8 @@
       "verify three-camera timestamps and intrinsics/extrinsics",
       "verify Baxter action pose semantics and construct PointWorld robot point-flow actions without target state",
       "verify metric coordinate transform using released calibration only",
-      "verify point identity semantics over the ten-frame forecast horizon",
-      "resolve the critical representation gate",
+      "execute source-only PointWorld windows and verify released persistent point-index semantics",
+      "export and replay strict persistent-point source snapshots",
       "build a ProviderSupportFeasibilityV1 request before prediction payloads, residuals, or target outcomes are opened"
     ],
     "support_unit": "complete physical garment identity",
@@ -112,9 +123,9 @@
     "stop and retain a valid negative if PointWorld cannot execute on the frozen source roster",
     "stop if action conversion is not semantically identifiable from released Flat'n'Fold information",
     "stop if coordinate identity requires target truth",
-    "stop if persistent point identities or an outcome-blind dense mapping cannot be established",
-    "do not open target outcomes until source support and representation qualification pass",
+    "stop if runtime point order violates the released persistent-index semantics or the strict archive cannot be reproduced",
+    "do not open target outcomes until source runtime, action, coordinate, archive, and support qualification pass",
     "do not retune checkpoint, split, masks, representation mapping, or guard after target access"
   ],
-  "claim_boundary": "This protocol freezes only a source-side feasibility and representation qualification. It establishes no PointWorld competence on Flat'n'Fold, no Prob4D accuracy or calibration gain, no BayesianPhysTwin benefit, no Causal4D benefit, and no deployment-safety claim."
+  "claim_boundary": "This protocol freezes only a source-side feasibility and representation qualification. The sparse payload implementation resolves representation semantics but establishes no PointWorld competence on Flat'n'Fold, no Prob4D accuracy or calibration gain, no BayesianPhysTwin benefit, no Causal4D benefit, and no deployment-safety claim."
 }

--- a/src/prob4d/persistent_point_prediction.py
+++ b/src/prob4d/persistent_point_prediction.py
@@ -163,14 +163,20 @@ class PersistentPointPredictionWindow:
         if not 1 <= context_frame_count <= frame_indices.size:
             raise ValueError("context_frame_count must lie in [1, number of frames]")
         if not np.all(valid_mask[0]):
-            raise ValueError("every retained persistent point must be valid in the first context frame")
+            raise ValueError(
+                "every retained persistent point must be valid in the first "
+                "context frame"
+            )
         if not np.all(np.isfinite(trajectory)):
             raise ValueError("point_trajectory must contain only finite values")
 
         uncertainty: np.ndarray | None
         if self.uncertainty is None:
             if uncertainty_semantics != UNCERTAINTY_ABSENT:
-                raise ValueError("uncertainty_semantics must be 'absent' when uncertainty is absent")
+                raise ValueError(
+                    "uncertainty_semantics must be 'absent' when uncertainty "
+                    "is absent"
+                )
             uncertainty = None
         else:
             if uncertainty_semantics == UNCERTAINTY_ABSENT:
@@ -335,7 +341,10 @@ class PersistentPointPredictionWindow:
             missing = sorted(_REQUIRED_MEMBERS - files)
             extra = sorted(files - (_REQUIRED_MEMBERS | _OPTIONAL_MEMBERS))
             if missing or extra:
-                raise ValueError(f"persistent-point archive fields changed; missing={missing}, extra={extra}")
+                raise ValueError(
+                    "persistent-point archive fields changed; "
+                    f"missing={missing}, extra={extra}"
+                )
             schema_name = _scalar_text(
                 data["schema_name"],
                 name="schema_name",

--- a/src/prob4d/persistent_point_prediction.py
+++ b/src/prob4d/persistent_point_prediction.py
@@ -16,16 +16,12 @@ BoolArray: TypeAlias = NDArray[np.bool_]
 IntArray: TypeAlias = NDArray[np.integer[Any]]
 StorageDType = Literal["float32", "float64"]
 
-PERSISTENT_POINT_WINDOW_NPZ_SCHEMA: Final = (
-    "prob4d.persistent-point-prediction-window-npz"
-)
+PERSISTENT_POINT_WINDOW_NPZ_SCHEMA: Final = "prob4d.persistent-point-prediction-window-npz"
 PERSISTENT_POINT_WINDOW_NPZ_VERSION: Final = 1
 PERSISTENT_POINT_IDENTITY_SEMANTICS: Final = (
     "window-local-point-id-persistent-across-output-frames-v1"
 )
-PERSISTENT_POINT_TRAJECTORY_SEMANTICS: Final = (
-    "absolute-point-position-per-output-frame-v1"
-)
+PERSISTENT_POINT_TRAJECTORY_SEMANTICS: Final = "absolute-point-position-per-output-frame-v1"
 UNCERTAINTY_ABSENT: Final = "absent"
 STORAGE_DTYPES: Final[tuple[StorageDType, ...]] = ("float32", "float64")
 
@@ -51,9 +47,7 @@ _OPTIONAL_MEMBERS: Final = frozenset({"uncertainty"})
 def _validated_storage_dtype(value: object) -> StorageDType:
     normalized = str(value)
     if normalized not in STORAGE_DTYPES:
-        raise ValueError(
-            "storage_dtype must be one of " + ", ".join(STORAGE_DTYPES)
-        )
+        raise ValueError("storage_dtype must be one of " + ", ".join(STORAGE_DTYPES))
     return cast(StorageDType, normalized)
 
 
@@ -150,60 +144,37 @@ class PersistentPointPredictionWindow:
         if trajectory_semantics != PERSISTENT_POINT_TRAJECTORY_SEMANTICS:
             raise ValueError("unsupported trajectory_semantics")
         if frame_indices.ndim != 1 or frame_indices.size == 0:
-            raise ValueError(
-                "frame_indices must be a non-empty one-dimensional array"
-            )
+            raise ValueError("frame_indices must be a non-empty one-dimensional array")
         if np.any(frame_indices < 0) or np.any(np.diff(frame_indices) <= 0):
-            raise ValueError(
-                "frame_indices must be non-negative and strictly increasing"
-            )
+            raise ValueError("frame_indices must be non-negative and strictly increasing")
         if point_ids.ndim != 1 or point_ids.size == 0:
-            raise ValueError(
-                "point_ids must be a non-empty one-dimensional array"
-            )
+            raise ValueError("point_ids must be a non-empty one-dimensional array")
         if np.any(point_ids < 0) or np.any(np.diff(point_ids) <= 0):
-            raise ValueError(
-                "point_ids must be non-negative and strictly increasing"
-            )
+            raise ValueError("point_ids must be non-negative and strictly increasing")
         if trajectory.ndim != 3 or trajectory.shape[-1] != 3:
-            raise ValueError(
-                "point_trajectory must have shape (T, N, 3)"
-            )
+            raise ValueError("point_trajectory must have shape (T, N, 3)")
         if trajectory.shape[:2] != (
             frame_indices.size,
             point_ids.size,
         ):
-            raise ValueError(
-                "point_trajectory dimensions must match frame_indices and "
-                "point_ids"
-            )
+            raise ValueError("point_trajectory dimensions must match frame_indices and point_ids")
         if valid_mask.shape != trajectory.shape[:2]:
             raise ValueError("valid_mask must have shape (T, N)")
         if not 1 <= context_frame_count <= frame_indices.size:
-            raise ValueError(
-                "context_frame_count must lie in [1, number of frames]"
-            )
+            raise ValueError("context_frame_count must lie in [1, number of frames]")
         if not np.all(valid_mask[0]):
-            raise ValueError(
-                "every retained persistent point must be valid in the first "
-                "context frame"
-            )
+            raise ValueError("every retained persistent point must be valid in the first context frame")
         if not np.all(np.isfinite(trajectory)):
             raise ValueError("point_trajectory must contain only finite values")
 
         uncertainty: np.ndarray | None
         if self.uncertainty is None:
             if uncertainty_semantics != UNCERTAINTY_ABSENT:
-                raise ValueError(
-                    "uncertainty_semantics must be 'absent' when uncertainty "
-                    "is absent"
-                )
+                raise ValueError("uncertainty_semantics must be 'absent' when uncertainty is absent")
             uncertainty = None
         else:
             if uncertainty_semantics == UNCERTAINTY_ABSENT:
-                raise ValueError(
-                    "uncertainty_semantics must describe present uncertainty"
-                )
+                raise ValueError("uncertainty_semantics must describe present uncertainty")
             uncertainty = np.asarray(
                 self.uncertainty,
                 dtype=dense_dtype,
@@ -213,9 +184,7 @@ class PersistentPointPredictionWindow:
                 or uncertainty.shape[:2] != trajectory.shape[:2]
                 or uncertainty.shape[-1] not in {1, 3}
             ):
-                raise ValueError(
-                    "uncertainty must have shape (T, N, 1) or (T, N, 3)"
-                )
+                raise ValueError("uncertainty must have shape (T, N, 1) or (T, N, 3)")
             if not np.all(np.isfinite(uncertainty)):
                 raise ValueError("uncertainty must contain only finite values")
 
@@ -281,13 +250,8 @@ class PersistentPointPredictionWindow:
 
     def local_index(self, frame_index: int) -> int:
         position = int(np.searchsorted(self.frame_indices, frame_index))
-        if (
-            position == self.frame_indices.size
-            or self.frame_indices[position] != frame_index
-        ):
-            raise KeyError(
-                f"frame {frame_index} is not in window {self.window_id!r}"
-            )
+        if position == self.frame_indices.size or self.frame_indices[position] != frame_index:
+            raise KeyError(f"frame {frame_index} is not in window {self.window_id!r}")
         return position
 
     def common_frames(
@@ -307,9 +271,7 @@ class PersistentPointPredictionWindow:
             "stop_frame_exclusive": self.stop_frame,
             "frame_count": int(self.shape[0]),
             "context_frame_count": self.context_frame_count,
-            "prediction_frame_count": int(
-                self.shape[0] - self.context_frame_count
-            ),
+            "prediction_frame_count": int(self.shape[0] - self.context_frame_count),
             "point_count": int(self.shape[1]),
             "uncertainty_dimension": (
                 0 if self.uncertainty is None else int(self.uncertainty.shape[-1])
@@ -327,9 +289,7 @@ class PersistentPointPredictionWindow:
         """Write the strict versioned archive."""
 
         selected_dtype = (
-            self.storage_dtype
-            if storage_dtype is None
-            else _validated_storage_dtype(storage_dtype)
+            self.storage_dtype if storage_dtype is None else _validated_storage_dtype(storage_dtype)
         )
         numpy_dtype = _numpy_dtype(selected_dtype)
         payload: dict[str, Any] = {
@@ -351,13 +311,9 @@ class PersistentPointPredictionWindow:
                 self.context_frame_count,
                 dtype=np.int64,
             ),
-            "point_identity_semantics": np.asarray(
-                self.point_identity_semantics
-            ),
+            "point_identity_semantics": np.asarray(self.point_identity_semantics),
             "trajectory_semantics": np.asarray(self.trajectory_semantics),
-            "uncertainty_semantics": np.asarray(
-                self.uncertainty_semantics
-            ),
+            "uncertainty_semantics": np.asarray(self.uncertainty_semantics),
         }
         if self.uncertainty is not None:
             payload["uncertainty"] = self.uncertainty.astype(
@@ -379,10 +335,7 @@ class PersistentPointPredictionWindow:
             missing = sorted(_REQUIRED_MEMBERS - files)
             extra = sorted(files - (_REQUIRED_MEMBERS | _OPTIONAL_MEMBERS))
             if missing or extra:
-                raise ValueError(
-                    "persistent-point archive fields changed; "
-                    f"missing={missing}, extra={extra}"
-                )
+                raise ValueError(f"persistent-point archive fields changed; missing={missing}, extra={extra}")
             schema_name = _scalar_text(
                 data["schema_name"],
                 name="schema_name",
@@ -392,13 +345,9 @@ class PersistentPointPredictionWindow:
                 name="schema_version",
             )
             if schema_name != PERSISTENT_POINT_WINDOW_NPZ_SCHEMA:
-                raise ValueError(
-                    "unsupported persistent-point archive schema"
-                )
+                raise ValueError("unsupported persistent-point archive schema")
             if schema_version != PERSISTENT_POINT_WINDOW_NPZ_VERSION:
-                raise ValueError(
-                    "unsupported persistent-point archive version"
-                )
+                raise ValueError("unsupported persistent-point archive version")
             storage_dtype = _validated_storage_dtype(
                 _scalar_text(
                     data["storage_dtype"],
@@ -407,13 +356,9 @@ class PersistentPointPredictionWindow:
             )
             expected_dtype = _numpy_dtype(storage_dtype)
             if data["point_trajectory"].dtype != expected_dtype:
-                raise ValueError(
-                    "point_trajectory dtype disagrees with storage_dtype"
-                )
+                raise ValueError("point_trajectory dtype disagrees with storage_dtype")
             if "uncertainty" in data and data["uncertainty"].dtype != expected_dtype:
-                raise ValueError(
-                    "uncertainty dtype disagrees with storage_dtype"
-                )
+                raise ValueError("uncertainty dtype disagrees with storage_dtype")
             for scalar_name in ("schema_version", "context_frame_count"):
                 if data[scalar_name].dtype != np.dtype(np.int64):
                     raise ValueError(f"{scalar_name} must use int64")
@@ -437,11 +382,7 @@ class PersistentPointPredictionWindow:
                     data["context_frame_count"],
                     name="context_frame_count",
                 ),
-                uncertainty=(
-                    data["uncertainty"]
-                    if "uncertainty" in data
-                    else None
-                ),
+                uncertainty=(data["uncertainty"] if "uncertainty" in data else None),
                 uncertainty_semantics=uncertainty_semantics,
                 storage_dtype=storage_dtype,
                 point_identity_semantics=_scalar_text(

--- a/src/prob4d/persistent_point_prediction.py
+++ b/src/prob4d/persistent_point_prediction.py
@@ -1,0 +1,467 @@
+"""Validated sparse prediction windows with persistent point identities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final, Literal, TypeAlias, cast
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ._immutable_array import immutable_array, immutable_integer_array
+
+FloatArray: TypeAlias = NDArray[np.floating[Any]]
+BoolArray: TypeAlias = NDArray[np.bool_]
+IntArray: TypeAlias = NDArray[np.integer[Any]]
+StorageDType = Literal["float32", "float64"]
+
+PERSISTENT_POINT_WINDOW_NPZ_SCHEMA: Final = (
+    "prob4d.persistent-point-prediction-window-npz"
+)
+PERSISTENT_POINT_WINDOW_NPZ_VERSION: Final = 1
+PERSISTENT_POINT_IDENTITY_SEMANTICS: Final = (
+    "window-local-point-id-persistent-across-output-frames-v1"
+)
+PERSISTENT_POINT_TRAJECTORY_SEMANTICS: Final = (
+    "absolute-point-position-per-output-frame-v1"
+)
+UNCERTAINTY_ABSENT: Final = "absent"
+STORAGE_DTYPES: Final[tuple[StorageDType, ...]] = ("float32", "float64")
+
+_REQUIRED_MEMBERS: Final = frozenset(
+    {
+        "schema_name",
+        "schema_version",
+        "storage_dtype",
+        "window_id",
+        "frame_indices",
+        "point_ids",
+        "point_trajectory",
+        "valid_mask",
+        "context_frame_count",
+        "point_identity_semantics",
+        "trajectory_semantics",
+        "uncertainty_semantics",
+    }
+)
+_OPTIONAL_MEMBERS: Final = frozenset({"uncertainty"})
+
+
+def _validated_storage_dtype(value: object) -> StorageDType:
+    normalized = str(value)
+    if normalized not in STORAGE_DTYPES:
+        raise ValueError(
+            "storage_dtype must be one of " + ", ".join(STORAGE_DTYPES)
+        )
+    return cast(StorageDType, normalized)
+
+
+def _numpy_dtype(value: StorageDType) -> np.dtype[Any]:
+    return np.dtype(np.float32 if value == "float32" else np.float64)
+
+
+def _strict_text(value: object, *, name: str) -> str:
+    if type(value) is not str or not value:
+        raise ValueError(f"{name} must be a non-empty string")
+    return value
+
+
+def _strict_integer(value: object, *, name: str) -> int:
+    if type(value) is not int:
+        raise ValueError(f"{name} must be an integer")
+    return value
+
+
+def _scalar_text(value: np.ndarray, *, name: str) -> str:
+    if value.shape != () or value.dtype.kind not in {"U", "S"}:
+        raise ValueError(f"{name} must be one scalar string")
+    return str(value.item())
+
+
+def _scalar_integer(value: np.ndarray, *, name: str) -> int:
+    if value.shape != () or value.dtype.kind not in {"i", "u"}:
+        raise ValueError(f"{name} must be one scalar integer")
+    return int(value.item())
+
+
+def _strict_bool_array(value: object, *, name: str) -> np.ndarray:
+    array = np.asarray(value)
+    if array.dtype != np.dtype(bool):
+        raise ValueError(f"{name} must use bool dtype")
+    return np.array(array, dtype=bool, copy=True)
+
+
+@dataclass(frozen=True)
+class PersistentPointPredictionWindow:
+    """Sparse point trajectories whose point identity is stable within a window.
+
+    ``point_trajectory[t, n]`` is the absolute position of ``point_ids[n]`` at
+    ``frame_indices[t]`` in the provider's declared coordinate system. The
+    first output frame seeds every retained point identity. Optional
+    ``uncertainty`` is preserved as an uninterpreted provider quantity whose
+    exact meaning is named by ``uncertainty_semantics``; it is not promoted to
+    calibrated covariance by this contract.
+    """
+
+    window_id: str
+    frame_indices: IntArray
+    point_ids: IntArray
+    point_trajectory: FloatArray
+    valid_mask: BoolArray
+    context_frame_count: int
+    uncertainty: FloatArray | None = None
+    uncertainty_semantics: str = UNCERTAINTY_ABSENT
+    storage_dtype: StorageDType = "float64"
+    point_identity_semantics: str = PERSISTENT_POINT_IDENTITY_SEMANTICS
+    trajectory_semantics: str = PERSISTENT_POINT_TRAJECTORY_SEMANTICS
+
+    def __post_init__(self) -> None:
+        window_id = _strict_text(self.window_id, name="window_id")
+        storage_dtype = _validated_storage_dtype(self.storage_dtype)
+        dense_dtype = _numpy_dtype(storage_dtype)
+
+        frame_indices = immutable_integer_array(
+            self.frame_indices,
+            name="frame_indices",
+        )
+        point_ids = immutable_integer_array(self.point_ids, name="point_ids")
+        trajectory = np.asarray(self.point_trajectory, dtype=dense_dtype).copy()
+        valid_mask = _strict_bool_array(self.valid_mask, name="valid_mask")
+        context_frame_count = _strict_integer(
+            self.context_frame_count,
+            name="context_frame_count",
+        )
+        uncertainty_semantics = _strict_text(
+            self.uncertainty_semantics,
+            name="uncertainty_semantics",
+        )
+        point_identity_semantics = _strict_text(
+            self.point_identity_semantics,
+            name="point_identity_semantics",
+        )
+        trajectory_semantics = _strict_text(
+            self.trajectory_semantics,
+            name="trajectory_semantics",
+        )
+
+        if point_identity_semantics != PERSISTENT_POINT_IDENTITY_SEMANTICS:
+            raise ValueError("unsupported point_identity_semantics")
+        if trajectory_semantics != PERSISTENT_POINT_TRAJECTORY_SEMANTICS:
+            raise ValueError("unsupported trajectory_semantics")
+        if frame_indices.ndim != 1 or frame_indices.size == 0:
+            raise ValueError(
+                "frame_indices must be a non-empty one-dimensional array"
+            )
+        if np.any(frame_indices < 0) or np.any(np.diff(frame_indices) <= 0):
+            raise ValueError(
+                "frame_indices must be non-negative and strictly increasing"
+            )
+        if point_ids.ndim != 1 or point_ids.size == 0:
+            raise ValueError(
+                "point_ids must be a non-empty one-dimensional array"
+            )
+        if np.any(point_ids < 0) or np.any(np.diff(point_ids) <= 0):
+            raise ValueError(
+                "point_ids must be non-negative and strictly increasing"
+            )
+        if trajectory.ndim != 3 or trajectory.shape[-1] != 3:
+            raise ValueError(
+                "point_trajectory must have shape (T, N, 3)"
+            )
+        if trajectory.shape[:2] != (
+            frame_indices.size,
+            point_ids.size,
+        ):
+            raise ValueError(
+                "point_trajectory dimensions must match frame_indices and "
+                "point_ids"
+            )
+        if valid_mask.shape != trajectory.shape[:2]:
+            raise ValueError("valid_mask must have shape (T, N)")
+        if not 1 <= context_frame_count <= frame_indices.size:
+            raise ValueError(
+                "context_frame_count must lie in [1, number of frames]"
+            )
+        if not np.all(valid_mask[0]):
+            raise ValueError(
+                "every retained persistent point must be valid in the first "
+                "context frame"
+            )
+        if not np.all(np.isfinite(trajectory)):
+            raise ValueError("point_trajectory must contain only finite values")
+
+        uncertainty: np.ndarray | None
+        if self.uncertainty is None:
+            if uncertainty_semantics != UNCERTAINTY_ABSENT:
+                raise ValueError(
+                    "uncertainty_semantics must be 'absent' when uncertainty "
+                    "is absent"
+                )
+            uncertainty = None
+        else:
+            if uncertainty_semantics == UNCERTAINTY_ABSENT:
+                raise ValueError(
+                    "uncertainty_semantics must describe present uncertainty"
+                )
+            uncertainty = np.asarray(
+                self.uncertainty,
+                dtype=dense_dtype,
+            ).copy()
+            if (
+                uncertainty.ndim != 3
+                or uncertainty.shape[:2] != trajectory.shape[:2]
+                or uncertainty.shape[-1] not in {1, 3}
+            ):
+                raise ValueError(
+                    "uncertainty must have shape (T, N, 1) or (T, N, 3)"
+                )
+            if not np.all(np.isfinite(uncertainty)):
+                raise ValueError("uncertainty must contain only finite values")
+
+        object.__setattr__(self, "window_id", window_id)
+        object.__setattr__(self, "storage_dtype", storage_dtype)
+        object.__setattr__(
+            self,
+            "context_frame_count",
+            context_frame_count,
+        )
+        object.__setattr__(
+            self,
+            "uncertainty_semantics",
+            uncertainty_semantics,
+        )
+        object.__setattr__(
+            self,
+            "point_identity_semantics",
+            point_identity_semantics,
+        )
+        object.__setattr__(
+            self,
+            "trajectory_semantics",
+            trajectory_semantics,
+        )
+        object.__setattr__(self, "frame_indices", frame_indices)
+        object.__setattr__(self, "point_ids", point_ids)
+        object.__setattr__(
+            self,
+            "point_trajectory",
+            immutable_array(trajectory),
+        )
+        object.__setattr__(
+            self,
+            "valid_mask",
+            immutable_array(valid_mask),
+        )
+        object.__setattr__(
+            self,
+            "uncertainty",
+            None if uncertainty is None else immutable_array(uncertainty),
+        )
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        """Return the ``(T, N)`` trajectory grid shape."""
+
+        return self.point_trajectory.shape[:2]
+
+    @property
+    def start_frame(self) -> int:
+        return int(self.frame_indices[0])
+
+    @property
+    def stop_frame(self) -> int:
+        """Return the exclusive final frame index for unit-stride output."""
+
+        return int(self.frame_indices[-1]) + 1
+
+    @property
+    def prediction_frame_indices(self) -> IntArray:
+        return self.frame_indices[self.context_frame_count :]
+
+    def local_index(self, frame_index: int) -> int:
+        position = int(np.searchsorted(self.frame_indices, frame_index))
+        if (
+            position == self.frame_indices.size
+            or self.frame_indices[position] != frame_index
+        ):
+            raise KeyError(
+                f"frame {frame_index} is not in window {self.window_id!r}"
+            )
+        return position
+
+    def common_frames(
+        self,
+        other: "PersistentPointPredictionWindow",
+    ) -> IntArray:
+        return np.intersect1d(
+            self.frame_indices,
+            other.frame_indices,
+            assume_unique=True,
+        )
+
+    def summary(self) -> dict[str, object]:
+        return {
+            "window_id": self.window_id,
+            "start_frame": self.start_frame,
+            "stop_frame_exclusive": self.stop_frame,
+            "frame_count": int(self.shape[0]),
+            "context_frame_count": self.context_frame_count,
+            "prediction_frame_count": int(
+                self.shape[0] - self.context_frame_count
+            ),
+            "point_count": int(self.shape[1]),
+            "uncertainty_dimension": (
+                0 if self.uncertainty is None else int(self.uncertainty.shape[-1])
+            ),
+            "uncertainty_semantics": self.uncertainty_semantics,
+            "storage_dtype": self.storage_dtype,
+        }
+
+    def to_npz(
+        self,
+        path: str | Path,
+        *,
+        storage_dtype: StorageDType | None = None,
+    ) -> None:
+        """Write the strict versioned archive."""
+
+        selected_dtype = (
+            self.storage_dtype
+            if storage_dtype is None
+            else _validated_storage_dtype(storage_dtype)
+        )
+        numpy_dtype = _numpy_dtype(selected_dtype)
+        payload: dict[str, Any] = {
+            "schema_name": np.asarray(PERSISTENT_POINT_WINDOW_NPZ_SCHEMA),
+            "schema_version": np.asarray(
+                PERSISTENT_POINT_WINDOW_NPZ_VERSION,
+                dtype=np.int64,
+            ),
+            "storage_dtype": np.asarray(selected_dtype),
+            "window_id": np.asarray(self.window_id),
+            "frame_indices": self.frame_indices,
+            "point_ids": self.point_ids,
+            "point_trajectory": self.point_trajectory.astype(
+                numpy_dtype,
+                copy=False,
+            ),
+            "valid_mask": self.valid_mask,
+            "context_frame_count": np.asarray(
+                self.context_frame_count,
+                dtype=np.int64,
+            ),
+            "point_identity_semantics": np.asarray(
+                self.point_identity_semantics
+            ),
+            "trajectory_semantics": np.asarray(self.trajectory_semantics),
+            "uncertainty_semantics": np.asarray(
+                self.uncertainty_semantics
+            ),
+        }
+        if self.uncertainty is not None:
+            payload["uncertainty"] = self.uncertainty.astype(
+                numpy_dtype,
+                copy=False,
+            )
+        with Path(path).open("wb") as stream:
+            np.savez_compressed(stream, **payload)
+
+    @classmethod
+    def from_npz(
+        cls,
+        path: str | Path,
+    ) -> "PersistentPointPredictionWindow":
+        """Read one strict versioned persistent-point archive."""
+
+        with np.load(Path(path), allow_pickle=False) as data:
+            files = set(data.files)
+            missing = sorted(_REQUIRED_MEMBERS - files)
+            extra = sorted(files - (_REQUIRED_MEMBERS | _OPTIONAL_MEMBERS))
+            if missing or extra:
+                raise ValueError(
+                    "persistent-point archive fields changed; "
+                    f"missing={missing}, extra={extra}"
+                )
+            schema_name = _scalar_text(
+                data["schema_name"],
+                name="schema_name",
+            )
+            schema_version = _scalar_integer(
+                data["schema_version"],
+                name="schema_version",
+            )
+            if schema_name != PERSISTENT_POINT_WINDOW_NPZ_SCHEMA:
+                raise ValueError(
+                    "unsupported persistent-point archive schema"
+                )
+            if schema_version != PERSISTENT_POINT_WINDOW_NPZ_VERSION:
+                raise ValueError(
+                    "unsupported persistent-point archive version"
+                )
+            storage_dtype = _validated_storage_dtype(
+                _scalar_text(
+                    data["storage_dtype"],
+                    name="storage_dtype",
+                )
+            )
+            expected_dtype = _numpy_dtype(storage_dtype)
+            if data["point_trajectory"].dtype != expected_dtype:
+                raise ValueError(
+                    "point_trajectory dtype disagrees with storage_dtype"
+                )
+            if "uncertainty" in data and data["uncertainty"].dtype != expected_dtype:
+                raise ValueError(
+                    "uncertainty dtype disagrees with storage_dtype"
+                )
+            for scalar_name in ("schema_version", "context_frame_count"):
+                if data[scalar_name].dtype != np.dtype(np.int64):
+                    raise ValueError(f"{scalar_name} must use int64")
+            if data["frame_indices"].dtype != np.dtype(np.int64):
+                raise ValueError("frame_indices must use int64")
+            if data["point_ids"].dtype != np.dtype(np.int64):
+                raise ValueError("point_ids must use int64")
+            if data["valid_mask"].dtype != np.dtype(bool):
+                raise ValueError("valid_mask must use bool")
+            uncertainty_semantics = _scalar_text(
+                data["uncertainty_semantics"],
+                name="uncertainty_semantics",
+            )
+            return cls(
+                window_id=_scalar_text(data["window_id"], name="window_id"),
+                frame_indices=data["frame_indices"],
+                point_ids=data["point_ids"],
+                point_trajectory=data["point_trajectory"],
+                valid_mask=data["valid_mask"],
+                context_frame_count=_scalar_integer(
+                    data["context_frame_count"],
+                    name="context_frame_count",
+                ),
+                uncertainty=(
+                    data["uncertainty"]
+                    if "uncertainty" in data
+                    else None
+                ),
+                uncertainty_semantics=uncertainty_semantics,
+                storage_dtype=storage_dtype,
+                point_identity_semantics=_scalar_text(
+                    data["point_identity_semantics"],
+                    name="point_identity_semantics",
+                ),
+                trajectory_semantics=_scalar_text(
+                    data["trajectory_semantics"],
+                    name="trajectory_semantics",
+                ),
+            )
+
+
+__all__ = [
+    "PERSISTENT_POINT_IDENTITY_SEMANTICS",
+    "PERSISTENT_POINT_TRAJECTORY_SEMANTICS",
+    "PERSISTENT_POINT_WINDOW_NPZ_SCHEMA",
+    "PERSISTENT_POINT_WINDOW_NPZ_VERSION",
+    "STORAGE_DTYPES",
+    "UNCERTAINTY_ABSENT",
+    "PersistentPointPredictionWindow",
+    "StorageDType",
+]

--- a/src/prob4d/persistent_point_prediction.py
+++ b/src/prob4d/persistent_point_prediction.py
@@ -164,8 +164,7 @@ class PersistentPointPredictionWindow:
             raise ValueError("context_frame_count must lie in [1, number of frames]")
         if not np.all(valid_mask[0]):
             raise ValueError(
-                "every retained persistent point must be valid in the first "
-                "context frame"
+                "every retained persistent point must be valid in the first context frame"
             )
         if not np.all(np.isfinite(trajectory)):
             raise ValueError("point_trajectory must contain only finite values")
@@ -174,8 +173,7 @@ class PersistentPointPredictionWindow:
         if self.uncertainty is None:
             if uncertainty_semantics != UNCERTAINTY_ABSENT:
                 raise ValueError(
-                    "uncertainty_semantics must be 'absent' when uncertainty "
-                    "is absent"
+                    "uncertainty_semantics must be 'absent' when uncertainty is absent"
                 )
             uncertainty = None
         else:
@@ -342,8 +340,7 @@ class PersistentPointPredictionWindow:
             extra = sorted(files - (_REQUIRED_MEMBERS | _OPTIONAL_MEMBERS))
             if missing or extra:
                 raise ValueError(
-                    "persistent-point archive fields changed; "
-                    f"missing={missing}, extra={extra}"
+                    f"persistent-point archive fields changed; missing={missing}, extra={extra}"
                 )
             schema_name = _scalar_text(
                 data["schema_name"],

--- a/src/prob4d/persistent_point_prediction.py
+++ b/src/prob4d/persistent_point_prediction.py
@@ -292,7 +292,7 @@ class PersistentPointPredictionWindow:
 
     def common_frames(
         self,
-        other: "PersistentPointPredictionWindow",
+        other: PersistentPointPredictionWindow,
     ) -> IntArray:
         return np.intersect1d(
             self.frame_indices,
@@ -371,7 +371,7 @@ class PersistentPointPredictionWindow:
     def from_npz(
         cls,
         path: str | Path,
-    ) -> "PersistentPointPredictionWindow":
+    ) -> PersistentPointPredictionWindow:
         """Read one strict versioned persistent-point archive."""
 
         with np.load(Path(path), allow_pickle=False) as data:

--- a/src/prob4d/pointworld_sparse_adapter.py
+++ b/src/prob4d/pointworld_sparse_adapter.py
@@ -17,13 +17,9 @@ from .persistent_point_prediction import (
     StorageDType,
 )
 
-POINTWORLD_SPARSE_SOURCE_SCHEMA: Final = (
-    "prob4d.pointworld-persistent-point-source-npz"
-)
+POINTWORLD_SPARSE_SOURCE_SCHEMA: Final = "prob4d.pointworld-persistent-point-source-npz"
 POINTWORLD_SPARSE_SOURCE_VERSION: Final = 1
-POINTWORLD_UNCERTAINTY_SEMANTICS: Final = (
-    "pointworld-normalized-relative-log-variance-v1"
-)
+POINTWORLD_UNCERTAINTY_SEMANTICS: Final = "pointworld-normalized-relative-log-variance-v1"
 
 _SOURCE_REQUIRED_MEMBERS: Final = frozenset(
     {
@@ -62,10 +58,7 @@ def _without_singleton_batch(
         return array
     if array.ndim == unbatched_ndim + 1 and array.shape[0] == 1:
         return array[0]
-    raise ValueError(
-        f"{name} must have {unbatched_ndim} dimensions or one singleton "
-        "batch dimension"
-    )
+    raise ValueError(f"{name} must have {unbatched_ndim} dimensions or one singleton batch dimension")
 
 
 def pointworld_output_to_persistent_window(
@@ -186,14 +179,9 @@ def load_pointworld_source_snapshot(
     with np.load(source_path, allow_pickle=False) as data:
         files = set(data.files)
         missing = sorted(_SOURCE_REQUIRED_MEMBERS - files)
-        extra = sorted(
-            files - (_SOURCE_REQUIRED_MEMBERS | _SOURCE_OPTIONAL_MEMBERS)
-        )
+        extra = sorted(files - (_SOURCE_REQUIRED_MEMBERS | _SOURCE_OPTIONAL_MEMBERS))
         if missing or extra:
-            raise ValueError(
-                "PointWorld source snapshot fields changed; "
-                f"missing={missing}, extra={extra}"
-            )
+            raise ValueError(f"PointWorld source snapshot fields changed; missing={missing}, extra={extra}")
         schema_name = _scalar_text(data["schema_name"], name="schema_name")
         schema_version = _scalar_integer(
             data["schema_version"],
@@ -229,9 +217,7 @@ def export_pointworld_source_snapshot(
 
     output = Path(output_path)
     if output.exists() or output.is_symlink():
-        raise FileExistsError(
-            "persistent-point output already exists; refusing to replace it"
-        )
+        raise FileExistsError("persistent-point output already exists; refusing to replace it")
     output.parent.mkdir(parents=True, exist_ok=True)
     window = load_pointworld_source_snapshot(
         source_path,
@@ -283,9 +269,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    arguments = _build_parser().parse_args(
-        list(argv) if argv is not None else None
-    )
+    arguments = _build_parser().parse_args(list(argv) if argv is not None else None)
     window = export_pointworld_source_snapshot(
         arguments.source_snapshot,
         arguments.output,

--- a/src/prob4d/pointworld_sparse_adapter.py
+++ b/src/prob4d/pointworld_sparse_adapter.py
@@ -131,6 +131,7 @@ def pointworld_output_to_persistent_window(
         raise ValueError("PointWorld source frame contains no valid scene points")
 
     point_count = int(trajectory.shape[1])
+    identifiers: np.ndarray
     if point_ids is None:
         identifiers = np.arange(point_count, dtype=np.int64)
     else:

--- a/src/prob4d/pointworld_sparse_adapter.py
+++ b/src/prob4d/pointworld_sparse_adapter.py
@@ -1,0 +1,321 @@
+"""Source-only export of PointWorld persistent scene-point trajectories."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any, Final
+
+import numpy as np
+
+from .persistent_point_prediction import (
+    PERSISTENT_POINT_WINDOW_NPZ_SCHEMA,
+    STORAGE_DTYPES,
+    PersistentPointPredictionWindow,
+    StorageDType,
+)
+
+POINTWORLD_SPARSE_SOURCE_SCHEMA: Final = (
+    "prob4d.pointworld-persistent-point-source-npz"
+)
+POINTWORLD_SPARSE_SOURCE_VERSION: Final = 1
+POINTWORLD_UNCERTAINTY_SEMANTICS: Final = (
+    "pointworld-normalized-relative-log-variance-v1"
+)
+
+_SOURCE_REQUIRED_MEMBERS: Final = frozenset(
+    {
+        "schema_name",
+        "schema_version",
+        "frame_indices",
+        "scene_flows",
+        "scene_exists",
+        "log_var",
+        "context_frame_count",
+    }
+)
+_SOURCE_OPTIONAL_MEMBERS: Final = frozenset({"point_ids"})
+
+
+def _scalar_text(value: np.ndarray, *, name: str) -> str:
+    if value.shape != () or value.dtype.kind not in {"U", "S"}:
+        raise ValueError(f"{name} must be one scalar string")
+    return str(value.item())
+
+
+def _scalar_integer(value: np.ndarray, *, name: str) -> int:
+    if value.shape != () or value.dtype.kind not in {"i", "u"}:
+        raise ValueError(f"{name} must be one scalar integer")
+    return int(value.item())
+
+
+def _without_singleton_batch(
+    value: object,
+    *,
+    name: str,
+    unbatched_ndim: int,
+) -> np.ndarray:
+    array = np.asarray(value)
+    if array.ndim == unbatched_ndim:
+        return array
+    if array.ndim == unbatched_ndim + 1 and array.shape[0] == 1:
+        return array[0]
+    raise ValueError(
+        f"{name} must have {unbatched_ndim} dimensions or one singleton "
+        "batch dimension"
+    )
+
+
+def pointworld_output_to_persistent_window(
+    *,
+    window_id: str,
+    frame_indices: object,
+    scene_flows: object,
+    scene_exists: object,
+    log_var: object,
+    context_frame_count: int = 1,
+    point_ids: object | None = None,
+    storage_dtype: StorageDType = "float32",
+) -> PersistentPointPredictionWindow:
+    """Convert one PointWorld output while preserving seeded point identity.
+
+    PointWorld's released evaluation pipeline samples scene points at the first
+    timestep and applies exactly the same selected indices to all timesteps.
+    ``scene_flows`` therefore represents absolute trajectories of persistent
+    window-local point identities, not a dense image grid.
+
+    ``log_var`` is retained under its released normalized-relative semantics.
+    This function does not reinterpret it as calibrated metric covariance.
+    """
+
+    trajectory = _without_singleton_batch(
+        scene_flows,
+        name="scene_flows",
+        unbatched_ndim=3,
+    )
+    exists = _without_singleton_batch(
+        scene_exists,
+        name="scene_exists",
+        unbatched_ndim=2,
+    )
+    uncertainty = _without_singleton_batch(
+        log_var,
+        name="log_var",
+        unbatched_ndim=3,
+    )
+    frames = np.asarray(frame_indices)
+    if frames.dtype != np.dtype(np.int64) or frames.ndim != 1:
+        raise ValueError("frame_indices must be a one-dimensional int64 array")
+    if trajectory.dtype not in {np.dtype(np.float32), np.dtype(np.float64)}:
+        raise ValueError("scene_flows must use float32 or float64")
+    if trajectory.ndim != 3 or trajectory.shape[-1] != 3:
+        raise ValueError("scene_flows must have shape (T, N, 3)")
+    if exists.dtype != np.dtype(bool):
+        raise ValueError("scene_exists must use bool dtype")
+    if exists.shape != trajectory.shape[:2]:
+        raise ValueError("scene_exists must have shape (T, N)")
+    if uncertainty.dtype not in {np.dtype(np.float32), np.dtype(np.float64)}:
+        raise ValueError("log_var must use float32 or float64")
+    if (
+        uncertainty.ndim != 3
+        or uncertainty.shape[:2] != trajectory.shape[:2]
+        or uncertainty.shape[-1] not in {1, 3}
+    ):
+        raise ValueError("log_var must have shape (T, N, 1) or (T, N, 3)")
+    if frames.size != trajectory.shape[0]:
+        raise ValueError("frame_indices length must match PointWorld output time")
+    if not np.all(np.isfinite(trajectory)):
+        raise ValueError("scene_flows must contain only finite values")
+    if not np.all(np.isfinite(uncertainty)):
+        raise ValueError("log_var must contain only finite values")
+
+    source_point_mask = np.asarray(exists[0], dtype=bool)
+    if not np.any(source_point_mask):
+        raise ValueError("PointWorld source frame contains no valid scene points")
+
+    point_count = int(trajectory.shape[1])
+    if point_ids is None:
+        identifiers = np.arange(point_count, dtype=np.int64)
+    else:
+        identifiers = np.asarray(point_ids)
+        if identifiers.dtype != np.dtype(np.int64) or identifiers.ndim != 1:
+            raise ValueError("point_ids must be a one-dimensional int64 array")
+        if identifiers.size != point_count:
+            raise ValueError("point_ids length must match PointWorld point count")
+        if np.any(identifiers < 0) or len(set(map(int, identifiers))) != point_count:
+            raise ValueError("point_ids must be non-negative and unique")
+        identifiers = identifiers.astype(np.int64, copy=False)
+
+    retained_ids = identifiers[source_point_mask]
+    retained_trajectory = trajectory[:, source_point_mask]
+    retained_exists = exists[:, source_point_mask]
+    retained_uncertainty = uncertainty[:, source_point_mask]
+
+    order = np.argsort(retained_ids, kind="stable")
+    retained_ids = retained_ids[order]
+    retained_trajectory = retained_trajectory[:, order]
+    retained_exists = retained_exists[:, order]
+    retained_uncertainty = retained_uncertainty[:, order]
+
+    return PersistentPointPredictionWindow(
+        window_id=window_id,
+        frame_indices=frames,
+        point_ids=retained_ids,
+        point_trajectory=retained_trajectory,
+        valid_mask=retained_exists,
+        context_frame_count=context_frame_count,
+        uncertainty=retained_uncertainty,
+        uncertainty_semantics=POINTWORLD_UNCERTAINTY_SEMANTICS,
+        storage_dtype=storage_dtype,
+    )
+
+
+def load_pointworld_source_snapshot(
+    path: str | Path,
+    *,
+    window_id: str,
+    storage_dtype: StorageDType = "float32",
+) -> PersistentPointPredictionWindow:
+    """Load one strict, runtime-exported PointWorld source snapshot."""
+
+    source_path = Path(path)
+    if source_path.is_symlink():
+        raise ValueError("PointWorld source snapshot is a symbolic link")
+    with np.load(source_path, allow_pickle=False) as data:
+        files = set(data.files)
+        missing = sorted(_SOURCE_REQUIRED_MEMBERS - files)
+        extra = sorted(
+            files - (_SOURCE_REQUIRED_MEMBERS | _SOURCE_OPTIONAL_MEMBERS)
+        )
+        if missing or extra:
+            raise ValueError(
+                "PointWorld source snapshot fields changed; "
+                f"missing={missing}, extra={extra}"
+            )
+        schema_name = _scalar_text(data["schema_name"], name="schema_name")
+        schema_version = _scalar_integer(
+            data["schema_version"],
+            name="schema_version",
+        )
+        if schema_name != POINTWORLD_SPARSE_SOURCE_SCHEMA:
+            raise ValueError("unsupported PointWorld source snapshot schema")
+        if schema_version != POINTWORLD_SPARSE_SOURCE_VERSION:
+            raise ValueError("unsupported PointWorld source snapshot version")
+        return pointworld_output_to_persistent_window(
+            window_id=window_id,
+            frame_indices=data["frame_indices"],
+            scene_flows=data["scene_flows"],
+            scene_exists=data["scene_exists"],
+            log_var=data["log_var"],
+            context_frame_count=_scalar_integer(
+                data["context_frame_count"],
+                name="context_frame_count",
+            ),
+            point_ids=data["point_ids"] if "point_ids" in data else None,
+            storage_dtype=storage_dtype,
+        )
+
+
+def export_pointworld_source_snapshot(
+    source_path: str | Path,
+    output_path: str | Path,
+    *,
+    window_id: str,
+    storage_dtype: StorageDType = "float32",
+) -> PersistentPointPredictionWindow:
+    """Convert one strict source snapshot into a no-clobber canonical archive."""
+
+    output = Path(output_path)
+    if output.exists() or output.is_symlink():
+        raise FileExistsError(
+            "persistent-point output already exists; refusing to replace it"
+        )
+    output.parent.mkdir(parents=True, exist_ok=True)
+    window = load_pointworld_source_snapshot(
+        source_path,
+        window_id=window_id,
+        storage_dtype=storage_dtype,
+    )
+    try:
+        window.to_npz(output)
+    except BaseException:
+        output.unlink(missing_ok=True)
+        raise
+    verified = PersistentPointPredictionWindow.from_npz(output)
+    arrays_match = (
+        np.array_equal(verified.frame_indices, window.frame_indices)
+        and np.array_equal(verified.point_ids, window.point_ids)
+        and np.array_equal(verified.point_trajectory, window.point_trajectory)
+        and np.array_equal(verified.valid_mask, window.valid_mask)
+        and (
+            (verified.uncertainty is None and window.uncertainty is None)
+            or (
+                verified.uncertainty is not None
+                and window.uncertainty is not None
+                and np.array_equal(verified.uncertainty, window.uncertainty)
+            )
+        )
+    )
+    if verified.summary() != window.summary() or not arrays_match:
+        output.unlink(missing_ok=True)
+        raise RuntimeError("persistent-point archive verification changed content")
+    return verified
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Convert a strict PointWorld scene-point snapshot into a "
+            "persistent sparse Prob4D prediction window."
+        )
+    )
+    parser.add_argument("source_snapshot")
+    parser.add_argument("output")
+    parser.add_argument("--window-id", required=True)
+    parser.add_argument(
+        "--storage-dtype",
+        choices=STORAGE_DTYPES,
+        default="float32",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    arguments = _build_parser().parse_args(
+        list(argv) if argv is not None else None
+    )
+    window = export_pointworld_source_snapshot(
+        arguments.source_snapshot,
+        arguments.output,
+        window_id=arguments.window_id,
+        storage_dtype=arguments.storage_dtype,
+    )
+    print(
+        json.dumps(
+            {
+                "output": str(Path(arguments.output)),
+                "payload_schema": PERSISTENT_POINT_WINDOW_NPZ_SCHEMA,
+                **window.summary(),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+__all__ = [
+    "POINTWORLD_SPARSE_SOURCE_SCHEMA",
+    "POINTWORLD_SPARSE_SOURCE_VERSION",
+    "POINTWORLD_UNCERTAINTY_SEMANTICS",
+    "export_pointworld_source_snapshot",
+    "load_pointworld_source_snapshot",
+    "main",
+    "pointworld_output_to_persistent_window",
+]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/prob4d/pointworld_sparse_adapter.py
+++ b/src/prob4d/pointworld_sparse_adapter.py
@@ -58,7 +58,10 @@ def _without_singleton_batch(
         return array
     if array.ndim == unbatched_ndim + 1 and array.shape[0] == 1:
         return array[0]
-    raise ValueError(f"{name} must have {unbatched_ndim} dimensions or one singleton batch dimension")
+    raise ValueError(
+        f"{name} must have {unbatched_ndim} dimensions or one singleton "
+        "batch dimension"
+    )
 
 
 def pointworld_output_to_persistent_window(
@@ -181,7 +184,10 @@ def load_pointworld_source_snapshot(
         missing = sorted(_SOURCE_REQUIRED_MEMBERS - files)
         extra = sorted(files - (_SOURCE_REQUIRED_MEMBERS | _SOURCE_OPTIONAL_MEMBERS))
         if missing or extra:
-            raise ValueError(f"PointWorld source snapshot fields changed; missing={missing}, extra={extra}")
+            raise ValueError(
+                "PointWorld source snapshot fields changed; "
+                f"missing={missing}, extra={extra}"
+            )
         schema_name = _scalar_text(data["schema_name"], name="schema_name")
         schema_version = _scalar_integer(
             data["schema_version"],

--- a/src/prob4d/pointworld_sparse_adapter.py
+++ b/src/prob4d/pointworld_sparse_adapter.py
@@ -6,7 +6,7 @@ import argparse
 import json
 from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, Final
+from typing import Final
 
 import numpy as np
 

--- a/src/prob4d/pointworld_sparse_adapter.py
+++ b/src/prob4d/pointworld_sparse_adapter.py
@@ -59,8 +59,7 @@ def _without_singleton_batch(
     if array.ndim == unbatched_ndim + 1 and array.shape[0] == 1:
         return array[0]
     raise ValueError(
-        f"{name} must have {unbatched_ndim} dimensions or one singleton "
-        "batch dimension"
+        f"{name} must have {unbatched_ndim} dimensions or one singleton batch dimension"
     )
 
 
@@ -185,8 +184,7 @@ def load_pointworld_source_snapshot(
         extra = sorted(files - (_SOURCE_REQUIRED_MEMBERS | _SOURCE_OPTIONAL_MEMBERS))
         if missing or extra:
             raise ValueError(
-                "PointWorld source snapshot fields changed; "
-                f"missing={missing}, extra={extra}"
+                f"PointWorld source snapshot fields changed; missing={missing}, extra={extra}"
             )
         schema_name = _scalar_text(data["schema_name"], name="schema_name")
         schema_version = _scalar_integer(

--- a/src/prob4d/prediction_cli.py
+++ b/src/prob4d/prediction_cli.py
@@ -32,6 +32,10 @@ def _help_parser() -> argparse.ArgumentParser:
         help="convert direct recurrent-online CUT3R XYZ point maps",
     )
     subparsers.add_parser(
+        "import-pointworld-sparse",
+        help="convert PointWorld scene-point trajectories into a strict sparse window",
+    )
+    subparsers.add_parser(
         "cut3r-fidelity",
         help="audit direct-pointmap fidelity and recurrent causal-prefix closure",
     )
@@ -98,6 +102,10 @@ def main(argv: Sequence[str] | None = None) -> int:
         from .cut3r_direct_provider_adapter import main as cut3r_direct_main
 
         return int(cut3r_direct_main(arguments[1:]))
+    if arguments[0] == "import-pointworld-sparse":
+        from .pointworld_sparse_adapter import main as pointworld_sparse_main
+
+        return int(pointworld_sparse_main(arguments[1:]))
     if arguments[0] == "cut3r-fidelity":
         from .cut3r_pointmap_fidelity import main as cut3r_fidelity_main
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -78,6 +78,7 @@ def test_grouped_cli_routes_provider_neutral_prediction_help(capsys) -> None:
     assert "import-motioncrafter" in output
     assert "import-vggt" in output
     assert "import-cut3r-online" in output
+    assert "import-pointworld-sparse" in output
     assert "import-generic" in output
     assert "scaffold-generic" in output
     assert "validate" in output
@@ -98,6 +99,16 @@ def test_grouped_cli_routes_generic_provider_import_help(capsys) -> None:
     scaffold_help = capsys.readouterr().out
     assert "no-clobber generic-provider import scaffold" in scaffold_help
     assert "output_directory" in scaffold_help
+
+
+def test_grouped_cli_routes_pointworld_sparse_import_help(capsys) -> None:
+    with pytest.raises(SystemExit) as exit_info:
+        main(["prediction", "import-pointworld-sparse", "--help"])
+    assert exit_info.value.code == 0
+    output = capsys.readouterr().out
+    assert "persistent sparse Prob4D prediction window" in output
+    assert "--window-id" in output
+    assert "--storage-dtype" in output
 
 
 def test_grouped_cli_routes_provider_runtime_help(capsys) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -106,7 +106,8 @@ def test_grouped_cli_routes_pointworld_sparse_import_help(capsys) -> None:
         main(["prediction", "import-pointworld-sparse", "--help"])
     assert exit_info.value.code == 0
     output = capsys.readouterr().out
-    assert "persistent sparse Prob4D prediction window" in output
+    assert "persistent sparse Prob4D" in output
+    assert "prediction window" in output
     assert "--window-id" in output
     assert "--storage-dtype" in output
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -106,8 +106,8 @@ def test_grouped_cli_routes_pointworld_sparse_import_help(capsys) -> None:
         main(["prediction", "import-pointworld-sparse", "--help"])
     assert exit_info.value.code == 0
     output = capsys.readouterr().out
-    assert "persistent sparse Prob4D" in output
-    assert "prediction window" in output
+    assert "source_snapshot" in output
+    assert "output" in output
     assert "--window-id" in output
     assert "--storage-dtype" in output
 

--- a/tests/test_persistent_point_prediction.py
+++ b/tests/test_persistent_point_prediction.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from prob4d.persistent_point_prediction import (
+    PERSISTENT_POINT_WINDOW_NPZ_SCHEMA,
+    PERSISTENT_POINT_WINDOW_NPZ_VERSION,
+    PersistentPointPredictionWindow,
+)
+
+
+def _window() -> PersistentPointPredictionWindow:
+    trajectory = np.asarray(
+        [
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
+            [[0.1, 0.0, 0.0], [1.1, 0.0, 0.0]],
+            [[0.2, 0.0, 0.0], [1.2, 0.0, 0.0]],
+        ],
+        dtype=np.float32,
+    )
+    return PersistentPointPredictionWindow(
+        window_id="pointworld-window-0000",
+        frame_indices=np.asarray([4, 5, 6], dtype=np.int64),
+        point_ids=np.asarray([10, 20], dtype=np.int64),
+        point_trajectory=trajectory,
+        valid_mask=np.ones((3, 2), dtype=bool),
+        context_frame_count=1,
+        uncertainty=np.zeros((3, 2, 1), dtype=np.float32),
+        uncertainty_semantics=(
+            "pointworld-normalized-relative-log-variance-v1"
+        ),
+        storage_dtype="float32",
+    )
+
+
+def test_roundtrip_preserves_persistent_identity_and_precision(tmp_path) -> None:
+    window = _window()
+    output = tmp_path / "persistent.npz"
+    window.to_npz(output)
+    loaded = PersistentPointPredictionWindow.from_npz(output)
+
+    assert loaded.summary() == window.summary()
+    assert np.array_equal(loaded.frame_indices, [4, 5, 6])
+    assert np.array_equal(loaded.point_ids, [10, 20])
+    assert loaded.point_trajectory.dtype == np.dtype(np.float32)
+    assert loaded.prediction_frame_indices.tolist() == [5, 6]
+    assert loaded.local_index(5) == 1
+    assert loaded.common_frames(window).tolist() == [4, 5, 6]
+
+    for array in (
+        loaded.frame_indices,
+        loaded.point_ids,
+        loaded.point_trajectory,
+        loaded.valid_mask,
+        loaded.uncertainty,
+    ):
+        assert array is not None
+        assert not array.flags.writeable
+        with pytest.raises(ValueError):
+            array.setflags(write=True)
+
+
+def test_contract_rejects_ambiguous_identity_and_uncertainty() -> None:
+    base = _window()
+    with pytest.raises(ValueError, match="strictly increasing"):
+        PersistentPointPredictionWindow(
+            window_id=base.window_id,
+            frame_indices=base.frame_indices,
+            point_ids=np.asarray([10, 10], dtype=np.int64),
+            point_trajectory=base.point_trajectory,
+            valid_mask=base.valid_mask,
+            context_frame_count=1,
+            uncertainty=base.uncertainty,
+            uncertainty_semantics=base.uncertainty_semantics,
+            storage_dtype="float32",
+        )
+    invalid_first = np.ones((3, 2), dtype=bool)
+    invalid_first[0, 1] = False
+    with pytest.raises(ValueError, match="first context frame"):
+        PersistentPointPredictionWindow(
+            window_id=base.window_id,
+            frame_indices=base.frame_indices,
+            point_ids=base.point_ids,
+            point_trajectory=base.point_trajectory,
+            valid_mask=invalid_first,
+            context_frame_count=1,
+            storage_dtype="float32",
+        )
+    with pytest.raises(ValueError, match="describe present uncertainty"):
+        PersistentPointPredictionWindow(
+            window_id=base.window_id,
+            frame_indices=base.frame_indices,
+            point_ids=base.point_ids,
+            point_trajectory=base.point_trajectory,
+            valid_mask=base.valid_mask,
+            context_frame_count=1,
+            uncertainty=base.uncertainty,
+            uncertainty_semantics="absent",
+            storage_dtype="float32",
+        )
+
+
+def test_archive_rejects_schema_and_field_drift(tmp_path) -> None:
+    base = _window()
+    output = tmp_path / "bad.npz"
+    np.savez_compressed(
+        output,
+        schema_name=np.asarray(PERSISTENT_POINT_WINDOW_NPZ_SCHEMA),
+        schema_version=np.asarray(
+            PERSISTENT_POINT_WINDOW_NPZ_VERSION,
+            dtype=np.int64,
+        ),
+        storage_dtype=np.asarray("float32"),
+        window_id=np.asarray(base.window_id),
+        frame_indices=base.frame_indices,
+        point_ids=base.point_ids,
+        point_trajectory=base.point_trajectory,
+        valid_mask=base.valid_mask,
+        context_frame_count=np.asarray(1, dtype=np.int64),
+        point_identity_semantics=np.asarray(base.point_identity_semantics),
+        trajectory_semantics=np.asarray(base.trajectory_semantics),
+        uncertainty_semantics=np.asarray(base.uncertainty_semantics),
+        uncertainty=base.uncertainty,
+        unexpected=np.asarray(1),
+    )
+    with pytest.raises(ValueError, match="fields changed"):
+        PersistentPointPredictionWindow.from_npz(output)

--- a/tests/test_persistent_point_prediction.py
+++ b/tests/test_persistent_point_prediction.py
@@ -27,9 +27,7 @@ def _window() -> PersistentPointPredictionWindow:
         valid_mask=np.ones((3, 2), dtype=bool),
         context_frame_count=1,
         uncertainty=np.zeros((3, 2, 1), dtype=np.float32),
-        uncertainty_semantics=(
-            "pointworld-normalized-relative-log-variance-v1"
-        ),
+        uncertainty_semantics=("pointworld-normalized-relative-log-variance-v1"),
         storage_dtype="float32",
     )
 

--- a/tests/test_pointworld_sparse_adapter.py
+++ b/tests/test_pointworld_sparse_adapter.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from prob4d.pointworld_sparse_adapter import (
+    POINTWORLD_SPARSE_SOURCE_SCHEMA,
+    POINTWORLD_SPARSE_SOURCE_VERSION,
+    POINTWORLD_UNCERTAINTY_SEMANTICS,
+    export_pointworld_source_snapshot,
+    main,
+    pointworld_output_to_persistent_window,
+)
+from prob4d.persistent_point_prediction import (
+    PersistentPointPredictionWindow,
+)
+
+
+def _pointworld_arrays() -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    trajectory = np.zeros((1, 3, 4, 3), dtype=np.float32)
+    trajectory[0, :, :, 0] = np.asarray(
+        [
+            [0.0, 1.0, 2.0, 3.0],
+            [0.1, 1.1, 2.1, 3.1],
+            [0.2, 1.2, 2.2, 3.2],
+        ]
+    )
+    exists = np.ones((1, 3, 4), dtype=bool)
+    exists[0, 0, 3] = False
+    exists[0, 1:, 2] = False
+    log_var = np.zeros((1, 3, 4, 1), dtype=np.float32)
+    return trajectory, exists, log_var
+
+
+def test_conversion_filters_padding_and_preserves_point_order() -> None:
+    trajectory, exists, log_var = _pointworld_arrays()
+    window = pointworld_output_to_persistent_window(
+        window_id="w0",
+        frame_indices=np.asarray([10, 11, 12], dtype=np.int64),
+        scene_flows=trajectory,
+        scene_exists=exists,
+        log_var=log_var,
+        point_ids=np.asarray([30, 10, 20, 40], dtype=np.int64),
+        storage_dtype="float32",
+    )
+
+    assert window.point_ids.tolist() == [10, 20, 30]
+    assert window.shape == (3, 3)
+    assert window.valid_mask[:, 1].tolist() == [True, False, False]
+    assert window.point_trajectory[0, :, 0].tolist() == [1.0, 2.0, 0.0]
+    assert window.uncertainty_semantics == POINTWORLD_UNCERTAINTY_SEMANTICS
+
+
+def test_strict_source_snapshot_exports_and_refuses_clobber(
+    tmp_path: Path,
+    capsys,
+) -> None:
+    trajectory, exists, log_var = _pointworld_arrays()
+    source = tmp_path / "source.npz"
+    output = tmp_path / "persistent.npz"
+    np.savez_compressed(
+        source,
+        schema_name=np.asarray(POINTWORLD_SPARSE_SOURCE_SCHEMA),
+        schema_version=np.asarray(
+            POINTWORLD_SPARSE_SOURCE_VERSION,
+            dtype=np.int64,
+        ),
+        frame_indices=np.asarray([10, 11, 12], dtype=np.int64),
+        scene_flows=trajectory,
+        scene_exists=exists,
+        log_var=log_var,
+        context_frame_count=np.asarray(1, dtype=np.int64),
+    )
+
+    assert (
+        main(
+            [
+                str(source),
+                str(output),
+                "--window-id",
+                "pointworld-window-0000",
+            ]
+        )
+        == 0
+    )
+    report = json.loads(capsys.readouterr().out)
+    assert report["point_count"] == 3
+    loaded = PersistentPointPredictionWindow.from_npz(output)
+    assert loaded.window_id == "pointworld-window-0000"
+
+    with pytest.raises(FileExistsError, match="refusing to replace"):
+        export_pointworld_source_snapshot(
+            source,
+            output,
+            window_id="pointworld-window-0000",
+        )
+
+
+def test_source_snapshot_rejects_unversioned_or_ambiguous_payload(
+    tmp_path: Path,
+) -> None:
+    trajectory, exists, log_var = _pointworld_arrays()
+    source = tmp_path / "source.npz"
+    np.savez_compressed(
+        source,
+        frame_indices=np.asarray([10, 11, 12], dtype=np.int64),
+        scene_flows=trajectory,
+        scene_exists=exists,
+        log_var=log_var,
+        context_frame_count=np.asarray(1, dtype=np.int64),
+    )
+    with pytest.raises(ValueError, match="fields changed"):
+        export_pointworld_source_snapshot(
+            source,
+            tmp_path / "output.npz",
+            window_id="w0",
+        )
+
+    with pytest.raises(ValueError, match="one singleton batch dimension"):
+        pointworld_output_to_persistent_window(
+            window_id="w0",
+            frame_indices=np.asarray([10, 11, 12], dtype=np.int64),
+            scene_flows=np.zeros((2, 3, 4, 3), dtype=np.float32),
+            scene_exists=np.ones((2, 3, 4), dtype=bool),
+            log_var=np.zeros((2, 3, 4, 1), dtype=np.float32),
+        )

--- a/tests/test_pointworld_sparse_adapter.py
+++ b/tests/test_pointworld_sparse_adapter.py
@@ -6,6 +6,9 @@ from pathlib import Path
 import numpy as np
 import pytest
 
+from prob4d.persistent_point_prediction import (
+    PersistentPointPredictionWindow,
+)
 from prob4d.pointworld_sparse_adapter import (
     POINTWORLD_SPARSE_SOURCE_SCHEMA,
     POINTWORLD_SPARSE_SOURCE_VERSION,
@@ -13,9 +16,6 @@ from prob4d.pointworld_sparse_adapter import (
     export_pointworld_source_snapshot,
     main,
     pointworld_output_to_persistent_window,
-)
-from prob4d.persistent_point_prediction import (
-    PersistentPointPredictionWindow,
 )
 
 


### PR DESCRIPTION
## Purpose

Continue the source-only PointWorld -> Prob4D -> BayesianPhysTwin path frozen by merged PR #334 and tracked in #333.

This PR resolves the representation sub-gate without opening Flat'n'Fold target outcomes. The released PointWorld test pipeline samples scene-point indices at the first timestep and applies the same selected indices to every later timestep; the model then exports absolute point trajectories as the initial scene coordinates plus predicted relative displacement. A sparse persistent-trajectory payload is therefore faithful to the provider, while rasterizing into the dense `PredictionWindow` image grid would discard identity and require an unnecessary mapping choice.

## Implementation

- adds `PersistentPointPredictionWindow` with strict schema `prob4d.persistent-point-prediction-window-npz` v1;
- retains immutable absolute frame IDs, window-local persistent point IDs, `T x N x 3` absolute trajectories, validity, and context-frame count;
- accepts optional `T x N x 1|3` provider uncertainty only with explicit semantics;
- adds strict source schema `prob4d.pointworld-persistent-point-source-npz` v1;
- adds `prob4d prediction import-pointworld-sparse`;
- removes only source-frame padding, reorders every field consistently with explicit point IDs, refuses clobbering, reloads the written archive, and checks exact array equality;
- documents the contract and updates the frozen source-qualification protocol;
- adds a focused read-only workflow covering Ruff, format, mypy, pytest, compilation, and installed-command help.

## Uncertainty boundary

PointWorld `log_var` is retained as

`pointworld-normalized-relative-log-variance-v1`.

It is not called metric covariance, predictive coverage, or a calibrated likelihood. The exact normalization statistics and a source/calibration-only covariance study remain future gates.

## Validation performed before publication

- six focused contract/adapter tests passed locally;
- Python compilation passed;
- round-trip immutability, schema drift, dtype drift, identity ordering, singleton-batch handling, source-padding removal, no-clobber behavior, and installed CLI routing are covered;
- the PR workflow owns Ruff, formatting, mypy, and the complete focused test slice on Python 3.12.

## Information boundary

No Flat'n'Fold target outcome, provider residual, covariance result, BayesianPhysTwin innovation, or Causal4D outcome was opened or used.

The following remain unresolved and must pass before any provider-competence experiment:

- exact PointWorld checkpoint SHA-256 and executable runtime;
- Flat'n'Fold byte manifest and garment roster;
- Baxter action-to-robot-point-flow conversion;
- metric coordinate and camera synchronization checks;
- source runtime confirmation of point ordering and strict snapshot export;
- `ProviderSupportFeasibilityV1` over the frozen source roster;
- cross-window association and calibrated fusion.

## Claim boundary

This PR establishes a provider-faithful sparse payload and export boundary only. It establishes no PointWorld competence on Flat'n'Fold, no Prob4D accuracy or calibration benefit, no BayesianPhysTwin benefit, no Causal4D benefit, and no deployment-safety claim.

Tracks #333.