### PR TITLE
Retain real DOT CUT3R dependence result and bound the next confirmation

### DIFF
--- a/evidence/dot-rope/cut3r-pooled-source-v1/RESULT.md
+++ b/evidence/dot-rope/cut3r-pooled-source-v1/RESULT.md
@@ -1,0 +1,66 @@
+# DOT rope CUT3R pooled source result v1
+
+## Status
+
+**Source-positive for a dependence diagnostic only.** The current CUT3R/Sim(3) stitching estimate is not promoted, and the current shared-quadratic covariance is not promoted.
+
+This record binds the completed source-development evaluation on public DOT rope sequences `R01`--`R03`. `R04`--`R70` remained outside this evaluation route.
+
+- provider run: `33329701704`
+- provider bundle ID: `952421d140731b2a6eb99df3cbd348653e04863fa457aaa490be31fe0b4c06a7`
+- marker-support audit run: `33338130219`
+- marker-support audit ID: `2b045cf62d1a4e385987def7c36674490130216e6bceb4883b4d86e445ec6049`
+- pooled evaluation run: `33338269873`
+- execution revision: `585e1b16042e9653fdcd151a90a56033bf0e47a2`
+- evaluation ID: `9f900046ba2700bbc7476a4a5cd9c0da87b7bbe124c3109572eeae989fe09acd`
+- workflow artifact SHA-256: `67bae296584da8fdb30e87dddbdf8b4bd5f2dfa163fe81fa98a57f8c1992c72a`
+- `result.json` SHA-256: `bdb2f825659cabe08cdf4377626904a51dae510e69340d85867fb20047c4567a`
+
+## Registered uncertainty comparison
+
+All covariance arms use the same provider mean. Lower normalized Gaussian NLL is better.
+
+| Method | Mean NLL / dim | Mean Mahalanobis | 95% covered | Mean predictive SD / span |
+|---|---:|---:|---:|---:|
+| **pointwise quadratic** | **0.766506** | **7.553** | **3/3** | 1.056488 |
+| cluster bootstrap fallback | 5.207030 | 375.188 | 1/3 | 0.065642 |
+| dominant rotation orbit | 10.617586 | 616.739 | 1/3 | 1.198704 |
+| shared quadratic curvature | 16.895744 | 919.978 | 1/3 | 1.056488 |
+| tensor Gauss-Hermite | 17.003451 | 925.211 | 1/3 | 0.998307 |
+| axis spherical-radial | 21.646245 | 1148.232 | 1/3 | 0.999371 |
+| scalar inflation | 28.678447 | 1480.743 | 1/3 | 1.989423 |
+| local first order | 38.001730 | 1936.620 | 1/3 | 0.994941 |
+
+The pointwise-quadratic arm improves mean NLL by `37.235223` nats/dimension relative to local first order and by `16.129238` nats/dimension relative to shared quadratic curvature on these three development sequences.
+
+## Dependence finding
+
+`pointwise_quadratic` and `shared_quadratic_curvature` have the same mean marginal predictive standard deviation to numerical precision (`1.056488250615809` versus `1.0564882506158095` of provider span), yet their mean joint NLL differs by `16.129238` nats/dimension.
+
+Therefore the source failure cannot be explained by marginal variance scale alone. It localizes to the **cross-query covariance / shared-dependence structure** of the current shared-quadratic approximation. This motivates a separately frozen dependence-strength calibration that leaves every marginal variance and every provider mean unchanged.
+
+This is not a universal superiority result: on `R02`, shared quadratic curvature and local first order score better than the pointwise arm. With only three source sequences, no population confidence interval or held-out superiority claim is made.
+
+## Reconstruction and stitching
+
+| Sequence | continuous / span | identity stitch / span | estimated Sim(3) stitch / span | oracle window / span |
+|---|---:|---:|---:|---:|
+| R01 | 0.094973 | 0.112156 | 0.102379 | 0.055046 |
+| R02 | 0.066431 | 0.037155 | 0.081340 | 0.029580 |
+| R03 | 0.051136 | 0.057282 | 0.058047 | 0.033581 |
+
+Estimated Sim(3) stitching improves over identity only on `R01` and is worse than the continuous-window prediction on all three sequences. The current stitching estimate is therefore **not promoted**. The oracle restarted window is better than the continuous run on all three sequences, which leaves headroom for a better alignment/fusion method without establishing that the current estimator achieves it.
+
+## Next registered scientific step
+
+Before opening any new DOT outcome, fit a single shared-dependence strength on `R01`--`R03` only:
+
+\[
+\Sigma_\alpha = \Sigma_{\mathrm{pointwise}} + \alpha\left(\Sigma_{\mathrm{shared}}-\Sigma_{\mathrm{pointwise}}\right),\qquad 0\leq\alpha\leq1.
+\]
+
+Because the endpoint covariances have matching diagonals, this family preserves the source-fitted marginal variances and varies only shared dependence. `alpha=0` reproduces the pointwise arm and `alpha=1` reproduces the current shared-quadratic arm. The source selection rule and a disjoint DOT confirmation cohort must be frozen before opening that cohort.
+
+## Claim boundary
+
+Source-development real-image/provider evidence on `R01`--`R03` only. It supports the bounded diagnosis that joint dependence modeling materially changes proper scores even when marginal uncertainty is unchanged. It does **not** establish held-out transfer, independent calibration, improved reconstruction from the current stitching estimator, BayesianPhysTwin benefit, Causal4D benefit, deployment safety, or state of the art.

