### PR TITLE
Prepare exact DOT hosted-relay trigger

### DIFF
--- a/protocols/execution_requests/dot_r04_r10_hosted_archive_relay_v1.json
+++ b/protocols/execution_requests/dot_r04_r10_hosted_archive_relay_v1.json
@@ -1,0 +1,24 @@
+{
+  "action": "relay-official-archive-and-rerun-exact-failed-job",
+  "archive_bytes": 1408905061,
+  "archive_md5": "ca546ff5f22c0279123ccb18509858ee",
+  "archive_name": "R01-10.zip",
+  "cache_path": "/home/github-runner/.cache/prob4d/dot-r04-r10-cut3r-gpuserver6000-v1/dot-v29/R01-10.zip",
+  "failed_recovery_run_id": 33442397966,
+  "marker_payload_access_inside_relay": false,
+  "provider_prediction_inside_relay": false,
+  "request_id": "0b5e388e12324f1bfe4a7c25fcd88d13b2a35e92eca2d45f52bd6881eb8574e8",
+  "runner_labels": [
+    "self-hosted",
+    "Linux",
+    "X64",
+    "gpuserver6000"
+  ],
+  "runner_name": "workstation2",
+  "schema": "prob4d.dot-r04-r10-hosted-archive-relay-request",
+  "schema_version": 1,
+  "scientific_inputs_changed": false,
+  "target_head_sha": "9e1b77b2e70685881db7f188a95a3a91443275e8",
+  "target_job_id": 99628289885,
+  "target_run_id": 33434695566
+}


### PR DESCRIPTION
## Purpose

Prepare the single content-addressed request needed to activate the bounded hosted archive relay from merged PR #429 **only if** direct recovery run `33442397966` terminates unsuccessfully.

## Frozen identity

- target workflow run: `33434695566`;
- exact failed provider job: `99628289885`;
- target head: `9e1b77b2e70685881db7f188a95a3a91443275e8`;
- official archive: `R01-10.zip`, 1,408,905,061 bytes, MD5 `ca546ff5f22c0279123ccb18509858ee`;
- destination cache: `/home/github-runner/.cache/prob4d/dot-r04-r10-cut3r-gpuserver6000-v1/dot-v29/R01-10.zip`;
- request ID: `0b5e388e12324f1bfe4a7c25fcd88d13b2a35e92eca2d45f52bd6881eb8574e8`.

The request states that no scientific input changes and that the relay itself performs no provider prediction or marker access.

## Merge boundary

Keep this PR unmerged while direct recovery `33442397966` is active or successful. If that run succeeds, close this PR without merge. If it fails, merging this one-file PR will invoke the already reviewed fail-closed relay and rerun only the exact failed provider job.

R11–R70 remain closed.