### PR TITLE
Run frozen DOT R04–R10 confirmation on gpuserver6000

### DIFF
--- a/.github/workflows/dot-rope-cut3r-heldout-confirmation-v1.yml
+++ b/.github/workflows/dot-rope-cut3r-heldout-confirmation-v1.yml
@@ -5,15 +5,16 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/dot-rope-cut3r-heldout-confirmation-v1.yml"
+      - "CHANGELOG.d/dot-r04-r10-gpuserver6000-v1.md"
       - "protocols/dot-rope-cut3r-heldout-confirmation-v1.json"
       - "scripts/science/run_dot_rope_cut3r_heldout_confirmation.py"
-      - "tests/test_dot_rope_cut3r_heldout_confirmation.py"
+      - "scripts/science/verify_dot_rope_cut3r_heldout_result.py"
       - "tests/test_dot_rope_cut3r_heldout_confirmation_workflow.py"
       - "tests/test_trusted_self_hosted_validation_policy.py"
   push:
     branches: [main]
     paths:
-      - "protocols/execution_requests/dot_rope_cut3r_heldout_confirmation_v1.json"
+      - "protocols/execution_requests/dot_rope_cut3r_heldout_confirmation_gpuserver6000_v1.json"
 
 permissions:
   contents: read
@@ -23,20 +24,23 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  REQUEST_PATH: protocols/execution_requests/dot_rope_cut3r_heldout_confirmation_v1.json
+  REQUEST_PATH: protocols/execution_requests/dot_rope_cut3r_heldout_confirmation_gpuserver6000_v1.json
   PROTOCOL_PATH: protocols/dot-rope-cut3r-heldout-confirmation-v1.json
-  DATASET_ROOT: /mnt/seagate10tb/florianpfaff/datasets/dot
-  CUT3R_RUNTIME_ROOT: /home/github-runner/.cache/prob4d/cut3r-runtime-v1
-  CUT3R_RUNTIME_CHECKOUT: /home/github-runner/.cache/prob4d/cut3r-runtime-v1/CUT3R
-  CUT3R_RUNTIME_PYTHON: /home/github-runner/.cache/prob4d/cut3r-runtime-v1/venv/bin/python
-  CUT3R_RUNTIME_CHECKPOINT: /home/github-runner/.cache/prob4d/cut3r-runtime-v1/cut3r_512_dpt_4_64.pth
-  CUT3R_RUNTIME_MANIFEST: /home/github-runner/.cache/prob4d/cut3r-runtime-v1/bootstrap-manifest.json
-  CUT3R_REVISION: 8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf
-  CUT3R_CHECKPOINT_SHA256: 45f7e98a0a64dbeb54901ae2b878cd8cd125f20a4497316483f0bd6f109f8103
   ARCHIVE_NAME: R01-10.zip
   ARCHIVE_MD5: ca546ff5f22c0279123ccb18509858ee
   DATASET_API: https://dataverse.orc.gmu.edu/api/datasets/:persistentId/?persistentId=doi:10.13021/ORC2020/XXLVXM
   DATAFILE_API_ROOT: https://dataverse.orc.gmu.edu/api/access/datafile
+  CUT3R_REVISION: 8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf
+  CUT3R_CHECKPOINT_SHA256: 45f7e98a0a64dbeb54901ae2b878cd8cd125f20a4497316483f0bd6f109f8103
+  CUT3R_CHECKPOINT_GDRIVE_ID: 1Asz-ZB3FfpzZYwunhQvNPZEUA8XUNAYD
+  ORIGINAL_RUN_ID: "33363832286"
+  ORIGINAL_HEAD_SHA: bb2179158b27178c6ebed9be866bee829108b72a
+  ORIGINAL_PROVIDER_JOB: Seal marker-free R04-R10 CUT3R predictions
+  RUNTIME_CACHE_ROOT: /home/github-runner/.cache/prob4d/dot-r04-r10-cut3r-gpuserver6000-v1
+  RETAINED_CUT3R_CHECKOUT: ${{ vars.CUT3R_CHECKOUT }}
+  RETAINED_CUT3R_CHECKPOINT: ${{ vars.CUT3R_CHECKPOINT }}
+  RETAINED_CUT3R_PYTHON: ${{ vars.CUT3R_PYTHON }}
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
   PYTHONHASHSEED: "0"
   PYTHONUNBUFFERED: "1"
   PYTHONDONTWRITEBYTECODE: "1"
@@ -47,24 +51,26 @@ env:
 
 jobs:
   contract:
-    name: Validate frozen held-out confirmation control plane
+    name: Validate frozen confirmation recovery control plane
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 25
     steps:
-      - name: Check out reviewed revision
+      - name: Check out exact reviewed revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
           clean: true
+
       - name: Set up Python 3.12
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
           cache: pip
           cache-dependency-path: pyproject.toml
-      - name: Validate frozen protocol, runner, and custody
+
+      - name: Validate frozen source, workflow, and custody policy
         shell: bash
         run: |
           set -euo pipefail
@@ -72,43 +78,51 @@ jobs:
           python -m pip check
           python -m ruff check \
             scripts/science/run_dot_rope_cut3r_heldout_confirmation.py \
-            tests/test_dot_rope_cut3r_heldout_confirmation.py \
+            scripts/science/verify_dot_rope_cut3r_heldout_result.py \
             tests/test_dot_rope_cut3r_heldout_confirmation_workflow.py \
             tests/test_trusted_self_hosted_validation_policy.py
           python -m ruff format --check \
             scripts/science/run_dot_rope_cut3r_heldout_confirmation.py \
-            tests/test_dot_rope_cut3r_heldout_confirmation.py \
+            scripts/science/verify_dot_rope_cut3r_heldout_result.py \
             tests/test_dot_rope_cut3r_heldout_confirmation_workflow.py \
             tests/test_trusted_self_hosted_validation_policy.py
           python -m pytest -q \
-            tests/test_dot_rope_cut3r_heldout_confirmation.py \
             tests/test_dot_rope_cut3r_heldout_confirmation_workflow.py \
+            tests/test_dot_rope_cut3r_heldout_confirmation.py \
+            tests/test_dot_rope_cut3r_heldout_result_verifier.py \
             tests/test_trusted_self_hosted_validation_policy.py \
             tests/test_github_action_pins.py
-          python -m compileall -q scripts/science/run_dot_rope_cut3r_heldout_confirmation.py
+          python -m compileall -q \
+            scripts/science/run_dot_rope_cut3r_heldout_confirmation.py \
+            scripts/science/verify_dot_rope_cut3r_heldout_result.py
 
   authorize:
-    name: Authorize one immutable held-out request
+    name: Authorize one immutable recovery and retire queued predecessor
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
+      actions: write
     outputs:
       request_id: ${{ steps.request.outputs.request_id }}
       head_sha: ${{ steps.request.outputs.head_sha }}
       protocol_git_blob_sha: ${{ steps.request.outputs.protocol_git_blob_sha }}
     steps:
-      - name: Check out exact merged revision
+      - name: Check out exact merged-main revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.sha }}
           fetch-depth: 2
           persist-credentials: false
           clean: true
+
       - name: Set up Python 3.12
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
-      - name: Require exactly one non-forced confirmation-request change
+
+      - name: Require exactly one non-forced recovery-request change
         id: request
         shell: bash
         env:
@@ -120,17 +134,21 @@ jobs:
         run: |
           set -euo pipefail
           test "$EVENT_REF" = "refs/heads/main"
-          test "$EVENT_AFTER" = "$(git rev-parse HEAD)"
+          test "$EVENT_AFTER" = "$(/usr/bin/git rev-parse HEAD)"
           test "$EVENT_FORCED" = "false"
           test "$EVENT_DELETED" = "false"
           test "$EVENT_BEFORE" != "0000000000000000000000000000000000000000"
