### PR TITLE
Add nonlinear circular-gauge query propagation

### DIFF
--- a/docs/circular-gauge-query.md
+++ b/docs/circular-gauge-query.md
@@ -1,0 +1,261 @@
+# Nonlinear physical queries under an unresolved circular gauge
+
+**Status:** experimental, locally implemented and tested on 2026-08-30. Additive
+patch reviewed against Prob4D `224d13dc9a93731ac5297b479eb1e121b3dbe659`.
+No stable API, existing estimator, admission decision, or historical evidence is
+changed. This is not a real-provider or deployment result.
+
+## Why this is a scientific extension rather than another adapter
+
+The existing `observable_gauge` path retains a rank-deficient Sim(3) information
+factor. `query_observability` projects that factor with a local query Jacobian.
+The separate gauge-linearization-closure diagnostic compares first-order
+propagation with a spherical-radial reference using `2r` symmetric points for a
+rank-`r` Gaussian coordinate covariance. These are useful, explicitly local
+instruments, but neither a local derivative nor that specific cubature rule
+establishes correctness for a nonlinear physical-query distribution.
+
+A circular ambiguity gives a rigorous example. Rotation about a line can be
+unobserved by collinear geometric correspondences. An off-axis point then lies
+on a circle, not on a Gaussian tangent line. In particular, a radial coordinate
+can have zero local derivative and strictly positive variance. The symmetric
+rank-one two-point cubature rule also misses that variance exactly.
+
+The extension propagates an **explicit conditional circular prior** through
+such queries, preserving a single shared phase across points and time. It
+provides exact conditional moments in a two-column covariance factor and
+joint linear-constraint event probabilities through unions of circular arcs.
+
+## Premises: local nullspace is not a global symmetry certificate
+
+Let `psi` denote the observable quotient and `phi` a residual rotation. The
+required likelihood property is the GLOBAL conditional invariance
+
+    L(y | psi, phi) = L(y | psi) for every supported phi.
+
+Under that premise,
+
+    p(phi | psi, y) = p(phi | psi).
+
+The conditional prior must be retained, not replaced by a uniform density, a
+zero twist, an arbitrary Gaussian, or an unconditional phase marginal. Prior
+correlation between `psi` and `phi` matters.
+
+A rank-six local Jacobian alone does not prove this premise. Nearly collinear
+geometry, oriented anisotropic likelihoods, physical contact, and additional
+sensors can make the rotation weakly informative rather than exactly
+unobserved. `validate_declared_line_support` only checks the supplied geometry
+against a declared line within numerical tolerance. It does not prove
+likelihood invariance. The caller owns that additional premise.
+
+The current implementation conditions on `psi`. It does not perform the
+outer integral over a complete physical belief. For a complete belief, use
+
+    E[q | y] = E_psi[ E[q | psi, y] ],
+    Cov(q | y) = E_psi[ Cov(q | psi, y) ]
+                + Cov_psi( E[q | psi, y] ).
+
+For a physical-particle mixture the corresponding sums must use the existing
+particle weights and each particle's conditional phase prior. That integration
+is a future adapter, not something claimed to have been executed here.
+
+## Exact conditional moment proposition
+
+For a fixed observable quotient, stack any number of points, frames, or linear
+query projections into
+
+    q(phi) = c + a cos(phi) + b sin(phi) = c + A t(phi),
+    A = [a b],  t(phi) = [cos(phi), sin(phi)]^T.
+
+Let `z_k = E[exp(i k phi)]`. Then
+
+    m = E[t] = [Re(z_1), Im(z_1)]^T,
+
+    E[t t^T] = 1/2 [[1 + Re(z_2), Im(z_2)],
+                       [Im(z_2), 1 - Re(z_2)]],
+
+    C = E[t t^T] - m m^T,
+    E[q] = c + A m,
+    Cov(q) = A C A^T.
+
+**Proof.** Expand the affine expression for `q`. Use
+`cos^2(phi)=(1+cos(2phi))/2`,
+`sin^2(phi)=(1-cos(2phi))/2`, and
+`sin(phi)cos(phi)=sin(2phi)/2`. No small-angle approximation is used.
+
+The complete stacked covariance has rank at most two for a fixed quotient,
+although the latent phase has only one dimension. A factor `A C^(1/2)` stores
+all cross-point and cross-time covariance in linear memory. Its two columns
+are harmonic covariance modes, not two independent phases.
+
+For a mixture of wrapped normals and a uniform component,
+
+    z_k = sum_j w_j exp(i k mu_j - k^2 sigma_j^2/2),  k != 0,
+    z_0 = 1.
+
+The uniform contribution vanishes for nonzero harmonics. The implementation
+uses component-centered covariance formulas and total covariance to avoid
+catastrophic cancellation for a narrow wrapped normal.
+
+## Analytic counterexample to the specified local and cubature rules
+
+Take a 100-mm off-axis point rotating about the z-axis:
+
+    q(phi) = r [cos(phi), sin(phi)],
+    phi ~ wrapped Normal(0, sigma^2).
+
+The radial coordinate has
+
+    E[q_x] = r exp(-sigma^2/2),
+    Var(q_x) = r^2/2 (1 - exp(-sigma^2))^2,
+    Var(q_y) = r^2/2 (1 - exp(-2 sigma^2)).
+
+For every `sigma > 0`, the radial variance is strictly positive. However,
+`d q_x/d phi` at zero is zero, so first-order propagation assigns zero radial
+variance. The rank-one spherical-radial rule evaluates `phi=+sigma` and
+`phi=-sigma`. Both have the same cosine, so that rule also assigns exactly
+zero radial variance. Its nonlinear mean correction does not repair the
+missing second moment.
+
+At `r=0.1 m`, `sigma=1 rad`, the exact radial mean is `60.653066 mm` and the
+standard deviation is `44.697673 mm`. For the illustrative event `q_x<50 mm`,
+the exact probability is `0.2950083103791666`. Both specified approximations
+assign probability zero because their deterministic radial prediction lies
+above the threshold. A model-conditional 10% gate would incorrectly admit
+those approximations.
+
+This does NOT show that all sigma-point methods fail. Higher-order
+Gauss-Hermite rules recover the smooth moments, and moment-matched circular
+sampling is established prior work. The bundled study retains all declared
+Gauss-Hermite orders rather than selecting the weakest one.
+
+## Why moment matching is still insufficient for event probabilities
+
+An exactly moment-matched Gaussian assigns probability `0.4058102397` to the
+same event, rather than `0.2950083104`. Likewise, 17-node Gauss-Hermite recovers
+the mean and variance to essentially machine precision but its direct
+indicator quadrature gives `0.2470489567`. Finite-node integration of a
+discontinuous indicator need not converge monotonically.
+
+The claim is not that quadrature cannot solve this problem. It is that accurate
+mean and covariance, or agreement of a limited cubature reference, is not an
+event-probability certificate. Here the circular structure admits a direct
+calculation without indicator quadrature.
+
+## Shared-phase joint-event proposition
+
+For one shared phase and registered affine constraints, write failure as
+
+    exists j: c_j + a_j cos(phi) + b_j sin(phi) > 0.
+
+Each nonconstant inequality is an arc with center `atan2(b_j,a_j)` and
+half-width `acos(-c_j / hypot(a_j,b_j))`, with constant, full-circle, and empty
+cases handled separately. Splitting at the period boundary and merging the
+arcs gives disjoint intervals `[l_i,u_i]` on `[0,2 pi]`.
+
+For a uniform prior, the probability is total arc length divided by `2 pi`.
+For a wrapped-normal component,
+
+    P = sum_i sum_{k in Z}
+        [Phi((u_i + 2 pi k - mu)/sigma)
+         - Phi((l_i + 2 pi k - mu)/sigma)].
+
+Mixture probabilities are the corresponding weighted sums. Finite summation
+over complete periods supplies a lower value and an upper value obtained by
+adding the omitted unwrapped-normal tails. This bounds truncation only; it is
+not formal floating-point interval arithmetic and does not bound model error.
+
+**Proof.** Rewrite each inequality as a shifted cosine, solve its superlevel
+set, and take the union. Integrate a wrapped density over that union by summing
+its lifted real-line normal components. Disjointness prevents double counting.
+The omitted union mass cannot exceed the omitted mass of the complete periods.
+
+A repeated constraint changes neither the arc union nor its probability.
+Treating frames as independent does not have this invariance. Five identical
+10%-risk constraints have joint risk 10%, not `1-0.9^5=40.951%`. Five disjoint
+phase-violation arcs of the same size have joint risk 50%, also not 40.951%.
+Thus an independence assumption can be either conservative or anticonservative.
+
+## Use
+
+```python
+import numpy as np
+from prob4d.circular_gauge_query import (
+    AffineCircularQuery,
+    CircularPrior,
+    bounded_risk_admissible,
+    path_violation_probability,
+    point_rotation_orbit,
+)
+
+# This must be an explicitly justified CONDITIONAL prior, not a convenience default.
+prior = CircularPrior.wrapped_normal(0.0, 1.0, prior_id="source-frozen-conditional-prior")
+orbit = point_rotation_orbit(
+    np.array([[0.1, 0.0, 0.0]]),
+    axis_origin=np.zeros(3),
+    axis_direction=np.array([0.0, 0.0, 1.0]),
+)
+factored = orbit.low_rank_moments(prior)  # mean plus (3 x 2) covariance factor
+
+# Positive violation means x < 0.05 m. There is no additional state/noise uncertainty here.
+violation = orbit.project(np.array([[-1.0, 0.0, 0.0]]), offset=np.array([0.05]))
+bounds = path_violation_probability(violation, prior)
+admitted = bounded_risk_admissible(bounds, maximum_risk=0.10)
+assert not admitted
+```
+
+The consumer must retain the complete caller-owned fallback on rejection.
+Nothing in this experimental module replaces a BayesianPhysTwin belief or
+issues a Causal4D action. Its risk calculation is conditional on the declared
+model, not a robot safety certificate.
+
+## Reproduction and evidence location
+
+```bash
+PYTHONPATH=src python -m pytest -q tests/test_circular_gauge_query.py
+PYTHONPATH=src python scripts/science/circular_gauge_query_study.py \
+  --output-dir /tmp/circular-gauge-control-new --plots
+python scripts/science/verify_circular_gauge_query_evidence.py \
+  --evidence-dir /tmp/circular-gauge-control-new --source-root .
+```
+
+The runtime module needs NumPy only. Tests use pytest; one numerical integration
+test additionally uses SciPy and is skipped if it is unavailable. Optional
+figures require Matplotlib. The evaluated environment ran all 36 tests without
+skips. Repository-wide CI, formatting, lint, installed-wheel integration, and
+provider execution were not run in this read-only session.
+
+Paper-facing JSON, CSV, figures, validation records, and interpretation belong
+in `FlorianPfaff/BayesianPhysTwin-Paper`, not in the public runtime code tree.
+
+## Relation to existing work and claim limits
+
+Circular moments, wrapped-normal filtering, deterministic circular sampling,
+Rao-Blackwellization, and degeneracy-aware registration are not new inventions.
+Relevant primary sources include:
+
+- Kurz, Gilitschenski, and Hanebeck, *Recursive Bayesian Filtering in Circular
+  State Spaces*, IEEE AES Magazine 31(3), 2016, DOI 10.1109/MAES.2016.150083;
+  author preprint: https://arxiv.org/abs/1501.05151.
+- Kurz, Gilitschenski, Siegwart, and Hanebeck, *Methods for Deterministic
+  Approximation of Circular Densities*, JAIF 11(2), 2016, pp. 138–156;
+  https://isif.org/media/methods-deterministic-approximation-circular-densities.
+- Kurz et al., including Florian Pfaff, *Directional Statistics and Filtering
+  Using libDirectional*, JSS 89(4), 2019, DOI 10.18637/jss.v089.i04.
+- Tuna et al., *X-ICP: Localizability-Aware LiDAR Registration for Robust
+  Localization in Extreme Environments*, IEEE T-RO 40, 2024, pp. 452–471;
+  https://arxiv.org/abs/2211.16335.
+- Huang, Mourikis, and Roumeliotis, *Observability-based Rules for Designing
+  Consistent EKF SLAM Estimators*, IJRR 29(5), 2010,
+  DOI 10.1177/0278364909353640.
+
+The candidate contribution is the narrower connection between retained
+unobservable 4-D gauge structure, nonlinear physical-query validity, shared
+trajectory uncertainty, and conditional exact fallback. The analytic
+counterexample and implementation establish a mechanism, not a field-wide
+novelty or empirical superiority claim.
+
+A material paper improvement still needs source evidence that this ambiguity
+occurs in the selected provider and a frozen downstream query evaluation. If
+that source check finds no material circular ambiguity, retain this as a
+bounded theory/diagnostic extension rather than force it into the main claim.

