### PR TITLE
Fix DOT R04–R10 archive recovery interpreter and resume logic

### DIFF
--- a/.github/workflows/recover-dot-r04-r10-archive-cache-v1.yml
+++ b/.github/workflows/recover-dot-r04-r10-archive-cache-v1.yml
@@ -1,24 +1,26 @@
-name: Recover frozen DOT R04-R10 archive cache v1
+name: Recover frozen DOT R04-R10 archive cache v2
 
 on:
   push:
     branches: [main]
     paths:
-      - "protocols/execution_requests/recover_dot_r04_r10_archive_gpuserver6000_v1.json"
+      - "protocols/execution_requests/recover_dot_r04_r10_archive_gpuserver6000_v2.json"
 
 permissions:
   contents: read
 
 concurrency:
-  group: recover-dot-r04-r10-archive-cache-v1
+  group: recover-dot-r04-r10-archive-cache-v2
   cancel-in-progress: false
 
 env:
-  REQUEST_PATH: protocols/execution_requests/recover_dot_r04_r10_archive_gpuserver6000_v1.json
+  REQUEST_PATH: protocols/execution_requests/recover_dot_r04_r10_archive_gpuserver6000_v2.json
   TARGET_RUN_ID: "33434695566"
   TARGET_HEAD_SHA: 9e1b77b2e70685881db7f188a95a3a91443275e8
+  FAILED_RECOVERY_RUN_ID: "33441147840"
   TARGET_WORKFLOW_PATH: .github/workflows/dot-rope-cut3r-heldout-confirmation-v1.yml
   TARGET_PROVIDER_JOB_NAME: Seal marker-free R04-R10 CUT3R predictions on gpuserver6000
+  ARCHIVE_STEP_NAME: Download and verify the official DOT R01-R10 archive
   ARCHIVE_NAME: R01-10.zip
   ARCHIVE_MD5: ca546ff5f22c0279123ccb18509858ee
   CACHE_ROOT: /home/github-runner/.cache/prob4d/dot-r04-r10-cut3r-gpuserver6000-v1/dot-v29
@@ -27,7 +29,7 @@ env:
 
 jobs:
   authorize:
-    name: Authorize one archive-only recovery request
+    name: Authorize one corrected archive-only recovery request
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -35,6 +37,7 @@ jobs:
       actions: read
     outputs:
       request_id: ${{ steps.request.outputs.request_id }}
+      provider_job_id: ${{ steps.guard.outputs.provider_job_id }}
     steps:
       - name: Check out exact request revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -66,7 +69,7 @@ jobs:
             printf '  %s\n' "${changed[@]}" >&2
             exit 2
           fi
-          REQUEST_PATH="$REQUEST_PATH" python - <<'PY'
+          REQUEST_PATH="$REQUEST_PATH" python3 - <<'PY'
           import hashlib
           import json
           import os
@@ -87,18 +90,19 @@ jobs:
               raise SystemExit("archive-recovery request identity mismatch")
           expected = {
               "schema": "prob4d.dot-r04-r10-archive-cache-recovery-request",
-              "schema_version": 1,
+              "schema_version": 2,
               "target_run_id": int(os.environ["TARGET_RUN_ID"]),
               "target_head_sha": os.environ["TARGET_HEAD_SHA"],
+              "failed_recovery_run_id": int(os.environ["FAILED_RECOVERY_RUN_ID"]),
               "target_provider_job_name": os.environ["TARGET_PROVIDER_JOB_NAME"],
               "archive_name": os.environ["ARCHIVE_NAME"],
               "archive_md5": os.environ["ARCHIVE_MD5"],
               "cache_path": f"{os.environ['CACHE_ROOT']}/{os.environ['ARCHIVE_NAME']}",
               "scientific_change": False,
               "reason": (
-                  "Recover or resume only the official archive acquisition lane; "
-                  "retain the frozen protocol, cohort, provider, thresholds, and "
-                  "marker-access order."
+                  "Correct only the recovery controller interpreter and resume the "
+                  "official archive; retain the frozen protocol, cohort, provider, "
+                  "thresholds, and marker-access order."
               ),
           }
           if value != expected:
