### PR TITLE
Reroute sealed DOT CUT3R experiment to gpuserver4090

### DIFF
--- a/.github/workflows/dot-rope-cut3r-native-provider-v1.yml
+++ b/.github/workflows/dot-rope-cut3r-native-provider-v1.yml
@@ -27,7 +27,7 @@ concurrency:
 env:
   REQUEST_PATH: protocols/execution_requests/dot_rope_cut3r_native_provider_v1.json
   PROTOCOL_PATH: protocols/dot-rope-cut3r-native-provider-v1.json
-  DATASET_ROOT: /mnt/seagate10tb/florianpfaff/datasets/dot-rope
+  DATASET_ROOT: /mnt/seagate10tb/florianpfaff/datasets/dot
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
   PYTHONHASHSEED: "0"
   PYTHONUNBUFFERED: "1"
@@ -47,6 +47,7 @@ jobs:
       - name: Check out reviewed revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
           clean: true
       - name: Set up Python 3.12
@@ -83,7 +84,7 @@ jobs:
     name: Authorize immutable merged-main request
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     outputs:
       request_id: ${{ steps.request.outputs.request_id }}
       protocol_id: ${{ steps.request.outputs.protocol_id }}
@@ -97,6 +98,10 @@ jobs:
           fetch-depth: 2
           persist-credentials: false
           clean: true
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
       - name: Require exactly one non-forced request-file change
         id: request
         shell: bash
@@ -122,117 +127,54 @@ jobs:
             exit 2
           fi
           protocol_blob=$(/usr/bin/git rev-parse "$EVENT_AFTER:$PROTOCOL_PATH")
-          PROTOCOL_BLOB="$protocol_blob" /usr/bin/python3 - <<'PY'
-          import hashlib
+          python -m pip install -e .
+          validation=$(
+            python scripts/science/run_dot_rope_cut3r_native_provider.py \
+              validate-request \
+              --request "$REQUEST_PATH" \
+              --protocol "$PROTOCOL_PATH" \
+              --protocol-git-blob-sha "$protocol_blob"
+          )
+          VALIDATION="$validation" \
+            PROTOCOL_BLOB="$protocol_blob" \
+            /usr/bin/python3 - <<'PY'
           import json
           import os
-          from pathlib import Path
 