--- a/evidence/dot-rope/cut3r-pooled-source-v1/evidence.json
+++ b/evidence/dot-rope/cut3r-pooled-source-v1/evidence.json
@@ -1,0 +1,162 @@
+{
+  "aggregate_methods": [
+    {
+      "covered_95_count": 3,
+      "mean_mahalanobis": 7.552763166029883,
+      "mean_normalized_nll_per_dimension": 0.7665063894782334,
+      "mean_predictive_sd_fraction_of_span": 1.056488250615809,
+      "method": "pointwise_quadratic",
+      "sequence_count": 3
+    },
+    {
+      "covered_95_count": 1,
+      "mean_mahalanobis": 375.18809236735416,
+      "mean_normalized_nll_per_dimension": 5.2070303551421775,
+      "mean_predictive_sd_fraction_of_span": 0.06564182894467284,
+      "method": "cluster_bootstrap_fallback",
+      "sequence_count": 3
+    },
+    {
+      "covered_95_count": 1,
+      "mean_mahalanobis": 616.7392746234306,
+      "mean_normalized_nll_per_dimension": 10.617586455242337,
+      "mean_predictive_sd_fraction_of_span": 1.198703750685696,
+      "method": "dominant_rotation_orbit",
+      "sequence_count": 3
+    },
+    {
+      "covered_95_count": 1,
+      "mean_mahalanobis": 919.9776606843046,
+      "mean_normalized_nll_per_dimension": 16.895744419825878,
+      "mean_predictive_sd_fraction_of_span": 1.0564882506158095,
+      "method": "shared_quadratic_curvature",
+      "sequence_count": 3
+    },
+    {
+      "covered_95_count": 1,
+      "mean_mahalanobis": 925.2105684424038,
+      "mean_normalized_nll_per_dimension": 17.003450583812352,
+      "mean_predictive_sd_fraction_of_span": 0.9983068337775681,
+      "method": "tensor_gauss_hermite",
+      "sequence_count": 3
+    },
+    {
+      "covered_95_count": 1,
+      "mean_mahalanobis": 1148.2317997711514,
+      "mean_normalized_nll_per_dimension": 21.64624517064006,
+      "mean_predictive_sd_fraction_of_span": 0.9993712926541631,
+      "method": "axis_spherical_radial",
+      "sequence_count": 3
+    },
+    {
+      "covered_95_count": 1,
+      "mean_mahalanobis": 1480.7428840860548,
+      "mean_normalized_nll_per_dimension": 28.678446844634646,
+      "mean_predictive_sd_fraction_of_span": 1.9894234376553541,
+      "method": "scalar_inflation",
+      "sequence_count": 3
+    },
+    {
+      "covered_95_count": 1,
+      "mean_mahalanobis": 1936.6204993095891,
+      "mean_normalized_nll_per_dimension": 38.001729615516915,
+      "mean_predictive_sd_fraction_of_span": 0.9949406423760333,
+      "method": "local_first_order",
+      "sequence_count": 3
+    }
+  ],
+  "claim_boundary": "Source-development pooled-marker evaluation of the immutable CUT3R provider bundle from workflow run 33329701704 on DOT R01-R03 only. The hosted marker-support audit in workflow run 33338130219 established that the current columns-0-1 pixel-zero-based convention is feasible when support is pooled across the registered frames. No normal-view pixels are decoded during evaluation; R04-R70 remain unopened. This does not establish held-out transfer, independent calibration, BayesianPhysTwin benefit, Causal4D benefit, safety, or state of the art.",
+  "decision": {
+    "current_stitching_promoted": false,
+    "next_step": "freeze an independent held-out DOT cohort before any new normal-view or marker payload access; compare pointwise quadratic, shared quadratic curvature, local first order, and a source-frozen correlation-tempering family without changing provider means",
+    "shared_quadratic_curvature_promoted": false,
+    "status": "source-positive-for-dependence-diagnostic-only"
+  },
+  "evaluation_id": "9f900046ba2700bbc7476a4a5cd9c0da87b7bbe124c3109572eeae989fe09acd",
+  "evidence_id": "2e2e4a7d61312f8b7b371dcd571c152e154474808b1bda8e4d2b6ac12c19ddaa",
+  "execution_revision": "585e1b16042e9653fdcd151a90a56033bf0e47a2",
+  "marker_audit": {
+    "audit_id": "2b045cf62d1a4e385987def7c36674490130216e6bceb4883b4d86e445ec6049",
+    "decision": "current-convention-pooled-support-feasible",
+    "run_id": 33338130219,
+    "selected_coordinate_candidate": "columns-0-1:pixel-zero-based"
+  },
+  "marker_support_id": "ac450e19654c8f2192069c5db9330de765ef5e4a87f36abffd37ec850551d52f",
+  "marker_support_json_sha256": "94d8c212664eb6c0d689f289af21a994c0617294443824f86ef5d18d48dc2a35",
+  "provider": {
+    "bundle_id": "952421d140731b2a6eb99df3cbd348653e04863fa457aaa490be31fe0b4c06a7",
+    "reserved_sequences": "R04-R70",
+    "run_id": 33329701704,
+    "source_sequences": [
+      "R01",
+      "R02",
+      "R03"
+    ]
+  },
+  "result_json_sha256": "bdb2f825659cabe08cdf4377626904a51dae510e69340d85867fb20047c4567a",
+  "schema": "prob4d.dot-rope-cut3r-pooled-source-evidence",
+  "schema_version": 1,
+  "sequences": [
+    {
+      "point_metrics": {
+        "continuous_rmse": 13.163306459477573,
+        "continuous_rmse_fraction_of_span": 0.09497317967336769,
+        "estimated_stitch_rmse": 14.18968872148919,
+        "estimated_stitch_rmse_fraction_of_span": 0.102378521734169,
+        "identity_stitch_rmse": 15.544871129699875,
+        "identity_stitch_rmse_fraction_of_span": 0.1121561549406429,
+        "oracle_window_rmse": 7.629322960830471,
+        "oracle_window_rmse_fraction_of_span": 0.05504552086329373,
+        "truth_span": 138.60025014165993
+      },
+      "query_dimension": 24,
+      "query_fixed_mean_error_fraction_of_span": 0.35598299408136863,
+      "sequence": "R01"
+    },
+    {
+      "point_metrics": {
+        "continuous_rmse": 12.344444809592574,
+        "continuous_rmse_fraction_of_span": 0.06643146424886662,
+        "estimated_stitch_rmse": 15.114726713077788,
+        "estimated_stitch_rmse_fraction_of_span": 0.08133969917310167,
+        "identity_stitch_rmse": 6.904244776105877,
+        "identity_stitch_rmse_fraction_of_span": 0.03715510070188727,
+        "oracle_window_rmse": 5.4967093296636085,
+        "oracle_window_rmse_fraction_of_span": 0.02958046756677196,
+        "truth_span": 185.82225981573455
+      },
+      "query_dimension": 24,
+      "query_fixed_mean_error_fraction_of_span": 0.11066644220156885,
+      "sequence": "R02"
+    },
+    {
+      "point_metrics": {
+        "continuous_rmse": 7.1035770600392905,
+        "continuous_rmse_fraction_of_span": 0.05113562321170002,
+        "estimated_stitch_rmse": 8.063695190300434,
+        "estimated_stitch_rmse_fraction_of_span": 0.05804710436166085,
+        "identity_stitch_rmse": 7.957405468935514,
+        "identity_stitch_rmse_fraction_of_span": 0.057281969965700195,
+        "oracle_window_rmse": 4.664985351969208,
+        "oracle_window_rmse_fraction_of_span": 0.033581241004384595,
+        "truth_span": 138.91640726916899
+      },
+      "query_dimension": 24,
+      "query_fixed_mean_error_fraction_of_span": 0.2671846968026064,
+      "sequence": "R03"
+    }
+  ],
+  "source_findings": {
+    "best_registered_uncertainty_method": "pointwise_quadratic",
+    "estimated_stitch_better_than_continuous_sequences": [],
+    "estimated_stitch_better_than_identity_sequences": [
+      "R01"
+    ],
+    "pointwise_and_shared_quadratic_equal_mean_sd_fraction_of_span": true,
+    "pointwise_vs_local_nll_per_dim_improvement": 37.235223226038684,
+    "pointwise_vs_shared_quadratic_nll_per_dim_improvement": 16.129238030347643
+  },
+  "workflow_artifact_id": 9746429825,
+  "workflow_artifact_sha256": "67bae296584da8fdb30e87dddbdf8b4bd5f2dfa163fe81fa98a57f8c1992c72a",
+  "workflow_run_id": 33338269873
+}


