### PR TITLE
Scientific kernel: posterior-preserving compression of shared observation noise

### DIFF
--- a/CHANGELOG.d/posterior-preserving-compression.md
+++ b/CHANGELOG.d/posterior-preserving-compression.md
@@ -1,0 +1,11 @@
+### Experimental scientific kernel
+
+- Add prior-aware shared-noise-factor compression preserving the complete
+  posterior of a frozen local Gaussian query, with a necessary/sufficient range
+  condition, minimum-rank proof and numerical downdate audit.
+- Return the exact original factor when a rank cap cannot preserve the posterior.
+- Add independent dense-reference tests, existing-operator integration coverage,
+  and a controlled Sim(3)-linearized study including a cached-query baseline.
+- No stable API/export change, provider promotion, calibration change, physical
+  update authorization, or access to closed/terminal data. The reduced factor
+  does not preserve observation evidence and must not be used to score it.

--- a/docs/posterior-preserving-compression.md
+++ b/docs/posterior-preserving-compression.md
@@ -1,0 +1,217 @@
+# Posterior-preserving shared-noise compression
+
+Status: **experimental local-Gaussian kernel**. This is not a provider/export
+change, a replacement calibration, or authorization to open any data. It answers
+a conditioning failure exposed by a controlled counterexample, not a retained
+real-provider failure. Existing terminal protocols and provider gates are unchanged.
+
+## The scientific distinction
+
+The existing [query-preserving compressor](query-preserving-compression.md)
+controls observation covariance projected through supplied Jacobians. It does
+not promise to preserve a Bayesian posterior after that observation is combined
+with a physical prior. The existing [query conditioner](query-posterior-conditioning.md)
+computes this posterior, but does not construct a reduced shared-noise factor.
+
+Here the compressed quantity is specifically the **latent shared observation-noise
+factor**, while the complete observation vector is retained. The chosen subspace
+depends on the complete physical prior and observation model. A low-energy mode
+can matter critically because conditioning weights directions by precision.
+
+This does not contradict the existing marginal compressor's documented guarantee.
+In particular, using the actual full-model Bayesian gain as its projection and
+preserving that projected covariance exactly already gives the same subspace
+condition below. The new kernel constructs this prior-aware subspace directly,
+establishes its minimal rank, and audits conditional rather than marginal errors.
+
+## Fixed-model theorem
+
+Let the centered joint Gaussian query and innovation have covariance blocks
+
+$$
+\operatorname{Cov}(q,y)=C,\qquad \operatorname{Cov}(q)=Q,\qquad
+S=\operatorname{Cov}(y)=A+UU^\top,\quad A\succ0.
+$$
+
+For example, $A=D+HPH^\top$, $C=LPH^\top$ and $Q=LPL^\top$ for
+$q=Lx$, $x\sim\mathcal N(m,P)$, and observation noise $D+UU^\top$.
+All blocks, means, row order and linearizations are held fixed.
+
+Choose an orthonormal latent projection $V$ and replace $U$ by $UV$:
+
+$$
+S_V=A+UVV^\top U^\top.
+$$
+
+**Proposition.** The query posterior mean for every innovation and the query
+posterior covariance are unchanged if and only if
+
+$$
+\operatorname{range}(U^\top S^{-1}C^\top)\subseteq\operatorname{range}(V).
+$$
+
+Within this family of orthogonal latent projections, the minimum retained rank is
+
+$$
+k_* = \operatorname{rank}(U^\top S^{-1}C^\top)\leq\dim(q).
+$$
+
+This is a minimum within the stated factor-projection family, not among all
+possible representations of a posterior. The count does not depend directly on
+the number of points, windows, or gauge variables. Stacking several queries into
+one joint query preserves their joint covariance, not just each marginal.
+
+### Proof and error identity
+
+Let $N$ span the orthogonal complement of $V$, $W=UN$, and
+$T=I-W^\top S^{-1}W$. Since $A\succ0$, $S_V\succ0$ and $T\succ0$.
+The inverse downdate identity gives
+
+$$
+S_V^{-1}=S^{-1}+S^{-1}WT^{-1}W^\top S^{-1}.
+$$
+
+Set $E=CS^{-1}W$, $K=CS^{-1}$ and $K_V=CS_V^{-1}$. Then
+
+$$
+K_V-K=ET^{-1}W^\top S^{-1},
+$$
+
+$$
+P_{q\mid y}-P_{q\mid y,V}=ET^{-1}E^\top\succeq0.
+$$
+
+The covariance difference is zero exactly when $E=0$, which is equivalent to
+the range condition and also makes the gain difference zero. Any containing
+subspace must have at least $k_*$ columns, and a basis of the displayed range
+attains this bound. This proves necessity, sufficiency and minimality.
+
+The same identity quantifies numerical truncation. For innovations drawn from
+the full model, the mean-error covariance is
+
+$$
+\mathbb E[(K_V-K)y y^\top(K_V-K)^\top]
+=ET^{-1}(W^\top S^{-1}W)T^{-1}E^\top.
+$$
+
+Thus a small discarded singular value is not enough: the downdate core may
+amplify it. The implementation checks gain error, posterior-relative covariance
+loss and expected posterior-normalized mean error before admitting a reduction.
+
+## Counterexample to marginal/trace-only reasoning
+
+Use a scalar $x\sim\mathcal N(0,1)$, $H=(1,1,0)^\top$,
+$D=\operatorname{diag}(1,10^{-4},1)$ and
+
+$$
+U=\begin{bmatrix}1000&0\\0&1\\0&0\end{bmatrix}.
+$$
+
+Keeping only the first column retains $10^6/(10^6+1)$ of the shared covariance
+trace and exactly preserves the marginal projection $J=(1,0,0)$. Nevertheless,
+the scalar posterior variance falls from approximately $0.500025$ to
+$0.00009999$: about 5,001-fold overconfidence relative to the full model.
+The posterior-aware one-column projection preserves the full posterior instead.
+The selected $J$ is not the full Bayesian gain $K$; conflating them is the failure.
+
+## Experimental API and numerical behavior
+
+```python
+from prob4d.posterior_preserving_compression import (
+    compress_shared_factor_for_posterior,
+)
+
+result = compress_shared_factor_for_posterior(
+    shared_factor_m,                    # (N, 3, R)
+    prior_query_covariance=query_prior, # (Q, Q)
+    query_observation_cross_covariance=query_cross, # (Q, N, 3) or (Q, 3N)
+    innovation_operator=full_innovation_operator,
+    maximum_rank=query_dimension,
+)
+```
+
+The operator must solve the **full** innovation covariance, not conditional noise
+alone. Prob4D's existing cached observation and low-rank innovation operators
+satisfy the solve protocol. A batched solve obtains responses to $U$ and $C^\top$.
+The SVD is query-posterior-whitened, avoiding dependence of the exact selected
+subspace on nonsingular query units or basis changes. Only numerical tolerances
+can affect near-rank-deficient decisions. Singular values at a truncation boundary
+are followed by the actual conditional-error audit, not accepted blindly.
+
+The kernel requires strictly positive-definite query prior and posterior
+covariance for relative auditing; dependent or deterministic query coordinates
+must first be reduced by the caller. It validates finite real inputs, covariance
+symmetry, posterior consistency, and the positive-definite innovation remainder.
+The caller must supply a valid SPD solver. It does not verify an arbitrary
+solver's complete unseen covariance or provenance.
+
+An insufficient rank cap returns an independent read-only copy of the **exact
+original factor** and an identity latent projection. It never substitutes an
+underqualified truncation or adds a ridge. Invalid inputs raise an exception.
+No fallback result authorizes a physical update: BayesianPhysTwin still owns
+complete-belief selection and its exact physical fallback.
+
+## Cost and the necessary simple baseline
+
+Construction needs the original factorization, responses to $R+Q$ right-hand
+sides, and an $R$-dimensional Gram/SVD audit. This implementation is **not** a
+streaming, subquadratic-rank construction and does not lower the initial peak
+memory. A reduced factor can lower a subsequently stored shared-factor payload
+from $3NR$ to $3Nk$ scalars. This is not a measured total-system speedup.
+
+For an immutable query and model, caching $(K,P_{q\mid y})$ is simpler and may
+be smaller/faster still. The controlled study therefore includes a
+`cached-full-query-message` reference. A paper must demonstrate why a consumer
+needs a factor-level representation, or report the direct-message baseline as
+preferable. Do not compare reduced factors against unnecessarily repeated full
+inference while omitting this cache baseline.
+
+## What is NOT preserved
+
+Observation log determinants, full joint observation likelihoods, other queries,
+and later recursive updates generally change. Do not use the compressed factor
+for provider competence scores, model comparison, mixture weights or robust
+reweighting. Use the full model for these quantities. Reconstruct the projection
+when the query, physical prior, cross covariance, linearization, observation row
+set, or robust weights change. A mixture of locally exact Gaussian queries need
+not have preserved mixture probabilities or a preserved global posterior.
+
+An existing `ObservationBeliefV1` or claim-bearing factor artifact is never
+modified or relabeled by this module. It is outside `prob4d.api.v2` and returns
+only an experimental query-bound result. Causal4D may consume only an admitted
+BayesianPhysTwin belief, not this reduced observation as a new general provider.
+
+## Reproduction and paper boundary
+
+```bash
+PYTHONPATH=src python -m pytest -q \
+  tests/test_posterior_preserving_compression.py \
+  tests/test_posterior_compression_operator_integration.py
+
+OPENBLAS_NUM_THREADS=1 PYTHONPATH=src python \
+  scripts/science/run_posterior_compression_study.py \
+  --protocol protocols/posterior-compression-controlled-v1.json \
+  --source-revision "$(git rev-parse HEAD)" \
+  --output-dir outputs/posterior-compression-controlled-v1
+```
+
+The study has twelve fixed geometry/window designs and 4,096 complete independent
+Gaussian draws per design. Shared errors follow a correlated seven-coordinate
+linearized Sim(3) chain. It compares full covariance, posterior-preserving rank
+three, equal-rank covariance PCA, conditional-only noise, and a cached full query
+message. All methods use paired draws. No real model, dataset, calibration cohort
+or sealed target is accessed. Generated paper evidence belongs in the paper repo.
+
+The mathematical proposition and controlled study support a narrower
+conditioning-exact representation claim. They do not establish useful provider
+means, real calibration, physical benefit, Causal4D benefit, safety or state of the
+art. They cannot rescue the terminal MotionCrafter/Deform360 experiments.
+
+Goal-oriented Bayesian reduction is established prior work: Spantini, Cui,
+Willcox, Tenorio and Marzouk, *Goal-Oriented Optimal Approximations of Bayesian
+Linear Inverse Problems*, SIAM J. Scientific Computing 39(5), S167--S196 (2017),
+DOI: `10.1137/16M1082123`, arXiv: `1607.01881`. That work studies optimal low-rank
+query-posterior covariance updates and posterior-mean maps. The present candidate
+contribution is the explicit shared-noise-factor projection, exact range/rank
+condition, error identity and Prob4D integration. No claim of first-ever
+goal-oriented inference or exhaustive novelty clearance is made.