@@ -107,41 +111,85 @@ jobs:
               output.write(f"request_id={supplied}\n")
           PY
 
-      - name: Verify target run identity without modifying it
+      - name: Verify both failed runs and forbid scientific advancement
+        id: guard
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          python - <<'PY'
+          python3 - <<'PY'
           import json
           import os
           import urllib.request
 
-          url = (
-              f"{os.environ['GITHUB_API_URL']}/repos/{os.environ['GITHUB_REPOSITORY']}"
-              f"/actions/runs/{os.environ['TARGET_RUN_ID']}"
-          )
-          request = urllib.request.Request(
-              url,
-              headers={
-                  "Accept": "application/vnd.github+json",
-                  "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
-                  "User-Agent": "Prob4D-DOT-archive-recovery/1",
-                  "X-GitHub-Api-Version": "2022-11-28",
-              },
-          )
-          with urllib.request.urlopen(request, timeout=60) as response:
-              run = json.load(response)
-          if run["head_sha"] != os.environ["TARGET_HEAD_SHA"]:
+          api = os.environ["GITHUB_API_URL"]
+          repository = os.environ["GITHUB_REPOSITORY"]
+          headers = {
+              "Accept": "application/vnd.github+json",
+              "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
+              "User-Agent": "Prob4D-DOT-archive-recovery/2",
+              "X-GitHub-Api-Version": "2022-11-28",
+          }
+
+          def get(path):
+              request = urllib.request.Request(
+                  f"{api}/repos/{repository}{path}", headers=headers
+              )
+              with urllib.request.urlopen(request, timeout=60) as response:
+                  return json.load(response)
+
+          target_id = int(os.environ["TARGET_RUN_ID"])
+          target = get(f"/actions/runs/{target_id}")
+          if target["head_sha"] != os.environ["TARGET_HEAD_SHA"]:
               raise SystemExit("target run head changed")
-          if run["path"] != os.environ["TARGET_WORKFLOW_PATH"]:
+          if target["path"] != os.environ["TARGET_WORKFLOW_PATH"]:
               raise SystemExit("target workflow changed")
+          if target["status"] != "completed" or target.get("conclusion") != "failure":
+              raise SystemExit("target run is not the expected failed terminal run")
+
+          failed_recovery_id = int(os.environ["FAILED_RECOVERY_RUN_ID"])
+          failed_recovery = get(f"/actions/runs/{failed_recovery_id}")
+          if failed_recovery["status"] != "completed" or failed_recovery.get("conclusion") != "failure":
+              raise SystemExit("predecessor recovery is not the expected failed run")
+
+          jobs = get(f"/actions/runs/{target_id}/jobs?per_page=100")["jobs"]
+          matches = [
+              job for job in jobs
+              if job["name"] == os.environ["TARGET_PROVIDER_JOB_NAME"]
+          ]
+          if len(matches) != 1:
+              raise SystemExit("target provider job is unavailable")
+          provider = matches[0]
+          steps = {step["name"]: step for step in (provider.get("steps") or [])}
+          archive = steps.get(os.environ["ARCHIVE_STEP_NAME"])
+          if archive is None or archive.get("conclusion") != "failure":
+              raise SystemExit("target did not fail at archive acquisition")
+          forbidden = {
+              "Predict from marker-free normal-view images only",
+              "Seal provider bundle before any marker access",
+              "Upload immutable provider seal before marker evaluation",
+          }
+          for name in forbidden:
+              step = steps.get(name) or {}
+              if step.get("status") == "completed" and step.get("conclusion") not in {
+                  None,
+                  "skipped",
+              }:
+                  raise SystemExit(f"provider advanced beyond archive acquisition at {name!r}")
+          artifacts = get(f"/actions/runs/{target_id}/artifacts?per_page=100")
+          prefix = "dot-rope-cut3r-heldout-provider-gpuserver6000-"
+          if any(item.get("name", "").startswith(prefix) for item in artifacts.get("artifacts", [])):
+              raise SystemExit("provider seal already exists")
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"provider_job_id={provider['id']}\n")
           print(json.dumps({
-              "run_id": run["id"],
-              "status": run["status"],
-              "conclusion": run.get("conclusion"),
-              "attempt": run["run_attempt"],
+              "target_run_id": target_id,
+              "target_attempt": target["run_attempt"],
+              "provider_job_id": provider["id"],
+              "failed_recovery_run_id": failed_recovery_id,
+              "marker_accessed": False,
           }, sort_keys=True))
           PY
 
