### PR TITLE
Route frozen DOT R11–R30 provider to gpuserver6000

### DIFF
--- a/.github/workflows/dot-rope-query-selective-heldout-v1.yml
+++ b/.github/workflows/dot-rope-query-selective-heldout-v1.yml
@@ -16,19 +16,20 @@ concurrency:
 env:
   REQUEST_PATH: protocols/execution_requests/dot_rope_query_selective_heldout_v1.json
   PROTOCOL_PATH: protocols/dot-rope-query-selective-heldout-v1.json
-  DATASET_ROOT: /mnt/seagate10tb/florianpfaff/datasets/dot
   R11_ARCHIVE: R11-20.zip
   R11_MD5: 23ce3e7067465d3edabe20b4c7cfa388
   R21_ARCHIVE: R21-30.zip
   R21_MD5: 8aee77f79d1aff6e1f3fd21886b251a0
   DATASET_API: https://dataverse.orc.gmu.edu/api/datasets/:persistentId/?persistentId=doi:10.13021/ORC2020/XXLVXM
   DATAFILE_API_ROOT: https://dataverse.orc.gmu.edu/api/access/datafile
-  CUT3R_RUNTIME_CHECKOUT: /home/github-runner/.cache/prob4d/cut3r-runtime-v1/CUT3R
-  CUT3R_RUNTIME_PYTHON: /home/github-runner/.cache/prob4d/cut3r-runtime-v1/venv/bin/python
-  CUT3R_RUNTIME_CHECKPOINT: /home/github-runner/.cache/prob4d/cut3r-runtime-v1/cut3r_512_dpt_4_64.pth
-  CUT3R_RUNTIME_MANIFEST: /home/github-runner/.cache/prob4d/cut3r-runtime-v1/bootstrap-manifest.json
   CUT3R_REVISION: 8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf
   CUT3R_CHECKPOINT_SHA256: 45f7e98a0a64dbeb54901ae2b878cd8cd125f20a4497316483f0bd6f109f8103
+  CUT3R_CHECKPOINT_GDRIVE_ID: 1Asz-ZB3FfpzZYwunhQvNPZEUA8XUNAYD
+  RUNTIME_CACHE_ROOT: /home/github-runner/.cache/prob4d/dot-r11-r30-cut3r-gpuserver6000-v1
+  RETAINED_CUT3R_CHECKOUT: ${{ vars.CUT3R_CHECKOUT }}
+  RETAINED_CUT3R_CHECKPOINT: ${{ vars.CUT3R_CHECKPOINT }}
+  RETAINED_CUT3R_PYTHON: ${{ vars.CUT3R_PYTHON }}
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
   PYTHONHASHSEED: "0"
   PYTHONUNBUFFERED: "1"
   PYTHONDONTWRITEBYTECODE: "1"
@@ -228,11 +229,11 @@ jobs:
           PY
 
   provider:
-    name: Seal marker-free R11-R30 CUT3R point maps
+    name: Seal marker-free R11-R30 CUT3R point maps on gpuserver6000
     if: github.event_name == 'push'
     needs: [authorize, prerequisite]
     environment: trusted-self-hosted-validation
-    runs-on: [self-hosted, Linux, X64, gpuserver4090]
+    runs-on: [self-hosted, gpuserver6000]
     timeout-minutes: 720
     permissions:
       contents: read
@@ -240,168 +241,438 @@ jobs:
       decision: ${{ steps.result.outputs.decision }}
       provider_bundle_id: ${{ steps.result.outputs.provider_bundle_id }}
     steps:
-      - name: Initialize isolated provider workspace
+      - name: Bind the intended GPU runner
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$RUNNER_NAME" = "workstation2"
+          test "$RUNNER_OS" = "Linux"
+          test "$RUNNER_ARCH" = "X64"
+          command -v nvidia-smi >/dev/null 2>&1
+          command -v c++ >/dev/null 2>&1
+          nvidia-smi --query-gpu=name,driver_version,memory.total --format=csv,noheader
+
+      - name: Initialize isolated prediction workspace
         id: workspace
         shell: bash
         run: |
           set -euo pipefail
-          root="${RUNNER_TEMP}/prob4d-dot-query-provider-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          root="${RUNNER_TEMP}/prob4d-dot-r11-r30-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          expected="${RUNNER_TEMP}/prob4d-dot-r11-r30-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          test "$root" = "$expected"
           /usr/bin/rm -rf -- "$root"