--- a/protocols/posterior-compression-controlled-v1.json
+++ b/protocols/posterior-compression-controlled-v1.json
@@ -1,0 +1,22 @@
+{
+  "schema": "prob4d.posterior-compression-controlled.v1",
+  "evidence_class": "controlled-linear-Gaussian-mechanism-not-real-provider",
+  "windows": [1, 4, 8],
+  "geometry_seeds": [101, 202, 303, 404],
+  "points_per_window": 16,
+  "draws_per_design": 4096,
+  "draw_seed_offset": 100000,
+  "physical_latent_dimension": 9,
+  "query_dimension": 3,
+  "chi_square_3_90_percent": 6.251388631170325,
+  "conditional_standard_deviation_m": 0.002,
+  "gauge_increment_standard_deviations": [0.015, 0.025, 0.025, 0.025, 0.006, 0.006, 0.006],
+  "rank_relative_tolerance": 1e-12,
+  "parity_relative_tolerance": 1e-9,
+  "methods": ["full", "posterior-preserving", "equal-rank-covariance-pca", "conditional-only", "cached-full-query-message"],
+  "statistical_unit": "independent complete synthetic state/gauge/observation-noise draw within a fixed design",
+  "primary_checks": ["full-gain-parity", "full-posterior-covariance-parity", "retained-rank"],
+  "secondary_metrics": ["query-gaussian-nll", "query-normalized-nees", "query-90-percent-ellipsoid-coverage", "shared-factor-payload-bytes"],
+  "no_real_data_access": true,
+  "no_target_promotion": true
+}

