### PR TITLE
Add bounded hosted relay for frozen DOT archive

### DIFF
--- a/.github/workflows/relay-dot-r04-r10-archive-v1.yml
+++ b/.github/workflows/relay-dot-r04-r10-archive-v1.yml
@@ -1,0 +1,530 @@
+name: Relay frozen DOT R04-R10 archive v1
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/relay-dot-r04-r10-archive-v1.yml"
+      - "CHANGELOG.d/dot-r04-r10-hosted-archive-relay-v1.md"
+      - "docs/dot-r04-r10-hosted-archive-relay-v1.md"
+      - "tests/test_dot_r04_r10_hosted_archive_relay_v1.py"
+      - "tests/test_trusted_self_hosted_validation_policy.py"
+  push:
+    branches: [main]
+    paths:
+      - "protocols/execution_requests/dot_r04_r10_hosted_archive_relay_v1.json"
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: dot-r04-r10-hosted-archive-relay-v1
+  cancel-in-progress: false
+
+env:
+  REQUEST_PATH: protocols/execution_requests/dot_r04_r10_hosted_archive_relay_v1.json
+  TARGET_RUN_ID: "33434695566"
+  TARGET_JOB_ID: "99628289885"
+  TARGET_HEAD_SHA: 9e1b77b2e70685881db7f188a95a3a91443275e8
+  RECOVERY_RUN_ID: "33442397966"
+  ARCHIVE_NAME: R01-10.zip
+  ARCHIVE_BYTES: "1408905061"
+  ARCHIVE_MD5: ca546ff5f22c0279123ccb18509858ee
+  DATASET_API: https://dataverse.orc.gmu.edu/api/datasets/:persistentId/?persistentId=doi:10.13021/ORC2020/XXLVXM
+  DATAFILE_API_ROOT: https://dataverse.orc.gmu.edu/api/access/datafile
+  CACHE_PATH: /home/github-runner/.cache/prob4d/dot-r04-r10-cut3r-gpuserver6000-v1/dot-v29/R01-10.zip
+  CHUNK_BYTES: "350000000"
+  PYTHONDONTWRITEBYTECODE: "1"
+  PYTHONHASHSEED: "0"
+  PYTHONUNBUFFERED: "1"
+
+jobs:
+  contract:
+    name: Validate hosted archive relay control plane
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out exact reviewed revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+          clean: true
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Validate focused workflow and repository policy
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install -e ".[dev]"
+          python -m ruff check \
+            tests/test_dot_r04_r10_hosted_archive_relay_v1.py \
+            tests/test_trusted_self_hosted_validation_policy.py
+          python -m pytest -q \
+            tests/test_dot_r04_r10_hosted_archive_relay_v1.py \
+            tests/test_trusted_self_hosted_validation_policy.py \
+            tests/test_github_action_pins.py
+
+  authorize:
+    name: Authorize one exact relay request after failed direct recovery
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      request_id: ${{ steps.request.outputs.request_id }}
+      head_sha: ${{ steps.request.outputs.head_sha }}
+    steps:
+      - name: Check out exact merged-main request revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 2
+          persist-credentials: false
+          clean: true
+      - name: Require exactly one content-addressed request change
+        id: request
+        shell: bash
+        env:
+          EVENT_REF: ${{ github.ref }}
+          EVENT_BEFORE: ${{ github.event.before }}
+          EVENT_AFTER: ${{ github.event.after }}
+          EVENT_FORCED: ${{ github.event.forced }}
+          EVENT_DELETED: ${{ github.event.deleted }}
+        run: |
+          set -euo pipefail
+          test "$EVENT_REF" = "refs/heads/main"
+          test "$EVENT_AFTER" = "$(/usr/bin/git rev-parse HEAD)"
+          test "$EVENT_FORCED" = "false"
+          test "$EVENT_DELETED" = "false"
+          test "$EVENT_BEFORE" != "0000000000000000000000000000000000000000"
+          mapfile -t changed < <(
+            /usr/bin/git diff --name-only "$EVENT_BEFORE" "$EVENT_AFTER" | sort
+          )
+          if [[ ${#changed[@]} -ne 1 || "${changed[0]}" != "$REQUEST_PATH" ]]; then
+            printf 'Expected only %s; changed paths were:\n' "$REQUEST_PATH" >&2
+            printf '  %s\n' "${changed[@]}" >&2
+            exit 2
+          fi
+          test -f "$REQUEST_PATH"
+          test ! -L "$REQUEST_PATH"
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          def canonical(value):
+              return (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode()
+
+          path = Path(os.environ["REQUEST_PATH"])
+          request = json.loads(path.read_text(encoding="utf-8"))
+          assert request["schema"] == "prob4d.dot-r04-r10-hosted-archive-relay-request"
+          assert request["schema_version"] == 1
+          payload = dict(request)
+          request_id = payload.pop("request_id")
+          assert hashlib.sha256(canonical(payload)).hexdigest() == request_id
+          assert request["target_run_id"] == int(os.environ["TARGET_RUN_ID"])
+          assert request["target_job_id"] == int(os.environ["TARGET_JOB_ID"])
+          assert request["target_head_sha"] == os.environ["TARGET_HEAD_SHA"]
+          assert request["failed_recovery_run_id"] == int(os.environ["RECOVERY_RUN_ID"])
+          assert request["archive_name"] == os.environ["ARCHIVE_NAME"]
+          assert request["archive_bytes"] == int(os.environ["ARCHIVE_BYTES"])
+          assert request["archive_md5"] == os.environ["ARCHIVE_MD5"]
+          assert request["cache_path"] == os.environ["CACHE_PATH"]
+          assert request["runner_labels"] == [
+              "self-hosted", "Linux", "X64", "gpuserver6000"
+          ]
+          assert request["runner_name"] == "workstation2"
+          assert request["scientific_inputs_changed"] is False
+          assert request["provider_prediction_inside_relay"] is False
+          assert request["marker_payload_access_inside_relay"] is False
+          assert request["action"] == "relay-official-archive-and-rerun-exact-failed-job"
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
+              output.write(f"request_id={request_id}\n")
+              output.write(f"head_sha={os.environ['EVENT_AFTER']}\n")
+          PY
+      - name: Require failed direct recovery and untouched failed provider run
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          import urllib.request
+
+          api = os.environ["GITHUB_API_URL"]
+          repository = os.environ["GITHUB_REPOSITORY"]
+          headers = {
+              "Accept": "application/vnd.github+json",
+              "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
+              "User-Agent": "Prob4D-DOT-hosted-relay/1",
+              "X-GitHub-Api-Version": "2022-11-28",
+          }
+
+          def get(path):
+              request = urllib.request.Request(
+                  f"{api}/repos/{repository}{path}", headers=headers
+              )
+              with urllib.request.urlopen(request, timeout=60) as response:
+                  return json.load(response)
+
+          recovery = get(f"/actions/runs/{os.environ['RECOVERY_RUN_ID']}")
+          if recovery["status"] != "completed" or recovery.get("conclusion") == "success":
+              raise SystemExit("direct recovery has not terminally failed; hosted relay is not authorized")
+
+          target = get(f"/actions/runs/{os.environ['TARGET_RUN_ID']}")
+          if target["head_sha"] != os.environ["TARGET_HEAD_SHA"]:
+              raise SystemExit("target run head changed")
+          if target["status"] != "completed" or target.get("conclusion") != "failure":
+              raise SystemExit("target run is no longer the failed pre-inference execution")
+          artifacts = get(f"/actions/runs/{os.environ['TARGET_RUN_ID']}/artifacts?per_page=100")
+          if int(artifacts.get("total_count", 0)) != 0:
+              raise SystemExit("target run unexpectedly published artifacts")
+          jobs = get(f"/actions/runs/{os.environ['TARGET_RUN_ID']}/jobs?per_page=100")["jobs"]
+          matches = [job for job in jobs if int(job["id"]) == int(os.environ["TARGET_JOB_ID"])]
+          if len(matches) != 1 or matches[0].get("conclusion") != "failure":
+              raise SystemExit("exact failed provider job is unavailable")
+          steps = {step["name"]: step for step in matches[0].get("steps", [])}
+          if steps.get("Download and verify the official DOT R01-R10 archive", {}).get("conclusion") != "failure":
+              raise SystemExit("provider failure was not the frozen archive-transfer failure")
+          for name in (
+              "Build and attest native CUT3R RoPE in an isolated checkout",
+              "Enable the hash-pinned legacy checkpoint loader",
+              "Predict from marker-free normal-view images only",
+              "Seal provider bundle before any marker access",
+          ):
+              if steps.get(name, {}).get("conclusion") not in {None, "skipped"}:
+                  raise SystemExit(f"target advanced beyond archive transfer: {name}")
+          PY
+
+  acquire:
+    name: Download and chunk publisher-verified DOT archive on hosted runner
+    if: github.event_name == 'push'
+    needs: authorize
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    outputs:
+      artifact_id: ${{ steps.upload.outputs.artifact-id }}
+      artifact_name: ${{ steps.identity.outputs.artifact_name }}
+    steps:
+      - name: Resolve official archive identity
+        id: metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          import urllib.request
+          from pathlib import Path
+
+          request = urllib.request.Request(
+              os.environ["DATASET_API"],
+              headers={"User-Agent": "Prob4D-DOT-hosted-relay/1"},
+          )
+          with urllib.request.urlopen(request, timeout=60) as response:
+              metadata = json.load(response)
+          if metadata.get("status") != "OK":
+              raise SystemExit("Dataverse metadata request did not return OK")
+          files = metadata["data"]["latestVersion"]["files"]
+          matches = [
+              entry["dataFile"]
+              for entry in files
+              if entry.get("dataFile", {}).get("filename") == os.environ["ARCHIVE_NAME"]
+          ]
+          if len(matches) != 1:
+              raise SystemExit("official metadata did not contain exactly one archive")
+          data_file = matches[0]
+          checksum = data_file.get("checksum") or {}
+          if checksum.get("type") != "MD5" or checksum.get("value", "").lower() != os.environ["ARCHIVE_MD5"]:
+              raise SystemExit("official archive checksum changed")
+          if int(data_file["filesize"]) != int(os.environ["ARCHIVE_BYTES"]):
+              raise SystemExit("official archive byte count changed")
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as output:
+              output.write(f"datafile_id={int(data_file['id'])}\n")
+          PY
+      - name: Download exact archive with bounded resumable retries
+        shell: bash
+        env:
+          DATAFILE_ID: ${{ steps.metadata.outputs.datafile_id }}
+        run: |
+          set -euo pipefail
+          root="$RUNNER_TEMP/dot-r04-r10-hosted-relay"
+          rm -rf -- "$root"
+          mkdir -p "$root/chunks"
+          archive="$root/$ARCHIVE_NAME"
+          url="$DATAFILE_API_ROOT/$DATAFILE_ID"
+          for attempt in 1 2 3 4 5 6; do
+            set +e
+            curl --fail --location --http1.1 \
+              --header 'Accept-Encoding: identity' \
+              --connect-timeout 30 --max-time 7200 \
+              --retry 8 --retry-all-errors --retry-delay 5 \
+              --continue-at - --output "$archive" "$url"
+            status=$?
+            set -e
+            size=0
+            test ! -f "$archive" || size=$(stat -c %s "$archive")
+            echo "attempt=$attempt status=$status bytes=$size"
+            if [[ "$size" -eq "$ARCHIVE_BYTES" ]]; then
+              break
+            fi
+            if [[ "$size" -gt "$ARCHIVE_BYTES" ]]; then
+              rm -f -- "$archive"
+            fi
+            sleep $((attempt * 5))
+          done
+          test -f "$archive"
+          test "$(stat -c %s "$archive")" = "$ARCHIVE_BYTES"
+          printf '%s  %s\n' "$ARCHIVE_MD5" "$archive" | md5sum --check --strict
+          split --bytes="$CHUNK_BYTES" --numeric-suffixes=0 --suffix-length=3 \
+            "$archive" "$root/chunks/part-"
+          ROOT="$root" python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          root = Path(os.environ["ROOT"])
+          parts = []
+          for path in sorted((root / "chunks").glob("part-*")):
+              digest = hashlib.sha256(path.read_bytes()).hexdigest()
+              parts.append({"name": path.name, "bytes": path.stat().st_size, "sha256": digest})
+          manifest = {
+              "schema": "prob4d.dot-r04-r10-hosted-archive-relay-manifest",
+              "schema_version": 1,
+              "archive_name": os.environ["ARCHIVE_NAME"],
+              "archive_bytes": int(os.environ["ARCHIVE_BYTES"]),
+              "archive_md5": os.environ["ARCHIVE_MD5"],
+              "chunk_bytes": int(os.environ["CHUNK_BYTES"]),
+              "parts": parts,
+          }
+          (root / "chunks" / "manifest.json").write_text(
+              json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+          )
+          PY
+          rm -f -- "$archive"
+      - name: Define transient artifact identity
+        id: identity
+        shell: bash
+        run: |
+          echo "artifact_name=dot-r04-r10-hosted-relay-${{ needs.authorize.outputs.request_id }}" \
+            >> "$GITHUB_OUTPUT"
+      - name: Upload one-day raw relay artifact
+        id: upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: ${{ steps.identity.outputs.artifact_name }}
+          path: ${{ runner.temp }}/dot-r04-r10-hosted-relay/chunks
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+
+  install:
+    name: Install exact archive into gpuserver6000 cache
+    if: >-
+      github.event_name == 'push' &&
+      github.actor == 'FlorianPfaff' &&
+      github.repository == 'IPS-Stuttgart/Prob4D'
+    needs: [authorize, acquire]
+    environment: trusted-self-hosted-validation
+    runs-on: [self-hosted, Linux, X64, gpuserver6000]
+    timeout-minutes: 180
+    permissions:
+      actions: read
+      contents: read
+    steps:
+      - name: Bind intended runner and initialize isolated workspace
+        id: workspace
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$RUNNER_NAME" = "workstation2"
+          test "$RUNNER_OS" = "Linux"
+          test "$RUNNER_ARCH" = "X64"
+          command -v flock >/dev/null
+          command -v md5sum >/dev/null
+          root="$RUNNER_TEMP/dot-r04-r10-hosted-relay-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          rm -rf -- "$root"
+          mkdir -p "$root/input" "$root/evidence"
+          echo "root=$root" >> "$GITHUB_OUTPUT"
+      - name: Check out exact authorized revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.authorize.outputs.head_sha }}
+          persist-credentials: false
+          clean: true
+      - name: Verify exact clean checkout
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(/usr/bin/git rev-parse HEAD)" = "${{ needs.authorize.outputs.head_sha }}"
+          test -z "$(/usr/bin/git status --porcelain=v1 --untracked-files=all)"
+      - name: Download checksum-bound relay chunks
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ${{ needs.acquire.outputs.artifact_name }}
+          path: ${{ steps.workspace.outputs.root }}/input
+      - name: Reconstruct, verify, and atomically install exact archive
+        shell: bash
+        env:
+          ROOT: ${{ steps.workspace.outputs.root }}
+          REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
+          RELAY_ARTIFACT_ID: ${{ needs.acquire.outputs.artifact_id }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          root = Path(os.environ["ROOT"])
+          manifest_path = root / "input" / "manifest.json"
+          manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+          assert manifest["schema"] == "prob4d.dot-r04-r10-hosted-archive-relay-manifest"
+          assert manifest["schema_version"] == 1
+          assert manifest["archive_name"] == os.environ["ARCHIVE_NAME"]
+          assert manifest["archive_bytes"] == int(os.environ["ARCHIVE_BYTES"])
+          assert manifest["archive_md5"] == os.environ["ARCHIVE_MD5"]
+          output = root / "reconstructed.zip"
+          total = 0
+          md5 = hashlib.md5()
+          with output.open("wb") as destination:
+              for item in manifest["parts"]:
+                  part = root / "input" / item["name"]
+                  data = part.read_bytes()
+                  assert len(data) == int(item["bytes"])
+                  assert hashlib.sha256(data).hexdigest() == item["sha256"]
+                  destination.write(data)
+                  md5.update(data)
+                  total += len(data)
+          assert total == int(os.environ["ARCHIVE_BYTES"])
+          assert md5.hexdigest() == os.environ["ARCHIVE_MD5"]
+          PY
+          mkdir -p "$(dirname "$CACHE_PATH")"
+          exec 9>"$CACHE_PATH.lock"
+          flock -x 9
+          valid=false
+          if [[ -f "$CACHE_PATH" ]]; then
+            size=$(stat -c %s "$CACHE_PATH")
+            measured=$(md5sum "$CACHE_PATH" | awk '{print $1}')
+            [[ "$size" = "$ARCHIVE_BYTES" && "$measured" = "$ARCHIVE_MD5" ]] && valid=true
+          fi
+          if [[ "$valid" != true ]]; then
+            mv -f -- "$ROOT/reconstructed.zip" "$CACHE_PATH"
+          fi
+          test "$(stat -c %s "$CACHE_PATH")" = "$ARCHIVE_BYTES"
+          printf '%s  %s\n' "$ARCHIVE_MD5" "$CACHE_PATH" | md5sum --check --strict
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          receipt = {
+              "schema": "prob4d.dot-r04-r10-hosted-archive-relay-receipt",
+              "schema_version": 1,
+              "request_id": os.environ["REQUEST_ID"],
+              "relay_artifact_id": int(os.environ["RELAY_ARTIFACT_ID"]),
+              "archive_name": os.environ["ARCHIVE_NAME"],
+              "archive_bytes": int(os.environ["ARCHIVE_BYTES"]),
+              "archive_md5": os.environ["ARCHIVE_MD5"],
+              "cache_path": os.environ["CACHE_PATH"],
+              "runner_name": os.environ["RUNNER_NAME"],
+              "raw_payload_uploaded_in_receipt": False,
+          }
+          path = Path(os.environ["ROOT"]) / "evidence" / "receipt.json"
+          path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+          PY
+      - name: Upload bounded install receipt
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: dot-r04-r10-hosted-relay-receipt-${{ github.run_attempt }}
+          path: ${{ steps.workspace.outputs.root }}/evidence
+          if-no-files-found: error
+          retention-days: 30
+      - name: Remove isolated raw relay workspace
+        if: always()
+        shell: bash
+        run: |
+          rm -rf -- "${{ steps.workspace.outputs.root }}"
+
+  finalize:
+    name: Delete transient relay and rerun exact failed provider job
+    if: always() && needs.acquire.result == 'success'
+    needs: [authorize, acquire, install]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Delete raw relay artifact and conditionally rerun exact job
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RAW_ARTIFACT_ID: ${{ needs.acquire.outputs.artifact_id }}
+          INSTALL_RESULT: ${{ needs.install.result }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          import urllib.error
+          import urllib.request
+
+          api = os.environ["GITHUB_API_URL"]
+          repository = os.environ["GITHUB_REPOSITORY"]
+          headers = {
+              "Accept": "application/vnd.github+json",
+              "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
+              "User-Agent": "Prob4D-DOT-hosted-relay/1",
+              "X-GitHub-Api-Version": "2022-11-28",
+          }
+
+          def call(path, *, method="GET"):
+              request = urllib.request.Request(
+                  f"{api}/repos/{repository}{path}", method=method, headers=headers
+              )
+              try:
+                  with urllib.request.urlopen(request, timeout=60) as response:
+                      raw = response.read()
+              except urllib.error.HTTPError as error:
+                  if method == "DELETE" and error.code == 404:
+                      return None
+                  raise
+              return json.loads(raw) if raw else None
+
+          artifact_id = int(os.environ["RAW_ARTIFACT_ID"])
+          call(f"/actions/artifacts/{artifact_id}", method="DELETE")
+          if os.environ["INSTALL_RESULT"] != "success":
+              raise SystemExit("archive installation failed after transient relay cleanup")
+
+          target = call(f"/actions/runs/{os.environ['TARGET_RUN_ID']}")
+          if target["head_sha"] != os.environ["TARGET_HEAD_SHA"]:
+              raise SystemExit("target run head changed")
+          if target["status"] in {"queued", "in_progress", "waiting", "pending"}:
+              print("exact target run is already active; no duplicate rerun requested")
+              raise SystemExit(0)
+          if target["status"] == "completed" and target.get("conclusion") == "success":
+              print("exact target run already succeeded; no duplicate rerun requested")
+              raise SystemExit(0)
+          artifacts = call(f"/actions/runs/{os.environ['TARGET_RUN_ID']}/artifacts?per_page=100")
+          if int(artifacts.get("total_count", 0)) != 0:
+              raise SystemExit("target run published evidence; automatic rerun refused")
+          if target["status"] != "completed" or target.get("conclusion") != "failure":
+              raise SystemExit("target run is not in the exact rerunnable failure state")
+          call(f"/actions/jobs/{os.environ['TARGET_JOB_ID']}/rerun", method="POST")
+          print("exact failed provider job and dependent evaluator were rerun")
+          PY

--- a/CHANGELOG.d/dot-r04-r10-hosted-archive-relay-v1.md
+++ b/CHANGELOG.d/dot-r04-r10-hosted-archive-relay-v1.md
@@ -1,0 +1,5 @@
+### Operational recovery
+
+- Add a fail-closed hosted relay for the exact publisher-verified DOT `R01-10.zip` archive when the direct `gpuserver6000` recovery terminates unsuccessfully.
+- Keep archive acquisition and transient artifact deletion on GitHub-hosted runners; grant the self-hosted install job read-only repository and Actions permissions.
+- Rerun only the already frozen failed R04–R10 provider job after exact byte-count and MD5 verification, with no scientific-input, provider, marker, or target-boundary change.

--- a/docs/dot-r04-r10-hosted-archive-relay-v1.md
+++ b/docs/dot-r04-r10-hosted-archive-relay-v1.md
@@ -1,0 +1,23 @@
+# DOT R04–R10 hosted archive relay v1
+
+This is an operational fallback for the already frozen DOT R04–R10 CUT3R confirmation. It is not a new scientific protocol and cannot be triggered while the direct `gpuserver6000` archive recovery is still active or successful.
+
+## Why it exists
+
+The frozen provider run `33434695566` stopped before image inference because the publisher archive connection ended about 1.9 MiB before the exact 1,408,905,061-byte payload was complete. It emitted no provider artifact and opened no marker payload. A direct resumable recovery is running separately as `33442397966`.
+
+The hosted relay may be authorized only if that direct recovery terminates without success and the original provider run remains in its exact pre-inference failure state.
+
+## Bounded route
+
+1. A GitHub-hosted job resolves `R01-10.zip` through the official Dataverse metadata API.
+2. It requires byte count `1408905061` and publisher MD5 `ca546ff5f22c0279123ccb18509858ee`.
+3. It downloads the archive with bounded resumable retries, verifies it, and uploads checksum-bound chunks as a one-day transient artifact.
+4. A read-only `gpuserver6000` job reconstructs and verifies the archive, then atomically installs it at the cache path already used by the frozen provider workflow.
+5. A final GitHub-hosted job deletes the raw relay artifact and reruns only the exact failed provider job, allowing its existing dependent evaluator and independent verifier to continue.
+
+## Information boundary
+
+The relay does not decode images, inspect provider predictions, open 2-D or 3-D markers, change any scientific input, or create a new confirmation attempt. The self-hosted job has no repository or Actions write permission. The raw archive is not retained in the bounded receipt and is deleted from GitHub after installation.
+
+No execution request is included with the control plane. A later main-branch commit may create only `protocols/execution_requests/dot_r04_r10_hosted_archive_relay_v1.json`, and only after the direct recovery has terminally failed.

--- a/tests/test_dot_r04_r10_hosted_archive_relay_v1.py
+++ b/tests/test_dot_r04_r10_hosted_archive_relay_v1.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "relay-dot-r04-r10-archive-v1.yml"
+REQUEST = ROOT / "protocols" / "execution_requests" / "dot_r04_r10_hosted_archive_relay_v1.json"
+
+
+def _text() -> str:
+    return WORKFLOW.read_text(encoding="utf-8")
+
+
+def _section(text: str, start: str, end: str | None = None) -> str:
+    value = text[text.index(start) :]
+    if end is not None:
+        value = value[: value.index(end)]
+    return value
+
+
+def test_relay_control_plane_does_not_include_an_execution_request() -> None:
+    assert WORKFLOW.is_file()
+    assert not REQUEST.exists()
+
+
+def test_relay_is_main_request_bound_and_target_identity_frozen() -> None:
+    text = _text()
+    assert "pull_request_target:" not in text
+    assert "branches: [main]" in text
+    assert 'protocols/execution_requests/dot_r04_r10_hosted_archive_relay_v1.json' in text
+    assert 'TARGET_RUN_ID: "33434695566"' in text
+    assert 'TARGET_JOB_ID: "99628289885"' in text
+    assert "TARGET_HEAD_SHA: 9e1b77b2e70685881db7f188a95a3a91443275e8" in text
+    assert 'RECOVERY_RUN_ID: "33442397966"' in text
+    assert 'ARCHIVE_BYTES: "1408905061"' in text
+    assert "ARCHIVE_MD5: ca546ff5f22c0279123ccb18509858ee" in text
+    assert 'test "$EVENT_REF" = "refs/heads/main"' in text
+    assert 'test "$EVENT_FORCED" = "false"' in text
+    assert 'test "$EVENT_DELETED" = "false"' in text
+    assert 'len(changed)' not in text
+    assert "hashlib.sha256(canonical(payload)).hexdigest() == request_id" in text
+
+
+def test_relay_requires_failed_preinference_states_before_transfer() -> None:
+    text = _text()
+    authorize = _section(text, "\n  authorize:", "\n  acquire:")
+    assert "direct recovery has not terminally failed" in authorize
+    assert "target run is no longer the failed pre-inference execution" in authorize
+    assert "target run unexpectedly published artifacts" in authorize
+    assert "Download and verify the official DOT R01-R10 archive" in authorize
+    assert "Predict from marker-free normal-view images only" in authorize
+    assert "Seal provider bundle before any marker access" in authorize
+    assert "provider_prediction_inside_relay" in authorize
+    assert "marker_payload_access_inside_relay" in authorize
+
+
+def test_raw_archive_download_and_install_are_checksum_bound() -> None:
+    text = _text()
+    acquire = _section(text, "\n  acquire:", "\n  install:")
+    install = _section(text, "\n  install:", "\n  finalize:")
+    assert "runs-on: ubuntu-latest" in acquire
+    assert "official archive checksum changed" in acquire
+    assert "official archive byte count changed" in acquire
+    assert "--continue-at -" in acquire
+    assert 'printf \'%s  %s\\n\' "$ARCHIVE_MD5" "$archive" | md5sum --check --strict' in acquire
+    assert "split --bytes=\"$CHUNK_BYTES\"" in acquire
+    assert "retention-days: 1" in acquire
+    assert "compression-level: 0" in acquire
+    assert "runs-on: [self-hosted, Linux, X64, gpuserver6000]" in install
+    assert 'test "$RUNNER_NAME" = "workstation2"' in install
+    assert "environment: trusted-self-hosted-validation" in install
+    assert "permissions:\n      actions: read\n      contents: read" in install
+    assert "actions: write" not in install
+    assert "flock -x 9" in install
+    assert "mv -f -- \"$ROOT/reconstructed.zip\" \"$CACHE_PATH\"" in install
+    assert "raw_payload_uploaded_in_receipt" in install
+    assert "rm -rf -- \"${{ steps.workspace.outputs.root }}\"" in install
+
+
+def test_transient_raw_artifact_is_deleted_on_hosted_runner_before_exact_rerun() -> None:
+    text = _text()
+    finalize = _section(text, "\n  finalize:")
+    assert "runs-on: ubuntu-latest" in finalize
+    assert "permissions:\n      actions: write\n      contents: read" in finalize
+    assert '/actions/artifacts/{artifact_id}' in finalize
+    assert "method=\"DELETE\"" in finalize
+    assert '/actions/jobs/{os.environ[\'TARGET_JOB_ID\']}/rerun' in finalize
+    assert "exact target run is already active; no duplicate rerun requested" in finalize
+    assert "target run published evidence; automatic rerun refused" in finalize
+    assert "secrets." not in text
+    assert "git push" not in text

--- a/tests/test_trusted_self_hosted_validation_policy.py
+++ b/tests/test_trusted_self_hosted_validation_policy.py
@@ -2,7 +2,7 @@
 
 The historical policy implementation is retained byte-for-byte in the adjacent
 non-test module. This wrapper adds the separately reviewed DOT R11--R30,
-DOT R04--R10 archive-recovery v2, and Tracking-Cloth query-portfolio workflows
+DOT R04--R10 recovery/relay, and Tracking-Cloth query-portfolio workflows
 before exposing the original test functions to pytest.
 """
 
@@ -26,6 +26,9 @@ DOT_ROPE_QUERY_SELECTIVE_HELDOUT_WORKFLOW = (
 DOT_ROPE_R04_R10_ARCHIVE_RECOVERY_V2_WORKFLOW = (
     POLICY.WORKFLOW_ROOT / "recover-dot-r04-r10-archive-cache-v2.yml"
 )
+DOT_ROPE_R04_R10_HOSTED_ARCHIVE_RELAY_WORKFLOW = (
+    POLICY.WORKFLOW_ROOT / "relay-dot-r04-r10-archive-v1.yml"
+)
 TRACKING_CLOTH_QUERY_PORTFOLIO_WORKFLOW = (
     POLICY.WORKFLOW_ROOT / "tracking-cloth-query-portfolio-v1.yml"
 )
@@ -33,6 +36,7 @@ POLICY.TRUSTED_SELF_HOSTED_WORKFLOWS = (
     *POLICY.TRUSTED_SELF_HOSTED_WORKFLOWS,
     DOT_ROPE_QUERY_SELECTIVE_HELDOUT_WORKFLOW,
     DOT_ROPE_R04_R10_ARCHIVE_RECOVERY_V2_WORKFLOW,
+    DOT_ROPE_R04_R10_HOSTED_ARCHIVE_RELAY_WORKFLOW,
     TRACKING_CLOTH_QUERY_PORTFOLIO_WORKFLOW,
 )
 


### PR DESCRIPTION
## Purpose

Provide a last-resort transport path for the exact official `R01-10.zip` archive if direct resumable recovery on `gpuserver6000` terminates unsuccessfully.

The frozen R04–R10 provider run `33434695566` stopped before image inference at archive download with `curl: (18)`, roughly 1.9 MiB short of the official 1,408,905,061-byte payload. It emitted no provider artifact and opened no marker data. Direct archive-only recovery run `33442397966` remains the preferred active route.

## Fail-closed trigger

This PR contains no execution request. A later main-only one-file request can run the relay only if:

- direct recovery `33442397966` is completed and non-successful;
- target run `33434695566` remains completed/failed at exact job `99628289885`;
- target head remains `9e1b77b2e70685881db7f188a95a3a91443275e8`;
- the target run has no artifacts;
- provider inference and provider sealing steps remain skipped.

## Relay route

1. A GitHub-hosted job resolves the official Dataverse entry and requires byte count `1408905061` and MD5 `ca546ff5f22c0279123ccb18509858ee`.
2. It downloads with bounded resumable retries, verifies the archive, splits it into SHA-256-bound chunks, and uploads a one-day uncompressed transient artifact.
3. A read-only self-hosted job on `[self-hosted, Linux, X64, gpuserver6000]` / `workstation2` reconstructs and verifies the bytes, then atomically installs the archive into the existing frozen-provider cache.
4. A GitHub-hosted finalizer deletes the transient raw artifact and reruns only the exact failed provider job, allowing the existing dependent evaluator and independent verifier to continue.

## Information boundary

The relay decodes no DOT payload, runs no provider, opens no 2-D or 3-D marker, changes no scientific input, and creates no new confirmation attempt. The self-hosted job has only `contents: read` and `actions: read`; all deletion/rerun write permission remains on a hosted runner. R11–R70 remain closed.

Related: #49.