-          /usr/bin/mkdir -p "$root/provider" "$root/home" "$root/cache" "$root/tmp"
+          /usr/bin/mkdir -p \
+            "$root/home" \
+            "$root/cache" \
+            "$root/tmp" \
+            "$root/evidence" \
+            "$root/provider"
           echo "root=$root" >> "$GITHUB_OUTPUT"
           {
             echo "HOME=$root/home"
             echo "XDG_CACHE_HOME=$root/cache"
+            echo "PIP_CACHE_DIR=$root/cache/pip"
+            echo "HF_HOME=$root/cache/huggingface"
             echo "TMPDIR=$root/tmp"
             echo "TORCH_EXTENSIONS_DIR=$root/cache/torch-extensions"
             echo "WANDB_MODE=disabled"
             echo "WANDB_DISABLED=true"
           } >> "$GITHUB_ENV"
-      - name: Require intended runner and exact official target archives
-        shell: bash
-        run: |
-          set -euo pipefail
-          test "$RUNNER_NAME" = "workstation1"
-          test "$RUNNER_OS" = "Linux"
-          test "$RUNNER_ARCH" = "X64"
-          command -v nvidia-smi >/dev/null 2>&1
-          test -d "$DATASET_ROOT"
-          test ! -L "$DATASET_ROOT"
-          for archive in "$R11_ARCHIVE" "$R21_ARCHIVE"; do
-            test -f "$DATASET_ROOT/$archive"
-            test -r "$DATASET_ROOT/$archive"
-          done
-          printf '%s  %s\n' "$R11_MD5" "$DATASET_ROOT/$R11_ARCHIVE" | md5sum --check --strict
-          printf '%s  %s\n' "$R21_MD5" "$DATASET_ROOT/$R21_ARCHIVE" | md5sum --check --strict
-          nvidia-smi --query-gpu=name,driver_version,memory.total --format=csv,noheader
-      - name: Check out exact authorized revision
+
+      - name: Check out exact authorized Prob4D revision
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ needs.authorize.outputs.head_sha }}
           fetch-depth: 0
           persist-credentials: false
           clean: true
-      - name: Verify clean exact checkout
+
+      - name: Verify clean exact Prob4D checkout
         shell: bash
         env:
           EXPECTED_HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
         run: |
           set -euo pipefail
-          test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
-          test -z "$(git status --porcelain=v1 --untracked-files=all)"
-      - name: Bind persistent CUDA 12.6 CUT3R runtime
+          test "$(/usr/bin/git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
+          test -z "$(/usr/bin/git status --porcelain=v1 --untracked-files=all)"
+          test "$(/usr/bin/git rev-parse HEAD:$PROTOCOL_PATH)" = \
+            "${{ needs.authorize.outputs.protocol_git_blob_sha }}"
+
+      - name: Check out exact public CUT3R revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: CUT3R/CUT3R
+          ref: 8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf
+          path: external/CUT3R
+          fetch-depth: 1
+          persist-credentials: false
+          clean: true
+
+      - name: Set up bootstrap Python 3.11
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+
+      - name: Select or bootstrap a CUDA CUT3R interpreter
         id: runtime
         shell: bash
         run: |
           set -euo pipefail
