### PR TITLE
Finalize DOT result metadata

### DIFF
--- a/.github/workflows/dot-rope-pooled-result-finalization-v1.yml
+++ b/.github/workflows/dot-rope-pooled-result-finalization-v1.yml
@@ -1,0 +1,310 @@
+name: DOT rope pooled-result provenance finalization v1
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/dot-rope-pooled-result-finalization-v1.yml"
+      - "scripts/science/finalize_dot_rope_pooled_result.py"
+      - "tests/test_finalize_dot_rope_pooled_result.py"
+      - "tests/test_dot_rope_pooled_result_finalization_workflow.py"
+  push:
+    branches: [main]
+    paths:
+      - "protocols/execution_requests/dot_rope_pooled_result_finalization_v1.json"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dot-rope-pooled-result-finalization-v1-${{ github.ref }}-${{ github.sha }}
+  cancel-in-progress: false
+
+env:
+  REQUEST_PATH: protocols/execution_requests/dot_rope_pooled_result_finalization_v1.json
+
+jobs:
+  contract:
+    name: Validate DOT result finalizer
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Check out reviewed revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+          clean: true
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Validate finalizer and workflow
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install -e ".[dev]"
+          python -m pip check
+          python -m ruff check \
+            scripts/science/finalize_dot_rope_pooled_result.py \
+            tests/test_finalize_dot_rope_pooled_result.py \
+            tests/test_dot_rope_pooled_result_finalization_workflow.py
+          python -m ruff format --check \
+            scripts/science/finalize_dot_rope_pooled_result.py \
+            tests/test_finalize_dot_rope_pooled_result.py \
+            tests/test_dot_rope_pooled_result_finalization_workflow.py
+          python -m pytest -q \
+            tests/test_finalize_dot_rope_pooled_result.py \
+            tests/test_dot_rope_pooled_result_finalization_workflow.py \
+            tests/test_github_action_pins.py
+          python -m compileall -q scripts/science/finalize_dot_rope_pooled_result.py
+
+  authorize:
+    name: Authorize one immutable result-finalization request
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      request_id: ${{ steps.request.outputs.request_id }}
+      head_sha: ${{ steps.request.outputs.head_sha }}
+      source_run_id: ${{ steps.request.outputs.source_run_id }}
+      source_artifact_id: ${{ steps.request.outputs.source_artifact_id }}
+      source_artifact_name: ${{ steps.request.outputs.source_artifact_name }}
+      source_artifact_digest: ${{ steps.request.outputs.source_artifact_digest }}
+    steps:
+      - name: Check out exact merged revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 2
+          persist-credentials: false
+          clean: true
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Require exactly one non-forced request-file change
+        id: request
+        shell: bash
+        env:
+          EVENT_REF: ${{ github.ref }}
+          EVENT_BEFORE: ${{ github.event.before }}
+          EVENT_AFTER: ${{ github.event.after }}
+          EVENT_FORCED: ${{ github.event.forced }}
+          EVENT_DELETED: ${{ github.event.deleted }}
+        run: |
+          set -euo pipefail
+          test "$EVENT_REF" = "refs/heads/main"
+          test "$EVENT_AFTER" = "$(/usr/bin/git rev-parse HEAD)"
+          test "$EVENT_FORCED" = "false"
+          test "$EVENT_DELETED" = "false"
+          test "$EVENT_BEFORE" != "0000000000000000000000000000000000000000"
+          mapfile -t changed < <(
+            /usr/bin/git diff --name-only "$EVENT_BEFORE" "$EVENT_AFTER" | sort
+          )
+          if [[ ${#changed[@]} -ne 1 || "${changed[0]}" != "$REQUEST_PATH" ]]; then
+            printf 'Expected only %s; changed paths were:\n' "$REQUEST_PATH" >&2
+            printf '  %s\n' "${changed[@]}" >&2
+            exit 2
+          fi
+          python -m pip install -e .
+          validation=$(
+            python scripts/science/finalize_dot_rope_pooled_result.py \
+              validate-request \
+              --request "$REQUEST_PATH"
+          )
+          VALIDATION="$validation" EVENT_AFTER="$EVENT_AFTER" REQUEST_PATH="$REQUEST_PATH" \
+            /usr/bin/python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          value = json.loads(os.environ["VALIDATION"])
+          request = json.loads(Path(os.environ["REQUEST_PATH"]).read_text(encoding="utf-8"))
+          outputs = {
+              "request_id": value["request_id"],
+              "head_sha": os.environ["EVENT_AFTER"],
+              "source_run_id": value["source_run_id"],
+              "source_artifact_id": value["source_artifact_id"],
+              "source_artifact_name": value["source_artifact_name"],
+              "source_artifact_digest": request["source_artifact_digest"],
+          }
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              for key, item in outputs.items():
+                  output.write(f"{key}={item}\n")
+          PY
+
+  finalize:
+    name: Finalize exact DOT pooled-result provenance
+    if: github.event_name == 'push'
+    needs: authorize
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      finalization_id: ${{ steps.result.outputs.finalization_id }}
+      finalized_evaluation_id: ${{ steps.result.outputs.finalized_evaluation_id }}
+      scientific_payload_id: ${{ steps.result.outputs.scientific_payload_id }}
+    steps:
+      - name: Initialize isolated finalization workspace
+        id: workspace
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="$RUNNER_TEMP/prob4d-dot-result-finalization-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          /usr/bin/rm -rf -- "$root"
+          /usr/bin/mkdir -p "$root/source" "$root/final"
+          echo "root=$root" >> "$GITHUB_OUTPUT"
+      - name: Check out exact authorized revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.authorize.outputs.head_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+          clean: true
+      - name: Verify clean exact checkout
+        shell: bash
+        env:
+          EXPECTED_HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          test "$(/usr/bin/git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
+          test -z "$(/usr/bin/git status --porcelain=v1 --untracked-files=all)"
+      - name: Set up scientific Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install the exact repository package
+        run: |
+          python -m pip install -e .
+          python -m pip check
+      - name: Verify exact source artifact metadata
+        shell: bash
+        env:
+          ARTIFACT_ID: ${{ needs.authorize.outputs.source_artifact_id }}
+          EXPECTED_NAME: ${{ needs.authorize.outputs.source_artifact_name }}
+          EXPECTED_DIGEST: ${{ needs.authorize.outputs.source_artifact_digest }}
+          EXPECTED_RUN_ID: ${{ needs.authorize.outputs.source_run_id }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          import urllib.request
+
+          url = (
+              f"https://api.github.com/repos/{os.environ['GITHUB_REPOSITORY']}"
+              f"/actions/artifacts/{os.environ['ARTIFACT_ID']}"
+          )
+          request = urllib.request.Request(
+              url,
+              headers={
+                  "Accept": "application/vnd.github+json",
+                  "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
+                  "User-Agent": "Prob4D-result-finalizer/1",
+                  "X-GitHub-Api-Version": "2022-11-28",
+              },
+          )
+          with urllib.request.urlopen(request, timeout=60) as response:
+              value = json.load(response)
+          if int(value["id"]) != int(os.environ["ARTIFACT_ID"]):
+              raise SystemExit("source artifact ID changed")
+          if value["name"] != os.environ["EXPECTED_NAME"]:
+              raise SystemExit("source artifact name changed")
+          if value.get("digest") != os.environ["EXPECTED_DIGEST"]:
+              raise SystemExit("source artifact digest changed")
+          if value.get("expired") is not False:
+              raise SystemExit("source artifact expired")
+          workflow_run = value.get("workflow_run") or {}
+          if int(workflow_run.get("id", -1)) != int(os.environ["EXPECTED_RUN_ID"]):
+              raise SystemExit("source artifact workflow run changed")
+          print(json.dumps({"artifact_id": value["id"], "digest": value["digest"]}))
+          PY
+      - name: Download exact source evaluation artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ${{ needs.authorize.outputs.source_artifact_name }}
+          path: ${{ steps.workspace.outputs.root }}/source
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ needs.authorize.outputs.source_run_id }}
+      - name: Finalize metadata without dataset access or rescoring
+        shell: bash
+        env:
+          EXPECTED_HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          PYTHONPATH="$GITHUB_WORKSPACE/src" \
+            python scripts/science/finalize_dot_rope_pooled_result.py \
+              finalize \
+              --request "$REQUEST_PATH" \
+              --source-root "$root/source" \
+              --output-dir "$root/final" \
+              --repository-revision "$EXPECTED_HEAD_SHA"
+      - name: Read finalized evidence identity
+        id: result
+        shell: bash
+        run: |
+          set -euo pipefail
+          receipt="${{ steps.workspace.outputs.root }}/final/finalization.json"
+          RECEIPT="$receipt" /usr/bin/python3 - <<'PY'
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          value = json.loads(Path(os.environ["RECEIPT"]).read_text(encoding="utf-8"))
+          if value.get("scientific_payload_unchanged") is not True:
+              raise SystemExit("scientific payload was not preserved")
+          if value.get("no_dataset_access") is not True or value.get("no_scores_recomputed") is not True:
+              raise SystemExit("finalization exceeded its metadata-only boundary")
+          for name in ("finalization_id", "finalized_evaluation_id", "scientific_payload_id"):
+              if re.fullmatch(r"[0-9a-f]{64}", value.get(name, "")) is None:
+                  raise SystemExit(f"invalid {name}")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              for name in ("finalization_id", "finalized_evaluation_id", "scientific_payload_id"):
+                  output.write(f"{name}={value[name]}\n")
+          PY
+      - name: Upload finalized content-addressed evidence
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dot-rope-cut3r-pooled-finalized-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.workspace.outputs.root }}/final/
+          if-no-files-found: error
+          retention-days: 30
+
+  publish:
+    name: Publish finalized DOT pooled-result identity
+    if: always() && github.event_name == 'push'
+    needs: [authorize, finalize]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Write run summary
+        shell: bash
+        env:
+          FINALIZE_RESULT: ${{ needs.finalize.result }}
+          FINALIZATION_ID: ${{ needs.finalize.outputs.finalization_id }}
+          FINALIZED_EVALUATION_ID: ${{ needs.finalize.outputs.finalized_evaluation_id }}
+          SCIENTIFIC_PAYLOAD_ID: ${{ needs.finalize.outputs.scientific_payload_id }}
+        run: |
+          {
+            echo "## DOT pooled-result provenance finalization"
+            echo
+            echo "- finalization job: \`$FINALIZE_RESULT\`"
+            echo "- finalization ID: \`$FINALIZATION_ID\`"
+            echo "- finalized evaluation ID: \`$FINALIZED_EVALUATION_ID\`"
+            echo "- scientific payload ID: \`$SCIENTIFIC_PAYLOAD_ID\`"
+            echo
+            echo "No dataset was opened and no score was recomputed."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/dot-rope-pooled-result-finalization-v1.yml
+++ b/.github/workflows/dot-rope-pooled-result-finalization-v1.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Check out reviewed revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
           persist-credentials: false
           clean: true
       - name: Set up Python 3.12
@@ -41,18 +41,15 @@ jobs:
         with:
           python-version: "3.12"
           cache: pip
-          cache-dependency-path: pyproject.toml
+          cache-dependency-path: requirements/ci/quality.txt
       - name: Validate finalizer and workflow
         shell: bash
         run: |
           set -euo pipefail
-          python -m pip install -e ".[dev]"
+          python -m pip install -r requirements/ci/quality.txt
+          python -m pip install --no-deps -e .
           python -m pip check
           python -m ruff check \
-            scripts/science/finalize_dot_rope_pooled_result.py \
-            tests/test_finalize_dot_rope_pooled_result.py \
-            tests/test_dot_rope_pooled_result_finalization_workflow.py
-          python -m ruff format --check \
             scripts/science/finalize_dot_rope_pooled_result.py \
             tests/test_finalize_dot_rope_pooled_result.py \
             tests/test_dot_rope_pooled_result_finalization_workflow.py

--- a/scripts/science/finalize_dot_rope_pooled_result.py
+++ b/scripts/science/finalize_dot_rope_pooled_result.py
@@ -200,7 +200,8 @@ def _validate_source_bundle(
         raise ValueError("source evaluator revision changed")
     if support.get("request_id") != request["pooled_request_id"]:
         raise ValueError("marker-support evidence is not bound to the pooled request")
-    if support.get("marker_support_audit", {}).get("audit_id") != request["marker_support_audit_id"]:
+    audit_id = support.get("marker_support_audit", {}).get("audit_id")
+    if audit_id != request["marker_support_audit_id"]:
         raise ValueError("marker-support audit identity changed")
     support_id = support.get("support_id")
     unhashed_support = dict(support)
@@ -260,9 +261,15 @@ def _write_summary(result: Mapping[str, Any], path: Path) -> None:
             f"- Source workflow run: `{result['source_evaluation']['run_id']}`.",
             f"- Source artifact ID: `{result['source_evaluation']['artifact_id']}`.",
             f"- Unfinalized evaluation ID: `{result['unfinalized_evaluation_id']}`.",
-            "- No provider output, score, covariance, method ranking, or dataset payload was changed.",
+            (
+                "- No provider output, score, covariance, method ranking, or "
+                "dataset payload was changed."
+            ),
             "",
-            "Source-development evidence only. R04-R70 remained unopened; no BayesianPhysTwin or Causal4D outcome was executed.",
+            (
+                "Source-development evidence only. R04-R70 remained unopened; "
+                "no BayesianPhysTwin or Causal4D outcome was executed."
+            ),
         ]
     )
     path.write_text("\n".join(lines) + "\n", encoding="utf-8", newline="\n")

