### PR TITLE
Repair the DOT runtime-smoke workspace without opening data

### DIFF
--- a/scripts/science/prepare_cut3r_runtime.py
+++ b/scripts/science/prepare_cut3r_runtime.py
@@ -26,6 +26,16 @@ _ORIGINAL_LOAD_CALL = '    ckpt = torch.load(model_path, map_location="cpu")\n'
 _PATCHED_LOAD_CALL = (
     '    ckpt = torch.load(model_path, map_location="cpu", weights_only=False)\n'
 )
+_TRUSTED_PROVIDER_SCRIPT_RELATIVE_PATH = Path(
+    "scripts/science/run_dot_rope_cut3r_native_provider.py"
+)
+_TRUSTED_PROVIDER_SCRIPT_GIT_BLOB_SHA1 = "612c8ae61b0a64d464256a11992b46c486c88012"
+_ORIGINAL_SMOKE_FRAME_CALL = (
+    "            frame_paths = _make_synthetic_frames(Path(temporary), count=3)\n"
+)
+_PATCHED_SMOKE_FRAME_CALL = (
+    '            frame_paths = _make_synthetic_frames(Path(temporary) / "frames", count=3)\n'
+)
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -79,17 +89,25 @@ def _content_id(payload: dict[str, object]) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
+def _trusted_request_selected() -> bool:
+    return os.environ.get("REQUEST_PATH") == _TRUSTED_REQUEST_PATH
+
+
+def _require_trusted_runtime_identity() -> None:
+    if os.environ.get("CUT3R_REVISION") != _TRUSTED_CUT3R_REVISION:
+        raise RuntimeError("trusted CUT3R compatibility revision changed")
+    if os.environ.get("CUT3R_CHECKPOINT_SHA256") != _TRUSTED_CHECKPOINT_SHA256:
+        raise RuntimeError("trusted CUT3R compatibility checkpoint digest changed")
+
+
 def _prepare_trusted_checkpoint_compatibility(
     checkout: Path,
 ) -> dict[str, object] | None:
     """Patch one hash-pinned CUT3R loader in the isolated DOT runtime copy."""
 
-    if os.environ.get("REQUEST_PATH") != _TRUSTED_REQUEST_PATH:
+    if not _trusted_request_selected():
         return None
-    if os.environ.get("CUT3R_REVISION") != _TRUSTED_CUT3R_REVISION:
-        raise RuntimeError("trusted CUT3R checkpoint compatibility revision changed")
-    if os.environ.get("CUT3R_CHECKPOINT_SHA256") != _TRUSTED_CHECKPOINT_SHA256:
-        raise RuntimeError("trusted CUT3R checkpoint compatibility digest changed")
+    _require_trusted_runtime_identity()
 
     checkpoint_text = os.environ.get("CUT3R_RUNTIME_CHECKPOINT")
     if not checkpoint_text:
@@ -143,6 +161,65 @@ def _prepare_trusted_checkpoint_compatibility(
     return record
 
 
+def _prepare_trusted_smoke_workspace_compatibility(
+    repository_root: Path,
+) -> dict[str, object] | None:
+    """Patch the registered pre-data smoke workspace call in the checked-out source."""
+
+    if not _trusted_request_selected():
+        return None
+    _require_trusted_runtime_identity()
+
+    root = repository_root.expanduser().resolve(strict=True)
+    source_path = root / _TRUSTED_PROVIDER_SCRIPT_RELATIVE_PATH
+    if source_path.is_symlink():
+        raise RuntimeError("trusted DOT provider source must not be a symbolic link")
+    resolved_source = source_path.resolve(strict=True)
+    try:
+        resolved_source.relative_to(root)
+    except ValueError as error:
+        raise RuntimeError("trusted DOT provider source escapes the checkout") from error
+    if not resolved_source.is_file():
+        raise RuntimeError("trusted DOT provider source is not a regular file")
+
+    source = resolved_source.read_bytes()
+    source_blob = _git_blob_sha1(source)
+    if source_blob != _TRUSTED_PROVIDER_SCRIPT_GIT_BLOB_SHA1:
+        raise RuntimeError("trusted DOT provider source bytes changed")
+    text = source.decode("utf-8")
+    if text.count(_ORIGINAL_SMOKE_FRAME_CALL) != 1 or _PATCHED_SMOKE_FRAME_CALL in text:
+        raise RuntimeError("trusted DOT runtime-smoke workspace call changed")
+
+    patched = text.replace(
+        _ORIGINAL_SMOKE_FRAME_CALL,
+        _PATCHED_SMOKE_FRAME_CALL,
+        1,
+    ).encode("utf-8")
+    resolved_source.write_bytes(patched)
+    record: dict[str, object] = {
+        "schema": "prob4d.dot-cut3r-runtime-smoke-workspace-compatibility",
+        "schema_version": 1,
+        "status": "trusted-smoke-child-workspace-enabled",
+        "request_path": _TRUSTED_REQUEST_PATH,
+        "cut3r_revision": _TRUSTED_CUT3R_REVISION,
+        "checkpoint_sha256": _TRUSTED_CHECKPOINT_SHA256,
+        "source_member": _TRUSTED_PROVIDER_SCRIPT_RELATIVE_PATH.as_posix(),
+        "source_git_blob_sha1": source_blob,
+        "source_sha256": hashlib.sha256(source).hexdigest(),
+        "patched_sha256": hashlib.sha256(patched).hexdigest(),
+        "workspace_policy": (
+            "TemporaryDirectory owns the parent; synthetic frames are written to "
+            "one newly created child directory."
+        ),
+        "information_boundary": (
+            "The repair changes only the dataset-free runtime smoke workspace and "
+            "does not open DOT normal-view images or marker payloads."
+        ),
+    }
+    record["artifact_id"] = _content_id(record)
+    return record
+
+
 def main() -> int:
     args = _parser().parse_args()
     checkout = args.cut3r_checkout.expanduser().resolve(strict=True)
@@ -163,12 +240,20 @@ def main() -> int:
         raise SystemExit(
             "verified CUT3R runtime receipt differs from the frozen artifact ID"
         )
-    compatibility = _prepare_trusted_checkpoint_compatibility(checkout)
+    checkpoint_compatibility = _prepare_trusted_checkpoint_compatibility(checkout)
+    smoke_compatibility = _prepare_trusted_smoke_workspace_compatibility(
+        Path(__file__).resolve().parents[2]
+    )
     _write_no_clobber(args.output, receipt)
-    if compatibility is not None:
+    if checkpoint_compatibility is not None:
         _write_no_clobber(
             args.output.with_name("checkpoint-load-compatibility.json"),
-            compatibility,
+            checkpoint_compatibility,
+        )
+    if smoke_compatibility is not None:
+        _write_no_clobber(
+            args.output.with_name("runtime-smoke-compatibility.json"),
+            smoke_compatibility,
         )
     print(receipt["artifact_id"])
     return 0

--- a/tests/test_prepare_cut3r_runtime.py
+++ b/tests/test_prepare_cut3r_runtime.py
@@ -47,6 +47,34 @@ def _configure_fixture(monkeypatch, module, tmp_path: Path) -> tuple[Path, Path,
     return checkout, model_path, source
 
 
+def _configure_smoke_fixture(
+    monkeypatch,
+    module,
+    tmp_path: Path,
+) -> tuple[Path, Path, bytes]:
+    repository_root = tmp_path / "repository"
+    source_path = repository_root / module._TRUSTED_PROVIDER_SCRIPT_RELATIVE_PATH
+    source_path.parent.mkdir(parents=True)
+    source = (
+        b"with tempfile.TemporaryDirectory(prefix=\"dot-cut3r-smoke-\") as temporary:\n"
+        b"            frame_paths = _make_synthetic_frames(Path(temporary), count=3)\n"
+        b"            prediction = runtime.infer(frame_paths, image_size=512)\n"
+    )
+    source_path.write_bytes(source)
+    monkeypatch.setattr(
+        module,
+        "_TRUSTED_PROVIDER_SCRIPT_GIT_BLOB_SHA1",
+        module._git_blob_sha1(source),
+    )
+    monkeypatch.setenv("REQUEST_PATH", module._TRUSTED_REQUEST_PATH)
+    monkeypatch.setenv("CUT3R_REVISION", module._TRUSTED_CUT3R_REVISION)
+    monkeypatch.setenv(
+        "CUT3R_CHECKPOINT_SHA256",
+        module._TRUSTED_CHECKPOINT_SHA256,
+    )
+    return repository_root, source_path, source
+
+
 def test_trusted_checkpoint_compatibility_is_hash_bound(
     monkeypatch,
     tmp_path: Path,
@@ -79,8 +107,49 @@ def test_trusted_checkpoint_compatibility_rejects_source_drift(
         module._prepare_trusted_checkpoint_compatibility(checkout.resolve())
 
 
+def test_trusted_smoke_workspace_compatibility_is_hash_bound(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_script()
+    repository_root, source_path, source = _configure_smoke_fixture(
+        monkeypatch,
+        module,
+        tmp_path,
+    )
+
+    record = module._prepare_trusted_smoke_workspace_compatibility(repository_root)
+
+    assert record is not None
+    assert record["status"] == "trusted-smoke-child-workspace-enabled"
+    assert record["source_git_blob_sha1"] == module._git_blob_sha1(source)
+    patched = source_path.read_text(encoding="utf-8")
+    assert '_make_synthetic_frames(Path(temporary) / "frames", count=3)' in patched
+    assert "_make_synthetic_frames(Path(temporary), count=3)" not in patched
+    unsigned = dict(record)
+    artifact_id = unsigned.pop("artifact_id")
+    assert artifact_id == module._content_id(unsigned)
+
+
+def test_trusted_smoke_workspace_compatibility_rejects_source_drift(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_script()
+    repository_root, source_path, _ = _configure_smoke_fixture(
+        monkeypatch,
+        module,
+        tmp_path,
+    )
+    source_path.write_text("unexpected source\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="provider source bytes changed"):
+        module._prepare_trusted_smoke_workspace_compatibility(repository_root)
+
+
 def test_unrelated_runtime_does_not_patch(monkeypatch, tmp_path: Path) -> None:
     module = _load_script()
     monkeypatch.delenv("REQUEST_PATH", raising=False)
 
     assert module._prepare_trusted_checkpoint_compatibility(tmp_path.resolve()) is None
+    assert module._prepare_trusted_smoke_workspace_compatibility(tmp_path.resolve()) is None


### PR DESCRIPTION
## Purpose

Continue the source-locked DOT rope evaluation after workflow run `33329050649` proved that the hash-bound checkpoint repair works: the exact CUT3R checkpoint loaded with all keys matched, but the dataset-free synthetic smoke then failed because `tempfile.TemporaryDirectory` had already created its path and `_make_synthetic_frames` tried to create the same directory with `exist_ok=False`.

The retained smoke artifact records `dataset_opened=false` and `synthetic_prediction_executed=false`. No DOT normal-view image, 2-D marker, or 3-D marker payload was opened, and R04–R70 remain reserved.

## Repair

During preparation of the isolated per-run runtime, patch exactly one registered call in the checked-out provider script:

```python
_make_synthetic_frames(Path(temporary), count=3)
```

becomes

```python
_make_synthetic_frames(Path(temporary) / "frames", count=3)
```

The repair runs only for the exact DOT sealed-runtime request and requires the frozen CUT3R revision and checkpoint SHA-256. It additionally verifies the provider script Git blob `612c8ae61b0a64d464256a11992b46c486c88012` and exact call-site preimage, fails closed on any drift, and writes a content-addressed `runtime-smoke-compatibility.json` receipt beside the existing native-RoPE and checkpoint receipts.

The patch affects only the synthetic, dataset-free smoke workspace. The provider, checkpoint, source sequences, windows, covariance closures, marker-access order, scoring code, and scientific protocol remain unchanged.

## Tests

Adds focused tests for:

- successful hash-bound child-workspace repair;
- exact artifact identity;
- provider-source drift rejection; and
- no-op behavior outside the registered request.

The prepared files passed five focused tests in an isolated local harness before push. Repository CI remains authoritative.

## Next execution boundary

After merge, one new immutable request-file-only commit will rerun the existing workflow on `gpuserver4090`. Marker data remain inaccessible unless the synthetic smoke passes and a marker-free provider bundle is sealed first.