-          test -x "$CUT3R_RUNTIME_PYTHON"
-          test -d "$CUT3R_RUNTIME_CHECKOUT/.git"
-          test -f "$CUT3R_RUNTIME_CHECKPOINT"
-          test -f "$CUT3R_RUNTIME_MANIFEST"
-          test "$(git -C "$CUT3R_RUNTIME_CHECKOUT" rev-parse HEAD)" = "$CUT3R_REVISION"
-          test "$(sha256sum "$CUT3R_RUNTIME_CHECKPOINT" | awk '{print $1}')" = \
+          root="${{ steps.workspace.outputs.root }}"
+          candidates=("")
+          add_candidate() {
+            local candidate="${1:-}"
+            [[ -n "$candidate" ]] || return 0
+            local existing
+            for existing in "${candidates[@]}"; do
+              [[ "$existing" != "$candidate" ]] || return 0
+            done
+            candidates+=("$candidate")
+          }
+          add_candidate "${RETAINED_CUT3R_PYTHON:-}"
+          if [[ -n "${RETAINED_CUT3R_CHECKOUT:-}" ]]; then
+            add_candidate "$RETAINED_CUT3R_CHECKOUT/.venv/bin/python"
+          fi
+          add_candidate /home/florianpfaff/conda_envs/cut3r/bin/python
+          add_candidate /home/florianpfaff/miniconda3/envs/cut3r/bin/python
+          add_candidate /home/florianpfaff/anaconda3/envs/cut3r/bin/python
+          add_candidate /home/github-runner/.conda/envs/cut3r/bin/python
+          add_candidate /home/github-runner/miniconda3/envs/cut3r/bin/python
+          add_candidate /home/github-runner/anaconda3/envs/cut3r/bin/python
+          add_candidate /opt/conda/envs/cut3r/bin/python
+
+          usable=""
+          for candidate in "${candidates[@]}"; do
+            [[ -x "$candidate" ]] || continue
+            echo "::group::CUT3R interpreter candidate $candidate"
+            if "$candidate" - <<'PY'
+          import accelerate
+          import cv2
+          import einops
+          import h5py
+          import hydra
+          import lpips
+          import numpy
+          import PIL
+          import roma
+          import scipy
+          import sklearn
+          import torch
+          import torchvision
+          import transformers
+
+          print("python-ready")
+          print("torch", torch.__version__)
+          print("torch_cuda", torch.version.cuda)
+          print("cuda_available", torch.cuda.is_available())
+          if not torch.cuda.is_available():
+              raise SystemExit(1)
+          print("gpu", torch.cuda.get_device_name(0))
+          PY
+            then
+              usable="$candidate"
+              echo "Selected $candidate"
+              echo "::endgroup::"
+              break
+            fi
+            echo "Rejected $candidate"
+            echo "::endgroup::"
+          done
+
+          if [[ -z "$usable" ]]; then
+            venv="$root/venv"
+            python -m venv "$venv"
+            usable="$venv/bin/python"
+            "$usable" -m pip install \
+              "pip==25.2" "setuptools==80.9.0" "wheel==0.45.1"
+            "$usable" -m pip install \
+              torch==2.11.0 torchvision==0.26.0 \
+              --index-url https://download.pytorch.org/whl/cu126
+            filtered="$root/cut3r-requirements.txt"
+            python - external/CUT3R/requirements.txt "$filtered" <<'PY'
+          import re
+          import sys
+          from pathlib import Path
+
+          source = Path(sys.argv[1]).read_text(encoding="utf-8").splitlines()
+          kept = []
+          for line in source:
+              stripped = line.strip()
+              if re.match(r"^(torch|torchvision)(?:\s|[<>=!~].*)?$", stripped, flags=re.I):
+                  continue
+              kept.append(line)
+          Path(sys.argv[2]).write_text("\n".join(kept) + "\n", encoding="utf-8")
+          PY
+            "$usable" -m pip install -r "$filtered" gdown==5.2.0
+            "$usable" -m pip check
+          fi
+
+          "$usable" - <<'PY'
+          import torch
+          print("selected_python_cuda", torch.cuda.is_available())
+          print("selected_gpu", torch.cuda.get_device_name(0))
+          if not torch.cuda.is_available():
+              raise SystemExit("selected CUT3R Python has no CUDA device")
+          PY
+          echo "python=$usable" >> "$GITHUB_OUTPUT"
+
+      - name: Acquire exact CUT3R checkpoint without opening DOT
+        id: checkpoint
+        shell: bash
+        run: |
+          set -euo pipefail
+          /usr/bin/mkdir -p "$RUNTIME_CACHE_ROOT"
+          selected=""
+          if [[ -n "${RETAINED_CUT3R_CHECKPOINT:-}" && -f "$RETAINED_CUT3R_CHECKPOINT" ]]; then
+            measured=$(sha256sum "$RETAINED_CUT3R_CHECKPOINT" | awk '{print $1}')
+            if [[ "$measured" = "$CUT3R_CHECKPOINT_SHA256" ]]; then
+              selected="$RETAINED_CUT3R_CHECKPOINT"
+            fi
+          fi
+          if [[ -z "$selected" ]]; then
+            selected="$RUNTIME_CACHE_ROOT/cut3r_512_dpt_4_64.pth"
+            valid=false
+            if [[ -f "$selected" ]]; then
+              measured=$(sha256sum "$selected" | awk '{print $1}')
+              [[ "$measured" = "$CUT3R_CHECKPOINT_SHA256" ]] && valid=true
+            fi
+            if [[ "$valid" != true ]]; then
+              part="$selected.part-${GITHUB_RUN_ID}"
+              /usr/bin/rm -f -- "$part"
+              python -m pip install gdown==5.2.0
+              PART="$part" python - <<'PY'
+          import os
+          import gdown
+
+          result = gdown.download(
+              id=os.environ["CUT3R_CHECKPOINT_GDRIVE_ID"],
+              output=os.environ["PART"],
+              quiet=False,
+          )
+          if result is None:
+              raise SystemExit("gdown did not produce the frozen CUT3R checkpoint")
+          PY
+              test "$(sha256sum "$part" | awk '{print $1}')" = \
+                "$CUT3R_CHECKPOINT_SHA256"
+              /usr/bin/mv -- "$part" "$selected"
+            fi
+          fi
+          test "$(sha256sum "$selected" | awk '{print $1}')" = \
             "$CUT3R_CHECKPOINT_SHA256"
