### PR TITLE
Add target-closed Deform360 source-bundle audit

### DIFF
--- a/.github/workflows/deform360-source-bundle-audit.yml
+++ b/.github/workflows/deform360-source-bundle-audit.yml
@@ -1,0 +1,389 @@
+name: Deform360 source-bundle audit
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/deform360-source-bundle-audit.yml"
+      - "scripts/science/audit_deform360_source_bundle.py"
+      - "protocols/deform360-source-bundle-audit-v1.json"
+      - "tests/test_deform360_source_bundle_audit.py"
+      - "tests/test_deform360_source_bundle_workflow_policy.py"
+      - "tests/test_trusted_self_hosted_validation_policy.py"
+      - "docs/deform360-source-bundle-audit.md"
+  push:
+    branches: [main]
+    paths:
+      - "protocols/execution_requests/deform360_source_bundle_audit_v1.json"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deform360-source-bundle-audit-${{ github.ref }}-${{ github.sha }}
+  cancel-in-progress: false
+
+env:
+  REQUEST_PATH: protocols/execution_requests/deform360_source_bundle_audit_v1.json
+  PROTOCOL_PATH: protocols/deform360-source-bundle-audit-v1.json
+  SOURCE_ROOT: /home/florianpfaff/deform360-fresh-source-processed-v1-1a3f9b1
+  metadata_access_authorized: "true"
+  file_content_reads_authorized: "false"
+  prediction_execution_authorized: "false"
+  provider_residuals_authorized: "false"
+  target_payloads_authorized: "false"
+  target_outcomes_authorized: "false"
+  dataset_mutation_authorized: "false"
+  PYTHONHASHSEED: "0"
+  PYTHONUNBUFFERED: "1"
+  PYTHONDONTWRITEBYTECODE: "1"
+
+jobs:
+  contract:
+    name: Validate metadata-audit control plane
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out proposed source
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Provision Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Install development environment
+        run: python -m pip install --no-cache-dir ".[dev]"
+      - name: Validate source, protocol, tests, and workflow policy
+        run: |
+          set -euo pipefail
+          python scripts/science/audit_deform360_source_bundle.py \
+            validate-protocol --protocol "$PROTOCOL_PATH"
+          python -m ruff check \
+            scripts/science/audit_deform360_source_bundle.py \
+            tests/test_deform360_source_bundle_audit.py \
+            tests/test_deform360_source_bundle_workflow_policy.py \
+            tests/test_trusted_self_hosted_validation_policy.py
+          python -m ruff format --check \
+            scripts/science/audit_deform360_source_bundle.py \
+            tests/test_deform360_source_bundle_audit.py \
+            tests/test_deform360_source_bundle_workflow_policy.py \
+            tests/test_trusted_self_hosted_validation_policy.py
+          python -m pytest -q \
+            tests/test_deform360_source_bundle_audit.py \
+            tests/test_deform360_source_bundle_workflow_policy.py \
+            tests/test_trusted_self_hosted_validation_policy.py \
+            tests/test_github_action_pins.py
+          python -m compileall -q scripts/science/audit_deform360_source_bundle.py
+
+  authorize:
+    name: Authorize merged metadata-only request
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      request_id: ${{ steps.request.outputs.request_id }}
+      head_sha: ${{ steps.request.outputs.head_sha }}
+      source_protocol_git_blob_sha: ${{ steps.request.outputs.source_protocol_git_blob_sha }}
+    steps:
+      - name: Check out exact merged revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Require one non-forced main request change
+        id: request
+        shell: bash
+        env:
+          EVENT_REF: ${{ github.ref }}
+          EVENT_BEFORE: ${{ github.event.before }}
+          EVENT_AFTER: ${{ github.event.after }}
+          EVENT_FORCED: ${{ github.event.forced }}
+          EVENT_DELETED: ${{ github.event.deleted }}
+        run: |
+          set -euo pipefail
+          test "$EVENT_REF" = "refs/heads/main"
+          test "$EVENT_FORCED" = "false"
+          test "$EVENT_DELETED" = "false"
+          test "$EVENT_AFTER" = "$(/usr/bin/git rev-parse HEAD)"
+          test "$EVENT_BEFORE" != "0000000000000000000000000000000000000000"
+          mapfile -t changed < <(
+            /usr/bin/git diff --name-only "$EVENT_BEFORE" "$EVENT_AFTER" | sort
+          )
+          if [[ ${#changed[@]} -ne 1 || "${changed[0]}" != "$REQUEST_PATH" ]]; then
+            printf 'Expected only %s; changed paths were:\n' "$REQUEST_PATH" >&2
+            printf '  %s\n' "${changed[@]}" >&2
+            exit 2
+          fi
+          test -f "$REQUEST_PATH"
+          test -f "$PROTOCOL_PATH"
+          source_blob=$(/usr/bin/git rev-parse "$EVENT_AFTER:$PROTOCOL_PATH")
+          validation=$(
+            /usr/bin/python3 scripts/science/audit_deform360_source_bundle.py \
+              validate-request \
+              --request "$REQUEST_PATH" \
+              --protocol "$PROTOCOL_PATH" \
+              --source-protocol-git-blob-sha "$source_blob"
+          )
+          request_id=$(
+            VALIDATION="$validation" /usr/bin/python3 - <<'PY'
+          import json
+          import os
+
+          print(json.loads(os.environ["VALIDATION"])["request_id"])
+          PY
+          )
+          echo "request_id=$request_id" >> "$GITHUB_OUTPUT"
+          echo "head_sha=$EVENT_AFTER" >> "$GITHUB_OUTPUT"
+          echo "source_protocol_git_blob_sha=$source_blob" >> "$GITHUB_OUTPUT"
+
+  execute:
+    name: Audit Deform360 source bundle on gpuserver4090
+    if: github.event_name == 'push'
+    needs: authorize
+    environment: trusted-self-hosted-validation
+    runs-on: [self-hosted, gpuserver4090]
+    timeout-minutes: 120
+    permissions:
+      contents: read
+    outputs:
+      decision: ${{ steps.finalize.outputs.decision }}
+      audit_id: ${{ steps.finalize.outputs.audit_id }}
+      metadata_manifest_sha256: ${{ steps.finalize.outputs.metadata_manifest_sha256 }}
+      file_count: ${{ steps.finalize.outputs.file_count }}
+      directory_count: ${{ steps.finalize.outputs.directory_count }}
+      total_regular_file_bytes: ${{ steps.finalize.outputs.total_regular_file_bytes }}
+      forbidden_skipped: ${{ steps.finalize.outputs.forbidden_skipped }}
+    steps:
+      - name: Require the intended runner class
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$RUNNER_OS" = "Linux"
+          test "$RUNNER_ARCH" = "X64"
+          test -x /usr/bin/python3
+      - name: Initialize isolated output workspace
+        id: workspace
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${RUNNER_TEMP}/prob4d-deform360-source-audit-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          /usr/bin/rm -rf -- "$root"
+          /usr/bin/mkdir -p "$root/evidence"
+          echo "root=$root" >> "$GITHUB_OUTPUT"
+      - name: Check out exact authorized Prob4D revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.authorize.outputs.head_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Verify clean exact checkout and fixed source boundary
+        shell: bash
+        env:
+          EXPECTED_HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          test "$(/usr/bin/git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
+          test -z "$(/usr/bin/git status --porcelain=v1 --untracked-files=all)"
+          test "$SOURCE_ROOT" = \
+            "/home/florianpfaff/deform360-fresh-source-processed-v1-1a3f9b1"
+          test "$metadata_access_authorized" = "true"
+          test "$file_content_reads_authorized" = "false"
+          test "$prediction_execution_authorized" = "false"
+          test "$provider_residuals_authorized" = "false"
+          test "$target_payloads_authorized" = "false"
+          test "$target_outcomes_authorized" = "false"
+          test "$dataset_mutation_authorized" = "false"
+      - name: Build bounded metadata-only inventory
+        id: inventory
+        continue-on-error: true
+        shell: bash
+        env:
+          EXPECTED_HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+          REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
+          SOURCE_PROTOCOL_GIT_BLOB_SHA: ${{ needs.authorize.outputs.source_protocol_git_blob_sha }}
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          /usr/bin/python3 scripts/science/audit_deform360_source_bundle.py \
+            inventory \
+            --request "$REQUEST_PATH" \
+            --protocol "$PROTOCOL_PATH" \
+            --source-protocol-git-blob-sha "$SOURCE_PROTOCOL_GIT_BLOB_SHA" \
+            --prob4d-revision "$EXPECTED_HEAD_SHA" \
+            --runner-name "$RUNNER_NAME" \
+            --github-run-id "$GITHUB_RUN_ID" \
+            --output "$root/evidence/result.json" \
+            --summary "$root/evidence/summary.md"
+      - name: Build sanitized outputs
+        id: finalize
+        if: always()
+        shell: bash
+        env:
+          INVENTORY_OUTCOME: ${{ steps.inventory.outcome }}
+          REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
+          EXPECTED_HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          result="$root/evidence/result.json"
+          if [[ ! -f "$result" ]]; then
+            RESULT="$result" /usr/bin/python3 - <<'PY'
+          import hashlib
+          import json
+          import os
+
+          record = {
+              "schema": "prob4d.deform360-source-bundle-audit-result",
+              "schema_version": 1,
+              "profile": "deform360-source-bundle-audit-v1",
+              "decision": "audit-technical-failure",
+              "request_id": os.environ["REQUEST_ID"],
+              "prob4d_revision": os.environ["EXPECTED_HEAD_SHA"],
+              "execution_boundary": {
+                  "dataset_file_contents_opened": False,
+                  "prediction_executed": False,
+                  "provider_residuals_opened": False,
+                  "target_payloads_opened": False,
+                  "target_outcomes_opened": False,
+                  "dataset_mutated": False,
+              },
+              "inventory": {},
+              "claim_boundary": (
+                  "Metadata-only source-bundle inventory failed before a complete "
+                  "inventory was produced; no target or file-content access was authorized."
+              ),
+          }
+          canonical = json.dumps(
+              record,
+              sort_keys=True,
+              separators=(",", ":"),
+          ).encode("utf-8")
+          record["audit_id"] = hashlib.sha256(canonical).hexdigest()
+          with open(os.environ["RESULT"], "w", encoding="utf-8") as output:
+              json.dump(record, output, indent=2, sort_keys=True)
+              output.write("\n")
+          PY
+          fi
+          RESULT="$result" /usr/bin/python3 - <<'PY'
+          import json
+          import os
+
+          result = json.load(open(os.environ["RESULT"], encoding="utf-8"))
+          inventory = result.get("inventory") or {}
+          counts = inventory.get("counts_including_root") or {}
+          values = {
+              "decision": result.get("decision", "audit-technical-failure"),
+              "audit_id": result.get("audit_id", "unavailable"),
+              "metadata_manifest_sha256": inventory.get(
+                  "metadata_manifest_sha256", "unavailable"
+              ),
+              "file_count": counts.get("file", 0),
+              "directory_count": counts.get("directory", 0),
+              "total_regular_file_bytes": inventory.get(
+                  "total_regular_file_bytes", 0
+              ),
+              "forbidden_skipped": inventory.get(
+                  "forbidden_path_components_skipped", 0
+              ),
+          }
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              for key, value in values.items():
+                  output.write(f"{key}={value}\n")
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary:
+              summary.write("## Deform360 source-bundle metadata audit\n\n")
+              for key, value in values.items():
+                  summary.write(f"- **{key}:** `{value}`\n")
+              summary.write(
+                  "\nNo dataset file contents, predictions, residuals, target payloads, "
+                  "or target outcomes were authorized.\n"
+              )
+          PY
+      - name: Upload sanitized metadata evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: deform360-source-bundle-audit-${{ needs.authorize.outputs.request_id }}
+          path: ${{ steps.workspace.outputs.root }}/evidence
+          if-no-files-found: error
+          retention-days: 30
+      - name: Enforce complete source inventory
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "${{ steps.finalize.outputs.decision }}" = "source-bundle-present"
+      - name: Remove isolated output workspace
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          test -n "$root"
+          /usr/bin/rm -rf -- "$root"
+
+  report:
+    name: Report source-bundle audit
+    if: always() && github.event_name == 'push'
+    needs: [authorize, execute]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Post result to issue 49
+        shell: bash
+        env:
+          API_URL: ${{ github.api_url }}
+          REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+          REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
+          EXECUTE_RESULT: ${{ needs.execute.result }}
+          DECISION: ${{ needs.execute.outputs.decision }}
+          AUDIT_ID: ${{ needs.execute.outputs.audit_id }}
+          MANIFEST_SHA256: ${{ needs.execute.outputs.metadata_manifest_sha256 }}
+          FILE_COUNT: ${{ needs.execute.outputs.file_count }}
+          DIRECTORY_COUNT: ${{ needs.execute.outputs.directory_count }}
+          TOTAL_BYTES: ${{ needs.execute.outputs.total_regular_file_bytes }}
+          FORBIDDEN_SKIPPED: ${{ needs.execute.outputs.forbidden_skipped }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          /usr/bin/python3 - <<'PY'
+          import json
+          import os
+          import urllib.request
+
+          body = f"""Deform360 processed source-bundle metadata audit completed.
+
+          - Request: `{os.environ.get('REQUEST_ID') or 'unavailable'}`
+          - Workflow result: `{os.environ.get('EXECUTE_RESULT') or 'unavailable'}`
+          - Audit decision: `{os.environ.get('DECISION') or 'unavailable'}`
+          - Audit ID: `{os.environ.get('AUDIT_ID') or 'unavailable'}`
+          - Metadata-manifest SHA-256: `{os.environ.get('MANIFEST_SHA256') or 'unavailable'}`
+          - Regular files: `{os.environ.get('FILE_COUNT') or '0'}`
+          - Directories including root: `{os.environ.get('DIRECTORY_COUNT') or '0'}`
+          - Regular-file bytes: `{os.environ.get('TOTAL_BYTES') or '0'}`
+          - Forbidden path components skipped: `{os.environ.get('FORBIDDEN_SKIPPED') or '0'}`
+          - Run: {os.environ['RUN_URL']}
+
+          This was a read-only metadata audit of the fixed processed source root on `gpuserver4090`. It did not open dataset file contents, follow symlinks, execute predictions, inspect provider residuals, open target payloads/outcomes, or modify the dataset. A positive inventory decision establishes availability and structure only, not provider competence or physical benefit.
+          """
+          request = urllib.request.Request(
+              f"{os.environ['API_URL']}/repos/{os.environ['REPOSITORY']}/issues/49/comments",
+              data=json.dumps({"body": body}).encode("utf-8"),
+              headers={
+                  "Accept": "application/vnd.github+json",
+                  "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+                  "Content-Type": "application/json",
+                  "X-GitHub-Api-Version": "2022-11-28",
+              },
+              method="POST",
+          )
+          with urllib.request.urlopen(request, timeout=30) as response:
+              if response.status not in {200, 201}:
+                  raise SystemExit(f"issue comment failed with HTTP {response.status}")
+          PY

--- a/docs/deform360-source-bundle-audit.md
+++ b/docs/deform360-source-bundle-audit.md
@@ -1,0 +1,76 @@
+# Deform360 processed source-bundle metadata audit
+
+This audit is the first source-only step toward a fresh real-provider study for
+Prob4D issue #49. It inventories the already staged processed source bundle on
+the self-hosted runner labelled `gpuserver4090`:
+
+```text
+/home/florianpfaff/deform360-fresh-source-processed-v1-1a3f9b1
+```
+
+The audit establishes whether the reviewed path is present, traversable, and
+bounded enough for later source-side adapter and query work. It does not test a
+4-D provider, fit covariance, inspect prediction residuals, select a gate, or
+open a held-out target.
+
+## Information boundary
+
+The runner may read directory entries and `lstat` metadata only. Dataset files
+are never opened. The implementation:
+
+- rejects a symlink as the source root;
+- never follows symlinks below the root;
+- skips a path component before `stat` or descent when its normalized name
+  contains `confirmation`, `fresh-validation`, `held-v8`, `shadow`, or `target`;
+- records only relative path, entry type, POSIX mode, and size in the metadata
+  manifest;
+- excludes modification times and file contents from the manifest;
+- caps traversal at 1,000,000 admitted entries and depth 64; and
+- writes evidence only to an isolated directory under `RUNNER_TEMP`.
+
+The checked protocol is
+[`protocols/deform360-source-bundle-audit-v1.json`](../protocols/deform360-source-bundle-audit-v1.json).
+Its content address binds the fixed root, runner label, forbidden tokens, limits,
+and all negative authorization flags.
+
+## Trigger and authorization
+
+The protected workflow is
+[`.github/workflows/deform360-source-bundle-audit.yml`](../.github/workflows/deform360-source-bundle-audit.yml).
+A run is admitted only when a non-forced push to `main` changes exactly:
+
+```text
+protocols/execution_requests/deform360_source_bundle_audit_v1.json
+```
+
+The request must bind the exact Git blob of the merged protocol. The hosted
+authorization job validates that identity before the self-hosted job is eligible.
+The self-hosted job has read-only repository permission and receives no
+repository write token. Issue reporting is isolated in a later hosted job.
+
+## Evidence
+
+A successful run uploads `result.json` and `summary.md`. The result contains:
+
+- a deterministic metadata-manifest SHA-256;
+- regular-file, directory, symlink, and other-entry counts;
+- total regular-file bytes;
+- depth and extension summaries;
+- bounded top-level, sample-path, and largest-file summaries;
+- counts of forbidden path components skipped;
+- bounded metadata-error accounting; and
+- explicit flags stating that no file content, prediction, residual, target, or
+  dataset mutation was authorized.
+
+The independent statistical units and any final Deform360 source/calibration/
+target split are not defined by this inventory. Historical object exclusions
+must be resolved and a new protocol must be frozen before a fresh target is
+opened.
+
+## Claim boundary
+
+A positive decision means only that the fixed processed source bundle is
+available and completely inventoried under the declared limits. It does not
+establish provider competence, covariance calibration, query benefit,
+BayesianPhysTwin benefit, Causal4D benefit, deployment safety, or state of the
+art.

--- a/protocols/deform360-source-bundle-audit-v1.json
+++ b/protocols/deform360-source-bundle-audit-v1.json
@@ -1,0 +1,30 @@
+{
+  "claim_boundary": "Metadata-only source-bundle inventory. No dataset file content, provider prediction, residual, target payload, target outcome, BayesianPhysTwin innovation, or Causal4D outcome is authorized.",
+  "dataset_mutation_authorized": false,
+  "file_content_reads_authorized": false,
+  "forbidden_path_tokens": [
+    "confirmation",
+    "fresh-validation",
+    "held-v8",
+    "shadow",
+    "target"
+  ],
+  "issue_number": 49,
+  "limits": {
+    "largest_file_limit": 100,
+    "max_depth": 64,
+    "max_entries": 1000000,
+    "sample_path_limit": 200
+  },
+  "metadata_access_authorized": true,
+  "prediction_execution_authorized": false,
+  "profile": "deform360-source-bundle-audit-v1",
+  "protocol_id": "e7d2326158c197dea9a43e5856308d868d31024d050a9e112ef8ed4f153d6d55",
+  "provider_residuals_authorized": false,
+  "runner_label": "gpuserver4090",
+  "schema": "prob4d.deform360-source-bundle-audit-protocol",
+  "schema_version": 1,
+  "source_root": "/home/florianpfaff/deform360-fresh-source-processed-v1-1a3f9b1",
+  "target_outcomes_authorized": false,
+  "target_payloads_authorized": false
+}

--- a/scripts/science/audit_deform360_source_bundle.py
+++ b/scripts/science/audit_deform360_source_bundle.py
@@ -25,9 +25,7 @@ REQUEST_SCHEMA = "prob4d.deform360-source-bundle-audit-request"
 RESULT_SCHEMA = "prob4d.deform360-source-bundle-audit-result"
 PROFILE = "deform360-source-bundle-audit-v1"
 ISSUE_NUMBER = 49
-EXPECTED_SOURCE_ROOT = Path(
-    "/home/florianpfaff/deform360-fresh-source-processed-v1-1a3f9b1"
-)
+EXPECTED_SOURCE_ROOT = Path("/home/florianpfaff/deform360-fresh-source-processed-v1-1a3f9b1")
 EXPECTED_RUNNER_LABEL = "gpuserver4090"
 EXPECTED_PROTOCOL_PATH = "protocols/deform360-source-bundle-audit-v1.json"
 EXPECTED_FORBIDDEN_TOKENS = (
@@ -96,9 +94,7 @@ def _require_int(
 
 def _require_sha(value: object, *, name: str, length: int) -> str:
     text = str(value)
-    if len(text) != length or any(
-        character not in "0123456789abcdef" for character in text
-    ):
+    if len(text) != length or any(character not in "0123456789abcdef" for character in text):
         raise AuditContractError(f"{name} must be a lowercase {length}-hex digest")
     return text
 
@@ -302,9 +298,7 @@ def scan_source_root(
                 break
 
             relative_path = (
-                entry.name
-                if not relative_directory
-                else f"{relative_directory}/{entry.name}"
+                entry.name if not relative_directory else f"{relative_directory}/{entry.name}"
             )
             depth = directory_depth + 1
             if depth > max_depth:
@@ -358,9 +352,7 @@ def scan_source_root(
 
     inventory = {
         "metadata_manifest_sha256": manifest.hexdigest(),
-        "metadata_manifest_semantics": (
-            "relative path, lstat type, POSIX mode, and size only"
-        ),
+        "metadata_manifest_semantics": ("relative path, lstat type, POSIX mode, and size only"),
         "entry_count_excluding_root": entry_count,
         "counts_including_root": dict(sorted(counts.items())),
         "total_regular_file_bytes": total_file_bytes,
@@ -370,8 +362,7 @@ def scan_source_root(
         },
         "extension_counts": dict(sorted(extensions.items())),
         "top_level": {
-            name: dict(sorted(summary.items()))
-            for name, summary in sorted(top_level.items())
+            name: dict(sorted(summary.items())) for name, summary in sorted(top_level.items())
         },
         "largest_regular_files": [
             {"path": path, "size_bytes": size}

--- a/scripts/science/audit_deform360_source_bundle.py
+++ b/scripts/science/audit_deform360_source_bundle.py
@@ -1,0 +1,546 @@
+#!/usr/bin/env python3
+"""Build a bounded metadata-only inventory of a staged Deform360 source bundle.
+
+The audit deliberately never opens a dataset file. It traverses directory
+entries with ``os.scandir`` and records only lstat-derived metadata. Symlinks are
+not followed, target-like path components are skipped before stat or descent,
+and all outputs are written outside the dataset root.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import heapq
+import json
+import os
+import stat
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+from typing import Any
+
+PROTOCOL_SCHEMA = "prob4d.deform360-source-bundle-audit-protocol"
+REQUEST_SCHEMA = "prob4d.deform360-source-bundle-audit-request"
+RESULT_SCHEMA = "prob4d.deform360-source-bundle-audit-result"
+PROFILE = "deform360-source-bundle-audit-v1"
+ISSUE_NUMBER = 49
+EXPECTED_SOURCE_ROOT = Path(
+    "/home/florianpfaff/deform360-fresh-source-processed-v1-1a3f9b1"
+)
+EXPECTED_RUNNER_LABEL = "gpuserver4090"
+EXPECTED_PROTOCOL_PATH = "protocols/deform360-source-bundle-audit-v1.json"
+EXPECTED_FORBIDDEN_TOKENS = (
+    "confirmation",
+    "fresh-validation",
+    "held-v8",
+    "shadow",
+    "target",
+)
+CLAIM_BOUNDARY = (
+    "Metadata-only source-bundle inventory. No dataset file content, provider "
+    "prediction, residual, target payload, target outcome, BayesianPhysTwin "
+    "innovation, or Causal4D outcome is authorized."
+)
+
+
+class AuditContractError(ValueError):
+    """Raised when a protocol or request violates the frozen contract."""
+
+
+def _canonical_bytes(record: dict[str, Any]) -> bytes:
+    return json.dumps(
+        record,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+
+
+def _content_id(record: dict[str, Any], identity_field: str) -> str:
+    identity = dict(record)
+    identity.pop(identity_field, None)
+    return hashlib.sha256(_canonical_bytes(identity)).hexdigest()
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise AuditContractError(f"cannot load JSON {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise AuditContractError(f"{path} must contain a JSON object")
+    return value
+
+
+def _require_bool(record: dict[str, Any], key: str, expected: bool) -> None:
+    value = record.get(key)
+    if type(value) is not bool or value is not expected:
+        raise AuditContractError(f"{key} must be {str(expected).lower()}")
+
+
+def _require_int(
+    record: dict[str, Any],
+    key: str,
+    *,
+    minimum: int,
+    maximum: int,
+) -> int:
+    value = record.get(key)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise AuditContractError(f"{key} must be an integer")
+    if not minimum <= value <= maximum:
+        raise AuditContractError(f"{key} must lie in [{minimum}, {maximum}]")
+    return value
+
+
+def _require_sha(value: object, *, name: str, length: int) -> str:
+    text = str(value)
+    if len(text) != length or any(character not in "0123456789abcdef" for character in text):
+        raise AuditContractError(f"{name} must be a lowercase {length}-hex digest")
+    return text
+
+
+def validate_protocol_record(record: dict[str, Any]) -> dict[str, Any]:
+    """Validate and return one frozen audit protocol."""
+
+    if record.get("schema") != PROTOCOL_SCHEMA:
+        raise AuditContractError("unexpected protocol schema")
+    if record.get("schema_version") != 1:
+        raise AuditContractError("protocol schema_version must be 1")
+    if record.get("profile") != PROFILE:
+        raise AuditContractError("unexpected protocol profile")
+    if record.get("issue_number") != ISSUE_NUMBER:
+        raise AuditContractError(f"issue_number must be {ISSUE_NUMBER}")
+    if record.get("source_root") != str(EXPECTED_SOURCE_ROOT):
+        raise AuditContractError("source_root differs from the reviewed source bundle")
+    if record.get("runner_label") != EXPECTED_RUNNER_LABEL:
+        raise AuditContractError("runner_label differs from the reviewed runner")
+    tokens = record.get("forbidden_path_tokens")
+    if tokens != list(EXPECTED_FORBIDDEN_TOKENS):
+        raise AuditContractError("forbidden_path_tokens differ from the reviewed set")
+    _require_bool(record, "metadata_access_authorized", True)
+    for key in (
+        "file_content_reads_authorized",
+        "prediction_execution_authorized",
+        "provider_residuals_authorized",
+        "target_payloads_authorized",
+        "target_outcomes_authorized",
+        "dataset_mutation_authorized",
+    ):
+        _require_bool(record, key, False)
+    limits = record.get("limits")
+    if not isinstance(limits, dict):
+        raise AuditContractError("limits must be a JSON object")
+    _require_int(limits, "max_entries", minimum=1, maximum=5_000_000)
+    _require_int(limits, "max_depth", minimum=1, maximum=128)
+    _require_int(limits, "largest_file_limit", minimum=0, maximum=500)
+    _require_int(limits, "sample_path_limit", minimum=0, maximum=1_000)
+    if record.get("claim_boundary") != CLAIM_BOUNDARY:
+        raise AuditContractError("protocol claim_boundary differs from the reviewed wording")
+    actual_id = _require_sha(record.get("protocol_id"), name="protocol_id", length=64)
+    expected_id = _content_id(record, "protocol_id")
+    if actual_id != expected_id:
+        raise AuditContractError("protocol_id mismatch")
+    return record
+
+
+def validate_request_record(
+    record: dict[str, Any],
+    *,
+    protocol: dict[str, Any],
+    source_protocol_git_blob_sha: str,
+) -> dict[str, Any]:
+    """Validate a one-shot execution request against the merged protocol blob."""
+
+    validate_protocol_record(protocol)
+    if record.get("schema") != REQUEST_SCHEMA:
+        raise AuditContractError("unexpected request schema")
+    if record.get("schema_version") != 1:
+        raise AuditContractError("request schema_version must be 1")
+    if record.get("profile") != PROFILE:
+        raise AuditContractError("unexpected request profile")
+    if record.get("issue_number") != ISSUE_NUMBER:
+        raise AuditContractError(f"issue_number must be {ISSUE_NUMBER}")
+    if record.get("source_protocol_path") != EXPECTED_PROTOCOL_PATH:
+        raise AuditContractError("request source_protocol_path mismatch")
+    blob = _require_sha(
+        record.get("source_protocol_git_blob_sha"),
+        name="source_protocol_git_blob_sha",
+        length=40,
+    )
+    expected_blob = _require_sha(
+        source_protocol_git_blob_sha,
+        name="expected source protocol Git blob SHA",
+        length=40,
+    )
+    if blob != expected_blob:
+        raise AuditContractError("request does not bind the merged protocol blob")
+    if record.get("protocol_id") != protocol["protocol_id"]:
+        raise AuditContractError("request protocol_id mismatch")
+    _require_bool(record, "execution_authorized", True)
+    _require_bool(record, "metadata_access_authorized", True)
+    for key in (
+        "file_content_reads_authorized",
+        "prediction_execution_authorized",
+        "provider_residuals_authorized",
+        "target_payloads_authorized",
+        "target_outcomes_authorized",
+        "dataset_mutation_authorized",
+    ):
+        _require_bool(record, key, False)
+    if record.get("claim_boundary") != CLAIM_BOUNDARY:
+        raise AuditContractError("request claim_boundary differs from the reviewed wording")
+    actual_id = _require_sha(record.get("request_id"), name="request_id", length=64)
+    expected_id = _content_id(record, "request_id")
+    if actual_id != expected_id:
+        raise AuditContractError("request_id mismatch")
+    return record
+
+
+def _forbidden_token(name: str, tokens: tuple[str, ...]) -> str | None:
+    normalized = name.casefold().replace("_", "-").replace(" ", "-")
+    for token in tokens:
+        if token in normalized:
+            return token
+    return None
+
+
+def _entry_type(mode: int) -> str:
+    if stat.S_ISREG(mode):
+        return "file"
+    if stat.S_ISDIR(mode):
+        return "directory"
+    if stat.S_ISLNK(mode):
+        return "symlink"
+    return "other"
+
+
+def _manifest_line(relative_path: str, kind: str, mode: int, size: int) -> bytes:
+    return f"{kind}\0{stat.S_IMODE(mode):04o}\0{size}\0{relative_path}\n".encode("utf-8")
+
+
+def scan_source_root(
+    source_root: Path,
+    *,
+    forbidden_tokens: tuple[str, ...],
+    max_entries: int,
+    max_depth: int,
+    largest_file_limit: int,
+    sample_path_limit: int,
+) -> tuple[str, dict[str, Any]]:
+    """Scan dataset metadata without following links or opening files."""
+
+    try:
+        root_stat = source_root.lstat()
+    except FileNotFoundError:
+        return "source-root-missing", {"error": "source root does not exist"}
+    except OSError as exc:
+        return "source-root-unreadable", {
+            "error": "source root metadata could not be read",
+            "errno": exc.errno,
+        }
+    if stat.S_ISLNK(root_stat.st_mode):
+        return "source-root-symlink-rejected", {"error": "source root is a symlink"}
+    if not stat.S_ISDIR(root_stat.st_mode):
+        return "source-root-not-directory", {"error": "source root is not a directory"}
+
+    counts: Counter[str] = Counter({"directory": 1})
+    extension_counts: Counter[str] = Counter()
+    depth_counts: Counter[int] = Counter({0: 1})
+    forbidden_counts: Counter[str] = Counter()
+    top_level: dict[str, Counter[str]] = defaultdict(Counter)
+    error_counts: Counter[str] = Counter()
+    error_samples: list[dict[str, Any]] = []
+    samples: list[dict[str, Any]] = []
+    largest: list[tuple[int, str]] = []
+    manifest = hashlib.sha256()
+    manifest.update(_manifest_line(".", "directory", root_stat.st_mode, root_stat.st_size))
+    entry_count = 0
+    total_regular_file_bytes = 0
+    maximum_depth_seen = 0
+    limit_exceeded = False
+
+    stack: list[tuple[Path, str, int]] = [(source_root, "", 0)]
+    while stack and not limit_exceeded:
+        directory, relative_directory, directory_depth = stack.pop()
+        try:
+            with os.scandir(directory) as iterator:
+                entries = sorted(iterator, key=lambda entry: entry.name)
+        except OSError as exc:
+            error_counts["directory-scan"] += 1
+            if len(error_samples) < 50:
+                error_samples.append(
+                    {
+                        "operation": "directory-scan",
+                        "path": relative_directory or ".",
+                        "errno": exc.errno,
+                    }
+                )
+            continue
+
+        child_directories: list[tuple[Path, str, int]] = []
+        for entry in entries:
+            token = _forbidden_token(entry.name, forbidden_tokens)
+            if token is not None:
+                forbidden_counts[token] += 1
+                counts["forbidden-subtree-skipped"] += 1
+                continue
+            if entry_count >= max_entries:
+                limit_exceeded = True
+                break
+            relative_path = (
+                entry.name if not relative_directory else f"{relative_directory}/{entry.name}"
+            )
+            depth = directory_depth + 1
+            if depth > max_depth:
+                counts["depth-limit-skipped"] += 1
+                continue
+            try:
+                metadata = entry.stat(follow_symlinks=False)
+            except OSError as exc:
+                error_counts["lstat"] += 1
+                if len(error_samples) < 50:
+                    error_samples.append(
+                        {
+                            "operation": "lstat",
+                            "path": relative_path,
+                            "errno": exc.errno,
+                        }
+                    )
+                continue
+
+            kind = _entry_type(metadata.st_mode)
+            size = int(metadata.st_size)
+            entry_count += 1
+            counts[kind] += 1
+            depth_counts[depth] += 1
+            maximum_depth_seen = max(maximum_depth_seen, depth)
+            manifest.update(_manifest_line(relative_path, kind, metadata.st_mode, size))
+
+            top_name = relative_path.split("/", 1)[0]
+            top_level[top_name]["entries"] += 1
+            top_level[top_name][kind] += 1
+            if kind == "file":
+                total_regular_file_bytes += size
+                top_level[top_name]["regular_file_bytes"] += size
+                suffix = Path(entry.name).suffix.casefold() or "<none>"
+                extension_counts[suffix] += 1
+                item = (size, relative_path)
+                if largest_file_limit > 0:
+                    if len(largest) < largest_file_limit:
+                        heapq.heappush(largest, item)
+                    elif item > largest[0]:
+                        heapq.heapreplace(largest, item)
+
+            if len(samples) < sample_path_limit:
+                samples.append({"path": relative_path, "type": kind, "size_bytes": size})
+            if kind == "directory":
+                child_directories.append((Path(entry.path), relative_path, depth))
+
+        for child in reversed(child_directories):
+            stack.append(child)
+
+    if limit_exceeded:
+        decision = "entry-limit-exceeded"
+    elif error_counts:
+        decision = "source-bundle-partial"
+    else:
+        decision = "source-bundle-present"
+
+    inventory = {
+        "metadata_manifest_sha256": manifest.hexdigest(),
+        "metadata_manifest_semantics": "relative path, lstat type, POSIX mode, and size only",
+        "entry_count_excluding_root": entry_count,
+        "counts_including_root": dict(sorted(counts.items())),
+        "total_regular_file_bytes": total_regular_file_bytes,
+        "maximum_depth_seen": maximum_depth_seen,
+        "depth_counts_including_root": {
+            str(depth): count for depth, count in sorted(depth_counts.items())
+        },
+        "extension_counts": dict(sorted(extension_counts.items())),
+        "top_level": {
+            name: dict(sorted(summary.items())) for name, summary in sorted(top_level.items())
+        },
+        "largest_regular_files": [
+            {"path": path, "size_bytes": size}
+            for size, path in sorted(largest, key=lambda value: (-value[0], value[1]))
+        ],
+        "deterministic_path_sample": samples,
+        "forbidden_path_components_skipped": sum(forbidden_counts.values()),
+        "forbidden_token_counts": dict(sorted(forbidden_counts.items())),
+        "metadata_error_counts": dict(sorted(error_counts.items())),
+        "metadata_error_samples": error_samples,
+        "entry_limit_exceeded": limit_exceeded,
+    }
+    return decision, inventory
+
+
+def build_audit_result(
+    *,
+    protocol: dict[str, Any],
+    request: dict[str, Any],
+    source_protocol_git_blob_sha: str,
+    prob4d_revision: str,
+    runner_name: str,
+    github_run_id: str,
+) -> dict[str, Any]:
+    """Validate contracts, scan the reviewed source root, and bind the result."""
+
+    validate_request_record(
+        request,
+        protocol=protocol,
+        source_protocol_git_blob_sha=source_protocol_git_blob_sha,
+    )
+    revision = _require_sha(prob4d_revision, name="prob4d_revision", length=40)
+    limits = protocol["limits"]
+    decision, inventory = scan_source_root(
+        Path(protocol["source_root"]),
+        forbidden_tokens=tuple(protocol["forbidden_path_tokens"]),
+        max_entries=limits["max_entries"],
+        max_depth=limits["max_depth"],
+        largest_file_limit=limits["largest_file_limit"],
+        sample_path_limit=limits["sample_path_limit"],
+    )
+    result: dict[str, Any] = {
+        "schema": RESULT_SCHEMA,
+        "schema_version": 1,
+        "profile": PROFILE,
+        "decision": decision,
+        "issue_number": ISSUE_NUMBER,
+        "protocol_id": protocol["protocol_id"],
+        "request_id": request["request_id"],
+        "source_protocol_git_blob_sha": source_protocol_git_blob_sha,
+        "prob4d_revision": revision,
+        "runner_name": runner_name,
+        "github_run_id": str(github_run_id),
+        "source_root": protocol["source_root"],
+        "execution_boundary": {
+            "metadata_accessed": True,
+            "dataset_file_contents_opened": False,
+            "symlinks_followed": False,
+            "prediction_executed": False,
+            "provider_residuals_opened": False,
+            "target_payloads_opened": False,
+            "target_outcomes_opened": False,
+            "dataset_mutated": False,
+            "outputs_written_outside_source_root": True,
+        },
+        "inventory": inventory,
+        "claim_boundary": CLAIM_BOUNDARY,
+    }
+    result["audit_id"] = _content_id(result, "audit_id")
+    return result
+
+
+def _write_result(path: Path, result: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _write_summary(path: Path, result: dict[str, Any]) -> None:
+    inventory = result.get("inventory") or {}
+    counts = inventory.get("counts_including_root") or {}
+    lines = [
+        "# Deform360 source-bundle metadata audit",
+        "",
+        f"- Decision: `{result['decision']}`",
+        f"- Audit ID: `{result['audit_id']}`",
+        f"- Request ID: `{result['request_id']}`",
+        f"- Source root: `{result['source_root']}`",
+        "- Metadata manifest SHA-256: "
+        f"`{inventory.get('metadata_manifest_sha256', 'unavailable')}`",
+        f"- Regular files: `{counts.get('file', 0)}`",
+        f"- Directories including root: `{counts.get('directory', 0)}`",
+        f"- Symlinks: `{counts.get('symlink', 0)}`",
+        f"- Regular-file bytes: `{inventory.get('total_regular_file_bytes', 0)}`",
+        "- Forbidden path components skipped: "
+        f"`{inventory.get('forbidden_path_components_skipped', 0)}`",
+        "",
+        "This audit read directory entries and lstat metadata only. It did not "
+        "open dataset file contents, follow symlinks, execute predictions, inspect "
+        "residuals or targets, or modify the source root.",
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _command_validate_protocol(args: argparse.Namespace) -> int:
+    protocol = validate_protocol_record(_load_json(Path(args.protocol)))
+    print(json.dumps({"protocol_id": protocol["protocol_id"]}, sort_keys=True))
+    return 0
+
+
+def _command_validate_request(args: argparse.Namespace) -> int:
+    protocol = _load_json(Path(args.protocol))
+    request = validate_request_record(
+        _load_json(Path(args.request)),
+        protocol=protocol,
+        source_protocol_git_blob_sha=args.source_protocol_git_blob_sha,
+    )
+    print(json.dumps({"request_id": request["request_id"]}, sort_keys=True))
+    return 0
+
+
+def _command_inventory(args: argparse.Namespace) -> int:
+    protocol = _load_json(Path(args.protocol))
+    output = Path(args.output).resolve(strict=False)
+    summary = Path(args.summary).resolve(strict=False)
+    source_root = Path(protocol.get("source_root", "")).resolve(strict=False)
+    if output == summary:
+        raise AuditContractError("output and summary paths must differ")
+    if output.is_relative_to(source_root) or summary.is_relative_to(source_root):
+        raise AuditContractError("audit outputs must remain outside the source root")
+    result = build_audit_result(
+        protocol=protocol,
+        request=_load_json(Path(args.request)),
+        source_protocol_git_blob_sha=args.source_protocol_git_blob_sha,
+        prob4d_revision=args.prob4d_revision,
+        runner_name=args.runner_name,
+        github_run_id=args.github_run_id,
+    )
+    _write_result(output, result)
+    _write_summary(summary, result)
+    print(json.dumps({"audit_id": result["audit_id"], "decision": result["decision"]}))
+    return 0 if result["decision"] == "source-bundle-present" else 3
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    validate_protocol = subparsers.add_parser("validate-protocol")
+    validate_protocol.add_argument("--protocol", required=True)
+    validate_protocol.set_defaults(function=_command_validate_protocol)
+
+    validate_request = subparsers.add_parser("validate-request")
+    validate_request.add_argument("--request", required=True)
+    validate_request.add_argument("--protocol", required=True)
+    validate_request.add_argument("--source-protocol-git-blob-sha", required=True)
+    validate_request.set_defaults(function=_command_validate_request)
+
+    inventory = subparsers.add_parser("inventory")
+    inventory.add_argument("--request", required=True)
+    inventory.add_argument("--protocol", required=True)
+    inventory.add_argument("--source-protocol-git-blob-sha", required=True)
+    inventory.add_argument("--prob4d-revision", required=True)
+    inventory.add_argument("--runner-name", required=True)
+    inventory.add_argument("--github-run-id", required=True)
+    inventory.add_argument("--output", required=True)
+    inventory.add_argument("--summary", required=True)
+    inventory.set_defaults(function=_command_inventory)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        return int(args.function(args))
+    except AuditContractError as exc:
+        print(f"contract error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/science/audit_deform360_source_bundle.py
+++ b/scripts/science/audit_deform360_source_bundle.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
 """Build a bounded metadata-only inventory of a staged Deform360 source bundle.
 
-The audit deliberately never opens a dataset file. It traverses directory
-entries with ``os.scandir`` and records only lstat-derived metadata. Symlinks are
-not followed, target-like path components are skipped before stat or descent,
-and all outputs are written outside the dataset root.
+The audit never opens a dataset file. It traverses directory entries with
+``os.scandir`` and records only ``lstat``-derived metadata. Symlinks are not
+followed, target-like path components are skipped before stat or descent, and
+all outputs are written outside the dataset root.
 """
 
 from __future__ import annotations
@@ -96,7 +96,9 @@ def _require_int(
 
 def _require_sha(value: object, *, name: str, length: int) -> str:
     text = str(value)
-    if len(text) != length or any(character not in "0123456789abcdef" for character in text):
+    if len(text) != length or any(
+        character not in "0123456789abcdef" for character in text
+    ):
         raise AuditContractError(f"{name} must be a lowercase {length}-hex digest")
     return text
 
@@ -116,9 +118,9 @@ def validate_protocol_record(record: dict[str, Any]) -> dict[str, Any]:
         raise AuditContractError("source_root differs from the reviewed source bundle")
     if record.get("runner_label") != EXPECTED_RUNNER_LABEL:
         raise AuditContractError("runner_label differs from the reviewed runner")
-    tokens = record.get("forbidden_path_tokens")
-    if tokens != list(EXPECTED_FORBIDDEN_TOKENS):
+    if record.get("forbidden_path_tokens") != list(EXPECTED_FORBIDDEN_TOKENS):
         raise AuditContractError("forbidden_path_tokens differ from the reviewed set")
+
     _require_bool(record, "metadata_access_authorized", True)
     for key in (
         "file_content_reads_authorized",
@@ -129,6 +131,7 @@ def validate_protocol_record(record: dict[str, Any]) -> dict[str, Any]:
         "dataset_mutation_authorized",
     ):
         _require_bool(record, key, False)
+
     limits = record.get("limits")
     if not isinstance(limits, dict):
         raise AuditContractError("limits must be a JSON object")
@@ -136,11 +139,11 @@ def validate_protocol_record(record: dict[str, Any]) -> dict[str, Any]:
     _require_int(limits, "max_depth", minimum=1, maximum=128)
     _require_int(limits, "largest_file_limit", minimum=0, maximum=500)
     _require_int(limits, "sample_path_limit", minimum=0, maximum=1_000)
+
     if record.get("claim_boundary") != CLAIM_BOUNDARY:
-        raise AuditContractError("protocol claim_boundary differs from the reviewed wording")
+        raise AuditContractError("protocol claim_boundary differs from reviewed wording")
     actual_id = _require_sha(record.get("protocol_id"), name="protocol_id", length=64)
-    expected_id = _content_id(record, "protocol_id")
-    if actual_id != expected_id:
+    if actual_id != _content_id(record, "protocol_id"):
         raise AuditContractError("protocol_id mismatch")
     return record
 
@@ -164,20 +167,22 @@ def validate_request_record(
         raise AuditContractError(f"issue_number must be {ISSUE_NUMBER}")
     if record.get("source_protocol_path") != EXPECTED_PROTOCOL_PATH:
         raise AuditContractError("request source_protocol_path mismatch")
-    blob = _require_sha(
+
+    request_blob = _require_sha(
         record.get("source_protocol_git_blob_sha"),
         name="source_protocol_git_blob_sha",
         length=40,
     )
-    expected_blob = _require_sha(
+    merged_blob = _require_sha(
         source_protocol_git_blob_sha,
         name="expected source protocol Git blob SHA",
         length=40,
     )
-    if blob != expected_blob:
+    if request_blob != merged_blob:
         raise AuditContractError("request does not bind the merged protocol blob")
     if record.get("protocol_id") != protocol["protocol_id"]:
         raise AuditContractError("request protocol_id mismatch")
+
     _require_bool(record, "execution_authorized", True)
     _require_bool(record, "metadata_access_authorized", True)
     for key in (
@@ -189,21 +194,18 @@ def validate_request_record(
         "dataset_mutation_authorized",
     ):
         _require_bool(record, key, False)
+
     if record.get("claim_boundary") != CLAIM_BOUNDARY:
-        raise AuditContractError("request claim_boundary differs from the reviewed wording")
+        raise AuditContractError("request claim_boundary differs from reviewed wording")
     actual_id = _require_sha(record.get("request_id"), name="request_id", length=64)
-    expected_id = _content_id(record, "request_id")
-    if actual_id != expected_id:
+    if actual_id != _content_id(record, "request_id"):
         raise AuditContractError("request_id mismatch")
     return record
 
 
 def _forbidden_token(name: str, tokens: tuple[str, ...]) -> str | None:
     normalized = name.casefold().replace("_", "-").replace(" ", "-")
-    for token in tokens:
-        if token in normalized:
-            return token
-    return None
+    return next((token for token in tokens if token in normalized), None)
 
 
 def _entry_type(mode: int) -> str:
@@ -217,7 +219,14 @@ def _entry_type(mode: int) -> str:
 
 
 def _manifest_line(relative_path: str, kind: str, mode: int, size: int) -> bytes:
-    return f"{kind}\0{stat.S_IMODE(mode):04o}\0{size}\0{relative_path}\n".encode("utf-8")
+    return f"{kind}\0{stat.S_IMODE(mode):04o}\0{size}\0{relative_path}\n".encode()
+
+
+def _root_failure(decision: str, message: str, errno: int | None = None):
+    result: dict[str, Any] = {"error": message}
+    if errno is not None:
+        result["errno"] = errno
+    return decision, result
 
 
 def scan_source_root(
@@ -234,41 +243,43 @@ def scan_source_root(
     try:
         root_stat = source_root.lstat()
     except FileNotFoundError:
-        return "source-root-missing", {"error": "source root does not exist"}
+        return _root_failure("source-root-missing", "source root does not exist")
     except OSError as exc:
-        return "source-root-unreadable", {
-            "error": "source root metadata could not be read",
-            "errno": exc.errno,
-        }
+        return _root_failure(
+            "source-root-unreadable",
+            "source root metadata could not be read",
+            exc.errno,
+        )
     if stat.S_ISLNK(root_stat.st_mode):
-        return "source-root-symlink-rejected", {"error": "source root is a symlink"}
+        return _root_failure("source-root-symlink-rejected", "source root is a symlink")
     if not stat.S_ISDIR(root_stat.st_mode):
-        return "source-root-not-directory", {"error": "source root is not a directory"}
+        return _root_failure("source-root-not-directory", "source root is not a directory")
 
     counts: Counter[str] = Counter({"directory": 1})
-    extension_counts: Counter[str] = Counter()
-    depth_counts: Counter[int] = Counter({0: 1})
-    forbidden_counts: Counter[str] = Counter()
+    extensions: Counter[str] = Counter()
+    depths: Counter[int] = Counter({0: 1})
+    forbidden: Counter[str] = Counter()
     top_level: dict[str, Counter[str]] = defaultdict(Counter)
-    error_counts: Counter[str] = Counter()
+    errors: Counter[str] = Counter()
     error_samples: list[dict[str, Any]] = []
     samples: list[dict[str, Any]] = []
     largest: list[tuple[int, str]] = []
     manifest = hashlib.sha256()
     manifest.update(_manifest_line(".", "directory", root_stat.st_mode, root_stat.st_size))
+
     entry_count = 0
-    total_regular_file_bytes = 0
+    total_file_bytes = 0
     maximum_depth_seen = 0
     limit_exceeded = False
-
     stack: list[tuple[Path, str, int]] = [(source_root, "", 0)]
+
     while stack and not limit_exceeded:
         directory, relative_directory, directory_depth = stack.pop()
         try:
             with os.scandir(directory) as iterator:
                 entries = sorted(iterator, key=lambda entry: entry.name)
         except OSError as exc:
-            error_counts["directory-scan"] += 1
+            errors["directory-scan"] += 1
             if len(error_samples) < 50:
                 error_samples.append(
                     {
@@ -281,16 +292,19 @@ def scan_source_root(
 
         child_directories: list[tuple[Path, str, int]] = []
         for entry in entries:
-            token = _forbidden_token(entry.name, forbidden_tokens)
-            if token is not None:
-                forbidden_counts[token] += 1
+            forbidden_token = _forbidden_token(entry.name, forbidden_tokens)
+            if forbidden_token is not None:
+                forbidden[forbidden_token] += 1
                 counts["forbidden-subtree-skipped"] += 1
                 continue
             if entry_count >= max_entries:
                 limit_exceeded = True
                 break
+
             relative_path = (
-                entry.name if not relative_directory else f"{relative_directory}/{entry.name}"
+                entry.name
+                if not relative_directory
+                else f"{relative_directory}/{entry.name}"
             )
             depth = directory_depth + 1
             if depth > max_depth:
@@ -299,14 +313,10 @@ def scan_source_root(
             try:
                 metadata = entry.stat(follow_symlinks=False)
             except OSError as exc:
-                error_counts["lstat"] += 1
+                errors["lstat"] += 1
                 if len(error_samples) < 50:
                     error_samples.append(
-                        {
-                            "operation": "lstat",
-                            "path": relative_path,
-                            "errno": exc.errno,
-                        }
+                        {"operation": "lstat", "path": relative_path, "errno": exc.errno}
                     )
                 continue
 
@@ -314,7 +324,7 @@ def scan_source_root(
             size = int(metadata.st_size)
             entry_count += 1
             counts[kind] += 1
-            depth_counts[depth] += 1
+            depths[depth] += 1
             maximum_depth_seen = max(maximum_depth_seen, depth)
             manifest.update(_manifest_line(relative_path, kind, metadata.st_mode, size))
 
@@ -322,10 +332,9 @@ def scan_source_root(
             top_level[top_name]["entries"] += 1
             top_level[top_name][kind] += 1
             if kind == "file":
-                total_regular_file_bytes += size
+                total_file_bytes += size
                 top_level[top_name]["regular_file_bytes"] += size
-                suffix = Path(entry.name).suffix.casefold() or "<none>"
-                extension_counts[suffix] += 1
+                extensions[Path(entry.name).suffix.casefold() or "<none>"] += 1
                 item = (size, relative_path)
                 if largest_file_limit > 0:
                     if len(largest) < largest_file_limit:
@@ -338,38 +347,40 @@ def scan_source_root(
             if kind == "directory":
                 child_directories.append((Path(entry.path), relative_path, depth))
 
-        for child in reversed(child_directories):
-            stack.append(child)
+        stack.extend(reversed(child_directories))
 
     if limit_exceeded:
         decision = "entry-limit-exceeded"
-    elif error_counts:
+    elif errors:
         decision = "source-bundle-partial"
     else:
         decision = "source-bundle-present"
 
     inventory = {
         "metadata_manifest_sha256": manifest.hexdigest(),
-        "metadata_manifest_semantics": "relative path, lstat type, POSIX mode, and size only",
+        "metadata_manifest_semantics": (
+            "relative path, lstat type, POSIX mode, and size only"
+        ),
         "entry_count_excluding_root": entry_count,
         "counts_including_root": dict(sorted(counts.items())),
-        "total_regular_file_bytes": total_regular_file_bytes,
+        "total_regular_file_bytes": total_file_bytes,
         "maximum_depth_seen": maximum_depth_seen,
         "depth_counts_including_root": {
-            str(depth): count for depth, count in sorted(depth_counts.items())
+            str(depth): count for depth, count in sorted(depths.items())
         },
-        "extension_counts": dict(sorted(extension_counts.items())),
+        "extension_counts": dict(sorted(extensions.items())),
         "top_level": {
-            name: dict(sorted(summary.items())) for name, summary in sorted(top_level.items())
+            name: dict(sorted(summary.items()))
+            for name, summary in sorted(top_level.items())
         },
         "largest_regular_files": [
             {"path": path, "size_bytes": size}
-            for size, path in sorted(largest, key=lambda value: (-value[0], value[1]))
+            for size, path in sorted(largest, key=lambda item: (-item[0], item[1]))
         ],
         "deterministic_path_sample": samples,
-        "forbidden_path_components_skipped": sum(forbidden_counts.values()),
-        "forbidden_token_counts": dict(sorted(forbidden_counts.items())),
-        "metadata_error_counts": dict(sorted(error_counts.items())),
+        "forbidden_path_components_skipped": sum(forbidden.values()),
+        "forbidden_token_counts": dict(sorted(forbidden.items())),
+        "metadata_error_counts": dict(sorted(errors.items())),
         "metadata_error_samples": error_samples,
         "entry_limit_exceeded": limit_exceeded,
     }
@@ -385,7 +396,7 @@ def build_audit_result(
     runner_name: str,
     github_run_id: str,
 ) -> dict[str, Any]:
-    """Validate contracts, scan the reviewed source root, and bind the result."""
+    """Validate contracts, scan the source root, and bind the result."""
 
     validate_request_record(
         request,
@@ -491,6 +502,7 @@ def _command_inventory(args: argparse.Namespace) -> int:
         raise AuditContractError("output and summary paths must differ")
     if output.is_relative_to(source_root) or summary.is_relative_to(source_root):
         raise AuditContractError("audit outputs must remain outside the source root")
+
     result = build_audit_result(
         protocol=protocol,
         request=_load_json(Path(args.request)),

--- a/tests/test_deform360_source_bundle_audit.py
+++ b/tests/test_deform360_source_bundle_audit.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import builtins
+import hashlib
+import importlib.util
+import json
+import os
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "science" / "audit_deform360_source_bundle.py"
+PROTOCOL = ROOT / "protocols" / "deform360-source-bundle-audit-v1.json"
+
+
+def _load_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("deform360_source_bundle_audit", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def audit() -> ModuleType:
+    return _load_module()
+
+
+def _canonical_id(record: dict[str, object], identity_field: str) -> str:
+    identity = dict(record)
+    identity.pop(identity_field, None)
+    canonical = json.dumps(
+        identity,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+def test_checked_protocol_is_canonical_and_target_closed(audit: ModuleType) -> None:
+    record = json.loads(PROTOCOL.read_text(encoding="utf-8"))
+
+    assert audit.validate_protocol_record(record) == record
+    assert record["protocol_id"] == _canonical_id(record, "protocol_id")
+    assert record["metadata_access_authorized"] is True
+    for key in (
+        "file_content_reads_authorized",
+        "prediction_execution_authorized",
+        "provider_residuals_authorized",
+        "target_payloads_authorized",
+        "target_outcomes_authorized",
+        "dataset_mutation_authorized",
+    ):
+        assert record[key] is False
+
+
+def test_request_binds_the_exact_protocol_blob(audit: ModuleType) -> None:
+    protocol = json.loads(PROTOCOL.read_text(encoding="utf-8"))
+    blob = "a" * 40
+    request: dict[str, object] = {
+        "schema": audit.REQUEST_SCHEMA,
+        "schema_version": 1,
+        "profile": audit.PROFILE,
+        "issue_number": audit.ISSUE_NUMBER,
+        "source_protocol_path": audit.EXPECTED_PROTOCOL_PATH,
+        "source_protocol_git_blob_sha": blob,
+        "protocol_id": protocol["protocol_id"],
+        "execution_authorized": True,
+        "metadata_access_authorized": True,
+        "file_content_reads_authorized": False,
+        "prediction_execution_authorized": False,
+        "provider_residuals_authorized": False,
+        "target_payloads_authorized": False,
+        "target_outcomes_authorized": False,
+        "dataset_mutation_authorized": False,
+        "claim_boundary": audit.CLAIM_BOUNDARY,
+    }
+    request["request_id"] = _canonical_id(request, "request_id")
+
+    assert (
+        audit.validate_request_record(
+            request,
+            protocol=protocol,
+            source_protocol_git_blob_sha=blob,
+        )
+        == request
+    )
+    with pytest.raises(audit.AuditContractError, match="merged protocol blob"):
+        audit.validate_request_record(
+            request,
+            protocol=protocol,
+            source_protocol_git_blob_sha="b" * 40,
+        )
+
+
+def test_scan_reads_metadata_only_skips_forbidden_paths_and_symlinks(
+    audit: ModuleType,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    (source / "object-a").mkdir()
+    (source / "object-a" / "prediction.npz").write_bytes(b"12345")
+    (source / "object-b.json").write_text("{}", encoding="utf-8")
+    (source / "target-secret").mkdir()
+    (source / "target-secret" / "must-not-appear.bin").write_bytes(b"secret")
+    (source / "shadow_payload.dat").write_bytes(b"secret")
+    (source / "link-to-object").symlink_to(source / "object-a", target_is_directory=True)
+
+    original_open = builtins.open
+
+    def guarded_open(file: object, *args: object, **kwargs: object):
+        path = Path(file) if isinstance(file, (str, os.PathLike)) else None
+        if path is not None and path.is_relative_to(source):
+            raise AssertionError(f"dataset content open attempted: {path}")
+        return original_open(file, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", guarded_open)
+    decision, inventory = audit.scan_source_root(
+        source,
+        forbidden_tokens=tuple(audit.EXPECTED_FORBIDDEN_TOKENS),
+        max_entries=100,
+        max_depth=10,
+        largest_file_limit=10,
+        sample_path_limit=20,
+    )
+
+    assert decision == "source-bundle-present"
+    counts = inventory["counts_including_root"]
+    assert counts["directory"] == 2
+    assert counts["file"] == 2
+    assert counts["symlink"] == 1
+    assert counts["forbidden-subtree-skipped"] == 2
+    assert inventory["total_regular_file_bytes"] == 7
+    assert inventory["forbidden_token_counts"] == {"shadow": 1, "target": 1}
+    serialized = json.dumps(inventory, sort_keys=True)
+    assert "must-not-appear" not in serialized
+    assert "target-secret" not in serialized
+    assert "shadow_payload" not in serialized
+    assert "prediction.npz" in serialized
+
+
+def test_scan_is_deterministic_under_mtime_changes(audit: ModuleType, tmp_path: Path) -> None:
+    source = tmp_path / "source"
+    source.mkdir()
+    payload = source / "object" / "prediction.npz"
+    payload.parent.mkdir()
+    payload.write_bytes(b"payload")
+
+    arguments = {
+        "forbidden_tokens": tuple(audit.EXPECTED_FORBIDDEN_TOKENS),
+        "max_entries": 100,
+        "max_depth": 10,
+        "largest_file_limit": 10,
+        "sample_path_limit": 20,
+    }
+    first_decision, first = audit.scan_source_root(source, **arguments)
+    os.utime(payload, (1_000_000_000, 1_000_000_000))
+    second_decision, second = audit.scan_source_root(source, **arguments)
+
+    assert first_decision == second_decision == "source-bundle-present"
+    assert first == second
+
+
+def test_missing_root_and_entry_limit_are_bounded(audit: ModuleType, tmp_path: Path) -> None:
+    missing_decision, missing = audit.scan_source_root(
+        tmp_path / "missing",
+        forbidden_tokens=tuple(audit.EXPECTED_FORBIDDEN_TOKENS),
+        max_entries=10,
+        max_depth=10,
+        largest_file_limit=10,
+        sample_path_limit=10,
+    )
+    assert missing_decision == "source-root-missing"
+    assert "does not exist" in missing["error"]
+
+    source = tmp_path / "source"
+    source.mkdir()
+    for index in range(3):
+        (source / f"file-{index}.bin").write_bytes(b"x")
+    limited_decision, limited = audit.scan_source_root(
+        source,
+        forbidden_tokens=tuple(audit.EXPECTED_FORBIDDEN_TOKENS),
+        max_entries=2,
+        max_depth=10,
+        largest_file_limit=10,
+        sample_path_limit=10,
+    )
+    assert limited_decision == "entry-limit-exceeded"
+    assert limited["entry_limit_exceeded"] is True
+    assert limited["entry_count_excluding_root"] == 2
+
+
+def test_tiny_limits_and_wrong_contracts_fail_closed(audit: ModuleType) -> None:
+    protocol = json.loads(PROTOCOL.read_text(encoding="utf-8"))
+    protocol["metadata_access_authorized"] = False
+    protocol["protocol_id"] = _canonical_id(protocol, "protocol_id")
+    with pytest.raises(audit.AuditContractError, match="metadata_access_authorized"):
+        audit.validate_protocol_record(protocol)

--- a/tests/test_deform360_source_bundle_workflow_policy.py
+++ b/tests/test_deform360_source_bundle_workflow_policy.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "deform360-source-bundle-audit.yml"
+
+
+def test_workflow_is_single_request_main_bound_and_metadata_only() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "\n  push:" in text
+    assert "branches: [main]" in text
+    assert "protocols/execution_requests/deform360_source_bundle_audit_v1.json" in text
+    assert "pull_request_target:" not in text
+    assert 'test "$EVENT_REF" = "refs/heads/main"' in text
+    assert 'test "$EVENT_FORCED" = "false"' in text
+    assert 'test "$EVENT_DELETED" = "false"' in text
+    assert "validate-request" in text
+    assert "source_protocol_git_blob_sha" in text
+    assert "environment: trusted-self-hosted-validation" in text
+    assert "runs-on: [self-hosted, gpuserver4090]" in text
+    assert 'test "$RUNNER_OS" = "Linux"' in text
+    assert 'test "$RUNNER_ARCH" = "X64"' in text
+    assert "persist-credentials: false" in text
+    assert "metadata_access_authorized" in text
+    assert "file_content_reads_authorized" in text
+    assert "prediction_execution_authorized" in text
+    assert "provider_residuals_authorized" in text
+    assert "target_payloads_authorized" in text
+    assert "target_outcomes_authorized" in text
+    assert "dataset_mutation_authorized" in text
+    assert "git push" not in text
+    assert "secrets." not in text
+
+
+def test_self_hosted_job_has_read_only_repository_access_and_sanitized_output() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    execute_start = text.index("\n  execute:")
+    report_start = text.index("\n  report:")
+    execute = text[execute_start:report_start]
+    report = text[report_start:]
+
+    assert "permissions:\n      contents: read" in execute
+    assert "issues: write" not in execute
+    assert "contents: write" not in execute
+    assert "pull-requests: write" not in execute
+    assert "GITHUB_TOKEN" not in execute
+    assert "/usr/bin/python3 scripts/science/audit_deform360_source_bundle.py" in execute
+    assert "--output \"$root/evidence/result.json\"" in execute
+    assert "--summary \"$root/evidence/summary.md\"" in execute
+    assert "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02" in execute
+    assert "test \"${{ steps.finalize.outputs.decision }}\" = \"source-bundle-present\"" in execute
+    assert '/usr/bin/rm -rf -- "$root"' in execute
+
+    assert "permissions:\n      contents: read\n      issues: write" in report
+    assert "runs-on: ubuntu-latest" in report
+    assert "GITHUB_TOKEN: ${{ github.token }}" in report
+
+
+def test_source_path_and_forbidden_boundaries_are_literal() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert (
+        "SOURCE_ROOT: "
+        "/home/florianpfaff/deform360-fresh-source-processed-v1-1a3f9b1"
+    ) in text
+    assert "dataset_file_contents_opened" in text
+    assert "follow symlinks" in text
+    assert "target_payloads_opened" in text
+    assert "target_outcomes_opened" in text
+    assert "dataset_mutated" in text

--- a/tests/test_deform360_source_bundle_workflow_policy.py
+++ b/tests/test_deform360_source_bundle_workflow_policy.py
@@ -47,10 +47,10 @@ def test_self_hosted_job_has_read_only_repository_access_and_sanitized_output() 
     assert "pull-requests: write" not in execute
     assert "GITHUB_TOKEN" not in execute
     assert "/usr/bin/python3 scripts/science/audit_deform360_source_bundle.py" in execute
-    assert "--output \"$root/evidence/result.json\"" in execute
-    assert "--summary \"$root/evidence/summary.md\"" in execute
+    assert '--output "$root/evidence/result.json"' in execute
+    assert '--summary "$root/evidence/summary.md"' in execute
     assert "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02" in execute
-    assert "test \"${{ steps.finalize.outputs.decision }}\" = \"source-bundle-present\"" in execute
+    assert 'test "${{ steps.finalize.outputs.decision }}" = "source-bundle-present"' in execute
     assert '/usr/bin/rm -rf -- "$root"' in execute
 
     assert "permissions:\n      contents: read\n      issues: write" in report
@@ -61,10 +61,7 @@ def test_self_hosted_job_has_read_only_repository_access_and_sanitized_output() 
 def test_source_path_and_forbidden_boundaries_are_literal() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
 
-    assert (
-        "SOURCE_ROOT: "
-        "/home/florianpfaff/deform360-fresh-source-processed-v1-1a3f9b1"
-    ) in text
+    assert ("SOURCE_ROOT: /home/florianpfaff/deform360-fresh-source-processed-v1-1a3f9b1") in text
     assert "dataset_file_contents_opened" in text
     assert "follow symlinks" in text
     assert "target_payloads_opened" in text

--- a/tests/test_trusted_self_hosted_validation_policy.py
+++ b/tests/test_trusted_self_hosted_validation_policy.py
@@ -10,9 +10,7 @@ SOURCE_FREEZE_AUTO_V2_WORKFLOW = WORKFLOW_ROOT / "cut3r-source-freeze-auto-v2.ym
 CUT3R_CHECKOUT_TRUST_RERUN_WORKFLOW = WORKFLOW_ROOT / "cut3r-checkout-trust-rerun-v1.yml"
 CUT3R_SOURCE_COMPARISON_V2_WORKFLOW = WORKFLOW_ROOT / "cut3r-source-comparison-v2.yml"
 POINTWORLD_MODEL_LOAD_SMOKE_WORKFLOW = WORKFLOW_ROOT / "pointworld-model-load-smoke.yml"
-DEFORM360_SOURCE_BUNDLE_AUDIT_WORKFLOW = (
-    WORKFLOW_ROOT / "deform360-source-bundle-audit.yml"
-)
+DEFORM360_SOURCE_BUNDLE_AUDIT_WORKFLOW = WORKFLOW_ROOT / "deform360-source-bundle-audit.yml"
 CUT3R_RUNNER_SELECTOR = (
     "runs-on: [self-hosted, Linux, X64, nvidia-smi, "
     + "data-prob4d-deform360-source-v1, prob4d-cut3r]"

--- a/tests/test_trusted_self_hosted_validation_policy.py
+++ b/tests/test_trusted_self_hosted_validation_policy.py
@@ -10,6 +10,9 @@ SOURCE_FREEZE_AUTO_V2_WORKFLOW = WORKFLOW_ROOT / "cut3r-source-freeze-auto-v2.ym
 CUT3R_CHECKOUT_TRUST_RERUN_WORKFLOW = WORKFLOW_ROOT / "cut3r-checkout-trust-rerun-v1.yml"
 CUT3R_SOURCE_COMPARISON_V2_WORKFLOW = WORKFLOW_ROOT / "cut3r-source-comparison-v2.yml"
 POINTWORLD_MODEL_LOAD_SMOKE_WORKFLOW = WORKFLOW_ROOT / "pointworld-model-load-smoke.yml"
+DEFORM360_SOURCE_BUNDLE_AUDIT_WORKFLOW = (
+    WORKFLOW_ROOT / "deform360-source-bundle-audit.yml"
+)
 CUT3R_RUNNER_SELECTOR = (
     "runs-on: [self-hosted, Linux, X64, nvidia-smi, "
     + "data-prob4d-deform360-source-v1, prob4d-cut3r]"
@@ -22,6 +25,7 @@ TRUSTED_SELF_HOSTED_WORKFLOWS = (
     SOURCE_FREEZE_AUTO_V2_WORKFLOW,
     CUT3R_CHECKOUT_TRUST_RERUN_WORKFLOW,
     POINTWORLD_MODEL_LOAD_SMOKE_WORKFLOW,
+    DEFORM360_SOURCE_BUNDLE_AUDIT_WORKFLOW,
 )
 REMOVED_TEMPORARY_WORKFLOWS = (
     WORKFLOW_ROOT / "issue-49-protected-cohort-inventory.yml",


### PR DESCRIPTION
## Purpose

Begin the fresh Deform360 validation path with a metadata-only inventory of the existing processed source bundle on the self-hosted runner labelled `gpuserver4090`.

The run targets exactly:

`/home/florianpfaff/deform360-fresh-source-processed-v1-1a3f9b1`

## Safety and evidence boundary

- metadata only: directory-entry names, types, mode bits, and regular-file sizes;
- no dataset file-content reads;
- no provider execution, predictions, residuals, covariance fitting, or target access;
- no dataset mutation;
- symlinks are recorded but never followed;
- target-like path components are skipped before stat or descent;
- evidence is written only under `RUNNER_TEMP` and uploaded from a read-only self-hosted job;
- a separate hosted job owns the issue-comment write token.

The metadata digest is deliberately not a byte-complete dataset manifest and establishes no provider competence or scientific performance.

## Control plane

The reviewed workflow is triggered after merge only when the single file `protocols/execution_requests/deform360_source_bundle_audit_v1.json` changes in a non-forced push to `main`. The request must bind the exact Git blob of the source protocol and its own canonical SHA-256 identity.

The execution job uses `runs-on: [self-hosted, gpuserver4090]` and the existing `trusted-self-hosted-validation` environment.

## Validation

Locally validated against the current repository with:

- Ruff check and formatting;
- focused source-audit tests;
- trusted self-hosted workflow policy tests;
- GitHub Action pin tests;
- Python compileall; and
- YAML parsing and whitespace checks.

Related: #49 and #348.