-          def canonical(value):
-              return json.dumps(
-                  value,
-                  sort_keys=True,
-                  separators=(",", ":"),
-                  ensure_ascii=False,
-                  allow_nan=False,
-              ).encode("utf-8")
-
-          protocol = json.loads(Path(os.environ["PROTOCOL_PATH"]).read_text())
-          unsigned_protocol = dict(protocol)
-          protocol_id = unsigned_protocol.pop("protocol_id", None)
-          measured_protocol_id = hashlib.sha256(canonical(unsigned_protocol)).hexdigest()
-          if protocol_id != measured_protocol_id:
-              raise SystemExit("protocol identity mismatch")
-          request = json.loads(Path(os.environ["REQUEST_PATH"]).read_text())
-          expected_fields = {
-              "schema",
-              "schema_version",
-              "request_id",
-              "protocol_path",
-              "protocol_git_blob_sha",
-              "runtime_smoke_authorized",
-              "normal_view_prediction_authorized",
-              "marker_2d_evaluation_authorized",
-              "marker_3d_evaluation_authorized",
-              "source_sequences",
-              "reserved_sequences",
-              "target_payloads_opened",
-              "bayesian_phystwin_executed",
-              "causal4d_executed",
-              "claim_boundary",
+          value = json.loads(os.environ["VALIDATION"])
+          outputs = {
+              "request_id": value["request_id"],
+              "protocol_id": value["protocol_id"],
+              "protocol_git_blob_sha": os.environ["PROTOCOL_BLOB"],
+              "head_sha": os.environ["EVENT_AFTER"],
           }
-          if set(request) != expected_fields:
-              raise SystemExit("execution request fields changed")
-          if request["schema"] != "prob4d.dot-rope-cut3r-native-provider-request":
-              raise SystemExit("execution request schema changed")
-          if request["schema_version"] != 1:
-              raise SystemExit("execution request version changed")
-          if request["protocol_path"] != os.environ["PROTOCOL_PATH"]:
-              raise SystemExit("execution request protocol path changed")
-          if request["protocol_git_blob_sha"] != os.environ["PROTOCOL_BLOB"]:
-              raise SystemExit("execution request protocol blob changed")
-          if request["source_sequences"] != ["R01", "R02", "R03"]:
-              raise SystemExit("source sequence boundary changed")
-          if request["reserved_sequences"] != "R04-R70":
-              raise SystemExit("reserved sequence boundary changed")
-          for name in (
-              "runtime_smoke_authorized",
-              "normal_view_prediction_authorized",
-              "marker_2d_evaluation_authorized",
-              "marker_3d_evaluation_authorized",
-          ):
-              if request[name] is not True:
-                  raise SystemExit(f"{name} is not authorized")
-          for name in (
-              "target_payloads_opened",
-              "bayesian_phystwin_executed",
-              "causal4d_executed",
-          ):
-              if request[name] is not False:
-                  raise SystemExit(f"{name} exceeds the source-only boundary")
-          unsigned_request = dict(request)
-          request_id = unsigned_request.pop("request_id", None)
-          measured_request_id = hashlib.sha256(canonical(unsigned_request)).hexdigest()
-          if request_id != measured_request_id:
-              raise SystemExit("execution request identity mismatch")
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
-              output.write(f"request_id={request_id}\n")
-              output.write(f"protocol_id={protocol_id}\n")
-              output.write(f"protocol_git_blob_sha={os.environ['PROTOCOL_BLOB']}\n")
-              output.write(f"head_sha={os.environ['EVENT_AFTER']}\n")
+              for key, item in outputs.items():
+                  output.write(f"{key}={item}\n")
           PY
 
-  runtime:
-    name: Compile and smoke native RoPE on gpuserver6000
+  provider:
+    name: Seal marker-free DOT predictions on gpuserver4090
     if: github.event_name == 'push'
     needs: authorize
     environment: trusted-self-hosted-validation
-    runs-on: [self-hosted, Linux, X64, gpuserver6000]
-    timeout-minutes: 180
+    runs-on: [self-hosted, Linux, X64, gpuserver4090]
+    timeout-minutes: 360
     permissions:
       contents: read
     outputs:
       decision: ${{ steps.result.outputs.decision }}
       runtime_artifact_id: ${{ steps.result.outputs.runtime_artifact_id }}
-      smoke_artifact_id: ${{ steps.result.outputs.smoke_artifact_id }}
+      provider_bundle_id: ${{ steps.result.outputs.provider_bundle_id }}
     steps:
-      - name: Require the intended runner
-        shell: bash
-        run: |
-          set -euo pipefail
-          test "$RUNNER_NAME" = "gpuserver6000"
-          test "$RUNNER_OS" = "Linux"
-          test "$RUNNER_ARCH" = "X64"
-          command -v nvidia-smi >/dev/null 2>&1
-          nvidia-smi --query-gpu=name,driver_version,memory.total --format=csv,noheader
-      - name: Initialize isolated runtime workspace
+      - name: Initialize isolated provider workspace
         id: workspace
         shell: bash
         run: |
           set -euo pipefail
-          root="${RUNNER_TEMP}/prob4d-dot-cut3r-runtime-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          root="${RUNNER_TEMP}/prob4d-dot-cut3r-provider-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
           /usr/bin/rm -rf -- "$root"
-          /usr/bin/mkdir -p "$root/evidence" "$root/home" "$root/cache" "$root/tmp"
+          /usr/bin/mkdir -p "$root/provider" "$root/home" "$root/cache" "$root/tmp"
           echo "root=$root" >> "$GITHUB_OUTPUT"
           {
             echo "HOME=$root/home"
@@ -242,6 +184,17 @@ jobs:
             echo "WANDB_MODE=disabled"
             echo "WANDB_DISABLED=true"
           } >> "$GITHUB_ENV"
+      - name: Require the intended runner and mounted archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$RUNNER_NAME" = "workstation1"
+          test "$RUNNER_OS" = "Linux"
+          test "$RUNNER_ARCH" = "X64"
+          command -v nvidia-smi >/dev/null 2>&1
+          test -d "$DATASET_ROOT"
+          test -r "$DATASET_ROOT/R01-10.zip"
+          nvidia-smi --query-gpu=name,driver_version,memory.total --format=csv,noheader
       - name: Check out exact authorized revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -266,9 +219,12 @@ jobs:
         run: |
           set -euo pipefail
           test -n "${CUT3R_CHECKOUT:-}"
+          test -d "$CUT3R_CHECKOUT"
           candidates=(
             "${CUT3R_PYTHON:-}"
             "$CUT3R_CHECKOUT/.venv/bin/python"
+            "/home/florianpfaff/conda_envs/cut3r/bin/python"
+            "/home/florianpfaff/miniconda3/envs/cut3r/bin/python"
             "/home/florian/conda_envs/cut3r/bin/python"
             "/home/github-runner/.conda/envs/cut3r/bin/python"
           )
@@ -291,14 +247,13 @@ jobs:
             exit 2
           }
           echo "python=$selected" >> "$GITHUB_OUTPUT"