--- a/scripts/science/run_posterior_compression_study.py
+++ b/scripts/science/run_posterior_compression_study.py
@@ -1,0 +1,225 @@
+"""Controlled Sim(3)-linearized study; no provider, data or target access.
+
+Run from the repository root with PYTHONPATH=src. The dense solver is an
+independent reference for a small controlled study, not a production backend.
+The protocol is hashed before drawing any outcomes. Output is a new directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import platform
+from pathlib import Path
+
+import numpy as np
+
+from prob4d.posterior_preserving_compression import (
+    compress_shared_factor_for_posterior,
+)
+
+
+class DenseReference:
+    def __init__(self, covariance: np.ndarray) -> None:
+        self.covariance = covariance
+        self.dimension = covariance.shape[0]
+        self.observation_count = self.dimension // 3
+
+    def solve(self, value: object) -> np.ndarray:
+        raw = np.asarray(value)
+        return np.linalg.solve(
+            self.covariance, raw.reshape(self.dimension, -1)
+        ).reshape(raw.shape)
+
+
+def skew(point: np.ndarray) -> np.ndarray:
+    x, y, z = point
+    return np.array([[0.0, -z, y], [z, 0.0, -x], [-y, x, 0.0]])
+
+
+def physical_map(point: np.ndarray) -> np.ndarray:
+    # Three translation, three rotation, and three bending modes, in metres.
+    return np.column_stack([
+        0.008 * np.eye(3), -0.025 * skew(point),
+        0.008 * (1.0 + (point[0] / 0.25) ** 2) * np.eye(3),
+    ])
+
+
+def make_design(protocol: dict, windows: int, seed: int):
+    rng = np.random.default_rng(seed)
+    n = protocol["points_per_window"]
+    points = rng.normal(size=(n, 3)) * np.array([0.16, 0.06, 0.04])
+    # Every window observes the same material points. Shared anchor and
+    # cumulative relative-gauge errors produce a correlated gauge chain.
+    local_j = np.concatenate([
+        np.column_stack([point, -skew(point), np.eye(3)]) for point in points
+    ], axis=0)
+    increments = np.diag(protocol["gauge_increment_standard_deviations"])
+    gauge_root = np.kron(np.tril(np.ones((windows, windows))), increments)
+    u = np.kron(np.eye(windows), local_j) @ gauge_root
+    f = np.tile(np.concatenate([physical_map(point) for point in points]), (windows, 1))
+    query = physical_map(np.array([0.25, 0.04, -0.02]))
+    noise_std = protocol["conditional_standard_deviation_m"]
+    d = noise_std**2 * np.eye(3 * n * windows)
+    return u, f, query, d
+
+
+def posterior(prior, cross, covariance):
+    gain = np.linalg.solve(covariance, cross.T).T
+    result = prior - gain @ cross.T
+    return gain, 0.5 * (result + result.T)
+
+
+def counterexample():
+    d = np.diag([1.0, 1e-4, 1.0])
+    f = np.array([[1.0], [1.0], [0.0]])
+    u = np.array([[1000.0, 0.0], [0.0, 1.0], [0.0, 0.0]])
+    a, prior, cross = d + f @ f.T, np.ones((1, 1)), f.T
+    s = a + u @ u.T
+    result = compress_shared_factor_for_posterior(
+        u.reshape(1, 3, 2), prior_query_covariance=prior,
+        query_observation_cross_covariance=cross,
+        innovation_operator=DenseReference(s), maximum_rank=1,
+    )
+    _, full = posterior(prior, cross, s)
+    _, naive = posterior(prior, cross, a + u[:, :1] @ u[:, :1].T)
+    reduced = result.compressed_factor_m.reshape(3, -1)
+    _, exact = posterior(prior, cross, a + reduced @ reduced.T)
+    return {
+        "shared_trace_fraction_retained_by_naive": float(1e6 / (1e6 + 1.0)),
+        "registered_marginal_projection": [1.0, 0.0, 0.0],
+        "marginal_projection_variance_full_and_naive": 1e6,
+        "full_posterior_variance": float(full[0, 0]),
+        "naive_posterior_variance": float(naive[0, 0]),
+        "posterior_preserving_variance": float(exact[0, 0]),
+        "naive_variance_understatement_factor": float(full[0, 0] / naive[0, 0]),
+        "compression": result.summary(),
+    }
+
+
+def evaluate_design(protocol, windows, seed):
+    u, f, query, d = make_design(protocol, windows, seed)
+    dimension, rank = u.shape
+    qdim = query.shape[0]
+    prior, cross = query @ query.T, query @ f.T
+    a = d + f @ f.T
+    s = a + u @ u.T
+    reference_gain, reference_covariance = posterior(prior, cross, s)
+    compression = compress_shared_factor_for_posterior(
+        u.reshape(-1, 3, rank), prior_query_covariance=prior,
+        query_observation_cross_covariance=cross,
+        innovation_operator=DenseReference(s), maximum_rank=qdim,
+        rank_relative_tolerance=protocol["rank_relative_tolerance"],
+        parity_relative_tolerance=protocol["parity_relative_tolerance"],
+    )
+    v = np.linalg.svd(u, full_matrices=False)[2].T[:, :qdim]
+    arms = {
+        "full": u,
+        "posterior-preserving": compression.compressed_factor_m.reshape(dimension, -1),
+        "equal-rank-covariance-pca": u @ v,
+        "conditional-only": np.empty((dimension, 0)),
+        "cached-full-query-message": None,
+    }
+    rng = np.random.default_rng(protocol["draw_seed_offset"] + 1000 * windows + seed)
+    samples = protocol["draws_per_design"]
+    state = rng.normal(size=(f.shape[1], samples))
+    innovation = (
+        f @ state + u @ rng.normal(size=(rank, samples))
+        + protocol["conditional_standard_deviation_m"]
+        * rng.normal(size=(dimension, samples))
+    )
+    truth = query @ state
+    results = []
+    for name, factor in arms.items():
+        if factor is None:
+            gain, covariance = reference_gain, reference_covariance
+            stored_rank, stored_bytes = None, 0
+        else:
+            gain, covariance = posterior(prior, cross, a + factor @ factor.T)
+            stored_rank, stored_bytes = factor.shape[1], factor.nbytes
+        root = np.linalg.cholesky(covariance)
+        error = truth - gain @ innovation
+        white_error = np.linalg.solve(root, error)
+        nees = np.sum(white_error**2, axis=0)
+        logdet = 2 * np.log(np.diag(root)).sum()
+        nll = 0.5 * (nees + logdet + qdim * math.log(2 * math.pi))
+        gain_error = np.linalg.norm(gain - reference_gain) / np.linalg.norm(reference_gain)
+        covariance_error = (
+            np.linalg.norm(covariance - reference_covariance)
+            / np.linalg.norm(reference_covariance)
+        )
+        results.append({
+            "method": name, "retained_rank": stored_rank,
+            "shared_factor_payload_bytes": stored_bytes,
+            "query_message_payload_bytes": gain.nbytes + covariance.nbytes,
+            "relative_gain_error": float(gain_error),
+            "relative_covariance_error": float(covariance_error),
+            "mean_query_nll_nats": float(np.mean(nll)),
+            "mean_normalized_nees": float(np.mean(nees) / qdim),
+            "coverage_90": float(np.mean(nees <= protocol["chi_square_3_90_percent"])),
+            "query_rmse_m": float(np.sqrt(np.mean(np.sum(error**2, axis=0)))),
+        })
+    return {
+        "windows": windows, "geometry_seed": seed, "observation_dimension": dimension,
+        "original_shared_rank": rank, "draw_count": samples,
+        "compression": compression.summary(), "methods": results,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--protocol", type=Path, default=Path(
+        "protocols/posterior-compression-controlled-v1.json"
+    ))
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--source-revision", required=True)
+    args = parser.parse_args()
+    protocol_bytes = args.protocol.read_bytes()
+    protocol = json.loads(protocol_bytes)
+    if protocol["schema"] != "prob4d.posterior-compression-controlled.v1":
+        raise ValueError("unsupported protocol")
+    if args.output_dir.exists():
+        raise FileExistsError("output directory already exists; never overwrite a run")
+    args.output_dir.mkdir(parents=True)
+    # Retain exactly the protocol bytes BEFORE generating any study outcomes.
+    (args.output_dir / "protocol.json").write_bytes(protocol_bytes)
+    root = Path(__file__).resolve().parents[2]
+    source_paths = [
+        Path("src/prob4d/posterior_preserving_compression.py"),
+        Path("scripts/science/run_posterior_compression_study.py"),
+    ]
+    manifest = {
+        "source_revision": args.source_revision,
+        "protocol_sha256": hashlib.sha256(protocol_bytes).hexdigest(),
+        "source_sha256": {
+            str(path): hashlib.sha256((root / path).read_bytes()).hexdigest()
+            for path in source_paths
+        },
+        "python": platform.python_version(), "numpy": np.__version__,
+        "real_provider_evidence": False, "sealed_data_accessed": False,
+    }
+    (args.output_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    report = {
+        "evidence_class": protocol["evidence_class"],
+        "counterexample": counterexample(),
+        "designs": [
+            evaluate_design(protocol, windows, seed)
+            for windows in protocol["windows"] for seed in protocol["geometry_seeds"]
+        ],
+    }
+    report_bytes = (json.dumps(report, indent=2, sort_keys=True, allow_nan=False) + "\n").encode()
+    (args.output_dir / "result.json").write_bytes(report_bytes)
+    manifest["result_sha256"] = hashlib.sha256(report_bytes).hexdigest()
+    (args.output_dir / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    print(json.dumps({"output_dir": str(args.output_dir), **manifest}, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/prob4d/posterior_preserving_compression.py
+++ b/src/prob4d/posterior_preserving_compression.py
@@ -1,0 +1,266 @@
+"""Shared-noise compression for a fixed, jointly Gaussian physical query.
+
+For innovation covariance S = A + U U.T, A positive definite, and query/data
+cross covariance C, retain range(U.T @ solve(S, C.T)).  This preserves the
+query's conditional mean for every innovation and its conditional covariance.
+It does NOT preserve the observation likelihood or an arbitrary next update.
+
+This experimental numerical kernel does not change any provider/export API.
+See docs/posterior-preserving-compression.md for the theorem and limitations.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+import numpy as np
+from numpy.typing import NDArray
+
+Array = NDArray[np.float64]
+
+
+class InnovationSolver(Protocol):
+    """Covariance-solve surface shared by Prob4D's innovation operators."""
+
+    @property
+    def observation_count(self) -> int: ...
+
+    @property
+    def dimension(self) -> int: ...
+
+    def solve(self, value: object) -> Array: ...
+
+
+def _array(value: object, name: str) -> Array:
+    raw = np.asarray(value)
+    if np.iscomplexobj(raw):
+        raise ValueError(f"{name} must be real")
+    result = np.asarray(raw, dtype=np.float64)
+    if not np.all(np.isfinite(result)):
+        raise ValueError(f"{name} must be finite")
+    return result
+
+
+def _symmetric(value: Array, name: str) -> Array:
+    if value.ndim != 2 or value.shape[0] != value.shape[1]:
+        raise ValueError(f"{name} must be square")
+    scale = float(np.linalg.norm(value, ord="fro"))
+    if float(np.linalg.norm(value - value.T, ord="fro")) > 1e-10 * scale:
+        raise ValueError(f"{name} must be symmetric")
+    return 0.5 * (value + value.T)
+
+
+def _cholesky(value: Array, name: str) -> Array:
+    try:
+        return np.linalg.cholesky(_symmetric(value, name))
+    except np.linalg.LinAlgError as exc:
+        raise ValueError(f"{name} must be strictly positive definite") from exc
+
+
+def _cho_solve(root: Array, value: Array) -> Array:
+    return np.linalg.solve(root.T, np.linalg.solve(root, value))
+
+
+def _whiten(root: Array, value: Array) -> Array:
+    left = np.linalg.solve(root, value)
+    return np.linalg.solve(root, left.T).T
+
+
+def _fraction(value: object, name: str, *, positive: bool) -> float:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(
+        value, (int, float, np.integer, np.floating)
+    ):
+        raise TypeError(f"{name} must be a real scalar")
+    result = float(value)
+    if not np.isfinite(result) or not 0.0 <= result < 1.0:
+        raise ValueError(f"{name} must lie in [0, 1)")
+    if positive and result == 0.0:
+        raise ValueError(f"{name} must be positive")
+    return result
+
+
+def _readonly(value: Array) -> Array:
+    result = np.array(value, dtype=np.float64, copy=True)
+    result.setflags(write=False)
+    return result
+
+
+@dataclass(frozen=True, slots=True)
+class PosteriorPreservingCompression:
+    """A query-bound factor, not a general-purpose replacement observation.
+
+    ``mean_shift_risk`` is E[||P_post^-1/2 (m_reduced-m_full)||^2] / Q
+    under the full innovation distribution.  Zero in exact arithmetic.
+    The other errors compare the gain and posterior covariance, not trace
+    retention in observation space. Arrays are independent read-only copies.
+    """
+
+    compressed_factor_m: Array
+    latent_projection: Array
+    numerical_required_rank: int
+    query_dimension: int
+    relative_gain_error: float
+    relative_covariance_error: float
+    mean_shift_risk: float
+    exact_fallback: bool
+    reason: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "compressed_factor_m", _readonly(self.compressed_factor_m))
+        object.__setattr__(self, "latent_projection", _readonly(self.latent_projection))
+
+    @property
+    def original_rank(self) -> int:
+        return int(self.latent_projection.shape[0])
+
+    @property
+    def retained_rank(self) -> int:
+        return int(self.latent_projection.shape[1])
+
+    def summary(self) -> dict[str, object]:
+        return {
+            "original_rank": self.original_rank,
+            "retained_rank": self.retained_rank,
+            "numerical_required_rank": self.numerical_required_rank,
+            "query_dimension": self.query_dimension,
+            "relative_gain_error": self.relative_gain_error,
+            "relative_covariance_error": self.relative_covariance_error,
+            "mean_shift_risk": self.mean_shift_risk,
+            "exact_fallback": self.exact_fallback,
+            "reason": self.reason,
+            "claim_boundary": "fixed-local-Gaussian-query-only; not observation evidence",
+        }
+
+
+def compress_shared_factor_for_posterior(
+    low_rank_factor_m: object,
+    *,
+    prior_query_covariance: object,
+    query_observation_cross_covariance: object,
+    innovation_operator: InnovationSolver,
+    maximum_rank: int | None = None,
+    rank_relative_tolerance: float = 1e-12,
+    parity_relative_tolerance: float = 1e-9,
+) -> PosteriorPreservingCompression:
+    """Return a minimum-range shared factor for one frozen Gaussian query.
+
+    Shapes: U=(N,3,R), prior query covariance=(Q,Q), C=(Q,N,3) or
+    (Q,3N). The solver must represent the FULL innovation covariance S,
+    including U U.T and the physical prior's observation covariance.
+    The same prior, cross covariance, row order, linearization and fixed
+    robust weights must be used by the consumer. No observed outcome is used
+    in constructing the projection.
+
+    In exact arithmetic the required rank is rank(U.T S^-1 C.T) <= Q.
+    SVD selects a numerical range; a downdate audit checks the actual gain,
+    relative posterior covariance loss and expected normalized mean error.
+    Numerical failures cause ValueError, never a ridge or silent clipping.
+    If no reduced rank meets the parity limits and rank cap, the exact
+    original factor is returned. The cap never forces information loss.
+
+    The implementation requires nondegenerate query prior and posterior
+    covariances for relative error auditing; deterministic/duplicated query
+    coordinates must first be reduced to an independent query basis.
+    """
+    factor = _array(low_rank_factor_m, "low_rank_factor_m")
+    if factor.ndim != 3 or factor.shape[0] < 1 or factor.shape[1] != 3:
+        raise ValueError("low_rank_factor_m must have shape (N, 3, R), N > 0")
+    count, _, rank = factor.shape
+    if (
+        innovation_operator.observation_count != count
+        or innovation_operator.dimension != 3 * count
+    ):
+        raise ValueError("innovation_operator dimensions do not match the factor")
+    if maximum_rank is not None:
+        if isinstance(maximum_rank, (bool, np.bool_)) or not isinstance(
+            maximum_rank, (int, np.integer)
+        ):
+            raise TypeError("maximum_rank must be a nonnegative integer or None")
+        if maximum_rank < 0:
+            raise ValueError("maximum_rank must be nonnegative")
+    rank_tol = _fraction(rank_relative_tolerance, "rank_relative_tolerance", positive=False)
+    parity_tol = _fraction(parity_relative_tolerance, "parity_relative_tolerance", positive=True)
+    prior = _array(prior_query_covariance, "prior_query_covariance")
+    if prior.ndim != 2 or prior.shape[0] < 1 or prior.shape[0] != prior.shape[1]:
+        raise ValueError("prior_query_covariance must be a nonempty square matrix")
+    _cholesky(prior, "prior_query_covariance")
+    qdim = prior.shape[0]
+    cross = _array(query_observation_cross_covariance, "query_observation_cross_covariance")
+    if cross.shape not in ((qdim, count, 3), (qdim, 3 * count)):
+        raise ValueError("query_observation_cross_covariance must have shape (Q,N,3) or (Q,3N)")
+    cross = cross.reshape(qdim, 3 * count)
+    u = factor.reshape(3 * count, rank)
+    rhs = np.concatenate((u, cross.T), axis=1).reshape(count, 3, rank + qdim)
+    solved = _array(innovation_operator.solve(rhs), "innovation solve")
+    if solved.shape != rhs.shape:
+        raise ValueError("innovation solve returned an incorrect shape")
+    solved = solved.reshape(3 * count, rank + qdim)
+    su, sc = solved[:, :rank], solved[:, rank:]
+    gain = sc.T
+    posterior = _symmetric(prior - cross @ sc, "full query posterior")
+    post_root = _cholesky(posterior, "full query posterior")
+    gram = _symmetric(u.T @ su, "shared precision Gram matrix")
+    # Equivalent to A = S - U U.T being positive definite, for an SPD S.
+    _cholesky(np.eye(rank) - gram, "innovation remainder")
+    response = u.T @ sc
+    normalized_response = np.linalg.solve(post_root, response.T).T
+    left, singular, _ = np.linalg.svd(normalized_response, full_matrices=True)
+    required = int(np.count_nonzero(singular > rank_tol * singular[0])) if singular.size else 0
+    white_gain = np.linalg.solve(post_root, gain)
+    gain_norm = float(np.linalg.norm(white_gain, ord="fro"))
+
+    def fallback(reason: str) -> PosteriorPreservingCompression:
+        return PosteriorPreservingCompression(
+            factor, np.eye(rank), required, qdim, 0.0, 0.0, 0.0, True, reason
+        )
+
+    if rank == 0:
+        return PosteriorPreservingCompression(
+            factor, np.empty((0, 0)), 0, qdim, 0.0, 0.0, 0.0, False,
+            "no-shared-factor",
+        )
+    limit = min(rank - 1, int(maximum_rank) if maximum_rank is not None else rank - 1)
+    for retained in range(required, limit + 1):
+        complement = left[:, retained:]
+        discarded_gram = complement.T @ gram @ complement
+        # The input Gram is already symmetric; cancellation near its nullspace
+        # requires symmetrizing the product, not a relative-to-zero rejection.
+        discarded_gram = 0.5 * (discarded_gram + discarded_gram.T)
+        core = _cholesky(np.eye(rank - retained) - discarded_gram, "compression downdate")
+        residual = response.T @ complement
+        solved_residual = _cho_solve(core, residual.T)
+        covariance_loss = residual @ solved_residual
+        gain_change = solved_residual.T @ (su @ complement).T
+        mean_error_covariance = solved_residual.T @ discarded_gram @ solved_residual
+        white_loss = _whiten(post_root, covariance_loss)
+        white_mean_error = _whiten(post_root, mean_error_covariance)
+        covariance_error = max(
+            float(np.linalg.eigvalsh(0.5 * (white_loss + white_loss.T))[-1]), 0.0
+        )
+        mean_risk = max(float(np.trace(white_mean_error)) / qdim, 0.0)
+        gain_change_norm = float(np.linalg.norm(np.linalg.solve(post_root, gain_change), ord="fro"))
+        gain_error = gain_change_norm / gain_norm if gain_norm else gain_change_norm
+        if not np.all(np.isfinite([covariance_error, mean_risk, gain_error])):
+            raise ValueError("compression audit produced nonfinite errors")
+        if (
+            gain_error <= parity_tol
+            and covariance_error <= parity_tol
+            and mean_risk <= parity_tol**2
+        ):
+            projection = left[:, :retained].copy()
+            # Fix column signs; repeated-subspace bases may still rotate by LAPACK version.
+            for column in range(retained):
+                pivot = int(np.argmax(np.abs(projection[:, column])))
+                if projection[pivot, column] < 0.0:
+                    projection[:, column] *= -1.0
+            return PosteriorPreservingCompression(
+                (u @ projection).reshape(count, 3, retained), projection,
+                required, qdim, gain_error, covariance_error, mean_risk, False,
+                "posterior-parity-validated",
+            )
+    reason = (
+        "full-rank-required" if required == rank
+        else "no-parity-preserving-reduction-within-cap"
+    )
+    return fallback(reason)

