### PR TITLE
Pin isolated CUT3R runtime to CUDA 12.6

### DIFF
--- a/.github/workflows/bootstrap-dot-cut3r-gpuserver4090-runtime.yml
+++ b/.github/workflows/bootstrap-dot-cut3r-gpuserver4090-runtime.yml
@@ -20,6 +20,7 @@ concurrency:
 env:
   RUNTIME_ROOT: /home/github-runner/.cache/prob4d/cut3r-runtime-v1
   BASE_PYTHON: /home/github-runner/.cache/datasets/venvs/hdetrackv2/bin/python
+  RUNTIME_PYTHON: /home/github-runner/.cache/prob4d/cut3r-runtime-v1/venv/bin/python
   CUT3R_REVISION: 8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf
   CHECKPOINT_NAME: cut3r_512_dpt_4_64.pth
   CHECKPOINT_SHA256: 45f7e98a0a64dbeb54901ae2b878cd8cd125f20a4497316483f0bd6f109f8103
@@ -27,6 +28,8 @@ env:
   PIP_DISABLE_PIP_VERSION_CHECK: "1"
   PYTHONDONTWRITEBYTECODE: "1"
   PYTHONUNBUFFERED: "1"
+  TORCH_CUDA_ARCH_LIST: "8.9"
+  MAX_JOBS: "2"
 
 jobs:
   contract:
@@ -47,8 +50,10 @@ jobs:
           grep -F 'runs-on: [self-hosted, Linux, X64, gpuserver4090]' "$workflow"
           grep -F 'CUT3R_REVISION: 8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf' "$workflow"
           grep -F 'CHECKPOINT_SHA256: 45f7e98a0a64dbeb54901ae2b878cd8cd125f20a4497316483f0bd6f109f8103' "$workflow"
-          grep -F 'BASE_PYTHON: /home/github-runner/.cache/datasets/venvs/hdetrackv2/bin/python' "$workflow"
-          grep -F 'RUNTIME_ROOT: /home/github-runner/.cache/prob4d/cut3r-runtime-v1' "$workflow"
+          grep -F 'RUNTIME_PYTHON: /home/github-runner/.cache/prob4d/cut3r-runtime-v1/venv/bin/python' "$workflow"
+          grep -F 'TORCH_CUDA_ARCH_LIST: "8.9"' "$workflow"
+          grep -F 'torch==2.11.0 torchvision==0.26.0' "$workflow"
+          grep -F 'https://download.pytorch.org/whl/cu126' "$workflow"
 
   bootstrap:
     name: Build frozen CUT3R runtime without DOT access
@@ -63,7 +68,7 @@ jobs:
           ref: ${{ github.sha }}
           persist-credentials: false
           clean: true
-      - name: Verify CUDA base interpreter and toolchain
+      - name: Verify runner and native CUDA toolchain
         shell: bash
         run: |
           set -euo pipefail
@@ -73,27 +78,17 @@ jobs:
           test -x "$BASE_PYTHON"
           command -v git
           command -v c++
+          command -v nvcc
           command -v nvidia-smi
           "$BASE_PYTHON" - <<'PY'
           import sys
-          import torch
-          import torchvision
-          import numpy
-          import PIL
-          print(f"python={sys.version.split()[0]}")
-          print(f"torch={torch.__version__}")
-          print(f"torchvision={torchvision.__version__}")
-          print(f"base_numpy={numpy.__version__}")
-          print(f"base_pillow={PIL.__version__}")
-          print(f"cuda_available={torch.cuda.is_available()}")
-          if not torch.cuda.is_available():
-              raise SystemExit("CUDA unavailable in retained base interpreter")
-          print(f"cuda_device={torch.cuda.get_device_name(0)}")
-          from torch.utils.cpp_extension import CUDA_HOME
-          print(f"cuda_home={CUDA_HOME}")
-          if CUDA_HOME is None:
-              raise SystemExit("PyTorch cannot locate a CUDA toolkit for native RoPE compilation")
+          import venv
+          print(f"bootstrap_python={sys.version.split()[0]}")
+          print(f"venv_module={venv.__name__}")
           PY