-      - name: Copy and build the pinned native-RoPE runtime
+      - name: Copy and bind the native-RoPE runtime
         shell: bash
         env:
           CUT3R_CHECKOUT: ${{ vars.CUT3R_CHECKOUT }}
         run: |
           set -euo pipefail
           root="${{ steps.workspace.outputs.root }}"
-          test -d "$CUT3R_CHECKOUT"
           /usr/bin/mkdir -p "$root/CUT3R"
           /usr/bin/cp -a "$CUT3R_CHECKOUT/." "$root/CUT3R/"
           PYTHONPATH="$GITHUB_WORKSPACE/src" \
@@ -306,8 +261,8 @@ jobs:
             scripts/science/prepare_cut3r_runtime.py \
               --cut3r-checkout "$root/CUT3R" \
               --build \
-              --output "$root/evidence/runtime-receipt.json"
-          RECEIPT="$root/evidence/runtime-receipt.json" \
+              --output "$root/provider/runtime-receipt.json"
+          RECEIPT="$root/provider/runtime-receipt.json" \
             "${{ steps.python.outputs.python }}" - <<'PY'
           import json
           import os
@@ -318,9 +273,8 @@ jobs:
           root = Path(os.environ["RECEIPT"]).parents[1]
           checkout = root / "CUT3R"
           relative = Path(receipt["extension"]["relative_path"])
-          extension = checkout / relative
-          with tarfile.open(root / "evidence" / "native-rope-extension.tar.gz", "w:gz") as archive:
-              archive.add(extension, arcname=relative.as_posix(), recursive=False)
+          with tarfile.open(root / "provider" / "native-rope-extension.tar.gz", "w:gz") as archive:
+              archive.add(checkout / relative, arcname=relative.as_posix(), recursive=False)
           PY
       - name: Run synthetic native-RoPE forward pass
         id: smoke
@@ -343,151 +297,11 @@ jobs:
               --prob4d-revision "$EXPECTED_HEAD_SHA" \
               --cut3r-checkout "$root/CUT3R" \
               --checkpoint "$CUT3R_CHECKPOINT" \