-          mapfile -t changed < <(git diff --name-only "$EVENT_BEFORE" "$EVENT_AFTER" | sort)
+          mapfile -t changed < <(
+            /usr/bin/git diff --name-only "$EVENT_BEFORE" "$EVENT_AFTER" | sort
+          )
           if [[ ${#changed[@]} -ne 1 || "${changed[0]}" != "$REQUEST_PATH" ]]; then
             printf 'Expected only %s; changed paths were:\n' "$REQUEST_PATH" >&2
             printf '  %s\n' "${changed[@]}" >&2
             exit 2
           fi
-          protocol_blob=$(git rev-parse "$EVENT_AFTER:$PROTOCOL_PATH")
+          test -f "$REQUEST_PATH"
+          test -f "$PROTOCOL_PATH"
+          protocol_blob=$(/usr/bin/git rev-parse "$EVENT_AFTER:$PROTOCOL_PATH")
           python -m pip install -e .
           validation=$(
             python scripts/science/run_dot_rope_cut3r_heldout_confirmation.py \
@@ -139,192 +157,523 @@ jobs:
               --protocol "$PROTOCOL_PATH" \
               --protocol-git-blob-sha "$protocol_blob"
           )
-          VALIDATION="$validation" PROTOCOL_BLOB="$protocol_blob" EVENT_AFTER="$EVENT_AFTER" \
+          VALIDATION="$validation" \
+            PROTOCOL_BLOB="$protocol_blob" \
+            EVENT_AFTER="$EVENT_AFTER" \
             python - <<'PY'
           import json
           import os
 
           value = json.loads(os.environ["VALIDATION"])
+          assert value["confirmation_sequences"] == [
+              "R04", "R05", "R06", "R07", "R08", "R09", "R10"
+          ]
+          assert value["reserved_sequences"] == "R11-R70"
+          outputs = {
+              "request_id": value["request_id"],
+              "head_sha": os.environ["EVENT_AFTER"],
+              "protocol_git_blob_sha": os.environ["PROTOCOL_BLOB"],
+          }
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
-              output.write(f"request_id={value['request_id']}\n")
-              output.write(f"head_sha={os.environ['EVENT_AFTER']}\n")
-              output.write(f"protocol_git_blob_sha={os.environ['PROTOCOL_BLOB']}\n")
+              for key, item in outputs.items():
+                  output.write(f"{key}={item}\n")
+          PY
+
+      - name: Prove the old gpuserver4090 run never opened confirmation data
+        shell: bash
+        env:
+          API_URL: ${{ github.api_url }}
+          REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from __future__ import annotations
+
+          import json
+          import os
+          import time
+          import urllib.request
+
+          api = os.environ["API_URL"]
+          repository = os.environ["REPOSITORY"]
+          run_id = int(os.environ["ORIGINAL_RUN_ID"])
+          headers = {
+              "Accept": "application/vnd.github+json",
+              "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+              "X-GitHub-Api-Version": "2022-11-28",
+          }
+
+          def request(path: str, *, method: str = "GET"):
+              value = urllib.request.Request(
+                  f"{api}/repos/{repository}{path}",
+                  method=method,
+                  headers=headers,
+              )
+              with urllib.request.urlopen(value, timeout=30) as response:
+                  raw = response.read()
+              return json.loads(raw) if raw else None
+
+          run = request(f"/actions/runs/{run_id}")
+          if run["head_sha"] != os.environ["ORIGINAL_HEAD_SHA"]:
+              raise SystemExit("queued predecessor head changed")
+          if run["run_attempt"] != 2:
+              raise SystemExit("queued predecessor attempt changed")
+          jobs = request(f"/actions/runs/{run_id}/jobs?per_page=100")["jobs"]
+          matches = [job for job in jobs if job["name"] == os.environ["ORIGINAL_PROVIDER_JOB"]]
+          if len(matches) != 1:
+              raise SystemExit("queued predecessor provider job is unavailable")
+          provider = matches[0]
+          artifacts = request(f"/actions/runs/{run_id}/artifacts?per_page=100")
+          untouched = (
+              artifacts["total_count"] == 0
+              and provider.get("conclusion") is None
+              and provider.get("runner_id") in (None, 0)
+              and not provider.get("runner_name")
+              and not provider.get("steps")
+          )
+          if not untouched:
+              raise SystemExit("old confirmation provider may have started; recovery is forbidden")
+
+          if run["status"] in {"queued", "in_progress"}:
+              request(f"/actions/runs/{run_id}/cancel", method="POST")
+              for _ in range(30):
+                  time.sleep(2)
+                  run = request(f"/actions/runs/{run_id}")
+                  if run["status"] == "completed":
+                      break
+              else:
+                  raise SystemExit("old queued confirmation did not cancel")
+          if run["status"] != "completed" or run["conclusion"] != "cancelled":
+              raise SystemExit("old confirmation did not end as an untouched cancellation")
+          print(json.dumps({
+              "retired_run_id": run_id,
+              "retired_conclusion": run["conclusion"],
+              "provider_steps": provider.get("steps") or [],
+              "artifact_count": artifacts["total_count"],
+          }, sort_keys=True))
           PY
 
   provider:
-    name: Seal marker-free R04-R10 CUT3R predictions
+    name: Seal marker-free R04-R10 CUT3R predictions on gpuserver6000
     if: github.event_name == 'push'
     needs: authorize
     environment: trusted-self-hosted-validation
-    runs-on: [self-hosted, Linux, X64, gpuserver4090]
-    timeout-minutes: 360
+    runs-on: [self-hosted, gpuserver6000]
+    timeout-minutes: 480
     permissions:
       contents: read
     outputs:
-      decision: ${{ steps.result.outputs.decision }}
-      provider_bundle_id: ${{ steps.result.outputs.provider_bundle_id }}
+      provider_bundle_id: ${{ steps.seal.outputs.provider_bundle_id }}
+      provider_artifact_name: ${{ steps.seal.outputs.provider_artifact_name }}
     steps:
-      - name: Initialize isolated provider workspace
+      - name: Bind the intended GPU runner
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$RUNNER_NAME" = "workstation2"
+          test "$RUNNER_OS" = "Linux"
+          test "$RUNNER_ARCH" = "X64"
+          command -v nvidia-smi >/dev/null 2>&1
+          command -v c++ >/dev/null 2>&1
+          nvidia-smi --query-gpu=name,driver_version,memory.total --format=csv,noheader
+
+      - name: Initialize isolated prediction workspace
         id: workspace
         shell: bash
         run: |
           set -euo pipefail
-          root="${RUNNER_TEMP}/prob4d-dot-heldout-provider-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          root="${RUNNER_TEMP}/prob4d-dot-r04-r10-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          expected="${RUNNER_TEMP}/prob4d-dot-r04-r10-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          test "$root" = "$expected"
           /usr/bin/rm -rf -- "$root"
-          /usr/bin/mkdir -p "$root/provider" "$root/home" "$root/cache" "$root/tmp"
+          /usr/bin/mkdir -p \
+            "$root/home" \
+            "$root/cache" \
+            "$root/tmp" \
+            "$root/evidence" \
+            "$root/provider"
           echo "root=$root" >> "$GITHUB_OUTPUT"
           {
             echo "HOME=$root/home"
             echo "XDG_CACHE_HOME=$root/cache"
+            echo "PIP_CACHE_DIR=$root/cache/pip"
+            echo "HF_HOME=$root/cache/huggingface"
             echo "TMPDIR=$root/tmp"
             echo "TORCH_EXTENSIONS_DIR=$root/cache/torch-extensions"
             echo "WANDB_MODE=disabled"
             echo "WANDB_DISABLED=true"
           } >> "$GITHUB_ENV"
-      - name: Require intended runner and official R01-10 archive
-        shell: bash
-        run: |
-          set -euo pipefail
-          test "$RUNNER_NAME" = "workstation1"
-          test "$RUNNER_OS" = "Linux"
-          test "$RUNNER_ARCH" = "X64"
-          command -v nvidia-smi >/dev/null 2>&1
-          test -d "$DATASET_ROOT"
-          test ! -L "$DATASET_ROOT"
-          test -f "$DATASET_ROOT/$ARCHIVE_NAME"
-          test -r "$DATASET_ROOT/$ARCHIVE_NAME"
-          printf '%s  %s\n' "$ARCHIVE_MD5" "$DATASET_ROOT/$ARCHIVE_NAME" | md5sum --check --strict
-          nvidia-smi --query-gpu=name,driver_version,memory.total --format=csv,noheader
-      - name: Check out exact authorized revision
+
+      - name: Check out exact authorized Prob4D revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.authorize.outputs.head_sha }}
           fetch-depth: 0
           persist-credentials: false
           clean: true
-      - name: Verify clean exact checkout
+
+      - name: Verify clean exact Prob4D checkout
         shell: bash
         env:
           EXPECTED_HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
         run: |
           set -euo pipefail
-          test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
-          test -z "$(git status --porcelain=v1 --untracked-files=all)"
-      - name: Bind persistent CUDA 12.6 CUT3R runtime
+          test "$(/usr/bin/git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
+          test -z "$(/usr/bin/git status --porcelain=v1 --untracked-files=all)"
+          test "$(/usr/bin/git rev-parse HEAD:$PROTOCOL_PATH)" = \
+            "${{ needs.authorize.outputs.protocol_git_blob_sha }}"
+
+      - name: Check out exact public CUT3R revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: CUT3R/CUT3R
+          ref: 8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf
+          path: external/CUT3R
+          fetch-depth: 1
+          persist-credentials: false
+          clean: true
+
+      - name: Set up bootstrap Python 3.11
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+
+      - name: Select or bootstrap a CUDA CUT3R interpreter
         id: runtime
         shell: bash
         run: |
           set -euo pipefail
-          test -x "$CUT3R_RUNTIME_PYTHON"
-          test -d "$CUT3R_RUNTIME_CHECKOUT/.git"
-          test -f "$CUT3R_RUNTIME_CHECKPOINT"
-          test -f "$CUT3R_RUNTIME_MANIFEST"
-          test "$(git -C "$CUT3R_RUNTIME_CHECKOUT" rev-parse HEAD)" = "$CUT3R_REVISION"
-          test "$(sha256sum "$CUT3R_RUNTIME_CHECKPOINT" | awk '{print $1}')" = \
-            "$CUT3R_CHECKPOINT_SHA256"
-          MANIFEST="$CUT3R_RUNTIME_MANIFEST" \
-            EXPECTED_REVISION="$CUT3R_REVISION" \
-            EXPECTED_CHECKPOINT_SHA256="$CUT3R_CHECKPOINT_SHA256" \
-            EXPECTED_PYTHON="$CUT3R_RUNTIME_PYTHON" \
-            "$CUT3R_RUNTIME_PYTHON" - <<'PY'
-          import json
-          import os
+          root="${{ steps.workspace.outputs.root }}"
+          candidates=("")
+          add_candidate() {
+            local candidate="${1:-}"
+            [[ -n "$candidate" ]] || return 0
+            local existing
+            for existing in "${candidates[@]}"; do
+              [[ "$existing" != "$candidate" ]] || return 0
+            done
+            candidates+=("$candidate")
+          }
+          add_candidate "${RETAINED_CUT3R_PYTHON:-}"
+          if [[ -n "${RETAINED_CUT3R_CHECKOUT:-}" ]]; then
+            add_candidate "$RETAINED_CUT3R_CHECKOUT/.venv/bin/python"
+          fi
+          add_candidate /home/florianpfaff/conda_envs/cut3r/bin/python
+          add_candidate /home/florianpfaff/miniconda3/envs/cut3r/bin/python
+          add_candidate /home/florianpfaff/anaconda3/envs/cut3r/bin/python
+          add_candidate /home/github-runner/.conda/envs/cut3r/bin/python
+          add_candidate /home/github-runner/miniconda3/envs/cut3r/bin/python
+          add_candidate /home/github-runner/anaconda3/envs/cut3r/bin/python
+          add_candidate /opt/conda/envs/cut3r/bin/python
+
+          usable=""
+          for candidate in "${candidates[@]}"; do
+            [[ -x "$candidate" ]] || continue
+            echo "::group::CUT3R interpreter candidate $candidate"
+            if "$candidate" - <<'PY'
+          import accelerate
+          import cv2
+          import einops
+          import h5py
+          import hydra
+          import lpips
+          import numpy
+          import PIL
+          import roma
+          import scipy
+          import sklearn
+          import torch
+          import torchvision
+          import transformers
+
+          print("python-ready")
+          print("torch", torch.__version__)
+          print("torch_cuda", torch.version.cuda)
+          print("cuda_available", torch.cuda.is_available())
+          if not torch.cuda.is_available():
+              raise SystemExit(1)
+          print("gpu", torch.cuda.get_device_name(0))
+          PY
+            then
+              usable="$candidate"
+              echo "Selected $candidate"
+              echo "::endgroup::"
+              break
+            fi
+            echo "Rejected $candidate"
+            echo "::endgroup::"
+          done
+
+          if [[ -z "$usable" ]]; then
+            venv="$root/venv"
+            python -m venv "$venv"
+            usable="$venv/bin/python"
+            "$usable" -m pip install \
+              "pip==25.2" "setuptools==80.9.0" "wheel==0.45.1"
+            "$usable" -m pip install \
+              torch==2.11.0 torchvision==0.26.0 \
+              --index-url https://download.pytorch.org/whl/cu126
+            filtered="$root/cut3r-requirements.txt"
+            python - external/CUT3R/requirements.txt "$filtered" <<'PY'
           import re
+          import sys
           from pathlib import Path
 
-          manifest = json.loads(Path(os.environ["MANIFEST"]).read_text(encoding="utf-8"))
-          if manifest.get("schema") != "prob4d.dot-cut3r-gpuserver4090-runtime-bootstrap":
-              raise SystemExit("runtime manifest schema changed")
-          if manifest.get("schema_version") != 4:
-              raise SystemExit("runtime manifest version changed")
-          if manifest.get("cut3r_revision") != os.environ["EXPECTED_REVISION"]:
-              raise SystemExit("runtime manifest binds another CUT3R revision")
-          checkpoint = manifest.get("checkpoint") or {}
-          if checkpoint.get("sha256") != os.environ["EXPECTED_CHECKPOINT_SHA256"]:
-              raise SystemExit("runtime manifest binds another checkpoint")
-          if manifest.get("runtime_python") != os.environ["EXPECTED_PYTHON"]:
-              raise SystemExit("runtime manifest binds another interpreter")
-          if not str(manifest.get("torch_version", "")).startswith("2.11.0"):
-              raise SystemExit("runtime manifest binds another Torch version")
-          if manifest.get("torch_cuda_version") != "12.6":
-              raise SystemExit("runtime manifest binds another CUDA version")
-          if manifest.get("cuda_available") is not True:
-              raise SystemExit("runtime manifest does not attest CUDA")
-          if manifest.get("dot_dataset_accessed") is not False:
-              raise SystemExit("runtime bootstrap crossed the DOT data boundary")
-          native_id = manifest.get("native_rope_artifact_id")
-          if not isinstance(native_id, str) or re.fullmatch(r"[0-9a-f]{64}", native_id) is None:
-              raise SystemExit("runtime manifest has no native RoPE identity")
-          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
-              output.write(f"native_rope_artifact_id={native_id}\n")
+          source = Path(sys.argv[1]).read_text(encoding="utf-8").splitlines()
+          kept = []
+          for line in source:
+              stripped = line.strip()
+              if re.match(r"^(torch|torchvision)(?:\s|[<>=!~].*)?$", stripped, flags=re.I):
+                  continue
+              kept.append(line)
+          Path(sys.argv[2]).write_text("\n".join(kept) + "\n", encoding="utf-8")
           PY
-      - name: Copy and attest native runtime without opening DOT
+            "$usable" -m pip install -r "$filtered" gdown==5.2.0
+            "$usable" -m pip check
+          fi
+
+          "$usable" - <<'PY'
+          import torch
+          print("selected_python_cuda", torch.cuda.is_available())
+          print("selected_gpu", torch.cuda.get_device_name(0))
+          if not torch.cuda.is_available():
+              raise SystemExit("selected CUT3R Python has no CUDA device")
+          PY
+          echo "python=$usable" >> "$GITHUB_OUTPUT"
+
+      - name: Acquire exact CUT3R checkpoint without opening DOT
+        id: checkpoint
+        shell: bash
+        run: |
+          set -euo pipefail
+          /usr/bin/mkdir -p "$RUNTIME_CACHE_ROOT"
+          selected=""
+          if [[ -n "${RETAINED_CUT3R_CHECKPOINT:-}" && -f "$RETAINED_CUT3R_CHECKPOINT" ]]; then
+            measured=$(sha256sum "$RETAINED_CUT3R_CHECKPOINT" | awk '{print $1}')
+            if [[ "$measured" = "$CUT3R_CHECKPOINT_SHA256" ]]; then
+              selected="$RETAINED_CUT3R_CHECKPOINT"
+            fi
+          fi
+          if [[ -z "$selected" ]]; then
+            selected="$RUNTIME_CACHE_ROOT/cut3r_512_dpt_4_64.pth"
+            valid=false
+            if [[ -f "$selected" ]]; then
+              measured=$(sha256sum "$selected" | awk '{print $1}')
+              [[ "$measured" = "$CUT3R_CHECKPOINT_SHA256" ]] && valid=true
+            fi
+            if [[ "$valid" != true ]]; then
+              part="$selected.part-${GITHUB_RUN_ID}"
+              /usr/bin/rm -f -- "$part"
+              python -m pip install gdown==5.2.0
+              PART="$part" python - <<'PY'
+          import os
+          import gdown
+
+          result = gdown.download(
+              id=os.environ["CUT3R_CHECKPOINT_GDRIVE_ID"],
+              output=os.environ["PART"],
+              quiet=False,
+          )
+          if result is None:
+              raise SystemExit("gdown did not produce the frozen CUT3R checkpoint")
+          PY
+              test "$(sha256sum "$part" | awk '{print $1}')" = \
+                "$CUT3R_CHECKPOINT_SHA256"
+              /usr/bin/mv -- "$part" "$selected"
+            fi
+          fi
+          test "$(sha256sum "$selected" | awk '{print $1}')" = \
+            "$CUT3R_CHECKPOINT_SHA256"
+          echo "path=$selected" >> "$GITHUB_OUTPUT"
+          stat -c 'checkpoint_bytes=%s' "$selected"
+
+      - name: Download and verify the official DOT R01-R10 archive
+        id: dataset
+        shell: bash
+        run: |
+          set -euo pipefail
+          cache="$RUNTIME_CACHE_ROOT/dot-v29"
+          /usr/bin/mkdir -p "$cache"
+          archive="$cache/$ARCHIVE_NAME"
+          valid=false
+          if [[ -f "$archive" ]]; then
+            measured=$(md5sum "$archive" | awk '{print $1}')
+            [[ "$measured" = "$ARCHIVE_MD5" ]] && valid=true
+          fi
+          if [[ "$valid" != true ]]; then
+            part="$archive.part-${GITHUB_RUN_ID}"
+            /usr/bin/rm -f -- "$part"
+            ARCHIVE_PATH="$part" python - <<'PY'
+          import json
+          import os
+          import shutil
+          import urllib.request
+
+          metadata_request = urllib.request.Request(
+              os.environ["DATASET_API"],
+              headers={"User-Agent": "Prob4D-DOT-R04-R10-confirmation/1"},
+          )
+          with urllib.request.urlopen(metadata_request, timeout=60) as response:
+              metadata = json.load(response)
+          if metadata.get("status") != "OK":
+              raise SystemExit("Dataverse metadata request did not return OK")
+          files = metadata["data"]["latestVersion"]["files"]
+          matches = [
+              entry["dataFile"]
+              for entry in files
+              if entry["dataFile"].get("filename") == os.environ["ARCHIVE_NAME"]
+          ]
+          if len(matches) != 1:
+              raise SystemExit("official DOT archive identity is ambiguous")
+          data_file = matches[0]
+          checksum = data_file.get("checksum") or {}
+          if checksum.get("type") != "MD5" or checksum.get("value") != os.environ["ARCHIVE_MD5"]:
+              raise SystemExit("publisher DOT archive checksum changed")
+          url = f"{os.environ['DATAFILE_API_ROOT']}/{data_file['id']}"
+          download = urllib.request.Request(
+              url,
+              headers={"User-Agent": "Prob4D-DOT-R04-R10-confirmation/1"},
+          )
+          with urllib.request.urlopen(download, timeout=120) as response, open(
+              os.environ["ARCHIVE_PATH"], "wb"
+          ) as output:
+              shutil.copyfileobj(response, output, length=1024 * 1024)
+          PY
+            printf '%s  %s\n' "$ARCHIVE_MD5" "$part" | md5sum --check --strict
+            /usr/bin/mv -- "$part" "$archive"
+          fi
+          printf '%s  %s\n' "$ARCHIVE_MD5" "$archive" | md5sum --check --strict
+          echo "root=$cache" >> "$GITHUB_OUTPUT"
+
+      - name: Build and attest native CUT3R RoPE in an isolated checkout
+        id: rope
         shell: bash
         env:
-          NATIVE_ROPE_ARTIFACT_ID: ${{ steps.runtime.outputs.native_rope_artifact_id }}
+          RUNTIME_PYTHON: ${{ steps.runtime.outputs.python }}
         run: |
           set -euo pipefail
           root="${{ steps.workspace.outputs.root }}"
-          mkdir -p "$root/CUT3R"
-          cp -a "$CUT3R_RUNTIME_CHECKOUT/." "$root/CUT3R/"
-          REQUEST_PATH=__heldout_runtime_verification__ \
-            PYTHONPATH="$GITHUB_WORKSPACE/src" \
-            "$CUT3R_RUNTIME_PYTHON" \
+          checkout="$root/CUT3R"
+          /usr/bin/mkdir -p "$checkout"
+          /usr/bin/cp -a external/CUT3R/. "$checkout/"
+          test "$(/usr/bin/git -C "$checkout" rev-parse HEAD)" = "$CUT3R_REVISION"
+          /usr/bin/find "$checkout/src/croco/models/curope" \
+            -maxdepth 1 -type f -name '*.so' -delete
+          /usr/bin/rm -rf -- "$checkout/src/croco/models/curope/build"
+
+          nvcc=""
+          for candidate in \
+            "$(command -v nvcc || true)" \
+            /usr/local/cuda/bin/nvcc \
+            /usr/local/cuda-12.6/bin/nvcc \
+            /usr/local/cuda-12.8/bin/nvcc
+          do
+            if [[ -x "$candidate" ]]; then
+              nvcc="$candidate"
+              break
+            fi
+          done
+          test -n "$nvcc" || {
+            echo "native RoPE requires an available nvcc compiler" >&2
+            exit 2
+          }
+          cuda_home=$(/usr/bin/dirname "$(/usr/bin/dirname "$nvcc")")
+          arch=$(
+            "$RUNTIME_PYTHON" - <<'PY'
+          import torch
+          major, minor = torch.cuda.get_device_capability(0)
+          print(f"{major}.{minor}")
+          PY
+          )
+          "$nvcc" --version
+          CUDA_HOME="$cuda_home" \
+            TORCH_CUDA_ARCH_LIST="$arch" \
+            MAX_JOBS=4 \
+            PYTHONPATH="$GITHUB_WORKSPACE/src:$checkout:$checkout/src" \
+            "$RUNTIME_PYTHON" \
             scripts/science/prepare_cut3r_runtime.py \
-              --cut3r-checkout "$root/CUT3R" \
-              --expected-artifact-id "$NATIVE_ROPE_ARTIFACT_ID" \
-              --output "$root/provider/runtime-receipt.json"
-      - name: Enable exact hash-bound legacy checkpoint load in isolated copy
+              --cut3r-checkout "$checkout" \
+              --build \
+              --output "$root/evidence/runtime-receipt.json"
+          echo "checkout=$checkout" >> "$GITHUB_OUTPUT"
+
+      - name: Enable the hash-pinned legacy checkpoint loader
         shell: bash
+        env:
+          CHECKPOINT_PATH: ${{ steps.checkpoint.outputs.path }}
+          CUT3R_CHECKOUT: ${{ steps.rope.outputs.checkout }}
         run: |
           set -euo pipefail
-          root="${{ steps.workspace.outputs.root }}"
-          CHECKOUT="$root/CUT3R" CHECKPOINT="$CUT3R_RUNTIME_CHECKPOINT" \
-            EXPECTED_CHECKPOINT="$CUT3R_CHECKPOINT_SHA256" \
-            "$CUT3R_RUNTIME_PYTHON" - <<'PY'
+          python - <<'PY'
           import hashlib
           import json
           import os
           from pathlib import Path
 
-          checkout = Path(os.environ["CHECKOUT"]).resolve(strict=True)
-          checkpoint = Path(os.environ["CHECKPOINT"]).resolve(strict=True)
-          digest = hashlib.sha256(checkpoint.read_bytes()).hexdigest()
-          if digest != os.environ["EXPECTED_CHECKPOINT"]:
-              raise SystemExit("held-out checkpoint bytes changed")
-          model = checkout / "src/dust3r/model.py"
-          source = model.read_bytes()
-          header = f"blob {len(source)}\0".encode("ascii")
-          blob = hashlib.sha1(header + source, usedforsecurity=False).hexdigest()
+          checkout = Path(os.environ["CUT3R_CHECKOUT"]).resolve(strict=True)
+          checkpoint = Path(os.environ["CHECKPOINT_PATH"]).resolve(strict=True)
+          if hashlib.sha256(checkpoint.read_bytes()).hexdigest() != os.environ["CUT3R_CHECKPOINT_SHA256"]:
+              raise SystemExit("checkpoint digest changed before compatibility patch")
+          path = checkout / "src/dust3r/model.py"
+          source = path.read_bytes()
+          framed = f"blob {len(source)}\0".encode("ascii") + source
+          blob = hashlib.sha1(framed, usedforsecurity=False).hexdigest()
           if blob != "7ed9f6106fb063686990c874ede99876ebc939ab":
-              raise SystemExit("held-out CUT3R model source blob changed")
+              raise SystemExit("CUT3R model source blob changed")
           original = '    ckpt = torch.load(model_path, map_location="cpu")\n'
-          patched = '    ckpt = torch.load(model_path, map_location="cpu", weights_only=False)\n'
+          replacement = (
+              '    ckpt = torch.load(model_path, map_location="cpu", '
+              'weights_only=False)\n'
+          )
           text = source.decode("utf-8")
-          if text.count(original) != 1 or patched in text:
-              raise SystemExit("held-out CUT3R load call changed")
-          output = text.replace(original, patched, 1).encode("utf-8")
-          model.write_bytes(output)
+          if text.count(original) != 1 or replacement in text:
+              raise SystemExit("CUT3R checkpoint loader shape changed")
+          patched = text.replace(original, replacement, 1).encode("utf-8")
+          path.write_bytes(patched)
           receipt = {
-              "schema": "prob4d.dot-cut3r-heldout-checkpoint-compatibility",
+              "schema": "prob4d.dot-r04-r10-checkpoint-compatibility",
               "schema_version": 1,
-              "cut3r_revision": os.environ.get("CUT3R_REVISION"),
+              "cut3r_revision": os.environ["CUT3R_REVISION"],
+              "checkpoint_sha256": os.environ["CUT3R_CHECKPOINT_SHA256"],
               "source_git_blob_sha1": blob,
               "source_sha256": hashlib.sha256(source).hexdigest(),
-              "patched_sha256": hashlib.sha256(output).hexdigest(),
-              "checkpoint_sha256": digest,
-              "policy": "weights_only=False only after exact source and checkpoint verification",
-              "dot_payloads_opened": False,
+              "patched_sha256": hashlib.sha256(patched).hexdigest(),
+              "torch_load_policy": "weights_only=False only at the pinned loader",
           }
-          Path(os.environ["RUNNER_TEMP"], "dot-heldout-checkpoint-compatibility.json").write_text(
-              json.dumps(receipt, indent=2, sort_keys=True) + "\n",
-              encoding="utf-8",
-          )
+          encoded = json.dumps(receipt, sort_keys=True, separators=(",", ":")).encode()
+          receipt["artifact_id"] = hashlib.sha256(encoded).hexdigest()
+          output = Path("${{ steps.workspace.outputs.root }}/evidence/checkpoint-load-compatibility.json")
+          output.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
           PY
-          cp "$RUNNER_TEMP/dot-heldout-checkpoint-compatibility.json" "$root/provider/"
-      - name: Predict R04-R10 from normal-view images only
-        id: execute
-        continue-on-error: true
+
+      - name: Predict from marker-free normal-view images only
+        shell: bash
+        env:
+          RUNTIME_PYTHON: ${{ steps.runtime.outputs.python }}
+          CHECKPOINT_PATH: ${{ steps.checkpoint.outputs.path }}
+          DATASET_ROOT: ${{ steps.dataset.outputs.root }}
+          CUT3R_CHECKOUT: ${{ steps.rope.outputs.checkout }}
+          REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
+          EXPECTED_HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          PYTHONPATH="$GITHUB_WORKSPACE/src:$GITHUB_WORKSPACE/scripts/science:$CUT3R_CHECKOUT:$CUT3R_CHECKOUT/src" \
+            "$RUNTIME_PYTHON" \
+            scripts/science/run_dot_rope_cut3r_heldout_confirmation.py \
+              predict \
+              --protocol "$PROTOCOL_PATH" \
+              --request-id "$REQUEST_ID" \
+              --prob4d-revision "$EXPECTED_HEAD_SHA" \
+              --dataset-root "$DATASET_ROOT" \
+              --cut3r-checkout "$CUT3R_CHECKOUT" \
+              --checkpoint "$CHECKPOINT_PATH" \
+              --runtime-receipt "$root/evidence/runtime-receipt.json" \
+              --output-dir "$root/provider"
+
+      - name: Seal provider bundle before any marker access
+        id: seal
         shell: bash
         env:
           REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
@@ -332,72 +681,94 @@ jobs:
         run: |
           set -euo pipefail
           root="${{ steps.workspace.outputs.root }}"
-          PYTHONPATH="$GITHUB_WORKSPACE/src:$GITHUB_WORKSPACE/scripts/science" \
-            "$CUT3R_RUNTIME_PYTHON" \
-            scripts/science/run_dot_rope_cut3r_heldout_confirmation.py \
-              predict \
-              --protocol "$PROTOCOL_PATH" \
-              --request-id "$REQUEST_ID" \
-              --prob4d-revision "$EXPECTED_HEAD_SHA" \
-              --dataset-root "$DATASET_ROOT" \
-              --cut3r-checkout "$root/CUT3R" \
-              --checkpoint "$CUT3R_RUNTIME_CHECKPOINT" \
-              --runtime-receipt "$root/provider/runtime-receipt.json" \
-              --output-dir "$root/provider/bundle"
-      - name: Read sealed provider result
-        id: result
-        if: always()
-        shell: bash
-        env:
-          EXECUTION_OUTCOME: ${{ steps.execute.outcome }}
-        run: |
-          set -euo pipefail
-          manifest="${{ steps.workspace.outputs.root }}/provider/bundle/manifest.json"
-          if [[ "$EXECUTION_OUTCOME" != "success" || ! -f "$manifest" ]]; then
-            echo "decision=technical-failure" >> "$GITHUB_OUTPUT"
-            echo "provider_bundle_id=unavailable" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          MANIFEST="$manifest" python - <<'PY'
+          PROVIDER="$root/provider" REQUEST_ID="$REQUEST_ID" EXPECTED_HEAD_SHA="$EXPECTED_HEAD_SHA" \
+            python - <<'PY'
+          import hashlib
           import json
           import os
-          import re
           from pathlib import Path
 
-          value = json.loads(Path(os.environ["MANIFEST"]).read_text(encoding="utf-8"))
-          if value.get("decision") != "sealed-provider-predictions":
-              raise SystemExit("held-out provider did not seal predictions")
-          bundle_id = value.get("provider_bundle_id", "")
-          if re.fullmatch(r"[0-9a-f]{64}", bundle_id) is None:
-              raise SystemExit("held-out provider bundle identity is invalid")
-          boundary = value.get("information_boundary") or {}
-          if boundary.get("two_dimensional_markers_opened") is not False:
-              raise SystemExit("provider opened 2-D markers")
-          if boundary.get("three_dimensional_markers_opened") is not False:
-              raise SystemExit("provider opened 3-D markers")
+          provider = Path(os.environ["PROVIDER"])
+          manifest = json.loads((provider / "manifest.json").read_text(encoding="utf-8"))
+          assert manifest["decision"] == "sealed-provider-predictions"
+          assert manifest["request_id"] == os.environ["REQUEST_ID"]
+          assert manifest["prob4d_revision"] == os.environ["EXPECTED_HEAD_SHA"]
+          assert manifest["dataset"]["source_sequences"] == [
+              "R04", "R05", "R06", "R07", "R08", "R09", "R10"
+          ]
+          assert manifest["dataset"]["reserved_sequences"] == "R11-R70"
+          assert len(manifest["outputs"]) == 21
+          boundary = manifest["information_boundary"]
+          assert boundary["normal_view_images_opened"] is True
+          assert boundary["two_dimensional_markers_opened"] is False
+          assert boundary["three_dimensional_markers_opened"] is False
+          assert boundary["target_payloads_opened"] is False
+          rows = []
+          for path in sorted(provider.rglob("*")):
+              if path.is_file():
+                  rows.append({
+                      "path": path.relative_to(provider).as_posix(),
+                      "bytes": path.stat().st_size,
+                      "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+                  })
+          seal = {
+              "schema": "prob4d.dot-rope-cut3r-heldout-provider-seal",
+              "schema_version": 1,
+              "request_id": manifest["request_id"],
+              "provider_bundle_id": manifest["provider_bundle_id"],
+              "files": rows,
+              "markers_opened": False,
+              "reserved_sequences": "R11-R70",
+          }
+          encoded = json.dumps(seal, sort_keys=True, separators=(",", ":")).encode()
+          seal["seal_id"] = hashlib.sha256(encoded).hexdigest()
+          (provider / "provider-seal.json").write_text(
+              json.dumps(seal, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          outputs = {
+              "provider_bundle_id": manifest["provider_bundle_id"],
+              "provider_artifact_name": (
+                  "dot-rope-cut3r-heldout-provider-gpuserver6000-"
+                  + manifest["request_id"]
+              ),
+          }
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
-              output.write("decision=sealed-provider-predictions\n")
-              output.write(f"provider_bundle_id={bundle_id}\n")
+              for key, value in outputs.items():
+                  output.write(f"{key}={value}\n")
           PY
-      - name: Upload immutable held-out provider bundle
-        if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+          /usr/bin/chmod -R a-w "$root/provider"
+
+      - name: Upload immutable provider seal before marker evaluation
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: dot-rope-cut3r-heldout-provider-${{ github.run_id }}-${{ github.run_attempt }}
+          name: ${{ steps.seal.outputs.provider_artifact_name }}
           path: ${{ steps.workspace.outputs.root }}/provider/
           if-no-files-found: error
+          retention-days: 90
+
+      - name: Upload bounded runtime receipts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: dot-rope-cut3r-heldout-runtime-gpuserver6000-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.workspace.outputs.root }}/evidence/
+          if-no-files-found: warn
           retention-days: 30
-      - name: Require sealed provider predictions
+
+      - name: Remove isolated prediction workspace
         if: always()
         shell: bash
-        env:
-          DECISION: ${{ steps.result.outputs.decision }}
         run: |
           set -euo pipefail
-          test "$DECISION" = "sealed-provider-predictions"
+          root="${{ steps.workspace.outputs.root }}"
+          expected="${RUNNER_TEMP}/prob4d-dot-r04-r10-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          test "$root" = "$expected"
+          /usr/bin/chmod -R u+w "$root" 2>/dev/null || true
+          /usr/bin/rm -rf -- "$root"
 
   evaluate:
-    name: Evaluate frozen R04-R10 markers after provider seal
+    name: Evaluate R04-R10 markers only after provider seal
     if: github.event_name == 'push'
     needs: [authorize, provider]
     runs-on: ubuntu-latest
@@ -408,64 +779,95 @@ jobs:
     outputs:
       decision: ${{ steps.result.outputs.decision }}
       result_id: ${{ steps.result.outputs.result_id }}
+      evaluation_artifact_name: ${{ steps.result.outputs.evaluation_artifact_name }}
     steps:
       - name: Initialize isolated evaluation workspace
         id: workspace
         shell: bash
         run: |
           set -euo pipefail
-          root="$RUNNER_TEMP/prob4d-dot-heldout-evaluation-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
-          rm -rf -- "$root"
-          mkdir -p "$root/provider" "$root/dataset" "$root/evidence"
+          root="$RUNNER_TEMP/prob4d-dot-r04-r10-evaluation-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          /usr/bin/rm -rf -- "$root"
+          /usr/bin/mkdir -p "$root/provider" "$root/dataset" "$root/evaluation"
           echo "root=$root" >> "$GITHUB_OUTPUT"
+
       - name: Check out exact authorized revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.authorize.outputs.head_sha }}
-          fetch-depth: 0
           persist-credentials: false
           clean: true
-      - name: Verify clean exact checkout
-        shell: bash
-        env:
-          EXPECTED_HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
-        run: |
-          set -euo pipefail
-          test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
-          test -z "$(git status --porcelain=v1 --untracked-files=all)"
-      - name: Set up scientific Python
+
+      - name: Set up scientific Python 3.12
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.12"
           cache: pip
           cache-dependency-path: pyproject.toml
-      - name: Install repository package
+
+      - name: Install exact repository package
+        shell: bash
         run: |
+          set -euo pipefail
           python -m pip install -e .
           python -m pip check
-      - name: Download exact sealed confirmation provider bundle
+
+      - name: Download the sealed marker-free provider bundle
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          name: dot-rope-cut3r-heldout-provider-${{ github.run_id }}-${{ github.run_attempt }}
+          name: ${{ needs.provider.outputs.provider_artifact_name }}
           path: ${{ steps.workspace.outputs.root }}/provider
-      - name: Resolve official DOT archive identity
-        id: archive
+
+      - name: Verify provider seal before downloading marker archive
+        shell: bash
+        env:
+          EXPECTED_BUNDLE_ID: ${{ needs.provider.outputs.provider_bundle_id }}
+          REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          PROVIDER="$root/provider" python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          provider = Path(os.environ["PROVIDER"])
+          manifest = json.loads((provider / "manifest.json").read_text(encoding="utf-8"))
+          seal = json.loads((provider / "provider-seal.json").read_text(encoding="utf-8"))
+          assert manifest["provider_bundle_id"] == os.environ["EXPECTED_BUNDLE_ID"]
+          assert manifest["request_id"] == os.environ["REQUEST_ID"]
+          assert seal["provider_bundle_id"] == manifest["provider_bundle_id"]
+          assert seal["markers_opened"] is False
+          unsigned = dict(seal)
+          seal_id = unsigned.pop("seal_id")
+          encoded = json.dumps(unsigned, sort_keys=True, separators=(",", ":")).encode()
+          assert hashlib.sha256(encoded).hexdigest() == seal_id
+          expected = {row["path"]: row for row in seal["files"]}
+          for relative, row in expected.items():
+              path = provider / relative
+              assert path.is_file()
+              assert path.stat().st_size == row["bytes"]
+              assert hashlib.sha256(path.read_bytes()).hexdigest() == row["sha256"]
+          PY
+
+      - name: Download and verify official R01-R10 marker archive
         shell: bash
         run: |
           set -euo pipefail
           root="${{ steps.workspace.outputs.root }}"
-          DATASET_API="$DATASET_API" ARCHIVE_NAME="$ARCHIVE_NAME" ARCHIVE_MD5="$ARCHIVE_MD5" \
-            ROOT="$root" python - <<'PY'
+          archive="$root/dataset/$ARCHIVE_NAME"
+          ARCHIVE_PATH="$archive" python - <<'PY'
           import json
           import os
+          import shutil
           import urllib.request
-          from pathlib import Path
 
-          request = urllib.request.Request(
+          metadata_request = urllib.request.Request(
               os.environ["DATASET_API"],
-              headers={"User-Agent": "Prob4D-DOT-heldout-confirmation/1"},
+              headers={"User-Agent": "Prob4D-DOT-R04-R10-evaluation/1"},
           )
-          with urllib.request.urlopen(request, timeout=60) as response:
+          with urllib.request.urlopen(metadata_request, timeout=60) as response:
               metadata = json.load(response)
           if metadata.get("status") != "OK":
               raise SystemExit("Dataverse metadata request did not return OK")
@@ -473,50 +875,28 @@ jobs:
           matches = [
               entry["dataFile"]
               for entry in files
-              if entry.get("dataFile", {}).get("filename") == os.environ["ARCHIVE_NAME"]
+              if entry["dataFile"].get("filename") == os.environ["ARCHIVE_NAME"]
           ]
           if len(matches) != 1:
-              raise SystemExit("official DOT metadata did not contain exactly one R01-10.zip")
+              raise SystemExit("official DOT archive identity is ambiguous")
           data_file = matches[0]
-          checksum = data_file.get("checksum", {})
-          if (
-              checksum.get("type") != "MD5"
-              or checksum.get("value", "").lower() != os.environ["ARCHIVE_MD5"]
-          ):
-              raise SystemExit("official DOT R01-10.zip checksum changed")
-          file_id = int(data_file["id"])
-          byte_count = int(data_file["filesize"])
-          receipt = {
-              "dataset_persistent_id": "doi:10.13021/ORC2020/XXLVXM",
-              "filename": data_file["filename"],
-              "datafile_id": file_id,
-              "byte_count": byte_count,
-              "checksum": checksum,
-          }
-          Path(os.environ["ROOT"], "evidence", "official-archive-metadata.json").write_text(
-              json.dumps(receipt, indent=2, sort_keys=True) + "\n",
-              encoding="utf-8",
+          checksum = data_file.get("checksum") or {}
+          if checksum.get("type") != "MD5" or checksum.get("value") != os.environ["ARCHIVE_MD5"]:
+              raise SystemExit("publisher DOT archive checksum changed")
+          url = f"{os.environ['DATAFILE_API_ROOT']}/{data_file['id']}"
+          download = urllib.request.Request(
+              url,
+              headers={"User-Agent": "Prob4D-DOT-R04-R10-evaluation/1"},
           )
-          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
-              output.write(f"datafile_id={file_id}\n")
-              output.write(f"byte_count={byte_count}\n")
+          with urllib.request.urlopen(download, timeout=120) as response, open(
+              os.environ["ARCHIVE_PATH"], "wb"
+          ) as output:
+              shutil.copyfileobj(response, output, length=1024 * 1024)
           PY
-      - name: Download and verify official R01-10.zip
-        shell: bash
-        env:
-          DATAFILE_ID: ${{ steps.archive.outputs.datafile_id }}
-          EXPECTED_BYTES: ${{ steps.archive.outputs.byte_count }}
-        run: |
-          set -euo pipefail
-          root="${{ steps.workspace.outputs.root }}"
-          archive="$root/dataset/$ARCHIVE_NAME"
-          curl --fail --location --retry 6 --retry-all-errors \
-            --connect-timeout 30 --output "$archive" \
-            "$DATAFILE_API_ROOT/$DATAFILE_ID"
-          test "$(stat -c %s "$archive")" = "$EXPECTED_BYTES"
           printf '%s  %s\n' "$ARCHIVE_MD5" "$archive" | md5sum --check --strict
-      - name: Open frozen R04-R10 marker outcomes and score once
-        id: execute
+
+      - name: Evaluate the frozen alpha and comparators
+        id: execution
         continue-on-error: true
         shell: bash
         env:
@@ -525,107 +905,115 @@ jobs:
         run: |
           set -euo pipefail
           root="${{ steps.workspace.outputs.root }}"
-          PYTHONPATH="$GITHUB_WORKSPACE/src:$GITHUB_WORKSPACE/scripts/science" \
-            python scripts/science/run_dot_rope_cut3r_heldout_confirmation.py \
-              evaluate \
-              --protocol "$PROTOCOL_PATH" \
-              --request-id "$REQUEST_ID" \
-              --prob4d-revision "$EXPECTED_HEAD_SHA" \
-              --dataset-root "$root/dataset" \
-              --provider-bundle "$root/provider/bundle" \
-              --output-dir "$root/evidence/result"
-      - name: Read bounded confirmation outcome
+          python scripts/science/run_dot_rope_cut3r_heldout_confirmation.py \
+            evaluate \
+            --protocol "$PROTOCOL_PATH" \
+            --request-id "$REQUEST_ID" \
+            --prob4d-revision "$EXPECTED_HEAD_SHA" \
+            --dataset-root "$root/dataset" \
+            --provider-bundle "$root/provider" \
+            --output-dir "$root/evaluation"
+
+      - name: Independently verify and classify the held-out result
         id: result
-        if: always()
         shell: bash
         env:
-          EXECUTION_OUTCOME: ${{ steps.execute.outcome }}
+          EXECUTION_OUTCOME: ${{ steps.execution.outcome }}
+          REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
         run: |
           set -euo pipefail
-          root="${{ steps.workspace.outputs.root }}/evidence/result"
-          ROOT="$root" EXECUTION_OUTCOME="$EXECUTION_OUTCOME" python - <<'PY'
+          root="${{ steps.workspace.outputs.root }}"
+          support="$root/evaluation/marker-support.json"
+          if [[ -f "$root/evaluation/result.json" ]]; then
+            result="$root/evaluation/result.json"
+          elif [[ -f "$root/evaluation/failure.json" ]]; then
+            result="$root/evaluation/failure.json"
+          else
+            echo "held-out evaluator emitted no result payload" >&2
+            exit 2
+          fi
+          python scripts/science/verify_dot_rope_cut3r_heldout_result.py \
+            "$result" \
+            --marker-support "$support" \
+            > "$root/evaluation/independent-verification.json"
+          RESULT="$result" EXECUTION_OUTCOME="$EXECUTION_OUTCOME" python - <<'PY'
           import json
           import os
-          import re
           from pathlib import Path
 
-          root = Path(os.environ["ROOT"])
-          complete = root / "result.json"
-          failed = root / "failure.json"
-          if complete.is_file():
-              value = json.loads(complete.read_text(encoding="utf-8"))
-              decision = value["decision"]
-              result_id = value["evaluation_id"]
-          elif failed.is_file():
-              value = json.loads(failed.read_text(encoding="utf-8"))
-              decision = value["decision"]
-              result_id = value["result_id"]
-          else:
-              raise SystemExit("held-out confirmation emitted no bounded result")
-          if re.fullmatch(r"[0-9a-f]{64}", result_id) is None:
-              raise SystemExit("held-out confirmation result identity is invalid")
-          allowed = {
+          result = json.loads(Path(os.environ["RESULT"]).read_text(encoding="utf-8"))
+          decision = result["decision"]
+          result_id = result.get("evaluation_id") or result.get("result_id")
+          permitted = {
               "heldout-strong-positive",
               "heldout-directional-positive",
               "heldout-mixed-or-negative",
               "heldout-support-negative",
               "technical-failure",
           }
-          if decision not in allowed:
-              raise SystemExit("held-out confirmation decision is unsupported")
+          if decision not in permitted:
+              raise SystemExit("held-out decision is outside the frozen roster")
+          if decision != "technical-failure" and os.environ["EXECUTION_OUTCOME"] != "success":
+              raise SystemExit("scientific result and process outcome disagree")
+          values = {
+              "decision": decision,
+              "result_id": result_id,
+              "evaluation_artifact_name": (
+                  "dot-rope-cut3r-heldout-evaluation-gpuserver6000-"
+                  + os.environ["REQUEST_ID"]
+              ),
+          }
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
-              output.write(f"decision={decision}\n")
-              output.write(f"result_id={result_id}\n")
+              for key, value in values.items():
+                  output.write(f"{key}={value}\n")
           PY
-      - name: Upload bounded held-out evidence
+          if [[ -f "$root/evaluation/SUMMARY.md" ]]; then
+            cat "$root/evaluation/SUMMARY.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload immutable held-out evaluation evidence
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: dot-rope-cut3r-heldout-evaluation-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ steps.workspace.outputs.root }}/evidence/
+          name: ${{ steps.result.outputs.evaluation_artifact_name || format('dot-rope-cut3r-heldout-evaluation-failed-{0}-{1}', github.run_id, github.run_attempt) }}
+          path: ${{ steps.workspace.outputs.root }}/evaluation/
           if-no-files-found: error
-          retention-days: 30
-      - name: Require scientific terminal outcome
-        if: always()
+          retention-days: 90
+
+      - name: Fail only for a bounded technical failure
+        if: steps.result.outputs.decision == 'technical-failure'
         shell: bash
-        env:
-          DECISION: ${{ steps.result.outputs.decision }}
         run: |
-          set -euo pipefail
-          case "$DECISION" in
-            heldout-strong-positive|heldout-directional-positive|heldout-mixed-or-negative|heldout-support-negative)
-              ;;
-            *)
-              exit 2
-              ;;
-          esac
+          echo "held-out confirmation ended in a bounded technical failure" >&2
+          exit 3
 
   publish:
-    name: Publish held-out terminal decision
+    name: Publish held-out decision summary
     if: always() && github.event_name == 'push'
     needs: [authorize, provider, evaluate]
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
-      - name: Write run summary
+      - name: Write immutable experiment summary
         shell: bash
         env:
-          PROVIDER_RESULT: ${{ needs.provider.result }}
-          PROVIDER_DECISION: ${{ needs.provider.outputs.decision }}
-          EVALUATION_RESULT: ${{ needs.evaluate.result }}
+          REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
+          PROVIDER_BUNDLE_ID: ${{ needs.provider.outputs.provider_bundle_id }}
           DECISION: ${{ needs.evaluate.outputs.decision }}
           RESULT_ID: ${{ needs.evaluate.outputs.result_id }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           {
-            echo "## DOT R04-R10 held-out CUT3R confirmation"
+            echo "## Frozen DOT R04-R10 confirmation"
             echo
-            echo "- provider job: \`$PROVIDER_RESULT\`"
-            echo "- provider decision: \`$PROVIDER_DECISION\`"
-            echo "- evaluation job: \`$EVALUATION_RESULT\`"
-            echo "- terminal decision: \`$DECISION\`"
-            echo "- result ID: \`$RESULT_ID\`"
-            echo "- source-frozen alpha: \`0.85\`"
+            echo "- request ID: \`$REQUEST_ID\`"
+            echo "- sealed provider bundle: \`$PROVIDER_BUNDLE_ID\`"
+            echo "- decision: **${DECISION:-unavailable}**"
+            echo "- result ID: \`${RESULT_ID:-unavailable}\`"
+            echo "- execution lane: \`gpuserver6000 / workstation2\`"
+            echo "- workflow run: $RUN_URL"
             echo
-            echo "No confirmation-side tuning is authorized. R11-R70 remain unopened."
+            echo "R11-R70 remained unopened. No confirmation-side tuning, BayesianPhysTwin, or Causal4D execution was performed."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.d/dot-r04-r10-gpuserver6000-v1.md
+++ b/CHANGELOG.d/dot-r04-r10-gpuserver6000-v1.md
@@ -1,0 +1,6 @@
+### Changed
+
+- Route the already frozen DOT R04–R10 CUT3R confirmation through the available `gpuserver6000` runner while preserving the exact protocol, request identity, CUT3R revision, checkpoint digest, source-fitted dependence strength, sequence roster, marker convention, comparators, and decision rule.
+- Prove and cancel the untouched queued `gpuserver4090` predecessor before the replacement provider may start.
+- Seal marker-free provider predictions as an immutable artifact before a separate GitHub-hosted job downloads or opens any 2-D or 3-D marker payload.
+- Reuse retained CUT3R assets only after exact identity checks, with a bounded bootstrap fallback and native-RoPE attestation.

--- a/tests/test_dot_rope_cut3r_heldout_confirmation_workflow.py
+++ b/tests/test_dot_rope_cut3r_heldout_confirmation_workflow.py
@@ -11,21 +11,25 @@ def test_confirmation_workflow_is_single_request_triggered_and_stage_sealed() ->
 
     assert "name: DOT rope CUT3R held-out confirmation v1" in text
     assert "branches: [main]" in text
-    assert "dot_rope_cut3r_heldout_confirmation_v1.json" in text
+    assert "dot_rope_cut3r_heldout_confirmation_gpuserver6000_v1.json" in text
     assert "pull_request_target:" not in text
     assert 'test "$EVENT_FORCED" = "false"' in text
     assert 'test "$EVENT_DELETED" = "false"' in text
+    assert "Prove the old gpuserver4090 run never opened confirmation data" in text
+    assert 'ORIGINAL_RUN_ID: "33363832286"' in text
+    assert "old confirmation provider may have started; recovery is forbidden" in text
     assert "normal-view images only" in text
     assert "after provider seal" in text
     assert "R11-R70 remain unopened" in text
 
 
-def test_confirmation_provider_is_read_only_and_bound_to_gpuserver4090() -> None:
+def test_confirmation_provider_is_read_only_and_bound_to_gpuserver6000() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
     provider = text[text.index("\n  provider:") : text.index("\n  evaluate:")]
 
-    assert "runs-on: [self-hosted, Linux, X64, gpuserver4090]" in provider
-    assert 'test "$RUNNER_NAME" = "workstation1"' in provider
+    assert "runs-on: [self-hosted, gpuserver6000]" in provider
+    assert 'test "$RUNNER_NAME" = "workstation2"' in provider
+    assert "gpuserver4090]" not in provider
     assert "environment: trusted-self-hosted-validation" in provider
     assert "permissions:\n      contents: read" in provider
     assert "contents: write" not in provider
@@ -34,6 +38,16 @@ def test_confirmation_provider_is_read_only_and_bound_to_gpuserver4090() -> None
     assert "weights_only=False" in provider
     assert "7ed9f6106fb063686990c874ede99876ebc939ab" in provider
     assert "45f7e98a0a64dbeb54901ae2b878cd8cd125f20a4497316483f0bd6f109f8103" in text
+    assert "8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf" in text
+    assert "CUT3R_CHECKOUT" in provider
+    assert "CUT3R_CHECKPOINT" in provider
+    assert "CUT3R_PYTHON" in provider
+    assert "prepare_cut3r_runtime.py" in provider
+    assert "native RoPE requires an available nvcc compiler" in provider
+    assert "provider-seal.json" in provider
+    assert provider.index("Predict from marker-free normal-view images only") < provider.index(
+        "Upload immutable provider seal before marker evaluation"
+    )
 
 
 def test_confirmation_marker_evaluation_is_hosted_and_frozen() -> None:
@@ -42,7 +56,11 @@ def test_confirmation_marker_evaluation_is_hosted_and_frozen() -> None:
 
     assert "runs-on: ubuntu-latest" in evaluation
     assert "actions: read" in evaluation
-    assert "R04-R10 marker outcomes" in evaluation
+    assert "Verify provider seal before downloading marker archive" in evaluation
+    assert evaluation.index("Verify provider seal before downloading marker archive") < evaluation.index(
+        "Download and verify official R01-R10 marker archive"
+    )
+    assert "Evaluate the frozen alpha and comparators" in evaluation
     assert "ca546ff5f22c0279123ccb18509858ee" in text
     assert "md5sum --check --strict" in text
     assert "heldout-strong-positive" in evaluation
@@ -50,5 +68,6 @@ def test_confirmation_marker_evaluation_is_hosted_and_frozen() -> None:
     assert "heldout-mixed-or-negative" in evaluation
     assert "heldout-support-negative" in evaluation
     assert "technical-failure" in evaluation
+    assert "verify_dot_rope_cut3r_heldout_result.py" in evaluation
     assert "git push" not in text
     assert "secrets." not in text

--- a/tests/test_dot_rope_cut3r_heldout_confirmation_workflow.py
+++ b/tests/test_dot_rope_cut3r_heldout_confirmation_workflow.py
@@ -20,7 +20,7 @@ def test_confirmation_workflow_is_single_request_triggered_and_stage_sealed() ->
     assert "old confirmation provider may have started; recovery is forbidden" in text
     assert "normal-view images only" in text
     assert "after provider seal" in text
-    assert "R11-R70 remain unopened" in text
+    assert "R11-R70 remained unopened" in text
 
 
 def test_confirmation_provider_is_read_only_and_bound_to_gpuserver6000() -> None:

--- a/tests/test_dot_rope_cut3r_heldout_confirmation_workflow.py
+++ b/tests/test_dot_rope_cut3r_heldout_confirmation_workflow.py
@@ -56,10 +56,13 @@ def test_confirmation_marker_evaluation_is_hosted_and_frozen() -> None:
 
     assert "runs-on: ubuntu-latest" in evaluation
     assert "actions: read" in evaluation
-    assert "Verify provider seal before downloading marker archive" in evaluation
-    assert evaluation.index("Verify provider seal before downloading marker archive") < evaluation.index(
+    verify_index = evaluation.index(
+        "Verify provider seal before downloading marker archive"
+    )
+    download_index = evaluation.index(
         "Download and verify official R01-R10 marker archive"
     )
+    assert verify_index < download_index
     assert "Evaluate the frozen alpha and comparators" in evaluation
     assert "ca546ff5f22c0279123ccb18509858ee" in text
     assert "md5sum --check --strict" in text

--- a/tests/test_dot_rope_cut3r_heldout_confirmation_workflow.py
+++ b/tests/test_dot_rope_cut3r_heldout_confirmation_workflow.py
@@ -56,12 +56,8 @@ def test_confirmation_marker_evaluation_is_hosted_and_frozen() -> None:
 
     assert "runs-on: ubuntu-latest" in evaluation
     assert "actions: read" in evaluation
-    verify_index = evaluation.index(
-        "Verify provider seal before downloading marker archive"
-    )
-    download_index = evaluation.index(
-        "Download and verify official R01-R10 marker archive"
-    )
+    verify_index = evaluation.index("Verify provider seal before downloading marker archive")
+    download_index = evaluation.index("Download and verify official R01-R10 marker archive")
     assert verify_index < download_index
     assert "Evaluate the frozen alpha and comparators" in evaluation
     assert "ca546ff5f22c0279123ccb18509858ee" in text


### PR DESCRIPTION
## Purpose

Move only the execution lane of the already frozen DOT R04–R10 CUT3R confirmation from the unavailable `gpuserver4090` runner to the available `gpuserver6000` runner.

## Scientific invariants retained

This change does not alter the protocol, request identity, source calibration, alpha, query definition, marker convention, sequence roster, provider checkpoint, CUT3R revision, windows, comparators, bootstrap procedure, or decision rule.

Frozen identities remain:

- request ID: `62d64df1b1b72f2b2aff0b17cf4c7aad245150f9fa1ff67712eedc0f4e109ce6`;
- protocol ID: `a83258295d5ecabd95017a775f334173bb48141918832fb1a065a1dff66d16ba`;
- source calibration ID: `943339ac864fda04cc59081bc81a605576b3c90bf0aa996aea00b00335cfc0c7`;
- alpha: `0.85`;
- CUT3R revision: `8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf`;
- checkpoint SHA-256: `45f7e98a0a64dbeb54901ae2b878cd8cd125f20a4497316483f0bd6f109f8103`;
- DOT archive MD5: `ca546ff5f22c0279123ccb18509858ee`;
- confirmation cohort: R04–R10;
- reserved cohort: R11–R70.

## Custody and execution

- A hosted authorization job proves that the old run `33363832286` remains step-free, unassigned, and artifact-free, then cancels it before replacement execution.
- The self-hosted job runs read-only on `gpuserver6000` / `workstation2`.
- Retained CUT3R assets are reused only if exact identities match; otherwise an isolated runtime is provisioned.
- Native RoPE is rebuilt and attested.
- The provider opens normal-view images only and uploads an immutable provider seal.
- A separate GitHub-hosted job verifies that seal before downloading or opening any 2-D or 3-D marker payload.
- The existing independent result verifier checks the final classification.

The one-file execution request is intentionally not included in this PR; it will be committed separately after this control plane passes review, so the push authorization can require exactly one changed path.