--- a/tests/test_posterior_compression_operator_integration.py
+++ b/tests/test_posterior_compression_operator_integration.py
@@ -1,0 +1,71 @@
+"""Exercise the new kernel through the existing production operator surfaces."""
+
+import numpy as np
+
+from prob4d.api.v2 import (
+    StackedObservationFactors,
+    build_observation_gaussian_operator,
+)
+from prob4d.posterior_preserving_compression import (
+    compress_shared_factor_for_posterior,
+)
+from prob4d.query_posterior import (
+    augment_observation_gaussian_operator,
+    condition_gaussian_query,
+)
+
+
+def test_existing_structured_operator_and_query_conditioner_parity():
+    conditional = np.array([np.diag([0.3, 0.4, 0.5]), np.diag([0.6, 0.7, 0.8])])
+    factors = StackedObservationFactors(
+        world_mean_m=np.zeros((2, 3)),
+        conditional_world_covariance_m2=conditional,
+        marginal_world_covariance_m2=conditional,
+        gauge_jacobian=np.zeros((2, 3, 7)),
+        gauge_prior_covariance=np.zeros((7, 7)),
+        association_probability=np.ones(2),
+        prior_reliability=np.ones(2),
+        prior_nominal_probability=np.ones(2),
+        composite_weight=np.ones(2),
+        point_ids=np.array([10, 20], dtype=np.int64),
+        frame_indices=np.array([0, 1], dtype=np.int64),
+        view_ids=("camera", "camera"),
+        factor_ids=("factor-0", "factor-1"),
+        correlation_group_ids=("group-0", "group-1"),
+        gauge_ids=("gauge-0",),
+        causal_frame_stop=2,
+    )
+    base = build_observation_gaussian_operator(factors)
+    rng = np.random.default_rng(20260830)
+    shared = rng.normal(size=(2, 3, 7)) / 3
+    physical = rng.normal(size=(2, 3, 4)) / 2
+    query = rng.normal(size=(2, 4))
+    prior = query @ query.T
+    cross = query @ physical.reshape(6, 4).T
+    full = augment_observation_gaussian_operator(
+        base, np.concatenate([shared, physical], axis=2)
+    )
+    result = compress_shared_factor_for_posterior(
+        shared, prior_query_covariance=prior,
+        query_observation_cross_covariance=cross,
+        innovation_operator=full, maximum_rank=2,
+    )
+    assert not result.exact_fallback
+    assert result.retained_rank == 2
+    reduced = augment_observation_gaussian_operator(
+        base, np.concatenate([result.compressed_factor_m, physical], axis=2)
+    )
+    for _ in range(8):
+        arguments = {
+            "prior_mean": np.zeros(2), "prior_covariance": prior,
+            "innovation": rng.normal(size=(2, 3)),
+            "query_observation_cross_covariance": cross,
+        }
+        reference = condition_gaussian_query(**arguments, innovation_operator=full)
+        actual = condition_gaussian_query(**arguments, innovation_operator=reduced)
+        np.testing.assert_allclose(actual.posterior_mean, reference.posterior_mean, atol=1e-11)
+        np.testing.assert_allclose(
+            actual.posterior_covariance, reference.posterior_covariance, atol=1e-11
+        )
+    # The observation evidence is deliberately NOT preserved by the theorem.
+    assert not np.isclose(full.log_determinant, reduced.log_determinant)

