### PR TITLE
[Superseded by #372] Bind the DOT CUT3R runtime to the host CUDA 12.6 toolkit

### DIFF
--- a/.github/workflows/bootstrap-dot-cut3r-gpuserver4090-runtime.yml
+++ b/.github/workflows/bootstrap-dot-cut3r-gpuserver4090-runtime.yml
@@ -21,6 +21,7 @@ env:
   RUNTIME_ROOT: /home/github-runner/.cache/prob4d/cut3r-runtime-v1
   BASE_PYTHON: /home/github-runner/.cache/datasets/venvs/hdetrackv2/bin/python
   RUNTIME_PYTHON: /home/github-runner/.cache/prob4d/cut3r-runtime-v1/venv/bin/python
+  CUDA_HOME: /usr/local/cuda
   CUT3R_REVISION: 8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf
   CHECKPOINT_NAME: cut3r_512_dpt_4_64.pth
   CHECKPOINT_SHA256: 45f7e98a0a64dbeb54901ae2b878cd8cd125f20a4497316483f0bd6f109f8103
@@ -51,6 +52,7 @@ jobs:
           grep -F 'CUT3R_REVISION: 8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf' "$workflow"
           grep -F 'CHECKPOINT_SHA256: 45f7e98a0a64dbeb54901ae2b878cd8cd125f20a4497316483f0bd6f109f8103' "$workflow"
           grep -F 'RUNTIME_PYTHON: /home/github-runner/.cache/prob4d/cut3r-runtime-v1/venv/bin/python' "$workflow"
+          grep -F 'CUDA_HOME: /usr/local/cuda' "$workflow"
           grep -F 'TORCH_CUDA_ARCH_LIST: "8.9"' "$workflow"
           grep -F 'torch==2.11.0 torchvision==0.26.0' "$workflow"
           grep -F 'https://download.pytorch.org/whl/cu126' "$workflow"
@@ -76,9 +78,9 @@ jobs:
           test "$RUNNER_OS" = "Linux"
           test "$RUNNER_ARCH" = "X64"
           test -x "$BASE_PYTHON"
+          test -x "$CUDA_HOME/bin/nvcc"
           command -v git
           command -v c++
-          command -v nvcc
           command -v nvidia-smi
           "$BASE_PYTHON" - <<'PY'
           import sys
@@ -86,9 +88,9 @@ jobs:
           print(f"bootstrap_python={sys.version.split()[0]}")
           print(f"venv_module={venv.__name__}")
           PY
-          nvcc --version
+          "$CUDA_HOME/bin/nvcc" --version
           nvidia-smi --query-gpu=name,driver_version,memory.total --format=csv,noheader
-          nvcc --version | grep -F 'release 12.6'
+          "$CUDA_HOME/bin/nvcc" --version | grep -F 'release 12.6'
       - name: Stage exact CUT3R source
         shell: bash
         run: |
@@ -230,7 +232,8 @@ jobs:
           checkout="$RUNTIME_ROOT/CUT3R"
           receipt="$RUNTIME_ROOT/runtime-receipt.json"
           rm -f "$receipt"
-          TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST" MAX_JOBS="$MAX_JOBS" \
+          CUDA_HOME="$CUDA_HOME" \
+            TORCH_CUDA_ARCH_LIST="$TORCH_CUDA_ARCH_LIST" MAX_JOBS="$MAX_JOBS" \
             PYTHONPATH="$GITHUB_WORKSPACE/src:$checkout:$checkout/src" \
             "$RUNTIME_PYTHON" \
             scripts/science/prepare_cut3r_runtime.py \


### PR DESCRIPTION
Superseded by merged PR #372, which already binds `CUDA_HOME=/usr/local/cuda`, invokes the CUDA 12.6 compiler by absolute path, reuses the staged exact CUT3R source/checkpoint, and completes the dedicated runtime without DOT access. This duplicate branch changed no data, model, checkpoint, or scientific protocol and opened no DOT payload.