### PR TITLE
Repair hash-bound CUT3R checkpoint loading for DOT runtime

### DIFF
--- a/scripts/science/prepare_cut3r_runtime.py
+++ b/scripts/science/prepare_cut3r_runtime.py
@@ -4,12 +4,28 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
 
 from prob4d.cut3r_runtime_contract import require_compiled_cut3r_rope
+
+_TRUSTED_REQUEST_PATH = (
+    "protocols/execution_requests/dot_rope_cut3r_sealed_runtime_v1.json"
+)
+_TRUSTED_CUT3R_REVISION = "8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf"
+_TRUSTED_CHECKPOINT_SHA256 = (
+    "45f7e98a0a64dbeb54901ae2b878cd8cd125f20a4497316483f0bd6f109f8103"
+)
+_TRUSTED_MODEL_RELATIVE_PATH = Path("src/dust3r/model.py")
+_TRUSTED_MODEL_GIT_BLOB_SHA1 = "7ed9f6106fb063686990c874ede99876ebc939ab"
+_ORIGINAL_LOAD_CALL = '    ckpt = torch.load(model_path, map_location="cpu")\n'
+_PATCHED_LOAD_CALL = (
+    '    ckpt = torch.load(model_path, map_location="cpu", weights_only=False)\n'
+)
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -39,6 +55,94 @@ def _write_no_clobber(path: Path, payload: dict[str, object]) -> None:
             raise
 
 
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _git_blob_sha1(payload: bytes) -> str:
+    framed = f"blob {len(payload)}\0".encode("ascii") + payload
+    return hashlib.sha1(framed, usedforsecurity=False).hexdigest()
+
+
+def _content_id(payload: dict[str, object]) -> str:
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _prepare_trusted_checkpoint_compatibility(
+    checkout: Path,
+) -> dict[str, object] | None:
+    """Patch one hash-pinned CUT3R loader in the isolated DOT runtime copy."""
+
+    if os.environ.get("REQUEST_PATH") != _TRUSTED_REQUEST_PATH:
+        return None
+    if os.environ.get("CUT3R_REVISION") != _TRUSTED_CUT3R_REVISION:
+        raise RuntimeError("trusted CUT3R checkpoint compatibility revision changed")
+    if os.environ.get("CUT3R_CHECKPOINT_SHA256") != _TRUSTED_CHECKPOINT_SHA256:
+        raise RuntimeError("trusted CUT3R checkpoint compatibility digest changed")
+
+    checkpoint_text = os.environ.get("CUT3R_RUNTIME_CHECKPOINT")
+    if not checkpoint_text:
+        raise RuntimeError("trusted CUT3R checkpoint path is missing")
+    checkpoint = Path(checkpoint_text).expanduser().resolve(strict=True)
+    if not checkpoint.is_file():
+        raise RuntimeError("trusted CUT3R checkpoint is not a regular file")
+    if _sha256(checkpoint) != _TRUSTED_CHECKPOINT_SHA256:
+        raise RuntimeError("trusted CUT3R checkpoint bytes changed")
+
+    model_path = checkout / _TRUSTED_MODEL_RELATIVE_PATH
+    if model_path.is_symlink():
+        raise RuntimeError("trusted CUT3R model source must not be a symbolic link")
+    resolved_model = model_path.resolve(strict=True)
+    try:
+        resolved_model.relative_to(checkout)
+    except ValueError as error:
+        raise RuntimeError("trusted CUT3R model source escapes the checkout") from error
+    if not resolved_model.is_file():
+        raise RuntimeError("trusted CUT3R model source is not a regular file")
+
+    source = resolved_model.read_bytes()
+    source_blob = _git_blob_sha1(source)
+    if source_blob != _TRUSTED_MODEL_GIT_BLOB_SHA1:
+        raise RuntimeError("trusted CUT3R model source bytes changed")
+    text = source.decode("utf-8")
+    if text.count(_ORIGINAL_LOAD_CALL) != 1 or _PATCHED_LOAD_CALL in text:
+        raise RuntimeError("trusted CUT3R checkpoint load call changed")
+
+    patched = text.replace(_ORIGINAL_LOAD_CALL, _PATCHED_LOAD_CALL, 1).encode("utf-8")
+    resolved_model.write_bytes(patched)
+    record: dict[str, object] = {
+        "schema": "prob4d.cut3r-trusted-checkpoint-load-compatibility",
+        "schema_version": 1,
+        "status": "trusted-legacy-checkpoint-loader-enabled",
+        "request_path": _TRUSTED_REQUEST_PATH,
+        "cut3r_revision": _TRUSTED_CUT3R_REVISION,
+        "source_member": _TRUSTED_MODEL_RELATIVE_PATH.as_posix(),
+        "source_git_blob_sha1": source_blob,
+        "source_sha256": hashlib.sha256(source).hexdigest(),
+        "patched_sha256": hashlib.sha256(patched).hexdigest(),
+        "checkpoint_name": checkpoint.name,
+        "checkpoint_sha256": _TRUSTED_CHECKPOINT_SHA256,
+        "torch_load_policy": "weights_only=False at the exact pinned CUT3R load_model call",
+        "security_boundary": (
+            "Legacy pickle loading is enabled only after the exact CUT3R revision, "
+            "source blob, execution request, and checkpoint SHA-256 are verified."
+        ),
+    }
+    record["artifact_id"] = _content_id(record)
+    return record
+
+
 def main() -> int:
     args = _parser().parse_args()
     checkout = args.cut3r_checkout.expanduser().resolve(strict=True)