-              --runtime-receipt "$root/evidence/runtime-receipt.json" \
-              --output-dir "$root/evidence/smoke"
-      - name: Read bounded runtime outputs
-        id: result
-        if: always()
-        shell: bash
-        run: |
-          set -euo pipefail
-          root="${{ steps.workspace.outputs.root }}"
-          RESULT="$root/evidence/smoke/smoke-result.json" \
-            RECEIPT="$root/evidence/runtime-receipt.json" \
-            /usr/bin/python3 - <<'PY'
-          import json
-          import os
-          from pathlib import Path
-
-          result = json.loads(Path(os.environ["RESULT"]).read_text(encoding="utf-8"))
-          receipt = json.loads(Path(os.environ["RECEIPT"]).read_text(encoding="utf-8"))
-          values = {
-              "decision": result["decision"],
-              "runtime_artifact_id": receipt["artifact_id"],
-              "smoke_artifact_id": result["artifact_id"],
-          }
-          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
-              for key, value in values.items():
-                  output.write(f"{key}={value}\n")
-          PY
-      - name: Upload bounded runtime evidence
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: dot-rope-cut3r-native-runtime-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ steps.workspace.outputs.root }}/evidence/
-          if-no-files-found: error
-          retention-days: 30
-      - name: Enforce successful runtime qualification
-        if: always()
-        shell: bash
-        env:
-          DECISION: ${{ steps.result.outputs.decision }}
-        run: |
-          set -euo pipefail
-          test "$DECISION" = "pass"
-
-  predict:
-    name: Seal marker-free DOT predictions on gpuserver6000
-    if: >-
-      github.event_name == 'push' &&
-      needs.runtime.outputs.decision == 'pass'
-    needs: [authorize, runtime]
-    environment: trusted-self-hosted-validation
-    runs-on: [self-hosted, Linux, X64, gpuserver6000]
-    timeout-minutes: 240
-    permissions:
-      contents: read
-    outputs:
-      decision: ${{ steps.result.outputs.decision }}
-      provider_bundle_id: ${{ steps.result.outputs.provider_bundle_id }}
-    steps:
-      - name: Require the intended runner
-        shell: bash
-        run: |
-          set -euo pipefail
-          test "$RUNNER_NAME" = "gpuserver6000"
-          test "$RUNNER_OS" = "Linux"
-          test "$RUNNER_ARCH" = "X64"
-          command -v nvidia-smi >/dev/null 2>&1
-      - name: Initialize isolated prediction workspace
-        id: workspace
-        shell: bash
-        run: |
-          set -euo pipefail
-          root="${RUNNER_TEMP}/prob4d-dot-cut3r-predict-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          /usr/bin/rm -rf -- "$root"
-          /usr/bin/mkdir -p "$root/runtime" "$root/provider" "$root/home" "$root/cache" "$root/tmp"
-          echo "root=$root" >> "$GITHUB_OUTPUT"
-          {
-            echo "HOME=$root/home"
-            echo "XDG_CACHE_HOME=$root/cache"
-            echo "TMPDIR=$root/tmp"
-            echo "TORCH_EXTENSIONS_DIR=$root/cache/torch-extensions"
-            echo "WANDB_MODE=disabled"
-            echo "WANDB_DISABLED=true"
-          } >> "$GITHUB_ENV"
-      - name: Check out exact authorized revision
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ needs.authorize.outputs.head_sha }}
-          fetch-depth: 0
-          persist-credentials: false
-          clean: true
-      - name: Download exact-run native runtime
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: dot-rope-cut3r-native-runtime-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ steps.workspace.outputs.root }}/runtime
-      - name: Select the retained CUT3R interpreter
-        id: python
-        shell: bash
-        env:
-          CUT3R_CHECKOUT: ${{ vars.CUT3R_CHECKOUT }}
-          CUT3R_PYTHON: ${{ vars.CUT3R_PYTHON }}
-        run: |
-          set -euo pipefail
-          candidates=(
-            "${CUT3R_PYTHON:-}"
-            "$CUT3R_CHECKOUT/.venv/bin/python"
-            "/home/florian/conda_envs/cut3r/bin/python"
-            "/home/github-runner/.conda/envs/cut3r/bin/python"
-          )
-          selected=""
-          for candidate in "${candidates[@]}"; do
-            [[ -n "$candidate" && -x "$candidate" ]] || continue
-            if "$candidate" - <<'PY' >/dev/null 2>&1
-          import numpy
-          import PIL
-          import torch
-          assert torch.cuda.is_available()
-          PY
-            then
-              selected="$candidate"
-              break
-            fi
-          done
-          test -n "$selected"
-          echo "python=$selected" >> "$GITHUB_OUTPUT"
-      - name: Restore and verify the exact native extension
-        shell: bash
-        env:
-          CUT3R_CHECKOUT: ${{ vars.CUT3R_CHECKOUT }}
-          EXPECTED_RUNTIME_ID: ${{ needs.runtime.outputs.runtime_artifact_id }}
-        run: |
-          set -euo pipefail
-          root="${{ steps.workspace.outputs.root }}"
-          /usr/bin/mkdir -p "$root/CUT3R"
-          /usr/bin/cp -a "$CUT3R_CHECKOUT/." "$root/CUT3R/"
-          /usr/bin/tar -xzf "$root/runtime/native-rope-extension.tar.gz" -C "$root/CUT3R"
-          PYTHONPATH="$GITHUB_WORKSPACE/src" \
-            "${{ steps.python.outputs.python }}" \
-            scripts/science/prepare_cut3r_runtime.py \
-              --cut3r-checkout "$root/CUT3R" \
-              --expected-artifact-id "$EXPECTED_RUNTIME_ID" \
-              --output "$root/provider/runtime-receipt.json"
+              --runtime-receipt "$root/provider/runtime-receipt.json" \
+              --output-dir "$root/provider/smoke"
       - name: Execute marker-free normal-view predictions
         id: execute
+        if: steps.smoke.outcome == 'success'
         continue-on-error: true
         shell: bash
         env:
@@ -515,26 +329,48 @@ jobs:
         shell: bash
         env:
           EXECUTION_OUTCOME: ${{ steps.execute.outcome }}
+          SMOKE_OUTCOME: ${{ steps.smoke.outcome }}
         run: |
           set -euo pipefail
           root="${{ steps.workspace.outputs.root }}"
-          manifest="$root/provider/bundle/manifest.json"
-          if [[ "$EXECUTION_OUTCOME" == "success" && -f "$manifest" ]]; then
-            MANIFEST="$manifest" /usr/bin/python3 - <<'PY'
+          ROOT="$root" /usr/bin/python3 - <<'PY'
           import json
           import os
           from pathlib import Path
 
-          value = json.loads(Path(os.environ["MANIFEST"]).read_text(encoding="utf-8"))
+          root = Path(os.environ["ROOT"])
+          manifest_path = root / "provider" / "bundle" / "manifest.json"
+          receipt_path = root / "provider" / "runtime-receipt.json"
+          smoke_path = root / "provider" / "smoke" / "smoke-result.json"
+          runtime_id = "unavailable"
+          if receipt_path.is_file():
+              runtime_id = json.loads(receipt_path.read_text(encoding="utf-8"))["artifact_id"]
+          if os.environ["EXECUTION_OUTCOME"] == "success" and manifest_path.is_file():
+              manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+              decision = manifest["decision"]
+              provider_id = manifest["provider_bundle_id"]
+          else:
+              decision = "technical-failure"
+              provider_id = "unavailable"
+              failure = {
+                  "schema": "prob4d.dot-rope-cut3r-gpuserver4090-technical-receipt",
+                  "schema_version": 1,
+                  "smoke_outcome": os.environ["SMOKE_OUTCOME"],
+                  "prediction_outcome": os.environ["EXECUTION_OUTCOME"],
+                  "runtime_artifact_id": runtime_id,
+                  "smoke_result_present": smoke_path.is_file(),
+                  "provider_manifest_present": manifest_path.is_file(),
+              }
+              (root / "provider" / "technical-receipt.json").write_text(
+                  json.dumps(failure, indent=2, sort_keys=True) + "\n",
+                  encoding="utf-8",
+              )
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
-              output.write(f"decision={value['decision']}\n")
-              output.write(f"provider_bundle_id={value['provider_bundle_id']}\n")
+              output.write(f"decision={decision}\n")
+              output.write(f"runtime_artifact_id={runtime_id}\n")
+              output.write(f"provider_bundle_id={provider_id}\n")
           PY
-          else
-            echo "decision=technical-failure" >> "$GITHUB_OUTPUT"
-            echo "provider_bundle_id=unavailable" >> "$GITHUB_OUTPUT"
-          fi
-      - name: Upload sealed provider bundle
+      - name: Upload sealed provider evidence
         if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -555,11 +391,11 @@ jobs:
     name: Evaluate sealed predictions against R01-R03 markers
     if: >-
       github.event_name == 'push' &&
-      needs.predict.outputs.decision == 'sealed-provider-predictions'
-    needs: [authorize, predict]
+      needs.provider.outputs.decision == 'sealed-provider-predictions'
+    needs: [authorize, provider]
     environment: trusted-self-hosted-validation
-    runs-on: [self-hosted, Linux, X64, gpuserver6000]
-    timeout-minutes: 90
+    runs-on: [self-hosted, Linux, X64, gpuserver4090]
+    timeout-minutes: 120
     permissions:
       contents: read
     outputs:
@@ -567,13 +403,6 @@ jobs:
       evaluation_id: ${{ steps.result.outputs.evaluation_id }}
       best_method: ${{ steps.result.outputs.best_method }}
     steps:
-      - name: Require the intended runner
-        shell: bash
-        run: |
-          set -euo pipefail
-          test "$RUNNER_NAME" = "gpuserver6000"
-          test "$RUNNER_OS" = "Linux"
-          test "$RUNNER_ARCH" = "X64"
       - name: Initialize isolated evaluation workspace
         id: workspace
         shell: bash
@@ -587,6 +416,14 @@ jobs:
             echo "HOME=$root/home"
             echo "TMPDIR=$root/tmp"
           } >> "$GITHUB_ENV"
