### PR TITLE
Fix pinned CUT3R model import in CUDA runtime completion

### DIFF
--- a/.github/workflows/complete-dot-cut3r-cu126-runtime.yml
+++ b/.github/workflows/complete-dot-cut3r-cu126-runtime.yml
@@ -62,6 +62,11 @@ jobs:
           grep -F 'torch==2.11.0 torchvision==0.26.0' "$workflow"
           grep -F 'EXPECTED_CUROPE_KERNELS_BLOB: 7156cd1bb935cb1f0be45e58add53f9c21505c20' "$workflow"
           grep -F 'EXPECTED_CUROPE_SETUP_BLOB: 02ddb0912370a67a49fd2bb91164cf2f1da8648e' "$workflow"
+          grep -F 'from dust3r.model import ARCroco3DStereo' "$workflow"
+          if grep -F 'AsymmetricCroCo3DStereo' "$workflow"; then
+            echo "incorrect upstream model class remains" >&2
+            exit 2
+          fi
           test -f "$patch"
           git apply --numstat "$patch"
           grep -F 'tokens.scalar_type()' "$patch"
@@ -267,8 +272,8 @@ jobs:
           PYTHONPATH="$GITHUB_WORKSPACE/src:$checkout:$checkout/src" \
             "$RUNTIME_PYTHON" - <<'PY'
           import torch
-          from dust3r.model import AsymmetricCroCo3DStereo
-          print(f"dust3r_model_import={AsymmetricCroCo3DStereo.__name__}")
+          from dust3r.model import ARCroco3DStereo
+          print(f"dust3r_model_import={ARCroco3DStereo.__name__}")
           print(f"torch={torch.__version__}")
           print(f"torch_cuda={torch.version.cuda}")
           print(f"cuda_available={torch.cuda.is_available()}")

--- a/.github/workflows/complete-dot-cut3r-cu126-runtime.yml
+++ b/.github/workflows/complete-dot-cut3r-cu126-runtime.yml
@@ -63,7 +63,8 @@ jobs:
           grep -F 'EXPECTED_CUROPE_KERNELS_BLOB: 7156cd1bb935cb1f0be45e58add53f9c21505c20' "$workflow"
           grep -F 'EXPECTED_CUROPE_SETUP_BLOB: 02ddb0912370a67a49fd2bb91164cf2f1da8648e' "$workflow"
           grep -F 'from dust3r.model import ARCroco3DStereo' "$workflow"
-          if grep -F 'AsymmetricCroCo3DStereo' "$workflow"; then
+          obsolete="Asymmetric""CroCo3DStereo"
+          if grep -F "from dust3r.model import $obsolete" "$workflow"; then
             echo "incorrect upstream model class remains" >&2
             exit 2
           fi


### PR DESCRIPTION
## Purpose

Repair the final source-bound import probe in the DOT CUT3R CUDA 12.6 runtime workflow before opening any DOT payload.

The previous self-hosted run successfully:

- created the isolated PyTorch 2.11.0+cu126 environment;
- verified CUDA 12.6 and the RTX 4090 runner;
- applied the frozen two-file compatibility patch;
- compiled and linked the native `curope` SM 89 extension.

It then failed because the workflow imported `AsymmetricCroCo3DStereo`, which does not exist at the pinned CUT3R revision. That revision exports `ARCroco3DStereo` from `src/dust3r/model.py`.

## Change

- replace only the incorrect import/probe name with `ARCroco3DStereo`;
- make the hosted contract assert the correct symbol and reject the obsolete one.

## Boundary

No dataset path is read by this workflow. Model weights, provider equations, checkpoint identity, CUT3R revision, PyTorch/CUDA versions, native patch, DOT protocol, source sequences, and reserved sequences are unchanged. Merging this workflow-file change deliberately triggers the target-closed runtime completion job on `[self-hosted, Linux, X64, gpuserver4090]`.