@@ -153,124 +201,23 @@ jobs:
     timeout-minutes: 360
     permissions:
       contents: read
-      actions: read
     outputs:
-      need_rerun: ${{ steps.target.outputs.need_rerun }}
-      provider_job_id: ${{ steps.target.outputs.provider_job_id }}
       receipt_id: ${{ steps.archive.outputs.receipt_id }}
     steps:
-      - name: Bind the intended recovery runner
+      - name: Bind the intended recovery runner and interpreter
         shell: bash
         run: |
           set -euo pipefail
           test "$RUNNER_NAME" = "workstation2"
           test "$RUNNER_OS" = "Linux"
           test "$RUNNER_ARCH" = "X64"
+          command -v python3 >/dev/null 2>&1
           command -v md5sum >/dev/null 2>&1
           command -v curl >/dev/null 2>&1
           command -v flock >/dev/null 2>&1
 
-      - name: Wait for the target attempt and authorize only pre-provider-seal recovery
-        id: target
-        shell: bash
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          python - <<'PY'
-          import json
-          import os
-          import time
-          import urllib.request
-
-          api = os.environ["GITHUB_API_URL"]
-          repository = os.environ["GITHUB_REPOSITORY"]
-          run_id = int(os.environ["TARGET_RUN_ID"])
-          headers = {
-              "Accept": "application/vnd.github+json",
-              "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
-              "User-Agent": "Prob4D-DOT-archive-recovery/1",
-              "X-GitHub-Api-Version": "2022-11-28",
-          }
-
-          def get(path):
-              request = urllib.request.Request(
-                  f"{api}/repos/{repository}{path}",
-                  headers=headers,
-              )
-              with urllib.request.urlopen(request, timeout=60) as response:
-                  return json.load(response)
-
-          for _ in range(240):
-              run = get(f"/actions/runs/{run_id}")
-              if run["head_sha"] != os.environ["TARGET_HEAD_SHA"]:
-                  raise SystemExit("target run head changed")
-              if run["path"] != os.environ["TARGET_WORKFLOW_PATH"]:
-                  raise SystemExit("target workflow changed")
-              if run["status"] == "completed":
-                  break
-              time.sleep(30)
-          else:
-              raise SystemExit("target run did not reach a terminal state")
-
-          jobs = get(f"/actions/runs/{run_id}/jobs?per_page=100")["jobs"]
-          matches = [
-              job for job in jobs
-              if job["name"] == os.environ["TARGET_PROVIDER_JOB_NAME"]
-          ]
-          if len(matches) != 1:
-              raise SystemExit("target provider job is unavailable")
-          provider = matches[0]
-
-          if run.get("conclusion") == "success":
-              need_rerun = False
-          else:
-              steps = {step["name"]: step for step in (provider.get("steps") or [])}
-              archive = steps.get("Download and verify the official DOT R01-R10 archive")
-              if archive is None:
-                  raise SystemExit("archive step is unavailable")
-              if archive.get("conclusion") == "success":
-                  raise SystemExit(
-                      "target failed after archive acquisition; archive-only recovery is forbidden"
-                  )
-              forbidden = {
-                  "Predict from marker-free normal-view images only",
-                  "Seal provider bundle before any marker access",
-                  "Upload immutable provider seal before marker evaluation",
-              }
-              for name in forbidden:
-                  step = steps.get(name) or {}
-                  if step.get("status") == "completed" and step.get("conclusion") not in {
-                      None, "skipped"
-                  }:
-                      raise SystemExit(
-                          f"provider advanced beyond archive acquisition at step {name!r}"
-                      )
-              artifacts = get(f"/actions/runs/{run_id}/artifacts?per_page=100")
-              provider_prefix = "dot-rope-cut3r-heldout-provider-gpuserver6000-"
-              if any(
-                  item.get("name", "").startswith(provider_prefix)
-                  for item in artifacts.get("artifacts", [])
-              ):
-                  raise SystemExit("provider seal already exists; archive recovery is forbidden")
-              need_rerun = True
-
-          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
-              output.write(f"need_rerun={'true' if need_rerun else 'false'}\n")
-              output.write(f"provider_job_id={provider['id']}\n")
-          print(json.dumps({
-              "run_id": run_id,
-              "run_conclusion": run.get("conclusion"),
-              "run_attempt": run["run_attempt"],
-              "provider_job_id": provider["id"],
-              "provider_conclusion": provider.get("conclusion"),
-              "need_rerun": need_rerun,
-          }, sort_keys=True))
-          PY
-
       - name: Reuse, salvage, or resumably acquire the exact official archive
         id: archive