-          MANIFEST="$CUT3R_RUNTIME_MANIFEST" \
-            EXPECTED_REVISION="$CUT3R_REVISION" \
-            EXPECTED_CHECKPOINT_SHA256="$CUT3R_CHECKPOINT_SHA256" \
-            EXPECTED_PYTHON="$CUT3R_RUNTIME_PYTHON" \
-            "$CUT3R_RUNTIME_PYTHON" - <<'PY'
+          echo "path=$selected" >> "$GITHUB_OUTPUT"
+          stat -c 'checkpoint_bytes=%s' "$selected"
+
+      - name: Resolve, download, and verify official R11-R30 archives
+        id: dataset
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          cache="$RUNTIME_CACHE_ROOT/dot-v29"
+          /usr/bin/mkdir -p "$cache"
+          ARCHIVE_TABLE="$root/tmp/archives.tsv" \
+            RECEIPT="$root/evidence/official-archives.json" \
+            python - <<'PY'
           import json
           import os
-          import re
+          import urllib.request
           from pathlib import Path
 
-          value = json.loads(Path(os.environ["MANIFEST"]).read_text(encoding="utf-8"))
-          if value.get("schema") != "prob4d.dot-cut3r-gpuserver4090-runtime-bootstrap":
-              raise SystemExit("runtime manifest schema changed")
-          if value.get("schema_version") != 4:
-              raise SystemExit("runtime manifest version changed")
-          if value.get("cut3r_revision") != os.environ["EXPECTED_REVISION"]:
-              raise SystemExit("runtime CUT3R revision changed")
-          checkpoint = value.get("checkpoint") or {}
-          if checkpoint.get("sha256") != os.environ["EXPECTED_CHECKPOINT_SHA256"]:
-              raise SystemExit("runtime checkpoint changed")
-          if value.get("runtime_python") != os.environ["EXPECTED_PYTHON"]:
-              raise SystemExit("runtime interpreter changed")
-          if value.get("torch_cuda_version") != "12.6":
-              raise SystemExit("runtime CUDA version changed")
-          if value.get("cuda_available") is not True:
-              raise SystemExit("runtime does not attest CUDA")
-          if value.get("dot_dataset_accessed") is not False:
-              raise SystemExit("runtime bootstrap crossed the DOT boundary")
-          native_id = value.get("native_rope_artifact_id")
-          if not isinstance(native_id, str) or re.fullmatch(r"[0-9a-f]{64}", native_id) is None:
-              raise SystemExit("runtime has no native RoPE identity")
-          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
-              output.write(f"native_rope_artifact_id={native_id}\n")
+          expected = {
+              os.environ["R11_ARCHIVE"]: os.environ["R11_MD5"],
+              os.environ["R21_ARCHIVE"]: os.environ["R21_MD5"],
+          }
+          request = urllib.request.Request(
+              os.environ["DATASET_API"],
+              headers={"User-Agent": "Prob4D-DOT-R11-R30-provider/1"},
+          )
+          with urllib.request.urlopen(request, timeout=60) as response:
+              metadata = json.load(response)
+          if metadata.get("status") != "OK":
+              raise SystemExit("Dataverse metadata request did not return OK")
+          files = metadata["data"]["latestVersion"]["files"]
+          by_name = {entry["dataFile"]["filename"]: entry["dataFile"] for entry in files}
+          rows = []
+          receipt = {}
+          for name, md5 in expected.items():
+              data_file = by_name.get(name)
+              if data_file is None:
+                  raise SystemExit(f"official DOT metadata lacks {name}")
+              checksum = data_file.get("checksum") or {}
+              if checksum.get("type") != "MD5" or checksum.get("value", "").lower() != md5:
+                  raise SystemExit(f"official checksum changed for {name}")
+              item = {
+                  "datafile_id": int(data_file["id"]),
+                  "byte_count": int(data_file["filesize"]),
+                  "checksum": checksum,
+              }
+              receipt[name] = item
+              rows.append((name, item["datafile_id"], item["byte_count"], md5))
+          Path(os.environ["RECEIPT"]).write_text(
+              json.dumps(receipt, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          Path(os.environ["ARCHIVE_TABLE"]).write_text(
+              "".join(f"{name}\t{file_id}\t{size}\t{md5}\n" for name, file_id, size, md5 in rows),
+              encoding="utf-8",
+          )
           PY
-      - name: Copy and attest native runtime without opening DOT
+
+          while IFS=$'\t' read -r name file_id bytes md5; do
+            archive="$cache/$name"
+            valid=false
+            if [[ -f "$archive" && "$(stat -c %s "$archive")" = "$bytes" ]]; then
+              measured=$(md5sum "$archive" | awk '{print $1}')
+              [[ "$measured" = "$md5" ]] && valid=true
+            fi
+            if [[ "$valid" != true ]]; then
+              part="$archive.partial"
+              if [[ -f "$part" ]]; then
+                part_bytes=$(stat -c %s "$part")
+                if (( part_bytes > bytes )); then
+                  /usr/bin/rm -f -- "$part"
+                fi
+              fi
+              curl --fail --location --retry 8 --retry-all-errors \
+                --connect-timeout 30 --continue-at - \
+                --output "$part" "$DATAFILE_API_ROOT/$file_id"
+              test "$(stat -c %s "$part")" = "$bytes"
+              printf '%s  %s\n' "$md5" "$part" | md5sum --check --strict
+              /usr/bin/mv -- "$part" "$archive"
+            fi
+            test "$(stat -c %s "$archive")" = "$bytes"
+            printf '%s  %s\n' "$md5" "$archive" | md5sum --check --strict
+          done < "$root/tmp/archives.tsv"
+          echo "root=$cache" >> "$GITHUB_OUTPUT"
+
+      - name: Build and attest native CUT3R RoPE in an isolated checkout
+        id: rope
         shell: bash
         env:
-          NATIVE_ROPE_ARTIFACT_ID: ${{ steps.runtime.outputs.native_rope_artifact_id }}
+          RUNTIME_PYTHON: ${{ steps.runtime.outputs.python }}
         run: |
           set -euo pipefail
           root="${{ steps.workspace.outputs.root }}"
-          mkdir -p "$root/CUT3R"
-          cp -a "$CUT3R_RUNTIME_CHECKOUT/." "$root/CUT3R/"
-          REQUEST_PATH=__query_selective_runtime_verification__ \
-            PYTHONPATH="$GITHUB_WORKSPACE/src" \
-            "$CUT3R_RUNTIME_PYTHON" scripts/science/prepare_cut3r_runtime.py \
-              --cut3r-checkout "$root/CUT3R" \
-              --expected-artifact-id "$NATIVE_ROPE_ARTIFACT_ID" \
-              --output "$root/provider/runtime-receipt.json"
-      - name: Enable exact hash-bound legacy checkpoint load in isolated copy
+          checkout="$root/CUT3R"
+          /usr/bin/mkdir -p "$checkout"
+          /usr/bin/cp -a external/CUT3R/. "$checkout/"
+          test "$(/usr/bin/git -C "$checkout" rev-parse HEAD)" = "$CUT3R_REVISION"
+          /usr/bin/find "$checkout/src/croco/models/curope" \
+            -maxdepth 1 -type f -name '*.so' -delete
+          /usr/bin/rm -rf -- "$checkout/src/croco/models/curope/build"
+
+          nvcc=""
+          for candidate in \
+            "$(command -v nvcc || true)" \
+            /usr/local/cuda/bin/nvcc \
+            /usr/local/cuda-12.6/bin/nvcc \
+            /usr/local/cuda-12.8/bin/nvcc
+          do
+            if [[ -x "$candidate" ]]; then
+              nvcc="$candidate"
+              break
+            fi
+          done
+          test -n "$nvcc" || {
+            echo "native RoPE requires an available nvcc compiler" >&2
+            exit 2
+          }
+          cuda_home=$(/usr/bin/dirname "$(/usr/bin/dirname "$nvcc")")
+          arch=$(
+            "$RUNTIME_PYTHON" - <<'PY'
+          import torch
+          major, minor = torch.cuda.get_device_capability(0)
+          print(f"{major}.{minor}")
+          PY
+          )
+          "$nvcc" --version
+          CUDA_HOME="$cuda_home" \
+            TORCH_CUDA_ARCH_LIST="$arch" \
+            MAX_JOBS=4 \
+            PYTHONPATH="$GITHUB_WORKSPACE/src:$checkout:$checkout/src" \
+            "$RUNTIME_PYTHON" \
+            scripts/science/prepare_cut3r_runtime.py \
+              --cut3r-checkout "$checkout" \
+              --build \
+              --output "$root/evidence/runtime-receipt.json"
+          echo "checkout=$checkout" >> "$GITHUB_OUTPUT"
+
+      - name: Enable the hash-pinned legacy checkpoint loader
         shell: bash
+        env:
+          CHECKPOINT_PATH: ${{ steps.checkpoint.outputs.path }}
+          CUT3R_CHECKOUT: ${{ steps.rope.outputs.checkout }}
         run: |
           set -euo pipefail
-          root="${{ steps.workspace.outputs.root }}"
-          CHECKOUT="$root/CUT3R" CHECKPOINT="$CUT3R_RUNTIME_CHECKPOINT" \
-            EXPECTED_CHECKPOINT="$CUT3R_CHECKPOINT_SHA256" \
-            "$CUT3R_RUNTIME_PYTHON" - <<'PY'
+          python - <<'PY'
           import hashlib
+          import json
           import os
           from pathlib import Path
 
-          checkout = Path(os.environ["CHECKOUT"]).resolve(strict=True)
-          checkpoint = Path(os.environ["CHECKPOINT"]).resolve(strict=True)
-          digest = hashlib.sha256(checkpoint.read_bytes()).hexdigest()
-          if digest != os.environ["EXPECTED_CHECKPOINT"]:
-              raise SystemExit("query-selective checkpoint bytes changed")
-          model = checkout / "src/dust3r/model.py"
-          source = model.read_bytes()
-          header = f"blob {len(source)}\0".encode("ascii")
-          blob = hashlib.sha1(header + source, usedforsecurity=False).hexdigest()
+          checkout = Path(os.environ["CUT3R_CHECKOUT"]).resolve(strict=True)
+          checkpoint = Path(os.environ["CHECKPOINT_PATH"]).resolve(strict=True)
+          if hashlib.sha256(checkpoint.read_bytes()).hexdigest() != os.environ["CUT3R_CHECKPOINT_SHA256"]:
+              raise SystemExit("checkpoint digest changed before compatibility patch")
+          path = checkout / "src/dust3r/model.py"
+          source = path.read_bytes()
+          framed = f"blob {len(source)}\0".encode("ascii") + source
+          blob = hashlib.sha1(framed, usedforsecurity=False).hexdigest()
           if blob != "7ed9f6106fb063686990c874ede99876ebc939ab":
-              raise SystemExit("query-selective CUT3R model source changed")
+              raise SystemExit("CUT3R model source blob changed")
           original = '    ckpt = torch.load(model_path, map_location="cpu")\n'
-          patched = '    ckpt = torch.load(model_path, map_location="cpu", weights_only=False)\n'
+          replacement = (
+              '    ckpt = torch.load(model_path, map_location="cpu", '
+              'weights_only=False)\n'
+          )
           text = source.decode("utf-8")
-          if text.count(original) != 1 or patched in text:
-              raise SystemExit("query-selective CUT3R load call changed")
-          model.write_text(text.replace(original, patched, 1), encoding="utf-8")
+          if text.count(original) != 1 or replacement in text:
+              raise SystemExit("CUT3R checkpoint loader shape changed")
+          patched = text.replace(original, replacement, 1).encode("utf-8")
+          path.write_bytes(patched)
+          receipt = {
+              "schema": "prob4d.dot-r11-r30-checkpoint-compatibility",
+              "schema_version": 1,
+              "cut3r_revision": os.environ["CUT3R_REVISION"],
+              "checkpoint_sha256": os.environ["CUT3R_CHECKPOINT_SHA256"],
+              "source_git_blob_sha1": blob,
+              "source_sha256": hashlib.sha256(source).hexdigest(),
+              "patched_sha256": hashlib.sha256(patched).hexdigest(),
+              "torch_load_policy": "weights_only=False only at the pinned loader",
+          }
+          encoded = json.dumps(receipt, sort_keys=True, separators=(",", ":")).encode()
+          receipt["artifact_id"] = hashlib.sha256(encoded).hexdigest()
+          output = Path("${{ steps.workspace.outputs.root }}/evidence/checkpoint-load-compatibility.json")
+          output.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
           PY
+
       - name: Predict R11-R30 from normal-view images only
         id: execute
         continue-on-error: true
         shell: bash
         env:
+          RUNTIME_PYTHON: ${{ steps.runtime.outputs.python }}
+          CHECKPOINT_PATH: ${{ steps.checkpoint.outputs.path }}
+          DATASET_ROOT: ${{ steps.dataset.outputs.root }}
+          CUT3R_CHECKOUT: ${{ steps.rope.outputs.checkout }}
           REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
           EXPECTED_HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
         run: |
           set -euo pipefail
           root="${{ steps.workspace.outputs.root }}"
-          PYTHONPATH="$GITHUB_WORKSPACE/src:$GITHUB_WORKSPACE/scripts/science" \
-            "$CUT3R_RUNTIME_PYTHON" \
+          PYTHONPATH="$GITHUB_WORKSPACE/src:$GITHUB_WORKSPACE/scripts/science:$CUT3R_CHECKOUT:$CUT3R_CHECKOUT/src" \
+            "$RUNTIME_PYTHON" \
             scripts/science/run_dot_rope_query_selective_heldout.py \
               predict \
               --protocol "$PROTOCOL_PATH" \
               --request-id "$REQUEST_ID" \
               --prob4d-revision "$EXPECTED_HEAD_SHA" \
               --dataset-root "$DATASET_ROOT" \
-              --cut3r-checkout "$root/CUT3R" \
-              --checkpoint "$CUT3R_RUNTIME_CHECKPOINT" \
-              --runtime-receipt "$root/provider/runtime-receipt.json" \
+              --cut3r-checkout "$CUT3R_CHECKOUT" \
+              --checkpoint "$CHECKPOINT_PATH" \
+              --runtime-receipt "$root/evidence/runtime-receipt.json" \
               --output-dir "$root/provider/bundle"
+
       - name: Read sealed provider result
         id: result
         if: always()
@@ -410,8 +681,30 @@ jobs:
           EXECUTION_OUTCOME: ${{ steps.execute.outcome }}
         run: |
           set -euo pipefail
-          manifest="${{ steps.workspace.outputs.root }}/provider/bundle/manifest.json"
+          root="${{ steps.workspace.outputs.root }}"
+          manifest="$root/provider/bundle/manifest.json"
           if [[ "$EXECUTION_OUTCOME" != "success" || ! -f "$manifest" ]]; then
+            ROOT="$root/provider" OUTCOME="${EXECUTION_OUTCOME:-not-run}" python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          root = Path(os.environ["ROOT"])
+          root.mkdir(parents=True, exist_ok=True)
+          (root / "technical-failure.json").write_text(
+              json.dumps(
+                  {
+                      "decision": "technical-failure",
+                      "execution_outcome": os.environ["OUTCOME"],
+                      "marker_payloads_opened": False,
+                  },
+                  indent=2,
+                  sort_keys=True,
+              )
+              + "\n",
+              encoding="utf-8",
+          )
+          PY
             echo "decision=technical-failure" >> "$GITHUB_OUTPUT"
             echo "provider_bundle_id=unavailable" >> "$GITHUB_OUTPUT"
             exit 0
@@ -437,14 +730,26 @@ jobs:
               output.write("decision=sealed-r11-r30-provider-predictions\n")
               output.write(f"provider_bundle_id={bundle_id}\n")
           PY
+          /usr/bin/chmod -R a-w "$root/provider"
+
       - name: Upload immutable R11-R30 provider bundle
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dot-rope-query-selective-provider-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ steps.workspace.outputs.root }}/provider/
           if-no-files-found: error
           retention-days: 30