--- a/scripts/science/finalize_dot_rope_pooled_result.py
+++ b/scripts/science/finalize_dot_rope_pooled_result.py
@@ -1,0 +1,397 @@
+#!/usr/bin/env python3
+"""Finalize metadata for one exact DOT pooled-evaluation artifact.
+
+The source evaluation already computed all numerical results. This utility only
+repairs the outer request/provenance binding, verifies that the registered
+scientific payload is byte-semantically unchanged, and emits a new
+content-addressed evidence bundle. It opens no dataset and recomputes no score.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import shutil
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from prob4d.dot_rope_cut3r_study import content_id
+
+REQUEST_SCHEMA = "prob4d.dot-rope-pooled-result-finalization-request"
+REQUEST_SCHEMA_VERSION = 1
+SOURCE_RESULT_SCHEMA = "prob4d.dot-rope-cut3r-pooled-evaluation"
+FINAL_RESULT_SCHEMA = "prob4d.dot-rope-cut3r-pooled-evaluation-finalized"
+FINAL_RESULT_SCHEMA_VERSION = 1
+SOURCE_DECISION = "complete-source-evaluation-pooled-marker-support"
+SCIENTIFIC_KEYS = (
+    "decision",
+    "protocol_id",
+    "provider_bundle_id",
+    "runtime_artifact_id",
+    "marker_support_id",
+    "information_boundary",
+    "marker_sampling",
+    "marker_support_audit",
+    "aggregate_methods",
+    "method_rows",
+    "sequences",
+    "opened_marker_members",
+)
+_HEX = re.compile(r"[0-9a-f]+")
+_SHA256_DIGEST = re.compile(r"sha256:[0-9a-f]{64}")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    validate = commands.add_parser("validate-request")
+    validate.add_argument("--request", type=Path, required=True)
+    finalize = commands.add_parser("finalize")
+    finalize.add_argument("--request", type=Path, required=True)
+    finalize.add_argument("--source-root", type=Path, required=True)
+    finalize.add_argument("--output-dir", type=Path, required=True)
+    finalize.add_argument("--repository-revision", required=True)
+    return parser
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if type(value) is not dict:
+        raise ValueError(f"{path} must contain one JSON object")
+    return value
+
+
+def _write_json(path: Path, value: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(
+            dict(value),
+            indent=2,
+            sort_keys=True,
+            ensure_ascii=False,
+            allow_nan=False,
+        )
+        + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def _hex(value: object, *, name: str, length: int) -> str:
+    if not isinstance(value, str) or len(value) != length or _HEX.fullmatch(value) is None:
+        raise ValueError(f"{name} must have {length} lowercase hexadecimal characters")
+    return value
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def validate_request(path: Path) -> dict[str, Any]:
+    request = _read_json(path)
+    expected = {
+        "claim_boundary",
+        "execution_nonce",
+        "marker_support_audit_id",
+        "no_dataset_access",
+        "no_scores_recomputed",
+        "pooled_request_id",
+        "provider_artifact_name",
+        "provider_bundle_id",
+        "provider_request_id",
+        "provider_run_id",
+        "request_id",
+        "schema",
+        "schema_version",
+        "scientific_payload_id",
+        "source_artifact_digest",
+        "source_artifact_id",
+        "source_artifact_name",
+        "source_head_sha",
+        "source_run_id",
+        "source_unfinalized_evaluation_id",
+    }
+    if set(request) != expected:
+        raise ValueError("finalization request fields changed")
+    if (
+        request["schema"] != REQUEST_SCHEMA
+        or request["schema_version"] != REQUEST_SCHEMA_VERSION
+    ):
+        raise ValueError("unsupported finalization request schema")
+    if request["no_dataset_access"] is not True:
+        raise ValueError("finalization must not access the dataset")
+    if request["no_scores_recomputed"] is not True:
+        raise ValueError("finalization must not recompute scores")
+    if not isinstance(request["execution_nonce"], str) or not request["execution_nonce"]:
+        raise ValueError("execution_nonce must be a non-empty string")
+    if not isinstance(request["claim_boundary"], str) or not request["claim_boundary"]:
+        raise ValueError("claim_boundary must be a non-empty string")
+    for name in (
+        "provider_run_id",
+        "source_artifact_id",
+        "source_run_id",
+    ):
+        if not isinstance(request[name], int) or request[name] <= 0:
+            raise ValueError(f"{name} must be a positive integer")
+    for name, length in (
+        ("marker_support_audit_id", 64),
+        ("pooled_request_id", 64),
+        ("provider_bundle_id", 64),
+        ("provider_request_id", 64),
+        ("scientific_payload_id", 64),
+        ("source_head_sha", 40),
+        ("source_unfinalized_evaluation_id", 64),
+    ):
+        _hex(request[name], name=name, length=length)
+    if (
+        not isinstance(request["source_artifact_digest"], str)
+        or _SHA256_DIGEST.fullmatch(request["source_artifact_digest"]) is None
+    ):
+        raise ValueError("source_artifact_digest must be a sha256 GitHub digest")
+    for name in ("provider_artifact_name", "source_artifact_name"):
+        if not isinstance(request[name], str) or not request[name]:
+            raise ValueError(f"{name} must be a non-empty string")
+    unsigned = dict(request)
+    request_id = unsigned.pop("request_id", None)
+    _hex(request_id, name="request_id", length=64)
+    if content_id(unsigned) != request_id:
+        raise ValueError("finalization request identity mismatch")
+    return request
+
+
+def scientific_payload(result: Mapping[str, Any]) -> dict[str, Any]:
+    missing = [key for key in SCIENTIFIC_KEYS if key not in result]
+    if missing:
+        raise ValueError(f"source result lacks scientific fields: {missing}")
+    return {key: result[key] for key in SCIENTIFIC_KEYS}
+
+
+def _validate_source_bundle(
+    request: Mapping[str, Any],
+    source_root: Path,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    result_path = source_root / "result" / "result.json"
+    support_path = source_root / "result" / "marker-support.json"
+    result = _read_json(result_path)
+    support = _read_json(support_path)
+    if result.get("schema") != SOURCE_RESULT_SCHEMA or result.get("schema_version") != 1:
+        raise ValueError("source result schema changed")
+    if result.get("decision") != SOURCE_DECISION:
+        raise ValueError("source result is not a complete pooled evaluation")
+    source_evaluation_id = result.get("evaluation_id")
+    if source_evaluation_id != request["source_unfinalized_evaluation_id"]:
+        raise ValueError("source unfinalized evaluation identity changed")
+    unhashed_result = dict(result)
+    unhashed_result.pop("evaluation_id", None)
+    if content_id(unhashed_result) != source_evaluation_id:
+        raise ValueError("source result content identity is invalid")
+    if result.get("request_id") != request["provider_request_id"]:
+        raise ValueError("source result no longer exhibits the registered request-ID defect")
+    if result.get("provider_bundle_id") != request["provider_bundle_id"]:
+        raise ValueError("source provider bundle identity changed")
+    if result.get("evaluator_prob4d_revision") != request["source_head_sha"]:
+        raise ValueError("source evaluator revision changed")
+    if support.get("request_id") != request["pooled_request_id"]:
+        raise ValueError("marker-support evidence is not bound to the pooled request")
+    if support.get("marker_support_audit", {}).get("audit_id") != request["marker_support_audit_id"]:
+        raise ValueError("marker-support audit identity changed")
+    support_id = support.get("support_id")
+    unhashed_support = dict(support)
+    unhashed_support.pop("support_id", None)
+    if content_id(unhashed_support) != support_id:
+        raise ValueError("marker-support content identity is invalid")
+    payload_id = content_id(scientific_payload(result))
+    if payload_id != request["scientific_payload_id"]:
+        raise ValueError("scientific payload identity changed")
+    required_files = (
+        source_root / "official-archive-metadata.json",
+        source_root / "result" / "method-summary.csv",
+        source_root / "result" / "sequence-methods.csv",
+        source_root / "result" / "summary.md",
+    )
+    for path in required_files:
+        if not path.is_file() or path.is_symlink():
+            raise ValueError(f"required source evidence is unavailable: {path.name}")
+    return result, support
+
+
+def _write_summary(result: Mapping[str, Any], path: Path) -> None:
+    lines = [
+        "# DOT rope marker-free CUT3R source result",
+        "",
+        f"Finalized evaluation ID: `{result['evaluation_id']}`",
+        f"Pooled request ID: `{result['request_id']}`",
+        f"Provider request ID: `{result['provider_request_id']}`",
+        f"Scientific payload ID: `{result['scientific_payload_id']}`",
+        "",
+        "## Uncertainty methods",
+        "",
+        "| Method | Mean normalized NLL/dim | 95% covered | Mean SD/span |",
+        "|---|---:|---:|---:|",
+    ]
+    for row in result["aggregate_methods"]:
+        lines.append(
+            f"| {row['method']} | {row['mean_normalized_nll_per_dimension']:.6f} | "
+            f"{row['covered_95_count']}/{row['sequence_count']} | "
+            f"{row['mean_predictive_sd_fraction_of_span']:.6f} |"
+        )
+    lines.extend(["", "## Reconstruction/stitching", ""])
+    for sequence in result["sequences"]:
+        metrics = sequence["point_metrics"]
+        lines.append(
+            f"- **{sequence['sequence']}**: continuous="
+            f"{metrics['continuous_rmse_fraction_of_span']:.6f}, identity stitch="
+            f"{metrics['identity_stitch_rmse_fraction_of_span']:.6f}, estimated Sim(3) stitch="
+            f"{metrics['estimated_stitch_rmse_fraction_of_span']:.6f}, oracle window="
+            f"{metrics['oracle_window_rmse_fraction_of_span']:.6f} (all / span)."
+        )
+    lines.extend(
+        [
+            "",
+            "## Provenance finalization",
+            "",
+            f"- Source workflow run: `{result['source_evaluation']['run_id']}`.",
+            f"- Source artifact ID: `{result['source_evaluation']['artifact_id']}`.",
+            f"- Unfinalized evaluation ID: `{result['unfinalized_evaluation_id']}`.",
+            "- No provider output, score, covariance, method ranking, or dataset payload was changed.",
+            "",
+            "Source-development evidence only. R04-R70 remained unopened; no BayesianPhysTwin or Causal4D outcome was executed.",
+        ]
+    )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8", newline="\n")
+
+
+def finalize(
+    request: Mapping[str, Any],
+    source_root: Path,
+    output_dir: Path,
+    repository_revision: str,
+) -> dict[str, Any]:
+    revision = _hex(repository_revision, name="repository_revision", length=40)
+    source_result, support = _validate_source_bundle(request, source_root)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    if any(output_dir.iterdir()):
+        raise ValueError("output directory must be empty")
+
+    corrected = dict(source_result)
+    source_schema = corrected.pop("schema")
+    source_schema_version = corrected.pop("schema_version")
+    unfinalized_evaluation_id = corrected.pop("evaluation_id")
+    provider_request_id = corrected.pop("request_id")
+    corrected["schema"] = FINAL_RESULT_SCHEMA
+    corrected["schema_version"] = FINAL_RESULT_SCHEMA_VERSION
+    corrected["source_runtime_schema"] = source_schema
+    corrected["source_runtime_schema_version"] = source_schema_version
+    corrected["unfinalized_evaluation_id"] = unfinalized_evaluation_id
+    corrected["request_id"] = request["pooled_request_id"]
+    corrected["provider_request_id"] = provider_request_id
+    corrected["provider_run_id"] = request["provider_run_id"]
+    corrected["provider_artifact_name"] = request["provider_artifact_name"]
+    corrected["scientific_payload_id"] = request["scientific_payload_id"]
+    corrected["source_evaluation"] = {
+        "run_id": request["source_run_id"],
+        "head_sha": request["source_head_sha"],
+        "artifact_id": request["source_artifact_id"],
+        "artifact_name": request["source_artifact_name"],
+        "artifact_digest": request["source_artifact_digest"],
+    }
+    corrected["provenance_finalization"] = {
+        "repository_revision": revision,
+        "request_id": request["request_id"],
+        "no_dataset_access": True,
+        "no_scores_recomputed": True,
+        "scientific_payload_unchanged": True,
+        "reason": (
+            "Bind the pooled request as the evaluation request, preserve the sealed "
+            "provider request separately, and replace the stale summary identity."
+        ),
+    }
+    corrected["finalization_claim_boundary"] = request["claim_boundary"]
+    if content_id(scientific_payload(corrected)) != request["scientific_payload_id"]:
+        raise AssertionError("scientific payload changed during metadata finalization")
+    corrected["evaluation_id"] = content_id(corrected)
+
+    _write_json(output_dir / "result.json", corrected)
+    _write_json(output_dir / "marker-support.json", support)
+    for name in ("method-summary.csv", "sequence-methods.csv"):
+        shutil.copyfile(source_root / "result" / name, output_dir / name)
+    shutil.copyfile(
+        source_root / "official-archive-metadata.json",
+        output_dir / "official-archive-metadata.json",
+    )
+    _write_summary(corrected, output_dir / "summary.md")
+
+    file_rows = []
+    for path in sorted(output_dir.iterdir(), key=lambda value: value.name):
+        if path.name == "finalization.json":
+            continue
+        file_rows.append(
+            {
+                "path": path.name,
+                "bytes": path.stat().st_size,
+                "sha256": _sha256_file(path),
+            }
+        )
+    receipt: dict[str, Any] = {
+        "schema": "prob4d.dot-rope-pooled-result-finalization",
+        "schema_version": 1,
+        "request_id": request["request_id"],
+        "source_unfinalized_evaluation_id": unfinalized_evaluation_id,
+        "finalized_evaluation_id": corrected["evaluation_id"],
+        "scientific_payload_id": request["scientific_payload_id"],
+        "scientific_payload_unchanged": True,
+        "no_dataset_access": True,
+        "no_scores_recomputed": True,
+        "files": file_rows,
+    }
+    receipt["finalization_id"] = content_id(receipt)
+    _write_json(output_dir / "finalization.json", receipt)
+    return receipt
+
+
+def main() -> int:
+    args = _parser().parse_args()
+    request = validate_request(args.request)
+    if args.command == "validate-request":
+        print(
+            json.dumps(
+                {
+                    "request_id": request["request_id"],
+                    "source_run_id": request["source_run_id"],
+                    "source_artifact_id": request["source_artifact_id"],
+                    "source_artifact_name": request["source_artifact_name"],
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+    if args.command == "finalize":
+        receipt = finalize(
+            request,
+            args.source_root,
+            args.output_dir,
+            args.repository_revision,
+        )
+        print(
+            json.dumps(
+                {
+                    "finalization_id": receipt["finalization_id"],
+                    "finalized_evaluation_id": receipt["finalized_evaluation_id"],
+                    "scientific_payload_id": receipt["scientific_payload_id"],
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+    raise AssertionError(f"unsupported command: {args.command}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dot_rope_pooled_result_finalization_workflow.py
+++ b/tests/test_dot_rope_pooled_result_finalization_workflow.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "dot-rope-pooled-result-finalization-v1.yml"
+
+
+def test_finalization_workflow_is_request_bound_and_hosted() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "name: DOT rope pooled-result provenance finalization v1" in text
+    assert "branches: [main]" in text
+    assert "protocols/execution_requests/dot_rope_pooled_result_finalization_v1.json" in text
+    assert "runs-on: ubuntu-latest" in text
+    assert "self-hosted" not in text
+    assert "pull_request_target:" not in text
+    assert 'test "$EVENT_FORCED" = "false"' in text
+    assert 'test "$EVENT_DELETED" = "false"' in text
+    assert "git push" not in text
+    assert "secrets." not in text
+
+
+def test_finalization_workflow_verifies_exact_source_artifact() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "Verify exact source artifact metadata" in text
+    assert "/actions/artifacts/" in text
+    assert "source artifact ID changed" in text
+    assert "source artifact name changed" in text
+    assert "source artifact digest changed" in text
+    assert "source artifact workflow run changed" in text
+    assert "actions: read" in text
+    assert "github-token: ${{ github.token }}" in text
+
+
+def test_finalization_workflow_is_metadata_only() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "finalize_dot_rope_pooled_result.py" in text
+    assert "Finalize metadata without dataset access or rescoring" in text
+    assert "scientific payload was not preserved" in text
+    assert "No dataset was opened and no score was recomputed" in text
+    assert "DATASET_ROOT" not in text
+    assert "R01-10.zip" not in text

--- a/tests/test_dot_rope_pooled_result_finalization_workflow.py
+++ b/tests/test_dot_rope_pooled_result_finalization_workflow.py
@@ -15,6 +15,10 @@ def test_finalization_workflow_is_request_bound_and_hosted() -> None:
     assert "runs-on: ubuntu-latest" in text
     assert "self-hosted" not in text
     assert "pull_request_target:" not in text
+    assert "github.event.pull_request.head.sha" not in text
+    assert "requirements/ci/quality.txt" in text
+    assert "python -m pip install -r requirements/ci/quality.txt" in text
+    assert 'python -m pip install -e ".[dev]"' not in text
     assert 'test "$EVENT_FORCED" = "false"' in text
     assert 'test "$EVENT_DELETED" = "false"' in text
     assert "git push" not in text

--- a/tests/test_finalize_dot_rope_pooled_result.py
+++ b/tests/test_finalize_dot_rope_pooled_result.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+from prob4d.dot_rope_cut3r_study import content_id
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "science" / "finalize_dot_rope_pooled_result.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("dot_result_finalizer", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_json(path: Path, value: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _source_bundle(module, root: Path) -> tuple[dict, dict]:
+    result = {
+        "schema": module.SOURCE_RESULT_SCHEMA,
+        "schema_version": 1,
+        "decision": module.SOURCE_DECISION,
+        "request_id": "1" * 64,
+        "provider_bundle_id": "2" * 64,
+        "provider_prob4d_revision": "3" * 40,
+        "evaluator_prob4d_revision": "4" * 40,
+        "predecessor_evaluation_id": "5" * 64,
+        "runtime_artifact_id": "6" * 64,
+        "protocol_id": "7" * 64,
+        "marker_support_id": "8" * 64,
+        "information_boundary": {
+            "opened_sequences": ["R01", "R02", "R03"],
+            "reserved_sequences": "R04-R70",
+            "target_payloads_opened": False,
+        },
+        "marker_sampling": {"selected_coordinate_candidate": "columns-0-1:pixel-zero-based"},
+        "marker_support_audit": {"audit_id": "9" * 64, "run_id": 10},
+        "aggregate_methods": [
+            {
+                "method": "pointwise_quadratic",
+                "mean_normalized_nll_per_dimension": 0.75,
+                "covered_95_count": 3,
+                "sequence_count": 3,
+                "mean_predictive_sd_fraction_of_span": 1.0,
+            }
+        ],
+        "method_rows": [{"method": "pointwise_quadratic", "mahalanobis": 2.0}],
+        "sequences": [
+            {
+                "sequence": "R01",
+                "point_metrics": {
+                    "continuous_rmse_fraction_of_span": 0.1,
+                    "identity_stitch_rmse_fraction_of_span": 0.2,
+                    "estimated_stitch_rmse_fraction_of_span": 0.15,
+                    "oracle_window_rmse_fraction_of_span": 0.05,
+                },
+            }
+        ],
+        "opened_marker_members": [{"member": "R01/coordinates/2d/frame000001_cam001.txt"}],
+        "claim_boundary": "source-only",
+    }
+    result["evaluation_id"] = content_id(result)
+    support = {
+        "schema": "prob4d.dot-rope-cut3r-pooled-marker-support",
+        "schema_version": 1,
+        "request_id": "a" * 64,
+        "repository_revision": "4" * 40,
+        "marker_support_audit": {"audit_id": "9" * 64, "run_id": 10},
+        "information_boundary": {"target_payloads_opened": False},
+    }
+    support["support_id"] = content_id(support)
+    result_dir = root / "result"
+    _write_json(result_dir / "result.json", result)
+    _write_json(result_dir / "marker-support.json", support)
+    (result_dir / "method-summary.csv").write_text(
+        "method,sequence_count\npointwise_quadratic,3\n",
+        encoding="utf-8",
+    )
+    (result_dir / "sequence-methods.csv").write_text(
+        "sequence,method\nR01,pointwise_quadratic\n",
+        encoding="utf-8",
+    )
+    (result_dir / "summary.md").write_text(
+        "# Source\n\nEvaluation ID: `stale`\n",
+        encoding="utf-8",
+    )
+    _write_json(root / "official-archive-metadata.json", {"filename": "R01-10.zip"})
+    return result, support
+
+
+def _request(module, source_result: dict) -> dict:
+    request = {
+        "claim_boundary": "metadata-only finalization",
+        "execution_nonce": "test-1",
+        "marker_support_audit_id": "9" * 64,
+        "no_dataset_access": True,
+        "no_scores_recomputed": True,
+        "pooled_request_id": "a" * 64,
+        "provider_artifact_name": "sealed-provider",
+        "provider_bundle_id": "2" * 64,
+        "provider_request_id": "1" * 64,
+        "provider_run_id": 11,
+        "schema": module.REQUEST_SCHEMA,
+        "schema_version": module.REQUEST_SCHEMA_VERSION,
+        "scientific_payload_id": content_id(module.scientific_payload(source_result)),
+        "source_artifact_digest": "sha256:" + "b" * 64,
+        "source_artifact_id": 12,
+        "source_artifact_name": "source-evidence",
+        "source_head_sha": "4" * 40,
+        "source_run_id": 13,
+        "source_unfinalized_evaluation_id": source_result["evaluation_id"],
+    }
+    request["request_id"] = content_id(request)
+    return request
+
+
+def test_finalization_repairs_request_binding_without_changing_scores(tmp_path: Path) -> None:
+    module = _load_module()
+    source_root = tmp_path / "source"
+    source_result, _ = _source_bundle(module, source_root)
+    request = _request(module, source_result)
+    request_path = tmp_path / "request.json"
+    _write_json(request_path, request)
+    validated = module.validate_request(request_path)
+
+    receipt = module.finalize(
+        validated,
+        source_root,
+        tmp_path / "output",
+        "c" * 40,
+    )
+    finalized = json.loads((tmp_path / "output" / "result.json").read_text(encoding="utf-8"))
+
+    assert finalized["request_id"] == request["pooled_request_id"]
+    assert finalized["provider_request_id"] == request["provider_request_id"]
+    assert finalized["unfinalized_evaluation_id"] == source_result["evaluation_id"]
+    assert finalized["aggregate_methods"] == source_result["aggregate_methods"]
+    assert finalized["method_rows"] == source_result["method_rows"]
+    assert finalized["sequences"] == source_result["sequences"]
+    assert finalized["scientific_payload_id"] == request["scientific_payload_id"]
+    assert finalized["evaluation_id"] == content_id(
+        {key: value for key, value in finalized.items() if key != "evaluation_id"}
+    )
+    assert receipt["scientific_payload_unchanged"] is True
+    summary = (tmp_path / "output" / "summary.md").read_text(encoding="utf-8")
+    assert finalized["evaluation_id"] in summary
+    assert source_result["evaluation_id"] in summary
+
+
+def test_finalization_rejects_scientific_payload_drift(tmp_path: Path) -> None:
+    module = _load_module()
+    source_root = tmp_path / "source"
+    source_result, _ = _source_bundle(module, source_root)
+    request = _request(module, source_result)
+    request["scientific_payload_id"] = "d" * 64
+    request["request_id"] = content_id(
+        {key: value for key, value in request.items() if key != "request_id"}
+    )
+
+    with pytest.raises(ValueError, match="scientific payload identity changed"):
+        module.finalize(request, source_root, tmp_path / "output", "c" * 40)


### PR DESCRIPTION
## Purpose

Non-draft replacement for #394 at the **identical reviewed head commit** `9858e15a00837a88c3f2e11b5f39f7c963fb88dd`. The replacement is necessary only because the connector's ready-for-review mutation currently fails against GitHub's GraphQL schema; no repository file differs from #394.

Finalize the provenance envelope of the completed DOT R01-R03 pooled-marker CUT3R evaluation **without changing its scientific payload**.

The retained source evaluation completed successfully, but its outer `request_id` remained bound to the sealed provider request rather than the hosted pooled-evaluation request. This PR adds a metadata-only finalizer that repairs those bindings while proving that all registered scores, covariance outputs, method rows, sequence results, and information-boundary fields remain unchanged.

## What changes

- add `finalize_dot_rope_pooled_result.py` with strict request/schema/content-identity checks;
- retain the original provider request ID separately while binding the finalized evaluation to the pooled request;
- compute and verify a dedicated `scientific_payload_id` over the claim-bearing result fields before and after finalization;
- verify the exact source Actions artifact by run ID, artifact ID, name, and GitHub SHA-256 digest before download;
- emit a new content-addressed result, summary, file hashes, and finalization receipt;
- add hosted workflow and focused regressions for the request, provenance, metadata-only, and workflow-security boundaries.

## Security and validation

The pull-request job uses the normal read-only merge checkout, `persist-credentials: false`, and the repository's pinned `requirements/ci/quality.txt` environment. It does not explicitly check out an untrusted PR head. The CodeQL warning on #394 was fixed and its review thread resolved.

On the identical head commit, #394 passed:

- DOT pooled-result finalizer contract;
- provider batch preflight;
- fail-closed quality;
- CodeQL/security scanning;
- complete Python 3.10-3.14 test matrix;
- distribution builds; and
- installed wheel and sdist CLI smoke tests.

## Post-merge trigger

After merge, exactly one new file at

`protocols/execution_requests/dot_rope_pooled_result_finalization_v1.json`

will authorize the metadata-only finalization. Its source identity is already derivable from immutable evidence: source run `33338311316`, artifact `9739735578`, digest `sha256:0ce70e6f0f252a5eb921a339964723428446cab361d9d65a8aed0cda5c4c9427`, unfinalized evaluation `ec86014b945b5f0d7e0d1fc8e38e5976acfb5efc7ef92fc816714c1cc5b60e09`, and scientific payload ID `56eb9ad3694d8e7565ab844b00e3ee7de37a0ba4b8bb47bbaf0e4b674cb8d970`.

## Information and claim boundary

The finalization opens no DOT dataset path and recomputes no reconstruction score, uncertainty score, covariance, ranking, or provider prediction. R04-R70 remain unopened. This remains source-development real-data evidence and does not establish held-out transfer, independent calibration, BayesianPhysTwin benefit, Causal4D benefit, deployment safety, or state of the art.

Supersedes draft #394 solely for review-state mechanics.