@@ -59,7 +163,13 @@ def main() -> int:
         raise SystemExit(
             "verified CUT3R runtime receipt differs from the frozen artifact ID"
         )
+    compatibility = _prepare_trusted_checkpoint_compatibility(checkout)
     _write_no_clobber(args.output, receipt)
+    if compatibility is not None:
+        _write_no_clobber(
+            args.output.with_name("checkpoint-load-compatibility.json"),
+            compatibility,
+        )
     print(receipt["artifact_id"])
     return 0
 

--- a/tests/test_prepare_cut3r_runtime.py
+++ b/tests/test_prepare_cut3r_runtime.py
@@ -23,11 +23,11 @@ def _configure_fixture(monkeypatch, module, tmp_path: Path) -> tuple[Path, Path,
     model_path = checkout / "src/dust3r/model.py"
     model_path.parent.mkdir(parents=True)
     source = (
-        "import torch\n\n"
-        "def load_model(model_path):\n"
-        '    ckpt = torch.load(model_path, map_location="cpu")\n'
-        "    return ckpt\n"
-    ).encode("utf-8")
+        b"import torch\n\n"
+        b"def load_model(model_path):\n"
+        b'    ckpt = torch.load(model_path, map_location="cpu")\n'
+        b"    return ckpt\n"
+    )
     model_path.write_bytes(source)
 
     checkpoint = tmp_path / "model.pth"