-        if: steps.target.outputs.need_rerun == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -279,13 +226,46 @@ jobs:
           flock -w 300 9
 
           archive="$CACHE_ROOT/$ARCHIVE_NAME"
-          stable_part="$archive.part"
+          stable_part="$archive.partial"
           source_kind=""
           source_path=""
+
+          read -r file_id expected_bytes < <(
+            python3 - <<'PY'
+          import json
+          import os
+          import urllib.request
+
+          request = urllib.request.Request(
+              os.environ["DATASET_API"],
+              headers={"User-Agent": "Prob4D-DOT-archive-recovery/2"},
+          )
+          with urllib.request.urlopen(request, timeout=60) as response:
+              metadata = json.load(response)
+          if metadata.get("status") != "OK":
+              raise SystemExit("Dataverse metadata request did not return OK")
+          files = metadata["data"]["latestVersion"]["files"]
+          matches = [
+              entry["dataFile"]
+              for entry in files
+              if entry["dataFile"].get("filename") == os.environ["ARCHIVE_NAME"]
+          ]
+          if len(matches) != 1:
+              raise SystemExit("official archive identity is ambiguous")
+          data_file = matches[0]
+          checksum = data_file.get("checksum") or {}
+          if checksum.get("type") != "MD5":
+              raise SystemExit("official archive checksum type changed")
+          if checksum.get("value", "").lower() != os.environ["ARCHIVE_MD5"]:
+              raise SystemExit("official archive checksum changed")
+          print(int(data_file["id"]), int(data_file["filesize"]))
+          PY
+          )
 
           valid_archive() {
             local path="$1"
             [[ -f "$path" ]] || return 1
+            [[ "$(stat -c %s "$path")" = "$expected_bytes" ]] || return 1
             [[ "$(md5sum "$path" | awk '{print $1}')" = "$ARCHIVE_MD5" ]]
           }
 
