### PR TITLE
Add shared-gauge curvature moments for tangent-null physical queries

### DIFF
--- a/docs/gauge-curvature.md
+++ b/docs/gauge-curvature.md
@@ -1,0 +1,221 @@
+# Shared-gauge curvature for physical 4D queries
+
+**Status:** experimental, additive numerical method; not a provider-v2 exporter,
+calibration certificate, or change to any existing admission rule.
+
+## Motivation and the exact boundary of the finding
+
+Prob4D's source-only closure diagnostic compares analytic first-order propagation
+with a spherical-radial rule evaluating `+/- sqrt(r) L[:, j]`. The relevant
+upstream implementation is `_sigma_points` in
+`src/prob4d/_gauge_linearization_numerics.py`, inspected at commit
+`224d13dc9a93731ac5297b479eb1e121b3dbe659` (blob
+`9dd800dbdd9b2f262eec0a50ddc3aaa2d871873c`). See the existing
+[gauge linearization closure guide](gauge-linearization-closure.md).
+
+Those two approximations can agree on zero query uncertainty even when the
+nonlinear query has positive variance. This is a query-level blind spot, **not**
+a demonstrated false pass of the entire existing closure/admission workflow.
+Other point-level, mean-shift, support, or physical guards may still reject.
+The original diagnostic and its frozen artifacts are intentionally unchanged.
+
+Take a point `(0, 0, ell)` and two independent zero-mean Gaussian angles with
+variance `sigma^2`. Compose `Rz(alpha) Ry(beta)` and query the y coordinate:
+
+\[
+q = \ell\sin\alpha\sin\beta,\qquad
+\mathbb E q=0,\qquad
+\operatorname{Var}(q)=\ell^2
+\left(\frac{1-e^{-2\sigma^2}}{2}\right)^2.
+\]
+
+The first derivative at zero vanishes. Every axis sigma point also makes one
+angle zero. Both approximations therefore report zero query variance. With
+`ell = 0.5 m` and `sigma = 0.1 rad`, the exact standard deviation is
+`4.950331673 mm`. A multiplicative covariance inflation cannot recover a
+missing direction whose original covariance is exactly zero.
+
+## Classical quadratic moments, represented jointly
+
+For a *complete joint* root `L`, write `g = mu + L z`, `z ~ N(0, I_r)`. Let a
+quadratic surrogate for each output coordinate be
+
+\[
+\widehat f_i(z)=c_i+a_i^\top z+\tfrac12 z^\top B_i z.
+\]
+
+Its exact Gaussian moments are
+
+\[
+m_i=c_i+\tfrac12\operatorname{tr}(B_i),\qquad
+\Sigma_{ij}=a_i^\top a_j+\tfrac12\operatorname{tr}(B_i B_j).
+\]
+
+These are established Gaussian moment identities, not a new filtering rule.
+They follow by expanding the polynomial and using zero odd Gaussian moments
+and the Gaussian fourth-moment identity.
+
+Store the joint covariance as `F F.T` with columns
+
+\[
+F=\left[A,\;\{B_{:,kk}/\sqrt2\}_k,\;\{B_{:,kl}\}_{k<l}\right].
+\]
+
+The associated centered polynomial features are `z_k`,
+`(z_k^2 - 1)/sqrt(2)`, and `z_k z_l`. They have identity second-moment matrix
+but are **not independent Gaussian variables**. This representation is a
+joint, positive-semidefinite second-moment representation, not an exact
+Gaussian pushforward and not a collection of new physical gauge freedoms.
+
+A fixed linear query `C` uses `C m` and `C F`, preserving correlations and
+cancellations across points. Adding a separate diagonal variance to every point
+is not equivalent. Exact quadratic moments are invariant under orthogonal
+changes of whitening basis; axis cubature need not be.
+
+The input/output cross covariance of the surrogate is `L A.T`. Curvature
+features contribute no input cross covariance under the stated Gaussian input,
+because the relevant odd moments vanish. Calling this API with a different
+root of the same shape does not establish correct source lineage.
+
+## A useful query-specific local result
+
+Let `q(epsilon) = C f(mu + epsilon L z)` with fixed `C`, and suppose the
+first-order query sensitivity `C J L` is zero. Assume a third-order Taylor
+expansion with an `L2` remainder of order `epsilon^4`, and finite moments of
+the displayed derivatives. If `B_i` is the Hessian of query coordinate i in
+these whitened coordinates, then
+
+\[
+\mathbb E q_i = q_i(0)+\frac{\epsilon^2}{2}\operatorname{tr}(B_i)
++O(\epsilon^4),
+\]
+\[
+\operatorname{Cov}(q_i,q_j)
+=\frac{\epsilon^4}{2}\operatorname{tr}(B_i B_j)+O(\epsilon^6).
+\]
+
+**Proof.** The linear term is absent. After centering, the leading random term
+is the centered quadratic polynomial of order `epsilon^2`. Its covariance is
+the Gaussian fourth-moment expression above. The covariance between the
+quadratic and cubic terms vanishes by Gaussian sign symmetry. Covariance with
+the fourth-order remainder and the cubic variance are of order `epsilon^6`
+under the assumed `L2` control. The mean of the cubic term is zero.
+
+Thus quadratic propagation recovers the leading nonzero uncertainty for this
+first-order-null query class. This does not imply a globally conservative
+bound. For a general query with nonzero linear sensitivity, omitted
+linear--cubic cross terms also occur at order `epsilon^4`; the quadratic
+surrogate is **not** a complete covariance expansion through that order.
+
+## Implementation
+
+`src/prob4d/gauge_curvature.py` adds an experimental module only. The stable
+`prob4d.api.v2` facade, CLI registry, artifact schemas, and existing closure
+rule are not modified.
+
+- `quadratic_gaussian_moments` consumes exact local quadratic coefficients.
+- `finite_difference_gauge_moments` computes linear, diagonal, and *all mixed*
+  curvature coefficients using a centered derivative stencil.
+- `sim3_chain_gauge_moments` evaluates actual Prob4D `Sim3` composition and
+  transforms the local points, optionally projecting directly to a fixed query.
+- `SharedGaugeMoments` supports joint covariance factors, covariance actions,
+  marginal variances, fixed-query projection, and input cross covariance.
+
+The derivative stencil uses `1 + 2 r^2` function calls. It is not an integration
+rule. Output factors require `p * [r + r(r+1)/2]` entries; direct projection
+replaces p by the query dimension. The default rank cap is 32 and raises an
+error rather than truncating uncertainty. No horizon-independent cost,
+automatic sparse reduction, or runtime speedup has been demonstrated.
+
+```python
+import numpy as np
+from prob4d.gauge_curvature import sim3_chain_gauge_moments
+
+# Prob4D vector convention: [log_scale, rotvec(3), translation(3)].
+# T0 = Rz(alpha), T1 = Ry(beta), independent sigma = 0.1 rad.
+root = np.zeros((14, 2))
+root[3, 0] = 0.1
+root[9, 1] = 0.1
+moments = sim3_chain_gauge_moments(
+    transform_vectors=np.zeros((2, 7)),
+    joint_covariance_root=root,
+    points_local_m=np.array([[0.0, 0.0, 0.5]]),
+    query_matrix=np.array([[0.0, 1.0, 0.0]]),
+    step=1e-3,
+)
+print(1000 * np.sqrt(moments.marginal_variance))  # approximately [5.0] mm
+print(moments.evaluation_count)  # 9
+```
+
+## Controlled study and required baselines
+
+After applying the patch to the pinned Prob4D checkout and installing it:
+
+```bash
+python -m pytest tests/test_gauge_curvature.py tests/test_gauge_curvature_study.py
+python examples/gauge_curvature_study.py --output-dir outputs/gauge-curvature-v1
+```
+
+The script refuses to overwrite a nonempty output directory. It verifies that
+both imported modules come from this checkout and that `sim3.py` has the
+pinned upstream Git blob identity. Its manifest records Python/NumPy versions,
+source hashes and output hashes. Candidate commit is null because the supplied
+patch was not pushed to GitHub.
+
+The study includes analytic truth, third-degree spherical-radial cubature,
+classical fifth-degree cubature, three-node-per-dimension Gauss--Hermite, and
+15-node-per-dimension Gauss--Hermite as an independent numerical reference.
+At rank two, three-node tensor Gauss--Hermite uses the same nine calls and is
+more accurate on the sine-product example. Classical fifth-degree cubature
+also has quadratic node count; no new asymptotic quadrature complexity is
+claimed. Its signed weights can yield a non-PSD covariance for some nonlinear
+maps, but that fact is not evidence of a performance advantage on real data.
+
+A separate scalar state-update analogue has observations
+`y_j = x + g + e_j`, with common sine-product gauge error g and independent
+point errors e_j. Hence the averaged measurement variance is
+`Var(g) + Var(e_j)/N`, not `(Var(g) + Var(e_j))/N`. The study compares
+uncorrected, pointwise-curvature, joint-curvature, quadrature, oracle-second-
+moment, and exact physical-prior fallback arms. Risks are analytic; coverage
+is measured separately using independent synthetic episodes.
+
+The full result bundle belongs to the paper repository at
+`evidence/prob4d_curvature_v1/`. It is a local exploratory mechanism study,
+not a preregistered real-data or cross-repository result. An oracle using the
+correct second moments is an optimal linear estimator, not the exact Bayesian
+posterior for non-Gaussian sine-product noise.
+
+## Integration and evidence boundaries
+
+Do not feed polynomial features into existing gauge-state fields or silently
+relax a claim-bearing loader. A future provider integration must specify the
+new shared-feature semantics, cross-window/root lineage, conditional-noise
+model, calibration partition, and downstream complete-belief routing in a
+separately versioned experiment. Conditional point noise is not included in
+this prototype. It may require further nonlinear marginalization if its
+covariance depends on gauge.
+
+Only the forward point map is differentiated here. The implementation does
+not certify a logarithmic gauge state, remove existing branch-cut checks,
+choose provider support, authorize target access, or select physical updates.
+Neither BayesianPhysTwin nor Causal4D was executed in this study. Existing
+fallback behavior might already reject the harmful unguarded comparator.
+
+Near-nominal NEES does not imply distributional calibration. Gaussian intervals
+are measured only for the stated controlled case. Larger gauge variances can
+make the Taylor model inaccurate: at sigma = 0.35 rad the example variance is
+overestimated by 27.12%. More points do not supply more independent gauge
+realizations or independent physical objects.
+
+## References and inspected source
+
+1. Shishan Yang and Marcus Baum. *Second-Order Extended Kalman Filter for
+   Extended Object and Group Tracking*. 2016. arXiv:1604.00219.
+2. Maria V. Kulikova and Gennady Yu. Kulikov. *MATLAB-based general approach
+   for square-root extended-unscented and fifth-degree cubature Kalman
+   filtering methods*. 2023. arXiv:2312.02846.
+3. Prob4D, commit `224d13dc9a93731ac5297b479eb1e121b3dbe659`,
+   `_gauge_linearization_numerics.py` and `docs/gauge-linearization-closure.md`.
+4. Prob4D `sim3.py`, Git blob
+   `dc84a889c1aecb6b7d7c16ad83604861744b995d`, verified byte-for-byte in local
+   validation. Its existing license and attribution are unchanged.

