### PR TITLE
Discover retained CUT3R CUDA interpreter on gpuserver4090

### DIFF
--- a/.github/workflows/dot-rope-cut3r-native-provider-v1.yml
+++ b/.github/workflows/dot-rope-cut3r-native-provider-v1.yml
@@ -220,30 +220,87 @@ jobs:
           set -euo pipefail
           test -n "${CUT3R_CHECKOUT:-}"
           test -d "$CUT3R_CHECKOUT"
-          candidates=(
-            "${CUT3R_PYTHON:-}"
-            "$CUT3R_CHECKOUT/.venv/bin/python"
-            "/home/florianpfaff/conda_envs/cut3r/bin/python"
-            "/home/florianpfaff/miniconda3/envs/cut3r/bin/python"
-            "/home/florian/conda_envs/cut3r/bin/python"
-            "/home/github-runner/.conda/envs/cut3r/bin/python"
+
+          candidates=()
+          add_candidate() {
+            local candidate="${1:-}"
+            [[ -n "$candidate" ]] || return 0
+            local existing
+            for existing in "${candidates[@]}"; do
+              [[ "$existing" != "$candidate" ]] || return 0
+            done
+            candidates+=("$candidate")
+          }
+
+          add_candidate "${CUT3R_PYTHON:-}"
+          add_candidate "$CUT3R_CHECKOUT/.venv/bin/python"
+          add_candidate "/home/florianpfaff/conda_envs/cut3r/bin/python"
+          add_candidate "/home/florianpfaff/miniconda3/envs/cut3r/bin/python"
+          add_candidate "/home/florianpfaff/anaconda3/envs/cut3r/bin/python"
+          add_candidate "/home/florian/conda_envs/cut3r/bin/python"
+          add_candidate "/home/florian/miniconda3/envs/cut3r/bin/python"
+          add_candidate "/home/florian/anaconda3/envs/cut3r/bin/python"
+          add_candidate "/home/github-runner/.conda/envs/cut3r/bin/python"
+          add_candidate "/home/github-runner/miniconda3/envs/cut3r/bin/python"
+          add_candidate "/home/github-runner/anaconda3/envs/cut3r/bin/python"
+          add_candidate "/mnt/seagate10tb/florianpfaff/conda_envs/cut3r/bin/python"
+          add_candidate "/opt/conda/envs/cut3r/bin/python"
+
+          roots=(
+            "/home/florianpfaff/conda_envs"
+            "/home/florianpfaff/miniconda3/envs"
+            "/home/florianpfaff/anaconda3/envs"
+            "/home/florian/conda_envs"
+            "/home/florian/miniconda3/envs"
+            "/home/florian/anaconda3/envs"
+            "/home/github-runner/.conda/envs"
+            "/home/github-runner/miniconda3/envs"
+            "/home/github-runner/anaconda3/envs"
+            "/mnt/seagate10tb/florianpfaff/conda_envs"
+            "/opt/conda/envs"
           )
+          for root in "${roots[@]}"; do
+            [[ -d "$root" ]] || continue
+            while IFS= read -r candidate; do
+              add_candidate "$candidate"
+            done < <(
+              find "$root" -mindepth 3 -maxdepth 3 -path '*/bin/python' -executable -print \
+                2>/dev/null | sort
+            )
+          done
+          add_candidate "$(command -v python3 || true)"
+          add_candidate "$(command -v python || true)"
+
           selected=""
           for candidate in "${candidates[@]}"; do
-            [[ -n "$candidate" && -x "$candidate" ]] || continue
-            if "$candidate" - <<'PY' >/dev/null 2>&1
+            [[ -x "$candidate" ]] || continue
+            echo "::group::CUT3R interpreter candidate $candidate"
+            if "$candidate" - <<'PY'
+          import sys
           import numpy
           import PIL
           import torch
-          assert torch.cuda.is_available()
+
+          print(f"python={sys.version.split()[0]}")
+          print(f"torch={torch.__version__}")
+          print(f"cuda_available={torch.cuda.is_available()}")
+          if torch.cuda.is_available():
+              print(f"cuda_device={torch.cuda.get_device_name(0)}")
+          else:
+              raise SystemExit(1)
           PY
             then
               selected="$candidate"
+              echo "Selected $candidate"
+              echo "::endgroup::"
               break
             fi
+            echo "Rejected $candidate"
+            echo "::endgroup::"
           done
           test -n "$selected" || {
             echo "No retained CUDA CUT3R Python environment is usable" >&2
+            echo "Searched explicit CUT3R_PYTHON, checkout .venv, retained Conda roots, and PATH." >&2
             exit 2
           }
           echo "python=$selected" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Purpose

Repair the source-safe technical failure from DOT workflow run `33318657383` without changing the scientific protocol, source roster, marker-access barrier, or target boundary.

The `gpuserver4090` runner and `/mnt/seagate10tb/florianpfaff/datasets/dot/R01-10.zip` were verified successfully. The run stopped before CUT3R model forward or DOT image/marker access because the workflow only checked a short hard-coded Python-path list.

## Change

- keep the exact `gpuserver4090` runner and DOT V29 mount contract;
- search the explicit `CUT3R_PYTHON`, the CUT3R checkout `.venv`, bounded retained Conda roots for the runner accounts/storage, and PATH;
- de-duplicate candidates;
- accept only an executable interpreter importing NumPy/Pillow/PyTorch with CUDA available;
- log Python/PyTorch/CUDA identity for every tested candidate so a retained technical failure is diagnosable.

The synthetic native-RoPE forward pass remains the first full CUT3R runtime test. No dataset or marker payload is opened by interpreter discovery.

## Information boundary

This PR does not modify `protocols/execution_requests/dot_rope_cut3r_native_provider_v1.json` and therefore does not trigger the registered source execution. After review/merge, a separate request-only commit is required. R04–R70 remain reserved; no BayesianPhysTwin or Causal4D outcome is authorized.