### PR TITLE
Make query observability invariant to output units

### DIFF
--- a/evidence/query-observability-control-v1/result.json
+++ b/evidence/query-observability-control-v1/result.json
@@ -27,20 +27,20 @@
       "admitted": true,
       "direct_observability_fraction": 1.0,
       "factor_rank": 7,
-      "metric_variance_reduction_fraction": 0.9090909090909091,
+      "metric_variance_reduction_fraction": 0.9090909090909092,
       "nullspace_sensitivity_fraction": 0.0,
       "posterior_metric_variance": 7.090909090909092,
       "prior_metric_variance": 78.0,
       "query_dimension": 3,
       "reason_codes": [],
-      "worst_supported_variance_ratio": 0.09090909090909093
+      "worst_supported_variance_ratio": 0.0909090909090909
     },
     "rank_six_off_support_query": {
       "admitted": false,
       "direct_observability_fraction": 0.6794871794871795,
       "factor_rank": 6,
-      "metric_variance_reduction_fraction": 0.6177156177156178,
-      "nullspace_sensitivity_fraction": 0.32051282051282054,
+      "metric_variance_reduction_fraction": 0.6177156177156177,
+      "nullspace_sensitivity_fraction": 0.3205128205128205,
       "posterior_metric_variance": 29.818181818181817,
       "prior_metric_variance": 78.0,
       "query_dimension": 3,
@@ -49,7 +49,7 @@
         "insufficient-query-variance-reduction",
         "excessive-worst-direction-variance-ratio"
       ],
-      "worst_supported_variance_ratio": 0.9650349650349651
+      "worst_supported_variance_ratio": 0.965034965034965
     },
     "rank_six_supported_query": {
       "admitted": true,
@@ -61,7 +61,7 @@
       "prior_metric_variance": 6.0,
       "query_dimension": 3,
       "reason_codes": [],
-      "worst_supported_variance_ratio": 0.09090909090909088
+      "worst_supported_variance_ratio": 0.09090909090909091
     }
   },
   "schema_name": "prob4d.query-conditioned-observability-control",

--- a/src/prob4d/query_observability.py
+++ b/src/prob4d/query_observability.py
@@ -97,16 +97,25 @@ def _supported_variance_ratio(
     prior_covariance: FloatArray,
     posterior_covariance: FloatArray,
 ) -> float:
-    eigenvalues, eigenvectors = np.linalg.eigh(prior_covariance)
+    # These covariances are expressed in the declared output metric. A shared
+    # normalization makes support independent of absolute units; an epsilon
+    # floor on the unscaled eigenvalues can erase an unresolved query.
+    scale = float(np.max(np.abs(prior_covariance), initial=0.0))
+    if not np.isfinite(scale):
+        raise ValueError("diagnostic query covariance must be finite")
+    if scale == 0.0:
+        return 0.0
+    normalized_prior = prior_covariance / scale
+    normalized_posterior = posterior_covariance / scale
+    eigenvalues, eigenvectors = np.linalg.eigh(normalized_prior)
     maximum = float(np.max(eigenvalues, initial=0.0))
-    threshold = max(maximum * 1e-10, np.finfo(np.float64).eps)
-    supported = eigenvalues > threshold
+    supported = eigenvalues > maximum * 1e-10
     if not np.any(supported):
         return 0.0
     whitener = (
         eigenvectors[:, supported] / np.sqrt(eigenvalues[supported])
     ).T
-    relative = whitener @ posterior_covariance @ whitener.T
+    relative = whitener @ normalized_posterior @ whitener.T
     relative = 0.5 * (relative + relative.T)
     maximum_ratio = float(np.max(np.linalg.eigvalsh(relative), initial=0.0))
     if maximum_ratio > 1.0 + 1e-8:
@@ -365,6 +374,8 @@ def evaluate_query_observability(
             name="query_metric",
         )
     )
+    if metric.shape != (query_jacobian.shape[0], query_jacobian.shape[0]):
+        raise ValueError("query_metric must match the query dimension")
     prior_information = np.linalg.solve(prior, np.eye(7))
     posterior_information = prior_information + factor.information_matrix
     posterior = np.linalg.solve(posterior_information, np.eye(7))