--- a/examples/gauge_curvature_study.py
+++ b/examples/gauge_curvature_study.py
@@ -1,0 +1,393 @@
+"""Reproduce controlled shared-curvature evidence; never opens a dataset.
+
+Run after installing the patched Prob4D checkout:
+    python examples/gauge_curvature_study.py --output-dir outputs/gauge-curvature-v1
+
+All cases and comparisons are fixed below. Results are local synthetic analysis,
+not provider calibration, BPT guard execution, or Causal4D intervention evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import itertools
+import json
+import math
+import platform
+from pathlib import Path
+
+import numpy as np
+
+import prob4d.gauge_curvature as curvature_module
+import prob4d.sim3 as sim3_module
+from prob4d.gauge_curvature import finite_difference_gauge_moments, sim3_chain_gauge_moments
+
+SIGMAS = (0.025, 0.05, 0.1, 0.2, 0.35)
+LEVERS_M = (0.25, 0.5, 1.0)
+POINT_COUNTS = (1, 16, 64, 256)
+PRIOR_SDS_M = (0.002, 0.005, 0.01)
+POINT_SD_M = 0.001
+STEPS = (0.01, 0.001, 0.0003)
+MONTE_CARLO_SEED = 20260830
+MONTE_CARLO_EPISODES = 131072
+UPSTREAM_PROB4D_COMMIT = "224d13dc9a93731ac5297b479eb1e121b3dbe659"
+UPSTREAM_SIM3_BLOB = "dc84a889c1aecb6b7d7c16ad83604861744b995d"
+
+
+def exact_sine_product_variance(sigma: float, lever: float) -> float:
+    """Independent analytic Gaussian characteristic-function result."""
+    return lever**2 * (-math.expm1(-2.0 * sigma**2) / 2.0)**2
+
+
+def axis_cubature(function, rank: int) -> tuple[float, float]:
+    samples = np.array([
+        function(sign * math.sqrt(rank) * np.eye(rank)[i])
+        for i in range(rank)
+        for sign in (-1.0, 1.0)
+    ])
+    return float(samples.mean()), float(np.mean((samples - samples.mean())**2))
+
+
+def fifth_degree_cubature(function, rank: int) -> tuple[float, float]:
+    """Classical fully symmetric degree-five Gaussian rule, 2*r*r+1 nodes.
+
+    The axial weights become negative for r > 4. This is an established
+    comparator, not the proposed method. Do not clip a negative variance.
+    """
+    values, weights = [function(np.zeros(rank))], [2.0 / (rank + 2.0)]
+    for i in range(rank):
+        for sign in (-1.0, 1.0):
+            values.append(function(sign * math.sqrt(rank + 2.0) * np.eye(rank)[i]))
+            weights.append((4.0 - rank) / (2.0 * (rank + 2.0)**2))
+    for i in range(rank):
+        for j in range(i + 1, rank):
+            for si, sj in itertools.product((-1.0, 1.0), repeat=2):
+                node = math.sqrt((rank + 2.0) / 2.0) * (si * np.eye(rank)[i] + sj * np.eye(rank)[j])
+                values.append(function(node))
+                weights.append(1.0 / (rank + 2.0)**2)
+    values, weights = np.asarray(values), np.asarray(weights)
+    mean = float(weights @ values)
+    return mean, float(weights @ ((values - mean)**2))
+
+
+def gauss_hermite_product(function, rank: int, order: int) -> tuple[float, float]:
+    nodes, weights = np.polynomial.hermite.hermgauss(order)
+    nodes, weights = math.sqrt(2.0) * nodes, weights / math.sqrt(math.pi)
+    values, masses = [], []
+    for indices in itertools.product(range(order), repeat=rank):
+        values.append(function(nodes[list(indices)]))
+        masses.append(float(np.prod(weights[list(indices)])))
+    values, masses = np.asarray(values), np.asarray(masses)
+    mean = float(masses @ values)
+    return mean, float(masses @ ((values - mean)**2))
+
+
+def curvature_case(sigma: float, lever: float, step: float):
+    root = np.zeros((14, 2))
+    root[3, 0] = sigma
+    root[9, 1] = sigma
+    return sim3_chain_gauge_moments(
+        np.zeros((2, 7)), root, [[0, 0, lever]],
+        query_matrix=[[0, 1, 0]], step=step,
+    )
+
+
+def gaussian_update_metrics(
+    prior_variance: float, actual_noise: float, assumed_noise: float | None,
+):
+    """Exact expected LMMSE risk using moments, despite non-Gaussian noise."""
+    if assumed_noise is None:
+        gain, posterior_variance = 0.0, prior_variance
+    else:
+        gain = prior_variance / (prior_variance + assumed_noise)
+        posterior_variance = prior_variance * assumed_noise / (prior_variance + assumed_noise)
+    mse = (1.0 - gain)**2 * prior_variance + gain**2 * actual_noise
+    return {
+        "gain": gain,
+        "posterior_variance_m2": posterior_variance,
+        "expected_mse_m2": mse,
+        "expected_rmse_mm": 1000.0 * math.sqrt(mse),
+        "expected_nees": mse / posterior_variance,
+        "expected_gaussian_nll_nats_in_meters": 0.5 * (
+            math.log(2.0 * math.pi * posterior_variance) + mse / posterior_variance
+        ),
+    }
+
+
+def write_csv(path: Path, rows: list[dict]) -> None:
+    with path.open("w", newline="", encoding="utf-8") as stream:
+        writer = csv.DictWriter(stream, fieldnames=list(rows[0]), lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def run(output_dir: Path) -> dict:
+    root = Path(__file__).resolve().parents[1]
+    if Path(curvature_module.__file__).resolve() != root / "src/prob4d/gauge_curvature.py":
+        raise ValueError("imported curvature module is not from this checkout")
+    if Path(sim3_module.__file__).resolve() != root / "src/prob4d/sim3.py":
+        raise ValueError("imported Sim3 module is not from this checkout")
+    sim3_bytes = (root / "src/prob4d/sim3.py").read_bytes()
+    sim3_blob = hashlib.sha1(
+        f"blob {len(sim3_bytes)}\0".encode() + sim3_bytes, usedforsecurity=False,
+    ).hexdigest()
+    if sim3_blob != UPSTREAM_SIM3_BLOB:
+        raise ValueError("Sim3 source differs from the pinned upstream validation blob")
+    if output_dir.exists() and any(output_dir.iterdir()):
+        raise ValueError("output directory must be empty; retained results are never overwritten")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    transform_rows, update_rows = [], []
+    numerical_step_relative_variance_spreads = []
+    for sigma, lever in itertools.product(SIGMAS, LEVERS_M):
+        truth = exact_sine_product_variance(sigma, lever)
+        def query(z, sigma=sigma, lever=lever):
+            return lever * math.sin(sigma * z[0]) * math.sin(sigma * z[1])
+        curvatures = [curvature_case(sigma, lever, step) for step in STEPS]
+        corrected = float(curvatures[1].marginal_variance[0])
+        step_vars = [float(c.marginal_variance[0]) for c in curvatures]
+        numerical_step_relative_variance_spreads.append(
+            (max(step_vars) - min(step_vars)) / corrected
+        )
+        axis_mean, axis_variance = axis_cubature(query, 2)
+        fifth_mean, fifth_variance = fifth_degree_cubature(query, 2)
+        gh3_mean, gh3_variance = gauss_hermite_product(query, 2, 3)
+        gh15_mean, gh15_variance = gauss_hermite_product(query, 2, 15)
+        methods = {
+            "first_order": (0.0, 0.0, 1),
+            "spherical_radial": (axis_mean, axis_variance, 4),
+            "shared_curvature": (float(curvatures[1].mean[0]), corrected, 9),
+            "fifth_degree": (fifth_mean, fifth_variance, 9),
+            "gauss_hermite3": (gh3_mean, gh3_variance, 9),
+            "gauss_hermite15_reference": (gh15_mean, gh15_variance, 225),
+        }
+        for method, (mean, variance, calls) in methods.items():
+            transform_rows.append({
+                "sigma_rad": sigma, "lever_m": lever, "method": method,
+                "mean_m": mean, "variance_m2": variance,
+                "sd_mm": 1000.0 * math.sqrt(variance),
+                "exact_variance_m2": truth,
+                "exact_sd_mm": 1000.0 * math.sqrt(truth),
+                "relative_variance_error": variance / truth - 1.0,
+                "forward_evaluation_count": calls,
+            })
+        for count, prior_sd in itertools.product(POINT_COUNTS, PRIOR_SDS_M):
+            conditional_average_var = POINT_SD_M**2 / count
+            noises = {
+                "physical_fallback": None,
+                "first_order": conditional_average_var,
+                "spherical_radial": conditional_average_var + axis_variance,
+                "pointwise_curvature": (POINT_SD_M**2 + corrected) / count,
+                "shared_curvature": conditional_average_var + corrected,
+                "fifth_degree_shared": conditional_average_var + fifth_variance,
+                "gauss_hermite3_shared": conditional_average_var + gh3_variance,
+                "oracle_second_moments_shared": conditional_average_var + truth,
+            }
+            for method, assumed_noise in noises.items():
+                update_rows.append({
+                    "sigma_rad": sigma, "lever_m": lever,
+                    "point_count": count, "prior_sd_mm": 1000.0 * prior_sd,
+                    "method": method,
+                    **gaussian_update_metrics(
+                        prior_sd**2, truth + conditional_average_var, assumed_noise,
+                    ),
+                })
+    # Independent synthetic episodes check coverage. It is not deduced from NEES.
+    headline = [r for r in update_rows if r["sigma_rad"] == 0.1 and r["lever_m"] == 0.5
+                and r["point_count"] == 64 and r["prior_sd_mm"] == 2.0]
+    rng = np.random.default_rng(MONTE_CARLO_SEED)
+    alpha, beta, state, averaged_noise = rng.normal(size=(4, MONTE_CARLO_EPISODES))
+    state *= 0.002
+    observation = state + 0.5 * np.sin(0.1 * alpha) * np.sin(0.1 * beta)
+    observation += POINT_SD_M / math.sqrt(64) * averaged_noise
+    coverage_rows = []
+    normal_90 = 1.6448536269514722
+    for row in headline:
+        error = row["gain"] * observation - state
+        posterior_sd = math.sqrt(row["posterior_variance_m2"])
+        covered = np.abs(error) <= normal_90 * posterior_sd
+        coverage = float(covered.mean())
+        coverage_rows.append({
+            "method": row["method"], "synthetic_episode_count": MONTE_CARLO_EPISODES,
+            "empirical_rmse_mm": 1000.0 * float(np.sqrt(np.mean(error**2))),
+            "nominal_90_coverage": coverage,
+            "coverage_binomial_standard_error": math.sqrt(
+                coverage * (1.0 - coverage) / MONTE_CARLO_EPISODES
+            ),
+            "interval_full_width_mm": 2000.0 * normal_90 * posterior_sd,
+        })
+    # Adversarial quadratic q=z0*z1 under 32 arbitrary whitening bases.
+    basis_rows = []
+    basis_rng = np.random.default_rng(64393)
+    rank = 7
+    rotations = [np.eye(rank)]
+    rotations += [np.linalg.qr(basis_rng.normal(size=(rank, rank)))[0] for _ in range(31)]
+    for index, rotation in enumerate(rotations):
+        def function(z, rotation=rotation):
+            rotated = rotation @ z
+            return float(rotated[0] * rotated[1])
+        _, axis_variance = axis_cubature(function, rank)
+        _, fifth_variance = fifth_degree_cubature(function, rank)
+        curvature = finite_difference_gauge_moments(
+            lambda x: np.array([x[0] * x[1]]), np.zeros(rank), rotation, step=0.01,
+        )
+        basis_rows.append({
+            "basis_index": index, "rank": rank, "true_variance": 1.0,
+            "axis_variance": axis_variance,
+            "fifth_degree_variance": fifth_variance,
+            "shared_curvature_variance": float(curvature.marginal_variance[0]),
+        })
+    by_method = {row["method"]: row for row in headline}
+    result = {
+        "classification": "local-controlled-method-study-not-real-provider-evidence",
+        "date": "2026-08-30",
+        "target_outcomes_used": False,
+        "public_datasets_opened": False,
+        "bpt_guard_executed": False,
+        "causal4d_pipeline_executed": False,
+        "upstream_prob4d_commit": UPSTREAM_PROB4D_COMMIT,
+        "upstream_sim3_git_blob": UPSTREAM_SIM3_BLOB,
+        "upstream_sim3_blob_verified": True,
+        "candidate_commit": None,
+        "candidate_identity": "uncommitted-additive-patch; SHA256 source identities in manifest",
+        "design": {
+            "sigmas_rad": SIGMAS, "levers_m": LEVERS_M, "point_counts": POINT_COUNTS,
+            "prior_sds_m": PRIOR_SDS_M, "point_sd_m": POINT_SD_M,
+            "finite_difference_steps": STEPS,
+            "primary_method_step": 0.001,
+            "transform_case_count": len(SIGMAS) * len(LEVERS_M),
+            "update_case_count": len(SIGMAS) * len(LEVERS_M) * len(POINT_COUNTS) * len(PRIOR_SDS_M),
+            "update_arms": 8,
+            "monte_carlo_seed": MONTE_CARLO_SEED,
+            "monte_carlo_episodes": MONTE_CARLO_EPISODES,
+            "selection": (
+                "fixed illustrative geometry and grid; exploratory, "
+                "not an independently preregistered claim"
+            ),
+        },
+        "headline_transform": [
+            r for r in transform_rows if r["sigma_rad"] == 0.1 and r["lever_m"] == 0.5
+        ],
+        "headline_update": headline,
+        "headline_coverage": coverage_rows,
+        "headline_rmse_reduction_vs_first_order": (
+            1.0 - by_method["shared_curvature"]["expected_rmse_mm"]
+            / by_method["first_order"]["expected_rmse_mm"]
+        ),
+        "headline_rmse_reduction_vs_physical_fallback": (
+            1.0 - by_method["shared_curvature"]["expected_rmse_mm"]
+            / by_method["physical_fallback"]["expected_rmse_mm"]
+        ),
+        "max_gh15_relative_variance_error": max(
+            abs(r["relative_variance_error"]) for r in transform_rows
+            if r["method"] == "gauss_hermite15_reference"
+        ),
+        "max_step_relative_variance_spread": max(numerical_step_relative_variance_spreads),
+        "axis_basis_variance_range": [
+            min(r["axis_variance"] for r in basis_rows),
+            max(r["axis_variance"] for r in basis_rows),
+        ],
+        "max_curvature_basis_variance_error": max(
+            abs(r["shared_curvature_variance"] - 1.0) for r in basis_rows
+        ),
+        "max_fifth_degree_basis_variance_error": max(
+            abs(r["fifth_degree_variance"] - 1.0) for r in basis_rows
+        ),
+        "evaluation_count_scaling_not_walltime": [
+            {
+                "rank": r, "axis": 2*r, "curvature": 1+2*r*r,
+                "fifth_degree": 1+2*r*r, "tensor_gh3": 3**r,
+            }
+            for r in (2, 4, 7, 14, 28)
+        ],
+        "limits": [
+            (
+                "Quadratic Gaussian moments and fifth-degree cubature are established methods, "
+                "not claimed as new."
+            ),
+            (
+                "The contribution candidate is joint curvature support for tangent-null "
+                "physical queries and its downstream consequence."
+            ),
+            (
+                "The Taylor closure is not exact for general nonlinear maps and is not "
+                "uniformly covariance-order-two accurate."
+            ),
+            (
+                "At rank two, three-node tensor Gauss-Hermite has the same evaluation count "
+                "and is more accurate on this sine example."
+            ),
+            (
+                "At general rank, classical fifth-degree cubature also has quadratic node "
+                "count; no novel complexity order is claimed."
+            ),
+            (
+                "Shared factors describe moments only; Gaussian interval coverage need not "
+                "equal nominal coverage."
+            ),
+            (
+                "This is an analytic scalar physical-update analogue, not execution of "
+                "BayesianPhysTwin or Causal4D."
+            ),
+            (
+                "No existing terminal result, claim registry, provider status, or sealed "
+                "data-access boundary has changed."
+            ),
+        ],
+    }
+    write_csv(output_dir / "transform_results.csv", transform_rows)
+    write_csv(output_dir / "update_results.csv", update_rows)
+    write_csv(output_dir / "coverage_results.csv", coverage_rows)
+    write_csv(output_dir / "whitening_basis_results.csv", basis_rows)
+    (output_dir / "summary.json").write_text(json.dumps(result, indent=2, allow_nan=False) + "\n")
+    root = Path(__file__).resolve().parents[1]
+    code_paths = [
+        root / "src/prob4d/gauge_curvature.py",
+        root / "src/prob4d/sim3.py",
+        root / "tests/test_gauge_curvature.py",
+        root / "tests/test_gauge_curvature_study.py",
+        Path(__file__).resolve(),
+    ]
+    manifest = {
+        "python_version": platform.python_version(), "numpy_version": np.__version__,
+        "upstream_prob4d_commit": UPSTREAM_PROB4D_COMMIT,
+        "candidate_commit": None,
+        "files": {
+            str(p.relative_to(root)): hashlib.sha256(p.read_bytes()).hexdigest()
+            for p in code_paths
+        },
+        "outputs": {
+            p.name: hashlib.sha256(p.read_bytes()).hexdigest()
+            for p in sorted(output_dir.iterdir()) if p.is_file()
+        },
+        "reproduce": (
+            "python examples/gauge_curvature_study.py "
+            "--output-dir outputs/gauge-curvature-v1"
+        ),
+    }
+    (output_dir / "run_manifest.json").write_text(
+        json.dumps(manifest, indent=2, allow_nan=False) + "\n"
+    )
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args()
+    result = run(args.output_dir)
+    print(json.dumps({
+        "classification": result["classification"],
+        "update_case_count": result["design"]["update_case_count"],
+        "headline_rmse_reduction_vs_first_order": result["headline_rmse_reduction_vs_first_order"],
+        "headline_rmse_reduction_vs_physical_fallback": (
+            result["headline_rmse_reduction_vs_physical_fallback"]
+        ),
+        "max_gh15_relative_variance_error": result["max_gh15_relative_variance_error"],
+        "max_step_relative_variance_spread": result["max_step_relative_variance_spread"],
+    }, indent=2, allow_nan=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/prob4d/gauge_curvature.py
+++ b/src/prob4d/gauge_curvature.py
@@ -1,0 +1,288 @@
+"""Experimental shared-gauge curvature moments; not a provider-v2 exporter.
+
+The formulas are the Gaussian moments of a *quadratic Taylor surrogate*.
+They are exact for a quadratic map, not an exact nonlinear pushforward, a
+calibration certificate, or a generally second-order-accurate covariance.
+In particular, linear--cubic terms of the same order are absent in general.
+See ``docs/gauge-curvature.md`` for the tangent-null result and scope.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+FloatArray = NDArray[np.float64]
+
+
+def _array(value: Any, *, ndim: int, name: str) -> FloatArray:
+    if np.iscomplexobj(np.asarray(value)):
+        raise ValueError(f"{name} must be real-valued")
+    array = np.array(value, dtype=np.float64, copy=True)
+    if array.ndim != ndim or not np.all(np.isfinite(array)):
+        raise ValueError(f"{name} must be a finite {ndim}-dimensional array")
+    return array
+
+
+def _finite_result(value: FloatArray, *, name: str) -> FloatArray:
+    if not np.all(np.isfinite(value)):
+        raise ValueError(f"{name} overflowed or became non-finite")
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class SharedGaugeMoments:
+    """Joint quadratic-surrogate moments, stored without a dense covariance.
+
+    Columns of both factors are *shared* across all output coordinates.
+    They are not independent per-point noise. Curvature columns are
+    orthogonal Gaussian polynomial features, not independent Gaussian
+    latent variables and not additional physical degrees of freedom.
+    """
+
+    mean: FloatArray
+    linear_factor: FloatArray
+    curvature_factor: FloatArray
+    evaluation_count: int = 0
+
+    def __post_init__(self) -> None:
+        mean = _array(self.mean, ndim=1, name="mean")
+        linear = _array(self.linear_factor, ndim=2, name="linear_factor")
+        curvature = _array(self.curvature_factor, ndim=2, name="curvature_factor")
+        if mean.size == 0 or linear.shape[0] != mean.size or curvature.shape[0] != mean.size:
+            raise ValueError("mean and factor output dimensions must agree and be positive")
+        rank = linear.shape[1]
+        if curvature.shape[1] != rank * (rank + 1) // 2:
+            raise ValueError("curvature_factor must contain all diagonal and mixed features")
+        if (
+            isinstance(self.evaluation_count, bool)
+            or not isinstance(self.evaluation_count, int)
+            or self.evaluation_count < 0
+        ):
+            raise ValueError("evaluation_count must be a nonnegative integer")
+        for name, array in (
+            ("mean", mean),
+            ("linear_factor", linear),
+            ("curvature_factor", curvature),
+        ):
+            array.setflags(write=False)
+            object.__setattr__(self, name, array)
+
+    @property
+    def input_rank(self) -> int:
+        return int(self.linear_factor.shape[1])
+
+    @property
+    def covariance_factor(self) -> FloatArray:
+        """Return F with Cov[f_quadratic] = F F.T; no compression is performed."""
+        return np.concatenate((self.linear_factor, self.curvature_factor), axis=1)
+
+    @property
+    def marginal_variance(self) -> FloatArray:
+        with np.errstate(over="ignore", invalid="ignore"):
+            result = np.sum(self.linear_factor**2, axis=1)
+            result += np.sum(self.curvature_factor**2, axis=1)
+        return _finite_result(result, name="marginal variance")
+
+    def covariance(self) -> FloatArray:
+        """Materialize the joint covariance only when explicitly requested."""
+        with np.errstate(over="ignore", invalid="ignore"):
+            result = self.linear_factor @ self.linear_factor.T
+            result += self.curvature_factor @ self.curvature_factor.T
+        return _finite_result(result, name="covariance")
+
+    def covariance_action(self, vector: Any) -> FloatArray:
+        """Multiply by the joint covariance, without constructing it."""
+        operand = _array(vector, ndim=1, name="vector")
+        if operand.shape != self.mean.shape:
+            raise ValueError("vector must have the output dimension")
+        with np.errstate(over="ignore", invalid="ignore"):
+            result = self.linear_factor @ (self.linear_factor.T @ operand)
+            result += self.curvature_factor @ (self.curvature_factor.T @ operand)
+        return _finite_result(result, name="covariance action")
+
+    def project(self, matrix: Any) -> SharedGaugeMoments:
+        """Project all outputs jointly through a fixed, outcome-independent map."""
+        projection = _array(matrix, ndim=2, name="projection")
+        if projection.shape[0] == 0 or projection.shape[1] != self.mean.size:
+            raise ValueError(
+                "projection must have shape (positive query dimension, output dimension)"
+            )
+        return SharedGaugeMoments(
+            mean=projection @ self.mean,
+            linear_factor=projection @ self.linear_factor,
+            curvature_factor=projection @ self.curvature_factor,
+            evaluation_count=self.evaluation_count,
+        )
+
+    def input_cross_covariance(self, covariance_root: Any) -> FloatArray:
+        """Return Cov[g, f_quadratic] = L A.T for g = mean + L z.
+
+        The root must use exactly the same whitened coordinates used to
+        construct these moments. Shape validation cannot certify that lineage.
+        """
+        root = _array(covariance_root, ndim=2, name="covariance_root")
+        if root.shape[0] == 0 or root.shape[1] != self.input_rank:
+            raise ValueError("covariance_root must use the same input rank")
+        with np.errstate(over="ignore", invalid="ignore"):
+            result = root @ self.linear_factor.T
+        return _finite_result(result, name="input cross covariance")
+
+
+def quadratic_gaussian_moments(
+    value_at_mean: Any,
+    linear: Any,
+    hessian: Any,
+) -> SharedGaugeMoments:
+    """Compute exact Gaussian moments of a quadratic in whitened coordinates.
+
+    For z ~ N(0, I_r), the output is
+    f_i(z) = c_i + A_i z + (1/2) z.T B_i z.
+    Arguments have shapes (p,), (p, r), and (p, r, r).
+    Each B_i must be symmetric. No covariance-rank truncation is used.
+    """
+    value = _array(value_at_mean, ndim=1, name="value_at_mean")
+    derivative = _array(linear, ndim=2, name="linear")
+    second = _array(hessian, ndim=3, name="hessian")
+    if value.size == 0 or derivative.shape[0] != value.size:
+        raise ValueError("value_at_mean and linear output dimensions must agree")
+    rank = derivative.shape[1]
+    if second.shape != (value.size, rank, rank):
+        raise ValueError("hessian must have shape (output dimension, input rank, input rank)")
+    if not np.allclose(second, np.swapaxes(second, 1, 2), atol=1e-12, rtol=1e-10):
+        raise ValueError("each output Hessian must be symmetric")
+    second = 0.5 * (second + np.swapaxes(second, 1, 2))
+    diagonal = np.diagonal(second, axis1=1, axis2=2)
+    columns = [diagonal[:, index] / math.sqrt(2.0) for index in range(rank)]
+    columns.extend(second[:, i, j] for i in range(rank) for j in range(i + 1, rank))
+    curvature = np.column_stack(columns) if columns else np.empty((value.size, 0))
+    return SharedGaugeMoments(
+        mean=value + 0.5 * np.sum(diagonal, axis=1),
+        linear_factor=derivative,
+        curvature_factor=curvature,
+    )
+
+
+def finite_difference_gauge_moments(
+    function: Callable[[FloatArray], Any],
+    mean: Any,
+    covariance_root: Any,
+    *,
+    step: float = 1e-3,
+    max_rank: int = 32,
+) -> SharedGaugeMoments:
+    """Build all local linear, diagonal-curvature, and mixed-curvature factors.
+
+    Differentiates z -> function(mean + covariance_root @ z) near z=0.
+    Uses 1 + 2 r**2 function calls; ``step`` is in standardized coordinates.
+    This is a derivative stencil, not a Gaussian quadrature rule. The callback
+    must be deterministic and may use only the caller-authorized data.
+
+    The caller supplies the *joint* covariance root across all gauges/windows.
+    A rank limit raises an error rather than silently discarding uncertainty.
+    Check numerical convergence with a second step before scientific use.
+    """
+    center = _array(mean, ndim=1, name="mean")
+    root = _array(covariance_root, ndim=2, name="covariance_root")
+    if center.size == 0 or root.shape[0] != center.size:
+        raise ValueError("mean and covariance_root input dimensions must agree")
+    if isinstance(step, bool) or not np.isfinite(step) or step <= 0:
+        raise ValueError("step must be finite and strictly positive")
+    if isinstance(max_rank, bool) or not isinstance(max_rank, int) or max_rank < 0:
+        raise ValueError("max_rank must be a nonnegative integer")
+    rank = root.shape[1]
+    if rank > max_rank:
+        raise ValueError("input rank exceeds max_rank; uncertainty was not truncated")
+    value = _array(function(center.copy()), ndim=1, name="function output")
+    if value.size == 0:
+        raise ValueError("function output must be nonempty")
+
+    def evaluate(offset: FloatArray) -> FloatArray:
+        argument = _finite_result(center + offset, name="stencil argument")
+        output = _array(function(argument), ndim=1, name="function output")
+        if output.shape != value.shape:
+            raise ValueError("function output shape changed inside the stencil")
+        return output
+
+    if rank == 0:
+        return SharedGaugeMoments(value, np.empty((value.size, 0)), np.empty((value.size, 0)), 1)
+    offsets = float(step) * root
+    first_columns: list[FloatArray] = []
+    diagonal_columns: list[FloatArray] = []
+    for index in range(rank):
+        plus = evaluate(offsets[:, index])
+        minus = evaluate(-offsets[:, index])
+        first_columns.append((plus - minus) / (2.0 * step))
+        diagonal_columns.append(((plus - value) + (minus - value)) / step**2)
+    curvature_columns = [column / math.sqrt(2.0) for column in diagonal_columns]
+    for i in range(rank):
+        for j in range(i + 1, rank):
+            pp = evaluate(offsets[:, i] + offsets[:, j])
+            pm = evaluate(offsets[:, i] - offsets[:, j])
+            mp = evaluate(-offsets[:, i] + offsets[:, j])
+            mm = evaluate(-offsets[:, i] - offsets[:, j])
+            curvature_columns.append(((pp - pm) - (mp - mm)) / (4.0 * step**2))
+    return SharedGaugeMoments(
+        mean=value + 0.5 * np.sum(np.column_stack(diagonal_columns), axis=1),
+        linear_factor=np.column_stack(first_columns),
+        curvature_factor=np.column_stack(curvature_columns),
+        evaluation_count=1 + 2 * rank**2,
+    )
+
+
+def sim3_chain_gauge_moments(
+    transform_vectors: Any,
+    joint_covariance_root: Any,
+    points_local_m: Any,
+    *,
+    query_matrix: Any | None = None,
+    step: float = 1e-3,
+    max_rank: int = 32,
+) -> SharedGaugeMoments:
+    """Apply local shared curvature to a chain of Prob4D ``Sim3`` transforms.
+
+    Transform vectors use Prob4D's [log_scale, rotvec(3), translation(3)]
+    convention. Chain order is T_0.compose(T_1).compose(...).
+    The joint root has shape (7*K, r); points have shape (N, 3).
+    A fixed query matrix has shape (q, 3*N), with point-major flattening.
+    Passing the query evaluates and stores its factors directly.
+
+    This computes smooth forward point coordinates, not a new logarithmic
+    gauge state. It does not change branch-cut, support, covariance-calibration,
+    export, or downstream admission policies. Conditional point noise is not
+    included and must remain a separately calibrated covariance component.
+    """
+    from .sim3 import Sim3
+
+    vectors = _array(transform_vectors, ndim=2, name="transform_vectors")
+    points = _array(points_local_m, ndim=2, name="points_local_m")
+    if vectors.shape[0] == 0 or vectors.shape[1] != 7:
+        raise ValueError("transform_vectors must have shape (K, 7), K >= 1")
+    if points.shape[0] == 0 or points.shape[1] != 3:
+        raise ValueError("points_local_m must have shape (N, 3), N >= 1")
+    projection = None
+    if query_matrix is not None:
+        projection = _array(query_matrix, ndim=2, name="query_matrix")
+        if projection.shape[0] == 0 or projection.shape[1] != points.size:
+            raise ValueError("query_matrix must have shape (q, 3*N), q >= 1")
+
+    def transform(flat: FloatArray) -> FloatArray:
+        transforms = [Sim3.from_vector(vector) for vector in flat.reshape(vectors.shape)]
+        current = transforms[0]
+        for following in transforms[1:]:
+            current = current.compose(following)
+        transformed = current.transform_points(points).reshape(-1)
+        return transformed if projection is None else projection @ transformed
+
+    return finite_difference_gauge_moments(
+        transform,
+        vectors.reshape(-1),
+        joint_covariance_root,
+        step=step,
+        max_rank=max_rank,
+    )