### PR DESCRIPTION
## Purpose

Retain the completed public real-data CUT3R source evaluation from workflow run `33338269873` as an immutable scientific record and make the next experimental decision explicit before any additional DOT outcome is opened.

## Bound result

- DOT source sequences: `R01-R03` only;
- provider run: `33329701704`;
- marker-support audit run: `33338130219`;
- pooled evaluation run: `33338269873`;
- evaluation ID: `9f900046ba2700bbc7476a4a5cd9c0da87b7bbe124c3109572eeae989fe09acd`;
- workflow artifact SHA-256: `67bae296584da8fdb30e87dddbdf8b4bd5f2dfa163fe81fa98a57f8c1992c72a`;
- authoritative `result.json` SHA-256: `bdb2f825659cabe08cdf4377626904a51dae510e69340d85867fb20047c4567a`.

## Main source finding

The registered `pointwise_quadratic` covariance has mean normalized joint NLL `0.766506` with `3/3` sequence-level 95% coverage. The current `shared_quadratic_curvature` arm has mean NLL `16.895744` with `1/3` coverage, and local first order has `38.001730` with `1/3` coverage.

Crucially, pointwise and shared quadratic have the same mean marginal predictive SD to numerical precision (`1.056488250615809` versus `1.0564882506158095` of span). Their `16.129238` nats/dimension NLL gap therefore localizes the important source failure to cross-query covariance / shared dependence rather than marginal variance scale.

This is not universal: on R02 the shared/local arms score better. With three development sequences no population superiority claim or confidence interval is made.

## Negative control retained

The estimated Sim(3) stitch improves over identity only on R01 and is worse than the continuous-window prediction on all three sequences. The current stitching estimator is explicitly **not promoted**. The oracle restarted window remains better than continuous on all three, showing headroom without claiming the current method captures it.

## Next frozen direction

The result motivates a single dependence-strength family

`Sigma_alpha = Sigma_pointwise + alpha (Sigma_shared - Sigma_pointwise)`, `0 <= alpha <= 1`.

When endpoint diagonals match, this changes shared correlation while preserving all marginal variances and all provider means. A source-only alpha selection on R01-R03 and a disjoint DOT confirmation cohort must be frozen before that cohort is opened.

## Files

- `evidence/dot-rope/cut3r-pooled-source-v1/evidence.json`
- `evidence/dot-rope/cut3r-pooled-source-v1/RESULT.md`

## Claim boundary

Source-development real-image/provider evidence only. R04-R70 were outside this evaluation route. No held-out transfer, independent calibration, current-stitching benefit, BayesianPhysTwin benefit, Causal4D benefit, deployment safety, or state-of-the-art claim is made.