### PR TITLE
Recover frozen Tracking Cloth evaluation from the official Zenodo release

### DIFF
--- a/.github/workflows/tracking-cloth-finite-orbit-hosted-recovery-v1.yml
+++ b/.github/workflows/tracking-cloth-finite-orbit-hosted-recovery-v1.yml
@@ -1,0 +1,376 @@
+name: Tracking Cloth finite-orbit hosted recovery v1
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/tracking-cloth-finite-orbit-hosted-recovery-v1.yml"
+      - "protocols/tracking-cloth-finite-orbit-real-v1.json"
+      - "scripts/science/run_tracking_cloth_finite_orbit_real_v1.py"
+      - "tests/test_tracking_cloth_finite_orbit_hosted_recovery_v1.py"
+      - "tests/test_tracking_cloth_finite_orbit_real_v1.py"
+  push:
+    branches: [main]
+    paths:
+      - "protocols/execution_requests/tracking_cloth_finite_orbit_hosted_recovery_v1.json"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tracking-cloth-finite-orbit-hosted-recovery-v1-${{ github.ref }}-${{ github.sha }}
+  cancel-in-progress: false
+
+env:
+  REQUEST_PATH: protocols/execution_requests/tracking_cloth_finite_orbit_hosted_recovery_v1.json
+  PROTOCOL_PATH: protocols/tracking-cloth-finite-orbit-real-v1.json
+  ZENODO_URL: https://zenodo.org/records/14644526/files/tracking_dataset.zip?download=1
+  ZENODO_MD5: b4868b702f8a42b2ea1069d0f1a3b8f6
+  ORIGINAL_RUN_ID: "33361712662"
+  ORIGINAL_HEAD_SHA: 5c4e3b4ebfe38a10b1d1635db62b23c4f1736770
+  ORIGINAL_JOB_NAME: Evaluate held-out collision geometry on gpuserver4090
+  PYTHONHASHSEED: "0"
+  PYTHONUNBUFFERED: "1"
+  PYTHONDONTWRITEBYTECODE: "1"
+  OMP_NUM_THREADS: "1"
+  OPENBLAS_NUM_THREADS: "1"
+  MKL_NUM_THREADS: "1"
+  NUMEXPR_NUM_THREADS: "1"
+
+jobs:
+  contract:
+    name: Validate hosted recovery capsule
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out exact reviewed revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+          clean: true
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Validate protocol, recovery contract, and implementation
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install -e ".[dev]"
+          python -m pip check
+          python -m ruff check \
+            scripts/science/run_tracking_cloth_finite_orbit_real_v1.py \
+            tests/test_tracking_cloth_finite_orbit_real_v1.py \
+            tests/test_tracking_cloth_finite_orbit_hosted_recovery_v1.py
+          python -m ruff format --check \
+            scripts/science/run_tracking_cloth_finite_orbit_real_v1.py \
+            tests/test_tracking_cloth_finite_orbit_real_v1.py \
+            tests/test_tracking_cloth_finite_orbit_hosted_recovery_v1.py
+          python -m pytest -q \
+            tests/test_tracking_cloth_finite_orbit_real_v1.py \
+            tests/test_tracking_cloth_finite_orbit_hosted_recovery_v1.py \
+            tests/test_github_action_pins.py
+          python -m compileall -q scripts/science/run_tracking_cloth_finite_orbit_real_v1.py
+
+  authorize:
+    name: Authorize recovery and retire unassigned predecessor
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: write
+      contents: read
+    outputs:
+      head_sha: ${{ steps.request.outputs.head_sha }}
+      protocol_blob: ${{ steps.request.outputs.protocol_blob }}
+      request_id: ${{ steps.request.outputs.request_id }}
+    steps:
+      - name: Check out exact merged-main revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 2
+          persist-credentials: false
+          clean: true
+      - name: Require exactly one immutable recovery request
+        id: request
+        shell: bash
+        env:
+          EVENT_BEFORE: ${{ github.event.before }}
+          EVENT_AFTER: ${{ github.event.after }}
+          EVENT_FORCED: ${{ github.event.forced }}
+          EVENT_DELETED: ${{ github.event.deleted }}
+          EVENT_REF: ${{ github.ref }}
+        run: |
+          set -euo pipefail
+          test "$EVENT_REF" = "refs/heads/main"
+          test "$EVENT_AFTER" = "$(git rev-parse HEAD)"
+          test "$EVENT_FORCED" = "false"
+          test "$EVENT_DELETED" = "false"
+          test "$EVENT_BEFORE" != "0000000000000000000000000000000000000000"
+          mapfile -t changed < <(git diff --name-only "$EVENT_BEFORE" "$EVENT_AFTER" | sort)
+          if [[ ${#changed[@]} -ne 1 || "${changed[0]}" != "$REQUEST_PATH" ]]; then
+            printf 'Expected only %s; changed paths were:\n' "$REQUEST_PATH" >&2
+            printf '  %s\n' "${changed[@]}" >&2
+            exit 2
+          fi
+          test -f "$REQUEST_PATH"
+          test ! -L "$REQUEST_PATH"
+          protocol_blob=$(git rev-parse "$EVENT_AFTER:$PROTOCOL_PATH")
+          PROTOCOL_BLOB="$protocol_blob" python - <<'PY'
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          request = json.loads(Path(os.environ["REQUEST_PATH"]).read_text(encoding="utf-8"))
+          assert request["schema"] == "prob4d.tracking-cloth-finite-orbit-hosted-recovery.v1"
+          assert re.fullmatch(r"[0-9a-f]{64}", request["request_id"])
+          assert request["protocol_id"] == "tracking-cloth-finite-orbit-real-v1"
+          assert request["protocol_git_blob_sha"] == os.environ["PROTOCOL_BLOB"]
+          assert request["superseded_run_id"] == int(os.environ["ORIGINAL_RUN_ID"])
+          assert request["superseded_head_sha"] == os.environ["ORIGINAL_HEAD_SHA"]
+          assert request["superseded_job_name"] == os.environ["ORIGINAL_JOB_NAME"]
+          assert request["zenodo_record"] == "14644526"
+          assert request["zenodo_md5"] == os.environ["ZENODO_MD5"]
+          assert request["opens_collision_outcomes"] is True
+          assert request["target_side_retuning_allowed"] is False
+          assert request["raw_data_publication_authorized"] is False
+          assert request["action"] == "cancel-unassigned-predecessor-and-evaluate-official-zenodo"
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
+              output.write(f"request_id={request['request_id']}\n")
+          PY
+          echo "head_sha=$EVENT_AFTER" >> "$GITHUB_OUTPUT"
+          echo "protocol_blob=$protocol_blob" >> "$GITHUB_OUTPUT"
+      - name: Prove predecessor never executed and retire it
+        shell: bash
+        env:
+          API_URL: ${{ github.api_url }}
+          REPOSITORY: ${{ github.repository }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from __future__ import annotations
+
+          import json
+          import os
+          import time
+          import urllib.error
+          import urllib.request
+
+          api = os.environ["API_URL"]
+          repository = os.environ["REPOSITORY"]
+          run_id = int(os.environ["ORIGINAL_RUN_ID"])
+          headers = {
+              "Accept": "application/vnd.github+json",
+              "Authorization": f"Bearer {os.environ['GITHUB_TOKEN']}",
+              "X-GitHub-Api-Version": "2022-11-28",
+          }
+
+          def call(path: str, *, method: str = "GET"):
+              request = urllib.request.Request(
+                  f"{api}/repos/{repository}{path}", method=method, headers=headers
+              )
+              with urllib.request.urlopen(request, timeout=30) as response:
+                  payload = response.read()
+              return json.loads(payload) if payload else None
+
+          run = call(f"/actions/runs/{run_id}")
+          if run["head_sha"] != os.environ["ORIGINAL_HEAD_SHA"]:
+              raise SystemExit("predecessor head SHA changed")
+          if run["run_attempt"] != 1:
+              raise SystemExit("predecessor attempt changed")
+          jobs = call(f"/actions/runs/{run_id}/jobs?per_page=100")["jobs"]
+          matches = [job for job in jobs if job["name"] == os.environ["ORIGINAL_JOB_NAME"]]
+          if len(matches) != 1:
+              raise SystemExit("predecessor data job is unavailable")
+          job = matches[0]
+          if job.get("steps"):
+              raise SystemExit("predecessor data job has executable steps")
+          if job.get("runner_id") not in (None, 0) or job.get("runner_name") not in (None, ""):
+              raise SystemExit("predecessor data job was assigned to a runner")
+          if job.get("labels") != ["self-hosted", "Linux", "X64", "gpuserver4090"]:
+              raise SystemExit("predecessor runner labels changed")
+          artifacts = call(f"/actions/runs/{run_id}/artifacts?per_page=100")["artifacts"]
+          if artifacts:
+              raise SystemExit("predecessor published an artifact")
+
+          if run["status"] == "queued":
+              try:
+                  call(f"/actions/runs/{run_id}/cancel", method="POST")
+              except urllib.error.HTTPError as error:
+                  if error.code != 409:
+                      raise
+              for _ in range(30):
+                  time.sleep(2)
+                  run = call(f"/actions/runs/{run_id}")
+                  if run["status"] == "completed":
+                      break
+              else:
+                  raise SystemExit("predecessor did not retire after cancellation")
+          if run["status"] != "completed" or run.get("conclusion") != "cancelled":
+              raise SystemExit("predecessor is neither unassigned-queued nor safely cancelled")
+
+          jobs = call(f"/actions/runs/{run_id}/jobs?per_page=100")["jobs"]
+          job = next(item for item in jobs if item["name"] == os.environ["ORIGINAL_JOB_NAME"])
+          if job.get("steps") or job.get("runner_id") not in (None, 0):
+              raise SystemExit("predecessor execution state changed during retirement")
+          if call(f"/actions/runs/{run_id}/artifacts?per_page=100")["artifacts"]:
+              raise SystemExit("predecessor acquired artifacts during retirement")
+          PY
+
+  evaluate:
+    name: Evaluate official Tracking Cloth Zenodo release
+    if: >-
+      github.event_name == 'push' &&
+      github.actor == 'FlorianPfaff' &&
+      github.repository == 'IPS-Stuttgart/Prob4D'
+    needs: authorize
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: Initialize isolated workspace
+        id: workspace
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${RUNNER_TEMP}/tracking-cloth-finite-orbit-hosted-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          rm -rf -- "$root"
+          mkdir -p "$root/data" "$root/evidence"
+          echo "root=$root" >> "$GITHUB_OUTPUT"
+      - name: Check out exact authorized revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.authorize.outputs.head_sha }}
+          persist-credentials: false
+          clean: true
+      - name: Verify clean source and protocol identity
+        env:
+          EXPECTED_HEAD: ${{ needs.authorize.outputs.head_sha }}
+          EXPECTED_PROTOCOL_BLOB: ${{ needs.authorize.outputs.protocol_blob }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD"
+          test "$(git rev-parse "HEAD:$PROTOCOL_PATH")" = "$EXPECTED_PROTOCOL_BLOB"
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Download, verify, and extract official release
+        id: data
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          archive="$root/tracking_dataset.zip"
+          curl --fail --location --retry 6 --retry-all-errors \
+            --connect-timeout 30 --output "$archive" "$ZENODO_URL"
+          printf '%s  %s\n' "$ZENODO_MD5" "$archive" | md5sum --check --strict
+          unzip -q "$archive" -d "$root/data"
+          count=$(find "$root/data" -type f -iname '*.csv' -printf '.' | wc -c)
+          test "$count" -eq 120
+          echo "dataset=$root/data" >> "$GITHUB_OUTPUT"
+      - name: Install pinned numerical runtime
+        shell: bash
+        run: |
+          python -m pip install --disable-pip-version-check "numpy==2.3.5"
+          python -m pip install --disable-pip-version-check --no-deps -e .
+          python -m pip check
+          python - <<'PY' > "${{ steps.workspace.outputs.root }}/runtime.json"
+          import json
+          import platform
+          import sys
+          import numpy
+
+          print(json.dumps({
+              "source": "checksum-verified-official-zenodo",
+              "python": platform.python_version(),
+              "executable": sys.executable,
+              "numpy": numpy.__version__,
+          }, indent=2, sort_keys=True))
+          PY
+      - name: Run source-sealed held-out evaluation
+        id: experiment
+        continue-on-error: true
+        shell: bash
+        env:
+          OUTPUT_DIR: ${{ steps.workspace.outputs.root }}/evidence
+          DATASET: ${{ steps.data.outputs.dataset }}
+          SOURCE_REVISION: ${{ needs.authorize.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          set +e
+          PYTHONPATH=src python scripts/science/run_tracking_cloth_finite_orbit_real_v1.py \
+            --dataset-root "$DATASET" \
+            --protocol "$PROTOCOL_PATH" \
+            --output-dir "$OUTPUT_DIR" \
+            --source-revision "$SOURCE_REVISION" \
+            > "$root/stdout.txt" 2> "$root/stderr.txt"
+          status=$?
+          set -e
+          printf '%s\n' "$status" > "$root/process-exit-code.txt"
+          echo "exit_code=$status" >> "$GITHUB_OUTPUT"
+          exit 0
+      - name: Remove raw release before publication
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          rm -rf -- "$root/data" "$root/tracking_dataset.zip"
+          if find "$root/evidence" -type f \( -iname '*.csv' -o -iname '*.zip' \) -print -quit | grep -q .; then
+            echo "Raw dataset payload appeared in evidence" >&2
+            exit 3
+          fi
+      - name: Upload compact immutable evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: tracking-cloth-finite-orbit-hosted-v1-${{ github.run_attempt }}
+          path: ${{ steps.workspace.outputs.root }}
+          if-no-files-found: error
+          retention-days: 30
+      - name: Publish compact summary
+        if: always()
+        shell: bash
+        run: |
+          root="${{ steps.workspace.outputs.root }}"
+          if test -f "$root/evidence/summary.md"; then
+            cat "$root/evidence/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          else
+            printf 'Evaluation did not produce summary.md.\n\n```text\n' >> "$GITHUB_STEP_SUMMARY"
+            tail -n 100 "$root/stderr.txt" >> "$GITHUB_STEP_SUMMARY" || true
+            printf '\n```\n' >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Enforce registered terminal result
+        shell: bash
+        env:
+          RESULT_PATH: ${{ steps.workspace.outputs.root }}/evidence/result.json
+          PROCESS_EXIT: ${{ steps.experiment.outputs.exit_code }}
+        run: |
+          set -euo pipefail
+          test "$PROCESS_EXIT" = "0"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          result = json.loads(Path(os.environ["RESULT_PATH"]).read_text(encoding="utf-8"))
+          assert result["status"] == "evaluated-real-geometry-passed"
+          assert result["aggregate"]["target_groups"] == 56
+          assert result["aggregate"]["total_cases"] >= 1000
+          failed = [name for name, passed in result["criteria"].items() if not passed]
+          if failed:
+              raise SystemExit("registered criteria failed: " + ", ".join(failed))
+          assert result["claim_boundary"]["learned_visual_provider"] is False
+          PY

--- a/CHANGELOG.d/tracking-cloth-finite-orbit-hosted-recovery-v1.md
+++ b/CHANGELOG.d/tracking-cloth-finite-orbit-hosted-recovery-v1.md
@@ -1,0 +1,5 @@
+### Experimental real-data recovery
+
+- Add a checksum-verified GitHub-hosted recovery path for the frozen Tracking Cloth finite-orbit evaluation.
+- Retire the unassigned, artifact-free `gpuserver4090` predecessor before opening the official Zenodo release.
+- Preserve the 64-source/56-target split, source-sealed marker selection, registered thresholds, and no-retuning boundary.

--- a/docs/tracking-cloth-finite-orbit-hosted-recovery-v1.md
+++ b/docs/tracking-cloth-finite-orbit-hosted-recovery-v1.md
@@ -1,0 +1,14 @@
+# Tracking Cloth finite-orbit hosted recovery v1
+
+The existing Tracking Cloth finite-orbit request was authorized on `main`, but its data job remained unassigned on the `gpuserver4090` selector. It has no executable steps, runner assignment, or artifacts.
+
+This recovery evaluates the unchanged protocol from the checksum-verified official Zenodo release. Before downloading the release, the hosted authorization job requires the predecessor run, head SHA, job name, runner labels, empty step list, zero runner assignment, and zero artifacts to match the frozen record, then retires the queued predecessor.
+
+The experiment retains the original information order:
+
+1. select the anchor/probe triplet from the 64 shaking and twisting source recordings;
+2. write the source seal;
+3. evaluate once on the 56 table-collision, stick-hitting, and self-collision recordings;
+4. publish compact evidence only, never raw CSV or ZIP payloads.
+
+This is public real-trajectory evidence under a controlled rank-deficient factor. It does not test a learned visual provider, identify a physical state, establish deployment calibration or safety, or claim state of the art.

--- a/evidence/tracking-cloth-finite-orbit-hosted-recovery-v1/README.md
+++ b/evidence/tracking-cloth-finite-orbit-hosted-recovery-v1/README.md
@@ -1,0 +1,6 @@
+# Tracking Cloth finite-orbit hosted recovery evidence
+
+No scientific result is committed in this pull request. After the reviewed control
+plane is merged, a separate request-only commit may execute the checksum-verified
+official Zenodo release. The workflow artifact, whether positive, negative, or
+technical, is the authoritative execution record.

--- a/protocols/README-tracking-cloth-hosted-recovery-v1.md
+++ b/protocols/README-tracking-cloth-hosted-recovery-v1.md
@@ -1,0 +1,10 @@
+# Tracking Cloth hosted recovery request
+
+The reviewed control plane is activated only by creating
+`protocols/execution_requests/tracking_cloth_finite_orbit_hosted_recovery_v1.json`
+on `main` after merge. The request schema is
+`protocols/tracking-cloth-finite-orbit-hosted-recovery-v1.schema.json`.
+
+The request does not change the scientific protocol. It authorizes retirement of
+the unassigned predecessor and one checksum-verified evaluation of the existing
+source-sealed protocol on the official Zenodo release.

--- a/protocols/notes/tracking-cloth-finite-orbit-hosted-recovery-v1.txt
+++ b/protocols/notes/tracking-cloth-finite-orbit-hosted-recovery-v1.txt
@@ -1,0 +1,7 @@
+protocol_id=tracking-cloth-finite-orbit-real-v1
+superseded_run_id=33361712662
+superseded_head_sha=5c4e3b4ebfe38a10b1d1635db62b23c4f1736770
+zenodo_record=14644526
+zenodo_md5=b4868b702f8a42b2ea1069d0f1a3b8f6
+target_side_retuning_allowed=false
+raw_data_publication_authorized=false

--- a/protocols/tracking-cloth-finite-orbit-hosted-recovery-v1.schema.json
+++ b/protocols/tracking-cloth-finite-orbit-hosted-recovery-v1.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "action": {"const": "cancel-unassigned-predecessor-and-evaluate-official-zenodo"},
+    "opens_collision_outcomes": {"const": true},
+    "protocol_git_blob_sha": {"pattern": "^[0-9a-f]{40}$", "type": "string"},
+    "protocol_id": {"const": "tracking-cloth-finite-orbit-real-v1"},
+    "raw_data_publication_authorized": {"const": false},
+    "request_id": {"pattern": "^[0-9a-f]{64}$", "type": "string"},
+    "schema": {"const": "prob4d.tracking-cloth-finite-orbit-hosted-recovery.v1"},
+    "superseded_head_sha": {"const": "5c4e3b4ebfe38a10b1d1635db62b23c4f1736770"},
+    "superseded_job_name": {"const": "Evaluate held-out collision geometry on gpuserver4090"},
+    "superseded_run_id": {"const": 33361712662},
+    "target_side_retuning_allowed": {"const": false},
+    "zenodo_md5": {"const": "b4868b702f8a42b2ea1069d0f1a3b8f6"},
+    "zenodo_record": {"const": "14644526"}
+  },
+  "required": [
+    "schema",
+    "request_id",
+    "protocol_id",
+    "protocol_git_blob_sha",
+    "superseded_run_id",
+    "superseded_head_sha",
+    "superseded_job_name",
+    "zenodo_record",
+    "zenodo_md5",
+    "opens_collision_outcomes",
+    "target_side_retuning_allowed",
+    "raw_data_publication_authorized",
+    "action"
+  ],
+  "title": "Tracking Cloth finite-orbit hosted recovery request",
+  "type": "object"
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,8 @@ select = ["E", "F", "I", "UP", "B"]
 
 [tool.ruff.lint.per-file-ignores]
 "scripts/science/run_pointworld_model_load_smoke.py" = ["UP022"]
+# Frozen standalone evidence evaluator; keep its reviewed Python 3.10 import surface unchanged.
+"scripts/science/run_tracking_cloth_finite_orbit_real_v1.py" = ["UP035"]
 # Standalone evidence script: the long Markdown result table is kept literal,
 # and its benchmark closures are called immediately inside each loop iteration.
 "scripts/science/run_tracking_cloth_query_portfolio_v1.py" = ["B023", "E501", "UP035"]

--- a/tests/test_tracking_cloth_finite_orbit_hosted_recovery_docs.py
+++ b/tests/test_tracking_cloth_finite_orbit_hosted_recovery_docs.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DOC = ROOT / "docs/tracking-cloth-finite-orbit-hosted-recovery-v1.md"
+
+
+def test_hosted_recovery_document_preserves_claim_boundary() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    assert "64 shaking and twisting source recordings" in text
+    assert "56 table-collision, stick-hitting, and self-collision recordings" in text
+    assert "publish compact evidence only" in text
+    assert "does not test a learned visual provider" in text
+    assert "deployment calibration or safety" in text

--- a/tests/test_tracking_cloth_finite_orbit_hosted_recovery_evidence.py
+++ b/tests/test_tracking_cloth_finite_orbit_hosted_recovery_evidence.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+README = ROOT / "evidence/tracking-cloth-finite-orbit-hosted-recovery-v1/README.md"
+
+
+def test_recovery_pr_contains_no_claimed_result() -> None:
+    text = README.read_text(encoding="utf-8")
+    assert "No scientific result is committed" in text
+    assert "separate request-only commit" in text
+    assert "positive, negative, or technical" in text

--- a/tests/test_tracking_cloth_finite_orbit_hosted_recovery_index.py
+++ b/tests/test_tracking_cloth_finite_orbit_hosted_recovery_index.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+INDEX = ROOT / "protocols/README-tracking-cloth-hosted-recovery-v1.md"
+
+
+def test_recovery_index_names_the_separate_request_and_schema() -> None:
+    text = INDEX.read_text(encoding="utf-8")
+    assert "tracking_cloth_finite_orbit_hosted_recovery_v1.json" in text
+    assert "tracking-cloth-finite-orbit-hosted-recovery-v1.schema.json" in text
+    assert "does not change the scientific protocol" in text

--- a/tests/test_tracking_cloth_finite_orbit_hosted_recovery_request_absence.py
+++ b/tests/test_tracking_cloth_finite_orbit_hosted_recovery_request_absence.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+REQUEST = (
+    ROOT
+    / "protocols/execution_requests/tracking_cloth_finite_orbit_hosted_recovery_v1.json"
+)
+
+
+def test_reviewed_control_plane_does_not_open_tracking_cloth_outcomes() -> None:
+    assert not REQUEST.exists()

--- a/tests/test_tracking_cloth_finite_orbit_hosted_recovery_schema.py
+++ b/tests/test_tracking_cloth_finite_orbit_hosted_recovery_schema.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCHEMA = ROOT / "protocols/tracking-cloth-finite-orbit-hosted-recovery-v1.schema.json"
+
+
+def test_hosted_recovery_schema_freezes_the_operational_boundary() -> None:
+    schema = json.loads(SCHEMA.read_text(encoding="utf-8"))
+    properties = schema["properties"]
+    assert schema["additionalProperties"] is False
+    assert properties["superseded_run_id"]["const"] == 33361712662
+    assert properties["opens_collision_outcomes"]["const"] is True
+    assert properties["target_side_retuning_allowed"]["const"] is False
+    assert properties["raw_data_publication_authorized"]["const"] is False
+    assert properties["zenodo_record"]["const"] == "14644526"
+    assert properties["zenodo_md5"]["const"] == "b4868b702f8a42b2ea1069d0f1a3b8f6"

--- a/tests/test_tracking_cloth_finite_orbit_hosted_recovery_v1.py
+++ b/tests/test_tracking_cloth_finite_orbit_hosted_recovery_v1.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github/workflows/tracking-cloth-finite-orbit-hosted-recovery-v1.yml"
+REQUEST = (
+    ROOT
+    / "protocols/execution_requests/tracking_cloth_finite_orbit_hosted_recovery_v1.json"
+)
+
+
+def _job(text: str, name: str, next_name: str | None = None) -> str:
+    start = text.index(f"\n  {name}:")
+    end = text.index(f"\n  {next_name}:", start) if next_name else len(text)
+    return text[start:end]
+
+
+def test_pull_request_review_is_separate_from_main_only_execution() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    prefix = text.split("permissions:", maxsplit=1)[0]
+    assert "\n  pull_request:" in prefix
+    assert "\n  push:" in prefix
+    assert "branches: [main]" in prefix
+    assert REQUEST.relative_to(ROOT).as_posix() in prefix
+    contract = _job(text, "contract", "authorize")
+    authorize = _job(text, "authorize", "evaluate")
+    evaluate = _job(text, "evaluate")
+    assert "github.event_name == 'pull_request'" in contract
+    assert "github.event_name == 'push'" in authorize
+    assert "github.event_name == 'push'" in evaluate
+    assert "runs-on: ubuntu-latest" in contract
+    assert "runs-on: ubuntu-latest" in authorize
+    assert "runs-on: ubuntu-latest" in evaluate
+    assert "self-hosted" not in text
+
+
+def test_recovery_requires_an_unassigned_artifact_free_predecessor() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    authorize = _job(text, "authorize", "evaluate")
+    assert 'ORIGINAL_RUN_ID: "33361712662"' in text
+    assert "5c4e3b4ebfe38a10b1d1635db62b23c4f1736770" in text
+    assert "Evaluate held-out collision geometry on gpuserver4090" in text
+    assert 'job.get("steps")' in authorize
+    assert 'job.get("runner_id") not in (None, 0)' in authorize
+    assert 'job.get("runner_name") not in (None, "")' in authorize
+    assert 'if artifacts:' in authorize
+    assert '/actions/runs/{run_id}/cancel' in authorize
+    assert 'run.get("conclusion") != "cancelled"' in authorize
+    assert "actions: write" in authorize
+    assert "contents: write" not in authorize
+
+
+def test_official_release_and_information_order_are_fixed() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    evaluate = _job(text, "evaluate")
+    assert "https://zenodo.org/records/14644526/files/tracking_dataset.zip?download=1" in text
+    assert "b4868b702f8a42b2ea1069d0f1a3b8f6" in text
+    assert 'test "$count" -eq 120' in evaluate
+    assert "run_tracking_cloth_finite_orbit_real_v1.py" in evaluate
+    assert "source-sealed held-out evaluation" in evaluate
+    assert "Remove raw release before publication" in evaluate
+    assert "Raw dataset payload appeared in evidence" in evaluate
+    assert 'result["aggregate"]["target_groups"] == 56' in evaluate
+    assert 'result["aggregate"]["total_cases"] >= 1000' in evaluate
+    assert 'result["claim_boundary"]["learned_visual_provider"] is False' in evaluate
+
+
+def test_external_actions_are_pinned_to_full_commit_shas() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("uses:"):
+            continue
+        target = stripped.split(maxsplit=1)[1]
+        if target.startswith("./"):
+            continue
+        revision = target.rsplit("@", maxsplit=1)[1].split(maxsplit=1)[0]
+        assert len(revision) == 40
+        assert all(character in "0123456789abcdef" for character in revision)
+
+
+def test_request_is_not_part_of_the_reviewed_control_plane() -> None:
+    assert not REQUEST.exists()

--- a/tests/test_tracking_cloth_finite_orbit_hosted_recovery_v1.py
+++ b/tests/test_tracking_cloth_finite_orbit_hosted_recovery_v1.py
@@ -44,8 +44,8 @@ def test_recovery_requires_an_unassigned_artifact_free_predecessor() -> None:
     assert 'job.get("steps")' in authorize
     assert 'job.get("runner_id") not in (None, 0)' in authorize
     assert 'job.get("runner_name") not in (None, "")' in authorize
-    assert 'if artifacts:' in authorize
-    assert '/actions/runs/{run_id}/cancel' in authorize
+    assert "if artifacts:" in authorize
+    assert "/actions/runs/{run_id}/cancel" in authorize
     assert 'run.get("conclusion") != "cancelled"' in authorize
     assert "actions: write" in authorize
     assert "contents: write" not in authorize
@@ -54,7 +54,10 @@ def test_recovery_requires_an_unassigned_artifact_free_predecessor() -> None:
 def test_official_release_and_information_order_are_fixed() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
     evaluate = _job(text, "evaluate")
-    assert "https://zenodo.org/records/14644526/files/tracking_dataset.zip?download=1" in text
+    assert (
+        "https://zenodo.org/records/14644526/files/tracking_dataset.zip?download=1"
+        in text
+    )
     assert "b4868b702f8a42b2ea1069d0f1a3b8f6" in text
     assert 'test "$count" -eq 120' in evaluate
     assert "run_tracking_cloth_finite_orbit_real_v1.py" in evaluate
@@ -63,7 +66,9 @@ def test_official_release_and_information_order_are_fixed() -> None:
     assert "Raw dataset payload appeared in evidence" in evaluate
     assert 'result["aggregate"]["target_groups"] == 56' in evaluate
     assert 'result["aggregate"]["total_cases"] >= 1000' in evaluate
-    assert 'result["claim_boundary"]["learned_visual_provider"] is False' in evaluate
+    assert (
+        'result["claim_boundary"]["learned_visual_provider"] is False' in evaluate
+    )
 
 
 def test_external_actions_are_pinned_to_full_commit_shas() -> None:

--- a/tests/test_tracking_cloth_finite_orbit_hosted_recovery_workflow_surface.py
+++ b/tests/test_tracking_cloth_finite_orbit_hosted_recovery_workflow_surface.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github/workflows/tracking-cloth-finite-orbit-hosted-recovery-v1.yml"
+
+
+def test_hosted_recovery_has_one_request_only_main_trigger() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    trigger = text.split("permissions:", maxsplit=1)[0]
+    request = (
+        "protocols/execution_requests/"
+        "tracking_cloth_finite_orbit_hosted_recovery_v1.json"
+    )
+    assert request in trigger
+    assert "branches: [main]" in trigger
+    assert "workflow_dispatch" not in trigger
+    assert "issue_comment" not in trigger

--- a/tests/test_tracking_cloth_finite_orbit_real_v1.py
+++ b/tests/test_tracking_cloth_finite_orbit_real_v1.py
@@ -9,7 +9,6 @@ from types import ModuleType
 
 import numpy as np
 
-
 ROOT = Path(__file__).resolve().parents[1]
 SCRIPT = ROOT / "scripts/science/run_tracking_cloth_finite_orbit_real_v1.py"
 
@@ -92,7 +91,9 @@ def test_marker_reader_handles_semicolon_decimal_comma_and_meter_units(tmp_path:
                 "m3_z [m]",
             ]
         )
-        writer.writerow(["0", "0,0", "0,0", "0,0", "0,0", "0,0", "0,1", "0,03", "0,0", "0,04"])
+        writer.writerow(
+            ["0", "0,0", "0,0", "0,0", "0,0", "0,0", "0,1", "0,03", "0,0", "0,04"]
+        )
     values, scale, details = module._read_markers(path, ["m1", "m2", "m3"])
     assert scale == 1000.0
     assert details["rows"] == 1


### PR DESCRIPTION
## Purpose

Execute the already frozen Tracking Cloth finite-orbit protocol after its `gpuserver4090` data job remained unassigned and artifact-free.

## Safe recovery boundary

The hosted authorization job acts only after verifying all of the following for retained run `33361712662`:

- exact head SHA `5c4e3b4ebfe38a10b1d1635db62b23c4f1736770`;
- exact job name and labels `[self-hosted, Linux, X64, gpuserver4090]`;
- no executable steps;
- no runner assignment;
- no workflow artifacts; and
- no alternate run attempt.

It then retires the inert predecessor before any hosted dataset access. Any assignment, execution, artifact, or identity drift fails closed.

## Official data path

The hosted evaluator downloads the public Zenodo record `14644526`, requires archive MD5 `b4868b702f8a42b2ea1069d0f1a3b8f6`, and requires exactly 120 extracted CSV recordings. Raw ZIP/CSV payloads are removed before artifact upload.

## Unchanged scientific protocol

- 64 shaking/twisting source recordings select and seal the anchor/probe triplet;
- 56 table-collision, stick-hitting, and self-collision recordings form the fixed target family;
- no target-side retuning is allowed;
- all thresholds, queries, seeds, coverage level, and registered criteria remain unchanged;
- a separate request-only commit is required after merge.

## Claim boundary

This is a public real-trajectory replication under a controlled rank-deficient factor. It does not test a learned visual provider, physical-state identification, deployment calibration or safety, BayesianPhysTwin/Causal4D benefit, or state of the art.

Related: #49.