--- a/tests/test_gauge_curvature.py
+++ b/tests/test_gauge_curvature.py
@@ -1,0 +1,317 @@
+"""Analytic, algebraic, finite-difference, and upstream-Sim3 regression tests."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from prob4d.gauge_curvature import (
+    SharedGaugeMoments,
+    finite_difference_gauge_moments,
+    quadratic_gaussian_moments,
+    sim3_chain_gauge_moments,
+)
+from prob4d.sim3 import Sim3
+
+
+def _quadratic_data(rank: int = 4, outputs: int = 6):
+    rng = np.random.default_rng(703)
+    c = rng.normal(size=outputs)
+    a = rng.normal(size=(outputs, rank))
+    b = rng.normal(size=(outputs, rank, rank))
+    b = 0.5 * (b + b.swapaxes(1, 2))
+    return c, a, b
+
+
+def _quadratic(c, a, b):
+    return lambda z: c + a @ z + 0.5 * np.einsum("i,pij,j->p", z, b, z)
+
+
+def _axis_rule(function, rank):
+    samples = [
+        function(sign * math.sqrt(rank) * np.eye(rank)[i])
+        for i in range(rank)
+        for sign in (-1.0, 1.0)
+    ]
+    values = np.asarray(samples)
+    return values.mean(axis=0), np.atleast_2d(np.cov(values.T, bias=True))
+
+
+def test_exact_quadratic_moments_against_gaussian_identity():
+    c, a, b = _quadratic_data()
+    result = quadratic_gaussian_moments(c, a, b)
+    expected_mean = c + 0.5 * np.trace(b, axis1=1, axis2=2)
+    expected_cov = a @ a.T + 0.5 * np.einsum("pij,qji->pq", b, b)
+    np.testing.assert_allclose(result.mean, expected_mean, atol=1e-14)
+    np.testing.assert_allclose(result.covariance(), expected_cov, atol=1e-13)
+    assert np.linalg.eigvalsh(result.covariance()).min() >= -1e-12
+
+
+def test_affine_map_exact_and_zero_curvature():
+    c, a, _ = _quadratic_data()
+    result = quadratic_gaussian_moments(c, a, np.zeros((len(c), a.shape[1], a.shape[1])))
+    np.testing.assert_array_equal(result.mean, c)
+    np.testing.assert_array_equal(result.curvature_factor, 0)
+    np.testing.assert_allclose(result.covariance(), a @ a.T)
+
+
+def test_mixed_product_is_invisible_to_axis_rule():
+    b = np.array([[[0.0, 1.0], [1.0, 0.0]]])
+    result = quadratic_gaussian_moments([0.0], np.zeros((1, 2)), b)
+    axis_mean, axis_cov = _axis_rule(lambda z: np.array([z[0] * z[1]]), 2)
+    np.testing.assert_array_equal(axis_mean, [0.0])
+    np.testing.assert_array_equal(axis_cov, [[0.0]])
+    np.testing.assert_array_equal(result.mean, [0.0])
+    np.testing.assert_array_equal(result.covariance(), [[1.0]])
+
+
+def test_square_variance_invisible_to_rank_one_axis_rule():
+    result = quadratic_gaussian_moments([0.0], [[0.0]], [[[2.0]]])
+    mean, covariance = _axis_rule(lambda z: z**2, 1)
+    np.testing.assert_array_equal(mean, [1.0])
+    np.testing.assert_array_equal(covariance, [[0.0]])
+    np.testing.assert_allclose(result.covariance(), [[2.0]])
+
+
+def test_radial_square_variance_invisible_to_axis_rule():
+    rank = 7
+    result = quadratic_gaussian_moments([0.0], np.zeros((1, rank)), [2.0 * np.eye(rank)])
+    _, covariance = _axis_rule(lambda z: np.array([z @ z]), rank)
+    np.testing.assert_allclose(covariance, 0, atol=1e-28)
+    np.testing.assert_allclose(result.mean, [rank])
+    np.testing.assert_allclose(result.covariance(), [[2.0 * rank]])
+
+
+def test_orthogonal_whitening_basis_invariance_for_exact_derivatives():
+    c, a, b = _quadratic_data()
+    rotation, _ = np.linalg.qr(np.random.default_rng(444).normal(size=(4, 4)))
+    transformed_b = np.einsum("ia,pij,jb->pab", rotation, b, rotation)
+    original = quadratic_gaussian_moments(c, a, b)
+    transformed = quadratic_gaussian_moments(c, a @ rotation, transformed_b)
+    np.testing.assert_allclose(transformed.mean, original.mean, atol=1e-13)
+    np.testing.assert_allclose(transformed.covariance(), original.covariance(), atol=1e-12)
+
+
+def test_projection_preserves_cross_point_and_query_covariance():
+    weights = np.array([1.0, -2.0, 4.0])
+    mixed = np.array([[0.0, 1.0], [1.0, 0.0]])
+    result = quadratic_gaussian_moments(
+        np.zeros(3), np.zeros((3, 2)), weights[:, None, None] * mixed,
+    )
+    np.testing.assert_allclose(result.covariance(), np.outer(weights, weights))
+    contrast = np.array([[2.0, 1.0, 0.0]])
+    np.testing.assert_allclose(result.project(contrast).covariance(), [[0.0]], atol=1e-25)
+    # Replacing the shared covariance with its diagonal destroys cancellation.
+    assert (contrast @ np.diag(result.marginal_variance) @ contrast.T)[0, 0] == 8.0
+
+
+def test_covariance_action_and_marginal_variance():
+    c, a, b = _quadratic_data()
+    result = quadratic_gaussian_moments(c, a, b)
+    v = np.arange(len(c), dtype=float)
+    np.testing.assert_allclose(result.covariance_action(v), result.covariance() @ v)
+    np.testing.assert_allclose(result.marginal_variance, np.diag(result.covariance()))
+    np.testing.assert_allclose(
+        result.covariance_factor @ result.covariance_factor.T, result.covariance(),
+    )
+
+
+def test_input_cross_covariance():
+    c, a, b = _quadratic_data()
+    root = np.random.default_rng(441).normal(size=(9, 4))
+    result = quadratic_gaussian_moments(c, a, b)
+    np.testing.assert_allclose(result.input_cross_covariance(root), root @ a.T)
+
+
+@pytest.mark.parametrize("rank", [1, 2, 4, 7])
+def test_finite_difference_quadratic_exactness_and_call_count(rank):
+    c, a, b = _quadratic_data(rank, 5)
+    calls = []
+    function = _quadratic(c, a, b)
+
+    def record(z):
+        calls.append(z.copy())
+        return function(z)
+
+    result = finite_difference_gauge_moments(record, np.zeros(rank), np.eye(rank), step=0.02)
+    expected = quadratic_gaussian_moments(c, a, b)
+    assert result.evaluation_count == len(calls) == 1 + 2 * rank**2
+    np.testing.assert_allclose(result.mean, expected.mean, rtol=1e-10, atol=1e-10)
+    np.testing.assert_allclose(result.covariance(), expected.covariance(), rtol=1e-10, atol=1e-10)
+
+
+def test_singular_correlated_root_and_nonzero_mean():
+    rng = np.random.default_rng(202)
+    c, a, b = _quadratic_data(5, 3)
+    center = rng.normal(size=5)
+    root = rng.normal(size=(5, 2))
+    function = _quadratic(c, a, b)
+    j = a + np.einsum("pij,j->pi", b, center)
+    white_h = np.einsum("ia,pij,jb->pab", root, b, root)
+    expected = quadratic_gaussian_moments(function(center), j @ root, white_h)
+    actual = finite_difference_gauge_moments(function, center, root, step=0.01)
+    np.testing.assert_allclose(actual.mean, expected.mean, atol=1e-9)
+    np.testing.assert_allclose(actual.covariance(), expected.covariance(), rtol=1e-9)
+
+
+def test_zero_rank_evaluates_once_and_keeps_exact_mean():
+    result = finite_difference_gauge_moments(
+        lambda x: np.array([x.sum()]), [1.0, 2.0], np.empty((2, 0)),
+    )
+    np.testing.assert_array_equal(result.mean, [3.0])
+    np.testing.assert_array_equal(result.covariance(), [[0.0]])
+    assert result.covariance_factor.shape == (1, 0)
+    assert result.evaluation_count == 1
+
+
+def _mixed_sim3_case(sigma=0.1, lever=0.5):
+    vectors = np.zeros((2, 7))
+    root = np.zeros((14, 2))
+    root[3, 0] = sigma  # T0: z-axis rotation alpha.
+    root[9, 1] = sigma  # T1: y-axis rotation beta.
+    return vectors, root, np.array([[0.0, 0.0, lever]])
+
+
+def test_upstream_sim3_chain_matches_independent_analytic_map():
+    alpha, beta, lever = 0.13, -0.21, 0.5
+    first, second = np.zeros(7), np.zeros(7)
+    first[3], second[2] = alpha, beta
+    composed = Sim3.from_vector(first).compose(Sim3.from_vector(second))
+    actual = composed.transform_points([[0, 0, lever]])[0]
+    expected = lever * np.array([
+        np.cos(alpha) * np.sin(beta), np.sin(alpha) * np.sin(beta), np.cos(beta),
+    ])
+    np.testing.assert_allclose(actual, expected, atol=1e-15)
+
+
+def test_sim3_mixed_rotation_query_recovers_missing_variance():
+    vectors, root, points = _mixed_sim3_case()
+    result = sim3_chain_gauge_moments(vectors, root, points, query_matrix=[[0.0, 1.0, 0.0]])
+    true_variance = 0.5**2 * ((1 - np.exp(-2 * 0.1**2)) / 2)**2
+    np.testing.assert_allclose(result.mean, [0.0], atol=1e-16)
+    np.testing.assert_allclose(result.marginal_variance, [0.5**2 * 0.1**4], rtol=2e-8)
+    assert 0 < result.marginal_variance[0] / true_variance - 1 < 0.021
+    assert result.evaluation_count == 9
+    np.testing.assert_array_equal(result.linear_factor, 0)
+
+
+def test_project_before_or_after_sim3_transform():
+    vectors, root, points = _mixed_sim3_case()
+    points = np.concatenate((points, 2.0 * points))
+    query = np.array([[0, 1, 0, 0, 0, 0], [0, -2, 0, 0, 1, 0]], dtype=float)
+    before = sim3_chain_gauge_moments(vectors, root, points, query_matrix=query)
+    after = sim3_chain_gauge_moments(vectors, root, points).project(query)
+    np.testing.assert_allclose(before.mean, after.mean, atol=1e-10)
+    np.testing.assert_allclose(before.covariance(), after.covariance(), atol=1e-10)
+    np.testing.assert_allclose(before.marginal_variance[1], 0, atol=1e-24)
+
+
+def test_common_translation_shared_across_points():
+    root = np.zeros((7, 1))
+    root[5, 0] = 0.03
+    points = np.array([[0, 0, 0], [1, 0, 0]], dtype=float)
+    query = np.array([[0, 1, 0, 0, 0, 0], [0, 0, 0, 0, 1, 0]])
+    result = sim3_chain_gauge_moments(np.zeros((1, 7)), root, points, query_matrix=query)
+    np.testing.assert_allclose(result.covariance(), np.full((2, 2), 0.03**2), atol=1e-14)
+
+
+def test_defensive_copy_and_readonly_storage():
+    c, a, b = _quadratic_data()
+    result = quadratic_gaussian_moments(c, a, b)
+    original = result.mean.copy()
+    c[:] = 123
+    a[:] = 321
+    b[:] = 222
+    np.testing.assert_array_equal(result.mean, original)
+    assert not result.mean.flags.writeable
+    assert not result.linear_factor.flags.writeable
+    assert not result.curvature_factor.flags.writeable
+    with pytest.raises(ValueError):
+        result.mean[0] = 1
+
+
+@pytest.mark.parametrize("step", [0.0, -0.1, np.inf, np.nan, True])
+def test_invalid_derivative_step_fails(step):
+    with pytest.raises(ValueError):
+        finite_difference_gauge_moments(lambda x: x, [0.0], [[1.0]], step=step)
+
+
+@pytest.mark.parametrize("bad", [np.inf, np.nan])
+def test_nonfinite_inputs_fail(bad):
+    with pytest.raises(ValueError):
+        quadratic_gaussian_moments([bad], [[0.0]], [[[0.0]]])
+    with pytest.raises(ValueError):
+        finite_difference_gauge_moments(lambda x: x, [0.0], [[bad]])
+    with pytest.raises(ValueError):
+        finite_difference_gauge_moments(lambda x: np.array([bad]), [0.0], [[1.0]])
+
+
+def test_asymmetric_hessian_fails():
+    with pytest.raises(ValueError, match="symmetric"):
+        quadratic_gaussian_moments([0.0], [[0.0, 0.0]], [[[0, 1], [0, 0]]])
+
+
+def test_rank_limit_never_silently_truncates():
+    with pytest.raises(ValueError, match="not truncated"):
+        finite_difference_gauge_moments(lambda x: x, np.zeros(4), np.eye(4), max_rank=3)
+
+
+@pytest.mark.parametrize("max_rank", [-1, 2.5, True])
+def test_invalid_rank_limit_fails(max_rank):
+    with pytest.raises(ValueError):
+        finite_difference_gauge_moments(lambda x: x, [0.0], [[1.0]], max_rank=max_rank)
+
+
+def test_changed_callback_shape_fails():
+    with pytest.raises(ValueError, match="shape changed"):
+        finite_difference_gauge_moments(lambda x: np.zeros(1 if x[0] == 0 else 2), [0.0], [[1.0]])
+
+
+def test_invalid_shapes_fail():
+    with pytest.raises(ValueError):
+        quadratic_gaussian_moments([0.0], [[0.0]], np.zeros((1, 2, 2)))
+    with pytest.raises(ValueError):
+        finite_difference_gauge_moments(lambda x: x, [0.0, 0.0], [[1.0]])
+    with pytest.raises(ValueError):
+        sim3_chain_gauge_moments(np.zeros((1, 6)), np.zeros((6, 0)), [[0, 0, 0]])
+    with pytest.raises(ValueError):
+        sim3_chain_gauge_moments(np.zeros((1, 7)), np.zeros((7, 0)), [[0, 0]])
+    with pytest.raises(ValueError):
+        sim3_chain_gauge_moments(
+            np.zeros((1, 7)), np.zeros((7, 0)), [[0, 0, 0]], query_matrix=[[1.0]],
+        )
+
+
+def test_missing_curvature_features_fail():
+    with pytest.raises(ValueError, match="all diagonal and mixed"):
+        SharedGaugeMoments(np.zeros(2), np.zeros((2, 3)), np.zeros((2, 3)))
+
+
+def test_invalid_projection_and_covariance_operands_fail():
+    result = quadratic_gaussian_moments([0.0], [[1.0]], [[[0.0]]])
+    with pytest.raises(ValueError):
+        result.project([[1.0, 2.0]])
+    with pytest.raises(ValueError):
+        result.covariance_action([1.0, 2.0])
+    with pytest.raises(ValueError):
+        result.input_cross_covariance([[1.0, 2.0]])
+
+
+def test_covariance_overflow_is_not_reported_as_finite():
+    result = quadratic_gaussian_moments([0.0], [[1e200]], [[[0.0]]])
+    with pytest.raises(ValueError, match="non-finite"):
+        result.covariance()
+    with pytest.raises(ValueError, match="non-finite"):
+        _ = result.marginal_variance
+
+
+def test_general_nonlinear_covariance_is_not_claimed_second_order_exact():
+    # For sin(sigma*z), the Hessian vanishes. The missing linear-cubic
+    # covariance term is O(sigma**4); the method must not claim to capture it.
+    sigma = 0.2
+    result = finite_difference_gauge_moments(lambda x: np.sin(x), [0.0], [[sigma]])
+    truth = (1 - np.exp(-2 * sigma**2)) / 2
+    assert result.marginal_variance[0] > truth
+    np.testing.assert_allclose(result.marginal_variance, [sigma**2], rtol=2e-8)

--- a/tests/test_gauge_curvature_study.py
+++ b/tests/test_gauge_curvature_study.py
@@ -1,0 +1,76 @@
+"""Verify the independent cubature comparators and exact-risk arithmetic."""
+
+from __future__ import annotations
+
+import importlib.util
+import math
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from prob4d.gauge_curvature import finite_difference_gauge_moments
+
+SPEC = importlib.util.spec_from_file_location(
+    "gauge_curvature_study",
+    Path(__file__).resolve().parents[1] / "examples/gauge_curvature_study.py",
+)
+assert SPEC is not None and SPEC.loader is not None
+STUDY = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(STUDY)
+
+
+@pytest.mark.parametrize("rank", [1, 2, 4, 7])
+def test_fifth_degree_rule_matches_gaussian_moments(rank):
+    for degree, exact in ((0, 1), (1, 0), (2, 1), (3, 0), (4, 3), (5, 0)):
+        mean, _ = STUDY.fifth_degree_cubature(lambda z: z[0]**degree, rank)
+        np.testing.assert_allclose(mean, exact, atol=2e-13)
+    if rank >= 2:
+        mean, _ = STUDY.fifth_degree_cubature(lambda z: z[0]**2 * z[1]**2, rank)
+        np.testing.assert_allclose(mean, 1.0, atol=2e-13)
+
+
+@pytest.mark.parametrize("sigma", [0.025, 0.1, 0.35])
+def test_independent_hermite_reference_matches_analytic_oracle(sigma):
+    _, variance = STUDY.gauss_hermite_product(
+        lambda z: 0.5 * math.sin(sigma * z[0]) * math.sin(sigma * z[1]), 2, 15,
+    )
+    np.testing.assert_allclose(
+        variance, STUDY.exact_sine_product_variance(sigma, 0.5), rtol=1e-13,
+    )
+
+
+def test_oracle_second_moments_have_nees_one_without_gaussian_noise_assumption():
+    result = STUDY.gaussian_update_metrics(0.002**2, 0.005**2, 0.005**2)
+    np.testing.assert_allclose(result["expected_nees"], 1.0, atol=1e-15)
+    np.testing.assert_allclose(result["expected_mse_m2"], result["posterior_variance_m2"])
+
+
+def test_exact_physical_fallback_ignores_observation_noise():
+    result = STUDY.gaussian_update_metrics(0.002**2, 100.0, None)
+    assert result["gain"] == 0
+    assert result["expected_rmse_mm"] == 2
+    assert result["expected_nees"] == 1
+
+
+def test_complex_gauge_inputs_fail_instead_of_discarding_imaginary_parts():
+    with pytest.raises(ValueError, match="real-valued"):
+        finite_difference_gauge_moments(lambda x: x, np.array([1 + 2j]), [[1.0]])
+
+
+def test_fourth_moment_complete_reference_is_not_axis_rule():
+    _, axis = STUDY.axis_cubature(lambda z: z[0] * z[1], 7)
+    _, fifth = STUDY.fifth_degree_cubature(lambda z: z[0] * z[1], 7)
+    assert axis == 0
+    np.testing.assert_allclose(fifth, 1.0, atol=1e-15)
+
+
+def test_fifth_degree_signed_weights_are_not_a_psd_guarantee():
+    # Rank seven has negative axial weights. An output concentrated at one
+    # such node gives a negative quadrature variance. This is an adversarial
+    # mathematical test, not a representative Sim3 performance claim.
+    def spike(z):
+        return float(abs(z[0] - 3.0) < 1e-12 and np.count_nonzero(z[1:]) == 0)
+
+    _, variance = STUDY.fifth_degree_cubature(spike, 7)
+    assert variance < 0

--- a/tests/test_gauge_curvature_study.py
+++ b/tests/test_gauge_curvature_study.py
@@ -23,7 +23,7 @@ SPEC.loader.exec_module(STUDY)
 @pytest.mark.parametrize("rank", [1, 2, 4, 7])
 def test_fifth_degree_rule_matches_gaussian_moments(rank):
     for degree, exact in ((0, 1), (1, 0), (2, 1), (3, 0), (4, 3), (5, 0)):
-        mean, _ = STUDY.fifth_degree_cubature(lambda z: z[0]**degree, rank)
+        mean, _ = STUDY.fifth_degree_cubature(lambda z, degree=degree: z[0]**degree, rank)
         np.testing.assert_allclose(mean, exact, atol=2e-13)
     if rank >= 2:
         mean, _ = STUDY.fifth_degree_cubature(lambda z: z[0]**2 * z[1]**2, rank)


### PR DESCRIPTION
## Scientific objective

Add an experimental, additive uncertainty representation for a specific nonlinear blind spot in shared `Sim(3)` gauge propagation.

For the controlled query

`q = ell * sin(alpha) * sin(beta)`

with independent zero-mean Gaussian rotations, both first-order propagation and the existing axis spherical-radial reference can report zero query variance even though the true variance is positive. This PR adds a quadratic Gaussian-moment representation that preserves the resulting curvature covariance *jointly* across outputs rather than treating it as independent pointwise noise.

This work complements the query-aware observability program in #339: observability decides whether information supports a declared physical query; this PR addresses a distinct case where the nonlinear query has leading uncertainty outside the first-order tangent response.

## Implementation

- `SharedGaugeMoments`: mean plus shared linear/curvature covariance factors, covariance actions, query projection, and input cross covariance.
- `quadratic_gaussian_moments`: exact Gaussian moments for a local quadratic surrogate.
- `finite_difference_gauge_moments`: centered stencil including all mixed second derivatives; `1 + 2 r^2` evaluations; hard rank cap rather than silent truncation.
- `sim3_chain_gauge_moments`: applies the method to the existing Prob4D `Sim3` chain and optionally projects directly to a fixed physical query.
- focused analytic/upstream-Sim3 regression tests and a deterministic controlled study.

The stable `prob4d.api.v2` facade, CLI registry, artifact schemas, provider-v2 exporter, admission rules, and existing gauge-linearization closure diagnostic are unchanged.

## Controlled finding

At `ell=0.5 m`, `sigma=0.1 rad`:

- exact query SD: `4.950331673 mm`;
- first-order SD: `0`;
- axis spherical-radial SD: `0`;
- quadratic shared-curvature SD: approximately `5.0 mm`.

In the fixed scalar physical-update analogue with 64 observations, 2 mm prior SD, and 1 mm independent point noise, the shared-curvature arm has expected RMSE `1.854503 mm` versus `2.000000 mm` for exact physical fallback, a `7.27%` reduction. The much larger improvement versus the deliberately unguarded first-order arm is not a claim about deployed BayesianPhysTwin.

Strong comparators are retained: fifth-degree cubature and 3-node tensor Gauss-Hermite are more accurate on the rank-two sine example; at `sigma=0.35 rad` the local quadratic approximation overestimates the example variance by `27.12%`.

## Validation already performed on the exact base

This branch starts at `224d13dc9a93731ac5297b479eb1e121b3dbe659`, the exact Prob4D revision used by the controlled study. The prepared patch passed 50 focused tests locally and a repeated study run produced byte-identical outputs/manifests. GitHub CI should independently validate the pushed branch.

## Evidence and claim boundary

Controlled synthetic mechanism evidence only. This PR does **not** establish:

- real-provider competence or transfer;
- calibrated real uncertainty;
- BayesianPhysTwin guard benefit;
- Causal4D intervention benefit;
- a new state-of-the-art result;
- globally conservative nonlinear uncertainty.

Quadratic Gaussian moments and higher-degree cubature are established prior art. The contribution candidate is the shared-query uncertainty semantics, the identified tangent-null/axis-rule blind spot, and a testable downstream consequence.

Paper-facing evidence is being submitted separately to `FlorianPfaff/BayesianPhysTwin-Paper` so code and scientific interpretation remain independently reviewable.

Refs #339 #49