### PR TITLE
Fix DOT CUT3R selector under nounset

### DIFF
--- a/.github/workflows/dot-rope-cut3r-native-provider-v1.yml
+++ b/.github/workflows/dot-rope-cut3r-native-provider-v1.yml
@@ -221,7 +221,7 @@ jobs:
           test -n "${CUT3R_CHECKOUT:-}"
           test -d "$CUT3R_CHECKOUT"
 
-          candidates=()
+          candidates=("")
           add_candidate() {
             local candidate="${1:-}"
             [[ -n "$candidate" ]] || return 0


### PR DESCRIPTION
## Purpose

Fix the source-safe technical failure in DOT run `33322175895` without changing any provider, dataset, protocol, or marker-access semantics.

The previous interpreter-discovery patch reached `gpuserver4090`, verified two RTX 4090 GPUs and the official `R01-10.zip`, but exited before testing any Python candidate. On this runner's Bash, expanding a declared-but-empty indexed array under `set -u` aborts the helper.

## Change

Initialize the candidate list with one empty sentinel. The existing candidate loop already ignores non-executable/empty entries, so this preserves all candidate semantics while making the deduplication helper nounset-safe.

This PR changes one line in the workflow. It does not modify the execution request and therefore does not trigger the DOT source experiment. R01-R03 remain unopened by the failed run; R04-R70 remain reserved; no BayesianPhysTwin or Causal4D outcome is authorized.