--- a/protocols/circular-gauge-query-control-v1.json
+++ b/protocols/circular-gauge-query-control-v1.json
@@ -1,0 +1,52 @@
+{
+  "schema": "prob4d.circular-gauge-query-control",
+  "version": 1,
+  "evidence_class": "exploratory-analytic-and-synthetic-mechanism-control",
+  "date": "2026-08-30",
+  "independent_prospective_confirmation": false,
+  "selection_note": "The analytic counterexample was deliberately constructed before this reproducibility specification. It is not a preregistered empirical discovery or an unopened real-data test.",
+  "reviewed_prob4d_revision": "224d13dc9a93731ac5297b479eb1e121b3dbe659",
+  "radius_m": 0.1,
+  "phase_mean_rad": 0.0,
+  "phase_stddev_rad": 1.0,
+  "violation_below_m": 0.05,
+  "illustrative_risk_budget": 0.1,
+  "monte_carlo_samples": 200000,
+  "monte_carlo_seed": 20260830,
+  "uniform_dependence_seed": 20260831,
+  "gauss_hermite_orders": [3, 5, 9, 17, 33, 65, 129],
+  "tail_tolerance": 1e-12,
+  "shared_phase_control": {
+    "constraints": 5,
+    "single_constraint_probability": 0.1,
+    "repeated_constraint_budget": 0.2,
+    "disjoint_constraint_budget": 0.45
+  },
+  "baselines": [
+    "independent reimplementation of first-order Gaussian propagation",
+    "independent reimplementation of the documented rank-one two-point spherical-radial rule",
+    "Gauss-Hermite quadrature with every declared order retained",
+    "Gaussian matched to exact transformed mean and variance",
+    "exact shared-phase circular moments and arc probabilities"
+  ],
+  "information_boundary": {
+    "provider_model_loaded": false,
+    "real_source_data_opened": false,
+    "real_target_data_opened": false,
+    "historical_terminal_study_retried": false,
+    "bayesian_phystwin_inference_run": false,
+    "causal4d_inference_run": false
+  },
+  "unsupported_claims": [
+    "novelty of circular moments or wrapped-normal filtering",
+    "all sigma-point or quadrature rules fail",
+    "full nonlinear Sim(3) posterior solved",
+    "local rank deficiency proves a global circular symmetry",
+    "complete physical uncertainty or dynamics uncertainty propagated",
+    "real-provider competence",
+    "real-world calibrated uncertainty",
+    "downstream empirical improvement",
+    "robot-control safety",
+    "state of the art"
+  ]
+}