+      - name: Require the intended runner and mounted archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$RUNNER_NAME" = "workstation1"
+          test "$RUNNER_OS" = "Linux"
+          test "$RUNNER_ARCH" = "X64"
+          test -r "$DATASET_ROOT/R01-10.zip"
       - name: Check out exact authorized revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -609,7 +446,9 @@ jobs:
           set -euo pipefail
           candidates=(
             "${CUT3R_PYTHON:-}"
-            "$CUT3R_CHECKOUT/.venv/bin/python"
+            "${CUT3R_CHECKOUT:-}/.venv/bin/python"
+            "/home/florianpfaff/conda_envs/cut3r/bin/python"
+            "/home/florianpfaff/miniconda3/envs/cut3r/bin/python"
             "/home/florian/conda_envs/cut3r/bin/python"
             "/home/github-runner/.conda/envs/cut3r/bin/python"
             "/usr/bin/python3"
@@ -692,7 +531,7 @@ jobs:
   report:
     name: Publish bounded experiment pointer
     if: always() && github.event_name == 'push'
-    needs: [authorize, runtime, predict, evaluate]
+    needs: [authorize, provider, evaluate]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -706,10 +545,9 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           GITHUB_TOKEN: ${{ github.token }}
           REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
-          RUNTIME_DECISION: ${{ needs.runtime.outputs.decision }}
-          RUNTIME_ID: ${{ needs.runtime.outputs.runtime_artifact_id }}
-          PROVIDER_DECISION: ${{ needs.predict.outputs.decision }}
-          PROVIDER_ID: ${{ needs.predict.outputs.provider_bundle_id }}
+          RUNTIME_ID: ${{ needs.provider.outputs.runtime_artifact_id }}
+          PROVIDER_DECISION: ${{ needs.provider.outputs.decision }}
+          PROVIDER_ID: ${{ needs.provider.outputs.provider_bundle_id }}
           EVALUATION_DECISION: ${{ needs.evaluate.outputs.decision }}
           EVALUATION_ID: ${{ needs.evaluate.outputs.evaluation_id }}
           BEST_METHOD: ${{ needs.evaluate.outputs.best_method }}
@@ -723,11 +561,10 @@ jobs:
 
           body = "\n".join(
               (
-                  "## DOT marker-free CUT3R source experiment",
+                  "## DOT marker-free CUT3R source experiment on gpuserver4090",
                   "",
                   f"- request ID: `{os.environ.get('REQUEST_ID') or 'unavailable'}`",
-                  f"- native runtime: `{os.environ.get('RUNTIME_DECISION') or 'skipped'}` / "
-                  f"`{os.environ.get('RUNTIME_ID') or 'unavailable'}`",
+                  f"- native runtime ID: `{os.environ.get('RUNTIME_ID') or 'unavailable'}`",
                   f"- sealed provider: `{os.environ.get('PROVIDER_DECISION') or 'skipped'}` / "
                   f"`{os.environ.get('PROVIDER_ID') or 'unavailable'}`",
                   f"- source evaluation: `{os.environ.get('EVALUATION_DECISION') or 'skipped'}` / "
@@ -735,9 +572,10 @@ jobs:
                   f"- lowest registered source NLL: `{os.environ.get('BEST_METHOD') or 'unavailable'}`",
                   f"- workflow run: {os.environ['RUN_URL']}",
                   "",
-                  "The provider stage opened only R01-R03 normal-view images. Marker payloads "
-                  "were available only to the later job after the provider bundle was sealed. "
-                  "R04-R70 remained unopened. No BayesianPhysTwin or Causal4D outcome was run.",
+                  "The provider stage could open only R01-R03 normal-view images from the "
+                  "official DOT V29 archive. Marker payloads were available only to the "
+                  "later job after the provider bundle was sealed. R04-R70 remained unopened. "
+                  "No BayesianPhysTwin or Causal4D outcome was run.",
               )
           )
           request = urllib.request.Request(

--- a/docs/dot-rope-cut3r-native-provider-v1.md
+++ b/docs/dot-rope-cut3r-native-provider-v1.md
@@ -23,11 +23,38 @@ templates, videos, BayesianPhysTwin outcomes, or Causal4D outcomes.
 ## Runtime qualification
 
 The historical CUT3R Python-RoPE source attempt is terminal and is not retried.
-A first self-hosted job copies the pinned checkout into an isolated workspace,
-builds the native CUDA RoPE extension, emits the existing content-bound runtime
-receipt, and runs a three-frame synthetic forward pass. The compiled extension
-and receipt are transferred as immutable Actions artifacts. The provider job
-must reproduce the same runtime artifact ID before opening a DOT image.
+A self-hosted provider job copies the pinned checkout into an isolated
+workspace, builds the native CUDA RoPE extension, emits the existing
+content-bound runtime receipt, and runs a three-frame synthetic forward pass.
+Only after that runtime smoke passes may the same marker-free job open the
+registered normal-view members and emit a sealed provider bundle. The separate
+evaluation job can open matching marker coordinates only when that bundle is
+present and has the registered `sealed-provider-predictions` disposition.
+
+## Execution route
+
+The reviewed control plane runs on the self-hosted label `gpuserver4090`, whose
+registered runner name is `workstation1`, and uses the official DOT V29 archive
+root:
+
+```text
+/mnt/seagate10tb/florianpfaff/datasets/dot
+```
+
+The earlier request run `33305718723` passed its hosted merged-main
+authorization but was assigned to `workstation2` under the stale
+`gpuserver6000` selector. Its exact-runner assertion failed before checkout,
+workspace creation, model loading, or dataset access; provider prediction and
+marker evaluation were skipped. The reroute changes only the trusted execution
+control plane and mount location. It does not change the scientific protocol,
+source roster, marker-access order, uncertainty methods, thresholds, or reserved
+sequence boundary.
+
+After the reroute is reviewed and merged, execution is requested by a new
+content-addressed change to only
+`protocols/execution_requests/dot_rope_cut3r_native_provider_v1.json`. The push
+workflow rejects forced pushes, new branches, multi-file request commits, an
+unbound protocol blob, or a request whose canonical identity is invalid.
 
 ## Provider comparison
 

--- a/tests/test_trusted_self_hosted_validation_policy.py
+++ b/tests/test_trusted_self_hosted_validation_policy.py
@@ -346,8 +346,9 @@ def test_dot_rope_cut3r_provider_is_main_request_bound_and_stage_sealed() -> Non
     assert "branches: [main]" in text
     assert "dot_rope_cut3r_native_provider_v1.json" in text
     assert "pull_request_target:" not in text
-    assert "runs-on: [self-hosted, Linux, X64, gpuserver6000]" in text
-    assert 'test "$RUNNER_NAME" = "gpuserver6000"' in text
+    assert "runs-on: [self-hosted, Linux, X64, gpuserver4090]" in text
+    assert 'test "$RUNNER_NAME" = "workstation1"' in text
+    assert "DATASET_ROOT: /mnt/seagate10tb/florianpfaff/datasets/dot" in text
     assert "native-rope-extension.tar.gz" in text
     assert "sealed-provider-predictions" in text
     assert "complete-source-evaluation" in text


### PR DESCRIPTION
## Purpose

Execute the already reviewed DOT V29 marker-free CUT3R source study on the available `gpuserver4090` runner and the newly completed official dataset root.

The previous immutable request run `33305718723` passed hosted authorization but was assigned to runner `workstation2` under the stale `gpuserver6000` selector. It failed the first exact-runner assertion before checkout, workspace creation, model loading, or dataset access. Prediction and marker evaluation were skipped; `R04-R70` remain unopened.

## Changes

- route both self-hosted stages through `[self-hosted, Linux, X64, gpuserver4090]`;
- bind the registered runner name `workstation1`;
- use `/mnt/seagate10tb/florianpfaff/datasets/dot` and require readable `R01-10.zip` before provider execution;
- preserve the frozen protocol `af6528f54699f3c9fb185764b029acd897a52e242e799d317e42710ee0f21c2c` and its R01-R03 / R04-R70 boundary;
- keep normal-view prediction and marker evaluation in separate jobs with a sealed provider artifact between them;
- retain the native CUDA RoPE receipt and synthetic forward-pass gate;
- emit bounded provider evidence and a technical receipt on incomplete execution;
- validate the immutable request through the canonical implementation rather than duplicating its schema logic in the workflow;
- update the trusted self-hosted workflow policy and execution documentation.

## Trigger after merge

A subsequent commit will change only `protocols/execution_requests/dot_rope_cut3r_native_provider_v1.json`, with a new canonical request ID. That one-file push is the only execution trigger.

## Scientific boundary

This remains source-development evidence on `R01-R03`. It cannot establish held-out transfer, independent calibration, BayesianPhysTwin benefit, Causal4D benefit, safety, or state of the art. It does not authorize access to `R04-R70`.

Refs #339