### PR TITLE
Fix queued self-hosted metadata guard for DOT recovery

### DIFF
--- a/.github/workflows/dot-rope-cut3r-heldout-queued-recovery-v1.yml
+++ b/.github/workflows/dot-rope-cut3r-heldout-queued-recovery-v1.yml
@@ -126,7 +126,7 @@ jobs:
               raise SystemExit("queued-recovery request fields changed")
           expected = {
               "schema": "prob4d.dot-rope-cut3r-heldout-queued-recovery-request",
-              "schema_version": 1,
+              "schema_version": 2,
               "superseded_run_id": int(os.environ["SUPERSEDED_RUN_ID"]),
               "superseded_head_sha": os.environ["SUPERSEDED_HEAD_SHA"],
               "target_workflow": os.environ["TARGET_WORKFLOW"],
@@ -228,8 +228,15 @@ jobs:
               raise SystemExit(
                   f"recovery requires queued run/provider; got run={run['status']} job={job['status']}"
               )
-          if job.get("started_at") is not None or job.get("steps") not in (None, []):
-              raise SystemExit("provider job has started; exact queued recovery forbidden")
+          if job.get("steps") not in (None, []):
+              raise SystemExit("provider job has executable steps; exact queued recovery forbidden")
+          if job.get("completed_at") is not None or job.get("conclusion") is not None:
+              raise SystemExit("provider job has completed; exact queued recovery forbidden")
+          if job.get("runner_id") not in (None, 0) or job.get("runner_name") not in (None, ""):
+              raise SystemExit("provider job is assigned to a runner; exact queued recovery forbidden")
+          expected_labels = {"self-hosted", "Linux", "X64", "gpuserver4090"}
+          if set(job.get("labels", [])) != expected_labels:
+              raise SystemExit("provider job runner labels changed")
 
           status, _ = call("POST", f"/repos/{repo}/actions/runs/{run_id}/cancel")
           if status not in (202, 204):
@@ -264,7 +271,7 @@ jobs:
 
           summary = {
               "schema": "prob4d.dot-rope-cut3r-heldout-queued-recovery-receipt",
-              "schema_version": 1,
+              "schema_version": 2,
               "run_id": run_id,
               "head_sha": latest["head_sha"],
               "run_attempt": latest["run_attempt"],

--- a/docs/dot-rope-cut3r-heldout-queued-recovery-v1.md
+++ b/docs/dot-rope-cut3r-heldout-queued-recovery-v1.md
@@ -2,7 +2,8 @@
 
 This operational helper addresses one retained scheduling state only: workflow
 run `33363832286` was authorized from the frozen R04-R10 request, but its
-self-hosted provider job remained queued before any provider step started.
+self-hosted provider job remained queued without a runner assignment or any
+provider step execution.
 
 The helper does **not** create a new scientific request. It may cancel and rerun
 that exact workflow run only when all of the following remain true at execution
@@ -10,29 +11,43 @@ time:
 
 - the run is still attempt 1 at head
   `bb2179158b27178c6ebed9be866bee829108b72a`;
-- the provider job `Seal marker-free R04-R10 CUT3R predictions` is still queued
-  and has no start time or steps;
+- the provider job `Seal marker-free R04-R10 CUT3R predictions` remains in
+  `queued` state with `runner_id` zero or absent, an empty runner name, no
+  executable steps, no conclusion, and no completion time;
+- its labels remain exactly `self-hosted`, `Linux`, `X64`, and
+  `gpuserver4090`;
 - the run has published zero artifacts;
 - the retained confirmation request is still
   `62d64df1b1b72f2b2aff0b17cf4c7aad245150f9fa1ff67712eedc0f4e109ce6`;
 - no scientific input, provider payload, marker payload, or outcome is changed
   or opened by the recovery helper.
 
+GitHub's Actions REST representation may populate a queued self-hosted job's
+`started_at` field with its creation timestamp before any runner is assigned.
+For the retained run this occurs together with `runner_id=0`, empty runner name,
+`steps=[]`, and `status=queued`. Recovery v2 therefore does not interpret
+`started_at` alone as provider execution. It fails closed on actual runner
+assignment, executable steps, completion, artifacts, a changed label set, or a
+changed workflow/run identity.
+
 If any condition is false, recovery fails closed. In particular, a run that has
-started, completed, published evidence, or already been retried is not touched.
+been assigned, executed, completed, published evidence, or already been retried
+is not touched.
 
 The recovery workflow itself runs only on a GitHub-hosted runner and has no DOT
 dataset path, GPU access, CUT3R checkout, checkpoint, marker reader, or
 BayesianPhysTwin/Causal4D access. Its only write permission is GitHub Actions
 control-plane access needed to cancel and rerun the exact retained workflow.
 
-Triggering is separated from implementation. After this helper is reviewed and
-merged, exactly one file may be added on `main`:
+Triggering is separated from implementation. After the recovery helper is
+reviewed and merged, exactly one file may change on `main`:
 
 `protocols/execution_requests/dot_rope_cut3r_heldout_queued_recovery_v1.json`
 
-That file is a content-addressed operational request. The push workflow verifies
-that it is the only changed path before touching the retained run.
+That file is a content-addressed operational request. Schema version 2 records
+the corrected queued-job interpretation; it changes no scientific input or
+retained R04-R10 protocol. The push workflow verifies that it is the only changed
+path before touching the retained run.
 
 This recovery changes no scientific claim. The R04-R10 confirmation remains
 owned by `protocols/dot-rope-cut3r-heldout-confirmation-v1.json`; R11-R70 remain

--- a/tests/test_dot_rope_cut3r_heldout_queued_recovery_workflow.py
+++ b/tests/test_dot_rope_cut3r_heldout_queued_recovery_workflow.py
@@ -18,9 +18,15 @@ def main() -> None:
         "RETAINED_PROTOCOL_ID: a83258295d5ecabd95017a775f334173bb48141918832fb1a065a1dff66d16ba",
         "EXPECTED_PROVIDER_JOB: Seal marker-free R04-R10 CUT3R predictions",
         "actions: write",
+        '"schema_version": 2',
         'run["status"] != "queued"',
         'job["status"] != "queued"',
-        'job.get("started_at") is not None',
+        'job.get("steps") not in (None, [])',
+        'job.get("completed_at") is not None',
+        'job.get("conclusion") is not None',
+        'job.get("runner_id") not in (None, 0)',
+        'job.get("runner_name") not in (None, "")',
+        'expected_labels = {"self-hosted", "Linux", "X64", "gpuserver4090"}',
         'artifacts.get("total_count", 0)',
         'f"/repos/{repo}/actions/runs/{run_id}/cancel"',
         'f"/repos/{repo}/actions/runs/{run_id}/rerun"',
@@ -32,9 +38,12 @@ def main() -> None:
     for needle in required:
         assert needle in text, needle
 
-    # The recovery helper itself is hosted and must not gain access to DOT or a GPU.
-    assert "self-hosted" not in text
-    assert "gpuserver4090" not in text
+    # GitHub may populate started_at at queue creation even while runner_id is 0.
+    # Assignment/execution is therefore guarded by runner identity, steps,
+    # completion, and queue state rather than by started_at alone.
+    assert 'job.get("started_at") is not None' not in text
+
+    # The recovery helper itself is hosted and must not gain DOT/GPU access.
     assert "DATASET_ROOT" not in text
     assert "/mnt/" not in text
     assert "nvidia-smi" not in text


### PR DESCRIPTION
## Purpose

Correct the operational recovery guard after GitHub's Actions REST API showed that an **unassigned queued self-hosted job** may have a non-null `started_at` equal to its creation time.

For retained DOT run `33363832286`, the provider job is still `status=queued`, `runner_id=0`, empty `runner_name`, `steps=[]`, no conclusion/completion, and has published no artifacts. No R04-R10 provider or marker payload has executed.

## Change

Recovery schema v2 removes `started_at` as a standalone execution signal and instead requires all of:

- run and provider job still queued;
- no executable steps;
- no completion or conclusion;
- `runner_id` absent/zero and runner name absent/empty;
- exact labels `self-hosted, Linux, X64, gpuserver4090`;
- zero run artifacts;
- unchanged run/head/request/protocol identities.

Any actual assignment or execution still fails closed. Scientific inputs, R04-R10 cohort, thresholds, CUT3R identity, marker order, and R11-R70 access remain unchanged.