### PR TITLE
Trigger corrected recovery of queued DOT R04-R10 run

### DIFF
--- a/protocols/execution_requests/dot_rope_cut3r_heldout_queued_recovery_v1.json
+++ b/protocols/execution_requests/dot_rope_cut3r_heldout_queued_recovery_v1.json
@@ -1,6 +1,6 @@
 {
   "schema": "prob4d.dot-rope-cut3r-heldout-queued-recovery-request",
-  "schema_version": 1,
+  "schema_version": 2,
   "superseded_run_id": 33363832286,
   "superseded_head_sha": "bb2179158b27178c6ebed9be866bee829108b72a",
   "target_workflow": "dot-rope-cut3r-heldout-confirmation-v1.yml",
@@ -13,5 +13,5 @@
   "artifacts_published": false,
   "scientific_inputs_changed": false,
   "action": "cancel-queued-and-rerun-exact-workflow-run",
-  "request_id": "3f60e16c4c6d16323322a2b363212c8392ad8a14c8daae02d58ccc9943519b8e"
+  "request_id": "387e88f4d63690472f82eafe3a1ce7bebdea5b62265c9c235f7aae36bf9b4032"
 }


### PR DESCRIPTION
Exactly one operational request file changes. Schema v2 records the corrected GitHub queued-job interpretation only; it changes no R04-R10 scientific input, cohort, threshold, provider identity, marker order, or target-access boundary.

At merge time the hosted recovery workflow independently requires run `33363832286` to remain attempt 1, queued, unassigned (`runner_id=0`, empty runner name), step-free, completion-free, artifact-free, and bound to the unchanged held-out request/protocol. Otherwise it fails closed.

If those checks pass, it cancels and reruns the exact same retained workflow run.