@@ -381,14 +392,26 @@ def evaluate_query_observability(
 
     metric_sqrt = np.linalg.cholesky(metric).T
     metric_jacobian = metric_sqrt @ query_jacobian
+    jacobian_scale = float(np.max(np.abs(metric_jacobian), initial=0.0))
+    if not np.isfinite(jacobian_scale):
+        raise ValueError("metric-weighted query Jacobian must be finite")
+    # This means local first-order insensitivity, not global invariance of a
+    # nonlinear query. Small nonzero sensitivities must not become invariant
+    # solely because the output units or metric scale changed.
+    gauge_invariant = not bool(np.any(query_jacobian))
+    if jacobian_scale == 0.0:
+        if not gauge_invariant:
+            raise ValueError("nonzero metric-weighted query Jacobian underflowed")
+        normalized_jacobian = metric_jacobian
+    else:
+        normalized_jacobian = metric_jacobian / jacobian_scale
     observable_energy = float(
-        np.sum((metric_jacobian @ factor.observable_basis) ** 2)
+        np.sum((normalized_jacobian @ factor.observable_basis) ** 2)
     )
     nullspace_energy = float(
-        np.sum((metric_jacobian @ factor.nullspace_basis) ** 2)
+        np.sum((normalized_jacobian @ factor.nullspace_basis) ** 2)
     )
     total_energy = observable_energy + nullspace_energy
-    gauge_invariant = bool(total_energy <= np.finfo(np.float64).eps)
     if gauge_invariant:
         direct_fraction = 1.0
         nullspace_fraction = 0.0
@@ -396,11 +419,29 @@ def evaluate_query_observability(
         direct_fraction = observable_energy / total_energy
         nullspace_fraction = nullspace_energy / total_energy
 
-    prior_trace = float(np.trace(metric @ prior_query))
-    posterior_trace = float(np.trace(metric @ posterior_query))
-    if prior_trace <= np.finfo(np.float64).eps:
+    # Rank/support decisions must use the same metric as direct observability.
+    # Under q_new = A q and M_new = A^{-T} M A^{-1}, these metric-space
+    # covariances differ only by orthogonal congruence and a common scale.
+    metric_prior_query = _symmetric_positive_semidefinite(
+        normalized_jacobian @ prior @ normalized_jacobian.T,
+        name="metric_prior_query_covariance",
+    )
+    metric_posterior_query = _symmetric_positive_semidefinite(
+        normalized_jacobian @ posterior @ normalized_jacobian.T,
+        name="metric_posterior_query_covariance",
+    )
+    covariance_scale = float(np.max(np.abs(metric_prior_query), initial=0.0))
+    if not np.isfinite(covariance_scale):
+        raise ValueError("metric-weighted prior query covariance must be finite")
+    if covariance_scale == 0.0:
+        if not gauge_invariant:
+            raise ValueError("nonzero prior query covariance underflowed")
         trace_reduction = 0.0
     else:
+        prior_trace = float(np.trace(metric_prior_query / covariance_scale))
+        posterior_trace = float(
+            np.trace(metric_posterior_query / covariance_scale)
+        )
         trace_reduction = float(
             np.clip((prior_trace - posterior_trace) / prior_trace, 0.0, 1.0)
         )
@@ -415,8 +456,8 @@ def evaluate_query_observability(
         posterior_query_covariance=posterior_query,
         metric_variance_reduction_fraction=trace_reduction,
         worst_supported_variance_ratio=_supported_variance_ratio(
-            prior_query,
-            posterior_query,
+            metric_prior_query,
+            metric_posterior_query,
         ),
         gauge_invariant_query=gauge_invariant,
     )

--- a/tests/test_query_observability_units.py
+++ b/tests/test_query_observability_units.py
@@ -1,0 +1,215 @@
+"""Coordinate/metric invariance tests for the query kernel, not factor fitting."""
+
+from types import SimpleNamespace
+from typing import cast
+
+import numpy as np
+import pytest
+
+from prob4d.observable_gauge import ObservableGaugeFactor
+from prob4d.query_observability import (
+    QueryObservabilityGate,
+    evaluate_query_observability,
+)
+
+
+@pytest.fixture
+def partial_factor() -> ObservableGaugeFactor:
+    # Analytic factor: x-axis twist is unobserved. The fixture deliberately
+    # isolates the query algebra from point-cloud fitting and provider code.
+    identity = np.eye(7)
+    basis = np.delete(identity, 1, axis=1)
+    return cast(
+        ObservableGaugeFactor,
+        SimpleNamespace(
+            rank=6,
+            information_matrix=10.0 * basis @ basis.T,
+            observable_basis=basis,
+            nullspace_basis=identity[:, 1:2],
+        ),
+    )
+
+
+def _query() -> np.ndarray:
+    jacobian = np.zeros((2, 7))
+    jacobian[0, 0] = 10.0
+    jacobian[1, 1] = 1.0
+    return jacobian
+
+
+def _evaluate(factor, jacobian, metric=None, prior=None):
+    return evaluate_query_observability(
+        factor,
+        prior_covariance_local=np.eye(7) if prior is None else prior,
+        query_jacobian_local=jacobian,
+        query_metric=metric,
+    )
+
+
+def _assert_unresolved(report):
+    assert report.direct_observability_fraction == pytest.approx(100.0 / 101.0)
+    assert report.metric_variance_reduction_fraction == pytest.approx(
+        1000.0 / 1111.0
+    )
+    assert report.worst_supported_variance_ratio == pytest.approx(1.0)
+    assert not report.gauge_invariant_query
+    decision = QueryObservabilityGate(0.8, 0.8, 0.5).evaluate(report)
+    assert not decision.admitted
+    assert decision.reason_codes == (
+        "excessive-worst-direction-variance-ratio",
+    )
+
+
+@pytest.mark.parametrize(
+    "exponent",
+    [-100, -20, -9, -6, -3, 0, 3, 9, 20, 100],
+)
+def test_uniform_unit_invariance(partial_factor, exponent):
+    scale = 10.0**exponent
+    _assert_unresolved(
+        _evaluate(
+            partial_factor,
+            scale * _query(),
+            np.eye(2) / scale**2,
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "exponent",
+    [-100, -20, -6, -3, 0, 3, 6, 20, 100],
+)
+def test_mixed_unit_invariance(partial_factor, exponent):
+    scale = 10.0**exponent
+    transform = np.diag([1.0, scale])
+    metric = np.diag([1.0, 1.0 / scale**2])
+    _assert_unresolved(_evaluate(partial_factor, transform @ _query(), metric))
+
+
+@pytest.mark.parametrize(
+    "exponent",
+    [-200, -40, -20, 0, 20, 40, 200],
+)
+def test_global_metric_scale_does_not_change_ratios(partial_factor, exponent):
+    _assert_unresolved(
+        _evaluate(
+            partial_factor,
+            _query(),
+            10.0**exponent * np.eye(2),
+        )
+    )
+
+
+@pytest.mark.parametrize("seed", list(range(8)))
+def test_invertible_output_reparameterization(partial_factor, seed):
+    rng = np.random.default_rng(seed)
+    left, _ = np.linalg.qr(rng.normal(size=(2, 2)))
+    right, _ = np.linalg.qr(rng.normal(size=(2, 2)))
+    transform = left @ np.diag([0.2, 3.0]) @ right
+    inverse = np.linalg.inv(transform)
+    _assert_unresolved(
+        _evaluate(
+            partial_factor,
+            transform @ _query(),
+            inverse.T @ inverse,
+        )
+    )
+
+
+def test_zero_query_remains_locally_insensitive(partial_factor):
+    report = _evaluate(partial_factor, np.zeros((2, 7)))
+    assert report.gauge_invariant_query
+    assert report.direct_observability_fraction == 1.0
+    assert report.nullspace_sensitivity_fraction == 0.0
+    assert report.metric_variance_reduction_fraction == 0.0
+    assert report.worst_supported_variance_ratio == 0.0
+
+
+def test_tiny_nonzero_query_is_not_declared_invariant(partial_factor):
+    jacobian = np.zeros((1, 7))
+    jacobian[0, 1] = 1e-100
+    report = _evaluate(partial_factor, jacobian)
+    assert not report.gauge_invariant_query
+    assert report.direct_observability_fraction == 0.0
+    assert report.nullspace_sensitivity_fraction == 1.0
+    assert report.worst_supported_variance_ratio == pytest.approx(1.0)
+
+
+def test_prior_correlation_does_not_create_direct_support(partial_factor):
+    prior = np.eye(7)
+    prior[0, 1] = prior[1, 0] = 0.9
+    jacobian = np.zeros((1, 7))
+    jacobian[0, 1] = 1.0
+    report = _evaluate(partial_factor, jacobian, prior=prior)
+    assert report.direct_observability_fraction == 0.0
+    assert report.metric_variance_reduction_fraction == pytest.approx(
+        0.81 * 10.0 / 11.0
+    )
+    assert report.worst_supported_variance_ratio == pytest.approx(
+        1.0 - 0.81 * 10.0 / 11.0
+    )
+
+
+def test_redundant_query_output_keeps_supported_variance(partial_factor):
+    jacobian = np.zeros((2, 7))
+    jacobian[:, 0] = [1.0, 2.0]
+    report = _evaluate(partial_factor, jacobian)
+    assert report.direct_observability_fraction == pytest.approx(1.0)
+    assert report.metric_variance_reduction_fraction == pytest.approx(10.0 / 11.0)
+    assert report.worst_supported_variance_ratio == pytest.approx(1.0 / 11.0)
+
+
+def test_report_covariances_keep_caller_units(partial_factor):
+    base = _evaluate(partial_factor, _query())
+    transform = np.array([[2.0, 0.2], [0.0, 0.1]])
+    inverse = np.linalg.inv(transform)
+    changed = _evaluate(
+        partial_factor,
+        transform @ _query(),
+        inverse.T @ inverse,
+    )
+    np.testing.assert_allclose(
+        changed.prior_query_covariance,
+        transform @ base.prior_query_covariance @ transform.T,
+    )
+    np.testing.assert_allclose(
+        changed.posterior_query_covariance,
+        transform @ base.posterior_query_covariance @ transform.T,
+    )
+
+
+def test_metric_shape_rejected_explicitly(partial_factor):
+    with pytest.raises(ValueError, match="query_metric must match"):
+        _evaluate(partial_factor, _query(), np.eye(3))
+
+
+@pytest.mark.parametrize(
+    "point,expected_direct,expected_ratio,expected_admitted",
+    [
+        ([1.0, 0.0, 0.0], 1.0, 1.0 / 11.0, True),
+        ([0.0, 5.0, 0.0], 53.0 / 78.0, 276.0 / 286.0, False),
+    ],
+)
+def test_existing_point_controls_preserved(
+    partial_factor,
+    point,
+    expected_direct,
+    expected_ratio,
+    expected_admitted,
+):
+    x, y, z = point
+    skew = np.array(
+        [
+            [0.0, -z, y],
+            [z, 0.0, -x],
+            [-y, x, 0.0],
+        ]
+    )
+    jacobian = np.column_stack([point, -skew, np.eye(3)])
+    report = _evaluate(partial_factor, jacobian)
+    assert report.direct_observability_fraction == pytest.approx(expected_direct)
+    assert report.worst_supported_variance_ratio == pytest.approx(expected_ratio)
+    assert (
+        QueryObservabilityGate(0.8, 0.8, 0.5).evaluate(report).admitted
+        == expected_admitted
+    )


### PR DESCRIPTION
## Purpose

Fix a numerical defect in the query-observability gate introduced by absolute floating-point support thresholds. The same physical query could change from rejection to admission under an invertible change of output units even when the query metric was transformed consistently.

This matters for the query-conditioned observability path added in #338 and the planned PointWorld/Flat'n'Fold qualification in #333: admission should depend on the physical query and declared metric, not whether the caller expresses a quantity in metres, millimetres, or another invertible coordinate basis.

## Fix

- normalize metric-weighted query Jacobians before direct-support calculations;
- compute variance-reduction and worst-direction support in the declared query metric;
- use a relative eigenvalue support cutoff after common covariance normalization rather than an absolute machine-epsilon floor;
- preserve reported prior/posterior query covariance in the caller's original coordinates;
- treat only an exactly zero local Jacobian as locally gauge-insensitive;
- reject a query metric whose dimension does not match the query explicitly.

Under `q_new = A q` and `M_new = A^{-T} M A^{-1}`, the diagnostic ratios are now invariant up to numerical precision.

## Regression coverage

Adds analytic tests for:

- uniform unit changes over many orders of magnitude;
- mixed-unit outputs;
- global metric rescaling;
- invertible non-diagonal output reparameterizations;
- tiny nonzero sensitivities;
- prior-mediated covariance reduction without fabricated direct support;
- redundant query outputs;
- caller-coordinate covariance preservation; and
- the existing supported-line / off-axis controls.

The local analytic audit used to prepare this patch produced 42 passing tests after the fix. The PR intentionally makes no provider-competence, calibration, BayesianPhysTwin-benefit, Causal4D-benefit, or deployment-safety claim.

Related: #338, #333, #49.