+          nvcc --version
+          nvidia-smi --query-gpu=name,driver_version,memory.total --format=csv,noheader
+          nvcc --version | grep -F 'release 12.6'
       - name: Stage exact CUT3R source
         shell: bash
         run: |
@@ -106,19 +101,26 @@ jobs:
           fi
           git -C "$checkout" fetch --force --no-tags origin "$CUT3R_REVISION"
           git -C "$checkout" checkout --detach --force "$CUT3R_REVISION"
+          git -C "$checkout" clean -fdx
           test "$(git -C "$checkout" rev-parse HEAD)" = "$CUT3R_REVISION"
-          test -z "$(git -C "$checkout" status --porcelain=v1 --untracked-files=no)"
-      - name: Build isolated CUT3R dependency layer
+          test -z "$(git -C "$checkout" status --porcelain=v1 --untracked-files=all)"
+      - name: Build isolated CUDA-12.6 CUT3R Python runtime
         shell: bash
         run: |
           set -euo pipefail
           checkout="$RUNTIME_ROOT/CUT3R"
-          deps="$RUNTIME_ROOT/deps"
-          staging="$RUNTIME_ROOT/deps.staging-${GITHUB_RUN_ID}"
+          venv="$RUNTIME_ROOT/venv"
+          staging="$RUNTIME_ROOT/venv.staging-${GITHUB_RUN_ID}"
           filtered="$RUNTIME_ROOT/requirements.runtime.txt"
+          constraints="$RUNTIME_ROOT/constraints.runtime.txt"
           rm -rf "$staging"
-          mkdir -p "$staging"
-          python3 - "$checkout/requirements.txt" "$filtered" <<'PY'
+          "$BASE_PYTHON" -m venv "$staging"
+          runtime_python="$staging/bin/python"
+          test -x "$runtime_python"
+          "$runtime_python" -m pip install \
+            torch==2.11.0 torchvision==0.26.0 \
+            --index-url https://download.pytorch.org/whl/cu126
+          python3 - "$checkout/requirements.txt" "$filtered" "$constraints" <<'PY'
           import re
           import sys
           from pathlib import Path
@@ -131,13 +133,19 @@ jobs:
                   continue
               kept.append(raw)
           Path(sys.argv[2]).write_text("\n".join(kept) + "\n", encoding="utf-8")
+          Path(sys.argv[3]).write_text(
+              "torch==2.11.0\n"
+              "torchvision==0.26.0\n"
+              "numpy==1.26.4\n"
+              "pillow==10.3.0\n",
+              encoding="utf-8",
+          )
           PY
-          "$BASE_PYTHON" -m pip install \
-            --upgrade \
-            --target "$staging" \
+          "$runtime_python" -m pip install \
+            --constraint "$constraints" \
             -r "$filtered" \
             gdown
-          PYTHONPATH="$staging" "$BASE_PYTHON" - <<'PY'
+          "$runtime_python" - <<'PY'
           import accelerate
           import einops
           import gdown
@@ -156,19 +164,34 @@ jobs:
           print(f"runtime_pillow={PIL.__version__}")
           print(f"runtime_torch={torch.__version__}")
           print(f"runtime_torchvision={torchvision.__version__}")
-          assert torch.cuda.is_available()
+          print(f"runtime_cuda={torch.version.cuda}")
+          print(f"cuda_available={torch.cuda.is_available()}")
+          if not torch.__version__.startswith("2.11.0"):
+              raise SystemExit(f"unexpected torch: {torch.__version__}")
+          if not torchvision.__version__.startswith("0.26.0"):
+              raise SystemExit(f"unexpected torchvision: {torchvision.__version__}")
+          if torch.version.cuda != "12.6":
+              raise SystemExit(f"unexpected torch CUDA build: {torch.version.cuda}")
+          if numpy.__version__ != "1.26.4":
+              raise SystemExit(f"unexpected NumPy: {numpy.__version__}")
+          if PIL.__version__ != "10.3.0":
+              raise SystemExit(f"unexpected Pillow: {PIL.__version__}")
+          if not torch.cuda.is_available():
+              raise SystemExit("CUDA unavailable in isolated CUT3R runtime")
+          print(f"cuda_device={torch.cuda.get_device_name(0)}")
           PY
