### PR TITLE
Add persistent-point provider artifact for PointWorld

### DIFF
--- a/.github/workflows/persistent-point-prediction.yml
+++ b/.github/workflows/persistent-point-prediction.yml
@@ -1,0 +1,96 @@
+name: Persistent-point prediction contract
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/persistent-point-prediction.yml"
+      - "docs/persistent-point-prediction-window.md"
+      - "evidence/pointworld-flatnfold-source-qualification-v1/representation-decision.json"
+      - "src/prob4d/persistent_point_prediction.py"
+      - "tests/test_persistent_point_prediction.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: persistent-point-prediction-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONUNBUFFERED: "1"
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out exact reviewed source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install lightweight development environment
+        run: |
+          python -m pip install -e ".[dev]" "numpy>=1.24,<2.3"
+          python -m pip check
+
+      - name: Lint and format focused sources
+        run: |
+          python -m ruff check \
+            src/prob4d/persistent_point_prediction.py \
+            tests/test_persistent_point_prediction.py
+          python -m ruff format --check --diff \
+            src/prob4d/persistent_point_prediction.py \
+            tests/test_persistent_point_prediction.py
+
+      - name: Type-check the persistent-point contract
+        run: python -m mypy src/prob4d/persistent_point_prediction.py
+
+      - name: Run focused contract tests
+        run: >-
+          python -m pytest -q
+          tests/test_persistent_point_prediction.py
+          tests/test_observation_factors.py
+
+      - name: Verify source-only representation evidence
+        run: |
+          python - <<'PY'
+          import hashlib
+          import json
+          from pathlib import Path
+
+          path = Path(
+              "evidence/pointworld-flatnfold-source-qualification-v1/"
+              "representation-decision.json"
+          )
+          record = json.loads(path.read_text(encoding="utf-8"))
+          decision_id = record.pop("representation_decision_id")
+          canonical = json.dumps(
+              record,
+              sort_keys=True,
+              separators=(",", ":"),
+              ensure_ascii=False,
+          )
+          assert hashlib.sha256(canonical.encode()).hexdigest() == decision_id
+          assert record["decision"]["status"] == (
+              "PERSISTENT_POINT_ARTIFACT_AUTHORIZED_PROVIDER_NOT_YET_QUALIFIED"
+          )
+          boundary = record["information_boundary"]
+          assert not boundary["prediction_payloads_opened"]
+          assert not boundary["provider_residuals_used"]
+          assert not boundary["target_outcomes_opened"]
+          assert not boundary["bayesian_phystwin_innovations_used"]
+          assert not boundary["causal4d_outcomes_used"]
+          PY
+
+      - name: Compile focused source
+        run: python -m py_compile src/prob4d/persistent_point_prediction.py

--- a/.github/workflows/persistent-point-prediction.yml
+++ b/.github/workflows/persistent-point-prediction.yml
@@ -6,7 +6,7 @@ on:
     paths:
       - ".github/workflows/persistent-point-prediction.yml"
       - "docs/persistent-point-prediction-window.md"
-      - "evidence/pointworld-flatnfold-source-qualification-v1/representation-decision.json"
+      - "evidence/pointworld-flatnfold-source-qualification-v1/*.json"
       - "src/prob4d/persistent_point_prediction.py"
       - "tests/test_persistent_point_prediction.py"
   workflow_dispatch:
@@ -61,35 +61,54 @@ jobs:
           tests/test_persistent_point_prediction.py
           tests/test_observation_factors.py
 
-      - name: Verify source-only representation evidence
+      - name: Verify source-only evidence
         run: |
           python - <<'PY'
           import hashlib
           import json
           from pathlib import Path
 
