### PR TITLE
Complete frozen CUT3R CUDA 12.6 runtime

### DIFF
--- a/.github/workflows/complete-dot-cut3r-cu126-runtime.yml
+++ b/.github/workflows/complete-dot-cut3r-cu126-runtime.yml
@@ -1,0 +1,266 @@
+name: Complete DOT CUT3R CUDA 12.6 runtime
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/complete-dot-cut3r-cu126-runtime.yml"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/complete-dot-cut3r-cu126-runtime.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: complete-dot-cut3r-cu126-runtime
+  cancel-in-progress: false
+
+env:
+  RUNTIME_ROOT: /home/github-runner/.cache/prob4d/cut3r-runtime-v1
+  BASE_PYTHON: /home/github-runner/.cache/datasets/venvs/hdetrackv2/bin/python
+  RUNTIME_PYTHON: /home/github-runner/.cache/prob4d/cut3r-runtime-v1/venv/bin/python
+  CUT3R_REVISION: 8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf
+  CHECKPOINT_NAME: cut3r_512_dpt_4_64.pth
+  CHECKPOINT_SHA256: 45f7e98a0a64dbeb54901ae2b878cd8cd125f20a4497316483f0bd6f109f8103
+  CUDA_HOME: /usr/local/cuda
+  TORCH_CUDA_ARCH_LIST: "8.9"
+  MAX_JOBS: "2"
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONDONTWRITEBYTECODE: "1"
+  PYTHONUNBUFFERED: "1"
+
+jobs:
+  contract:
+    name: Validate CUDA-runtime completion contract
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+      - name: Validate frozen identities
+        shell: bash
+        run: |
+          set -euo pipefail
+          workflow=.github/workflows/complete-dot-cut3r-cu126-runtime.yml
+          grep -F 'runs-on: [self-hosted, Linux, X64, gpuserver4090]' "$workflow"
+          grep -F 'CUT3R_REVISION: 8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf' "$workflow"
+          grep -F 'CHECKPOINT_SHA256: 45f7e98a0a64dbeb54901ae2b878cd8cd125f20a4497316483f0bd6f109f8103' "$workflow"
+          grep -F 'CUDA_HOME: /usr/local/cuda' "$workflow"
+          grep -F 'TORCH_CUDA_ARCH_LIST: "8.9"' "$workflow"
+          grep -F 'torch==2.11.0 torchvision==0.26.0' "$workflow"
+
+  complete:
+    name: Complete frozen CUT3R runtime without DOT access
+    if: github.event_name == 'push'
+    environment: trusted-self-hosted-validation
+    runs-on: [self-hosted, Linux, X64, gpuserver4090]
+    timeout-minutes: 180
+    steps:
+      - name: Check out exact Prob4D revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          clean: true
+      - name: Verify persistent frozen inputs and CUDA 12.6
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$RUNNER_NAME" = "workstation1"
+          test "$RUNNER_OS" = "Linux"
+          test "$RUNNER_ARCH" = "X64"
+          test -x "$BASE_PYTHON"
+          test -x "$CUDA_HOME/bin/nvcc"
+          "$CUDA_HOME/bin/nvcc" --version
+          "$CUDA_HOME/bin/nvcc" --version | grep -F 'release 12.6'
+          echo "$CUDA_HOME/bin" >> "$GITHUB_PATH"
+          checkout="$RUNTIME_ROOT/CUT3R"
+          checkpoint="$RUNTIME_ROOT/$CHECKPOINT_NAME"
+          test -d "$checkout/.git"
+          test "$(git -C "$checkout" rev-parse HEAD)" = "$CUT3R_REVISION"
+          git -C "$checkout" clean -fdx
+          test -z "$(git -C "$checkout" status --porcelain=v1 --untracked-files=all)"
+          test -f "$checkpoint"
+          test "$(sha256sum "$checkpoint" | awk '{print $1}')" = "$CHECKPOINT_SHA256"
+          test "$(stat -c '%s' "$checkpoint")" = "3173761006"
+          nvidia-smi --query-gpu=name,driver_version,memory.total --format=csv,noheader
+      - name: Create isolated CUT3R CUDA-12.6 venv
+        shell: bash
+        run: |
+          set -euo pipefail
+          checkout="$RUNTIME_ROOT/CUT3R"
+          staging="$RUNTIME_ROOT/venv.staging-${GITHUB_RUN_ID}"
+          filtered="$RUNTIME_ROOT/requirements.runtime.txt"
+          constraints="$RUNTIME_ROOT/constraints.runtime.txt"
+          rm -rf "$staging"
+          "$BASE_PYTHON" -m venv "$staging"
+          py="$staging/bin/python"
+          "$py" -m pip install \
+            torch==2.11.0 torchvision==0.26.0 \
+            --index-url https://download.pytorch.org/whl/cu126
+          python3 - "$checkout/requirements.txt" "$filtered" "$constraints" <<'PY'
+          import re
+          import sys
+          from pathlib import Path
+
+          source = Path(sys.argv[1]).read_text(encoding="utf-8").splitlines()
+          kept = []
+          for raw in source:
+              stripped = raw.strip()
+              if re.match(r"^(torch|torchvision)(?:\s|[<>=!~].*)?$", stripped, flags=re.I):
+                  continue
+              kept.append(raw)
+          Path(sys.argv[2]).write_text("\n".join(kept) + "\n", encoding="utf-8")
+          Path(sys.argv[3]).write_text(
+              "torch==2.11.0\n"
+              "torchvision==0.26.0\n"
+              "numpy==1.26.4\n"
+              "pillow==10.3.0\n",
+              encoding="utf-8",
+          )
+          PY
+          "$py" -m pip install --constraint "$constraints" -r "$filtered" gdown
+          "$py" - <<'PY'
+          import numpy
+          import PIL
+          import torch
+          import torchvision
+          print(f"torch={torch.__version__}")
+          print(f"torchvision={torchvision.__version__}")
+          print(f"torch_cuda={torch.version.cuda}")
+          print(f"numpy={numpy.__version__}")
+          print(f"pillow={PIL.__version__}")
+          print(f"cuda_available={torch.cuda.is_available()}")
+          if not torch.__version__.startswith("2.11.0"):
+              raise SystemExit(torch.__version__)
+          if not torchvision.__version__.startswith("0.26.0"):
+              raise SystemExit(torchvision.__version__)
+          if torch.version.cuda != "12.6":
+              raise SystemExit(str(torch.version.cuda))
+          if numpy.__version__ != "1.26.4":
+              raise SystemExit(numpy.__version__)
+          if PIL.__version__ != "10.3.0":
+              raise SystemExit(PIL.__version__)
+          if not torch.cuda.is_available():
+              raise SystemExit("CUDA unavailable")
+          print(f"cuda_device={torch.cuda.get_device_name(0)}")
+          PY
+          rm -rf "$RUNTIME_ROOT/venv.previous"
+          if [[ -d "$RUNTIME_ROOT/venv" ]]; then
+            mv "$RUNTIME_ROOT/venv" "$RUNTIME_ROOT/venv.previous"
+          fi
+          mv "$staging" "$RUNTIME_ROOT/venv"
+          rm -rf "$RUNTIME_ROOT/venv.previous"
+          test -x "$RUNTIME_PYTHON"
+      - name: Compile and attest native CUT3R RoPE
+        shell: bash
+        run: |
+          set -euo pipefail
+          checkout="$RUNTIME_ROOT/CUT3R"
+          receipt="$RUNTIME_ROOT/runtime-receipt.json"
+          rm -f "$receipt"
+          PATH="$CUDA_HOME/bin:$PATH" \
+            CUDA_HOME="$CUDA_HOME" \
+            TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST" \
+            MAX_JOBS="$MAX_JOBS" \
+            PYTHONPATH="$GITHUB_WORKSPACE/src:$checkout:$checkout/src" \
+            "$RUNTIME_PYTHON" \
+            scripts/science/prepare_cut3r_runtime.py \
+              --cut3r-checkout "$checkout" \
+              --build \
+              --output "$receipt"
+          PYTHONPATH="$GITHUB_WORKSPACE/src:$checkout:$checkout/src" \
+            "$RUNTIME_PYTHON" - <<'PY'
+          import torch
+          from dust3r.model import AsymmetricCroCo3DStereo
+          print(f"dust3r_model_import={AsymmetricCroCo3DStereo.__name__}")
+          print(f"torch={torch.__version__}")
+          print(f"torch_cuda={torch.version.cuda}")
+          print(f"cuda_available={torch.cuda.is_available()}")
+          if torch.version.cuda != "12.6" or not torch.cuda.is_available():
+              raise SystemExit("runtime CUDA contract failed")
+          PY
+      - name: Seal content-addressed runtime manifest
+        shell: bash
+        run: |
+          set -euo pipefail
+          RUNTIME_ROOT="$RUNTIME_ROOT" \
+            RUNTIME_PYTHON="$RUNTIME_PYTHON" \
+            CUT3R_REVISION="$CUT3R_REVISION" \
+            CHECKPOINT_NAME="$CHECKPOINT_NAME" \
+            CHECKPOINT_SHA256="$CHECKPOINT_SHA256" \
+            "$RUNTIME_PYTHON" - <<'PY'
+          import hashlib
+          import json
+          import os
+          import platform
+          import subprocess
+          from pathlib import Path
+
+          import numpy
+          import PIL
+          import torch
+          import torchvision
+
+          root = Path(os.environ["RUNTIME_ROOT"])
+          receipt = json.loads((root / "runtime-receipt.json").read_text(encoding="utf-8"))
+          deps = json.loads(subprocess.run(
+              [os.environ["RUNTIME_PYTHON"], "-m", "pip", "list", "--format", "json"],
+              check=True,
+              capture_output=True,
+              text=True,
+          ).stdout)
+          payload = {
+              "schema": "prob4d.dot-cut3r-gpuserver4090-runtime-bootstrap",
+              "schema_version": 3,
+              "cut3r_revision": os.environ["CUT3R_REVISION"],
+              "checkpoint": {
+                  "filename": os.environ["CHECKPOINT_NAME"],
+                  "sha256": os.environ["CHECKPOINT_SHA256"],
+                  "byte_count": (root / os.environ["CHECKPOINT_NAME"]).stat().st_size,
+              },
+              "runtime_python": os.environ["RUNTIME_PYTHON"],
+              "python_version": platform.python_version(),
+              "torch_version": torch.__version__,
+              "torchvision_version": torchvision.__version__,
+              "torch_cuda_version": torch.version.cuda,
+              "cuda_available": bool(torch.cuda.is_available()),
+              "cuda_device": torch.cuda.get_device_name(0) if torch.cuda.is_available() else None,
+              "numpy_version": numpy.__version__,
+              "pillow_version": PIL.__version__,
+              "dependencies": deps,
+              "native_rope_artifact_id": receipt["artifact_id"],
+              "dot_dataset_accessed": False,
+          }
+          canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+          payload["bootstrap_id"] = hashlib.sha256(canonical).hexdigest()
+          (root / "bootstrap-manifest.json").write_text(
+              json.dumps(payload, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          print(json.dumps({
+              "bootstrap_id": payload["bootstrap_id"],
+              "native_rope_artifact_id": payload["native_rope_artifact_id"],
+              "torch_version": payload["torch_version"],
+              "torch_cuda_version": payload["torch_cuda_version"],
+              "checkpoint_sha256": payload["checkpoint"]["sha256"],
+              "cuda_device": payload["cuda_device"],
+          }, sort_keys=True))
+          PY
+      - name: Upload compact runtime receipts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dot-cut3r-cu126-runtime-${{ github.run_id }}
+          path: |
+            /home/github-runner/.cache/prob4d/cut3r-runtime-v1/runtime-receipt.json
+            /home/github-runner/.cache/prob4d/cut3r-runtime-v1/bootstrap-manifest.json
+            /home/github-runner/.cache/prob4d/cut3r-runtime-v1/requirements.runtime.txt
+            /home/github-runner/.cache/prob4d/cut3r-runtime-v1/constraints.runtime.txt
+          if-no-files-found: warn
+          retention-days: 30


### PR DESCRIPTION
## Purpose

Complete the target-closed CUT3R runtime using the source and checkpoint already staged and verified by the earlier bootstrap. Run `33323862459` stopped only because `nvcc` is installed at `/usr/local/cuda/bin/nvcc` rather than on the Actions PATH.

## Runtime contract

- exact CUT3R revision `8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf`;
- exact checkpoint `cut3r_512_dpt_4_64.pth`, SHA-256 `45f7e98a0a64dbeb54901ae2b878cd8cd125f20a4497316483f0bd6f109f8103`, 3,173,761,006 bytes;
- native toolkit `/usr/local/cuda`, required CUDA 12.6;
- isolated persistent venv with `torch==2.11.0`, `torchvision==0.26.0`, official cu126 wheels, CUT3R NumPy/Pillow pins, and remaining upstream requirements;
- native RoPE compiled for RTX 4090 (`sm_89`);
- content-addressed runtime manifest with exact dependency list and `dot_dataset_accessed=false`.

The shared HDETrack Python is used only to create the venv. No DOT archive, normal-view image, marker payload, BayesianPhysTwin outcome, or Causal4D outcome is referenced or opened.