-          rm -rf "$deps.previous"
-          if [[ -d "$deps" ]]; then
-            mv "$deps" "$deps.previous"
+          rm -rf "$venv.previous"
+          if [[ -d "$venv" ]]; then
+            mv "$venv" "$venv.previous"
           fi
-          mv "$staging" "$deps"
-          rm -rf "$deps.previous"
+          mv "$staging" "$venv"
+          rm -rf "$venv.previous"
+          test -x "$RUNTIME_PYTHON"
       - name: Acquire and verify exact CUT3R checkpoint
         shell: bash
         run: |
           set -euo pipefail
-          deps="$RUNTIME_ROOT/deps"
+          test -x "$RUNTIME_PYTHON"
           checkpoint="$RUNTIME_ROOT/$CHECKPOINT_NAME"
           part="$checkpoint.part-${GITHUB_RUN_ID}"
           valid=false
@@ -180,8 +203,8 @@ jobs:
           fi
           if [[ "$valid" != true ]]; then
             rm -f "$part"
-            PYTHONPATH="$deps" CHECKPOINT_GDRIVE_ID="$CHECKPOINT_GDRIVE_ID" PART="$part" \
-              "$BASE_PYTHON" - <<'PY'
+            CHECKPOINT_GDRIVE_ID="$CHECKPOINT_GDRIVE_ID" PART="$part" \
+              "$RUNTIME_PYTHON" - <<'PY'
           import os
           import gdown
 
@@ -205,35 +228,38 @@ jobs:
         run: |
           set -euo pipefail
           checkout="$RUNTIME_ROOT/CUT3R"
-          deps="$RUNTIME_ROOT/deps"
           receipt="$RUNTIME_ROOT/runtime-receipt.json"
           rm -f "$receipt"
-          PYTHONPATH="$GITHUB_WORKSPACE/src:$deps:$checkout:$checkout/src" \
-            "$BASE_PYTHON" \
+          TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST" MAX_JOBS="$MAX_JOBS" \
+            PYTHONPATH="$GITHUB_WORKSPACE/src:$checkout:$checkout/src" \
+            "$RUNTIME_PYTHON" \
             scripts/science/prepare_cut3r_runtime.py \
               --cut3r-checkout "$checkout" \
               --build \
               --output "$receipt"
-          PYTHONPATH="$GITHUB_WORKSPACE/src:$deps:$checkout:$checkout/src" \
-            "$BASE_PYTHON" - <<'PY'
+          PYTHONPATH="$GITHUB_WORKSPACE/src:$checkout:$checkout/src" \
+            "$RUNTIME_PYTHON" - <<'PY'
           import torch
           from dust3r.model import AsymmetricCroCo3DStereo
           print(f"dust3r_model_import={AsymmetricCroCo3DStereo.__name__}")
+          print(f"runtime_torch={torch.__version__}")
+          print(f"runtime_cuda={torch.version.cuda}")
           print(f"cuda_available={torch.cuda.is_available()}")
+          if torch.version.cuda != "12.6":
+              raise SystemExit(f"unexpected torch CUDA build after native RoPE build: {torch.version.cuda}")
           if not torch.cuda.is_available():
-              raise SystemExit("CUDA disappeared after dependency staging")
+              raise SystemExit("CUDA disappeared after native RoPE build")
           PY
       - name: Seal runtime bootstrap manifest
         shell: bash
         run: |
           set -euo pipefail
-          PYTHONPATH="$RUNTIME_ROOT/deps" \
-            RUNTIME_ROOT="$RUNTIME_ROOT" \
-            BASE_PYTHON="$BASE_PYTHON" \
+          RUNTIME_ROOT="$RUNTIME_ROOT" \
+            RUNTIME_PYTHON="$RUNTIME_PYTHON" \
             CUT3R_REVISION="$CUT3R_REVISION" \
             CHECKPOINT_NAME="$CHECKPOINT_NAME" \
             CHECKPOINT_SHA256="$CHECKPOINT_SHA256" \
