### PR TITLE
Bind Deform360 audit to canonical processed repository

### DIFF
--- a/.github/workflows/deform360-source-bundle-audit.yml
+++ b/.github/workflows/deform360-source-bundle-audit.yml
@@ -26,7 +26,7 @@ concurrency:
 env:
   REQUEST_PATH: protocols/execution_requests/deform360_source_bundle_audit_v1.json
   PROTOCOL_PATH: protocols/deform360-source-bundle-audit-v1.json
-  SOURCE_ROOT: /home/florianpfaff/deform360-fresh-source-processed-v1-1a3f9b1
+  SOURCE_ROOT: /mnt/seagate10tb/florianpfaff/datasets/deform360/processed-repository
   metadata_access_authorized: "true"
   file_content_reads_authorized: "false"
   prediction_execution_authorized: "false"
@@ -189,7 +189,7 @@ jobs:
           test "$(/usr/bin/git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
           test -z "$(/usr/bin/git status --porcelain=v1 --untracked-files=all)"
           test "$SOURCE_ROOT" = \
-            "/home/florianpfaff/deform360-fresh-source-processed-v1-1a3f9b1"
+            "/mnt/seagate10tb/florianpfaff/datasets/deform360/processed-repository"
           test "$metadata_access_authorized" = "true"
           test "$file_content_reads_authorized" = "false"
           test "$prediction_execution_authorized" = "false"

--- a/docs/deform360-source-bundle-audit.md
+++ b/docs/deform360-source-bundle-audit.md
@@ -1,11 +1,11 @@
 # Deform360 processed source-bundle metadata audit
 
 This audit is the first source-only step toward a fresh real-provider study for
-Prob4D issue #49. It inventories the already staged processed source bundle on
+Prob4D issue #49. It inventories the canonical processed Deform360 repository on
 the self-hosted runner labelled `gpuserver4090`:
 
 ```text
-/home/florianpfaff/deform360-fresh-source-processed-v1-1a3f9b1
+/mnt/seagate10tb/florianpfaff/datasets/deform360/processed-repository
 ```
 
 The audit establishes whether the reviewed path is present, traversable, and

--- a/protocols/deform360-source-bundle-audit-v1.json
+++ b/protocols/deform360-source-bundle-audit-v1.json
@@ -19,13 +19,13 @@
   "metadata_access_authorized": true,
   "prediction_execution_authorized": false,
   "profile": "deform360-source-bundle-audit-v1",
-  "protocol_id": "70aa9a0ced4d537abd5848b3b405fbc23a1f272fa8e3ca3a7ee14de12231af50",
+  "protocol_id": "fe08a93348a22c69aa1a405cd2374ffb38891b3e237e5657a74dd6c8bbde25d5",
   "provider_residuals_authorized": false,
   "root_symlink_target_reporting_authorized": true,
   "runner_label": "gpuserver4090",
   "schema": "prob4d.deform360-source-bundle-audit-protocol",
   "schema_version": 1,
-  "source_root": "/home/github-runner/.cache/datasets/deform360-fresh-source-processed-v1-1a3f9b1",
+  "source_root": "/mnt/seagate10tb/florianpfaff/datasets/deform360/processed-repository",
   "target_outcomes_authorized": false,
   "target_payloads_authorized": false
 }

--- a/scripts/science/audit_deform360_source_bundle.py
+++ b/scripts/science/audit_deform360_source_bundle.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Bind the Deform360 metadata audit to its reviewed physical source directory."""
+"""Bind the Deform360 metadata audit to the reviewed processed repository."""
 
 from __future__ import annotations
 
@@ -16,7 +16,7 @@ if _SPEC is None or _SPEC.loader is None:
 _IMPLEMENTATION = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(_IMPLEMENTATION)
 _IMPLEMENTATION.EXPECTED_SOURCE_ROOT = Path(
-    "/home/github-runner/.cache/datasets/deform360-fresh-source-processed-v1-1a3f9b1"
+    "/mnt/seagate10tb/florianpfaff/datasets/deform360/processed-repository"
 )
 
 for _name in dir(_IMPLEMENTATION):

--- a/tests/test_deform360_source_bundle_workflow_policy.py
+++ b/tests/test_deform360_source_bundle_workflow_policy.py
@@ -82,7 +82,9 @@ def test_source_root_link_is_reported_without_resolution_or_traversal() -> None:
 def test_source_path_and_forbidden_boundaries_are_literal() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
 
-    assert ("SOURCE_ROOT: /home/florianpfaff/deform360-fresh-source-processed-v1-1a3f9b1") in text
+    assert (
+        "SOURCE_ROOT: /mnt/seagate10tb/florianpfaff/datasets/deform360/processed-repository"
+    ) in text
     assert "dataset_file_contents_opened" in text
     assert "follow symlinks" in text
     assert "target_payloads_opened" in text

--- a/tests/test_trusted_self_hosted_validation_policy.py
+++ b/tests/test_trusted_self_hosted_validation_policy.py
@@ -15,9 +15,7 @@ DOT_ROPE_CUT3R_NATIVE_PROVIDER_WORKFLOW = WORKFLOW_ROOT / "dot-rope-cut3r-native
 DOT_CUT3R_RUNTIME_BOOTSTRAP_WORKFLOW = (
     WORKFLOW_ROOT / "bootstrap-dot-cut3r-gpuserver4090-runtime.yml"
 )
-DOT_CUT3R_RUNTIME_COMPLETE_WORKFLOW = (
-    WORKFLOW_ROOT / "complete-dot-cut3r-cu126-runtime.yml"
-)
+DOT_CUT3R_RUNTIME_COMPLETE_WORKFLOW = WORKFLOW_ROOT / "complete-dot-cut3r-cu126-runtime.yml"
 CUT3R_RUNNER_SELECTOR = (
     "runs-on: [self-hosted, Linux, X64, nvidia-smi, "
     + "data-prob4d-deform360-source-v1, prob4d-cut3r]"


### PR DESCRIPTION
## Purpose

Use the canonical processed Deform360 repository supplied for the `gpuserver4090` runner:

`/mnt/seagate10tb/florianpfaff/datasets/deform360/processed-repository`

## Change

- rebind the retained metadata-only scanner to the canonical processed repository;
- update the content-addressed protocol;
- align the workflow's fixed root, policy test, and documentation.

## Boundary

This remains a metadata-only source qualification. Dataset file contents, provider predictions, residuals, target payloads, target outcomes, BayesianPhysTwin innovations, Causal4D outcomes, and dataset mutation remain unauthorized. Symlinks are not followed.

After merge, execution will be requested through a separate commit changing only `protocols/execution_requests/deform360_source_bundle_audit_v1.json`, so the reviewed single-file trigger contract remains intact.

Related: #49.