### PR TITLE
[Superseded by #343] Add finite-angle axial gauge moments and local-observability failure control

### DIFF
--- a/.github/workflows/axial-gauge-moment-closure.yml
+++ b/.github/workflows/axial-gauge-moment-closure.yml
@@ -1,0 +1,88 @@
+name: Axial gauge moment closure
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/axial-gauge-moment-closure.yml"
+      - "src/prob4d/axial_gauge_moments.py"
+      - "src/prob4d/axial_gauge_moment_study.py"
+      - "src/prob4d/observable_gauge.py"
+      - "src/prob4d/query_observability.py"
+      - "src/prob4d/sim3.py"
+      - "tests/test_axial_gauge_moments.py"
+      - "tests/test_axial_gauge_observability_integration.py"
+      - "protocols/axial-gauge-moment-closure-v1.json"
+      - "docs/axial-gauge-moment-closure.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: axial-gauge-moment-closure-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  conditional-moment-contract:
+    name: Conditional moments and local-gate regression
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install development environment
+        run: |
+          python -m pip install -e ".[dev]"
+          python -m pip install "numpy>=1.24,<2.3"
+      - name: Lint focused files
+        run: |
+          python -m ruff check \
+            src/prob4d/axial_gauge_moments.py \
+            src/prob4d/axial_gauge_moment_study.py \
+            tests/test_axial_gauge_moments.py \
+            tests/test_axial_gauge_observability_integration.py
+      - name: Check formatting and show any required changes
+        if: always()
+        run: |
+          python -m ruff format --diff \
+            src/prob4d/axial_gauge_moments.py \
+            src/prob4d/axial_gauge_moment_study.py \
+            tests/test_axial_gauge_moments.py \
+            tests/test_axial_gauge_observability_integration.py
+      - name: Type check focused modules
+        if: always()
+        run: |
+          python -m mypy \
+            src/prob4d/axial_gauge_moments.py \
+            src/prob4d/axial_gauge_moment_study.py
+      - name: Verify exact moments and existing observable-gauge integration
+        if: always()
+        run: |
+          python -m pytest -q \
+            tests/test_axial_gauge_moments.py \
+            tests/test_axial_gauge_observability_integration.py \
+            tests/test_observable_gauge.py \
+            tests/test_query_observability.py
+      - name: Reproduce analytic control without real-data access
+        if: always()
+        run: |
+          python -m prob4d.axial_gauge_moment_study \
+            --protocol protocols/axial-gauge-moment-closure-v1.json \
+            --output outputs/axial-gauge-moment-closure-v1/result.json
+      - name: Retain numerical reproduction
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: axial-gauge-moment-closure-v1
+          path: outputs/axial-gauge-moment-closure-v1/
+          if-no-files-found: warn
+          retention-days: 30

--- a/docs/axial-gauge-moment-closure.md
+++ b/docs/axial-gauge-moment-closure.md
@@ -1,0 +1,209 @@
+# Finite-angle closure for an unobserved axial gauge
+
+Status: **experimental conditional kernel and designed analytic control**.
+No real provider, protected target, BayesianPhysTwin execution, or Causal4D
+execution is used. The stable exporter, local query gate, and exact-fallback
+semantics are unchanged.
+
+## Scientific question
+
+The observable-subspace factor preserves a missing local gauge direction.
+The query-conditioned gate then projects covariance through a local Jacobian.
+Neither operation alone establishes that a query is constant over the complete
+finite set of transformations that the measurement cannot distinguish.
+
+For points on a known line, rotation about that line leaves their positions
+unchanged. An off-axis probe has radial query
+
+\[
+q(\theta)=r\cos\theta,\qquad q'(0)=0.
+\]
+
+The derivative is zero although the query varies over the unobserved rotation.
+A local scalar-query certificate can therefore miss this uncertainty. The
+existing full-position gate does see its first-order tangential component;
+this is not a claim that every query or every sigma-point scheme fails.
+
+`prob4d.axial_gauge_moments` retains the finite axial orbit and propagates its
+first two circular moments into **joint** point and linear-query moments.
+`tests/test_axial_gauge_observability_integration.py` connects the counterexample
+to the existing local gate without changing its documented local semantics.
+
+## Exact conditional propagation
+
+Let the unit axis be \(u\), the pivot be \(c\), and the reference point be \(p_i\).
+Define
+
+\[
+z_i=c+uu^\top(p_i-c),\quad
+ a_i=(I-uu^\top)(p_i-c),\quad b_i=u\times a_i.
+\]
+
+Rodrigues' formula gives the complete orbit
+
+\[
+p_i(\theta)=z_i+a_i\cos\theta+b_i\sin\theta.
+\]
+
+For \(h(\theta)=[\cos\theta,\sin\theta]^\top\), retain
+\(m=E[h]\) and \(C=\operatorname{Cov}(h)\). These are equivalent to the first
+two complex trigonometric moments, not a complete angular density. Stack
+\(A_i=[a_i,b_i]\) into \(A\). Then
+
+\[
+E[p]=z+Am,\qquad \operatorname{Cov}(p)=ACA^\top=LL^\top,
+\quad L=AC^{1/2}.
+\]
+
+The **shared axial contribution has rank at most two**, regardless of the
+number of points. The implementation stores an `N x 3 x 2` factor rather than
+a dense `3N x 3N` covariance. It never interprets the rows as independent noise.
+For any declared linear query \(q=Wp\), its moments are exactly
+
+\[
+E[q]=W(z+Am),\qquad \operatorname{Cov}(q)=(WL)(WL)^\top.
+\]
+
+The componentwise full-orbit bounds are
+
+\[
+(Wz)_j\ \pm\ \sqrt{(Wa)_j^2+(Wb)_j^2}.
+\]
+
+These are bounds over the entire circle, not credible intervals, a joint box
+whose corners are simultaneously attainable, or necessarily the support of the
+supplied angular law. A component is constant over the circle precisely when
+both its cosine and sine coefficients vanish. Checking only its derivative at
+one angle is insufficient.
+
+### Angular laws
+
+`CircularMoments2` accepts a validated mean/covariance of `(cos, sin)`, provides
+uniform and wrapped-normal constructors, and computes exact moments of a finite
+weighted angular law. Finite laws may be multimodal.
+
+For a centered wrapped normal with underlying variance \(v\),
+
+\[
+E[r\cos\theta]=r e^{-v/2},\qquad
+\operatorname{Var}(r\cos\theta)=\tfrac12 r^2(1-e^{-v})^2.
+\]
+
+The implementation uses `expm1` to preserve the small radial term when \(v\)
+is tiny. It does not replace the user's angular law with a fitted Gaussian or
+infer an angular prior from evaluation outcomes.
+
+## Limits that matter for integration
+
+The axis, pivot, scale, and reference geometry are fixed or conditioned on.
+This is **not** exact propagation of a general seven-dimensional Sim(3)
+Gaussian. A small local information eigenvalue is not proof of an exact finite
+symmetry: near-collinear geometry can contain weak but genuine twist evidence.
+The caller must justify the orbit from its measurement model and retain that
+weak evidence when it exists.
+
+If other gauge variables \(\eta\) are uncertain or correlated with the angle,
+use conditional moments and the law of total covariance:
+
+\[
+E[p]=E_\eta[E[p\mid\eta]],\quad
+\operatorname{Cov}(p)=E_\eta[\operatorname{Cov}(p\mid\eta)]
+ +\operatorname{Cov}_\eta(E[p\mid\eta]).
+\]
+
+A full implementation of that integration is future work; it is not provided
+by this conditional kernel. Do not add this term to an existing gauge
+covariance that already contains the same twist. Independent readout noise may
+be added only under an explicit independence assumption. Nonlinear physical
+queries require additional integration, not the linear `project` shortcut.
+
+Moment exactness does not establish calibrated probabilities, Gaussian tails,
+physical correctness, or safe admission. BayesianPhysTwin still owns complete
+candidate construction and exact caller-owned fallback; Causal4D consumes only
+a separately admitted physical belief.
+
+## Reproduction
+
+```bash
+python -m pytest -q \
+  tests/test_axial_gauge_moments.py \
+  tests/test_axial_gauge_observability_integration.py
+python -m prob4d.axial_gauge_moment_study \
+  --protocol protocols/axial-gauge-moment-closure-v1.json \
+  --output outputs/axial-gauge-moment-closure-v1/result.json
+```
+
+The output is created exclusively: an existing result is never overwritten.
+It records the complete protocol, source-file hashes, runtime, all method rows,
+and a canonical content identity. Final paper-facing result bytes belong in
+`FlorianPfaff/BayesianPhysTwin-Paper`, not this code repository.
+
+The designed control uses a 100 mm off-axis radius, a wrapped-normal angular
+standard deviation sweep of 0.1, 0.5, 1, 2, and 3 radians, and independent 5 mm
+readout noise. It retains first order, second order, two-point spherical-radial
+cubature, Gauss-Hermite with 5 and 32 nodes, exact circular moments, and a
+separate 128-node numerical reference. A 20 mm standard-deviation screen is
+illustrative only and is not a production guard or a safety threshold.
+
+At one radian, the expected radial mean and standard deviation are 60.653 mm
+and 44.976 mm. First order reports 100 mm and 5 mm. Two symmetric cubature
+points also report zero axial radial variance because their cosines coincide.
+**32-node Gauss-Hermite agrees with the exact result** in this primary case.
+It must remain in any paper comparison. The Gaussian expected score evaluates
+moment approximations under the designed law; it is not empirical Gaussian
+calibration. The shared-copy control is an algebraic dependence check, not 64
+independent observations or physical trials.
+
+## Contribution and prior art
+
+Neither unobservable registration directions nor circular moments are new.
+Localizability-aware registration is established, for example by X-ICP [1].
+Directional estimation already provides analytic wrapped-normal trigonometric
+moments, circular mixtures, and moment-preserving deterministic sampling [2].
+Classical Rodrigues propagation and the law of total covariance are used here.
+
+The candidate Prob4D contribution is narrower: preserve an unresolved finite
+rotation in a learned-4D gauge, distinguish local derivative support from
+finite-orbit query invariance, and retain its nonlinear **shared** uncertainty
+through physical-query projection. Exact rank-two propagation gives a compact
+implementation and an analytic check on numerical integration. It is not a
+new general theorem about observability or a claim to outperform sufficiently
+accurate quadrature.
+
+General query-quotient lifting and physical-identifiability theory already
+belong to the ecosystem's theory companion. This module does not reclaim those
+theorems or require another standalone manuscript.
+
+## What would make the paper materially stronger
+
+The largest missing evidence remains one fresh real-provider result. Complete
+the existing source-only PointWorld/Flat'n'Fold qualification in issue #333,
+then separately freeze a held-out provider study. Do not reopen the terminal
+MotionCrafter, official-Hub Deform360, v6.1, or CUT3R cohorts.
+
+Only use this axial path where source geometry and the measurement model
+justify it. Register queries and source/calibration thresholds before opening
+held-out outcomes. Include on-axis and off-axis queries, shared and incorrectly
+independent covariance ablations, local Gaussian and strong nonlinear
+quadrature baselines, unchanged physical fallback, and the strongest simple
+deterministic comparator. Score provider quality separately from downstream
+physical-query value; use garment/object-session inference units, proper
+scores, interval width, admitted-update harm, fallback frequency, and paired
+query error. Report negatives and unsupported geometries without replacement.
+
+PointWorld's action-conditioned point-flow model [3] is a candidate provider,
+not evidence that it works on Flat'n'Fold or benefits BayesianPhysTwin.
+Causal4D is optional downstream evidence and cannot rescue an upstream failure.
+No current paper requires new hardware acquisition.
+
+## References
+
+1. Tuna et al., *X-ICP: Localizability-Aware LiDAR Registration for Robust
+   Localization in Extreme Environments*, arXiv:2211.16335.
+   https://arxiv.org/abs/2211.16335
+2. Kurz et al., *Directional Statistics and Filtering Using libDirectional*,
+   Journal of Statistical Software 89(4), 2019; arXiv:1712.09718.
+   https://www.jstatsoft.org/article/view/v089i04
+3. Huang et al., *PointWorld: Scaling 3D World Models for In-The-Wild Robotic
+   Manipulation*, arXiv:2601.03782, 2026.
+   https://arxiv.org/abs/2601.03782

--- a/protocols/axial-gauge-moment-closure-v1.json
+++ b/protocols/axial-gauge-moment-closure-v1.json
@@ -1,0 +1,21 @@
+{
+  "schema": "prob4d.axial-gauge-moment-control.v1",
+  "evidence_kind": "designed-analytic-mechanism-control",
+  "radius_m": 0.1,
+  "independent_readout_std_m": 0.005,
+  "wrapped_normal_std_radians": [0.1, 0.5, 1.0, 2.0, 3.0],
+  "primary_std_radians": 1.0,
+  "illustrative_std_screen_m": 0.02,
+  "shared_point_copies": 64,
+  "reference_hermite_nodes": 128,
+  "methods": ["first-order", "second-order", "spherical-radial-2", "gauss-hermite-5", "gauss-hermite-32", "exact-circular-moments"],
+  "information_boundary": {
+    "real_provider_predictions": false,
+    "source_outcomes": false,
+    "target_outcomes": false,
+    "bayesian_phystwin_execution": false,
+    "causal4d_execution": false,
+    "protected_cohort_access_authorized": false
+  },
+  "claim_boundary": "Conditional exact axial point/query moments and a deterministic local-linearization counterexample only. No real-provider, calibration, physical-benefit, causal-benefit, safety, or state-of-the-art claim. The illustrative variance screen is not a production guard."
+}

--- a/src/prob4d/axial_gauge_moment_study.py
+++ b/src/prob4d/axial_gauge_moment_study.py
@@ -97,7 +97,8 @@ def _validate_protocol(protocol: dict[str, Any]) -> None:
     if len(set(sigmas)) != len(sigmas) or protocol["primary_std_radians"] not in sigmas:
         raise ValueError("primary case must occur once in the declared sweep")
     for key, lower, upper in (
-        ("shared_point_copies", 2, 10000), ("reference_hermite_nodes", 64, 256)
+        ("shared_point_copies", 2, 10000),
+        ("reference_hermite_nodes", 64, 256),
     ):
         value = protocol[key]
         if type(value) is not int or not lower <= value <= upper:

--- a/src/prob4d/axial_gauge_moment_study.py
+++ b/src/prob4d/axial_gauge_moment_study.py
@@ -1,0 +1,239 @@
+"""Reproduce a target-free analytic control for nonlinear axial gauge moments.
+
+Results are generated evidence and belong in BayesianPhysTwin-Paper, not in the
+code repository. Gaussian expected scores assess moment approximations only;
+the non-Gaussian orbit law is not called a calibrated Gaussian posterior.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import platform
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from . import axial_gauge_moments
+from .axial_gauge_moments import AxialGaugeOrbit, CircularMoments2
+
+SCHEMA = "prob4d.axial-gauge-moment-control.v1"
+METHODS = (
+    "first-order",
+    "second-order",
+    "spherical-radial-2",
+    "gauss-hermite-5",
+    "gauss-hermite-32",
+    "exact-circular-moments",
+)
+
+
+def _canonical(value: object) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False).encode()
+
+
+def _hermite_radial(radius: float, sigma: float, nodes: int) -> tuple[float, float]:
+    locations, mass = np.polynomial.hermite.hermgauss(nodes)
+    probability = mass / np.sqrt(np.pi)
+    query = radius * np.cos(np.sqrt(2.0) * sigma * locations)
+    mean = float(probability @ query)
+    return mean, float(probability @ (query - mean) ** 2)
+
+
+def _validate_protocol(protocol: dict[str, Any]) -> None:
+    required = {
+        "schema",
+        "evidence_kind",
+        "radius_m",
+        "independent_readout_std_m",
+        "wrapped_normal_std_radians",
+        "primary_std_radians",
+        "illustrative_std_screen_m",
+        "shared_point_copies",
+        "reference_hermite_nodes",
+        "methods",
+        "information_boundary",
+        "claim_boundary",
+    }
+    if set(protocol) != required or protocol["schema"] != SCHEMA:
+        raise ValueError("unknown protocol schema or fields")
+    if protocol["evidence_kind"] != "designed-analytic-mechanism-control":
+        raise ValueError("this runner is only an analytic mechanism control")
+    boundary = protocol["information_boundary"]
+    expected_boundary = {
+        "real_provider_predictions",
+        "source_outcomes",
+        "target_outcomes",
+        "bayesian_phystwin_execution",
+        "causal4d_execution",
+        "protected_cohort_access_authorized",
+    }
+    if not isinstance(boundary, dict) or set(boundary) != expected_boundary:
+        raise ValueError("information boundary must be complete")
+    if any(value is not False for value in boundary.values()):
+        raise ValueError("this control cannot authorize real-data or downstream access")
+    if protocol["methods"] != list(METHODS):
+        raise ValueError("the complete declared method set is required")
+    for key in ("radius_m", "independent_readout_std_m", "illustrative_std_screen_m"):
+        value = protocol[key]
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError(f"{key} must be numeric")
+        if not math.isfinite(value) or value <= 0.0:
+            raise ValueError(f"{key} must be finite and positive")
+    sigmas = protocol["wrapped_normal_std_radians"]
+    if not isinstance(sigmas, list) or not sigmas:
+        raise ValueError("a nonempty angular sweep is required")
+    if any(
+        isinstance(sigma, bool)
+        or not isinstance(sigma, (int, float))
+        or not math.isfinite(sigma)
+        or sigma <= 0.0
+        for sigma in sigmas
+    ):
+        raise ValueError("angular standard deviations must be finite and positive")
+    if len(set(sigmas)) != len(sigmas) or protocol["primary_std_radians"] not in sigmas:
+        raise ValueError("primary case must occur once in the declared sweep")
+    for key, lower, upper in (
+        ("shared_point_copies", 2, 10000), ("reference_hermite_nodes", 64, 256)
+    ):
+        value = protocol[key]
+        if type(value) is not int or not lower <= value <= upper:
+            raise ValueError(f"{key} must be an integer in [{lower}, {upper}]")
+    if not isinstance(protocol["claim_boundary"], str) or not protocol["claim_boundary"].strip():
+        raise ValueError("claim_boundary must be nonempty")
+
+
+def build_report(protocol: dict[str, Any]) -> dict[str, Any]:
+    _validate_protocol(protocol)
+    radius = float(protocol["radius_m"])
+    noise_variance = float(protocol["independent_readout_std_m"]) ** 2
+    orbit = AxialGaugeOrbit(axis=np.array([0.0, 0.0, 1.0]), pivot=np.zeros(3))
+    point = np.array([[radius, 0.0, 0.0]])
+    weights = np.array([[1.0, 0.0, 0.0]])
+    cases: list[dict[str, Any]] = []
+    for sigma_value in protocol["wrapped_normal_std_radians"]:
+        sigma = float(sigma_value)
+        angular = CircularMoments2.wrapped_normal(0.0, sigma * sigma)
+        query = orbit.point_moments(point, angular).project(weights)
+        truth_mean = float(query.mean[0])
+        truth_variance = float(query.covariance[0, 0]) + noise_variance
+        reference_mean, reference_variance = _hermite_radial(
+            radius, sigma, protocol["reference_hermite_nodes"]
+        )
+        approximations = {
+            "first-order": (radius, 0.0),
+            "second-order": (radius * (1.0 - 0.5 * sigma**2), 0.5 * radius**2 * sigma**4),
+            "spherical-radial-2": (radius * float(np.cos(sigma)), 0.0),
+            "gauss-hermite-5": _hermite_radial(radius, sigma, 5),
+            "gauss-hermite-32": _hermite_radial(radius, sigma, 32),
+            "exact-circular-moments": (truth_mean, truth_variance - noise_variance),
+        }
+        rows = []
+        for name in METHODS:
+            mean, axial_variance = approximations[name]
+            variance = axial_variance + noise_variance
+            expected_squared_error = truth_variance + (truth_mean - mean) ** 2
+            expected_score = 0.5 * (
+                math.log(2.0 * math.pi * variance) + expected_squared_error / variance
+            )
+            rows.append(
+                {
+                    "method": name,
+                    "query_mean_m": mean,
+                    "query_std_m": math.sqrt(variance),
+                    "axial_variance_m2": axial_variance,
+                    "expected_gaussian_nll_nats_metre_coordinates": expected_score,
+                    "expected_squared_standardized_error": expected_squared_error / variance,
+                    "illustrative_std_screen_passes": math.sqrt(variance)
+                    <= float(protocol["illustrative_std_screen_m"]),
+                }
+            )
+        cases.append(
+            {
+                "angular_std_radians": sigma,
+                "true_query_mean_m": truth_mean,
+                "true_query_variance_m2": truth_variance,
+                "local_angular_derivative_m_per_radian": 0.0,
+                "full_orbit_bounds_m": query.full_orbit_bounds[0].tolist(),
+                "reference_mean_absolute_error_m": abs(reference_mean - truth_mean),
+                "reference_variance_absolute_error_m2": abs(
+                    reference_variance + noise_variance - truth_variance
+                ),
+                "methods": rows,
+            }
+        )
+    copies = protocol["shared_point_copies"]
+    shared = orbit.point_moments(
+        np.repeat(point, copies, axis=0),
+        CircularMoments2.wrapped_normal(0.0, float(protocol["primary_std_radians"]) ** 2),
+    )
+    average_weights = np.zeros((copies, 3))
+    average_weights[:, 0] = 1.0 / copies
+    exact_average = float(shared.project(average_weights).covariance[0, 0])
+    independent_average = float(np.sum(shared.marginal_covariance[:, 0, 0]) / copies**2)
+    contrast = np.zeros((copies, 3))
+    contrast[0, 0], contrast[1, 0] = 1.0, -1.0
+    source_hashes = {
+        "src/prob4d/axial_gauge_moments.py": hashlib.sha256(
+            Path(axial_gauge_moments.__file__).read_bytes()
+        ).hexdigest(),
+        "src/prob4d/axial_gauge_moment_study.py": hashlib.sha256(
+            Path(__file__).read_bytes()
+        ).hexdigest(),
+    }
+    report: dict[str, Any] = {
+        "schema": "prob4d.axial-gauge-moment-result.v1",
+        "evidence_kind": protocol["evidence_kind"],
+        "protocol": protocol,
+        "protocol_sha256": hashlib.sha256(_canonical(protocol)).hexdigest(),
+        "source_file_sha256": source_hashes,
+        "runtime": {"python": platform.python_version(), "numpy": np.__version__},
+        "cases": cases,
+        "shared_covariance_control": {
+            "point_copies_not_independent_units": copies,
+            "shared_average_axial_variance_m2": exact_average,
+            "invalid_independent_average_axial_variance_m2": independent_average,
+            "variance_understatement_factor": exact_average / independent_average,
+            "identical_point_contrast_axial_variance_m2": float(
+                shared.project(contrast).covariance[0, 0]
+            ),
+            "shared_factor_shape": list(shared.shared_factors.shape),
+        },
+        "claim_boundary": protocol["claim_boundary"],
+    }
+    report["artifact_id"] = hashlib.sha256(_canonical(report)).hexdigest()
+    return report
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--protocol", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args(argv)
+    protocol = json.loads(
+        args.protocol.read_text(encoding="utf-8"), object_pairs_hook=_unique_object
+    )
+    report = build_report(protocol)
+    content = json.dumps(report, sort_keys=True, indent=2, allow_nan=False) + "\n"
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    # Exclusive creation: a previous retained result is never overwritten.
+    with args.output.open("x", encoding="utf-8") as stream:
+        stream.write(content)
+    print(report["artifact_id"])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/prob4d/axial_gauge_moments.py
+++ b/src/prob4d/axial_gauge_moments.py
@@ -74,9 +74,7 @@ class CircularMoments2:
         symmetric = 0.5 * (covariance + covariance.T)
         if float(np.linalg.eigvalsh(symmetric)[0]) < -_ROUNDOFF:
             raise ValueError("circular covariance must be positive semidefinite")
-        if not np.isclose(
-            float(np.trace(symmetric) + mean @ mean), 1.0, atol=_ROUNDOFF, rtol=0.0
-        ):
+        if not np.isclose(float(np.trace(symmetric) + mean @ mean), 1.0, atol=_ROUNDOFF, rtol=0.0):
             raise ValueError("circular moments must satisfy E[cos^2 + sin^2] = 1")
         symmetric.setflags(write=False)
         object.__setattr__(self, "mean", mean)

--- a/src/prob4d/axial_gauge_moments.py
+++ b/src/prob4d/axial_gauge_moments.py
@@ -1,0 +1,292 @@
+"""Exact shared point/query moments for a declared axial gauge ambiguity.
+
+Experimental, conditional geometric kernel; not a provider-v2 exporter or a
+complete Sim(3) posterior. An exact stabilizer must be justified from the
+measurement model, not inferred from a numerically small Hessian eigenvalue.
+The angular law is supplied by the caller and is never fitted here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TypeAlias
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+
+FloatArray: TypeAlias = NDArray[np.float64]
+_ROUNDOFF = 128.0 * np.finfo(np.float64).eps
+
+
+def _array(value: ArrayLike, *, name: str) -> FloatArray:
+    raw = np.asarray(value)
+    if raw.dtype.kind not in "iuf":
+        raise ValueError(f"{name} must contain real numeric values")
+    result = np.array(raw, dtype=np.float64, copy=True)
+    if not np.all(np.isfinite(result)):
+        raise ValueError(f"{name} must be finite")
+    result.setflags(write=False)
+    return result
+
+
+def _vector(value: ArrayLike, size: int, *, name: str) -> FloatArray:
+    result = _array(value, name=name)
+    if result.shape != (size,):
+        raise ValueError(f"{name} must have shape ({size},)")
+    return result
+
+
+def _points(value: ArrayLike, *, name: str = "points") -> FloatArray:
+    result = _array(value, name=name)
+    if result.ndim != 2 or result.shape[0] == 0 or result.shape[1] != 3:
+        raise ValueError(f"{name} must have nonempty shape (N, 3)")
+    return result
+
+
+def _finite_scalar(value: float, *, name: str) -> float:
+    if isinstance(value, (bool, np.bool_)):
+        raise ValueError(f"{name} must be a real scalar")
+    result = float(value)
+    if not np.isfinite(result):
+        raise ValueError(f"{name} must be finite")
+    return result
+
+
+@dataclass(frozen=True)
+class CircularMoments2:
+    """Mean/covariance of (cos(theta), sin(theta)), not a full angular density.
+
+    These are equivalent to the first two complex trigonometric moments. The
+    centered representation avoids catastrophic subtraction for narrow wrapped
+    normals. Matching these moments does not specify tails or credible regions.
+    """
+
+    mean: FloatArray
+    covariance: FloatArray
+
+    def __post_init__(self) -> None:
+        mean = _vector(self.mean, 2, name="circular mean")
+        covariance = _array(self.covariance, name="circular covariance")
+        if covariance.shape != (2, 2):
+            raise ValueError("circular covariance must have shape (2, 2)")
+        if not np.allclose(covariance, covariance.T, atol=_ROUNDOFF, rtol=0.0):
+            raise ValueError("circular covariance must be symmetric")
+        symmetric = 0.5 * (covariance + covariance.T)
+        if float(np.linalg.eigvalsh(symmetric)[0]) < -_ROUNDOFF:
+            raise ValueError("circular covariance must be positive semidefinite")
+        if not np.isclose(
+            float(np.trace(symmetric) + mean @ mean), 1.0, atol=_ROUNDOFF, rtol=0.0
+        ):
+            raise ValueError("circular moments must satisfy E[cos^2 + sin^2] = 1")
+        symmetric.setflags(write=False)
+        object.__setattr__(self, "mean", mean)
+        object.__setattr__(self, "covariance", symmetric)
+
+    @classmethod
+    def uniform(cls) -> CircularMoments2:
+        return cls(np.zeros(2), 0.5 * np.eye(2))
+
+    @classmethod
+    def wrapped_normal(cls, mean_radians: float, variance_radians2: float) -> CircularMoments2:
+        """Exact moments of theta = Normal(mean, variance) modulo 2*pi."""
+        mean = _finite_scalar(mean_radians, name="mean_radians")
+        variance = _finite_scalar(variance_radians2, name="variance_radians2")
+        if variance < 0.0:
+            raise ValueError("variance_radians2 must be nonnegative")
+        cosine, sine = float(np.cos(mean)), float(np.sin(mean))
+        rotation = np.array([[cosine, -sine], [sine, cosine]])
+        attenuation = float(np.exp(-0.5 * variance))
+        # expm1 retains the O(variance^2) radial term for narrow laws.
+        radial = 0.5 * float(-np.expm1(-variance)) ** 2
+        tangential = 0.5 * float(-np.expm1(-variance)) * (1.0 + float(np.exp(-variance)))
+        covariance = rotation @ np.diag([radial, tangential]) @ rotation.T
+        return cls(attenuation * np.array([cosine, sine]), covariance)
+
+    @classmethod
+    def from_atoms(cls, angles: ArrayLike, weights: ArrayLike) -> CircularMoments2:
+        """Exact moments of a finite angular law; weights need not sum to one."""
+        theta = _array(angles, name="angles")
+        mass = _array(weights, name="weights")
+        if theta.ndim != 1 or theta.size == 0 or mass.shape != theta.shape:
+            raise ValueError("angles and weights must have the same nonempty 1D shape")
+        if np.any(mass < 0.0) or float(np.max(mass)) <= 0.0:
+            raise ValueError("weights must be nonnegative with positive total mass")
+        scaled = mass / float(np.max(mass))
+        probability = scaled / float(np.sum(scaled))
+        values = np.column_stack((np.cos(theta), np.sin(theta)))
+        mean = probability @ values
+        centered = values - mean
+        covariance = (centered.T * probability) @ centered
+        return cls(mean, covariance)
+
+    @property
+    def first_moment(self) -> complex:
+        return complex(float(self.mean[0]), float(self.mean[1]))
+
+    @property
+    def second_moment(self) -> complex:
+        raw = self.covariance + np.outer(self.mean, self.mean)
+        return complex(float(raw[0, 0] - raw[1, 1]), float(2.0 * raw[0, 1]))
+
+    @property
+    def covariance_root(self) -> FloatArray:
+        eigenvalues, eigenvectors = np.linalg.eigh(self.covariance)
+        root = eigenvectors * np.sqrt(np.maximum(eigenvalues, 0.0))
+        root.setflags(write=False)
+        return root
+
+
+@dataclass(frozen=True)
+class AxialQueryMoments:
+    """Exact moments and componentwise full-orbit bounds for a linear query.
+
+    Bounds describe all angles in [0, 2*pi), not a credible region and not
+    necessarily the support of the caller's angular law. The covariance is only
+    the shared axial contribution, without point noise or other gauge terms.
+    """
+
+    mean: FloatArray
+    shared_factors: FloatArray
+    orbit_center: FloatArray
+    cosine_coefficients: FloatArray
+    sine_coefficients: FloatArray
+
+    def __post_init__(self) -> None:
+        mean = _array(self.mean, name="query mean")
+        if mean.ndim != 1 or mean.size == 0:
+            raise ValueError("query mean must be a nonempty vector")
+        factors = _array(self.shared_factors, name="query shared_factors")
+        if factors.shape != (mean.size, 2):
+            raise ValueError("query shared_factors must have shape (Q, 2)")
+        object.__setattr__(self, "mean", mean)
+        object.__setattr__(self, "shared_factors", factors)
+        for name in ("orbit_center", "cosine_coefficients", "sine_coefficients"):
+            object.__setattr__(self, name, _vector(getattr(self, name), mean.size, name=name))
+
+    @property
+    def covariance(self) -> FloatArray:
+        return _array(self.shared_factors @ self.shared_factors.T, name="query covariance")
+
+    @property
+    def orbit_amplitude(self) -> FloatArray:
+        return _array(
+            np.hypot(self.cosine_coefficients, self.sine_coefficients), name="orbit amplitude"
+        )
+
+    @property
+    def full_orbit_bounds(self) -> FloatArray:
+        amplitude = self.orbit_amplitude
+        return _array(
+            np.column_stack((self.orbit_center - amplitude, self.orbit_center + amplitude)),
+            name="full orbit bounds",
+        )
+
+
+@dataclass(frozen=True)
+class AxialPointMoments:
+    """N point means and one shared rank-at-most-two covariance factor.
+
+    Flatten ``shared_factors`` to (3*N, 2); its product with its transpose is the
+    complete joint axial covariance. Never treat its rows as independent noise.
+    """
+
+    mean: FloatArray
+    shared_factors: FloatArray
+    orbit_center: FloatArray
+    cosine_coefficients: FloatArray
+    sine_coefficients: FloatArray
+
+    def __post_init__(self) -> None:
+        mean = _points(self.mean, name="point mean")
+        factors = _array(self.shared_factors, name="point shared_factors")
+        if factors.shape != (*mean.shape, 2):
+            raise ValueError("point shared_factors must have shape (N, 3, 2)")
+        object.__setattr__(self, "mean", mean)
+        object.__setattr__(self, "shared_factors", factors)
+        for name in ("orbit_center", "cosine_coefficients", "sine_coefficients"):
+            value = _points(getattr(self, name), name=name)
+            if value.shape != mean.shape:
+                raise ValueError(f"{name} must match point mean shape")
+            object.__setattr__(self, name, value)
+
+    @property
+    def marginal_covariance(self) -> FloatArray:
+        return _array(
+            np.einsum("nik,njk->nij", self.shared_factors, self.shared_factors),
+            name="marginal covariance",
+        )
+
+    def project(self, weights: ArrayLike) -> AxialQueryMoments:
+        """Project q_d = sum_{n,c} weights[d,n,c] * point[n,c].
+
+        Shape (N, 3) denotes one scalar query; (Q, N, 3) denotes Q queries.
+        Point ordering/identity and any additional covariance are caller-owned.
+        """
+        matrix = _array(weights, name="query weights")
+        if matrix.ndim == 2:
+            matrix = matrix[None, :, :]
+        if matrix.ndim != 3 or matrix.shape[0] == 0 or matrix.shape[1:] != self.mean.shape:
+            raise ValueError("query weights must have shape (N, 3) or (Q, N, 3)")
+        return AxialQueryMoments(
+            mean=np.einsum("qnc,nc->q", matrix, self.mean),
+            shared_factors=np.einsum("qnc,nck->qk", matrix, self.shared_factors),
+            orbit_center=np.einsum("qnc,nc->q", matrix, self.orbit_center),
+            cosine_coefficients=np.einsum("qnc,nc->q", matrix, self.cosine_coefficients),
+            sine_coefficients=np.einsum("qnc,nc->q", matrix, self.sine_coefficients),
+        )
+
+
+@dataclass(frozen=True)
+class AxialGaugeOrbit:
+    """Declared rotations about a fixed world-frame line through ``pivot``.
+
+    The observable quotient (axis, pivot, scale and reference points) is held
+    fixed. For an uncertain quotient use conditional angular moments and the
+    law of total covariance; adding independent covariance is not valid when
+    that quotient and the angle are correlated.
+    """
+
+    axis: FloatArray
+    pivot: FloatArray
+
+    def __post_init__(self) -> None:
+        axis = _vector(self.axis, 3, name="axis")
+        pivot = _vector(self.pivot, 3, name="pivot")
+        magnitude = float(np.max(np.abs(axis)))
+        if magnitude == 0.0:
+            raise ValueError("axis must be nonzero")
+        scaled = axis / magnitude
+        unit = scaled / float(np.linalg.norm(scaled))
+        unit.setflags(write=False)
+        object.__setattr__(self, "axis", unit)
+        object.__setattr__(self, "pivot", pivot)
+
+    def coefficients(self, points: ArrayLike) -> tuple[FloatArray, FloatArray, FloatArray]:
+        reference = _points(points)
+        offset = reference - self.pivot
+        parallel = np.outer(offset @ self.axis, self.axis)
+        cosine = offset - parallel
+        sine = np.cross(self.axis, cosine)
+        return (
+            _array(self.pivot + parallel, name="orbit center"),
+            _array(cosine, name="cosine coefficients"),
+            _array(sine, name="sine coefficients"),
+        )
+
+    def support_orbit_diameter(self, support_points: ArrayLike) -> FloatArray:
+        """Per-point maximum movement over the full orbit, equal to 2*radius.
+
+        Exact collinear point support has zero diameter. A small nonzero value
+        is not a proof of an exact likelihood symmetry.
+        """
+        _, cosine, _ = self.coefficients(support_points)
+        return _array(2.0 * np.linalg.norm(cosine, axis=1), name="support orbit diameter")
+
+    def point_moments(self, points: ArrayLike, angular: CircularMoments2) -> AxialPointMoments:
+        if not isinstance(angular, CircularMoments2):
+            raise TypeError("angular must be CircularMoments2")
+        center, cosine, sine = self.coefficients(points)
+        design = np.stack((cosine, sine), axis=-1)
+        mean = center + design @ angular.mean
+        factors = design @ angular.covariance_root
+        return AxialPointMoments(mean, factors, center, cosine, sine)

--- a/tests/test_axial_gauge_moments.py
+++ b/tests/test_axial_gauge_moments.py
@@ -1,0 +1,292 @@
+"""Independent numerical and adversarial controls for exact axial moments."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from prob4d.axial_gauge_moment_study import build_report, main
+from prob4d.axial_gauge_moments import AxialGaugeOrbit, CircularMoments2
+
+ROOT = Path(__file__).resolve().parents[1]
+PROTOCOL = ROOT / "protocols" / "axial-gauge-moment-closure-v1.json"
+
+
+def _direct_rodrigues(points, axis, pivot, angles, weights):
+    """Independent full rotations, rather than the implementation's factorization."""
+    axis = np.asarray(axis, dtype=float)
+    axis /= np.linalg.norm(axis)
+    x, y, z = axis
+    skew = np.array([[0.0, -z, y], [z, 0.0, -x], [-y, x, 0.0]])
+    values = []
+    for angle in angles:
+        rotation = np.eye(3) + np.sin(angle) * skew + (1.0 - np.cos(angle)) * (skew @ skew)
+        values.append(((points - pivot) @ rotation.T + pivot).reshape(-1))
+    values = np.asarray(values)
+    probability = np.asarray(weights) / np.sum(weights)
+    mean = probability @ values
+    centered = values - mean
+    return mean, (centered.T * probability) @ centered
+
+
+def _joint(result):
+    factor = result.shared_factors.reshape(-1, 2)
+    return factor @ factor.T
+
+
+def test_uniform_ring_is_rank_two_and_preserves_cross_point_dependence():
+    points = np.array([[0.1, 0.0, 0.0], [-0.1, 0.0, 0.5]])
+    result = AxialGaugeOrbit(np.array([0.0, 0.0, 1.0]), np.zeros(3)).point_moments(
+        points, CircularMoments2.uniform()
+    )
+    np.testing.assert_allclose(result.mean, [[0.0, 0.0, 0.0], [0.0, 0.0, 0.5]])
+    np.testing.assert_allclose(result.marginal_covariance[0], np.diag([0.005, 0.005, 0.0]))
+    np.testing.assert_allclose(_joint(result)[:3, 3:], np.diag([-0.005, -0.005, 0.0]))
+    assert np.linalg.matrix_rank(_joint(result), tol=1e-14) == 2
+
+
+@pytest.mark.parametrize("mean,variance", [(0.0, 0.0), (0.7, 0.01), (-2.0, 1.0), (2.9, 9.0)])
+def test_wrapped_normal_matches_independent_rodrigues_quadrature(mean, variance):
+    points = np.array([[0.2, -0.1, 0.3], [-0.7, 0.5, 0.1], [0.0, 0.0, 0.0]])
+    axis, pivot = np.array([1.0, 2.0, -3.0]), np.array([0.1, 0.2, 0.3])
+    angular = CircularMoments2.wrapped_normal(mean, variance)
+    nodes, weights = np.polynomial.hermite.hermgauss(128)
+    expected_mean, expected_covariance = _direct_rodrigues(
+        points, axis, pivot, mean + np.sqrt(2.0 * variance) * nodes, weights
+    )
+    actual = AxialGaugeOrbit(axis, pivot).point_moments(points, angular)
+    np.testing.assert_allclose(actual.mean.reshape(-1), expected_mean, atol=2e-14, rtol=2e-13)
+    np.testing.assert_allclose(_joint(actual), expected_covariance, atol=2e-14, rtol=2e-13)
+    np.testing.assert_allclose(angular.first_moment, np.exp(1j * mean - variance / 2), atol=1e-15)
+    np.testing.assert_allclose(angular.second_moment, np.exp(2j * mean - 2 * variance), atol=1e-15)
+
+
+def test_multimodal_atoms_and_linear_query_match_dense_reference():
+    rng = np.random.default_rng(48271)
+    points = rng.normal(size=(7, 3))
+    axis, pivot = np.array([2.0, 1.0, 3.0]), np.array([-0.3, 0.7, 1.2])
+    angles, weights = np.array([-2.8, -0.4, 0.5, 2.2]), np.array([1.0, 5.0, 3.0, 7.0])
+    angular = CircularMoments2.from_atoms(angles, weights)
+    actual = AxialGaugeOrbit(axis, pivot).point_moments(points, angular)
+    mean, covariance = _direct_rodrigues(points, axis, pivot, angles, weights)
+    np.testing.assert_allclose(actual.mean.reshape(-1), mean, atol=1e-14)
+    np.testing.assert_allclose(_joint(actual), covariance, atol=1e-14)
+    matrix = rng.normal(size=(4, 7, 3))
+    query = actual.project(matrix)
+    flat = matrix.reshape(4, -1)
+    np.testing.assert_allclose(query.mean, flat @ mean, atol=1e-14)
+    np.testing.assert_allclose(query.covariance, flat @ covariance @ flat.T, atol=1e-12)
+
+
+def test_small_variance_retains_second_order_radial_variance():
+    variance = 1e-12
+    angular = CircularMoments2.wrapped_normal(0.0, variance)
+    np.testing.assert_allclose(angular.covariance[0, 0], 0.5 * variance**2, rtol=2e-12, atol=0.0)
+    np.testing.assert_allclose(angular.covariance[1, 1], variance, rtol=2e-12, atol=0.0)
+    assert np.all(CircularMoments2.wrapped_normal(0.3, 0.0).covariance == 0.0
+
+
+def test_very_broad_wrapped_normal_has_uniform_limit():
+    actual = CircularMoments2.wrapped_normal(1.2, 1e300)
+    np.testing.assert_allclose(actual.mean, [0.0, 0.0], atol=0.0)
+    np.testing.assert_allclose(actual.covariance, 0.5 * np.eye(2), atol=1e-15)
+
+
+def test_axis_sign_and_angle_reflection_preserve_moments():
+    points = np.array([[0.1, 0.2, -0.3], [0.6, 0.2, 0.1]])
+    axis, pivot = np.array([1.0, 3.0, -2.0]), np.array([0.2, -0.5, 0.1])
+    first = AxialGaugeOrbit(axis, pivot).point_moments(
+        points, CircularMoments2.wrapped_normal(0.9, 0.8)
+    )
+    second = AxialGaugeOrbit(-axis, pivot).point_moments(
+        points, CircularMoments2.wrapped_normal(-0.9, 0.8)
+    )
+    np.testing.assert_allclose(first.mean, second.mean, atol=1e-15)
+    np.testing.assert_allclose(_joint(first), _joint(second), atol=1e-15)
+
+
+def test_similarity_frame_equivariance():
+    points = np.array([[0.2, -0.1, 0.3], [-0.7, 0.5, 0.1]])
+    axis, pivot = np.array([1.0, 2.0, -3.0]), np.array([0.1, 0.2, 0.3])
+    angular = CircularMoments2.wrapped_normal(0.4, 2.0)
+    rotation = np.array([[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]])
+    scale, shift = 3.7, np.array([5.0, -7.0, 2.0])
+    first = AxialGaugeOrbit(axis, pivot).point_moments(points, angular)
+    second = AxialGaugeOrbit(rotation @ axis, scale * (rotation @ pivot) + shift).point_moments(
+        scale * (points @ rotation.T) + shift, angular
+    )
+    np.testing.assert_allclose(second.mean, scale * (first.mean @ rotation.T) + shift, atol=1e-14)
+    transform = np.kron(np.eye(2), scale * rotation)
+    np.testing.assert_allclose(_joint(second), transform @ _joint(first) @ transform.T, atol=1e-13)
+
+
+def test_shared_uncertainty_does_not_average_away_and_identical_contrast_cancels():
+    copies = 64
+    points = np.tile([0.1, 0.0, 0.0], (copies, 1))
+    moments = AxialGaugeOrbit(np.array([0.0, 0.0, 1.0]), np.zeros(3)).point_moments(
+        points, CircularMoments2.wrapped_normal(0.0, 1.0)
+    )
+    weights = np.zeros((copies, 3))
+    weights[:, 0] = 1.0 / copies
+    np.testing.assert_allclose(
+        moments.project(weights).covariance[0, 0], moments.marginal_covariance[0, 0, 0]
+    )
+    weights[:] = 0.0
+    weights[0, 0], weights[1, 0] = 1.0, -1.0
+    np.testing.assert_array_equal(moments.project(weights).covariance, [[0.0]])
+
+
+def test_zero_local_derivative_is_not_global_query_invariance():
+    orbit = AxialGaugeOrbit(np.array([0.0, 0.0, 1.0]), np.zeros(3))
+    query = orbit.point_moments(
+        [[0.1, 0.0, 0.0]], CircularMoments2.wrapped_normal(0.0, 1.0)
+    ).project([[1.0, 0.0, 0.0]])
+    assert query.sine_coefficients[0] == 0.0  # dq/dtheta at theta = 0.
+    assert query.orbit_amplitude[0] == 0.1
+    assert query.covariance[0, 0] > 0.0019
+    np.testing.assert_allclose(query.full_orbit_bounds, [[-0.1, 0.1]])
+    # Two equally weighted +/-sigma points have the same cosine: no radial variance.
+    cubature = CircularMoments2.from_atoms([-1.0, 1.0], [0.5, 0.5])
+    cubature_query = orbit.point_moments([[0.1, 0.0, 0.0]], cubature).project([[1.0, 0.0, 0.0]])
+    assert cubature_query.covariance[0, 0] == 0.0
+
+
+def test_collinear_support_is_unchanged_but_near_collinearity_is_not_exact():
+    orbit = AxialGaugeOrbit(np.array([0.0, 0.0, 1.0]), np.zeros(3))
+    support = np.array([[0.0, 0.0, -0.2], [0.0, 0.0, 0.0], [0.0, 0.0, 0.3]])
+    np.testing.assert_array_equal(orbit.support_orbit_diameter(support), np.zeros(3))
+    moments = orbit.point_moments(support, CircularMoments2.uniform())
+    np.testing.assert_array_equal(moments.mean, support)
+    np.testing.assert_array_equal(moments.shared_factors, np.zeros((3, 3, 2)))
+    support[0, 0] = 1e-8
+    assert orbit.support_orbit_diameter(support)[0] == 2e-8
+
+
+def test_full_orbit_bounds_are_componentwise_and_tight():
+    orbit = AxialGaugeOrbit(np.array([0.0, 0.0, 1.0]), np.array([1.0, 2.0, 3.0]))
+    points = np.array([[2.0, 4.0, 5.0]])
+    query = orbit.point_moments(points, CircularMoments2.uniform()).project(
+        np.eye(3).reshape(3, 1, 3)
+    )
+    for index in range(3):
+        angle = np.arctan2(query.sine_coefficients[index], query.cosine_coefficients[index])
+        upper = (
+            query.orbit_center[index]
+            + query.cosine_coefficients[index] * np.cos(angle)
+            + query.sine_coefficients[index] * np.sin(angle)
+        )
+        np.testing.assert_allclose(upper, query.full_orbit_bounds[index, 1], atol=1e-14)
+
+
+def test_inputs_are_copied_and_outputs_are_readonly():
+    axis, pivot = np.array([0.0, 0.0, 1.0]), np.zeros(3)
+    orbit = AxialGaugeOrbit(axis, pivot)
+    axis[:] = 7.0
+    pivot[:] = 9.0
+    result = orbit.point_moments([[0.1, 0.0, 0.0]], CircularMoments2.uniform())
+    for array in (
+        orbit.axis, orbit.pivot, result.mean, result.shared_factors, result.marginal_covariance
+    ):
+        assert not array.flags.writeable
+    np.testing.assert_allclose(orbit.axis, [0.0, 0.0, 1.0])
+    np.testing.assert_allclose(orbit.pivot, [0.0, 0.0, 0.0])
+
+
+@pytest.mark.parametrize(
+    "mean,covariance",
+    [
+        ([0.0, 0.0], [[1.0, 0.0], [0.0, -1.0]]),
+        ([0.0, 0.0], [[0.5, 0.2], [0.0, 0.5]]),
+        ([1.0, 1.0], [[0.0, 0.0], [0.0, 0.0]]),
+        ([0.0, 0.0], [[0.0, 0.0], [0.0, 0.0]]),
+        ([np.nan, 0.0], [[0.5, 0.0], [0.0, 0.5]]),
+    ],
+)
+def test_invalid_circular_moments_rejected(mean, covariance):
+    with pytest.raises(ValueError):
+        CircularMoments2(np.asarray(mean), np.asarray(covariance))
+
+
+@pytest.mark.parametrize(
+    "angles,weights",
+    [
+        ([], []),
+        ([0.0], [0.0]),
+        ([0.0, 1.0], [1.0, -1.0]),
+        ([0.0], [np.nan]),
+        ([np.inf], [1.0]),
+        ([0.0], [1.0, 1.0]),
+    ],
+)
+def test_invalid_atoms_rejected(angles, weights):
+    with pytest.raises(ValueError):
+        CircularMoments2.from_atoms(angles, weights)
+
+
+@pytest.mark.parametrize("mean,variance", [(np.nan, 1.0), (0.0, np.inf), (0.0, -1.0), (True, 1.0)])
+def test_invalid_wrapped_normals_rejected(mean, variance):
+    with pytest.raises(ValueError):
+        CircularMoments2.wrapped_normal(mean, variance)
+
+
+def test_invalid_geometry_and_query_shapes_rejected():
+    with pytest.raises(ValueError):
+        AxialGaugeOrbit(np.zeros(3), np.zeros(3))
+    orbit = AxialGaugeOrbit(np.array([0.0, 0.0, 1.0]), np.zeros(3))
+    for bad in ([[0.0, np.inf, 0.0]], [[1j, 0.0, 0.0]], [], [[1.0, 2.0]]):
+        with pytest.raises(ValueError):
+            orbit.point_moments(bad, CircularMoments2.uniform())
+    points = orbit.point_moments([[0.1, 0.0, 0.0]], CircularMoments2.uniform())
+    for bad in ([1.0, 2.0, 3.0], np.ones((1, 2, 3)), np.ones((0, 1, 3))):
+        with pytest.raises(ValueError):
+            points.project(bad)
+
+
+def test_protocol_reproduces_counterexample_and_retains_strong_quadrature_control():
+    report = build_report(json.loads(PROTOCOL.read_text()))
+    primary = next(row for row in report["cases"] if row["angular_std_radians"] == 1.0)
+    methods = {row["method"]: row for row in primary["methods"]}
+    assert methods["first-order"]["illustrative_std_screen_passes"]
+    assert not methods["exact-circular-moments"]["illustrative_std_screen_passes"]
+    np.testing.assert_allclose(
+        methods["exact-circular-moments"]["query_std_m"], 0.04497646055959317
+    )
+    np.testing.assert_allclose(
+        methods["gauss-hermite-32"]["query_std_m"],
+        methods["exact-circular-moments"]["query_std_m"],
+        atol=1e-14,
+    )
+    for case in report["cases"]:
+        assert case["reference_mean_absolute_error_m"] < 1e-13
+        assert case["reference_variance_absolute_error_m2"] < 1e-13
+    np.testing.assert_allclose(
+        report["shared_covariance_control"]["variance_understatement_factor"], 64.0
+    )
+
+
+def test_study_rejects_target_access_and_changed_arm_set():
+    protocol = json.loads(PROTOCOL.read_text())
+    for mutation in ("target", "methods", "unknown"):
+        changed = copy.deepcopy(protocol)
+        if mutation == "target":
+            changed["information_boundary"]["target_outcomes"] = True
+        elif mutation == "methods":
+            changed["methods"] = ["first-order", "exact-circular-moments"]
+        else:
+            changed["unregistered"] = 1
+        with pytest.raises(ValueError):
+            build_report(changed)
+
+
+def test_study_cli_does_not_overwrite_retained_evidence(tmp_path):
+    output = tmp_path / "result.json"
+    args = ["--protocol", str(PROTOCOL), "--output", str(output)]
+    assert main(args) == 0
+    retained = output.read_bytes()
+    with pytest.raises(FileExistsError):
+        main(args)
+    assert output.read_bytes() == retained

--- a/tests/test_axial_gauge_moments.py
+++ b/tests/test_axial_gauge_moments.py
@@ -87,7 +87,7 @@ def test_small_variance_retains_second_order_radial_variance():
     angular = CircularMoments2.wrapped_normal(0.0, variance)
     np.testing.assert_allclose(angular.covariance[0, 0], 0.5 * variance**2, rtol=2e-12, atol=0.0)
     np.testing.assert_allclose(angular.covariance[1, 1], variance, rtol=2e-12, atol=0.0)
-    assert np.all(CircularMoments2.wrapped_normal(0.3, 0.0).covariance == 0.0
+    assert np.all(CircularMoments2.wrapped_normal(0.3, 0.0).covariance == 0.0)
 
 
 def test_very_broad_wrapped_normal_has_uniform_limit():
@@ -142,9 +142,8 @@ def test_shared_uncertainty_does_not_average_away_and_identical_contrast_cancels
 
 def test_zero_local_derivative_is_not_global_query_invariance():
     orbit = AxialGaugeOrbit(np.array([0.0, 0.0, 1.0]), np.zeros(3))
-    query = orbit.point_moments(
-        [[0.1, 0.0, 0.0]], CircularMoments2.wrapped_normal(0.0, 1.0)
-    ).project([[1.0, 0.0, 0.0]])
+    moments = orbit.point_moments([[0.1, 0.0, 0.0]], CircularMoments2.wrapped_normal(0.0, 1.0))
+    query = moments.project([[1.0, 0.0, 0.0]])
     assert query.sine_coefficients[0] == 0.0  # dq/dtheta at theta = 0.
     assert query.orbit_amplitude[0] == 0.1
     assert query.covariance[0, 0] > 0.0019
@@ -169,9 +168,8 @@ def test_collinear_support_is_unchanged_but_near_collinearity_is_not_exact():
 def test_full_orbit_bounds_are_componentwise_and_tight():
     orbit = AxialGaugeOrbit(np.array([0.0, 0.0, 1.0]), np.array([1.0, 2.0, 3.0]))
     points = np.array([[2.0, 4.0, 5.0]])
-    query = orbit.point_moments(points, CircularMoments2.uniform()).project(
-        np.eye(3).reshape(3, 1, 3)
-    )
+    moments = orbit.point_moments(points, CircularMoments2.uniform())
+    query = moments.project(np.eye(3).reshape(3, 1, 3))
     for index in range(3):
         angle = np.arctan2(query.sine_coefficients[index], query.cosine_coefficients[index])
         upper = (
@@ -189,7 +187,11 @@ def test_inputs_are_copied_and_outputs_are_readonly():
     pivot[:] = 9.0
     result = orbit.point_moments([[0.1, 0.0, 0.0]], CircularMoments2.uniform())
     for array in (
-        orbit.axis, orbit.pivot, result.mean, result.shared_factors, result.marginal_covariance
+        orbit.axis,
+        orbit.pivot,
+        result.mean,
+        result.shared_factors,
+        result.marginal_covariance,
     ):
         assert not array.flags.writeable
     np.testing.assert_allclose(orbit.axis, [0.0, 0.0, 1.0])

--- a/tests/test_axial_gauge_observability_integration.py
+++ b/tests/test_axial_gauge_observability_integration.py
@@ -56,9 +56,9 @@ def test_locally_admitted_radial_query_has_finite_unobserved_orbit_variance():
     # This isolates the axial conditional contribution. It is NOT an exact
     # replacement for every term of the complete seven-dimensional posterior.
     orbit = AxialGaugeOrbit(np.array([0.0, 0.0, 1.0]), np.zeros(3))
-    query = orbit.point_moments(
-        point[None, :], CircularMoments2.wrapped_normal(0.0, 1.0)
-    ).project([[1.0, 0.0, 0.0]])
+    query = orbit.point_moments(point[None, :], CircularMoments2.wrapped_normal(0.0, 1.0)).project(
+        [[1.0, 0.0, 0.0]]
+    )
     assert query.covariance[0, 0] > 0.0019
     np.testing.assert_allclose(query.full_orbit_bounds, [[-0.1, 0.1]])
 

--- a/tests/test_axial_gauge_observability_integration.py
+++ b/tests/test_axial_gauge_observability_integration.py
@@ -1,0 +1,75 @@
+"""Connect the finite-angle control to the existing *local* observability gate.
+
+These tests do not change the gate or promote this conditional kernel to the
+claim-bearing exporter. They expose why a local certificate needs a separate
+finite-angle closure check before it is interpreted globally.
+"""
+
+import numpy as np
+
+from prob4d.axial_gauge_moments import AxialGaugeOrbit, CircularMoments2
+from prob4d.observable_gauge import CentroidGaugeChart, ObservableGaugeFactor
+from prob4d.query_observability import (
+    QueryObservabilityGate,
+    evaluate_query_observability,
+    point_position_query_jacobian,
+)
+from prob4d.sim3 import Sim3
+
+
+def _z_axis_factor():
+    basis = np.eye(7)
+    return ObservableGaugeFactor(
+        chart=CentroidGaugeChart(
+            linearization=Sim3(scale=1.0, rotation=np.eye(3), translation=np.zeros(3)),
+            source_centroid=np.zeros(3),
+            cloud_scale=0.1,
+        ),
+        observable_basis=basis[:, [0, 1, 2, 4, 5, 6]],
+        nullspace_basis=basis[:, 3:4],
+        observable_information=999.0 * np.eye(6),
+        normalized_geometry_spectrum=np.array([1.0] * 6 + [0.0]),
+        rank_threshold=1e-8,
+        residual_rms=0.01,
+        residual_variance=0.0001,
+        inlier_fraction=1.0,
+        num_correspondences=48,
+        covariance_method="iid_observable_information_v1",
+    )
+
+
+def test_locally_admitted_radial_query_has_finite_unobserved_orbit_variance():
+    factor = _z_axis_factor()
+    point = np.array([0.1, 0.0, 0.0])
+    jacobian = point_position_query_jacobian(factor, point)[0:1]
+    report = evaluate_query_observability(
+        factor,
+        prior_covariance_local=np.eye(7),
+        query_jacobian_local=jacobian,
+    )
+    gate = QueryObservabilityGate(0.99, 0.9, 0.1)
+    assert gate.evaluate(report).admitted
+    np.testing.assert_allclose(report.direct_observability_fraction, 1.0)
+    np.testing.assert_allclose(report.posterior_query_covariance, [[0.00002]])
+    np.testing.assert_array_equal(jacobian @ factor.nullspace_basis, [[0.0]])
+
+    # This isolates the axial conditional contribution. It is NOT an exact
+    # replacement for every term of the complete seven-dimensional posterior.
+    orbit = AxialGaugeOrbit(np.array([0.0, 0.0, 1.0]), np.zeros(3))
+    query = orbit.point_moments(
+        point[None, :], CircularMoments2.wrapped_normal(0.0, 1.0)
+    ).project([[1.0, 0.0, 0.0]])
+    assert query.covariance[0, 0] > 0.0019
+    np.testing.assert_allclose(query.full_orbit_bounds, [[-0.1, 0.1]])
+
+
+def test_full_position_gate_still_detects_the_first_order_tangential_nullspace():
+    factor = _z_axis_factor()
+    jacobian = point_position_query_jacobian(factor, np.array([0.1, 0.0, 0.0]))
+    report = evaluate_query_observability(
+        factor,
+        prior_covariance_local=np.eye(7),
+        query_jacobian_local=jacobian,
+    )
+    assert not QueryObservabilityGate(0.99, 0.9, 0.1).evaluate(report).admitted
+    assert report.nullspace_sensitivity_fraction > 0.0


### PR DESCRIPTION
## Scientific contribution

Extend the observable-subspace and query-observability work with an explicit finite-angle uncertainty kernel. For a declared axial ambiguity, the scalar off-axis query `q(theta) = r cos(theta)` has zero derivative at zero but nonzero finite-angle variance. Preserving a local nullspace is necessary, but a local query projection alone does not establish global query invariance.

The new kernel propagates the first two circular moments into exact conditional point and linear-query means and a shared rank-at-most-two covariance factor. It retains cross-point dependence, supports uniform, wrapped-normal, and finite multimodal angular laws, and exposes componentwise full-circle bounds separately from probability intervals.

## Designed analytic control

100 mm radial offset; angular standard deviation 1 rad; independent 5 mm readout noise:

| Method | Radial mean [mm] | Standard deviation [mm] |
|---|---:|---:|
| First order | 100.000 | 5.000 |
| Second order | 50.000 | 70.887 |
| Two-point spherical-radial | 54.030 | 5.000 |
| Gauss-Hermite, 5 nodes | 60.656 | 45.707 |
| Gauss-Hermite, 32 nodes | 60.653 | 44.976 |
| Exact circular moments | 60.653 | 44.976 |

The strong quadrature baseline is deliberately retained and agrees with the exact result. A separate 128-node reference agrees across the declared angular sweep. The shared-copy control shows that incorrectly independent point covariance understates average variance 64-fold; the 64 copies are not independent experimental units.

## Files and validation

- `src/prob4d/axial_gauge_moments.py`: conditional nonlinear shared-moment kernel;
- `src/prob4d/axial_gauge_moment_study.py`: source-hashed, no-clobber analytic control;
- `protocols/axial-gauge-moment-closure-v1.json`: complete method set and no-real-data boundary;
- `tests/test_axial_gauge_moments.py`: independent Rodrigues/quadrature checks, small/broad angular laws, frame equivariance, multimodality, dependence, invalid inputs, and no-clobber publication;
- `tests/test_axial_gauge_observability_integration.py`: existing local scalar-gate failure control and full-position negative control;
- `docs/axial-gauge-moment-closure.md`: derivation, prior art, integration limits, and paper strategy;
- hosted read-only workflow: lint, formatting, typing, existing-gauge integration, and numerical reproduction.

Before publication: **34 focused tests passed locally** and Python compilation passed. The additional two integration tests require the complete repository and are assigned to CI. Local Ruff/MyPy and the full repository suite could not be run in the isolated environment; this PR remains draft pending the authoritative hosted checks.

## Boundaries

This is a fixed/conditional-axis kernel, **not** exact integration of a general seven-dimensional Sim(3) posterior. An exact finite symmetry must be justified by the measurement model, not inferred from a small Hessian eigenvalue. Quotient/angle dependence requires conditional integration and the law of total covariance; do not double-count twist by adding this term to a covariance that already includes it.

Circular moments, Rodrigues propagation, and registration degeneracy are classical. No novelty claim is made for those ingredients, and no superiority over accurate quadrature is claimed. General quotient-lifting theory remains with the existing theory companion.

No stable exporter, current local gate, physical fallback, provider qualification, protected cohort, target result, or existing claim status changes. This establishes designed mechanism/software evidence only, not real-provider competence, calibration, BayesianPhysTwin benefit, Causal4D benefit, safety, or state of the art.

The largest remaining paper-strength gain is a fresh real-provider study after the existing PointWorld/Flat'n'Fold source qualification in #333. This PR neither reopens terminal studies nor authorizes target access. Paper-facing result bytes and interpretation will be recorded separately in `FlorianPfaff/BayesianPhysTwin-Paper`.