-          path = Path(
-              "evidence/pointworld-flatnfold-source-qualification-v1/"
-              "representation-decision.json"
+          root = Path("evidence/pointworld-flatnfold-source-qualification-v1")
+
+          representation = json.loads(
+              (root / "representation-decision.json").read_text(encoding="utf-8")
           )
-          record = json.loads(path.read_text(encoding="utf-8"))
-          decision_id = record.pop("representation_decision_id")
+          decision_id = representation.pop("representation_decision_id")
           canonical = json.dumps(
-              record,
+              representation,
               sort_keys=True,
               separators=(",", ":"),
               ensure_ascii=False,
           )
           assert hashlib.sha256(canonical.encode()).hexdigest() == decision_id
-          assert record["decision"]["status"] == (
+          assert representation["decision"]["status"] == (
               "PERSISTENT_POINT_ARTIFACT_AUTHORIZED_PROVIDER_NOT_YET_QUALIFIED"
           )
-          boundary = record["information_boundary"]
-          assert not boundary["prediction_payloads_opened"]
-          assert not boundary["provider_residuals_used"]
-          assert not boundary["target_outcomes_opened"]
-          assert not boundary["bayesian_phystwin_innovations_used"]
-          assert not boundary["causal4d_outcomes_used"]
+
+          audit = json.loads(
+              (root / "static-source-audit.json").read_text(encoding="utf-8")
+          )
+          audit_id = audit.pop("static_source_audit_id")
+          canonical = json.dumps(
+              audit,
+              sort_keys=True,
+              separators=(",", ":"),
+              ensure_ascii=False,
+          )
+          assert hashlib.sha256(canonical.encode()).hexdigest() == audit_id
+          assert audit["decision"]["status"] == (
+              "SOURCE_STATIC_AUDIT_COMPLETE_DATASET_BYTE_QUALIFICATION_REQUIRED"
+          )
+          assert audit["decision"]["representation_gate_resolved"]
+          assert not audit["decision"]["provider_support_feasibility_authorized"]
+
+          for record in (representation, audit):
+              boundary = record["information_boundary"]
+              assert not boundary["prediction_payloads_opened"]
+              assert not boundary["provider_residuals_used"]
+              assert not boundary["target_outcomes_opened"]
+              assert not boundary["bayesian_phystwin_innovations_used"]
+              assert not boundary["causal4d_outcomes_used"]
           PY
 
       - name: Compile focused source

--- a/docs/dual-gripper-surface-action.md
+++ b/docs/dual-gripper-surface-action.md
@@ -1,0 +1,108 @@
+# Dual-gripper surface action bridge
+
+`prob4d.dual_gripper_surface_action` converts two rigid end-effector pose
+trajectories into the sampled robot surface-point trajectories consumed by
+PointWorld.
+
+It is an additive source-qualification artifact for the proposed
+PointWorld–Flat'n'Fold study. It does not modify PointWorld, the production
+Prob4D provider, or BayesianPhysTwin.
+
+## Motivation
+
+The released PointWorld input pipeline obtains `robot_flows` by sampling robot
+surface points from a compatible kinematic model over the full action horizon.
+Its built-in conversion supports DROID/Panda and BEHAVIOR embodiments.
+
+Flat'n'Fold instead exposes two Baxter end-effector tracker streams containing
+position, quaternion orientation, and gripper state, plus one electric-gripper
+STL mesh. The inspected public source does not establish complete Baxter joint
+trajectories or a PointWorld-compatible Baxter URDF sampler.
+
+The narrow source-only bridge is therefore:
+
+1. load the exact gripper STL bytes outside Prob4D;
+2. deterministically sample a fixed set of points and normals;
+3. bind the sampled template by SHA-256;
+4. express the right and left samples in their respective tracker frames using a
+   separately bound tracker-to-template calibration;
+5. transform the same material surface points with each timestamped tracker pose;
+   and
+6. retain binary gripper state as the released PointWorld bimanual feature.
+
+This is a **dual-gripper-surface** action representation. It is not claimed to be
+equivalent to PointWorld's released DROID or BEHAVIOR full-robot inputs.
+
+## Construction
+
+```python
+from prob4d.dual_gripper_surface_action import (
+    dual_gripper_surface_action_from_tracker_poses,
+)
+
+action = dual_gripper_surface_action_from_tracker_poses(
+    action_id="garment-07-demo-03-action-000",
+    frame_indices=absolute_frames,
+    surface_points_tracker=points_right_then_left,
+    surface_normals_tracker=normals_right_then_left,
+    positions_world_from_tracker=positions_right_then_left,
+    quaternions_world_from_tracker_wxyz=quaternions_right_then_left,
+    gripper_open=open_right_then_left,
+    template_id=sampled_template_sha256,
+    tracker_calibration_id=tracker_to_template_calibration_sha256,
+    pose_stream_id=pose_stream_manifest_sha256,
+    timestamp_association_id=timestamp_association_sha256,
+)
+
+action.to_npz("action-000.dual-gripper.npz")
+pointworld_fields = action.pointworld_sample()
+```
+
+The public Flat'n'Fold parser uses quaternion order `[w, x, y, z]` and rounds
+components to three decimal places. The bridge deterministically normalizes each
+finite nonzero quaternion before constructing the rotation matrix.
+
+## Artifact contract
+
+The NPZ schema is `prob4d.dual-gripper-surface-action-window-npz` version 1.
+It stores:
+
+- absolute frame indices;
+- stable surface-point identities;
+- right/left arm and template-point indices;
+- `T × N × 3` robot positions, normals, and magenta colors;
+- complete rigid-template support;
+- `T × 2` right/left gripper state;
+- template, tracker-calibration, pose-stream, and timestamp-association IDs; and
+- explicit action, identity, and coordinate semantics.
+
+Arm order is fixed as right then left, matching PointWorld's bimanual feature
+allocation. Point identity is derived from template ID, tracker-calibration ID,
+arm, and source template index. It is therefore stable across action windows
+only when the exact hardware template and calibration match.
+
+## Remaining information gap
+
+The bridge code can transform a frozen template and pose stream, but the public
+repository alone does not provide enough evidence to instantiate a claim-bearing
+Flat'n'Fold action artifact. Source qualification still has to bind:
+
+- the exact STL bytes and deterministic surface-sampling report;
+- tracker-to-template transforms for both arms;
+- timestamped right/left pose and gripper-state bytes;
+- one-to-one camera/action associations with a frozen maximum skew;
+- metric frame orientation and units;
+- technical-failure and missing-frame handling; and
+- the exact PointWorld checkpoint/runtime using the resulting representation.
+
+The gripper-only representation also creates embodiment shift relative to the
+released PointWorld training domains. Its source competence must be measured
+before a held-out target garment is opened.
+
+## Claim boundary
+
+A valid action archive proves deterministic rigid transformation, identity,
+shape, dtype, and provenance semantics for its exact inputs. It does not prove
+correct mesh-to-tracker calibration, timestamp synchronization, PointWorld
+compatibility, provider accuracy, uncertainty calibration, Prob4D fusion
+benefit, BayesianPhysTwin benefit, Causal4D benefit, or deployment safety.

--- a/docs/persistent-point-prediction-window.md
+++ b/docs/persistent-point-prediction-window.md
@@ -1,0 +1,110 @@
+# Persistent-point prediction windows
+
+`prob4d.persistent_point_prediction` is an additive experimental artifact for
+providers whose native output is a fixed sparse scene-point axis rather than a
+dense image-grid point map.
+
+It was introduced to resolve the source-side representation gate in the
+PointWorld–Flat'n'Fold qualification protocol without rasterizing PointWorld
+predictions onto a target-dependent RGB-D grid.
+
+## Source-side PointWorld finding
+
+At PointWorld revision `05484826dfef74cbe278a3974179a5a16705d35d`, the
+released model:
+
+- obtains `scene_coord0` from the first scene-point frame;
+- predicts a `B x T x N_scene x 3` relative displacement tensor;
+- forms absolute predicted positions as `scene_coord0 + displacement`; and
+- emits a `B x T x N_scene x 1` log-variance tensor.
+
+Consequently, the `N_scene` axis is a persistent provider seed axis within one
+forecast window. It should be preserved, not reshaped into `H x W`.
+
+The uncertainty head is trained against normalized initial-frame-relative
+scene displacement. Its output is therefore **not** a calibrated metric point
+covariance. The artifact retains the raw log variance together with the SHA-256
+identity of the normalization statistics that give it meaning.
+
+## Contract
+
+```python
+from prob4d.persistent_point_prediction import (
+    persistent_point_window_from_pointworld,
+)
+
+window = persistent_point_window_from_pointworld(
+    window_id="garment-07-demo-03-window-000",
+    frame_indices=absolute_output_frames,
+    scene_positions=pointworld_output["scene_flows"][0].cpu().numpy(),
+    scene_valid_mask=scene_valid_mask[0].cpu().numpy(),
+    reported_log_variance=pointworld_output["log_var"][0].cpu().numpy(),
+    normalization_id=normalization_statistics_sha256,
+)
+window.to_npz("window-000.persistent-points.npz")
+```
+
+The version-1 archive stores:
+
+- exact absolute output-frame indices;
+- source point-axis indices;
+- deterministic window-scoped integer point identities;
+- `T x N x 3` point positions;
+- `T x N` validity;
+- explicit position and identity semantics; and
+- optional raw provider log variance, its semantics, and its normalization ID.
+
+Arrays are defensively owned and read-only after validation. The NPZ reader
+rejects unknown fields, missing fields, dtype drift, malformed identities,
+nonfinite active observations, incomplete uncertainty metadata, and schema drift.
+
+## Identity boundary
+
+PointWorld seed index `n` is persistent across frames **within one forecast
+window**. The adapter hashes `(window_id, source_point_index)` into a positive
+`int64` identifier so the same numeric source index in two different windows is
+not silently interpreted as the same material point.
+
+This does not establish cross-window correspondence. A future cross-window
+association layer must declare and validate that relationship separately.
+
+## Calibration boundary
+
+`reported_log_variance` is retained exactly as provider output. It must not be
+passed directly to `ObservationFactor.local_covariance_m2`.
+
+Before downstream use, a source/calibration-only step must establish:
+
+1. the exact PointWorld checkpoint and normalization-statistics identities;
+2. a mapping from normalized displacement log variance to conditional metric
+   point covariance, including anisotropy assumptions;
+3. dependence groups for points, frames, stochastic members, and overlapping
+   windows; and
+4. held-out coverage, proper-score, and covariance-width behavior.
+
+A valid negative calibration result retains the raw predictions but does not
+authorize uncertainty-weighted fusion.
+
+## Remaining PointWorld qualification work
+
+This artifact resolves only the representation-shape question. Issue #333 still
+requires source-only completion of:
+
+- checkpoint and runtime binding;
+- Flat'n'Fold dataset-byte and garment-roster inventory;
+- three-camera timestamp and geometry verification;
+- Baxter action conversion into PointWorld robot point flows;
+- metric-frame verification;
+- visual and action source-lineage semantics;
+- covariance/reliability calibration design; and
+- `ProviderSupportFeasibilityV1` evaluation before target outcomes.
+
+No target garment outcome, BayesianPhysTwin innovation, or Causal4D result is
+needed or permitted for these steps.
+
+## Claim boundary
+
+A valid persistent-point archive proves shape, identity, dtype, and semantic
+interoperability for the exact bytes it contains. It does not establish provider
+accuracy, calibrated uncertainty, cross-window material identity, Prob4D fusion
+benefit, BayesianPhysTwin benefit, Causal4D benefit, or deployment safety.

--- a/docs/pointworld-flatnfold-study.md
+++ b/docs/pointworld-flatnfold-study.md
@@ -2,102 +2,237 @@
 
 ## Purpose
 
-This branch starts the highest-value remaining Prob4D paper experiment: test whether a provider-agnostic, correlation-aware recursive belief improves a real action-conditioned 3-D world model and one frozen downstream BayesianPhysTwin query.
+This is the highest-value remaining Prob4D paper experiment: test whether a
+provider-agnostic, correlation-aware recursive belief improves a real
+action-conditioned 3-D world model and one frozen downstream BayesianPhysTwin
+query.
 
-The intended external provider is PointWorld (`NVlabs/PointWorld`) and the intended independent real cohort is the robot subset of Flat'n'Fold (`lipeng-zhuang521/flat-n-fold`). The experiment is deliberately separated from the terminal CUT3R attempt, the already-opened MotionCrafter/Deform360 cohorts, and the locked Causal4D physical-acquisition protocol.
+The intended external provider is PointWorld (`NVlabs/PointWorld`) and the
+intended independent real cohort is the robot subset of Flat'n'Fold
+(`lipeng-zhuang521/flat-n-fold`). The experiment is deliberately separated from
+the terminal CUT3R attempt, the already-opened MotionCrafter/Deform360 cohorts,
+and the locked Causal4D physical-acquisition protocol.
 
-The present branch is **source qualification only**. No target outcome may be opened or used to choose a representation mapping, checkpoint, split, mask, exclusion, covariance treatment, or downstream query.
+The current work remains **source qualification only**. No target outcome may be
+opened or used to choose a representation mapping, checkpoint, split, mask,
+exclusion, covariance treatment, action conversion, synchronization rule, or
+downstream query.
 
-The machine-readable lock is `protocols/pointworld-flatnfold-source-qualification-v1.json`.
+The machine-readable source lock is
+`protocols/pointworld-flatnfold-source-qualification-v1.json`. Source-only
+representation and static-input findings are retained under
+`evidence/pointworld-flatnfold-source-qualification-v1/`.
 
 ## Frozen public revisions
 
-The source-qualification protocol binds:
+The original source-qualification protocol binds:
 
 - Prob4D: `d02f057671023ff586ebfc15c904dbb0a60f4425`;
 - BayesianPhysTwin: `b5f07d649ac2cd7dc6ca1aceb4004ff4803bddc8`;
 - PointWorld: `05484826dfef74cbe278a3974179a5a16705d35d`;
 - Flat'n'Fold code: `fa0d3d17ac827e7b5c43ec1ef7c0c38ad5e39340`.
 
-These source revisions are not a completed experiment lock. The exact PointWorld checkpoint bytes, runtime, Flat'n'Fold dataset bytes, garment roster, frame/action schedule, and downstream query still have to be bound before target access.
+The persistent-point follow-up was implemented additively on later Prob4D main
+without changing the production dense provider, estimator, gauge, fusion, or
+BayesianPhysTwin contracts. The exact PointWorld checkpoint bytes, runtime,
+normalization-statistics bytes, Flat'n'Fold dataset bytes, garment roster,
+frame/action schedule, and downstream query remain unbound.
 
 ## Why this experiment
 
-Prob4D already contains the methodological ingredients needed for a paper contribution: joint gauge uncertainty, cross-window covariance, covariance intersection, guarded multi-edge graph fusion, finite-sample source-cycle admission, sparse metric-anchor calibration, provider-neutral manifests, and exact fallback. Another covariance or planner component would add complexity without resolving the main empirical gap.
+Prob4D already contains the methodological ingredients needed for a paper
+contribution: joint gauge uncertainty, cross-window covariance, covariance
+intersection, guarded multi-edge graph fusion, finite-sample source-cycle
+admission, sparse metric-anchor calibration, provider-neutral manifests, and
+exact fallback. Another covariance or planner component would add complexity
+without resolving the main empirical gap.
 
-The missing evidence is a fresh real provider and fresh physical object/session cohort showing that the same recursive belief machinery can wrap a different action-conditioned model and improve a downstream physical query.
+The missing evidence is a fresh real provider and fresh physical object/session
+cohort showing that the same recursive belief machinery can wrap a different
+action-conditioned model and improve a downstream physical query.
 
-PointWorld is a materially different provider from MotionCrafter. Its released model predicts full-scene 3-D point flows from RGB-D observations and robot actions represented as 3-D point flows. Flat'n'Fold provides 887 robot demonstrations over 44 garments in eight categories, with three-camera RGB-D observations, camera calibration, Baxter action information, and point-cloud construction code.
+PointWorld is materially different from MotionCrafter. Its released model
+predicts full-scene 3-D point flows from RGB-D observations and robot actions
+represented as 3-D point flows. Flat'n'Fold reports 887 robot demonstrations over
+44 garments in eight categories, with three-camera RGB-D observations, camera
+calibration, Baxter action information, and point-cloud construction code.
 
-## Critical source-side representation gate
+## Representation gate: resolved at the artifact level
 
-This is the first issue that must be resolved before an adapter is authorized.
+Prob4D `PredictionWindow` v2 stores a dense `T × H × W × 3` image-grid point
+map. The released PointWorld model instead preserves `N_scene` seeded scene
+points. At the pinned PointWorld revision it:
 
-Prob4D `PredictionWindow` v2 stores a dense `T × H × W × 3` point map and, when present, a dense scene-flow field on the same grid. The released PointWorld model instead predicts over `N_scene` seeded scene points: its dynamics output is shaped `B × T × N_scene × 3`, with a heteroscedastic log-variance output shaped `B × T × N_scene × 1`.
+1. takes the first scene-point frame as `scene_coord0`;
+2. predicts `B × T × N_scene × 3` relative displacements;
+3. forms absolute positions as `scene_coord0 + displacement`; and
+4. emits `B × T × N_scene × 1` log variance.
 
-Therefore we must **not** silently reshape or nearest-neighbor rasterize PointWorld output into a Prob4D image grid. One of the following must be established using source information only:
+The source-point axis is therefore persistent within one PointWorld forecast
+window. Rasterizing it onto `H × W` would discard native identity and introduce
+an unnecessary mapping.
 
-1. a deterministic mapping from every PointWorld scene point back to a registered RGB-D grid location, preserving identity and without using future/target truth;
-2. a separately versioned sparse persistent-point provider contract in Prob4D, with explicit point identities, source lineage, dependence groups, and calibrated uncertainty semantics; or
-3. a valid negative result that this PointWorld version is not compatible with the current Prob4D claim.
+Prob4D now provides the separately versioned experimental artifact
+`PersistentPointPredictionWindow`, serialized as
+`prob4d.persistent-point-prediction-window-npz` version 1. It retains:
 
-Target-truth nearest-neighbor mapping, target-tuned interpolation, and post-outcome removal of unsupported garments are prohibited.
+- absolute output-frame indices;
+- source point-axis indices;
+- deterministic window-scoped point IDs;
+- `T × N × 3` absolute positions;
+- `T × N` validity;
+- explicit position and identity semantics; and
+- optional raw PointWorld log variance plus the exact normalization-statistics
+  SHA-256 that gives that quantity meaning.
 
-## Source-only qualification sequence
+Point IDs deliberately differ across windows. This resolves the representation
+shape without silently claiming cross-window material correspondence.
+
+PointWorld's uncertainty head is trained against normalized initial-frame-relative
+displacement. Its scalar log variance is retained as raw provider evidence and
+is **not** called metric covariance. It must not be passed directly to
+`ObservationFactor.local_covariance_m2`.
+
+The representation decision is
+`evidence/pointworld-flatnfold-source-qualification-v1/representation-decision.json`.
+Its status is
+`PERSISTENT_POINT_ARTIFACT_AUTHORIZED_PROVIDER_NOT_YET_QUALIFIED`.
+
+## Static camera and action audit
+
+The pinned source files establish some useful facts but do not yet authorize an
+executable PointWorld bridge.
+
+### PointWorld action input
+
+PointWorld consumes sampled robot surface-point positions over the complete
+horizon. Its released domain dispatch accepts only `behavior` and `droid`:
+
+- BEHAVIOR requires joint positions, joint names, base pose, and a compatible
+  robot sampler;
+- DROID requires seven Panda joint positions, gripper positions, and a compatible
+  robot sampler.
+
+### Flat'n'Fold action source
+
+The public Flat'n'Fold parser reads per-arm end-effector position, quaternion
+orientation, and binary gripper state. The repository also supplies one electric
+Baxter-gripper STL mesh. The inspected public source does not establish complete
+Baxter joint trajectories or a PointWorld-compatible Baxter robot sampler.
+
+A technically defensible source-only candidate is therefore to sample the frozen
+gripper mesh once and transform the same surface points with the two timestamped
+end-effector pose streams. That candidate must be labelled a distribution-shifted
+**dual-gripper-surface** action representation, not as equivalent to the released
+DROID or BEHAVIOR robot representation. Mesh sampling, open/closed geometry,
+coordinates, interpolation, arm identity, and source lineage must be frozen
+before target access.
+
+### Camera geometry and synchronization
+
+The published calibration text gives intrinsic tuples for front, top, and side
+cameras and separate robot-demonstration extrinsics for top and side. The merge
+script uses the robot-specific top/side extrinsics and the published front
+extrinsic.
+
+Two source limitations remain:
+
+1. the front visualization helper passes intrinsic values inconsistent with the
+   published front tuple, so that helper is not an authoritative calibration
+   implementation; and
+2. the three-camera merge script defines nearest-timestamp logic but comments out
+   its use, pairing sorted front/top/side filenames by list index instead.
+
+The dataset bytes must therefore demonstrate one-to-one timestamp association,
+a frozen maximum skew, and action-to-camera synchronization. Sorted-index pairing
+alone is not accepted.
+
+The complete static result is
+`evidence/pointworld-flatnfold-source-qualification-v1/static-source-audit.json`.
+Its status is
+`SOURCE_STATIC_AUDIT_COMPLETE_DATASET_BYTE_QUALIFICATION_REQUIRED`.
+
+## Remaining source-only qualification sequence
 
 Before provider residuals or target outcomes are opened:
 
-1. bind the exact PointWorld checkpoint SHA-256 and runtime environment;
+1. bind the exact PointWorld checkpoint SHA-256, runtime, and normalization
+   statistics SHA-256;
 2. inventory the Flat'n'Fold robot data and bind the exact byte manifest;
-3. freeze complete physical garment identities as the top-level statistical units;
-4. verify camera timestamp coverage plus intrinsic and extrinsic identities;
-5. verify that Baxter action poses can be converted to PointWorld robot point-flow actions without target state;
+3. freeze complete physical garment identities as the top-level statistical
+   units;
+4. verify three-camera timestamp coverage, one-to-one association, maximum skew,
+   and intrinsic/extrinsic identities from the dataset bytes;
+5. freeze and execute the dual-gripper-surface action conversion, or retain an
+   action-representation-negative result;
 6. verify metric coordinate transformations using released calibration only;
-7. verify PointWorld scene-point identity semantics over the ten-frame prediction horizon;
-8. resolve the representation gate above;
-9. create an outcome-blind `ProviderSupportFeasibilityV1` request with all required streams and geometry support;
+7. bind complete visual and action source lineage for every forecast frame;
+8. calibrate PointWorld uncertainty and source reliability on source/calibration
+   garments only, or retain a calibration-negative result;
+9. create an outcome-blind `ProviderSupportFeasibilityV1` request with all
+   required streams and geometry support; and
 10. stop if the support gate fails.
 
-The existing `prob4d.provider_support_feasibility` contract should be reused; no PointWorld-specific support framework is needed.
+The existing `prob4d.provider_support_feasibility` contract should be reused; no
+PointWorld-specific support framework is needed.
 
 ## Later held-out study, only after qualification passes
 
-Use complete garment identity as the independent unit. Demonstrations/sessions are nested observations; frames, pixels, and points are not independent replicates.
+Use complete garment identity as the independent unit. Demonstrations/sessions
+are nested observations; frames and points are not independent replicates.
 
 The primary provider comparison should remain small:
 
 1. raw/disjoint PointWorld;
-2. decoded uniform overlap fusion;
-3. Prob4D sequential full-joint spanning tree;
+2. uniform overlap fusion;
+3. Prob4D sequential full-joint spanning tree; and
 4. conformal-guarded full-joint graph with exact tree fallback.
 
-Useful diagnostic controls include persistence, latest-window overwrite, naive precision fusion, and the unguarded graph.
+Useful diagnostic controls include persistence, latest-window overwrite, naive
+precision fusion, and the unguarded graph.
 
-Provider endpoints should include long-horizon and terminal point/flow error, overlap seam or drift, proper score, 50/90/95% coverage, normalized NEES, covariance width, support/fallback accounting, and worst-garment performance. Inference should cluster at garment identity.
+Provider endpoints should include long-horizon and terminal point/flow error,
+overlap seam or drift, proper score, 50/90/95% coverage, normalized NEES,
+covariance width, support/fallback accounting, and worst-garment performance.
+Inference should cluster at garment identity.
 
 ## BayesianPhysTwin gate
 
 Freeze exactly one downstream physical query before target access. Compare:
 
 1. unchanged physical fallback;
-2. BayesianPhysTwin with raw PointWorld observations;
+2. BayesianPhysTwin with raw PointWorld observations; and
 3. BayesianPhysTwin with the selected Prob4D belief.
 
-Report query error/proper score, coverage and width, accepted/rejected/fallback counts, harmful accepted updates, and worst accepted regret. Rejected or unsupported observations must return the exact physical fallback.
+Report query error/proper score, coverage and width,
+accepted/rejected/unsupported/fallback counts, harmful accepted updates, and
+worst accepted regret. Rejected or unsupported observations must return the exact
+physical fallback.
 
-Provider competence and downstream value are separate conjunctive claims: neither may rescue failure of the other.
+Provider competence and downstream value are separate conjunctive claims:
+neither may rescue failure of the other.
 
 ## Causal4D boundary
 
-Do not modify the locked Causal4D physical protocol to enlarge this result. Causal4D can be described as a compatible later consumer, but the PointWorld/Flat'n'Fold study must stand on its own provider and BayesianPhysTwin evidence.
+Do not modify the locked Causal4D physical protocol to enlarge this result.
+Causal4D can be described as a compatible later consumer, but the
+PointWorld/Flat'n'Fold study must stand on its own provider and BayesianPhysTwin
+evidence.
 
 ## Completion states
 
-This source-qualification branch should close with exactly one of these outcomes:
+Source qualification closes with exactly one of these outcomes:
 
-- **authorized:** PointWorld action, coordinate, point-identity, representation, and support semantics are frozen without target outcomes, permitting a new held-out protocol version;
-- **representation-negative:** the sparse PointWorld output cannot be mapped into a defensible Prob4D observation contract without target-dependent choices;
-- **support-negative:** the required Flat'n'Fold streams/geometry do not support the frozen provider version;
-- **runtime-negative:** the exact released PointWorld checkpoint cannot execute on the frozen source inventory.
+- **authorized:** PointWorld action, coordinate, point-identity, representation,
+  calibration, lineage, and support semantics are frozen without target outcomes;
+- **action-negative:** the Flat'n'Fold Baxter records cannot be converted into a
+  defensible PointWorld robot point-flow input;
+- **support-negative:** the required Flat'n'Fold streams, synchronization, or
+  geometry do not support the frozen provider version;
+- **runtime-negative:** the exact released PointWorld checkpoint cannot execute
+  on the frozen source inventory; or
+- **calibration-negative:** the provider runs but its source-only uncertainty or
+  reliability treatment does not pass the frozen calibration gate.
 
-Any negative state is a complete result for this protocol. A later retry requires a new protocol version rather than rewriting this one.
+Any negative state is a complete result for this protocol. A later retry requires
+a new protocol version rather than rewriting this one.

--- a/evidence/pointworld-flatnfold-source-qualification-v1/action-bridge-decision.json
+++ b/evidence/pointworld-flatnfold-source-qualification-v1/action-bridge-decision.json
@@ -1,0 +1,63 @@
+{
+  "claim_boundary": "This decision establishes only the implementation and validation of a provenance-bound rigid dual-gripper surface action artifact. It does not establish correct Flat'n'Fold calibration or synchronization, executable PointWorld support, provider competence, calibrated uncertainty, Prob4D benefit, BayesianPhysTwin benefit, Causal4D benefit, or deployment safety.",
+  "decision": {
+    "artifact_schema_name": "prob4d.dual-gripper-surface-action-window-npz",
+    "artifact_schema_version": 1,
+    "dataset_action_bytes_opened": false,
+    "dataset_instantiation_authorized": false,
+    "equivalent_to_released_pointworld_domains_claimed": false,
+    "full_baxter_kinematics_claimed": false,
+    "pointworld_fields_exposed": [
+      "robot_flows",
+      "robot_normals",
+      "robot_colors",
+      "right_gripper_open",
+      "left_gripper_open",
+      "__has_right_gripper__",
+      "__has_left_gripper__"
+    ],
+    "status": "DUAL_GRIPPER_ACTION_ARTIFACT_IMPLEMENTED_DATASET_INSTANTIATION_NOT_AUTHORIZED"
+  },
+  "implemented_semantics": {
+    "arm_order": [
+      "right",
+      "left"
+    ],
+    "colors": "constant-magenta-v1",
+    "coordinate_semantics": "metric-world-frame-v1",
+    "gripper_state": "binary-right-left-feature-v1",
+    "point_identity": "template-calibration-arm-index-hash-v1",
+    "pose_quaternion_order": "wxyz",
+    "quaternion_policy": "normalize-finite-nonzero-v1",
+    "template_support": "fixed-equal-count-rigid-surface-points-per-arm-v1"
+  },
+  "information_boundary": {
+    "bayesian_phystwin_innovations_used": false,
+    "causal4d_outcomes_used": false,
+    "prediction_payloads_opened": false,
+    "provider_residuals_used": false,
+    "target_outcomes_opened": false
+  },
+  "protocol_id": "prob4d-pointworld-flatnfold-source-qualification-v1",
+  "provenance_bindings": [
+    "sampled gripper template SHA-256",
+    "tracker-to-template calibration SHA-256",
+    "pose-stream manifest SHA-256",
+    "timestamp-association SHA-256",
+    "absolute output frame indices"
+  ],
+  "schema_name": "prob4d.pointworld-flatnfold-action-bridge-decision",
+  "schema_version": 1,
+  "source_revision": "f2ce63dd60aced4f2888985b9d1df0363b2d2fca",
+  "unresolved_before_dataset_instantiation": [
+    "exact Flat'n'Fold gripper mesh sampling report",
+    "right and left tracker-to-template transforms",
+    "exact pose and gripper-state byte manifests",
+    "camera/action one-to-one timestamp association and maximum skew",
+    "metric frame verification",
+    "technical-failure and missing-frame policy",
+    "PointWorld checkpoint/runtime execution with the gripper-only representation",
+    "source-only embodiment-shift competence gate"
+  ],
+  "action_bridge_decision_id": "432549ed44b395a0f7c82194a95ce00ac27776ad31cdc6ae3cdb06b519a443bd"
+}

--- a/evidence/pointworld-flatnfold-source-qualification-v1/representation-decision.json
+++ b/evidence/pointworld-flatnfold-source-qualification-v1/representation-decision.json
@@ -1,0 +1,51 @@
+{
+  "claim_boundary": "This decision resolves only the source-code representation mismatch. It does not establish executable provider support, PointWorld competence, calibrated uncertainty, Prob4D benefit, BayesianPhysTwin benefit, Causal4D benefit, or deployment safety.",
+  "decision": {
+    "artifact_schema_name": "prob4d.persistent-point-prediction-window-npz",
+    "artifact_schema_version": 1,
+    "cross_window_identity_claimed": false,
+    "dense_rasterization_required": false,
+    "rationale": "PointWorld predicts the positions of one seeded scene-point axis over the complete forecast window; preserving that axis is lossless and avoids target-dependent rasterization.",
+    "reported_log_variance_promoted_to_metric_covariance": false,
+    "selected_resolution_path": "separately versioned sparse persistent-point provider artifact",
+    "status": "PERSISTENT_POINT_ARTIFACT_AUTHORIZED_PROVIDER_NOT_YET_QUALIFIED"
+  },
+  "decision_scope": "SOURCE_CODE_REPRESENTATION_ONLY",
+  "information_boundary": {
+    "bayesian_phystwin_innovations_used": false,
+    "causal4d_outcomes_used": false,
+    "prediction_payloads_opened": false,
+    "provider_residuals_used": false,
+    "target_outcomes_opened": false
+  },
+  "observed_pointworld_contract": {
+    "absolute_position_construction": "out['scene_flows'] = scene_coord0.unsqueeze(1) + pred",
+    "initial_scene_axis": "scene_coord0 = data_dict['scene_flows'][:, 0]",
+    "relative_prediction_shape": "B,T,N_scene,3",
+    "reported_log_variance_shape": "B,T,N_scene,1",
+    "reported_uncertainty_training_target": "normalized initial-frame-relative displacement",
+    "source_file": "pointworld/base.py",
+    "within_window_point_identity": "persistent source point-axis index"
+  },
+  "protocol_id": "prob4d-pointworld-flatnfold-source-qualification-v1",
+  "representation_decision_id": "7eb476111b038fe88b344002dd83e5cf910c20ec4d6da5200d52ea8c678cbfe6",
+  "schema_name": "prob4d.pointworld-representation-decision",
+  "schema_version": 1,
+  "source_revisions": {
+    "bayesian_phystwin": "b5f07d649ac2cd7dc6ca1aceb4004ff4803bddc8",
+    "flatnfold": "fa0d3d17ac827e7b5c43ec1ef7c0c38ad5e39340",
+    "pointworld": "05484826dfef74cbe278a3974179a5a16705d35d",
+    "prob4d": "8d275a6352dd606e79d06b1508c67854ebd06a29"
+  },
+  "unresolved_before_provider_authorization": [
+    "exact PointWorld checkpoint SHA-256",
+    "exact PointWorld runtime and normalization-statistics SHA-256",
+    "Flat'n'Fold dataset-byte manifest and complete garment roster",
+    "three-camera timestamp, intrinsic, and extrinsic support",
+    "Baxter action-to-robot-point-flow conversion",
+    "metric coordinate transformation",
+    "visual and action source lineage",
+    "source-only uncertainty and reliability calibration",
+    "outcome-blind ProviderSupportFeasibilityV1 result"
+  ]
+}

--- a/evidence/pointworld-flatnfold-source-qualification-v1/static-source-audit.json
+++ b/evidence/pointworld-flatnfold-source-qualification-v1/static-source-audit.json
@@ -1,0 +1,92 @@
+{
+  "authorized_path": {
+    "action_candidate": "dual-gripper-surface-points-from-frozen-mesh-and-pose-v1",
+    "conditions": [
+      "Use the exact gripper mesh bytes and two timestamped end-effector pose streams.",
+      "Freeze mesh sampling, gripper-state geometry, coordinate transforms, and all interpolation rules on source data only.",
+      "Retain the resulting PointWorld input as a distribution-shifted adapter; do not call it equivalent to the released DROID or BEHAVIOR robot representation.",
+      "Require exact source lineage for every forecast frame.",
+      "Stop before target access if complete camera/action synchronization cannot be demonstrated from dataset bytes."
+    ],
+    "representation_artifact": "prob4d.persistent-point-prediction-window-npz-v1"
+  },
+  "claim_boundary": "This source-only audit records representation and input-contract facts from pinned public source files. It does not establish executable dataset support, PointWorld competence, calibrated uncertainty, Prob4D benefit, BayesianPhysTwin benefit, Causal4D benefit, or deployment safety.",
+  "decision": {
+    "action_bridge_implemented": false,
+    "camera_geometry_verified_on_dataset_bytes": false,
+    "provider_support_feasibility_authorized": false,
+    "representation_gate_resolved": true,
+    "status": "SOURCE_STATIC_AUDIT_COMPLETE_DATASET_BYTE_QUALIFICATION_REQUIRED",
+    "timestamp_alignment_verified_on_dataset_bytes": false
+  },
+  "information_boundary": {
+    "bayesian_phystwin_innovations_used": false,
+    "causal4d_outcomes_used": false,
+    "prediction_payloads_opened": false,
+    "provider_residuals_used": false,
+    "target_outcomes_opened": false
+  },
+  "observations": {
+    "camera_geometry": [
+      "The published text provides three intrinsic tuples and robot-specific top/side extrinsics.",
+      "The merge script uses the robot-specific top/side extrinsics and the published front extrinsic.",
+      "The front visualization helper passes values inconsistent with the published front intrinsic tuple; it is not accepted as an authoritative calibration implementation."
+    ],
+    "flatnfold_action_source": [
+      "The public parser reads per-arm end-effector position, quaternion orientation, and binary gripper state.",
+      "The repository provides one electric-gripper STL mesh.",
+      "The repository source inspected here does not establish complete Baxter joint trajectories or a PointWorld-compatible Baxter robot sampler."
+    ],
+    "pointworld_action_input": [
+      "PointWorld consumes sampled robot surface-point positions over the complete horizon.",
+      "Released domain conversion dispatch accepts only behavior and droid.",
+      "Behavior conversion requires joint positions, joint names, base pose, and a compatible robot sampler.",
+      "DROID conversion requires seven Panda joint positions, gripper positions, and a compatible robot sampler."
+    ],
+    "temporal_alignment": [
+      "The three-camera merge script contains nearest-timestamp logic but comments out its use.",
+      "The executed loop pairs sorted front, top, and side filenames by list index.",
+      "No maximum inter-camera skew, one-to-one timestamp audit, or action-to-camera synchronization rule is established by the inspected source."
+    ]
+  },
+  "protocol_id": "prob4d-pointworld-flatnfold-source-qualification-v1",
+  "schema_name": "prob4d.pointworld-flatnfold-static-source-audit",
+  "schema_version": 1,
+  "source_files": {
+    "flatnfold_action_visualization": {
+      "blob_sha": "7e832694906d6e6199a4d6f8b396838ca8f82167",
+      "path": "Pointcloud/pointcloud_convert_match.py"
+    },
+    "flatnfold_camera_parameters": {
+      "blob_sha": "006ad0e8018c056b044931bbd787334c31538842",
+      "path": "Hardware/Camera parameter.txt"
+    },
+    "flatnfold_gripper_mesh": {
+      "blob_sha": "7b49b6ebc806b3df98b6451ff6c0d0202f832b17",
+      "path": "Hardware/electric_gripper_w_fingers.STL"
+    },
+    "flatnfold_pointcloud_merge": {
+      "blob_sha": "f71b38411767a75c7d9d2a1baab8891a480ca708",
+      "path": "Pointcloud/pointcloud_merge_threecamera.py"
+    },
+    "pointworld_model": {
+      "blob_sha": "a83cca41e41fd3736cd03909dc8397714dbc2368",
+      "path": "pointworld/base.py"
+    },
+    "pointworld_robot_adapter": {
+      "blob_sha": "2922cb769d944deaa4093d909931ae9007dcdec7",
+      "path": "dataset_components/robot.py"
+    },
+    "pointworld_uncertainty_loss": {
+      "blob_sha": "7c9e17e707471ea21b32e8f41ed961a22f58e8ba",
+      "path": "pointworld/losses.py"
+    }
+  },
+  "source_revisions": {
+    "bayesian_phystwin": "b5f07d649ac2cd7dc6ca1aceb4004ff4803bddc8",
+    "flatnfold": "fa0d3d17ac827e7b5c43ec1ef7c0c38ad5e39340",
+    "pointworld": "05484826dfef74cbe278a3974179a5a16705d35d",
+    "prob4d": "5d0fd7c9191075c05e4f08620aa1ff01cda02a44"
+  },
+  "static_source_audit_id": "68c988a8dbc7dd1d73c2b65031ddadf106ce6385159cfee1ba427cb724b75e99"
+}

--- a/src/prob4d/dual_gripper_surface_action.py
+++ b/src/prob4d/dual_gripper_surface_action.py
@@ -1,0 +1,612 @@
+"""Rigid dual-gripper surface trajectories for action-conditioned providers.
+
+Flat'n'Fold exposes two end-effector pose streams and one gripper mesh, whereas
+PointWorld consumes sampled robot surface-point trajectories. This module
+provides a strict additive bridge between those representations without claiming
+that a gripper-only Baxter representation is equivalent to PointWorld's released
+DROID or BEHAVIOR robot inputs.
+
+The caller owns mesh loading and deterministic surface sampling. Prob4D binds the
+resulting template, tracker calibration, pose stream, and timestamp association
+by SHA-256 before transforming the fixed surface points through time.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final, Literal, TypeAlias, cast
+
+import numpy as np
+from numpy.typing import NDArray
+
+FloatArray: TypeAlias = NDArray[np.floating[Any]]
+BoolArray: TypeAlias = NDArray[np.bool_]
+IntArray: TypeAlias = NDArray[np.integer[Any]]
+StorageDType = Literal["float32", "float64"]
+
+DUAL_GRIPPER_ACTION_NPZ_SCHEMA: Final = (
+    "prob4d.dual-gripper-surface-action-window-npz"
+)
+DUAL_GRIPPER_ACTION_NPZ_VERSION: Final = 1
+DUAL_GRIPPER_ACTION_STORAGE_DTYPES: Final[tuple[StorageDType, ...]] = (
+    "float32",
+    "float64",
+)
+DUAL_GRIPPER_ACTION_SEMANTICS: Final = (
+    "dual-rigid-gripper-surface-points-from-wxyz-tracker-poses-v1"
+)
+DUAL_GRIPPER_POINT_IDENTITY_SEMANTICS: Final = (
+    "arm-template-calibration-scoped-surface-point-hash-v1"
+)
+DUAL_GRIPPER_COORDINATE_SEMANTICS: Final = "metric-world-frame-v1"
+DUAL_GRIPPER_ARM_ORDER: Final[tuple[str, str]] = ("right", "left")
+
+_REQUIRED_MEMBERS: Final = frozenset(
+    {
+        "schema_name",
+        "schema_version",
+        "storage_dtype",
+        "action_id",
+        "frame_indices",
+        "point_ids",
+        "template_point_indices",
+        "arm_ids",
+        "robot_positions",
+        "robot_normals",
+        "robot_colors",
+        "robot_exists",
+        "gripper_open",
+        "template_id",
+        "tracker_calibration_id",
+        "pose_stream_id",
+        "timestamp_association_id",
+        "action_semantics",
+        "point_identity_semantics",
+        "coordinate_semantics",
+    }
+)
+
+
+def _readonly(value: np.ndarray) -> np.ndarray:
+    result = np.array(value, copy=True)
+    result.setflags(write=False)
+    return result
+
+
+def _strict_text(value: Any, *, name: str) -> str:
+    if type(value) is not str or not value:
+        raise TypeError(f"{name} must be one nonempty literal string")
+    return value
+
+
+def _strict_sha256(value: Any, *, name: str) -> str:
+    result = _strict_text(value, name=name)
+    if len(result) != 64 or result != result.lower():
+        raise ValueError(f"{name} must be one lowercase SHA-256 digest")
+    try:
+        decoded = bytes.fromhex(result)
+    except ValueError as error:
+        raise ValueError(f"{name} must be one lowercase SHA-256 digest") from error
+    if len(decoded) != 32:
+        raise ValueError(f"{name} must be one lowercase SHA-256 digest")
+    return result
+
+
+def _storage_dtype(value: Any) -> StorageDType:
+    normalized = str(value)
+    if normalized not in DUAL_GRIPPER_ACTION_STORAGE_DTYPES:
+        raise ValueError(
+            "storage_dtype must be one of "
+            + ", ".join(DUAL_GRIPPER_ACTION_STORAGE_DTYPES)
+        )
+    return cast(StorageDType, normalized)
+
+
+def _numpy_dtype(value: StorageDType) -> np.dtype[Any]:
+    return np.dtype(np.float32 if value == "float32" else np.float64)
+
+
+def _scalar_text(value: np.ndarray, *, name: str) -> str:
+    if value.shape != () or value.dtype.kind not in {"U", "S"}:
+        raise ValueError(f"{name} must be one scalar string")
+    return _strict_text(str(value.item()), name=name)
+
+
+def _scalar_integer(value: np.ndarray, *, name: str) -> int:
+    if value.shape != () or value.dtype.kind not in {"i", "u"}:
+        raise ValueError(f"{name} must be one scalar integer")
+    return int(value.item())
+
+
+def _integer_vector(value: Any, *, name: str, nonempty: bool) -> np.ndarray:
+    raw = np.asarray(value)
+    if raw.ndim != 1:
+        raise ValueError(f"{name} must be one vector")
+    if nonempty and raw.size == 0:
+        raise ValueError(f"{name} must not be empty")
+    if raw.dtype.kind not in {"i", "u"}:
+        raise TypeError(f"{name} must contain genuine integers")
+    if raw.dtype.kind == "u" and raw.size and int(np.max(raw)) > np.iinfo(np.int64).max:
+        raise ValueError(f"{name} values must fit in int64")
+    result = np.asarray(raw, dtype=np.int64)
+    if np.any(result < 0):
+        raise ValueError(f"{name} must be nonnegative")
+    return result
+
+
+def _unit_normals(value: Any, *, name: str, dtype: np.dtype[Any]) -> np.ndarray:
+    result = np.asarray(value, dtype=dtype).copy()
+    if result.ndim != 3 or result.shape[0] != 2 or result.shape[-1] != 3:
+        raise ValueError(f"{name} must have shape (2, M, 3)")
+    if result.shape[1] == 0:
+        raise ValueError(f"{name} must contain at least one point per arm")
+    if not np.all(np.isfinite(result)):
+        raise ValueError(f"{name} must be finite")
+    norms = np.linalg.norm(result, axis=-1, keepdims=True)
+    if np.any(norms <= np.finfo(np.float64).eps):
+        raise ValueError(f"{name} entries must be nonzero")
+    result /= norms
+    return result
+
+
+def _rotation_matrices_from_wxyz(value: Any, *, dtype: np.dtype[Any]) -> np.ndarray:
+    quaternions = np.asarray(value, dtype=dtype).copy()
+    if quaternions.ndim != 3 or quaternions.shape[1:] != (2, 4):
+        raise ValueError("quaternions_world_from_tracker_wxyz must have shape (T, 2, 4)")
+    if not np.all(np.isfinite(quaternions)):
+        raise ValueError("quaternions_world_from_tracker_wxyz must be finite")
+    norms = np.linalg.norm(quaternions, axis=-1, keepdims=True)
+    if np.any(norms <= np.finfo(np.float64).eps):
+        raise ValueError("quaternions_world_from_tracker_wxyz must be nonzero")
+    quaternions /= norms
+
+    w = quaternions[..., 0]
+    x = quaternions[..., 1]
+    y = quaternions[..., 2]
+    z = quaternions[..., 3]
+    matrices = np.empty((*quaternions.shape[:2], 3, 3), dtype=dtype)
+    matrices[..., 0, 0] = 1.0 - 2.0 * (y * y + z * z)
+    matrices[..., 0, 1] = 2.0 * (x * y - z * w)
+    matrices[..., 0, 2] = 2.0 * (x * z + y * w)
+    matrices[..., 1, 0] = 2.0 * (x * y + z * w)
+    matrices[..., 1, 1] = 1.0 - 2.0 * (x * x + z * z)
+    matrices[..., 1, 2] = 2.0 * (y * z - x * w)
+    matrices[..., 2, 0] = 2.0 * (x * z - y * w)
+    matrices[..., 2, 1] = 2.0 * (y * z + x * w)
+    matrices[..., 2, 2] = 1.0 - 2.0 * (x * x + y * y)
+    return matrices
+
+
+def _surface_point_ids(
+    template_id: str,
+    tracker_calibration_id: str,
+    points_per_arm: int,
+) -> np.ndarray:
+    point_ids = np.empty(2 * points_per_arm, dtype=np.int64)
+    for arm_id, arm_name in enumerate(DUAL_GRIPPER_ARM_ORDER):
+        for source_index in range(points_per_arm):
+            payload = (
+                f"{template_id}\x00{tracker_calibration_id}\x00"
+                f"{arm_name}\x00{source_index}"
+            ).encode()
+            digest = hashlib.sha256(payload).digest()
+            point_ids[arm_id * points_per_arm + source_index] = (
+                int.from_bytes(digest[:8]) & ((1 << 63) - 1)
+            )
+    if len(np.unique(point_ids)) != len(point_ids):
+        raise ValueError("dual-gripper surface point identity collision")
+    return point_ids
+
+
+@dataclass(frozen=True, slots=True)
+class DualGripperSurfaceActionWindow:
+    """One bimanual rigid-surface action trajectory.
+
+    Arm order is always right then left to match PointWorld's bimanual feature
+    allocation. Surface identity is stable across action windows only when the
+    exact template and tracker-calibration IDs match.
+    """
+
+    action_id: str
+    frame_indices: IntArray
+    point_ids: IntArray
+    template_point_indices: IntArray
+    arm_ids: IntArray
+    robot_positions: FloatArray
+    robot_normals: FloatArray
+    robot_colors: FloatArray
+    robot_exists: BoolArray
+    gripper_open: BoolArray
+    template_id: str
+    tracker_calibration_id: str
+    pose_stream_id: str
+    timestamp_association_id: str
+    action_semantics: str = DUAL_GRIPPER_ACTION_SEMANTICS
+    point_identity_semantics: str = DUAL_GRIPPER_POINT_IDENTITY_SEMANTICS
+    coordinate_semantics: str = DUAL_GRIPPER_COORDINATE_SEMANTICS
+    storage_dtype: StorageDType = "float32"
+
+    def __post_init__(self) -> None:
+        action_id = _strict_text(self.action_id, name="action_id")
+        storage_dtype = _storage_dtype(self.storage_dtype)
+        dtype = _numpy_dtype(storage_dtype)
+        frame_indices = _integer_vector(
+            self.frame_indices,
+            name="frame_indices",
+            nonempty=True,
+        )
+        if np.any(np.diff(frame_indices) <= 0):
+            raise ValueError("frame_indices must be strictly increasing")
+        point_ids = _integer_vector(self.point_ids, name="point_ids", nonempty=True)
+        template_indices = _integer_vector(
+            self.template_point_indices,
+            name="template_point_indices",
+            nonempty=True,
+        )
+        arm_ids = _integer_vector(self.arm_ids, name="arm_ids", nonempty=True)
+        point_count = len(point_ids)
+        if len(template_indices) != point_count or len(arm_ids) != point_count:
+            raise ValueError("point IDs, template indices, and arm IDs must align")
+        if len(np.unique(point_ids)) != point_count:
+            raise ValueError("point_ids must be unique")
+        if set(np.unique(arm_ids)) != {0, 1}:
+            raise ValueError("arm_ids must contain both right=0 and left=1")
+        right_count = int(np.sum(arm_ids == 0))
+        left_count = int(np.sum(arm_ids == 1))
+        if right_count != left_count:
+            raise ValueError("right and left arms must retain equal template support")
+        if not np.array_equal(
+            template_indices[:right_count],
+            np.arange(right_count, dtype=np.int64),
+        ) or not np.array_equal(
+            template_indices[right_count:],
+            np.arange(left_count, dtype=np.int64),
+        ):
+            raise ValueError("template_point_indices must be canonical within each arm")
+        if not np.all(arm_ids[:right_count] == 0) or not np.all(arm_ids[right_count:] == 1):
+            raise ValueError("point order must be right arm followed by left arm")
+
+        expected = (len(frame_indices), point_count)
+        positions = np.asarray(self.robot_positions, dtype=dtype).copy()
+        normals = np.asarray(self.robot_normals, dtype=dtype).copy()
+        colors = np.asarray(self.robot_colors, dtype=dtype).copy()
+        if positions.shape != (*expected, 3):
+            raise ValueError("robot_positions must have shape (T, N, 3)")
+        if normals.shape != positions.shape:
+            raise ValueError("robot_normals must match robot_positions")
+        if colors.shape != positions.shape:
+            raise ValueError("robot_colors must match robot_positions")
+        if not np.all(np.isfinite(positions)):
+            raise ValueError("robot_positions must be finite")
+        if not np.all(np.isfinite(normals)):
+            raise ValueError("robot_normals must be finite")
+        normal_norms = np.linalg.norm(normals, axis=-1, keepdims=True)
+        if np.any(normal_norms <= np.finfo(np.float64).eps):
+            raise ValueError("robot_normals must be nonzero")
+        normals /= normal_norms
+        if not np.all(np.isfinite(colors)) or np.any((colors < 0.0) | (colors > 1.0)):
+            raise ValueError("robot_colors must be finite and lie in [0, 1]")
+
+        raw_exists = np.asarray(self.robot_exists)
+        raw_open = np.asarray(self.gripper_open)
+        if raw_exists.dtype != np.dtype(bool) or raw_exists.shape != expected:
+            raise TypeError("robot_exists must be bool with shape (T, N)")
+        if raw_open.dtype != np.dtype(bool) or raw_open.shape != (len(frame_indices), 2):
+            raise TypeError("gripper_open must be bool with shape (T, 2)")
+        if not np.all(raw_exists):
+            raise ValueError("version 1 requires complete rigid-template support")
+
+        object.__setattr__(self, "action_id", action_id)
+        object.__setattr__(self, "storage_dtype", storage_dtype)
+        object.__setattr__(
+            self,
+            "template_id",
+            _strict_sha256(self.template_id, name="template_id"),
+        )
+        object.__setattr__(
+            self,
+            "tracker_calibration_id",
+            _strict_sha256(
+                self.tracker_calibration_id,
+                name="tracker_calibration_id",
+            ),
+        )
+        object.__setattr__(
+            self,
+            "pose_stream_id",
+            _strict_sha256(self.pose_stream_id, name="pose_stream_id"),
+        )
+        object.__setattr__(
+            self,
+            "timestamp_association_id",
+            _strict_sha256(
+                self.timestamp_association_id,
+                name="timestamp_association_id",
+            ),
+        )
+        for field_name in (
+            "action_semantics",
+            "point_identity_semantics",
+            "coordinate_semantics",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _strict_text(getattr(self, field_name), name=field_name),
+            )
+        object.__setattr__(self, "frame_indices", _readonly(frame_indices))
+        object.__setattr__(self, "point_ids", _readonly(point_ids))
+        object.__setattr__(
+            self,
+            "template_point_indices",
+            _readonly(template_indices),
+        )
+        object.__setattr__(self, "arm_ids", _readonly(arm_ids))
+        object.__setattr__(self, "robot_positions", _readonly(positions))
+        object.__setattr__(self, "robot_normals", _readonly(normals))
+        object.__setattr__(self, "robot_colors", _readonly(colors))
+        object.__setattr__(self, "robot_exists", _readonly(raw_exists))
+        object.__setattr__(self, "gripper_open", _readonly(raw_open))
+
+    @property
+    def frame_count(self) -> int:
+        return len(self.frame_indices)
+
+    @property
+    def point_count(self) -> int:
+        return len(self.point_ids)
+
+    @property
+    def points_per_arm(self) -> int:
+        return self.point_count // 2
+
+    def pointworld_sample(self) -> dict[str, object]:
+        """Return the released PointWorld sample fields owned by this artifact."""
+
+        return {
+            "robot_flows": np.array(self.robot_positions, copy=True),
+            "robot_normals": np.array(self.robot_normals, copy=True),
+            "robot_colors": np.array(self.robot_colors, copy=True),
+            "right_gripper_open": np.asarray(
+                self.gripper_open[:, 0:1],
+                dtype=np.float32,
+            ),
+            "left_gripper_open": np.asarray(
+                self.gripper_open[:, 1:2],
+                dtype=np.float32,
+            ),
+            "__has_right_gripper__": True,
+            "__has_left_gripper__": True,
+        }
+
+    def to_npz(
+        self,
+        path: str | Path,
+        *,
+        storage_dtype: StorageDType | None = None,
+    ) -> None:
+        selected_dtype = (
+            self.storage_dtype
+            if storage_dtype is None
+            else _storage_dtype(storage_dtype)
+        )
+        dtype = _numpy_dtype(selected_dtype)
+        np.savez_compressed(
+            Path(path),
+            schema_name=np.asarray(DUAL_GRIPPER_ACTION_NPZ_SCHEMA),
+            schema_version=np.asarray(DUAL_GRIPPER_ACTION_NPZ_VERSION, dtype=np.int64),
+            storage_dtype=np.asarray(selected_dtype),
+            action_id=np.asarray(self.action_id),
+            frame_indices=np.asarray(self.frame_indices, dtype=np.int64),
+            point_ids=np.asarray(self.point_ids, dtype=np.int64),
+            template_point_indices=np.asarray(
+                self.template_point_indices,
+                dtype=np.int64,
+            ),
+            arm_ids=np.asarray(self.arm_ids, dtype=np.int64),
+            robot_positions=np.asarray(self.robot_positions, dtype=dtype),
+            robot_normals=np.asarray(self.robot_normals, dtype=dtype),
+            robot_colors=np.asarray(self.robot_colors, dtype=dtype),
+            robot_exists=np.asarray(self.robot_exists, dtype=bool),
+            gripper_open=np.asarray(self.gripper_open, dtype=bool),
+            template_id=np.asarray(self.template_id),
+            tracker_calibration_id=np.asarray(self.tracker_calibration_id),
+            pose_stream_id=np.asarray(self.pose_stream_id),
+            timestamp_association_id=np.asarray(self.timestamp_association_id),
+            action_semantics=np.asarray(self.action_semantics),
+            point_identity_semantics=np.asarray(self.point_identity_semantics),
+            coordinate_semantics=np.asarray(self.coordinate_semantics),
+        )
+
+    @classmethod
+    def from_npz(cls, path: str | Path) -> DualGripperSurfaceActionWindow:
+        with np.load(Path(path), allow_pickle=False) as data:
+            files = set(data.files)
+            missing = sorted(_REQUIRED_MEMBERS - files)
+            extra = sorted(files - _REQUIRED_MEMBERS)
+            if missing or extra:
+                raise ValueError(
+                    "dual-gripper action archive fields changed; "
+                    f"missing={missing}, extra={extra}"
+                )
+            schema = _scalar_text(data["schema_name"], name="schema_name")
+            version = _scalar_integer(data["schema_version"], name="schema_version")
+            if schema != DUAL_GRIPPER_ACTION_NPZ_SCHEMA:
+                raise ValueError("unsupported dual-gripper action archive schema")
+            if version != DUAL_GRIPPER_ACTION_NPZ_VERSION:
+                raise ValueError("unsupported dual-gripper action archive version")
+            storage_dtype = _storage_dtype(
+                _scalar_text(data["storage_dtype"], name="storage_dtype")
+            )
+            expected_dtype = _numpy_dtype(storage_dtype)
+            for field in ("robot_positions", "robot_normals", "robot_colors"):
+                if data[field].dtype != expected_dtype:
+                    raise ValueError(f"{field} dtype disagrees with storage_dtype")
+            for field in (
+                "frame_indices",
+                "point_ids",
+                "template_point_indices",
+                "arm_ids",
+            ):
+                if data[field].dtype != np.dtype(np.int64):
+                    raise ValueError(f"{field} must use int64")
+            for field in ("robot_exists", "gripper_open"):
+                if data[field].dtype != np.dtype(bool):
+                    raise ValueError(f"{field} must use bool")
+
+            return cls(
+                action_id=_scalar_text(data["action_id"], name="action_id"),
+                frame_indices=data["frame_indices"],
+                point_ids=data["point_ids"],
+                template_point_indices=data["template_point_indices"],
+                arm_ids=data["arm_ids"],
+                robot_positions=data["robot_positions"],
+                robot_normals=data["robot_normals"],
+                robot_colors=data["robot_colors"],
+                robot_exists=data["robot_exists"],
+                gripper_open=data["gripper_open"],
+                template_id=_scalar_text(data["template_id"], name="template_id"),
+                tracker_calibration_id=_scalar_text(
+                    data["tracker_calibration_id"],
+                    name="tracker_calibration_id",
+                ),
+                pose_stream_id=_scalar_text(
+                    data["pose_stream_id"],
+                    name="pose_stream_id",
+                ),
+                timestamp_association_id=_scalar_text(
+                    data["timestamp_association_id"],
+                    name="timestamp_association_id",
+                ),
+                action_semantics=_scalar_text(
+                    data["action_semantics"],
+                    name="action_semantics",
+                ),
+                point_identity_semantics=_scalar_text(
+                    data["point_identity_semantics"],
+                    name="point_identity_semantics",
+                ),
+                coordinate_semantics=_scalar_text(
+                    data["coordinate_semantics"],
+                    name="coordinate_semantics",
+                ),
+                storage_dtype=storage_dtype,
+            )
+
+
+def dual_gripper_surface_action_from_tracker_poses(
+    *,
+    action_id: str,
+    frame_indices: Any,
+    surface_points_tracker: Any,
+    surface_normals_tracker: Any,
+    positions_world_from_tracker: Any,
+    quaternions_world_from_tracker_wxyz: Any,
+    gripper_open: Any,
+    template_id: str,
+    tracker_calibration_id: str,
+    pose_stream_id: str,
+    timestamp_association_id: str,
+    storage_dtype: StorageDType = "float32",
+) -> DualGripperSurfaceActionWindow:
+    """Transform fixed right/left gripper templates through timestamped poses.
+
+    ``surface_points_tracker`` and ``surface_normals_tracker`` use shape
+    ``(2, M, 3)`` in right-then-left tracker frames. Quaternions use Flat'n'Fold's
+    documented parser order ``[w, x, y, z]`` and are deterministically normalized
+    before use, accommodating the public parser's three-decimal rounding.
+    """
+
+    selected_dtype = _storage_dtype(storage_dtype)
+    dtype = _numpy_dtype(selected_dtype)
+    frames = _integer_vector(frame_indices, name="frame_indices", nonempty=True)
+    if np.any(np.diff(frames) <= 0):
+        raise ValueError("frame_indices must be strictly increasing")
+    template = np.asarray(surface_points_tracker, dtype=dtype).copy()
+    if template.ndim != 3 or template.shape[0] != 2 or template.shape[-1] != 3:
+        raise ValueError("surface_points_tracker must have shape (2, M, 3)")
+    if template.shape[1] == 0 or not np.all(np.isfinite(template)):
+        raise ValueError("surface_points_tracker must be finite and nonempty")
+    template_normals = _unit_normals(
+        surface_normals_tracker,
+        name="surface_normals_tracker",
+        dtype=dtype,
+    )
+    if template_normals.shape != template.shape:
+        raise ValueError("surface points and normals must align")
+
+    translations = np.asarray(positions_world_from_tracker, dtype=dtype).copy()
+    if translations.shape != (len(frames), 2, 3):
+        raise ValueError("positions_world_from_tracker must have shape (T, 2, 3)")
+    if not np.all(np.isfinite(translations)):
+        raise ValueError("positions_world_from_tracker must be finite")
+    rotations = _rotation_matrices_from_wxyz(
+        quaternions_world_from_tracker_wxyz,
+        dtype=dtype,
+    )
+    if rotations.shape[:2] != translations.shape[:2]:
+        raise ValueError("quaternion and translation trajectories must align")
+    raw_open = np.asarray(gripper_open)
+    if raw_open.dtype != np.dtype(bool) or raw_open.shape != (len(frames), 2):
+        raise TypeError("gripper_open must be bool with shape (T, 2)")
+
+    transformed_points = np.einsum("taij,amj->tami", rotations, template)
+    transformed_points += translations[:, :, None, :]
+    transformed_normals = np.einsum("taij,amj->tami", rotations, template_normals)
+    transformed_normals /= np.linalg.norm(
+        transformed_normals,
+        axis=-1,
+        keepdims=True,
+    )
+    points_per_arm = template.shape[1]
+    robot_positions = transformed_points.reshape(len(frames), 2 * points_per_arm, 3)
+    robot_normals = transformed_normals.reshape(len(frames), 2 * points_per_arm, 3)
+    robot_colors = np.empty_like(robot_positions)
+    robot_colors[..., 0] = 1.0
+    robot_colors[..., 1] = 0.0
+    robot_colors[..., 2] = 1.0
+    point_ids = _surface_point_ids(
+        _strict_sha256(template_id, name="template_id"),
+        _strict_sha256(
+            tracker_calibration_id,
+            name="tracker_calibration_id",
+        ),
+        points_per_arm,
+    )
+    template_indices = np.tile(
+        np.arange(points_per_arm, dtype=np.int64),
+        2,
+    )
+    arm_ids = np.repeat(np.arange(2, dtype=np.int64), points_per_arm)
+
+    return DualGripperSurfaceActionWindow(
+        action_id=action_id,
+        frame_indices=frames,
+        point_ids=point_ids,
+        template_point_indices=template_indices,
+        arm_ids=arm_ids,
+        robot_positions=robot_positions,
+        robot_normals=robot_normals,
+        robot_colors=robot_colors,
+        robot_exists=np.ones((len(frames), 2 * points_per_arm), dtype=bool),
+        gripper_open=raw_open,
+        template_id=template_id,
+        tracker_calibration_id=tracker_calibration_id,
+        pose_stream_id=pose_stream_id,
+        timestamp_association_id=timestamp_association_id,
+        storage_dtype=selected_dtype,
+    )
+
+
+__all__ = [
+    "DUAL_GRIPPER_ACTION_NPZ_SCHEMA",
+    "DUAL_GRIPPER_ACTION_NPZ_VERSION",
+    "DUAL_GRIPPER_ACTION_SEMANTICS",
+    "DUAL_GRIPPER_ARM_ORDER",
+    "DUAL_GRIPPER_COORDINATE_SEMANTICS",
+    "DUAL_GRIPPER_POINT_IDENTITY_SEMANTICS",
+    "DualGripperSurfaceActionWindow",
+    "dual_gripper_surface_action_from_tracker_poses",
+]

--- a/src/prob4d/persistent_point_prediction.py
+++ b/src/prob4d/persistent_point_prediction.py
@@ -156,7 +156,7 @@ def window_scoped_point_ids(
     for position, source_index in enumerate(source_indices):
         payload = f"{identifier}\x00{int(source_index)}".encode("utf-8")
         digest = hashlib.sha256(payload).digest()
-        point_ids[position] = int.from_bytes(digest[:8], "big") & ((1 << 63) - 1)
+        point_ids[position] = int.from_bytes(digest[:8]) & ((1 << 63) - 1)
     if len(np.unique(point_ids)) != len(point_ids):
         raise ValueError("window-scoped point identity collision")
     return cast(IntArray, _readonly(point_ids))

--- a/src/prob4d/persistent_point_prediction.py
+++ b/src/prob4d/persistent_point_prediction.py
@@ -1,0 +1,545 @@
+"""Versioned persistent-point prediction windows for sparse 4-D providers.
+
+The dense :class:`prob4d.data.PredictionWindow` contract is intentionally tied to
+an image-grid point map. Action-conditioned point-world models instead retain a
+fixed scene-point axis and predict the positions of those seeded points over a
+future horizon. This module preserves that representation without rasterizing it
+onto a target-dependent image grid.
+
+Provider-reported log variance is retained as an explicitly uncalibrated field.
+It is not converted into metric covariance by this contract.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final, Literal, TypeAlias, cast
+
+import numpy as np
+from numpy.typing import NDArray
+
+FloatArray: TypeAlias = NDArray[np.floating[Any]]
+BoolArray: TypeAlias = NDArray[np.bool_]
+IntArray: TypeAlias = NDArray[np.integer[Any]]
+StorageDType = Literal["float32", "float64"]
+
+PERSISTENT_POINT_WINDOW_NPZ_SCHEMA: Final = (
+    "prob4d.persistent-point-prediction-window-npz"
+)
+PERSISTENT_POINT_WINDOW_NPZ_VERSION: Final = 1
+PERSISTENT_POINT_STORAGE_DTYPES: Final[tuple[StorageDType, ...]] = (
+    "float32",
+    "float64",
+)
+POINTWORLD_POSITION_SEMANTICS: Final = (
+    "absolute-position-of-seeded-scene-point-v1"
+)
+POINTWORLD_POINT_IDENTITY_SEMANTICS: Final = (
+    "window-scoped-persistent-source-axis-hash-v1"
+)
+POINTWORLD_REPORTED_UNCERTAINTY_SEMANTICS: Final = (
+    "provider-log-variance-of-normalized-initial-frame-relative-displacement-v1"
+)
+
+_REQUIRED_MEMBERS: Final = frozenset(
+    {
+        "schema_name",
+        "schema_version",
+        "storage_dtype",
+        "window_id",
+        "frame_indices",
+        "source_point_indices",
+        "point_ids",
+        "point_positions",
+        "valid_mask",
+        "position_semantics",
+        "point_identity_semantics",
+    }
+)
+_REPORTED_UNCERTAINTY_MEMBERS: Final = frozenset(
+    {
+        "reported_log_variance",
+        "reported_uncertainty_semantics",
+        "reported_uncertainty_reference_id",
+    }
+)
+
+
+def _readonly(value: np.ndarray) -> np.ndarray:
+    result = np.array(value, copy=True)
+    result.setflags(write=False)
+    return result
+
+
+def _validated_storage_dtype(value: Any) -> StorageDType:
+    normalized = str(value)
+    if normalized not in PERSISTENT_POINT_STORAGE_DTYPES:
+        raise ValueError(
+            "storage_dtype must be one of "
+            + ", ".join(PERSISTENT_POINT_STORAGE_DTYPES)
+        )
+    return cast(StorageDType, normalized)
+
+
+def _numpy_dtype(value: StorageDType) -> np.dtype[Any]:
+    return np.dtype(np.float32 if value == "float32" else np.float64)
+
+
+def _scalar_text(value: np.ndarray, *, name: str) -> str:
+    if value.shape != () or value.dtype.kind not in {"U", "S"}:
+        raise ValueError(f"{name} must be one scalar string")
+    result = str(value.item())
+    if not result:
+        raise ValueError(f"{name} must not be empty")
+    return result
+
+
+def _scalar_integer(value: np.ndarray, *, name: str) -> int:
+    if value.shape != () or value.dtype.kind not in {"i", "u"}:
+        raise ValueError(f"{name} must be one scalar integer")
+    return int(value.item())
+
+
+def _nonempty_text(value: Any, *, name: str) -> str:
+    if type(value) is not str or not value:
+        raise TypeError(f"{name} must be one nonempty literal string")
+    return value
+
+
+def _sha256(value: Any, *, name: str) -> str:
+    result = _nonempty_text(value, name=name)
+    if len(result) != 64:
+        raise ValueError(f"{name} must be one lowercase SHA-256 digest")
+    try:
+        decoded = bytes.fromhex(result)
+    except ValueError as error:
+        raise ValueError(f"{name} must be one lowercase SHA-256 digest") from error
+    if len(decoded) != 32 or result != result.lower():
+        raise ValueError(f"{name} must be one lowercase SHA-256 digest")
+    return result
+
+
+def _integer_vector(value: Any, *, name: str, nonempty: bool) -> np.ndarray:
+    raw = np.asarray(value)
+    if raw.ndim != 1:
+        raise ValueError(f"{name} must be one vector")
+    if nonempty and raw.size == 0:
+        raise ValueError(f"{name} must not be empty")
+    if raw.dtype.kind not in {"i", "u"}:
+        raise TypeError(f"{name} must contain genuine integers")
+    if raw.dtype.kind == "u" and raw.size and int(np.max(raw)) > np.iinfo(np.int64).max:
+        raise ValueError(f"{name} values must fit in int64")
+    result = np.asarray(raw, dtype=np.int64)
+    if np.any(result < 0):
+        raise ValueError(f"{name} must be nonnegative")
+    return result
+
+
+def window_scoped_point_ids(
+    window_id: str,
+    source_point_indices: Any,
+) -> IntArray:
+    """Derive deterministic identities without asserting cross-window association."""
+
+    identifier = _nonempty_text(window_id, name="window_id")
+    source_indices = _integer_vector(
+        source_point_indices,
+        name="source_point_indices",
+        nonempty=True,
+    )
+    if len(np.unique(source_indices)) != len(source_indices):
+        raise ValueError("source_point_indices must be unique")
+
+    point_ids = np.empty(len(source_indices), dtype=np.int64)
+    for position, source_index in enumerate(source_indices):
+        payload = f"{identifier}\x00{int(source_index)}".encode("utf-8")
+        digest = hashlib.sha256(payload).digest()
+        point_ids[position] = int.from_bytes(digest[:8], "big") & ((1 << 63) - 1)
+    if len(np.unique(point_ids)) != len(point_ids):
+        raise ValueError("window-scoped point identity collision")
+    return cast(IntArray, _readonly(point_ids))
+
+
+@dataclass(frozen=True, slots=True)
+class PersistentPointPredictionWindow:
+    """One sparse prediction window with persistent point identities.
+
+    ``point_positions[t, n]`` describes the same provider seed identified by
+    ``point_ids[n]`` at every frame in the window. The identity is persistent
+    only under the declared ``point_identity_semantics``; the PointWorld adapter
+    deliberately assigns different identities to points from different windows.
+
+    ``reported_log_variance`` is raw provider output tied to
+    ``reported_uncertainty_reference_id``. It is not metric covariance and must
+    be calibrated before it is used as ``ObservationFactor.local_covariance_m2``.
+    """
+
+    window_id: str
+    frame_indices: IntArray
+    source_point_indices: IntArray
+    point_ids: IntArray
+    point_positions: FloatArray
+    valid_mask: BoolArray
+    position_semantics: str
+    point_identity_semantics: str
+    reported_log_variance: FloatArray | None = None
+    reported_uncertainty_semantics: str | None = None
+    reported_uncertainty_reference_id: str | None = None
+    storage_dtype: StorageDType = "float64"
+
+    def __post_init__(self) -> None:
+        window_id = _nonempty_text(self.window_id, name="window_id")
+        position_semantics = _nonempty_text(
+            self.position_semantics,
+            name="position_semantics",
+        )
+        point_identity_semantics = _nonempty_text(
+            self.point_identity_semantics,
+            name="point_identity_semantics",
+        )
+        storage_dtype = _validated_storage_dtype(self.storage_dtype)
+        dtype = _numpy_dtype(storage_dtype)
+
+        frame_indices = _integer_vector(
+            self.frame_indices,
+            name="frame_indices",
+            nonempty=True,
+        )
+        if np.any(np.diff(frame_indices) <= 0):
+            raise ValueError("frame_indices must be strictly increasing")
+        source_indices = _integer_vector(
+            self.source_point_indices,
+            name="source_point_indices",
+            nonempty=True,
+        )
+        point_ids = _integer_vector(
+            self.point_ids,
+            name="point_ids",
+            nonempty=True,
+        )
+        if len(source_indices) != len(point_ids):
+            raise ValueError("source_point_indices and point_ids must have equal length")
+        if len(np.unique(source_indices)) != len(source_indices):
+            raise ValueError("source_point_indices must be unique")
+        if len(np.unique(point_ids)) != len(point_ids):
+            raise ValueError("point_ids must be unique")
+
+        positions = np.asarray(self.point_positions, dtype=dtype).copy()
+        raw_valid = np.asarray(self.valid_mask)
+        if raw_valid.dtype != np.dtype(bool):
+            raise TypeError("valid_mask must have bool dtype")
+        valid = raw_valid.copy()
+        expected_shape = (len(frame_indices), len(point_ids))
+        if positions.shape != (*expected_shape, 3):
+            raise ValueError(
+                "point_positions must have shape "
+                f"({expected_shape[0]}, {expected_shape[1]}, 3)"
+            )
+        if valid.shape != expected_shape:
+            raise ValueError(
+                "valid_mask must have shape "
+                f"({expected_shape[0]}, {expected_shape[1]})"
+            )
+        if not np.all(np.isfinite(positions[valid])):
+            raise ValueError("valid point positions must be finite")
+
+        uncertainty_fields = (
+            self.reported_log_variance,
+            self.reported_uncertainty_semantics,
+            self.reported_uncertainty_reference_id,
+        )
+        present = tuple(item is not None for item in uncertainty_fields)
+        if any(present) and not all(present):
+            raise ValueError(
+                "reported uncertainty payload, semantics, and reference ID "
+                "must either all be present or all be absent"
+            )
+
+        reported_log_variance: np.ndarray | None = None
+        reported_uncertainty_semantics: str | None = None
+        reported_uncertainty_reference_id: str | None = None
+        if all(present):
+            assert self.reported_log_variance is not None
+            assert self.reported_uncertainty_semantics is not None
+            assert self.reported_uncertainty_reference_id is not None
+            reported_log_variance = np.asarray(
+                self.reported_log_variance,
+                dtype=dtype,
+            ).copy()
+            if reported_log_variance.shape not in {
+                (*expected_shape, 1),
+                (*expected_shape, 3),
+            }:
+                raise ValueError(
+                    "reported_log_variance must have shape (T, N, 1) or (T, N, 3)"
+                )
+            active_uncertainty = np.broadcast_to(
+                valid[..., None],
+                reported_log_variance.shape,
+            )
+            if not np.all(np.isfinite(reported_log_variance[active_uncertainty])):
+                raise ValueError("valid reported log variances must be finite")
+            reported_uncertainty_semantics = _nonempty_text(
+                self.reported_uncertainty_semantics,
+                name="reported_uncertainty_semantics",
+            )
+            reported_uncertainty_reference_id = _sha256(
+                self.reported_uncertainty_reference_id,
+                name="reported_uncertainty_reference_id",
+            )
+
+        object.__setattr__(self, "window_id", window_id)
+        object.__setattr__(self, "position_semantics", position_semantics)
+        object.__setattr__(
+            self,
+            "point_identity_semantics",
+            point_identity_semantics,
+        )
+        object.__setattr__(self, "storage_dtype", storage_dtype)
+        object.__setattr__(self, "frame_indices", _readonly(frame_indices))
+        object.__setattr__(
+            self,
+            "source_point_indices",
+            _readonly(source_indices),
+        )
+        object.__setattr__(self, "point_ids", _readonly(point_ids))
+        object.__setattr__(self, "point_positions", _readonly(positions))
+        object.__setattr__(self, "valid_mask", _readonly(valid))
+        object.__setattr__(
+            self,
+            "reported_log_variance",
+            None if reported_log_variance is None else _readonly(reported_log_variance),
+        )
+        object.__setattr__(
+            self,
+            "reported_uncertainty_semantics",
+            reported_uncertainty_semantics,
+        )
+        object.__setattr__(
+            self,
+            "reported_uncertainty_reference_id",
+            reported_uncertainty_reference_id,
+        )
+
+    @property
+    def shape(self) -> tuple[int, int]:
+        """Return ``(frame_count, point_count)``."""
+
+        return self.valid_mask.shape
+
+    @property
+    def frame_count(self) -> int:
+        return self.shape[0]
+
+    @property
+    def point_count(self) -> int:
+        return self.shape[1]
+
+    @property
+    def has_reported_uncertainty(self) -> bool:
+        return self.reported_log_variance is not None
+
+    def local_index(self, frame_index: int) -> int:
+        position = int(np.searchsorted(self.frame_indices, frame_index))
+        if position == self.frame_count or self.frame_indices[position] != frame_index:
+            raise KeyError(f"frame {frame_index} is not in window {self.window_id!r}")
+        return position
+
+    def to_npz(
+        self,
+        path: str | Path,
+        *,
+        storage_dtype: StorageDType | None = None,
+    ) -> None:
+        """Write a strict versioned archive while preserving semantic labels."""
+
+        selected_dtype = (
+            self.storage_dtype
+            if storage_dtype is None
+            else _validated_storage_dtype(storage_dtype)
+        )
+        dtype = _numpy_dtype(selected_dtype)
+        payload: dict[str, Any] = {
+            "schema_name": np.asarray(PERSISTENT_POINT_WINDOW_NPZ_SCHEMA),
+            "schema_version": np.asarray(
+                PERSISTENT_POINT_WINDOW_NPZ_VERSION,
+                dtype=np.int64,
+            ),
+            "storage_dtype": np.asarray(selected_dtype),
+            "window_id": np.asarray(self.window_id),
+            "frame_indices": np.asarray(self.frame_indices, dtype=np.int64),
+            "source_point_indices": np.asarray(
+                self.source_point_indices,
+                dtype=np.int64,
+            ),
+            "point_ids": np.asarray(self.point_ids, dtype=np.int64),
+            "point_positions": np.asarray(self.point_positions, dtype=dtype),
+            "valid_mask": np.asarray(self.valid_mask, dtype=bool),
+            "position_semantics": np.asarray(self.position_semantics),
+            "point_identity_semantics": np.asarray(self.point_identity_semantics),
+        }
+        if self.reported_log_variance is not None:
+            assert self.reported_uncertainty_semantics is not None
+            assert self.reported_uncertainty_reference_id is not None
+            payload.update(
+                {
+                    "reported_log_variance": np.asarray(
+                        self.reported_log_variance,
+                        dtype=dtype,
+                    ),
+                    "reported_uncertainty_semantics": np.asarray(
+                        self.reported_uncertainty_semantics
+                    ),
+                    "reported_uncertainty_reference_id": np.asarray(
+                        self.reported_uncertainty_reference_id
+                    ),
+                }
+            )
+        np.savez_compressed(Path(path), **payload)
+
+    @classmethod
+    def from_npz(cls, path: str | Path) -> PersistentPointPredictionWindow:
+        """Load and revalidate one strict persistent-point archive."""
+
+        with np.load(Path(path), allow_pickle=False) as data:
+            files = set(data.files)
+            allowed = _REQUIRED_MEMBERS | _REPORTED_UNCERTAINTY_MEMBERS
+            missing = sorted(_REQUIRED_MEMBERS - files)
+            extra = sorted(files - allowed)
+            if missing or extra:
+                raise ValueError(
+                    "persistent-point archive fields changed; "
+                    f"missing={missing}, extra={extra}"
+                )
+            uncertainty_present = _REPORTED_UNCERTAINTY_MEMBERS.intersection(files)
+            if uncertainty_present and uncertainty_present != _REPORTED_UNCERTAINTY_MEMBERS:
+                raise ValueError("persistent-point uncertainty members must be complete")
+            schema = _scalar_text(data["schema_name"], name="schema_name")
+            version = _scalar_integer(data["schema_version"], name="schema_version")
+            if schema != PERSISTENT_POINT_WINDOW_NPZ_SCHEMA:
+                raise ValueError("unsupported persistent-point archive schema")
+            if version != PERSISTENT_POINT_WINDOW_NPZ_VERSION:
+                raise ValueError("unsupported persistent-point archive version")
+            storage_dtype = _validated_storage_dtype(
+                _scalar_text(data["storage_dtype"], name="storage_dtype")
+            )
+            expected_dtype = _numpy_dtype(storage_dtype)
+            for field in ("point_positions", "reported_log_variance"):
+                if field in files and data[field].dtype != expected_dtype:
+                    raise ValueError(f"{field} dtype disagrees with storage_dtype")
+            for field in ("frame_indices", "source_point_indices", "point_ids"):
+                if data[field].dtype != np.dtype(np.int64):
+                    raise ValueError(f"{field} must use int64")
+            if data["valid_mask"].dtype != np.dtype(bool):
+                raise ValueError("valid_mask must use bool")
+
+            return cls(
+                window_id=_scalar_text(data["window_id"], name="window_id"),
+                frame_indices=data["frame_indices"],
+                source_point_indices=data["source_point_indices"],
+                point_ids=data["point_ids"],
+                point_positions=data["point_positions"],
+                valid_mask=data["valid_mask"],
+                position_semantics=_scalar_text(
+                    data["position_semantics"],
+                    name="position_semantics",
+                ),
+                point_identity_semantics=_scalar_text(
+                    data["point_identity_semantics"],
+                    name="point_identity_semantics",
+                ),
+                reported_log_variance=(
+                    data["reported_log_variance"]
+                    if "reported_log_variance" in files
+                    else None
+                ),
+                reported_uncertainty_semantics=(
+                    _scalar_text(
+                        data["reported_uncertainty_semantics"],
+                        name="reported_uncertainty_semantics",
+                    )
+                    if "reported_uncertainty_semantics" in files
+                    else None
+                ),
+                reported_uncertainty_reference_id=(
+                    _scalar_text(
+                        data["reported_uncertainty_reference_id"],
+                        name="reported_uncertainty_reference_id",
+                    )
+                    if "reported_uncertainty_reference_id" in files
+                    else None
+                ),
+                storage_dtype=storage_dtype,
+            )
+
+
+def persistent_point_window_from_pointworld(
+    *,
+    window_id: str,
+    frame_indices: Any,
+    scene_positions: Any,
+    scene_valid_mask: Any,
+    reported_log_variance: Any,
+    normalization_id: str,
+    source_point_indices: Any | None = None,
+    storage_dtype: StorageDType = "float32",
+) -> PersistentPointPredictionWindow:
+    """Convert one released PointWorld output without dense rasterization.
+
+    The caller supplies NumPy-compatible snapshots of PointWorld's
+    ``out['scene_flows']``, validity mask, and ``out['log_var']`` after selecting
+    one batch member. The raw log variance remains tied to the exact
+    normalization-statistics digest and is deliberately not promoted to metric
+    covariance.
+    """
+
+    positions = np.asarray(scene_positions)
+    if positions.ndim != 3 or positions.shape[-1] != 3:
+        raise ValueError("PointWorld scene_positions must have shape (T, N, 3)")
+    point_count = positions.shape[1]
+    source_indices = (
+        np.arange(point_count, dtype=np.int64)
+        if source_point_indices is None
+        else _integer_vector(
+            source_point_indices,
+            name="source_point_indices",
+            nonempty=True,
+        )
+    )
+    if len(source_indices) != point_count:
+        raise ValueError("source_point_indices length must match PointWorld point axis")
+    raw_log_variance = np.asarray(reported_log_variance)
+    if raw_log_variance.shape != (*positions.shape[:2], 1):
+        raise ValueError("PointWorld reported_log_variance must have shape (T, N, 1)")
+
+    return PersistentPointPredictionWindow(
+        window_id=window_id,
+        frame_indices=frame_indices,
+        source_point_indices=source_indices,
+        point_ids=window_scoped_point_ids(window_id, source_indices),
+        point_positions=positions,
+        valid_mask=scene_valid_mask,
+        position_semantics=POINTWORLD_POSITION_SEMANTICS,
+        point_identity_semantics=POINTWORLD_POINT_IDENTITY_SEMANTICS,
+        reported_log_variance=raw_log_variance,
+        reported_uncertainty_semantics=(
+            POINTWORLD_REPORTED_UNCERTAINTY_SEMANTICS
+        ),
+        reported_uncertainty_reference_id=normalization_id,
+        storage_dtype=storage_dtype,
+    )
+
+
+__all__ = [
+    "PERSISTENT_POINT_STORAGE_DTYPES",
+    "PERSISTENT_POINT_WINDOW_NPZ_SCHEMA",
+    "PERSISTENT_POINT_WINDOW_NPZ_VERSION",
+    "POINTWORLD_POINT_IDENTITY_SEMANTICS",
+    "POINTWORLD_POSITION_SEMANTICS",
+    "POINTWORLD_REPORTED_UNCERTAINTY_SEMANTICS",
+    "PersistentPointPredictionWindow",
+    "persistent_point_window_from_pointworld",
+    "window_scoped_point_ids",
+]

--- a/src/prob4d/persistent_point_prediction.py
+++ b/src/prob4d/persistent_point_prediction.py
@@ -154,7 +154,7 @@ def window_scoped_point_ids(
 
     point_ids = np.empty(len(source_indices), dtype=np.int64)
     for position, source_index in enumerate(source_indices):
-        payload = f"{identifier}\x00{int(source_index)}".encode("utf-8")
+        payload = f"{identifier}\x00{int(source_index)}".encode()
         digest = hashlib.sha256(payload).digest()
         point_ids[position] = int.from_bytes(digest[:8]) & ((1 << 63) - 1)
     if len(np.unique(point_ids)) != len(point_ids):

--- a/tests/test_dual_gripper_surface_action.py
+++ b/tests/test_dual_gripper_surface_action.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from prob4d.dual_gripper_surface_action import (
+    DUAL_GRIPPER_ACTION_SEMANTICS,
+    DUAL_GRIPPER_ARM_ORDER,
+    DualGripperSurfaceActionWindow,
+    dual_gripper_surface_action_from_tracker_poses,
+)
+
+
+def _action(
+    *,
+    action_id: str = "flatnfold-action-000",
+    tracker_calibration_id: str = "b" * 64,
+) -> DualGripperSurfaceActionWindow:
+    surface_points = np.asarray(
+        [
+            [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0]],
+            [[0.0, 0.0, 0.0], [0.0, 1.0, 0.0]],
+        ],
+        dtype=np.float32,
+    )
+    surface_normals = np.asarray(
+        [
+            [[0.0, 0.0, 2.0], [0.0, 0.0, 3.0]],
+            [[0.0, 0.0, 4.0], [0.0, 0.0, 5.0]],
+        ],
+        dtype=np.float32,
+    )
+    positions = np.asarray(
+        [
+            [[0.0, 0.0, 0.0], [10.0, 0.0, 0.0]],
+            [[0.0, 1.0, 0.0], [10.0, 1.0, 0.0]],
+        ],
+        dtype=np.float32,
+    )
+    quaternions = np.zeros((2, 2, 4), dtype=np.float32)
+    quaternions[..., 0] = 2.0  # deliberately non-unit wxyz identity
+    gripper_open = np.asarray([[True, False], [False, True]], dtype=bool)
+    return dual_gripper_surface_action_from_tracker_poses(
+        action_id=action_id,
+        frame_indices=np.asarray([20, 21], dtype=np.int64),
+        surface_points_tracker=surface_points,
+        surface_normals_tracker=surface_normals,
+        positions_world_from_tracker=positions,
+        quaternions_world_from_tracker_wxyz=quaternions,
+        gripper_open=gripper_open,
+        template_id="a" * 64,
+        tracker_calibration_id=tracker_calibration_id,
+        pose_stream_id="c" * 64,
+        timestamp_association_id="d" * 64,
+    )
+
+
+def test_action_transforms_right_then_left_and_normalizes_quaternions() -> None:
+    action = _action()
+
+    assert DUAL_GRIPPER_ARM_ORDER == ("right", "left")
+    assert action.action_semantics == DUAL_GRIPPER_ACTION_SEMANTICS
+    assert action.frame_count == 2
+    assert action.point_count == 4
+    assert action.points_per_arm == 2
+    assert np.array_equal(action.arm_ids, [0, 0, 1, 1])
+    assert np.array_equal(action.template_point_indices, [0, 1, 0, 1])
+    assert np.allclose(
+        action.robot_positions[0],
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [10.0, 0.0, 0.0],
+            [10.0, 1.0, 0.0],
+        ],
+    )
+    assert np.allclose(action.robot_positions[1] - action.robot_positions[0], [0, 1, 0])
+    assert np.allclose(np.linalg.norm(action.robot_normals, axis=-1), 1.0)
+    assert np.allclose(action.robot_colors, [1.0, 0.0, 1.0])
+    assert np.all(action.robot_exists)
+    assert not action.robot_positions.flags.writeable
+
+
+def test_point_ids_are_template_and_calibration_scoped_not_action_scoped() -> None:
+    first = _action(action_id="first")
+    second = _action(action_id="second")
+    recalibrated = _action(action_id="third", tracker_calibration_id="e" * 64)
+
+    assert np.array_equal(first.point_ids, second.point_ids)
+    assert not np.any(np.isin(first.point_ids, recalibrated.point_ids))
+
+
+def test_pointworld_sample_exposes_bimanual_fields_with_owned_arrays() -> None:
+    action = _action()
+    sample = action.pointworld_sample()
+
+    assert sample["__has_right_gripper__"] is True
+    assert sample["__has_left_gripper__"] is True
+    assert np.asarray(sample["robot_flows"]).shape == (2, 4, 3)
+    assert np.asarray(sample["robot_normals"]).shape == (2, 4, 3)
+    assert np.asarray(sample["robot_colors"]).shape == (2, 4, 3)
+    assert np.array_equal(
+        sample["right_gripper_open"],
+        np.asarray([[1.0], [0.0]], dtype=np.float32),
+    )
+    assert np.array_equal(
+        sample["left_gripper_open"],
+        np.asarray([[0.0], [1.0]], dtype=np.float32),
+    )
+
+    robot_flows = np.asarray(sample["robot_flows"])
+    robot_flows[0, 0] = 99.0
+    assert not np.allclose(robot_flows, action.robot_positions)
+
+
+def test_action_archive_roundtrip(tmp_path: Path) -> None:
+    action = _action()
+    archive = tmp_path / "action.npz"
+    action.to_npz(archive)
+    restored = DualGripperSurfaceActionWindow.from_npz(archive)
+
+    assert restored.action_id == action.action_id
+    assert restored.storage_dtype == "float32"
+    assert restored.template_id == action.template_id
+    assert restored.tracker_calibration_id == action.tracker_calibration_id
+    assert restored.pose_stream_id == action.pose_stream_id
+    assert restored.timestamp_association_id == action.timestamp_association_id
+    assert np.array_equal(restored.frame_indices, action.frame_indices)
+    assert np.array_equal(restored.point_ids, action.point_ids)
+    assert np.array_equal(restored.robot_positions, action.robot_positions)
+    assert np.array_equal(restored.robot_normals, action.robot_normals)
+    assert np.array_equal(restored.gripper_open, action.gripper_open)
+
+
+def test_rotation_is_applied_to_points_and_normals() -> None:
+    points = np.asarray(
+        [
+            [[1.0, 0.0, 0.0]],
+            [[1.0, 0.0, 0.0]],
+        ],
+        dtype=np.float64,
+    )
+    normals = np.array(points, copy=True)
+    translations = np.zeros((1, 2, 3), dtype=np.float64)
+    angle = np.pi / 2.0
+    quaternions = np.asarray(
+        [[[np.cos(angle / 2.0), 0.0, 0.0, np.sin(angle / 2.0)]] * 2],
+        dtype=np.float64,
+    )
+    action = dual_gripper_surface_action_from_tracker_poses(
+        action_id="rotated",
+        frame_indices=np.asarray([0], dtype=np.int64),
+        surface_points_tracker=points,
+        surface_normals_tracker=normals,
+        positions_world_from_tracker=translations,
+        quaternions_world_from_tracker_wxyz=quaternions,
+        gripper_open=np.asarray([[False, False]], dtype=bool),
+        template_id="1" * 64,
+        tracker_calibration_id="2" * 64,
+        pose_stream_id="3" * 64,
+        timestamp_association_id="4" * 64,
+        storage_dtype="float64",
+    )
+
+    assert np.allclose(action.robot_positions[0], [[0, 1, 0], [0, 1, 0]], atol=1e-12)
+    assert np.allclose(action.robot_normals[0], [[0, 1, 0], [0, 1, 0]], atol=1e-12)
+
+
+def test_action_rejects_nonboolean_gripper_state() -> None:
+    action = _action()
+    with pytest.raises(TypeError, match="gripper_open must be bool"):
+        dual_gripper_surface_action_from_tracker_poses(
+            action_id="bad-open",
+            frame_indices=action.frame_indices,
+            surface_points_tracker=np.zeros((2, 1, 3), dtype=np.float32),
+            surface_normals_tracker=np.asarray(
+                [[[0.0, 0.0, 1.0]], [[0.0, 0.0, 1.0]]],
+                dtype=np.float32,
+            ),
+            positions_world_from_tracker=np.zeros((2, 2, 3), dtype=np.float32),
+            quaternions_world_from_tracker_wxyz=np.asarray(
+                [[[1.0, 0.0, 0.0, 0.0]] * 2] * 2,
+                dtype=np.float32,
+            ),
+            gripper_open=np.zeros((2, 2), dtype=np.int64),
+            template_id="a" * 64,
+            tracker_calibration_id="b" * 64,
+            pose_stream_id="c" * 64,
+            timestamp_association_id="d" * 64,
+        )
+
+
+def test_action_rejects_missing_or_misaligned_rigid_support() -> None:
+    action = _action()
+    with pytest.raises(ValueError, match="must have shape \(2, M, 3\)"):
+        dual_gripper_surface_action_from_tracker_poses(
+            action_id="one-arm-template",
+            frame_indices=action.frame_indices,
+            surface_points_tracker=np.zeros((1, 2, 3), dtype=np.float32),
+            surface_normals_tracker=np.ones((1, 2, 3), dtype=np.float32),
+            positions_world_from_tracker=np.zeros((2, 2, 3), dtype=np.float32),
+            quaternions_world_from_tracker_wxyz=np.asarray(
+                [[[1.0, 0.0, 0.0, 0.0]] * 2] * 2,
+                dtype=np.float32,
+            ),
+            gripper_open=np.zeros((2, 2), dtype=bool),
+            template_id="a" * 64,
+            tracker_calibration_id="b" * 64,
+            pose_stream_id="c" * 64,
+            timestamp_association_id="d" * 64,
+        )
+
+    with pytest.raises(ValueError, match="quaternion and translation trajectories must align"):
+        dual_gripper_surface_action_from_tracker_poses(
+            action_id="misaligned-poses",
+            frame_indices=action.frame_indices,
+            surface_points_tracker=np.zeros((2, 1, 3), dtype=np.float32),
+            surface_normals_tracker=np.asarray(
+                [[[0.0, 0.0, 1.0]], [[0.0, 0.0, 1.0]]],
+                dtype=np.float32,
+            ),
+            positions_world_from_tracker=np.zeros((2, 2, 3), dtype=np.float32),
+            quaternions_world_from_tracker_wxyz=np.asarray(
+                [[[1.0, 0.0, 0.0, 0.0]] * 2],
+                dtype=np.float32,
+            ),
+            gripper_open=np.zeros((2, 2), dtype=bool),
+            template_id="a" * 64,
+            tracker_calibration_id="b" * 64,
+            pose_stream_id="c" * 64,
+            timestamp_association_id="d" * 64,
+        )
+
+
+def test_archive_rejects_unknown_field(tmp_path: Path) -> None:
+    action = _action()
+    path = tmp_path / "bad.npz"
+    np.savez_compressed(
+        path,
+        schema_name=np.asarray("prob4d.dual-gripper-surface-action-window-npz"),
+        schema_version=np.asarray(1, dtype=np.int64),
+        storage_dtype=np.asarray("float32"),
+        action_id=np.asarray(action.action_id),
+        frame_indices=action.frame_indices,
+        point_ids=action.point_ids,
+        template_point_indices=action.template_point_indices,
+        arm_ids=action.arm_ids,
+        robot_positions=action.robot_positions,
+        robot_normals=action.robot_normals,
+        robot_colors=action.robot_colors,
+        robot_exists=action.robot_exists,
+        gripper_open=action.gripper_open,
+        template_id=np.asarray(action.template_id),
+        tracker_calibration_id=np.asarray(action.tracker_calibration_id),
+        pose_stream_id=np.asarray(action.pose_stream_id),
+        timestamp_association_id=np.asarray(action.timestamp_association_id),
+        action_semantics=np.asarray(action.action_semantics),
+        point_identity_semantics=np.asarray(action.point_identity_semantics),
+        coordinate_semantics=np.asarray(action.coordinate_semantics),
+        unexpected=np.asarray(1),
+    )
+
+    with pytest.raises(ValueError, match=r"extra=\['unexpected'\]"):
+        DualGripperSurfaceActionWindow.from_npz(path)

--- a/tests/test_persistent_point_prediction.py
+++ b/tests/test_persistent_point_prediction.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from prob4d.persistent_point_prediction import (
+    POINTWORLD_POINT_IDENTITY_SEMANTICS,
+    POINTWORLD_REPORTED_UNCERTAINTY_SEMANTICS,
+    PersistentPointPredictionWindow,
+    persistent_point_window_from_pointworld,
+)
+
+
+def _pointworld_window() -> PersistentPointPredictionWindow:
+    positions = np.arange(3 * 4 * 3, dtype=np.float32).reshape(3, 4, 3) / 10.0
+    valid = np.ones((3, 4), dtype=bool)
+    log_variance = np.full((3, 4, 1), -4.0, dtype=np.float32)
+    return persistent_point_window_from_pointworld(
+        window_id="pointworld-window-000",
+        frame_indices=np.asarray([10, 11, 12], dtype=np.int64),
+        scene_positions=positions,
+        scene_valid_mask=valid,
+        reported_log_variance=log_variance,
+        normalization_id="a" * 64,
+    )
+
+
+def test_pointworld_adapter_preserves_persistent_axis_and_roundtrips(
+    tmp_path: Path,
+) -> None:
+    window = _pointworld_window()
+
+    assert window.shape == (3, 4)
+    assert window.storage_dtype == "float32"
+    assert window.point_identity_semantics == POINTWORLD_POINT_IDENTITY_SEMANTICS
+    assert (
+        window.reported_uncertainty_semantics
+        == POINTWORLD_REPORTED_UNCERTAINTY_SEMANTICS
+    )
+    assert window.reported_uncertainty_reference_id == "a" * 64
+    assert len(np.unique(window.point_ids)) == window.point_count
+    assert not window.point_ids.flags.writeable
+    assert not window.point_positions.flags.writeable
+
+    archive = tmp_path / "window.npz"
+    window.to_npz(archive)
+    restored = PersistentPointPredictionWindow.from_npz(archive)
+
+    assert restored.window_id == window.window_id
+    assert restored.position_semantics == window.position_semantics
+    assert np.array_equal(restored.frame_indices, window.frame_indices)
+    assert np.array_equal(restored.source_point_indices, window.source_point_indices)
+    assert np.array_equal(restored.point_ids, window.point_ids)
+    assert np.array_equal(restored.point_positions, window.point_positions)
+    assert np.array_equal(restored.reported_log_variance, window.reported_log_variance)
+
+
+def test_window_scoped_ids_do_not_assert_cross_window_identity() -> None:
+    first = _pointworld_window()
+    second = persistent_point_window_from_pointworld(
+        window_id="pointworld-window-001",
+        frame_indices=first.frame_indices,
+        scene_positions=first.point_positions,
+        scene_valid_mask=first.valid_mask,
+        reported_log_variance=first.reported_log_variance,
+        normalization_id="a" * 64,
+    )
+
+    assert np.array_equal(first.source_point_indices, second.source_point_indices)
+    assert not np.any(np.isin(first.point_ids, second.point_ids))
+
+
+def test_invalid_entries_may_be_nonfinite_but_valid_entries_may_not() -> None:
+    window = _pointworld_window()
+    positions = np.array(window.point_positions, copy=True)
+    valid = np.array(window.valid_mask, copy=True)
+    valid[1, 2] = False
+    positions[1, 2] = np.nan
+
+    accepted = persistent_point_window_from_pointworld(
+        window_id="invalid-row-is-masked",
+        frame_indices=window.frame_indices,
+        scene_positions=positions,
+        scene_valid_mask=valid,
+        reported_log_variance=window.reported_log_variance,
+        normalization_id="b" * 64,
+    )
+    assert not accepted.valid_mask[1, 2]
+
+    valid[1, 2] = True
+    with pytest.raises(ValueError, match="valid point positions must be finite"):
+        persistent_point_window_from_pointworld(
+            window_id="invalid-row-is-active",
+            frame_indices=window.frame_indices,
+            scene_positions=positions,
+            scene_valid_mask=valid,
+            reported_log_variance=window.reported_log_variance,
+            normalization_id="b" * 64,
+        )
+
+
+def test_pointworld_adapter_rejects_vector_log_variance() -> None:
+    window = _pointworld_window()
+    with pytest.raises(ValueError, match=r"must have shape \(T, N, 1\)"):
+        persistent_point_window_from_pointworld(
+            window_id="wrong-logvar-shape",
+            frame_indices=window.frame_indices,
+            scene_positions=window.point_positions,
+            scene_valid_mask=window.valid_mask,
+            reported_log_variance=np.zeros((3, 4, 3), dtype=np.float32),
+            normalization_id="c" * 64,
+        )
+
+
+def test_uncertainty_fields_are_all_or_none() -> None:
+    window = _pointworld_window()
+    with pytest.raises(ValueError, match="must either all be present or all be absent"):
+        PersistentPointPredictionWindow(
+            window_id="incomplete-uncertainty",
+            frame_indices=window.frame_indices,
+            source_point_indices=window.source_point_indices,
+            point_ids=window.point_ids,
+            point_positions=window.point_positions,
+            valid_mask=window.valid_mask,
+            position_semantics=window.position_semantics,
+            point_identity_semantics=window.point_identity_semantics,
+            reported_log_variance=window.reported_log_variance,
+            storage_dtype="float32",
+        )
+
+
+def test_source_indices_must_be_genuine_unique_integers() -> None:
+    window = _pointworld_window()
+    with pytest.raises(TypeError, match="genuine integers"):
+        persistent_point_window_from_pointworld(
+            window_id="float-source-indices",
+            frame_indices=window.frame_indices,
+            scene_positions=window.point_positions,
+            scene_valid_mask=window.valid_mask,
+            reported_log_variance=window.reported_log_variance,
+            normalization_id="d" * 64,
+            source_point_indices=np.asarray([0.0, 1.0, 2.0, 3.0]),
+        )
+
+    with pytest.raises(ValueError, match="source_point_indices must be unique"):
+        persistent_point_window_from_pointworld(
+            window_id="duplicate-source-indices",
+            frame_indices=window.frame_indices,
+            scene_positions=window.point_positions,
+            scene_valid_mask=window.valid_mask,
+            reported_log_variance=window.reported_log_variance,
+            normalization_id="d" * 64,
+            source_point_indices=np.asarray([0, 1, 1, 3], dtype=np.int64),
+        )
+
+
+def test_archive_rejects_unknown_fields(tmp_path: Path) -> None:
+    window = _pointworld_window()
+    path = tmp_path / "bad.npz"
+    np.savez_compressed(
+        path,
+        schema_name=np.asarray("prob4d.persistent-point-prediction-window-npz"),
+        schema_version=np.asarray(1, dtype=np.int64),
+        storage_dtype=np.asarray("float32"),
+        window_id=np.asarray(window.window_id),
+        frame_indices=window.frame_indices,
+        source_point_indices=window.source_point_indices,
+        point_ids=window.point_ids,
+        point_positions=window.point_positions,
+        valid_mask=window.valid_mask,
+        position_semantics=np.asarray(window.position_semantics),
+        point_identity_semantics=np.asarray(window.point_identity_semantics),
+        reported_log_variance=window.reported_log_variance,
+        reported_uncertainty_semantics=np.asarray(
+            window.reported_uncertainty_semantics
+        ),
+        reported_uncertainty_reference_id=np.asarray(
+            window.reported_uncertainty_reference_id
+        ),
+        unexpected=np.asarray(1),
+    )
+
+    with pytest.raises(ValueError, match=r"extra=\['unexpected'\]"):
+        PersistentPointPredictionWindow.from_npz(path)


### PR DESCRIPTION
## Purpose

Continue issue #333 by resolving the PointWorld representation mismatch without target-dependent rasterization.

The released PointWorld model keeps one seeded `N_scene` point axis over a forecast window. This PR adds a strict versioned artifact that preserves those identities and absolute predicted positions directly.

## What is added

- `src/prob4d/persistent_point_prediction.py`
  - immutable `PersistentPointPredictionWindow`;
  - strict versioned NPZ round trip;
  - deterministic window-scoped point IDs that do not assert cross-window identity;
  - PointWorld conversion from `scene_flows`, validity, and scalar `log_var` arrays;
  - explicit storage of provider uncertainty semantics and normalization-statistics SHA-256.
- `tests/test_persistent_point_prediction.py`
  - round-trip, identity, dtype, finite-value, malformed uncertainty, source-index, and unknown-field tests.
- `docs/persistent-point-prediction-window.md`
  - representation, identity, uncertainty-calibration, and claim boundaries.
- `evidence/pointworld-flatnfold-source-qualification-v1/representation-decision.json`
  - content-addressed source-only decision; no prediction payload, residual, target, BayesianPhysTwin, or Causal4D outcome was opened.
- focused GitHub Actions validation.

## Scientific decision

The representation path is now **artifact-authorized but the provider is not yet qualified**.

PointWorld constructs absolute positions as its initial scene points plus predicted normalized-relative displacement. The same `N_scene` axis persists over the output horizon. Its scalar log variance is trained in normalized relative-displacement coordinates, so this PR deliberately retains it as raw provider evidence and does not call it metric covariance.

No dense `H x W` adapter is introduced. Points from different forecast windows receive different identities until an explicit cross-window association is established.

## Remaining gates

This PR does not bind the exact checkpoint, runtime, normalization bytes, Flat'n'Fold dataset manifest/garment roster, camera/action transforms, visual/action lineage, uncertainty calibration, or `ProviderSupportFeasibilityV1` result. Those remain source-only work under #333 before any target outcome.

## Validation performed before push

A standalone execution of the new module and test file passed `7/7` focused tests and Python compilation. The PR workflow adds repository lint, formatter, mypy, evidence-digest, observation-factor compatibility, and compile checks.

## Claim boundary

This is interoperability and source-representation evidence only. It does not establish PointWorld competence, calibrated uncertainty, Prob4D fusion benefit, BayesianPhysTwin benefit, Causal4D benefit, or deployment safety.