### PR TITLE
Inventory DOT rope on gpuserver6000 for shared-curvature validation

### DIFF
--- a/.github/workflows/dot-rope-curvature-v1.yml
+++ b/.github/workflows/dot-rope-curvature-v1.yml
@@ -1,0 +1,201 @@
+# workflow-lifecycle: temporary
+# workflow-owner: IPS-Stuttgart maintainers
+name: DOT rope curvature inventory v1
+
+on:
+  pull_request:
+    branches:
+      - science/shared-gauge-curvature-v1
+      - main
+    paths:
+      - .github/workflows/dot-rope-curvature-v1.yml
+      - experiments/dot_rope_curvature_v1/**
+      - tests/test_dot_rope_inventory_v1.py
+  push:
+    branches:
+      - science/dot-rope-curvature-pilot-v1
+    paths:
+      - protocols/execution_requests/dot_rope_curvature_inventory_v1.json
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dot-rope-curvature-v1-${{ github.ref }}-${{ github.sha }}
+  cancel-in-progress: false
+
+env:
+  REQUEST_PATH: protocols/execution_requests/dot_rope_curvature_inventory_v1.json
+  DATASET_ROOT: /mnt/seagate10tb/florianpfaff/datasets/dot-rope
+  REQUIRED_RUNNER_LABEL: gpuserver6000
+  PYTHONHASHSEED: "0"
+  PYTHONUNBUFFERED: "1"
+  PYTHONDONTWRITEBYTECODE: "1"
+  OMP_NUM_THREADS: "1"
+  OPENBLAS_NUM_THREADS: "1"
+  MKL_NUM_THREADS: "1"
+
+jobs:
+  contracts:
+    name: DOT rope target-closed contracts
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out proposed source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Install focused validation tools
+        run: python -m pip install --no-cache-dir pytest ruff
+      - name: Validate inventory code and contracts
+        run: |
+          set -euo pipefail
+          python -m ruff check \
+            experiments/dot_rope_curvature_v1 \
+            tests/test_dot_rope_inventory_v1.py
+          python -m ruff format --check \
+            experiments/dot_rope_curvature_v1 \
+            tests/test_dot_rope_inventory_v1.py
+          python -m pytest -q tests/test_dot_rope_inventory_v1.py
+          python -m compileall -q experiments/dot_rope_curvature_v1
+
+  authorize:
+    name: Authorize target-closed inventory request
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      source_revision: ${{ steps.request.outputs.source_revision }}
+      execution_revision: ${{ steps.request.outputs.execution_revision }}
+      request_id: ${{ steps.request.outputs.request_id }}
+    steps:
+      - name: Check out exact request revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 2
+          persist-credentials: false
+      - name: Require one non-forced request addition
+        id: request
+        shell: bash
+        env:
+          EVENT_BEFORE: ${{ github.event.before }}
+          EVENT_AFTER: ${{ github.event.after }}
+          EVENT_FORCED: ${{ github.event.forced }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REPOSITORY" = "IPS-Stuttgart/Prob4D"
+          test "$GITHUB_REF" = "refs/heads/science/dot-rope-curvature-pilot-v1"
+          test "$EVENT_FORCED" = "false"
+          test "$EVENT_BEFORE" != "0000000000000000000000000000000000000000"
+          test "$EVENT_AFTER" = "$(git rev-parse HEAD)"
+          mapfile -t changed < <(git diff --name-status "$EVENT_BEFORE" "$EVENT_AFTER")
+          printf 'Changed files:\n%s\n' "${changed[*]}"
+          test "${#changed[@]}" -eq 1
+          test "${changed[0]}" = $'A\t'"$REQUEST_PATH"
+          validation=$(
+            python experiments/dot_rope_curvature_v1/inventory.py validate-request \
+              --request "$REQUEST_PATH" \
+              --expected-source-revision "$EVENT_BEFORE"
+          )
+          request_id=$(
+            VALIDATION="$validation" python - <<'PY'
+          import json
+          import os
+
+          print(json.loads(os.environ["VALIDATION"])["request_id"])
+          PY
+          )
+          echo "source_revision=$EVENT_BEFORE" >> "$GITHUB_OUTPUT"
+          echo "execution_revision=$EVENT_AFTER" >> "$GITHUB_OUTPUT"
+          echo "request_id=$request_id" >> "$GITHUB_OUTPUT"
+
+  inventory:
+    name: Read-only DOT rope inventory / gpuserver6000
+    if: github.event_name == 'push'
+    needs: authorize
+    runs-on: [self-hosted, Linux, X64, gpuserver6000]
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: Require intended runner class and installed dataset
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$RUNNER_OS" = "Linux"
+          test "$RUNNER_ARCH" = "X64"
+          command -v python3 >/dev/null
+          test -d "$DATASET_ROOT"
+          test -r "$DATASET_ROOT"
+          printf 'Runner=%s OS=%s ARCH=%s required_label=%s\n' \
+            "$RUNNER_NAME" "$RUNNER_OS" "$RUNNER_ARCH" "$REQUIRED_RUNNER_LABEL"
+          python3 --version
+      - name: Initialize isolated scratch
+        id: workspace
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="$RUNNER_TEMP/dot-rope-curvature-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          rm -rf -- "$root"
+          mkdir -p "$root/output" "$root/home" "$root/tmp"
+          echo "root=$root" >> "$GITHUB_OUTPUT"
+          {
+            echo "HOME=$root/home"
+            echo "TMPDIR=$root/tmp"
+            echo "DOT_OUTPUT=$root/output"
+          } >> "$GITHUB_ENV"
+      - name: Check out exact authorized revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.authorize.outputs.execution_revision }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Verify clean exact checkout
+        shell: bash
+        env:
+          EXPECTED_REVISION: ${{ needs.authorize.outputs.execution_revision }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$EXPECTED_REVISION"
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+      - name: Inventory publisher archives without decoding members
+        shell: bash
+        env:
+          SOURCE_REVISION: ${{ needs.authorize.outputs.source_revision }}
+          EXECUTION_REVISION: ${{ needs.authorize.outputs.execution_revision }}
+        run: |
+          set -euo pipefail
+          python3 experiments/dot_rope_curvature_v1/inventory.py inventory \
+            --dataset-root "$DATASET_ROOT" \
+            --output "$DOT_OUTPUT" \
+            --request "$REQUEST_PATH" \
+            --source-revision "$SOURCE_REVISION" \
+            --execution-revision "$EXECUTION_REVISION"
+          cat "$DOT_OUTPUT/report.md" >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload aggregate inventory evidence only
+        if: always() && env.DOT_OUTPUT != ''
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dot-rope-inventory-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ env.DOT_OUTPUT }}/inventory.json
+            ${{ env.DOT_OUTPUT }}/archives.csv
+            ${{ env.DOT_OUTPUT }}/extensions.csv
+            ${{ env.DOT_OUTPUT }}/sequences.csv
+            ${{ env.DOT_OUTPUT }}/development_member_sample.txt
+            ${{ env.DOT_OUTPUT }}/report.md
+          if-no-files-found: error
+          retention-days: 90
+      - name: Remove isolated scratch
+        if: always()
+        shell: bash
+        run: |
+          if test -n "${{ steps.workspace.outputs.root }}"; then
+            rm -rf -- "${{ steps.workspace.outputs.root }}"
+          fi

--- a/.github/workflows/dot-rope-curvature-v1.yml
+++ b/.github/workflows/dot-rope-curvature-v1.yml
@@ -80,7 +80,7 @@ jobs:
           ref: ${{ github.sha }}
           fetch-depth: 2
           persist-credentials: false
-      - name: Require one non-forced request addition
+      - name: Require one non-forced request addition or revision
         id: request
         shell: bash
         env:
@@ -97,7 +97,10 @@ jobs:
           mapfile -t changed < <(git diff --name-status "$EVENT_BEFORE" "$EVENT_AFTER")
           printf 'Changed files:\n%s\n' "${changed[*]}"
           test "${#changed[@]}" -eq 1
-          test "${changed[0]}" = $'A\t'"$REQUEST_PATH"
+          case "${changed[0]}" in
+            $'A\t'"$REQUEST_PATH"|$'M\t'"$REQUEST_PATH") ;;
+            *) echo "Expected an added or modified $REQUEST_PATH" >&2; exit 2 ;;
+          esac
           validation=$(
             python experiments/dot_rope_curvature_v1/inventory.py validate-request \
               --request "$REQUEST_PATH" \
@@ -119,7 +122,7 @@ jobs:
     name: Read-only DOT rope inventory / gpuserver6000
     if: github.event_name == 'push'
     needs: authorize
-    runs-on: [self-hosted, Linux, X64, gpuserver6000]
+    runs-on: [self-hosted, gpuserver6000]
     timeout-minutes: 60
     permissions:
       contents: read

--- a/experiments/dot_rope_curvature_v1/README.md
+++ b/experiments/dot_rope_curvature_v1/README.md
@@ -1,0 +1,28 @@
+# DOT rope shared-curvature validation
+
+This experiment is the public real-data follow-up to the controlled shared-gauge
+curvature result. The initial stage inventories the seven publisher ZIP archives
+at the fixed `gpuserver6000` path. It verifies the publisher MD5 values and reads
+ZIP central directories, but it does not open or extract any member payload.
+
+The split is frozen before trajectory inspection:
+
+- development: `R01-R30`;
+- calibration: `R31-R40`;
+- held out: `R41-R70`.
+
+The first stage answers only whether the installed release is complete and what
+source-side parser is required. A later source-only stage may decode development
+payloads to construct a real-camera/oracle-correspondence geometry experiment.
+Calibration and held-out payload access require separate request records and
+cannot be authorized by the inventory result.
+
+The intended scientific comparison holds provider means fixed and compares
+first-order shared gauge, axis spherical-radial propagation, scalar inflation,
+pointwise curvature, shared quadratic curvature, and higher-degree cubature.
+Primary endpoints will be sequence-clustered proper score, coverage with width,
+and the non-averaging behavior of shared uncertainty across rope query points.
+
+No workflow in this directory may upload videos, images, meshes, dense
+trajectories, or raw correspondences. Only aggregate, sanitized evidence is
+allowed.

--- a/experiments/dot_rope_curvature_v1/__init__.py
+++ b/experiments/dot_rope_curvature_v1/__init__.py
@@ -1,0 +1,1 @@
+"""Target-closed DOT rope curvature feasibility study."""

--- a/experiments/dot_rope_curvature_v1/inventory.py
+++ b/experiments/dot_rope_curvature_v1/inventory.py
@@ -1,0 +1,508 @@
+"""Inventory the public DOT rope archives without decoding trajectory payloads."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import os
+import re
+import stat
+from collections import Counter
+from pathlib import Path, PurePosixPath
+from typing import Any
+from zipfile import BadZipFile, ZipFile, ZipInfo
+
+EXPECTED_ARCHIVES: tuple[tuple[str, str, int, int], ...] = (
+    ("R01-10.zip", "ca546ff5f22c0279123ccb18509858ee", 1, 10),
+    ("R11-20.zip", "23ce3e7067465d3edabe20b4c7cfa388", 11, 20),
+    ("R21-30.zip", "8aee77f79d1aff6e1f3fd21886b251a0", 21, 30),
+    ("R31-40.zip", "8a96081d20af9fa486fafa8e24e54442", 31, 40),
+    ("R41-50.zip", "fe1edaf708d0dc55ebf108d24badacce", 41, 50),
+    ("R51-60.zip", "aa74ff1f12a898d61e5255abf09680aa", 51, 60),
+    ("R61-70.zip", "da7a7a11a7d4e4541c891f3fafbe07b7", 61, 70),
+)
+
+REQUEST_SCHEMA = "dot-rope-curvature-inventory-request-v1"
+RESULT_SCHEMA = "dot-rope-curvature-inventory-v1"
+FIXED_DATASET_ROOT = "/mnt/seagate10tb/florianpfaff/datasets/dot-rope"
+FIXED_RUNNER_LABEL = "gpuserver6000"
+SEQUENCE_PATTERN = re.compile(r"(?<![A-Za-z0-9])R(\d{2})(?!\d)", re.IGNORECASE)
+DIGIT_PATTERN = re.compile(r"\d+")
+
+
+def split_for_sequence(sequence_number: int) -> str:
+    """Return the prospectively frozen split for one DOT rope sequence."""
+
+    if 1 <= sequence_number <= 30:
+        return "development"
+    if 31 <= sequence_number <= 40:
+        return "calibration"
+    if 41 <= sequence_number <= 70:
+        return "held_out"
+    return "outside_protocol"
+
+
+def sequence_id_from_member(name: str) -> str | None:
+    """Extract an ``Rxx`` identifier from an archive member path."""
+
+    match = SEQUENCE_PATTERN.search(name)
+    if match is None:
+        return None
+    return f"R{int(match.group(1)):02d}"
+
+
+def member_name_is_safe(name: str) -> bool:
+    """Reject absolute, traversal, NUL-containing, or backslash paths."""
+
+    if not name or "\x00" in name or "\\" in name:
+        return False
+    path = PurePosixPath(name)
+    return not path.is_absolute() and ".." not in path.parts
+
+
+def zip_info_is_symlink(info: ZipInfo) -> bool:
+    """Return whether a ZIP member advertises a symbolic-link file mode."""
+
+    mode = info.external_attr >> 16
+    return stat.S_IFMT(mode) == stat.S_IFLNK
+
+
+def normalized_member_pattern(name: str) -> str:
+    """Collapse numeric path components to expose repeated dataset layouts."""
+
+    normalized = SEQUENCE_PATTERN.sub("R##", name)
+    return DIGIT_PATTERN.sub("#", normalized)
+
+
+def hash_file(path: Path, algorithm: str = "md5") -> str:
+    """Hash a file without loading it into memory."""
+
+    digest = hashlib.new(algorithm)
+    with path.open("rb") as handle:
+        while block := handle.read(8 * 1024 * 1024):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _extension(name: str) -> str:
+    suffix = PurePosixPath(name).suffix.lower()
+    return suffix if suffix else "<none>"
+
+
+def inventory_archive(
+    path: Path,
+    *,
+    expected_md5: str,
+    sequence_start: int,
+    sequence_stop: int,
+    source_sample_limit: int = 400,
+) -> tuple[dict[str, Any], list[str]]:
+    """Inspect one archive using its central directory only.
+
+    Compressed archive bytes are read for the publisher MD5. Member payloads are
+    never opened or extracted by this function.
+    """
+
+    if not path.is_file():
+        raise FileNotFoundError(f"Missing required archive: {path.name}")
+
+    observed_md5 = hash_file(path)
+    extension_counts: Counter[str] = Counter()
+    prefix_counts: Counter[str] = Counter()
+    pattern_counts: Counter[str] = Counter()
+    sequence_counts: Counter[str] = Counter()
+    member_names: set[str] = set()
+    duplicate_names: list[str] = []
+    unsafe_names: list[str] = []
+    encrypted_names: list[str] = []
+    symlink_names: list[str] = []
+    source_sample: list[str] = []
+    file_count = 0
+    directory_count = 0
+    compressed_bytes = 0
+    uncompressed_bytes = 0
+    largest_member_bytes = 0
+
+    try:
+        with ZipFile(path) as archive:
+            archive_comment_bytes = len(archive.comment)
+            for info in archive.infolist():
+                name = info.filename
+                if name in member_names:
+                    duplicate_names.append(name)
+                member_names.add(name)
+                if not member_name_is_safe(name):
+                    unsafe_names.append(name)
+                if info.flag_bits & 0x1:
+                    encrypted_names.append(name)
+                if zip_info_is_symlink(info):
+                    symlink_names.append(name)
+                if info.is_dir():
+                    directory_count += 1
+                    continue
+
+                file_count += 1
+                compressed_bytes += info.compress_size
+                uncompressed_bytes += info.file_size
+                largest_member_bytes = max(largest_member_bytes, info.file_size)
+                extension_counts[_extension(name)] += 1
+                path_parts = PurePosixPath(name).parts
+                prefix_counts[path_parts[0] if path_parts else "<root>"] += 1
+                pattern_counts[normalized_member_pattern(name)] += 1
+                sequence_id = sequence_id_from_member(name)
+                if sequence_id is not None:
+                    sequence_counts[sequence_id] += 1
+                    sequence_number = int(sequence_id[1:])
+                    if (
+                        split_for_sequence(sequence_number) == "development"
+                        and len(source_sample) < source_sample_limit
+                    ):
+                        source_sample.append(name)
+    except BadZipFile as exc:
+        raise ValueError(f"Invalid ZIP central directory: {path.name}") from exc
+
+    record: dict[str, Any] = {
+        "archive": path.name,
+        "size_bytes": path.stat().st_size,
+        "expected_md5": expected_md5,
+        "observed_md5": observed_md5,
+        "publisher_md5_matches": observed_md5 == expected_md5,
+        "nominal_sequence_start": sequence_start,
+        "nominal_sequence_stop": sequence_stop,
+        "nominal_split": split_for_sequence(sequence_start),
+        "file_count": file_count,
+        "directory_count": directory_count,
+        "compressed_member_bytes": compressed_bytes,
+        "uncompressed_member_bytes": uncompressed_bytes,
+        "largest_member_bytes": largest_member_bytes,
+        "archive_comment_bytes": archive_comment_bytes,
+        "duplicate_member_count": len(duplicate_names),
+        "unsafe_member_count": len(unsafe_names),
+        "encrypted_member_count": len(encrypted_names),
+        "symlink_member_count": len(symlink_names),
+        "sequence_counts": dict(sorted(sequence_counts.items())),
+        "extension_counts": dict(extension_counts.most_common()),
+        "top_level_prefix_counts": dict(prefix_counts.most_common(30)),
+        "common_member_patterns": dict(pattern_counts.most_common(80)),
+        "payload_members_opened": 0,
+    }
+    problems = {
+        "duplicate_members": duplicate_names[:20],
+        "unsafe_members": unsafe_names[:20],
+        "encrypted_members": encrypted_names[:20],
+        "symlink_members": symlink_names[:20],
+    }
+    record["problem_samples"] = problems
+    return record, source_sample
+
+
+def validate_request(
+    request_path: Path,
+    *,
+    expected_source_revision: str | None = None,
+) -> dict[str, Any]:
+    """Validate the immutable execution request without touching the dataset."""
+
+    request = json.loads(request_path.read_text(encoding="utf-8"))
+    required: dict[str, Any] = {
+        "schema": REQUEST_SCHEMA,
+        "mode": "inventory",
+        "dataset_root": FIXED_DATASET_ROOT,
+        "runner_label": FIXED_RUNNER_LABEL,
+        "development_sequences": "R01-R30",
+        "calibration_sequences": "R31-R40",
+        "held_out_sequences": "R41-R70",
+        "held_out_payload_decode_authorized": False,
+        "provider_execution_authorized": False,
+        "paper_claim_authorized": False,
+        "evidence_class": (
+            "public-real-data inventory; central-directory metadata only; "
+            "no provider or target outcome claim"
+        ),
+    }
+    for key, expected in required.items():
+        if request.get(key) != expected:
+            raise ValueError(
+                f"Invalid request field {key!r}: expected {expected!r}, "
+                f"got {request.get(key)!r}"
+            )
+
+    allowed = set(required) | {"request_id", "expected_source_revision"}
+    unknown = set(request) - allowed
+    if unknown:
+        raise ValueError(f"Unknown request fields: {sorted(unknown)}")
+    if not request.get("request_id"):
+        raise ValueError("request_id must be nonempty")
+    revision = request.get("expected_source_revision", "")
+    if len(revision) != 40 or any(char not in "0123456789abcdef" for char in revision):
+        raise ValueError("expected_source_revision must be a lowercase commit SHA")
+    if expected_source_revision is not None and revision != expected_source_revision:
+        raise ValueError(
+            "request expected_source_revision does not match the authorized source revision"
+        )
+    return request
+
+
+def _write_csv(path: Path, fieldnames: list[str], rows: list[dict[str, Any]]) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def run_inventory(
+    *,
+    dataset_root: Path,
+    output_dir: Path,
+    request_path: Path,
+    source_revision: str,
+    execution_revision: str,
+) -> dict[str, Any]:
+    """Run the target-closed archive inventory and write aggregate evidence."""
+
+    request = validate_request(
+        request_path,
+        expected_source_revision=source_revision,
+    )
+    if str(dataset_root) != FIXED_DATASET_ROOT:
+        raise ValueError(f"dataset_root must equal {FIXED_DATASET_ROOT}")
+    if not dataset_root.is_dir():
+        raise FileNotFoundError(f"Dataset root does not exist: {dataset_root}")
+
+    output_dir.mkdir(parents=True, exist_ok=False)
+    records: list[dict[str, Any]] = []
+    source_samples: list[str] = []
+    for archive_name, expected_md5, sequence_start, sequence_stop in EXPECTED_ARCHIVES:
+        record, sample = inventory_archive(
+            dataset_root / archive_name,
+            expected_md5=expected_md5,
+            sequence_start=sequence_start,
+            sequence_stop=sequence_stop,
+            source_sample_limit=max(0, 600 - len(source_samples)),
+        )
+        records.append(record)
+        source_samples.extend(sample)
+
+    expected_names = {item[0] for item in EXPECTED_ARCHIVES}
+    observed_zip_names = {path.name for path in dataset_root.glob("*.zip")}
+    extra_zip_names = sorted(observed_zip_names - expected_names)
+    missing_zip_names = sorted(expected_names - observed_zip_names)
+    valid = (
+        not missing_zip_names
+        and all(record["publisher_md5_matches"] for record in records)
+        and all(record["duplicate_member_count"] == 0 for record in records)
+        and all(record["unsafe_member_count"] == 0 for record in records)
+        and all(record["encrypted_member_count"] == 0 for record in records)
+        and all(record["symlink_member_count"] == 0 for record in records)
+    )
+
+    aggregate_extensions: Counter[str] = Counter()
+    aggregate_sequences: Counter[str] = Counter()
+    for record in records:
+        aggregate_extensions.update(record["extension_counts"])
+        aggregate_sequences.update(record["sequence_counts"])
+
+    result: dict[str, Any] = {
+        "schema": RESULT_SCHEMA,
+        "decision": "inventory-pass" if valid else "inventory-fail",
+        "classification": (
+            "public real-data archive inventory; no member payload decoded; "
+            "not provider competence or paper evidence"
+        ),
+        "request": request,
+        "source_revision": source_revision,
+        "execution_revision": execution_revision,
+        "github_run_id": os.environ.get("GITHUB_RUN_ID"),
+        "github_run_attempt": os.environ.get("GITHUB_RUN_ATTEMPT"),
+        "runner_name": os.environ.get("RUNNER_NAME"),
+        "runner_label_required": FIXED_RUNNER_LABEL,
+        "dataset": {
+            "persistent_id": "doi:10.13021/ORC2020/XXLVXM",
+            "publisher_version": "29.0",
+            "license": "CC0-1.0",
+            "dataset_root": str(dataset_root),
+            "expected_archive_count": len(EXPECTED_ARCHIVES),
+            "observed_zip_count": len(observed_zip_names),
+            "missing_zip_names": missing_zip_names,
+            "extra_zip_names": extra_zip_names,
+        },
+        "information_boundary": {
+            "development_sequences": "R01-R30",
+            "calibration_sequences": "R31-R40",
+            "held_out_sequences": "R41-R70",
+            "archive_bytes_read_for_md5": True,
+            "zip_central_directories_read": True,
+            "member_payloads_opened": 0,
+            "member_payloads_extracted": 0,
+            "held_out_payloads_decoded": 0,
+            "provider_executed": False,
+            "outcome_metrics_computed": False,
+        },
+        "archives": records,
+        "aggregate_extension_counts": dict(aggregate_extensions.most_common()),
+        "aggregate_sequence_counts": dict(sorted(aggregate_sequences.items())),
+    }
+
+    (output_dir / "inventory.json").write_text(
+        json.dumps(result, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    archive_rows = [
+        {
+            key: record[key]
+            for key in (
+                "archive",
+                "size_bytes",
+                "expected_md5",
+                "observed_md5",
+                "publisher_md5_matches",
+                "nominal_sequence_start",
+                "nominal_sequence_stop",
+                "nominal_split",
+                "file_count",
+                "directory_count",
+                "compressed_member_bytes",
+                "uncompressed_member_bytes",
+                "largest_member_bytes",
+                "duplicate_member_count",
+                "unsafe_member_count",
+                "encrypted_member_count",
+                "symlink_member_count",
+                "payload_members_opened",
+            )
+        }
+        for record in records
+    ]
+    _write_csv(output_dir / "archives.csv", list(archive_rows[0]), archive_rows)
+    _write_csv(
+        output_dir / "extensions.csv",
+        ["extension", "member_count"],
+        [
+            {"extension": extension, "member_count": count}
+            for extension, count in aggregate_extensions.most_common()
+        ],
+    )
+    _write_csv(
+        output_dir / "sequences.csv",
+        ["sequence", "split", "member_count"],
+        [
+            {
+                "sequence": sequence,
+                "split": split_for_sequence(int(sequence[1:])),
+                "member_count": count,
+            }
+            for sequence, count in sorted(aggregate_sequences.items())
+        ],
+    )
+    (output_dir / "development_member_sample.txt").write_text(
+        "\n".join(source_samples[:600]) + ("\n" if source_samples else ""),
+        encoding="utf-8",
+    )
+
+    total_size = sum(record["size_bytes"] for record in records)
+    total_members = sum(record["file_count"] for record in records)
+    report_lines = [
+        "# DOT rope target-closed archive inventory",
+        "",
+        f"- Decision: **{result['decision']}**",
+        f"- Runner: `{result['runner_name']}`; required label: `{FIXED_RUNNER_LABEL}`",
+        f"- Archive count: `{len(records)}`; total bytes: `{total_size}`",
+        f"- File members represented: `{total_members}`",
+        "- Publisher MD5 matches: "
+        + ("all seven" if all(row["publisher_md5_matches"] for row in records) else "NO"),
+        "- Member payloads decoded/extracted: `0/0`",
+        "- Frozen split: development `R01-R30`, calibration `R31-R40`, "
+        "held-out `R41-R70`",
+        "",
+        "## Archive summary",
+        "",
+        "| Archive | Split | Files | Uncompressed bytes | MD5 |",
+        "|---|---:|---:|---:|---:|",
+    ]
+    for record in records:
+        report_lines.append(
+            "| {archive} | {split} | {files} | {bytes} | {status} |".format(
+                archive=record["archive"],
+                split=record["nominal_split"],
+                files=record["file_count"],
+                bytes=record["uncompressed_member_bytes"],
+                status="pass" if record["publisher_md5_matches"] else "FAIL",
+            )
+        )
+    report_lines.extend(
+        [
+            "",
+            "## Most common file extensions",
+            "",
+        ]
+    )
+    for extension, count in aggregate_extensions.most_common(20):
+        report_lines.append(f"- `{extension}`: {count}")
+    report_lines.extend(
+        [
+            "",
+            "## Development-member sample",
+            "",
+            "The first development paths are listed to guide a source-only parser. "
+            "No member bytes were opened.",
+            "",
+            "```text",
+            *source_samples[:120],
+            "```",
+            "",
+            "This run is an operational inventory only. It does not establish "
+            "real-provider accuracy, calibration, BayesianPhysTwin benefit, "
+            "Causal4D benefit, or state of the art.",
+        ]
+    )
+    report = "\n".join(report_lines) + "\n"
+    (output_dir / "report.md").write_text(report, encoding="utf-8")
+    print(report)
+
+    if not valid:
+        raise RuntimeError("DOT rope archive inventory failed; inspect inventory.json")
+    return result
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    validate = subparsers.add_parser("validate-request")
+    validate.add_argument("--request", type=Path, required=True)
+    validate.add_argument("--expected-source-revision")
+
+    inventory = subparsers.add_parser("inventory")
+    inventory.add_argument("--dataset-root", type=Path, required=True)
+    inventory.add_argument("--output", type=Path, required=True)
+    inventory.add_argument("--request", type=Path, required=True)
+    inventory.add_argument("--source-revision", required=True)
+    inventory.add_argument("--execution-revision", required=True)
+    return parser
+
+
+def main() -> int:
+    args = _build_parser().parse_args()
+    if args.command == "validate-request":
+        request = validate_request(
+            args.request,
+            expected_source_revision=args.expected_source_revision,
+        )
+        print(json.dumps(request, sort_keys=True))
+        return 0
+    if args.command == "inventory":
+        run_inventory(
+            dataset_root=args.dataset_root,
+            output_dir=args.output,
+            request_path=args.request,
+            source_revision=args.source_revision,
+            execution_revision=args.execution_revision,
+        )
+        return 0
+    raise AssertionError(f"Unhandled command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/experiments/dot_rope_curvature_v1/protocol.json
+++ b/experiments/dot_rope_curvature_v1/protocol.json
@@ -1,0 +1,34 @@
+{
+  "schema": "dot-rope-curvature-protocol-v1",
+  "dataset": {
+    "name": "Deformable Object Tracking Dataset (DOT) - rope subset",
+    "persistent_id": "doi:10.13021/ORC2020/XXLVXM",
+    "publisher_version": "29.0",
+    "license": "CC0-1.0",
+    "dataset_root": "/mnt/seagate10tb/florianpfaff/datasets/dot-rope",
+    "archives": [
+      {"name": "R01-10.zip", "md5": "ca546ff5f22c0279123ccb18509858ee"},
+      {"name": "R11-20.zip", "md5": "23ce3e7067465d3edabe20b4c7cfa388"},
+      {"name": "R21-30.zip", "md5": "8aee77f79d1aff6e1f3fd21886b251a0"},
+      {"name": "R31-40.zip", "md5": "8a96081d20af9fa486fafa8e24e54442"},
+      {"name": "R41-50.zip", "md5": "fe1edaf708d0dc55ebf108d24badacce"},
+      {"name": "R51-60.zip", "md5": "aa74ff1f12a898d61e5255abf09680aa"},
+      {"name": "R61-70.zip", "md5": "da7a7a11a7d4e4541c891f3fafbe07b7"}
+    ]
+  },
+  "prospective_split": {
+    "development": "R01-R30",
+    "calibration": "R31-R40",
+    "held_out": "R41-R70"
+  },
+  "inventory_boundary": {
+    "archive_bytes_may_be_read_for_publisher_checksums": true,
+    "zip_central_directories_may_be_read": true,
+    "member_payload_decode_authorized": false,
+    "member_extraction_authorized": false,
+    "provider_execution_authorized": false,
+    "outcome_scoring_authorized": false
+  },
+  "next_stage_after_inventory": "Freeze a source-only parser and real-camera geometry audit before any held-out payload is decoded.",
+  "claim_boundary": "Operational inventory only; no provider competence, calibration, BayesianPhysTwin, Causal4D, or state-of-the-art claim."
+}

--- a/protocols/execution_requests/dot_rope_curvature_inventory_v1.json
+++ b/protocols/execution_requests/dot_rope_curvature_inventory_v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "dot-rope-curvature-inventory-request-v1",
-  "request_id": "dot-rope-gpuserver6000-inventory-2026-08-30-v1",
+  "request_id": "dot-rope-gpuserver6000-inventory-2026-08-30-v2",
   "mode": "inventory",
   "dataset_root": "/mnt/seagate10tb/florianpfaff/datasets/dot-rope",
   "runner_label": "gpuserver6000",
@@ -11,5 +11,5 @@
   "provider_execution_authorized": false,
   "paper_claim_authorized": false,
   "evidence_class": "public-real-data inventory; central-directory metadata only; no provider or target outcome claim",
-  "expected_source_revision": "eb1afd56a5b61c1854f9c552f6b1440252c07839"
+  "expected_source_revision": "1f6771a95cedac5553a782c8f5c8c007ea63bae1"
 }

--- a/protocols/execution_requests/dot_rope_curvature_inventory_v1.json
+++ b/protocols/execution_requests/dot_rope_curvature_inventory_v1.json
@@ -1,0 +1,15 @@
+{
+  "schema": "dot-rope-curvature-inventory-request-v1",
+  "request_id": "dot-rope-gpuserver6000-inventory-2026-08-30-v1",
+  "mode": "inventory",
+  "dataset_root": "/mnt/seagate10tb/florianpfaff/datasets/dot-rope",
+  "runner_label": "gpuserver6000",
+  "development_sequences": "R01-R30",
+  "calibration_sequences": "R31-R40",
+  "held_out_sequences": "R41-R70",
+  "held_out_payload_decode_authorized": false,
+  "provider_execution_authorized": false,
+  "paper_claim_authorized": false,
+  "evidence_class": "public-real-data inventory; central-directory metadata only; no provider or target outcome claim",
+  "expected_source_revision": "eb1afd56a5b61c1854f9c552f6b1440252c07839"
+}

--- a/tests/test_dot_rope_inventory_v1.py
+++ b/tests/test_dot_rope_inventory_v1.py
@@ -1,0 +1,79 @@
+"""Tests for the target-closed DOT rope archive inventory."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from zipfile import ZipFile, ZipInfo
+
+import pytest
+
+from experiments.dot_rope_curvature_v1.inventory import (
+    inventory_archive,
+    member_name_is_safe,
+    normalized_member_pattern,
+    sequence_id_from_member,
+    split_for_sequence,
+    zip_info_is_symlink,
+)
+
+
+@pytest.mark.parametrize(
+    ("sequence_number", "expected"),
+    [
+        (1, "development"),
+        (30, "development"),
+        (31, "calibration"),
+        (40, "calibration"),
+        (41, "held_out"),
+        (70, "held_out"),
+        (0, "outside_protocol"),
+        (71, "outside_protocol"),
+    ],
+)
+def test_split_for_sequence(sequence_number: int, expected: str) -> None:
+    assert split_for_sequence(sequence_number) == expected
+
+
+def test_member_safety_and_sequence_detection() -> None:
+    assert member_name_is_safe("R01/camera/000001.png")
+    assert not member_name_is_safe("../escape")
+    assert not member_name_is_safe("/absolute")
+    assert not member_name_is_safe("R01\\windows")
+    assert sequence_id_from_member("dataset/R07/track.npy") == "R07"
+    assert sequence_id_from_member("dataset/no_sequence/track.npy") is None
+    assert normalized_member_pattern("R07/cam12/frame000123.png") == (
+        "R##/cam#/frame#.png"
+    )
+
+
+def test_symlink_detection() -> None:
+    regular = ZipInfo("regular.txt")
+    regular.external_attr = 0o100644 << 16
+    symlink = ZipInfo("link")
+    symlink.external_attr = 0o120777 << 16
+    assert not zip_info_is_symlink(regular)
+    assert zip_info_is_symlink(symlink)
+
+
+def test_inventory_archive_reads_central_directory_only(tmp_path: Path) -> None:
+    archive_path = tmp_path / "R01-10.zip"
+    with ZipFile(archive_path, "w") as archive:
+        archive.writestr("R01/camera/000001.png", b"not-an-image")
+        archive.writestr("R02/ground_truth/track.npy", b"not-a-numpy-array")
+        archive.writestr("README.txt", b"metadata")
+    expected_md5 = hashlib.md5(archive_path.read_bytes()).hexdigest()  # noqa: S324
+
+    record, sample = inventory_archive(
+        archive_path,
+        expected_md5=expected_md5,
+        sequence_start=1,
+        sequence_stop=10,
+    )
+
+    assert record["publisher_md5_matches"] is True
+    assert record["file_count"] == 3
+    assert record["payload_members_opened"] == 0
+    assert record["sequence_counts"] == {"R01": 1, "R02": 1}
+    assert "R01/camera/000001.png" in sample
+    assert record["unsafe_member_count"] == 0

--- a/tests/test_dot_rope_inventory_v1.py
+++ b/tests/test_dot_rope_inventory_v1.py
@@ -42,9 +42,7 @@ def test_member_safety_and_sequence_detection() -> None:
     assert not member_name_is_safe("R01\\windows")
     assert sequence_id_from_member("dataset/R07/track.npy") == "R07"
     assert sequence_id_from_member("dataset/no_sequence/track.npy") is None
-    assert normalized_member_pattern("R07/cam12/frame000123.png") == (
-        "R##/cam#/frame#.png"
-    )
+    assert normalized_member_pattern("R07/cam12/frame000123.png") == ("R##/cam#/frame#.png")
 
 
 def test_symlink_detection() -> None:


### PR DESCRIPTION
## Objective

Start the public real-data validation path for the shared-gauge curvature method in #349 using the already installed DOT rope archives at

`/mnt/seagate10tb/florianpfaff/datasets/dot-rope`

This is a stacked draft on `science/shared-gauge-curvature-v1`. It does not change the method in #349.

## Prospective information boundary

Before any trajectory payload is decoded, this branch freezes:

- development sequences: `R01-R30`;
- calibration sequences: `R31-R40`;
- held-out sequences: `R41-R70`.

The first authorized run may read archive bytes for publisher MD5 checks and ZIP central directories only. It may not open or extract any archive member, execute a provider, compute outcome metrics, or authorize a paper claim.

## Workflow

A one-file request commit triggers a read-only job on

`[self-hosted, Linux, X64, gpuserver6000]`.

The job verifies all seven official archive checksums, audits member safety and schema patterns, and uploads only aggregate JSON/CSV/Markdown plus a development-path sample. It never uploads images, videos, meshes, trajectories, or correspondences.

Run requested in Actions run `33302260594`. The hosted authorization gate passed; the self-hosted inventory job is queued at PR creation time.

## Next stage, not authorized here

After inventory, freeze a source-only parser and an oracle-correspondence/real-camera geometry audit on `R01-R30`. Calibration and held-out payload access require separate immutable requests. The eventual test will compare first-order shared gauge, axis spherical-radial propagation, scalar inflation, pointwise curvature, shared quadratic curvature, and strong cubature baselines while holding means fixed.

## Claim boundary

Operational prerequisite only. This PR cannot establish provider competence, real uncertainty calibration, BayesianPhysTwin benefit, Causal4D benefit, arbitrary-rope transfer, or state of the art.

Refs #339 #49