### PR TITLE
Fix PointWorld gpuserver6000 runner identity check

### DIFF
--- a/.github/workflows/pointworld-model-load-smoke.yml
+++ b/.github/workflows/pointworld-model-load-smoke.yml
@@ -160,7 +160,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          test "$RUNNER_NAME" = "gpuserver6000"
+          test "$RUNNER_NAME" = "workstation2"
           test "$RUNNER_OS" = "Linux"
           test "$RUNNER_ARCH" = "X64"
           command -v nvidia-smi >/dev/null

--- a/tests/test_trusted_self_hosted_validation_policy.py
+++ b/tests/test_trusted_self_hosted_validation_policy.py
@@ -311,9 +311,9 @@ def test_pointworld_model_load_smoke_is_main_request_bound_and_target_closed() -
     assert "source_protocol_git_blob_sha" in text
     assert "environment: trusted-self-hosted-validation" in text
     assert POINTWORLD_MODEL_LOAD_RUNNER_SELECTOR in text
-    assert 'test "$RUNNER_NAME" = "gpuserver6000"' in text
+    assert 'test "$RUNNER_NAME" = "workstation2"' in text
     assert "host-workstation2" not in text
-    assert 'test "$RUNNER_NAME" = "workstation2"' not in text
+    assert 'test "$RUNNER_NAME" = "gpuserver6000"' not in text
     assert 'test "$RUNNER_OS" = "Linux"' in text
     assert 'test "$RUNNER_ARCH" = "X64"' in text
     assert "command -v nvidia-smi" in text


### PR DESCRIPTION
The `gpuserver6000` value is a self-hosted runner label, while the registered GitHub Actions runner name remains `workstation2`. Run #9 proved the label dispatch works: the job was accepted on the intended machine and failed only because the workflow incorrectly required `RUNNER_NAME=gpuserver6000`.

This keeps `runs-on: [self-hosted, gpuserver6000]`, restores the machine identity check to `RUNNER_NAME=workstation2`, and updates the focused policy test accordingly. No dataset, prediction, residual, or target outcome is opened by this change.