--- a/tests/test_prepare_cut3r_runtime.py
+++ b/tests/test_prepare_cut3r_runtime.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts/science/prepare_cut3r_runtime.py"
+
+
+def _load_script():
+    spec = importlib.util.spec_from_file_location("prepare_cut3r_runtime", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _configure_fixture(monkeypatch, module, tmp_path: Path) -> tuple[Path, Path, bytes]:
+    checkout = tmp_path / "CUT3R"
+    model_path = checkout / "src/dust3r/model.py"
+    model_path.parent.mkdir(parents=True)
+    source = (
+        "import torch\n\n"
+        "def load_model(model_path):\n"
+        '    ckpt = torch.load(model_path, map_location="cpu")\n'
+        "    return ckpt\n"
+    ).encode("utf-8")
+    model_path.write_bytes(source)
+
+    checkpoint = tmp_path / "model.pth"
+    checkpoint.write_bytes(b"exact trusted checkpoint fixture")
+    checkpoint_sha256 = hashlib.sha256(checkpoint.read_bytes()).hexdigest()
+
+    monkeypatch.setattr(
+        module,
+        "_TRUSTED_MODEL_GIT_BLOB_SHA1",
+        module._git_blob_sha1(source),
+    )
+    monkeypatch.setattr(module, "_TRUSTED_CHECKPOINT_SHA256", checkpoint_sha256)
+    monkeypatch.setenv("REQUEST_PATH", module._TRUSTED_REQUEST_PATH)
+    monkeypatch.setenv("CUT3R_REVISION", module._TRUSTED_CUT3R_REVISION)
+    monkeypatch.setenv("CUT3R_CHECKPOINT_SHA256", checkpoint_sha256)
+    monkeypatch.setenv("CUT3R_RUNTIME_CHECKPOINT", str(checkpoint))
+    return checkout, model_path, source
+
+
+def test_trusted_checkpoint_compatibility_is_hash_bound(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_script()
+    checkout, model_path, source = _configure_fixture(monkeypatch, module, tmp_path)
+
+    record = module._prepare_trusted_checkpoint_compatibility(checkout.resolve())
+
+    assert record is not None
+    assert record["status"] == "trusted-legacy-checkpoint-loader-enabled"
+    assert record["source_git_blob_sha1"] == module._git_blob_sha1(source)
+    assert record["checkpoint_sha256"] == module._TRUSTED_CHECKPOINT_SHA256
+    patched = model_path.read_text(encoding="utf-8")
+    assert patched.count("weights_only=False") == 1
+    unsigned = dict(record)
+    artifact_id = unsigned.pop("artifact_id")
+    assert artifact_id == module._content_id(unsigned)
+
+
+def test_trusted_checkpoint_compatibility_rejects_source_drift(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_script()
+    checkout, model_path, _ = _configure_fixture(monkeypatch, module, tmp_path)
+    model_path.write_text("unexpected source\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="source bytes changed"):
+        module._prepare_trusted_checkpoint_compatibility(checkout.resolve())
+
+
+def test_unrelated_runtime_does_not_patch(monkeypatch, tmp_path: Path) -> None:
+    module = _load_script()
+    monkeypatch.delenv("REQUEST_PATH", raising=False)
+
+    assert module._prepare_trusted_checkpoint_compatibility(tmp_path.resolve()) is None


### PR DESCRIPTION
## Purpose

Resume the existing source-locked DOT rope experiment after the sealed CUDA 12.6 runtime reached CUT3R model loading and stopped before opening any DOT payload. PyTorch 2.11 defaults `torch.load` to `weights_only=True`; the exact pinned CUT3R checkpoint contains its OmegaConf model configuration and therefore cannot be loaded by the restricted unpickler.

## Repair

This PR keeps the provider, checkpoint bytes, CUT3R revision, DOT source roster, marker-free/marker-separated information order, and scientific protocol unchanged. During preparation of the isolated per-run CUT3R copy it changes exactly one upstream call from

```python
torch.load(model_path, map_location="cpu")
```

to

```python
torch.load(model_path, map_location="cpu", weights_only=False)
```

only after verifying all of the following:

- the exact DOT sealed-runtime execution-request path;
- CUT3R revision `8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf`;
- upstream `src/dust3r/model.py` Git blob `7ed9f6106fb063686990c874ede99876ebc939ab`;
- checkpoint SHA-256 `45f7e98a0a64dbeb54901ae2b878cd8cd125f20a4497316483f0bd6f109f8103`; and
- the exact one-line load-call preimage.

The original persistent CUT3R checkout is not modified. A content-addressed compatibility receipt is written beside the native-RoPE receipt. Any revision, source, request, checkpoint, or call-site drift fails closed.

## Tests

Adds focused tests for the successful hash-bound rewrite, source-drift rejection, and no-op behavior outside the registered request.

## Scientific boundary

This is a localized runtime compatibility repair, not a method, data-selection, calibration, threshold, or result change. It opens no DOT payload by itself and does not alter the source sequences `R01`–`R03` or the reserved `R04`–`R70` boundary. The next merged-main one-file execution request will rerun the existing sealed workflow and retain its positive, negative, or technical outcome.