+
+      - name: Upload bounded gpuserver6000 runtime receipts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: dot-rope-query-selective-runtime-gpuserver6000-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.workspace.outputs.root }}/evidence/
+          if-no-files-found: warn
+          retention-days: 30
+
       - name: Require sealed provider predictions
         if: always()
         shell: bash
@@ -453,6 +758,17 @@ jobs:
         run: |
           set -euo pipefail
           test "$DECISION" = "sealed-r11-r30-provider-predictions"
+
+      - name: Remove isolated provider workspace
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          expected="${RUNNER_TEMP}/prob4d-dot-r11-r30-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          test "$root" = "$expected"
+          /usr/bin/chmod -R u+w "$root" 2>/dev/null || true
+          /usr/bin/rm -rf -- "$root"
 
   seal:
     name: Seal factors and query decisions from 2-D markers only

--- a/tests/test_dot_rope_query_selective_heldout_workflow.py
+++ b/tests/test_dot_rope_query_selective_heldout_workflow.py
@@ -60,10 +60,10 @@ def test_only_provider_job_uses_the_protected_gpu_runner() -> None:
     provider = _job(text, "provider", "seal")
     seal = _job(text, "seal", "evaluate")
     evaluate = _job(text, "evaluate", "publish")
-    selector = "runs-on: [self-hosted, Linux, X64, gpuserver4090]"
+    selector = "runs-on: [self-hosted, gpuserver6000]"
     assert selector in provider
     assert "environment: trusted-self-hosted-validation" in provider