--- a/scripts/science/circular_gauge_query_study.py
+++ b/scripts/science/circular_gauge_query_study.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Reproduce analytic/synthetic circular-gauge controls without accessing data.
+
+Run with PYTHONPATH=src. Only the optional --plots flag requires Matplotlib.
+No provider inference, existing benchmark, or protected source/target is read.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import io
+import json
+import math
+import platform
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from prob4d.circular_gauge_query import (
+    AffineCircularQuery,
+    CircularPrior,
+    bounded_risk_admissible,
+    path_violation_probability,
+)
+
+ROOT = Path(__file__).resolve().parents[2]
+PROTOCOL = ROOT / "protocols/circular-gauge-query-control-v1.json"
+
+
+def write_new(path: Path, data: bytes) -> None:
+    """No-clobber output; exact existing bytes are idempotent."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        if path.read_bytes() != data:
+            raise FileExistsError(f"refusing to change existing evidence: {path}")
+        return
+    with path.open("xb") as stream:
+        stream.write(data)
+
+
+def json_bytes(value: Any) -> bytes:
+    return (json.dumps(value, indent=2, sort_keys=True, allow_nan=False) + "\n").encode()
+
+
+def wilson_interval(successes: int, count: int) -> list[float]:
+    z = 1.959963984540054
+    fraction = successes / count
+    denominator = 1 + z * z / count
+    center = (fraction + z * z / (2 * count)) / denominator
+    radius = z * math.sqrt(fraction * (1 - fraction) / count + z * z / (4 * count * count)) / denominator
+    return [center - radius, center + radius]
+
+
+def gaussian_probability_below(mean: float, variance: float, threshold: float) -> float:
+    if variance == 0:
+        return float(mean < threshold)
+    return 0.5 * math.erfc((mean - threshold) / math.sqrt(2 * variance))
+
+
+def run() -> dict[str, Any]:
+    protocol = json.loads(PROTOCOL.read_text())
+    radius = protocol["radius_m"]
+    sigma = protocol["phase_stddev_rad"]
+    threshold = protocol["violation_below_m"]
+    risk_budget = protocol["illustrative_risk_budget"]
+    prior = CircularPrior.wrapped_normal(0, sigma, prior_id="explicit-control-conditional-prior-v1")
+    coordinate = AffineCircularQuery(np.array([0.0]), np.array([radius]), np.array([0.0]))
+    violation = AffineCircularQuery(np.array([threshold]), np.array([-radius]), np.array([0.0]))
+    moments = coordinate.moments(prior)
+    probability = path_violation_probability(violation, prior, tail_tolerance=protocol["tail_tolerance"])
+    true_mean, true_variance = float(moments.mean[0]), float(moments.covariance[0, 0])
+    rows: list[dict[str, Any]] = []
+
+    def add(name: str, mean: float, variance: float, risk: float, order: int | None = None) -> None:
+        rows.append({
+            "method": name,
+            "quadrature_order": order,
+            "mean_mm": mean * 1000,
+            "stddev_mm": math.sqrt(max(0.0, variance)) * 1000,
+            "variance_m2": variance,
+            "violation_probability": risk,
+            "probability_absolute_error": abs(risk - probability.lower),
+            "mean_absolute_error_mm": abs(mean - true_mean) * 1000,
+            "admitted_at_illustrative_budget": risk <= risk_budget,
+        })
+
+    add("first-order-Gaussian", radius, 0.0, gaussian_probability_below(radius, 0.0, threshold))
+    sigma_points = np.array([-sigma, sigma])
+    sigma_outputs = radius * np.cos(sigma_points)
+    add("two-point-spherical-radial", float(sigma_outputs.mean()), float(sigma_outputs.var()), float(np.mean(sigma_outputs < threshold)), 2)
+    for order in protocol["gauss_hermite_orders"]:
+        locations, weights = np.polynomial.hermite.hermgauss(order)
+        phases = math.sqrt(2) * sigma * locations
+        weights = weights / math.sqrt(math.pi)
+        outputs = radius * np.cos(phases)
+        mean = float(weights @ outputs)
+        variance = float(weights @ ((outputs - mean) ** 2))
+        add(f"Gauss-Hermite-{order}", mean, variance, float(weights @ (outputs < threshold)), order)
+    add("moment-exact-Gaussian", true_mean, true_variance, gaussian_probability_below(true_mean, true_variance, threshold))
+    add("exact-circular-shared-phase", true_mean, true_variance, probability.upper)
+
+    count = protocol["monte_carlo_samples"]
+    random = np.random.default_rng(protocol["monte_carlo_seed"])
+    actual = radius * np.cos(random.normal(0.0, sigma, count))
+    failures = int(np.count_nonzero(actual < threshold))
+    control = {
+        "radius_mm": radius * 1000,
+        "phase_stddev_rad": sigma,
+        "violation_below_mm": threshold * 1000,
+        "illustrative_risk_budget": risk_budget,
+        "exact_mean_mm": true_mean * 1000,
+        "exact_stddev_mm": math.sqrt(true_variance) * 1000,
+        "exact_violation_probability": probability.lower,
+        "omitted_normal_tail_bound": probability.omitted_tail_bound,
+        "analytic_admission": bounded_risk_admissible(probability, maximum_risk=risk_budget),
+        "monte_carlo": {
+            "independent_controlled_phase_draws": count,
+            "seed": protocol["monte_carlo_seed"],
+            "violation_count": failures,
+            "violation_fraction": failures / count,
+            "wilson_95_interval": wilson_interval(failures, count),
+            "mean_mm": float(actual.mean()) * 1000,
+            "stddev_mm": float(actual.std(ddof=0)) * 1000,
+            "standard_error_mean_mm": float(actual.std(ddof=1)) / math.sqrt(count) * 1000,
+        },
+    }
+
+    uniform = CircularPrior.uniform(prior_id="explicit-control-uniform-shared-phase-v1")
+    constraint_count = protocol["shared_phase_control"]["constraints"]
+    half_width = math.pi * protocol["shared_phase_control"]["single_constraint_probability"]
+    cosine_threshold = math.cos(half_width)
+    repeated = AffineCircularQuery(np.full(constraint_count, -cosine_threshold), np.ones(constraint_count), np.zeros(constraint_count))
+    centers = np.arange(constraint_count) * 2 * math.pi / constraint_count
+    disjoint = AffineCircularQuery(np.full(constraint_count, -cosine_threshold), np.cos(centers), np.sin(centers))
+    true_repeated = path_violation_probability(repeated, uniform).lower
+    true_disjoint = path_violation_probability(disjoint, uniform).lower
+    independent = 1 - (1 - protocol["shared_phase_control"]["single_constraint_probability"]) ** constraint_count
+    uniform_draws = np.random.default_rng(protocol["uniform_dependence_seed"]).uniform(0, 2 * math.pi, count)
+    dependence = []
+    for name, query, truth, budget in [
+        ("five-identical-constraints", repeated, true_repeated, protocol["shared_phase_control"]["repeated_constraint_budget"]),
+        ("five-disjoint-phase-constraints", disjoint, true_disjoint, protocol["shared_phase_control"]["disjoint_constraint_budget"]),
+    ]:
+        observed = int(np.count_nonzero(np.any(query.evaluate(uniform_draws) > 0, axis=1)))
+        dependence.append({
+            "case": name,
+            "constraint_count": constraint_count,
+            "single_constraint_probability": protocol["shared_phase_control"]["single_constraint_probability"],
+            "exact_joint_probability": truth,
+            "incorrect_independent_probability": independent,
+            "illustrative_risk_budget": budget,
+            "exact_admission": truth <= budget,
+            "incorrect_independent_admission": independent <= budget,
+            "monte_carlo_violation_count": observed,
+            "monte_carlo_violation_fraction": observed / count,
+            "monte_carlo_wilson_95_interval": wilson_interval(observed, count),
+        })
+    return {
+        "schema": "prob4d.circular-gauge-query-study-result",
+        "version": 1,
+        "evidence_class": protocol["evidence_class"],
+        "date": protocol["date"],
+        "runtime": {"python": platform.python_version(), "numpy": np.__version__},
+        "baseline_implementation_boundary": "Independent implementations of mathematical approximation rules; not an execution of unmodified Prob4D, BayesianPhysTwin, or Causal4D pipelines.",
+        "information_boundary": protocol["information_boundary"],
+        "analytic_control": control,
+        "method_results": rows,
+        "shared_phase_controls": dependence,
+        "interpretation": {
+            "positive": "Exact conditional circular moments recover nonlinear radial uncertainty missed by the specified first-order and two-point rules. Shared-phase arc integration recovers joint event risk without assuming independent frames.",
+            "important_control": "High-order Gauss-Hermite recovers smooth moments. Its finite-node indicator probabilities need not converge monotonically. Exact first and second moments alone do not determine an event probability.",
+            "scope": "Declared one-axis rotation at a fixed observable quotient, with an explicit circular prior. Real-provider and complete-dynamics uncertainty are not evaluated.",
+            "unsupported_claims": protocol["unsupported_claims"],
+        },
+    }
+
+
+def plots(result: dict[str, Any], output: Path) -> None:
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    # Each figure is distinct; default Matplotlib colors and styling are used.
+    sigma = np.linspace(0.02, 2.5, 200)
+    std = 100 / math.sqrt(2) * (-np.expm1(-sigma**2))
+    fig, axis = plt.subplots(figsize=(7.5, 4.7))
+    axis.plot(sigma, std, label="Exact circular radial standard deviation")
+    axis.plot(sigma, np.zeros_like(sigma), linestyle="--", label="First-order and two-point rules")
+    axis.set(xlabel="Unobserved twist standard deviation (rad)", ylabel="Radial standard deviation (mm)", title="A one-dimensional gauge can create two covariance modes")
+    axis.legend()
+    axis.grid(alpha=0.25)
+    fig.tight_layout()
+    fig.savefig(output / "radial_uncertainty.png", dpi=180)
+    plt.close(fig)
+
+    rows = [row for row in result["method_results"] if row["method"].startswith("Gauss-Hermite")]
+    fig, axis = plt.subplots(figsize=(7.5, 4.7))
+    axis.plot([row["quadrature_order"] for row in rows], [100 * row["violation_probability"] for row in rows], marker="o", label="Gauss-Hermite indicator integration")
+    axis.axhline(100 * result["analytic_control"]["exact_violation_probability"], linestyle="--", label="Exact circular arc probability")
+    axis.set_xscale("log", base=2)
+    axis.set_xticks([row["quadrature_order"] for row in rows], [str(row["quadrature_order"]) for row in rows])
+    axis.set(xlabel="Quadrature nodes", ylabel="Predicted violation probability (%)", title="Accurate moments do not guarantee accurate tail events")
+    axis.legend()
+    axis.grid(alpha=0.25)
+    fig.tight_layout()
+    fig.savefig(output / "event_probability_quadrature.png", dpi=180)
+    plt.close(fig)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--plots", action="store_true")
+    arguments = parser.parse_args()
+    output = arguments.output_dir.resolve()
+    output.mkdir(parents=True, exist_ok=True)
+    if arguments.plots and any((output / name).exists() for name in ["radial_uncertainty.png", "event_probability_quadrature.png"]):
+        raise FileExistsError("plots require an output directory without existing figures")
+    result = run()
+    write_new(output / "result.json", json_bytes(result))
+    write_new(output / "protocol.json", PROTOCOL.read_bytes())
+    buffer = io.StringIO(newline="")
+    writer = csv.DictWriter(
+        buffer, fieldnames=list(result["method_results"][0]), lineterminator="\n"
+    )
+    writer.writeheader()
+    writer.writerows(result["method_results"])
+    write_new(output / "method_results.csv", buffer.getvalue().encode())
+    if arguments.plots:
+        plots(result, output)
+    files = [
+        ROOT / "src/prob4d/circular_gauge_query.py",
+        ROOT / "tests/test_circular_gauge_query.py",
+        Path(__file__).resolve(),
+        PROTOCOL,
+    ]
+    manifest = {
+        "schema": "prob4d.circular-gauge-query-evidence-manifest",
+        "version": 1,
+        "reviewed_prob4d_revision": "224d13dc9a93731ac5297b479eb1e121b3dbe659",
+        "publication_state": "local-unpublished-additive-patch",
+        "source_files": {str(path.relative_to(ROOT)): hashlib.sha256(path.read_bytes()).hexdigest() for path in files},
+        "output_files": {path.name: hashlib.sha256(path.read_bytes()).hexdigest() for path in sorted(output.iterdir()) if path.is_file() and path.name != "manifest.json"},
+        "command": "PYTHONPATH=src python scripts/science/circular_gauge_query_study.py --output-dir <new-directory>" + (" --plots" if arguments.plots else ""),
+        "real_data_or_models_accessed": False,
+    }
+    write_new(output / "manifest.json", json_bytes(manifest))
+    print(json.dumps(result["analytic_control"], indent=2))
+    print(json.dumps(result["shared_phase_controls"], indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/science/verify_circular_gauge_query_evidence.py
+++ b/scripts/science/verify_circular_gauge_query_evidence.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Verify evidence hashes and analytic controls without importing Prob4D."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--evidence-dir", type=Path, required=True)
+    parser.add_argument("--source-root", type=Path, required=True)
+    args = parser.parse_args()
+    evidence, source = args.evidence_dir.resolve(), args.source_root.resolve()
+    manifest = json.loads((evidence / "manifest.json").read_text())
+    result = json.loads((evidence / "result.json").read_text())
+    verified_files = 0
+    for name, expected in manifest["source_files"].items():
+        path = (source / name).resolve()
+        if not path.is_relative_to(source):
+            raise ValueError("nonlocal source path")
+        if hashlib.sha256(path.read_bytes()).hexdigest() != expected:
+            raise ValueError(f"source digest mismatch: {name}")
+        verified_files += 1
+    for name, expected in manifest["output_files"].items():
+        path = (evidence / name).resolve()
+        if not path.is_relative_to(evidence):
+            raise ValueError("nonlocal output path")
+        if hashlib.sha256(path.read_bytes()).hexdigest() != expected:
+            raise ValueError(f"evidence digest mismatch: {name}")
+        verified_files += 1
+    control = result["analytic_control"]
+    radius = control["radius_mm"] / 1000
+    sigma = control["phase_stddev_rad"]
+    threshold = control["violation_below_mm"] / 1000
+    expected_mean_mm = radius * math.exp(-sigma**2 / 2) * 1000
+    expected_std_mm = radius * (-math.expm1(-sigma**2)) / math.sqrt(2) * 1000
+    boundary = math.acos(threshold / radius)
+    # Independent lifted-interval formula, evaluated with the standard library.
+    normal_cdf = lambda x: 0.5 * (1 + math.erf(x / math.sqrt(2)))
+    expected_probability = math.fsum(
+        normal_cdf((2 * math.pi - boundary + 2 * k * math.pi) / sigma)
+        - normal_cdf((boundary + 2 * k * math.pi) / sigma)
+        for k in range(-8, 9)
+    )
+    checks = {
+        "radial_mean_mm_error": abs(control["exact_mean_mm"] - expected_mean_mm),
+        "radial_stddev_mm_error": abs(control["exact_stddev_mm"] - expected_std_mm),
+        "event_probability_error": abs(control["exact_violation_probability"] - expected_probability),
+        "repeated_constraint_probability_error": abs(result["shared_phase_controls"][0]["exact_joint_probability"] - 0.1),
+        "disjoint_constraint_probability_error": abs(result["shared_phase_controls"][1]["exact_joint_probability"] - 0.5),
+    }
+    if max(checks.values()) > 1e-12:
+        raise ValueError(f"analytic verification failed: {checks}")
+    if any(result["information_boundary"].values()):
+        raise ValueError("unexpected real-data or pipeline access in controlled evidence")
+    lo, hi = control["monte_carlo"]["wilson_95_interval"]
+    report = {
+        "status": "passed",
+        "prob4d_imported": False,
+        "files_hash_verified": verified_files,
+        "analytic_checks": checks,
+        "analytic_risk_inside_observed_monte_carlo_95_interval": lo <= expected_probability <= hi,
+        "statistical_note": "Monte Carlo agreement is a check on this controlled generator, not independent real-world calibration.",
+        "upstream_repository_ci_run": False,
+    }
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/prob4d/circular_gauge_query.py
+++ b/src/prob4d/circular_gauge_query.py
@@ -1,0 +1,466 @@
+"""Experimental nonlinear query propagation for a declared circular gauge.
+
+This is NOT a replacement for the Sim(3) estimator or a provider admission gate.
+The caller must supply the CONDITIONAL circular prior at a fixed observable
+quotient and justify a common, global one-axis rotation symmetry. A local
+rank-deficient Jacobian alone does not establish that symmetry.
+
+For q(phi) = c + a*cos(phi) + b*sin(phi), moments are analytic. Joint events
+q_j(phi) > 0 are unions of circular arcs sharing ONE phi. Wrapped-normal arc
+probabilities retain an explicit omitted-normal-tail bound. That bound excludes
+floating-point rounding, model error, and uncertainty in the fixed quotient.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from math import acos, atan2, erfc, erf, floor, fsum, hypot, pi, sqrt
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+FloatArray = NDArray[np.float64]
+_TAU = 2.0 * pi
+_SQRT2 = sqrt(2.0)
+
+
+def _vector(value: Any, name: str, *, allow_empty: bool = False) -> FloatArray:
+    result = np.asarray(value, dtype=np.float64).copy()
+    if result.ndim != 1 or (result.size == 0 and not allow_empty):
+        raise ValueError(f"{name} must be a {'possibly empty ' if allow_empty else ''}vector")
+    if not np.all(np.isfinite(result)):
+        raise ValueError(f"{name} must be finite")
+    result.setflags(write=False)
+    return result
+
+
+def _finite_scalar(value: Any, name: str) -> float:
+    if isinstance(value, (bool, np.bool_)) or np.ndim(value) != 0:
+        raise ValueError(f"{name} must be a finite scalar, not a boolean or array")
+    result = float(value)
+    if not np.isfinite(result):
+        raise ValueError(f"{name} must be finite")
+    return result
+
+
+def _positive_integer(value: Any, name: str) -> int:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)):
+        raise ValueError(f"{name} must be an integer")
+    if value < 1:
+        raise ValueError(f"{name} must be positive")
+    return int(value)
+
+
+@dataclass(frozen=True)
+class CircularPrior:
+    """An explicit mixture of wrapped normals and a uniform circular density.
+
+    Positive standard deviations ensure absolute continuity, so isolated arc
+    endpoints have zero probability. Weights must already sum to one; the only
+    normalization performed is removal of accepted floating-point roundoff.
+    ``prior_id`` is caller provenance, not a calibration or validation claim.
+    """
+
+    weights: FloatArray
+    means: FloatArray
+    stddevs: FloatArray
+    uniform_weight: float
+    prior_id: str
+
+    def __post_init__(self) -> None:
+        weights = _vector(self.weights, "weights", allow_empty=True)
+        means = _vector(self.means, "means", allow_empty=True)
+        stddevs = _vector(self.stddevs, "stddevs", allow_empty=True)
+        if weights.shape != means.shape or weights.shape != stddevs.shape:
+            raise ValueError("weights, means, and stddevs must have identical shapes")
+        if np.any(weights < 0.0) or np.any(stddevs <= 0.0):
+            raise ValueError("weights must be nonnegative and stddevs strictly positive")
+        uniform = _finite_scalar(self.uniform_weight, "uniform_weight")
+        if not 0.0 <= uniform <= 1.0:
+            raise ValueError("uniform_weight must lie in [0, 1]")
+        total = fsum([uniform, *weights.tolist()])
+        if abs(total - 1.0) > 1e-12:
+            raise ValueError("complete prior weights must sum to one")
+        if not isinstance(self.prior_id, str) or not self.prior_id.strip():
+            raise ValueError("prior_id must be a nonempty string")
+        weights = _vector(weights / total, "weights", allow_empty=True)
+        means = _vector(np.remainder(means, _TAU), "means", allow_empty=True)
+        object.__setattr__(self, "weights", weights)
+        object.__setattr__(self, "means", means)
+        object.__setattr__(self, "stddevs", stddevs)
+        object.__setattr__(self, "uniform_weight", uniform / total)
+
+    @classmethod
+    def wrapped_normal(cls, mean: float, stddev: float, *, prior_id: str) -> CircularPrior:
+        return cls(np.array([1.0]), np.array([mean]), np.array([stddev]), 0.0, prior_id)
+
+    @classmethod
+    def uniform(cls, *, prior_id: str) -> CircularPrior:
+        return cls(np.empty(0), np.empty(0), np.empty(0), 1.0, prior_id)
+
+    def trigonometric_moment(self, order: int) -> complex:
+        """Return E[exp(i*order*phi)]; negative orders use conjugacy."""
+        if isinstance(order, (bool, np.bool_)) or not isinstance(order, (int, np.integer)):
+            raise ValueError("order must be an integer")
+        if order == 0:
+            return 1.0 + 0.0j
+        if abs(order) > 1_000_000:
+            raise ValueError("order exceeds the supported numerical range")
+        with np.errstate(over="ignore", under="ignore"):
+            magnitude = np.exp(-0.5 * (float(order) * self.stddevs) ** 2)
+        return complex(np.sum(self.weights * magnitude * np.exp(1j * order * self.means)))
+
+    def trigonometric_mean_covariance(self) -> tuple[FloatArray, FloatArray]:
+        """Stable moments of [cos(phi), sin(phi)], including narrow priors.
+
+        Component-centered formulas and the law of total covariance avoid
+        cancellation in Var(cos(phi)) as a wrapped-normal variance tends to zero.
+        """
+        component_means: list[FloatArray] = []
+        component_covariances: list[FloatArray] = []
+        component_weights: list[float] = []
+        if self.uniform_weight:
+            component_means.append(np.zeros(2))
+            component_covariances.append(0.5 * np.eye(2))
+            component_weights.append(self.uniform_weight)
+        for weight, mean, stddev in zip(self.weights, self.means, self.stddevs):
+            if weight == 0.0:
+                continue
+            with np.errstate(over="ignore", under="ignore"):
+                variance = float(np.square(stddev))
+                rho = float(np.exp(-0.5 * variance))
+                var_cos = 0.5 * float(-np.expm1(-variance)) ** 2
+                var_sin = 0.5 * float(-np.expm1(-2.0 * variance))
+            cosine, sine = float(np.cos(mean)), float(np.sin(mean))
+            rotation = np.array([[cosine, -sine], [sine, cosine]])
+            component_means.append(rho * rotation[:, 0])
+            component_covariances.append(rotation @ np.diag([var_cos, var_sin]) @ rotation.T)
+            component_weights.append(float(weight))
+        result_mean = sum(w * m for w, m in zip(component_weights, component_means))
+        result_covariance = np.zeros((2, 2))
+        for weight, mean, covariance in zip(
+            component_weights, component_means, component_covariances
+        ):
+            delta = mean - result_mean
+            result_covariance += weight * (covariance + np.outer(delta, delta))
+        result_mean = np.asarray(result_mean, dtype=np.float64)
+        result_covariance = 0.5 * (result_covariance + result_covariance.T)
+        result_mean.setflags(write=False)
+        result_covariance.setflags(write=False)
+        return result_mean, result_covariance
+
+
+@dataclass(frozen=True)
+class QueryMoments:
+    mean: FloatArray
+    covariance: FloatArray
+
+    def __post_init__(self) -> None:
+        mean = _vector(self.mean, "mean")
+        covariance = np.asarray(self.covariance, dtype=np.float64).copy()
+        if covariance.shape != (mean.size, mean.size) or not np.all(np.isfinite(covariance)):
+            raise ValueError("covariance must be a finite square matrix matching the mean")
+        if not np.allclose(covariance, covariance.T, rtol=1e-12, atol=1e-14):
+            raise ValueError("covariance must be symmetric")
+        scale = max(float(np.max(np.abs(covariance))), np.finfo(float).tiny)
+        if float(np.linalg.eigvalsh(covariance).min()) < -1e-10 * scale:
+            raise ValueError("covariance must be positive semidefinite")
+        covariance.setflags(write=False)
+        object.__setattr__(self, "mean", mean)
+        object.__setattr__(self, "covariance", covariance)
+
+
+@dataclass(frozen=True)
+class QueryMomentFactor:
+    """Linear-memory exact moment representation; covariance = factor @ factor.T.
+
+    The two columns are harmonic covariance modes, not two independent phases.
+    """
+
+    mean: FloatArray
+    factor: FloatArray
+
+    def __post_init__(self) -> None:
+        mean = _vector(self.mean, "mean")
+        factor = np.asarray(self.factor, dtype=np.float64).copy()
+        if factor.shape != (mean.size, 2) or not np.all(np.isfinite(factor)):
+            raise ValueError("factor must be finite with shape (query_dimension, 2)")
+        factor.setflags(write=False)
+        object.__setattr__(self, "mean", mean)
+        object.__setattr__(self, "factor", factor)
+
+    @property
+    def marginal_variance(self) -> FloatArray:
+        result = np.sum(self.factor**2, axis=1)
+        result.setflags(write=False)
+        return result
+
+    def dense(self, *, maximum_dimension: int = 2048) -> QueryMoments:
+        maximum_dimension = _positive_integer(maximum_dimension, "maximum_dimension")
+        if self.mean.size > maximum_dimension:
+            raise ValueError("dense covariance exceeds maximum_dimension; retain the factor")
+        return QueryMoments(self.mean, self.factor @ self.factor.T)
+
+
+@dataclass(frozen=True)
+class AffineCircularQuery:
+    """A complete, jointly rotated query q(phi)=offset+cosine*cos(phi)+sine*sin(phi).
+
+    Every output coordinate shares the same phase. The query can stack points,
+    frames, or linear clearance constraints. Those are not independent samples.
+    """
+
+    offset: FloatArray
+    cosine: FloatArray
+    sine: FloatArray
+
+    def __post_init__(self) -> None:
+        for name in ("offset", "cosine", "sine"):
+            object.__setattr__(self, name, _vector(getattr(self, name), name))
+        if self.offset.shape != self.cosine.shape or self.offset.shape != self.sine.shape:
+            raise ValueError("offset, cosine, and sine must have identical shapes")
+
+    def evaluate(self, phase: Any) -> FloatArray:
+        phase_array = np.asarray(phase, dtype=np.float64)
+        if not np.all(np.isfinite(phase_array)):
+            raise ValueError("phase must be finite")
+        return (
+            self.offset
+            + np.cos(phase_array)[..., None] * self.cosine
+            + np.sin(phase_array)[..., None] * self.sine
+        )
+
+    def project(self, matrix: Any, *, offset: Any | None = None) -> AffineCircularQuery:
+        projection = np.asarray(matrix, dtype=np.float64)
+        if (
+            projection.ndim != 2
+            or projection.shape[0] < 1
+            or projection.shape[1] != self.offset.size
+            or not np.all(np.isfinite(projection))
+        ):
+            raise ValueError("matrix must be finite with shape (Q, original_dimension)")
+        shift = np.zeros(projection.shape[0]) if offset is None else _vector(offset, "offset")
+        if shift.shape != (projection.shape[0],):
+            raise ValueError("offset must match the projected dimension")
+        return AffineCircularQuery(
+            projection @ self.offset + shift,
+            projection @ self.cosine,
+            projection @ self.sine,
+        )
+
+    def low_rank_moments(self, prior: CircularPrior) -> QueryMomentFactor:
+        """Exact shared-phase moments in O(query_dimension) storage."""
+        mean, covariance = prior.trigonometric_mean_covariance()
+        mapping = np.column_stack((self.cosine, self.sine))
+        values, vectors = np.linalg.eigh(covariance)
+        root = vectors * np.sqrt(np.maximum(values, 0.0))
+        return QueryMomentFactor(self.offset + mapping @ mean, mapping @ root)
+
+    def moments(self, prior: CircularPrior) -> QueryMoments:
+        """Dense conditional moments for small queries; not a Gaussian assertion."""
+        return self.low_rank_moments(prior).dense()
+
+
+def point_rotation_orbit(
+    points: Any, *, axis_origin: Any, axis_direction: Any
+) -> AffineCircularQuery:
+    """Build a stacked point orbit by Rodrigues' formula in a declared frame.
+
+    The supplied points are already conditional on all observable quotient
+    coordinates. This function does not fit Sim(3) or prove a gauge symmetry.
+    """
+    points_array = np.asarray(points, dtype=np.float64)
+    if (
+        points_array.ndim != 2
+        or points_array.shape[0] < 1
+        or points_array.shape[1] != 3
+        or not np.all(np.isfinite(points_array))
+    ):
+        raise ValueError("points must be a finite, nonempty (N, 3) matrix")
+    origin = _vector(axis_origin, "axis_origin")
+    direction = _vector(axis_direction, "axis_direction")
+    if origin.shape != (3,) or direction.shape != (3,):
+        raise ValueError("axis origin and direction must have three coordinates")
+    direction_norm = float(np.linalg.norm(direction))
+    if direction_norm == 0.0 or not np.isfinite(direction_norm):
+        raise ValueError("axis_direction must have a finite nonzero norm")
+    direction = direction / direction_norm
+    relative = points_array - origin
+    parallel = np.outer(relative @ direction, direction)
+    perpendicular = relative - parallel
+    return AffineCircularQuery(
+        (origin + parallel).reshape(-1),
+        perpendicular.reshape(-1),
+        np.cross(direction, perpendicular).reshape(-1),
+    )
+
+
+def validate_declared_line_support(
+    points: Any, *, axis_origin: Any, axis_direction: Any, tolerance: float = 1e-12
+) -> float:
+    """Check line geometry only; return its maximum transverse residual.
+
+    A local nullspace is not an admissible substitute for this geometric
+    premise. Even this check does not prove that a provider likelihood, a
+    physical model, or a conditional prior has the required global symmetry.
+    """
+    tolerance = _finite_scalar(tolerance, "tolerance")
+    if tolerance < 0.0:
+        raise ValueError("tolerance must be nonnegative")
+    orbit = point_rotation_orbit(points, axis_origin=axis_origin, axis_direction=axis_direction)
+    residual = float(np.max(np.linalg.norm(orbit.cosine.reshape(-1, 3), axis=1)))
+    point_array = np.asarray(points, dtype=np.float64)
+    if point_array.shape[0] < 2 or float(np.linalg.norm(np.ptp(point_array, axis=0))) <= tolerance:
+        raise ValueError("line support must contain at least two separated points")
+    if residual > tolerance:
+        raise ValueError("declared support is not on the rotation axis")
+    return residual
+
+
+def violation_arcs(query: AffineCircularQuery) -> tuple[tuple[float, float], ...]:
+    """Disjoint intervals for the joint event ANY q_j(phi)>0, on [0,2*pi].
+
+    Endpoints have zero mass under every supported prior. Geometric roundoff
+    near exact tangencies is not included in the subsequent normal-tail bound.
+    """
+    intervals: list[tuple[float, float]] = []
+    for offset, cosine, sine in zip(query.offset, query.cosine, query.sine):
+        amplitude = hypot(float(cosine), float(sine))
+        if amplitude == 0.0:
+            if offset > 0.0:
+                return ((0.0, _TAU),)
+            continue
+        threshold = -float(offset) / amplitude
+        if threshold <= -1.0:
+            return ((0.0, _TAU),)
+        if threshold >= 1.0:
+            continue
+        center = atan2(float(sine), float(cosine)) % _TAU
+        width = acos(threshold)
+        left, right = center - width, center + width
+        if left < 0.0:
+            intervals.extend(((0.0, right), (left + _TAU, _TAU)))
+        elif right > _TAU:
+            intervals.extend(((0.0, right - _TAU), (left, _TAU)))
+        else:
+            intervals.append((left, right))
+    merged: list[tuple[float, float]] = []
+    for left, right in sorted(intervals):
+        if merged and left <= merged[-1][1]:
+            merged[-1] = (merged[-1][0], max(right, merged[-1][1]))
+        else:
+            merged.append((left, right))
+    return tuple(merged)
+
+
+def _normal_interval(left: float, right: float) -> float:
+    """Stable standard-normal mass without subtraction of two values near 1."""
+    if right <= 0.0:
+        return 0.5 * (erfc(-right / _SQRT2) - erfc(-left / _SQRT2))
+    if left >= 0.0:
+        return 0.5 * (erfc(left / _SQRT2) - erfc(right / _SQRT2))
+    return 0.5 * (erf(right / _SQRT2) - erf(left / _SQRT2))
+
+
+@dataclass(frozen=True)
+class ProbabilityBounds:
+    """Analytic probability bracket for omitted tails, not interval arithmetic."""
+
+    lower: float
+    upper: float
+    omitted_tail_bound: float
+    arc_count: int
+
+    def __post_init__(self) -> None:
+        lower = _finite_scalar(self.lower, "lower")
+        upper = _finite_scalar(self.upper, "upper")
+        bound = _finite_scalar(self.omitted_tail_bound, "omitted_tail_bound")
+        if not 0.0 <= lower <= upper <= 1.0 or not 0.0 <= bound <= 1.0:
+            raise ValueError("invalid probability bounds")
+        if upper - lower > bound + 1e-14:
+            raise ValueError("bracket width exceeds its tail bound")
+        if isinstance(self.arc_count, (bool, np.bool_)) or not isinstance(
+            self.arc_count, (int, np.integer)
+        ) or self.arc_count < 0:
+            raise ValueError("arc_count must be a nonnegative integer")
+
+
+def path_violation_probability(
+    query: AffineCircularQuery,
+    prior: CircularPrior,
+    *,
+    tail_tolerance: float = 1e-12,
+    max_periods: int = 100_000,
+) -> ProbabilityBounds:
+    """Probability that any stacked constraint fails under one shared phase.
+
+    Exact arc geometry, exact uniform integration, and normal-CDF sums with an
+    explicit omitted-tail bound. No per-frame independence approximation or
+    Gaussian approximation of the transformed query is used. The fixed-quotient
+    model excludes extra measurement, dynamics, and contact uncertainty.
+    """
+    tolerance = _finite_scalar(tail_tolerance, "tail_tolerance")
+    if not 0.0 < tolerance < 0.25:
+        raise ValueError("tail_tolerance must lie in (0, 0.25)")
+    max_periods = _positive_integer(max_periods, "max_periods")
+    arcs = violation_arcs(query)
+    if not arcs:
+        return ProbabilityBounds(0.0, 0.0, 0.0, 0)
+    if arcs == ((0.0, _TAU),):
+        return ProbabilityBounds(1.0, 1.0, 0.0, 1)
+    probability_terms = [prior.uniform_weight * fsum(right - left for left, right in arcs) / _TAU]
+    tail_terms: list[float] = []
+    cutoff = 4.0
+    while erfc(cutoff / _SQRT2) > tolerance:
+        cutoff += 1.0
+    for weight, mean, stddev in zip(prior.weights, prior.means, prior.stddevs):
+        if weight == 0.0:
+            continue
+        scaled_cutoff = cutoff * float(stddev)
+        if not np.isfinite(scaled_cutoff) or scaled_cutoff / _TAU > max_periods:
+            raise ValueError("prior exceeds max_periods; no probability estimate was produced")
+        first = floor((float(mean) - scaled_cutoff) / _TAU)
+        last = floor((float(mean) + scaled_cutoff) / _TAU)
+        if last - first + 1 > max_periods:
+            raise ValueError("prior exceeds max_periods; no probability estimate was produced")
+        component_terms = []
+        for period in range(first, last + 1):
+            for left, right in arcs:
+                component_terms.append(
+                    _normal_interval(
+                        (left + _TAU * period - mean) / stddev,
+                        (right + _TAU * period - mean) / stddev,
+                    )
+                )
+        lower_cut = (first * _TAU - mean) / stddev
+        upper_cut = ((last + 1) * _TAU - mean) / stddev
+        tail = 0.5 * erfc(-lower_cut / _SQRT2) + 0.5 * erfc(upper_cut / _SQRT2)
+        probability_terms.append(float(weight) * fsum(component_terms))
+        tail_terms.append(float(weight) * tail)
+    lower = float(np.clip(fsum(probability_terms), 0.0, 1.0))
+    tail_bound = float(np.clip(fsum(tail_terms), 0.0, 1.0))
+    upper = min(1.0, lower + tail_bound)
+    return ProbabilityBounds(lower, upper, tail_bound, len(arcs))
+
+
+def bounded_risk_admissible(bounds: ProbabilityBounds, *, maximum_risk: float) -> bool:
+    """Model-conditional decision only; the consumer owns complete-belief fallback."""
+    risk = _finite_scalar(maximum_risk, "maximum_risk")
+    if not 0.0 <= risk <= 1.0:
+        raise ValueError("maximum_risk must lie in [0, 1]")
+    return bounds.upper <= risk
+
+
+__all__ = [
+    "AffineCircularQuery",
+    "CircularPrior",
+    "ProbabilityBounds",
+    "QueryMoments",
+    "QueryMomentFactor",
+    "bounded_risk_admissible",
+    "path_violation_probability",
+    "point_rotation_orbit",
+    "validate_declared_line_support",
+    "violation_arcs",
+]