-            "$BASE_PYTHON" - <<'PY'
+            "$RUNTIME_PYTHON" - <<'PY'
           import hashlib
           import json
           import os
@@ -249,7 +275,7 @@ jobs:
           root = Path(os.environ["RUNTIME_ROOT"])
           receipt = json.loads((root / "runtime-receipt.json").read_text(encoding="utf-8"))
           deps_list = subprocess.run(
-              [os.environ["BASE_PYTHON"], "-m", "pip", "list", "--path", str(root / "deps"), "--format", "json"],
+              [os.environ["RUNTIME_PYTHON"], "-m", "pip", "list", "--format", "json"],
               check=True,
               capture_output=True,
               text=True,
@@ -257,17 +283,18 @@ jobs:
           dependencies = json.loads(deps_list)
           payload = {
               "schema": "prob4d.dot-cut3r-gpuserver4090-runtime-bootstrap",
-              "schema_version": 1,
+              "schema_version": 2,
               "cut3r_revision": os.environ["CUT3R_REVISION"],
               "checkpoint": {
                   "filename": os.environ["CHECKPOINT_NAME"],
                   "sha256": os.environ["CHECKPOINT_SHA256"],
                   "byte_count": (root / os.environ["CHECKPOINT_NAME"]).stat().st_size,
               },
-              "base_python": os.environ["BASE_PYTHON"],
+              "runtime_python": os.environ["RUNTIME_PYTHON"],
               "python_version": platform.python_version(),
               "torch_version": torch.__version__,
               "torchvision_version": torchvision.__version__,
+              "torch_cuda_version": torch.version.cuda,
               "cuda_available": bool(torch.cuda.is_available()),
               "cuda_device": torch.cuda.get_device_name(0) if torch.cuda.is_available() else None,
               "runtime_numpy_version": numpy.__version__,
@@ -287,6 +314,7 @@ jobs:
               "native_rope_artifact_id": payload["native_rope_artifact_id"],
               "checkpoint_sha256": payload["checkpoint"]["sha256"],
               "torch_version": payload["torch_version"],
+              "torch_cuda_version": payload["torch_cuda_version"],
               "cuda_device": payload["cuda_device"],
           }, sort_keys=True))
           PY
@@ -299,5 +327,6 @@ jobs:
             /home/github-runner/.cache/prob4d/cut3r-runtime-v1/runtime-receipt.json
             /home/github-runner/.cache/prob4d/cut3r-runtime-v1/bootstrap-manifest.json
             /home/github-runner/.cache/prob4d/cut3r-runtime-v1/requirements.runtime.txt
+            /home/github-runner/.cache/prob4d/cut3r-runtime-v1/constraints.runtime.txt
           if-no-files-found: warn
           retention-days: 30


### PR DESCRIPTION
## Purpose

Repair the target-closed bootstrap failure from run `33323403454`. Source staging, dependency acquisition, and exact checkpoint verification succeeded. Native RoPE compilation failed because `pip --upgrade --target` transitively replaced the validated Torch runtime with Torch 2.13 / CUDA 13.0, while `gpuserver4090` exposes the native CUDA 12.6 toolkit.

## Change

Build CUT3R in its own persistent venv at `/home/github-runner/.cache/prob4d/cut3r-runtime-v1/venv` and install the official CUDA-12.6 wheels `torch==2.11.0` / `torchvision==0.26.0` before the remaining CUT3R requirements. The remaining resolver is constrained to that Torch pair plus CUT3R's frozen NumPy 1.26.4 and Pillow 10.3.0. Native RoPE is compiled with `TORCH_CUDA_ARCH_LIST=8.9` for the RTX 4090 and the bootstrap manifest records the exact Torch CUDA build.

The already SHA-verified CUT3R checkpoint is reused if present. The shared HDETrack environment is no longer part of the runtime after venv creation; it is used only as the Python executable that creates the isolated venv.

## Information boundary

This changes only the target-closed runtime bootstrap. It contains no DOT dataset path and performs no normal-view, marker, BayesianPhysTwin, or Causal4D access. No execution request is modified.