-    assert 'test "$RUNNER_NAME" = "workstation1"' in provider
+    assert 'test "$RUNNER_NAME" = "workstation2"' in provider
     assert "ref: ${{ needs.authorize.outputs.head_sha }}" in provider
     assert "persist-credentials: false" in provider
     assert "contents: write" not in provider
@@ -83,6 +83,9 @@ def test_archive_and_information_boundaries_are_explicit() -> None:
     provider = _job(text, "provider", "seal")
     seal = _job(text, "seal", "evaluate")
     evaluate = _job(text, "evaluate", "publish")
+    assert "Resolve, download, and verify official R11-R30 archives" in provider
+    assert "--continue-at -" in provider
+    assert "Build and attest native CUT3R RoPE in an isolated checkout" in provider
     assert "Predict R11-R30 from normal-view images only" in provider
     assert "two_dimensional_markers_opened" in provider
     assert "three_dimensional_markers_opened" in provider


### PR DESCRIPTION
## Purpose

Make the already frozen DOT R11–R30 query-selective CUT3R continuation executable on the available `gpuserver6000` / `workstation2` runner.

## Execution-lane changes

- replace the unavailable `gpuserver4090` / `workstation1` binding with `[self-hosted, gpuserver6000]` and an exact `workstation2` assertion;
- retain the exact CUT3R revision and checkpoint identity;
- select or bootstrap a CUDA CUT3R interpreter using the same bounded strategy as the R04–R10 confirmation;
- obtain `R11-20.zip` and `R21-30.zip` only after the prerequisite is independently verified;
- reuse verified cache/local copies or resumably download the publisher archives with exact byte-count and MD5 checks;
- rebuild and attest native CUT3R RoPE in an isolated checkout;
- retain marker-free normal-view prediction, immutable provider sealing, hosted 2-D factor sealing, and hosted 3-D outcome evaluation; and
- update the focused workflow test for the new protected runner and resumable archive lane.

## Scientific invariants

Unchanged: protocol identity, R11–R30 cohort, R31–R70 reserve, exact R04–R10 `heldout-strong-positive` artifact prerequisite, query gate, rank threshold, local prior, methods, query definitions, independent unit, 20,000 sequence-bootstrap replicates, terminal criteria, and prediction-before-marker information order.

This PR contains no execution request and cannot open R11–R30. A later one-file request remains impossible unless the exact R04–R10 artifact independently verifies as `heldout-strong-positive`.