### PR TITLE
Run PointWorld model-load smoke on gpuserver6000

### DIFF
--- a/.github/workflows/pointworld-model-load-smoke.yml
+++ b/.github/workflows/pointworld-model-load-smoke.yml
@@ -137,11 +137,11 @@ jobs:
           echo "source_protocol_git_blob_sha=$source_blob" >> "$GITHUB_OUTPUT"
 
   execute:
-    name: Load PointWorld on workstation2
+    name: Load PointWorld on gpuserver6000
     if: github.event_name == 'push'
     needs: authorize
     environment: trusted-self-hosted-validation
-    runs-on: [self-hosted, host-workstation2]
+    runs-on: [self-hosted, gpuserver6000]
     timeout-minutes: 180
     permissions:
       contents: read
@@ -160,7 +160,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          test "$RUNNER_NAME" = "workstation2"
+          test "$RUNNER_NAME" = "gpuserver6000"
           test "$RUNNER_OS" = "Linux"
           test "$RUNNER_ARCH" = "X64"
           command -v nvidia-smi >/dev/null

--- a/docs/pointworld-model-load-smoke.md
+++ b/docs/pointworld-model-load-smoke.md
@@ -34,7 +34,7 @@ The request must bind the Git blob of
 Dataset access, prediction execution, provider residuals, and target outcomes
 must all remain explicitly unauthorized.
 
-## Staged paths on workstation2
+## Staged paths on gpuserver6000
 
 The frozen runner alias is:
 
@@ -59,5 +59,5 @@ repository-write permission.
 ## Claim boundary
 
 A passing result means only that these exact model assets can be initialized on
-workstation2. It is not PointWorld validation on Flat'n'Fold and carries no
+gpuserver6000. It is not PointWorld validation on Flat'n'Fold and carries no
 Prob4D, BayesianPhysTwin, Causal4D, accuracy, calibration, or safety claim.

--- a/protocols/pointworld-model-load-smoke-v1.json
+++ b/protocols/pointworld-model-load-smoke-v1.json
@@ -34,5 +34,5 @@
     "torch_cuda_version",
     "torch_version"
   ],
-  "claim_boundary": "This dataset-free smoke verifies only exact staged asset identity and complete PointWorld plus DINOv3 model initialization on workstation2. It executes no prediction, opens no dataset or residual, and establishes no PointWorld competence, Prob4D accuracy or calibration benefit, BayesianPhysTwin benefit, Causal4D benefit, or deployment-safety claim."
+  "claim_boundary": "This dataset-free smoke verifies only exact staged asset identity and complete PointWorld plus DINOv3 model initialization on gpuserver6000. It executes no prediction, opens no dataset or residual, and establishes no PointWorld competence, Prob4D accuracy or calibration benefit, BayesianPhysTwin benefit, Causal4D benefit, or deployment-safety claim."
 }

--- a/tests/test_trusted_self_hosted_validation_policy.py
+++ b/tests/test_trusted_self_hosted_validation_policy.py
@@ -15,6 +15,7 @@ CUT3R_RUNNER_SELECTOR = (
     + "data-prob4d-deform360-source-v1, prob4d-cut3r]"
 )
 CUT3R_AUTO_V2_RUNNER_SELECTOR = "runs-on: [self-hosted, host-workstation2]"
+POINTWORLD_MODEL_LOAD_RUNNER_SELECTOR = "runs-on: [self-hosted, gpuserver6000]"
 TRUSTED_SELF_HOSTED_WORKFLOWS = (
     TRUSTED_WORKFLOW,
     SOURCE_FREEZE_EXECUTION_WORKFLOW,
@@ -305,8 +306,10 @@ def test_pointworld_model_load_smoke_is_main_request_bound_and_target_closed() -
     assert "validate-request" in text
     assert "source_protocol_git_blob_sha" in text
     assert "environment: trusted-self-hosted-validation" in text
-    assert CUT3R_AUTO_V2_RUNNER_SELECTOR in text
-    assert 'test "$RUNNER_NAME" = "workstation2"' in text
+    assert POINTWORLD_MODEL_LOAD_RUNNER_SELECTOR in text
+    assert 'test "$RUNNER_NAME" = "gpuserver6000"' in text
+    assert "host-workstation2" not in text
+    assert 'test "$RUNNER_NAME" = "workstation2"' not in text
     assert 'test "$RUNNER_OS" = "Linux"' in text
     assert 'test "$RUNNER_ARCH" = "X64"' in text
     assert "command -v nvidia-smi" in text


### PR DESCRIPTION
## Change

Replace the PointWorld smoke runner selector `host-workstation2` with `gpuserver6000` and bind the hard runner-name check to `gpuserver6000`.

The focused self-hosted policy test now has a separate PointWorld runner selector, so the retained CUT3R workflows continue using their existing `host-workstation2` contract. Documentation and the frozen smoke claim boundary are updated consistently.

## Execution

After merge, the canonical request will be regenerated against the new protocol blob and committed as the sole `main`-branch file change. That will trigger a new target-closed smoke run on `[self-hosted, gpuserver6000]`.

No dataset, prediction, provider residual, target outcome, BayesianPhysTwin innovation, or Causal4D outcome is authorized.