--- a/tests/test_circular_gauge_query.py
+++ b/tests/test_circular_gauge_query.py
@@ -1,0 +1,320 @@
+"""Focused analytic and adversarial tests; no provider or held-out data access."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from prob4d.circular_gauge_query import (
+    AffineCircularQuery,
+    CircularPrior,
+    ProbabilityBounds,
+    QueryMoments,
+    bounded_risk_admissible,
+    path_violation_probability,
+    point_rotation_orbit,
+    validate_declared_line_support,
+    violation_arcs,
+)
+
+
+def normal(mu: float = 0.0, sigma: float = 1.0) -> CircularPrior:
+    return CircularPrior.wrapped_normal(mu, sigma, prior_id="test-explicit-conditional-prior")
+
+
+def scalar_event(c: float, a: float, b: float = 0.0) -> AffineCircularQuery:
+    return AffineCircularQuery(np.array([c]), np.array([a]), np.array([b]))
+
+
+def test_wrapped_normal_characteristic_and_conjugacy() -> None:
+    prior = normal(0.4, 0.8)
+    for order in range(-5, 6):
+        assert prior.trigonometric_moment(order) == pytest.approx(
+            np.exp(1j * order * 0.4 - 0.5 * (order * 0.8) ** 2), abs=1e-14
+        )
+
+
+def test_uniform_moments_and_complete_explicit_prior() -> None:
+    prior = CircularPrior.uniform(prior_id="explicit-uniform")
+    mean, covariance = prior.trigonometric_mean_covariance()
+    np.testing.assert_array_equal(mean, np.zeros(2))
+    np.testing.assert_array_equal(covariance, np.eye(2) / 2)
+    assert prior.trigonometric_moment(0) == 1
+    assert prior.trigonometric_moment(1) == 0
+
+
+def test_stable_narrow_prior_variance() -> None:
+    prior = normal(0.0, 1e-8)
+    _, covariance = prior.trigonometric_mean_covariance()
+    assert covariance[0, 0] == pytest.approx(0.5e-32, rel=1e-12, abs=0)
+    assert covariance[1, 1] == pytest.approx(1e-16, rel=1e-12, abs=0)
+
+
+def test_analytic_radial_counterexample() -> None:
+    prior = normal()
+    radius = 0.1
+    query = scalar_event(0, radius)
+    result = query.moments(prior)
+    assert result.mean[0] == pytest.approx(radius * np.exp(-0.5), abs=1e-15)
+    assert result.covariance[0, 0] == pytest.approx(
+        0.5 * radius**2 * (-np.expm1(-1.0)) ** 2, abs=1e-16
+    )
+    # Both a first derivative and the documented rank-one +/-sigma rule miss it.
+    derivative = -radius * np.sin(0.0)
+    sigma_samples = query.evaluate(np.array([-1.0, 1.0]))[:, 0]
+    assert derivative**2 == 0.0
+    assert np.var(sigma_samples) == 0.0
+    assert result.covariance[0, 0] > 0.001
+
+
+def test_mixture_moments_equal_first_two_fourier_moments() -> None:
+    prior = CircularPrior(
+        np.array([0.25, 0.5]), np.array([0.2, 2.7]), np.array([0.3, 1.1]), 0.25, "mixture"
+    )
+    mean, covariance = prior.trigonometric_mean_covariance()
+    first, second = prior.trigonometric_moment(1), prior.trigonometric_moment(2)
+    expected_mean = np.array([first.real, first.imag])
+    second_moment = np.array(
+        [[(1 + second.real) / 2, second.imag / 2],
+         [second.imag / 2, (1 - second.real) / 2]]
+    )
+    np.testing.assert_allclose(mean, expected_mean, atol=1e-15)
+    np.testing.assert_allclose(covariance, second_moment - np.outer(mean, mean), atol=1e-15)
+
+
+def test_joint_point_covariance_preserves_shared_phase() -> None:
+    query = point_rotation_orbit(
+        np.array([[0.1, 0, 0], [0.1, 0, 0.2]]),
+        axis_origin=np.zeros(3), axis_direction=[0, 0, 1],
+    )
+    result = query.moments(normal())
+    np.testing.assert_allclose(result.covariance[0:3, 3:6], result.covariance[0:3, 0:3])
+    assert np.linalg.matrix_rank(result.covariance, tol=1e-12) == 2
+    np.testing.assert_allclose(query.evaluate([0])[0], [0.1, 0, 0, 0.1, 0, 0.2])
+
+
+def test_point_orbit_matches_independent_rodrigues_formula() -> None:
+    rng = np.random.default_rng(123)
+    points, origin, axis = rng.normal(size=(7, 3)), rng.normal(size=3), rng.normal(size=3)
+    unit = axis / np.linalg.norm(axis)
+    skew = np.array([[0, -unit[2], unit[1]], [unit[2], 0, -unit[0]], [-unit[1], unit[0], 0]])
+    query = point_rotation_orbit(points, axis_origin=origin, axis_direction=axis)
+    for angle in [-2.8, -0.1, 0.0, 0.4, 2.9]:
+        rotation = np.eye(3) + math.sin(angle) * skew + (1 - math.cos(angle)) * (skew @ skew)
+        expected = (points - origin) @ rotation.T + origin
+        np.testing.assert_allclose(query.evaluate(angle).reshape(-1, 3), expected, atol=2e-15)
+
+
+def test_invariant_line_has_zero_uncertainty_and_retains_prior() -> None:
+    points = np.array([[0, 0, -2], [0, 0, 0], [0, 0, 3]], dtype=float)
+    prior = normal(0.4, 2.0)
+    before = (prior.weights.copy(), prior.means.copy(), prior.stddevs.copy())
+    assert validate_declared_line_support(points, axis_origin=[0, 0, 0], axis_direction=[0, 0, 3]) == 0
+    result = point_rotation_orbit(points, axis_origin=[0, 0, 0], axis_direction=[0, 0, 3]).moments(prior)
+    np.testing.assert_array_equal(result.mean, points.reshape(-1))
+    np.testing.assert_array_equal(result.covariance, np.zeros((9, 9)))
+    for original, actual in zip(before, (prior.weights, prior.means, prior.stddevs)):
+        np.testing.assert_array_equal(original, actual)
+
+
+def test_projection_and_coordinate_rescaling() -> None:
+    query = AffineCircularQuery(np.array([1.0, 2.0]), np.array([0.3, 0.1]), np.array([0.2, -0.4]))
+    matrix, shift = np.array([[2.0, -3.0]]), np.array([0.7])
+    transformed = query.project(matrix, offset=shift)
+    moments, projected = query.moments(normal()), transformed.moments(normal())
+    np.testing.assert_allclose(projected.mean, matrix @ moments.mean + shift)
+    np.testing.assert_allclose(projected.covariance, matrix @ moments.covariance @ matrix.T)
+    original = path_violation_probability(query, normal())
+    scaled = path_violation_probability(AffineCircularQuery(query.offset * 1000, query.cosine * 1000, query.sine * 1000), normal())
+    assert original.lower == pytest.approx(scaled.lower, abs=1e-14)
+
+
+def test_probability_against_independent_unwrapped_normal_formula() -> None:
+    probability = path_violation_probability(scalar_event(0.05, -0.1), normal())
+    # x<radius/2 iff phi lies in (pi/3+2k*pi, 5pi/3+2k*pi).
+    cdf = lambda x: (1.0 + math.erf(x / math.sqrt(2.0))) / 2.0
+    expected = math.fsum(
+        cdf(5 * math.pi / 3 + 2 * k * math.pi) - cdf(math.pi / 3 + 2 * k * math.pi)
+        for k in range(-5, 6)
+    )
+    assert probability.lower == pytest.approx(expected, abs=2e-15)
+    assert probability.upper - probability.lower <= 1e-12
+    assert probability.lower == pytest.approx(0.2950083103791666, abs=1e-15)
+    assert not bounded_risk_admissible(probability, maximum_risk=0.10)
+
+
+def test_wraparound_and_rotation_equivariance() -> None:
+    query = AffineCircularQuery(np.array([-0.4, -0.7]), np.array([1.0, 0.0]), np.array([0.0, 1.0]))
+    prior = normal(0.8, 0.7)
+    for shift in [0.2, 2.0, 6.0, -1.7]:
+        shifted = AffineCircularQuery(
+            query.offset,
+            query.cosine * np.cos(shift) - query.sine * np.sin(shift),
+            query.cosine * np.sin(shift) + query.sine * np.cos(shift),
+        )
+        actual = path_violation_probability(shifted, normal(0.8 + shift, 0.7))
+        expected = path_violation_probability(query, prior)
+        assert actual.lower == pytest.approx(expected.lower, abs=2e-14)
+
+
+def test_uniform_arc_length() -> None:
+    result = path_violation_probability(scalar_event(-0.5, 1), CircularPrior.uniform(prior_id="uniform"))
+    assert result.lower == pytest.approx(1 / 3, abs=1e-15)
+    assert result.upper == result.lower
+    assert result.omitted_tail_bound == 0
+
+
+def test_repeated_constraint_is_not_new_independent_risk() -> None:
+    prior = CircularPrior.uniform(prior_id="uniform")
+    threshold = math.cos(math.pi / 10)
+    single = path_violation_probability(scalar_event(-threshold, 1), prior)
+    repeated = AffineCircularQuery(np.full(5, -threshold), np.ones(5), np.zeros(5))
+    result = path_violation_probability(repeated, prior)
+    assert result.lower == pytest.approx(0.1, abs=1e-15)
+    assert result.lower == single.lower
+    assert 1 - (1 - single.lower) ** 5 == pytest.approx(0.40951)
+
+
+def test_independence_can_also_underestimate_risk() -> None:
+    phases = np.arange(5) * (2 * math.pi / 5)
+    query = AffineCircularQuery(
+        np.full(5, -math.cos(math.pi / 10)), np.cos(phases), np.sin(phases)
+    )
+    result = path_violation_probability(query, CircularPrior.uniform(prior_id="uniform"))
+    assert result.lower == pytest.approx(0.5, abs=1e-15)
+    assert 1 - 0.9**5 < 0.45 < result.lower
+
+
+@pytest.mark.parametrize("c,a,expected", [(1, 0, 1), (0, 0, 0), (-1, 0, 0), (1, 1, 1), (-1, 1, 0), (2, 1, 1), (-2, 1, 0)])
+def test_constant_and_tangent_events(c: float, a: float, expected: float) -> None:
+    result = path_violation_probability(scalar_event(c, a), normal())
+    assert result.lower == result.upper == expected
+
+
+def test_arc_partition_matches_direct_evaluation() -> None:
+    rng = np.random.default_rng(654)
+    angles = (np.arange(10001) + 0.321) / 10001 * 2 * math.pi
+    for _ in range(30):
+        query = AffineCircularQuery(rng.uniform(-1.5, 0.0, 5), rng.normal(size=5), rng.normal(size=5))
+        arcs = violation_arcs(query)
+        analytic_mask = np.zeros(angles.shape, dtype=bool)
+        for left, right in arcs:
+            analytic_mask |= (angles > left) & (angles < right)
+        np.testing.assert_array_equal(analytic_mask, np.any(query.evaluate(angles) > 0, axis=1))
+
+
+def test_probabilities_match_independent_density_integration() -> None:
+    scipy = pytest.importorskip("scipy.integrate")
+    prior = CircularPrior(np.array([0.3, 0.45]), np.array([0.2, 3.9]), np.array([0.4, 1.8]), 0.25, "mixed")
+    query = AffineCircularQuery(np.array([-0.8, -0.9]), np.array([1, -0.5]), np.array([0.0, 0.9]))
+    def density(phi: float) -> float:
+        total = prior.uniform_weight / (2 * math.pi)
+        for weight, mean, std in zip(prior.weights, prior.means, prior.stddevs):
+            total += weight * sum(
+                math.exp(-0.5 * ((phi + 2 * k * math.pi - mean) / std) ** 2)
+                / (math.sqrt(2 * math.pi) * std) for k in range(-12, 13)
+            )
+        return float(total)
+    expected = sum(scipy.quad(density, left, right, epsabs=1e-13, epsrel=1e-13)[0] for left, right in violation_arcs(query))
+    result = path_violation_probability(query, prior)
+    assert result.lower == pytest.approx(expected, abs=3e-14)
+
+
+def test_tail_bound_encloses_tighter_sum() -> None:
+    prior = normal(0.8, 4.0)
+    query = scalar_event(-0.3, 0.7, 0.8)
+    loose = path_violation_probability(query, prior, tail_tolerance=0.01)
+    tight = path_violation_probability(query, prior, tail_tolerance=1e-15)
+    assert loose.lower <= tight.lower + 1e-15
+    assert tight.upper <= loose.upper + 1e-15
+    assert loose.omitted_tail_bound <= 0.01
+
+
+def test_probability_is_monotonic_as_failure_threshold_increases() -> None:
+    prior = normal(0.5, 1.2)
+    values = [path_violation_probability(scalar_event(-threshold, 1), prior).lower for threshold in np.linspace(-1, 1, 31)]
+    assert np.all(np.diff(values) <= 1e-14)
+
+
+def test_arrays_are_immutable_copies() -> None:
+    weights = np.array([1.0])
+    prior = CircularPrior(weights, np.array([0.0]), np.array([1.0]), 0, "immutable")
+    weights[0] = 0.1
+    assert prior.weights[0] == 1
+    with pytest.raises(ValueError):
+        prior.means[0] = 1
+    query = scalar_event(0.0, 0.1)
+    with pytest.raises(ValueError):
+        query.cosine[0] = 7
+    with pytest.raises(ValueError):
+        query.moments(prior).covariance[0, 0] = -1
+
+
+@pytest.mark.parametrize("stddev", [0.0, -1.0, float("nan"), float("inf")])
+def test_invalid_standard_deviation_is_rejected(stddev: float) -> None:
+    with pytest.raises(ValueError):
+        normal(0, stddev)
+
+
+def test_invalid_prior_and_shapes_are_rejected() -> None:
+    for args in [([0.4], [0], [1], 0, "x"), ([-1], [0], [1], 0, "x"), ([1], [], [1], 0, "x"), ([1], [0], [1], 0, "")]:
+        with pytest.raises(ValueError):
+            CircularPrior(*args)
+    with pytest.raises(ValueError):
+        AffineCircularQuery(np.array([0, 0]), np.array([1]), np.array([0]))
+    with pytest.raises(ValueError):
+        AffineCircularQuery(np.array([0]), np.array([np.nan]), np.array([0]))
+    with pytest.raises(ValueError):
+        scalar_event(0, 1).project(np.eye(2))
+    with pytest.raises(ValueError):
+        QueryMoments(np.array([0.0]), np.array([[-1.0]]))
+
+
+def test_bent_or_unsupported_geometry_is_not_promoted() -> None:
+    for points in [np.array([[0, 0, 0], [1e-3, 0, 1]]), np.zeros((2, 3)), np.zeros((1, 3))]:
+        with pytest.raises(ValueError):
+            validate_declared_line_support(points, axis_origin=[0, 0, 0], axis_direction=[0, 0, 1])
+    with pytest.raises(ValueError):
+        point_rotation_orbit([[0, 0, 0]], axis_origin=[0, 0, 0], axis_direction=[0, 0, 0])
+
+
+def test_bad_risk_parameters_fail_closed() -> None:
+    for tolerance in [0, -1, 0.3, np.nan, True]:
+        with pytest.raises(ValueError):
+            path_violation_probability(scalar_event(0, 1), normal(), tail_tolerance=tolerance)
+    for count in [0, -1, True, 2.3]:
+        with pytest.raises(ValueError):
+            path_violation_probability(scalar_event(0, 1), normal(), max_periods=count)
+    with pytest.raises(ValueError):
+        path_violation_probability(scalar_event(0, 1), normal(0, 1e20), max_periods=10)
+    for risk in [-0.1, 1.1, np.nan, True]:
+        with pytest.raises(ValueError):
+            bounded_risk_admissible(ProbabilityBounds(0, 0, 0, 0), maximum_risk=risk)
+
+
+def test_complete_belief_fallback_can_preserve_caller_identity() -> None:
+    fallback, candidate = object(), object()
+    bound = path_violation_probability(scalar_event(0.05, -0.1), normal())
+    selected = candidate if bounded_risk_admissible(bound, maximum_risk=0.1) else fallback
+    assert selected is fallback
+    # This is caller-level behavior only, not a claim to have run BayesianPhysTwin.
+
+
+def test_low_rank_factor_preserves_exact_dense_moments() -> None:
+    query = AffineCircularQuery(np.zeros(3), np.array([1.0, 0.0, 1.0]), np.array([0.0, 1.0, 1.0]))
+    factor = query.low_rank_moments(normal())
+    dense = query.moments(normal())
+    np.testing.assert_allclose(factor.factor @ factor.factor.T, dense.covariance, atol=1e-15)
+    np.testing.assert_allclose(factor.marginal_variance, np.diag(dense.covariance), atol=1e-15)
+    assert factor.factor.shape == (3, 2)
+
+
+def test_large_query_stays_linear_memory_and_dense_fails_closed() -> None:
+    query = AffineCircularQuery(np.zeros(10000), np.ones(10000), np.zeros(10000))
+    factor = query.low_rank_moments(normal())
+    assert factor.factor.shape == (10000, 2)
+    assert factor.factor.nbytes == 160000
+    with pytest.raises(ValueError):
+        factor.dense()


### PR DESCRIPTION
## Purpose

Add an experimental method kernel for **nonlinear physical-query uncertainty under a declared unresolved circular gauge**. The contribution is deliberately narrower than a new provider adapter: it asks whether retaining a rank-deficient 4-D gauge is sufficient when a downstream physical query is nonlinear in the unobserved direction.

This is additive and does not modify provider-v2, the stable API, existing estimators, admission decisions, or historical evidence.

## Method

For a fixed observable quotient and an explicitly justified conditional circular prior, the new module represents a complete stacked query as

```text
q(phi) = c + a cos(phi) + b sin(phi)
```

with **one shared phase** across points and time. It provides:

- exact conditional first and second moments from circular harmonics;
- a two-column covariance factor preserving all cross-point/cross-time dependence in linear memory;
- exact union-of-arcs geometry for affine path constraints;
- wrapped-normal mixture event probabilities with an explicit omitted-normal-tail bound; and
- a model-conditional risk predicate whose caller still owns exact fallback.

A local rank-deficient Jacobian is explicitly **not** treated as proof of a global circular symmetry. The caller must justify the likelihood invariance and retain the conditional phase prior rather than inventing a uniform/zero-twist replacement.

## Controlled analytic result

For a 100 mm off-axis probe with unresolved phase `phi ~ WN(0, 1 rad^2)` and the illustrative event `x < 50 mm`:

| Representation | radial mean | radial std. | P(x < 50 mm) |
| --- | ---: | ---: | ---: |
| first-order Gaussian | 100.000 mm | 0.000 mm | 0.000% |
| rank-one `+/- sigma` spherical-radial | 54.030 mm | 0.000 mm | 0.000% |
| 17-node Gauss-Hermite, direct indicator | 60.653 mm | 44.698 mm | 24.705% |
| exact-moment Gaussian | 60.653 mm | 44.698 mm | 40.581% |
| exact circular shared phase | **60.653 mm** | **44.698 mm** | **29.501%** |

An independent 200,000-draw Monte Carlo control gives 29.601% violation, with a 95% Wilson interval containing the analytic value.

This is a counterexample to the **specified local and rank-one two-point rules**, not a claim that all sigma-point methods fail. Higher-order quadrature recovers the smooth moments; matching moments alone still does not certify a discontinuous event probability.

## Shared-phase dependence control

Five constraints with identical 10% marginal phase risk have 10% joint risk when they are the same event. Five disjoint phase arcs with the same marginals have 50% joint risk. Treating the five constraints as independent gives `1 - 0.9^5 = 40.951%` in both cases, so the independence approximation can be either conservative or anticonservative.

## Files

- `src/prob4d/circular_gauge_query.py` — experimental runtime kernel;
- `tests/test_circular_gauge_query.py` — analytic, adversarial, geometry, probability, and dependence tests;
- `scripts/science/circular_gauge_query_study.py` — deterministic analytic/synthetic study;
- `scripts/science/verify_circular_gauge_query_evidence.py` — independent standard-library verifier that imports no Prob4D code;
- `protocols/circular-gauge-query-control-v1.json` — frozen mechanism-study specification;
- `docs/circular-gauge-query.md` — derivation, assumptions, claim limits, and prospective empirical path.

## Validation

The exact branch bytes were checked against the locally validated files. On those bytes:

```text
PYTHONPATH=src python -m pytest -q tests/test_circular_gauge_query.py
36 passed in 1.17s
```

The previously generated evidence bundle was additionally checked by the independent standard-library verifier for analytic values and source/evidence hashes. Full repository CI, installed-wheel integration, real-provider execution, and provider target scoring are intentionally left to the PR/repository workflows.

## Information and claim boundary

This study opens no real source or target data and runs no real provider, BayesianPhysTwin, or Causal4D inference. It establishes a bounded mechanism/theory result only. It does **not** establish:

- real-provider competence or unseen-object benefit;
- calibrated real-world uncertainty;
- a complete nonlinear Sim(3) posterior;
- that every local gauge nullspace is a global circular symmetry;
- BayesianPhysTwin or Causal4D empirical improvement;
- robot-control safety; or
- state of the art.

The PointWorld/Flat'n'Fold path in #333 remains independently gated. This kernel must not authorize target access or rescue a failed provider gate. It becomes paper-material only if source-side evidence supports a material residual circular ambiguity for the registered query; otherwise it remains a bounded diagnostic/theory extension.

Tracks the method-level objective of #49 without changing its provider-competence decision order.