--- a/tests/test_posterior_preserving_compression.py
+++ b/tests/test_posterior_preserving_compression.py
@@ -1,0 +1,287 @@
+"""Independent dense references for the experimental compression theorem."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from prob4d.posterior_preserving_compression import (
+    compress_shared_factor_for_posterior,
+)
+
+
+class DenseInnovation:
+    """Test-only oracle; production uses Prob4D's structured operator."""
+
+    def __init__(self, covariance: np.ndarray) -> None:
+        self.covariance = covariance.copy()
+        self.dimension = covariance.shape[0]
+        self.observation_count = self.dimension // 3
+        self.calls = 0
+
+    def solve(self, value: object) -> np.ndarray:
+        self.calls += 1
+        raw = np.asarray(value)
+        return np.linalg.solve(
+            self.covariance, raw.reshape(self.dimension, -1)
+        ).reshape(raw.shape)
+
+
+def model(seed: int = 17, rank: int = 7, qdim: int = 3):
+    rng = np.random.default_rng(seed)
+    dimension, state_dimension = 36, 8
+    d = np.diag(rng.uniform(0.3, 1.5, dimension))
+    u = rng.normal(size=(dimension, rank)) / np.sqrt(max(rank, 1))
+    f = rng.normal(size=(dimension, state_dimension)) / 2
+    g = rng.normal(size=(qdim, state_dimension))
+    prior, cross = g @ g.T, g @ f.T
+    a = d + f @ f.T
+    s = a + u @ u.T
+    return u, prior, cross, a, s
+
+
+def compress(u, prior, cross, s, **kwargs):
+    return compress_shared_factor_for_posterior(
+        u.reshape(s.shape[0] // 3, 3, u.shape[1]),
+        prior_query_covariance=prior,
+        query_observation_cross_covariance=cross,
+        innovation_operator=DenseInnovation(s),
+        **kwargs,
+    )
+
+
+def posterior(prior, cross, s):
+    gain = np.linalg.solve(s, cross.T).T
+    return gain, prior - gain @ cross.T
+
+
+@pytest.mark.parametrize("seed", range(8))
+@pytest.mark.parametrize("rank,qdim", [(7, 1), (14, 3), (28, 5)])
+def test_exact_gain_for_every_innovation_and_query_covariance(seed, rank, qdim):
+    u, prior, cross, a, s = model(seed, rank, qdim)
+    solver = DenseInnovation(s)
+    result = compress_shared_factor_for_posterior(
+        u.reshape(-1, 3, rank),
+        prior_query_covariance=prior,
+        query_observation_cross_covariance=cross.reshape(qdim, -1, 3),
+        innovation_operator=solver,
+    )
+    reduced = result.compressed_factor_m.reshape(s.shape[0], -1)
+    gain, covariance = posterior(prior, cross, s)
+    new_gain, new_covariance = posterior(prior, cross, a + reduced @ reduced.T)
+    assert solver.calls == 1
+    assert not result.exact_fallback
+    assert result.retained_rank == result.numerical_required_rank == qdim
+    np.testing.assert_allclose(new_gain, gain, atol=2e-13, rtol=2e-11)
+    np.testing.assert_allclose(new_covariance, covariance, atol=2e-12, rtol=2e-11)
+    np.testing.assert_allclose(
+        result.latent_projection.T @ result.latent_projection,
+        np.eye(qdim), atol=1e-12,
+    )
+    assert result.mean_shift_risk < 1e-20
+    assert result.relative_covariance_error < 1e-20
+
+
+def test_covariance_trace_and_marginal_preservation_can_break_posterior():
+    d = np.diag([1.0, 1e-4, 1.0])
+    f = np.array([[1.0], [1.0], [0.0]])
+    u = np.array([[1000.0, 0.0], [0.0, 1.0], [0.0, 0.0]])
+    a, prior, cross = d + f @ f.T, np.ones((1, 1)), f.T
+    s = a + u @ u.T
+    marginal_projection = np.array([[1.0, 0.0, 0.0]])
+    naive = u[:, :1]
+    np.testing.assert_array_equal(
+        marginal_projection @ u @ u.T @ marginal_projection.T,
+        marginal_projection @ naive @ naive.T @ marginal_projection.T,
+    )
+    assert np.sum(naive**2) / np.sum(u**2) > 0.999999
+    full_gain, full_covariance = posterior(prior, cross, s)
+    _, naive_covariance = posterior(prior, cross, a + naive @ naive.T)
+    assert full_covariance[0, 0] / naive_covariance[0, 0] > 5000
+    result = compress(u, prior, cross, s, maximum_rank=1)
+    assert result.retained_rank == 1
+    assert not result.exact_fallback
+    reduced = result.compressed_factor_m.reshape(3, 1)
+    new_gain, new_covariance = posterior(prior, cross, a + reduced @ reduced.T)
+    np.testing.assert_allclose(new_gain, full_gain, atol=2e-12)
+    np.testing.assert_allclose(new_covariance, full_covariance, atol=2e-12)
+
+
+def test_rank_cap_returns_original_factor_not_an_inexact_truncation():
+    u, prior, cross, _, s = model()
+    result = compress(u, prior, cross, s, maximum_rank=2)
+    assert result.exact_fallback
+    assert result.retained_rank == 7
+    assert result.reason == "no-parity-preserving-reduction-within-cap"
+    assert result.compressed_factor_m.tobytes() == u.reshape(-1, 3, 7).tobytes()
+    np.testing.assert_array_equal(result.latent_projection, np.eye(7))
+
+
+def test_full_rank_is_necessary_for_a_full_query():
+    u, prior, cross, _, s = model(rank=2, qdim=3)
+    result = compress(u, prior, cross, s)
+    assert result.exact_fallback
+    assert result.reason == "full-rank-required"
+    assert result.retained_rank == 2
+
+
+def test_zero_cross_covariance_discards_every_shared_direction():
+    u, prior, cross, _, s = model()
+    result = compress(u, prior, np.zeros_like(cross), s, maximum_rank=0)
+    assert not result.exact_fallback
+    assert result.retained_rank == 0
+    assert result.compressed_factor_m.shape == (12, 3, 0)
+
+
+def test_no_shared_factor_has_a_well_defined_empty_result():
+    u, prior, cross, _, s = model(rank=0)
+    result = compress(u, prior, cross, s)
+    assert result.original_rank == result.retained_rank == 0
+    assert not result.exact_fallback
+    assert result.reason == "no-shared-factor"
+
+
+def test_rank_deficient_shared_factor_does_not_invent_information():
+    u, prior, cross, a, _ = model(rank=1)
+    u = np.column_stack([u, 2 * u, np.zeros_like(u), -u])
+    s = a + u @ u.T
+    result = compress(u, prior, cross, s)
+    assert result.retained_rank == 1
+    reduced = result.compressed_factor_m.reshape(36, 1)
+    np.testing.assert_allclose(reduced @ reduced.T, u @ u.T, atol=1e-12)
+
+
+def test_too_aggressive_numerical_rank_is_audited_and_repaired():
+    u, prior, cross, _, s = model(rank=7, qdim=3)
+    cross = cross.copy()
+    cross[1:] *= 1e-3
+    prior = 100.0 * np.eye(3)
+    result = compress(u, prior, cross, s, rank_relative_tolerance=0.9)
+    assert result.numerical_required_rank == 1
+    assert result.retained_rank == 3
+    capped = compress(
+        u, prior, cross, s, rank_relative_tolerance=0.9, maximum_rank=1
+    )
+    assert capped.exact_fallback
+
+
+@pytest.mark.parametrize("scale", [1e-6, 1.0, 1e6])
+def test_query_units_and_invertible_query_basis_do_not_change_subspace(scale):
+    u, prior, cross, _, s = model()
+    original = compress(u, prior, cross, s)
+    transform = scale * np.array([[2.0, 0.1, 0.3], [0.2, 0.7, 0.0], [0.0, 0.2, 3.0]])
+    changed = compress(u, transform @ prior @ transform.T, transform @ cross, s)
+    np.testing.assert_allclose(
+        original.latent_projection @ original.latent_projection.T,
+        changed.latent_projection @ changed.latent_projection.T,
+        atol=1e-11,
+    )
+
+
+def test_latent_orthogonal_reparameterization_preserves_compressed_covariance():
+    u, prior, cross, _, s = model()
+    orthogonal, _ = np.linalg.qr(np.random.default_rng(4).normal(size=(7, 7)))
+    first = compress(u, prior, cross, s)
+    second = compress(u @ orthogonal, prior, cross, s)
+    a = first.compressed_factor_m.reshape(36, 3)
+    b = second.compressed_factor_m.reshape(36, 3)
+    np.testing.assert_allclose(a @ a.T, b @ b.T, atol=1e-11)
+
+
+def test_inputs_are_not_mutated_and_outputs_are_independent_readonly_copies():
+    u, prior, cross, _, s = model()
+    before = [x.copy() for x in (u, prior, cross)]
+    result = compress(u, prior, cross, s)
+    retained = result.compressed_factor_m.copy()
+    for value, expected in zip((u, prior, cross), before, strict=True):
+        np.testing.assert_array_equal(value, expected)
+        value.fill(0)
+    np.testing.assert_array_equal(result.compressed_factor_m, retained)
+    assert not result.compressed_factor_m.flags.writeable
+    assert not result.latent_projection.flags.writeable
+    assert not np.shares_memory(result.compressed_factor_m, u)
+
+
+@pytest.mark.parametrize("cap", [True, np.bool_(False), 1.5, "2"])
+def test_noninteger_rank_caps_are_rejected(cap):
+    u, prior, cross, _, s = model()
+    with pytest.raises(TypeError, match="maximum_rank"):
+        compress(u, prior, cross, s, maximum_rank=cap)
+
+
+@pytest.mark.parametrize("name,value", [
+    ("maximum_rank", -1),
+    ("rank_relative_tolerance", -1),
+    ("rank_relative_tolerance", 1.0),
+    ("rank_relative_tolerance", np.nan),
+    ("parity_relative_tolerance", 0.0),
+    ("parity_relative_tolerance", np.inf),
+])
+def test_invalid_numeric_policy_is_rejected(name, value):
+    u, prior, cross, _, s = model()
+    with pytest.raises(ValueError):
+        compress(u, prior, cross, s, **{name: value})
+
+
+def test_inconsistent_covariance_blocks_fail_without_ridge():
+    u, prior, cross, _, s = model()
+    with pytest.raises(ValueError, match="full query posterior"):
+        compress(u, prior, cross * 100, s)
+    with pytest.raises(ValueError, match="innovation remainder"):
+        compress(u * 100, prior, cross, s)
+    with pytest.raises(ValueError, match="prior_query_covariance"):
+        compress(u, -prior, cross, s)
+    bad = prior.copy()
+    bad[0, 1] += 1
+    with pytest.raises(ValueError, match="symmetric"):
+        compress(u, bad, cross, s)
+
+
+@pytest.mark.parametrize("kind", ["nan", "complex"])
+def test_invalid_factor_is_rejected(kind):
+    u, prior, cross, _, s = model()
+    if kind == "nan":
+        u[0, 0] = np.nan
+    else:
+        u = u.astype(complex) + 1j
+    with pytest.raises(ValueError):
+        compress(u, prior, cross, s)
+
+
+def test_solver_dimensions_and_return_shape_are_checked():
+    u, prior, cross, _, s = model()
+    with pytest.raises(ValueError, match="dimensions"):
+        compress_shared_factor_for_posterior(
+            u.reshape(-1, 3, 7), prior_query_covariance=prior,
+            query_observation_cross_covariance=cross,
+            innovation_operator=DenseInnovation(np.eye(3)),
+        )
+    solver = DenseInnovation(s)
+    solver.solve = lambda rhs: np.zeros((3, 3))
+    with pytest.raises(ValueError, match="incorrect shape"):
+        compress_shared_factor_for_posterior(
+            u.reshape(-1, 3, 7), prior_query_covariance=prior,
+            query_observation_cross_covariance=cross,
+            innovation_operator=solver,
+        )
+
+
+def test_changing_the_query_invalidates_the_original_compression():
+    u, prior, cross, a, s = model(rank=7, qdim=3)
+    result = compress(u, prior[:1, :1], cross[:1], s)
+    reduced = result.compressed_factor_m.reshape(36, -1)
+    _, full_covariance = posterior(prior[1:, 1:], cross[1:], s)
+    _, changed_covariance = posterior(
+        prior[1:, 1:], cross[1:], a + reduced @ reduced.T
+    )
+    assert np.linalg.norm(full_covariance - changed_covariance) > 1e-3
+
+
+def test_nonzero_discarded_response_has_strictly_positive_covariance_loss():
+    u, prior, cross, a, s = model(rank=7, qdim=3)
+    v = np.eye(7)[:, :2]
+    reduced = u @ v
+    _, full_covariance = posterior(prior, cross, s)
+    _, reduced_covariance = posterior(prior, cross, a + reduced @ reduced.T)
+    loss = full_covariance - reduced_covariance
+    assert np.linalg.eigvalsh(loss).min() > 1e-4


### PR DESCRIPTION
## Research question and contribution
Can shared 4D observation uncertainty be compressed while preserving the **conditioned physical-query posterior**, rather than only a marginal covariance projection?

For a frozen local Gaussian model with full innovation covariance `S = A + U U.T`, `A > 0`, and query/innovation cross covariance `C`, retaining `range(U.T solve(S, C.T))` preserves the query gain for every innovation and its posterior covariance. The documentation proves necessity, sufficiency, minimal rank `rank(U.T solve(S,C.T)) <= query_dimension`, and an explicit covariance/mean-error identity for truncation.

This extends the existing marginal query compressor and structured query conditioner; it does not claim either existing module violates its documented contract. If the marginal projection is already the full Bayesian gain, its exact preservation gives the same subspace condition. Goal-oriented inference is established prior work (Spantini et al., 2017, DOI 10.1137/16M1082123); no first-ever or SOTA claim is made.

## Retained failure / first readiness boundary
An analytic counterexample retains 99.9999000001% of shared covariance trace and an exact declared marginal projection, yet understates conditioned scalar variance by 5000.7475x. The new rank-one factor preserves it. This is an algebraic conditioning failure, **not a localized real-provider failure**. No provider admission/readiness gate changes and no new point-covariance family, target guard, adapter, or calibration is introduced.

## Implementation
- Experimental NumPy-only `posterior_preserving_compression` module; no stable API or claim-bearing export changes.
- Batched existing-operator solve protocol and posterior-whitened numerical subspace selection.
- Downdate audits of gain, posterior covariance and expected normalized mean error.
- Exact original-factor fallback if the rank cap cannot preserve the posterior; no ridge or forced truncation.
- Proof, counterexample, independent tests, existing-operator integration test, and fixed controlled Sim(3)-linearized protocol.

## Validation actually performed
Local Python 3.13.5 / NumPy 2.3.5:
- `PYTHONPATH=src OPENBLAS_NUM_THREADS=1 python -m pytest -q tests/test_posterior_preserving_compression.py`: **52 passed**.
- Syntax compilation passed for the module, study script and integration test.
- The full repository suite, Ruff, and existing-operator integration test were **not run locally**: this workspace contains the new files, not a complete checkout. The integration test is included for repository CI; do not interpret its existence as a pass.

The complete controlled protocol was committed at `3ff5188603bf99c93560fec68671b30e2f7b0daa` before executing its outcomes. All 12 designs (1/4/8 windows x 4 geometry seeds), with 4096 complete independent synthetic Gaussian draws each, completed. All retained rank 3, without fallback. Maximum independently recomputed relative gain error: `2.3886e-12`; posterior-covariance error: `1.6316e-14`. At 8 windows, full rank 56 and reduced rank 3 both achieved 89.7888% nominal-90% query ellipsoid coverage and normalized NEES 1.003264. A cached full-query-message comparator reproduces the same result exactly. Source/protocol/result hashes are retained with the generated evidence for the paper repository.

## Strict claim and cost boundary
This preserves one frozen local-Gaussian query, **not observation log likelihood, mixture weights, robust reweighting, other queries, or later recursive updates**. Rebuild when the model/query changes. It does not establish real-provider competence, calibration, BayesianPhysTwin/Causal4D benefit, deployment safety or state of the art.

An 18.67x reduction in the 8-window shared-factor payload is not a total-system speedup or lower construction peak memory. Constructing the projector uses the full-model solve. Caching the gain and query covariance is an essential, often preferable baseline and is explicitly included.

No data was downloaded/opened, no sealed targets or terminal experiments were touched, no self-hosted workflow was changed/dispatched, and no frozen calibration/artifact needs regeneration. Review before merge.