@@ -319,48 +299,30 @@ jobs:
           if [[ -z "$source_kind" ]]; then
             mapfile -t partials < <(
               find "$CACHE_ROOT" -maxdepth 1 -type f \
-                \( -name "$ARCHIVE_NAME.part" -o -name "$ARCHIVE_NAME.part-*" \) \
+                \( -name "$ARCHIVE_NAME.part" -o -name "$ARCHIVE_NAME.part-*" \
+                   -o -name "$ARCHIVE_NAME.partial" \) \
                 -printf '%s\t%p\n' | sort -rn
             )
             if [[ ${#partials[@]} -gt 0 ]]; then
               largest="${partials[0]#*$'\t'}"
-              if [[ "$largest" != "$stable_part" ]]; then
-                if [[ ! -f "$stable_part" || $(stat -c %s "$largest") -gt $(stat -c %s "$stable_part") ]]; then
+              largest_bytes=$(stat -c %s "$largest")
+              if (( largest_bytes < expected_bytes )); then
+                if [[ "$largest" != "$stable_part" ]]; then
+                  /usr/bin/rm -f -- "$stable_part"
                   /usr/bin/mv -- "$largest" "$stable_part"
                 fi
+              elif (( largest_bytes == expected_bytes )) && valid_archive "$largest"; then
+                /usr/bin/mv -- "$largest" "$archive"
+                source_kind="verified-complete-partial"
+                source_path="$largest"
+              else
+                /usr/bin/rm -f -- "$largest"
               fi
             fi
+          fi
 
-            read -r file_id expected_bytes < <(
-              python - <<'PY'
-          import json
-          import os
-          import urllib.request
-
-          request = urllib.request.Request(
-              os.environ["DATASET_API"],
-              headers={"User-Agent": "Prob4D-DOT-archive-recovery/1"},
-          )
-          with urllib.request.urlopen(request, timeout=60) as response:
-              metadata = json.load(response)
-          files = metadata["data"]["latestVersion"]["files"]
-          matches = [
-              entry["dataFile"]
-              for entry in files
-              if entry["dataFile"].get("filename") == os.environ["ARCHIVE_NAME"]
-          ]
-          if len(matches) != 1:
-              raise SystemExit("official archive identity is ambiguous")
-          data_file = matches[0]
-          checksum = data_file.get("checksum") or {}
-          if checksum.get("type") != "MD5":
-              raise SystemExit("official archive checksum type changed")
-          if checksum.get("value", "").lower() != os.environ["ARCHIVE_MD5"]:
-              raise SystemExit("official archive checksum changed")
-          print(int(data_file["id"]), int(data_file["filesize"]))
-          PY
-            )
-            if [[ -f "$stable_part" && $(stat -c %s "$stable_part") -gt "$expected_bytes" ]]; then
+          if [[ -z "$source_kind" ]]; then
+            if [[ -f "$stable_part" && $(stat -c %s "$stable_part") -ge "$expected_bytes" ]]; then
               /usr/bin/rm -f -- "$stable_part"
             fi
             url="$DATAFILE_API_ROOT/$file_id"
@@ -400,11 +362,12 @@ jobs:
             source_path="$url"
           fi
 
+          test "$(stat -c %s "$archive")" = "$expected_bytes"
           printf '%s  %s\n' "$ARCHIVE_MD5" "$archive" | md5sum --check --strict
           chmod a-w "$archive"
 
           ARCHIVE="$archive" SOURCE_KIND="$source_kind" SOURCE_PATH="$source_path" \
-            REQUEST_ID="${{ needs.authorize.outputs.request_id }}" python - <<'PY'
+            REQUEST_ID="${{ needs.authorize.outputs.request_id }}" python3 - <<'PY'
           import hashlib
           import json
           import os
@@ -413,10 +376,11 @@ jobs:
           archive = Path(os.environ["ARCHIVE"])
           receipt = {
               "schema": "prob4d.dot-r04-r10-archive-cache-recovery-receipt",
-              "schema_version": 1,
+              "schema_version": 2,
               "request_id": os.environ["REQUEST_ID"],
               "target_run_id": int(os.environ["TARGET_RUN_ID"]),
               "target_head_sha": os.environ["TARGET_HEAD_SHA"],
+              "failed_recovery_run_id": int(os.environ["FAILED_RECOVERY_RUN_ID"]),
               "archive_name": os.environ["ARCHIVE_NAME"],
               "archive_md5": os.environ["ARCHIVE_MD5"],
               "archive_bytes": archive.stat().st_size,
@@ -437,7 +401,7 @@ jobs:
               allow_nan=False,
           ).encode("utf-8")
           receipt["receipt_id"] = hashlib.sha256(encoded).hexdigest()
-          output_path = Path(os.environ["CACHE_ROOT"]) / "archive-recovery-receipt.json"
+          output_path = Path(os.environ["CACHE_ROOT"]) / "archive-recovery-v2-receipt.json"
           output_path.write_text(
               json.dumps(receipt, indent=2, sort_keys=True) + "\n",
               encoding="utf-8",
@@ -447,32 +411,31 @@ jobs:
           PY
 
       - name: Upload bounded archive-recovery receipt
-        if: always() && steps.target.outputs.need_rerun == 'true'
+        if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          name: dot-r04-r10-archive-recovery-${{ github.run_id }}-${{ github.run_attempt }}
-          path: ${{ env.CACHE_ROOT }}/archive-recovery-receipt.json
+          name: dot-r04-r10-archive-recovery-v2-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ env.CACHE_ROOT }}/archive-recovery-v2-receipt.json
           if-no-files-found: warn
           retention-days: 30
 
   rerun:
-    name: Re-run the frozen provider job and its dependents
+    name: Re-run the exact frozen provider job and dependents
     needs: [authorize, prime]
-    if: needs.prime.outputs.need_rerun == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
       contents: read
       actions: write
     steps:
-      - name: Re-run the exact failed provider job
+      - name: Re-run exact failed job
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-          PROVIDER_JOB_ID: ${{ needs.prime.outputs.provider_job_id }}
+          PROVIDER_JOB_ID: ${{ needs.authorize.outputs.provider_job_id }}
         run: |
           set -euo pipefail
-          python - <<'PY'
+          python3 - <<'PY'
           import os
           import urllib.request
 
@@ -487,7 +450,7 @@ jobs:
                   "Accept": "application/vnd.github+json",
                   "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
                   "Content-Length": "0",
-                  "User-Agent": "Prob4D-DOT-archive-recovery/1",
+                  "User-Agent": "Prob4D-DOT-archive-recovery/2",
                   "X-GitHub-Api-Version": "2022-11-28",
               },
           )
@@ -498,7 +461,7 @@ jobs:
           PY
 
   publish:
-    name: Publish archive-recovery controller decision
+    name: Publish corrected archive-recovery decision
     if: always()
     needs: [authorize, prime, rerun]
     runs-on: ubuntu-latest
@@ -510,21 +473,19 @@ jobs:
         env:
           AUTHORIZE_RESULT: ${{ needs.authorize.result }}
           PRIME_RESULT: ${{ needs.prime.result }}
-          NEED_RERUN: ${{ needs.prime.outputs.need_rerun }}
-          PROVIDER_JOB_ID: ${{ needs.prime.outputs.provider_job_id }}
+          PROVIDER_JOB_ID: ${{ needs.authorize.outputs.provider_job_id }}
           RECEIPT_ID: ${{ needs.prime.outputs.receipt_id }}
           RERUN_RESULT: ${{ needs.rerun.result }}
         run: |
           {
-            echo "## Frozen DOT R04-R10 archive recovery"
+            echo "## Frozen DOT R04-R10 archive recovery v2"
             echo
             echo "- authorization: \`$AUTHORIZE_RESULT\`"
             echo "- cache prime: \`$PRIME_RESULT\`"
-            echo "- provider rerun required: \`$NEED_RERUN\`"
             echo "- provider job ID: \`$PROVIDER_JOB_ID\`"
             echo "- archive receipt ID: \`$RECEIPT_ID\`"
             echo "- rerun request: \`$RERUN_RESULT\`"
             echo
-            echo "No archive was extracted and no marker payload was opened by this controller."
+            echo "No archive was extracted and no image or marker payload was opened by this controller."
             echo "The frozen protocol, cohort, provider, thresholds, and evaluation order were unchanged."
           } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Purpose

Correct the purely operational failure in recovery run `33441147840` and resume the exact frozen R04–R10 confirmation without changing its scientific protocol.

The first recovery controller passed its hosted authorization, then failed on `workstation2` before any archive operation because that runner exposes `python3`, not `python`. The original confirmation itself had previously failed MD5 during non-resumable archive transfer, before CUT3R inference, provider sealing, or marker access.

## Changes

- bind the self-hosted controller to `python3`;
- require the original confirmation run and the failed recovery run by exact IDs;
- independently verify that the original provider failed at archive acquisition and never advanced into inference/sealing;
- verify that no provider-seal artifact exists;
- obtain the publisher byte count and MD5 before transfer;
- reuse a valid complete archive or a verified local copy;
- salvage the largest incomplete original transfer when shorter than the publisher byte count;
- resume through the official Dataverse endpoint with retries, speed/timeout guards, and one fresh fallback;
- promote the archive only after exact byte-count and MD5 verification;
- retain a bounded receipt declaring no extraction, image access, marker access, or scientific change; and
- rerun the exact failed provider job and its dependent hosted scorer through the Actions API.

## Scientific invariants

Unchanged: R04–R10 cohort, R11–R70 reserve, source calibration and `alpha=0.85`, provider checkpoint and CUT3R revision, coordinate convention, windows, query, comparators, bootstrap, decision rule, and prediction-before-marker custody.

This PR contains no request file and cannot start recovery. Execution still requires a later reviewed one-file content-addressed request on `main`.