### PR TITLE
Correct frozen DOT R11–R30 gpuserver6000 control plane

### DIFF
--- a/.github/workflows/dot-rope-query-selective-heldout-gpuserver6000-v3.yml
+++ b/.github/workflows/dot-rope-query-selective-heldout-gpuserver6000-v3.yml
@@ -1,0 +1,801 @@
+name: DOT rope query-selective held-out CUT3R gpuserver6000 v3
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/dot-rope-query-selective-heldout-gpuserver6000-v3.yml"
+      - "CHANGELOG.d/dot-query-selective-gpuserver6000-v3.md"
+      - "scripts/science/materialize_verified_dot_archives.py"
+      - "tests/test_dot_rope_query_selective_gpuserver6000_v3_workflow.py"
+      - "tests/test_materialize_verified_dot_archives.py"
+  push:
+    branches: [main]
+    paths:
+      - "protocols/execution_requests/dot_rope_query_selective_heldout_gpuserver6000_v3.json"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dot-rope-query-selective-heldout-gpuserver6000-v3-${{ github.ref }}-${{ github.sha }}
+  cancel-in-progress: false
+
+env:
+  REQUEST_PATH: protocols/execution_requests/dot_rope_query_selective_heldout_gpuserver6000_v3.json
+  PROTOCOL_PATH: protocols/dot-rope-query-selective-heldout-v1.json
+  RUNTIME_ROOT: /home/github-runner/.cache/prob4d/dot-r11-r30-cut3r-gpuserver6000-v1
+  ARCHIVE_ROOT: /home/github-runner/.cache/prob4d/dot-r11-r30-archives-v29
+  CUT3R_REVISION: 8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf
+  CUT3R_CHECKPOINT_SHA256: 45f7e98a0a64dbeb54901ae2b878cd8cd125f20a4497316483f0bd6f109f8103
+  R11_ARCHIVE: R11-20.zip
+  R11_MD5: 23ce3e7067465d3edabe20b4c7cfa388
+  R21_ARCHIVE: R21-30.zip
+  R21_MD5: 8aee77f79d1aff6e1f3fd21886b251a0
+  DATASET_API: https://dataverse.orc.gmu.edu/api/datasets/:persistentId/?persistentId=doi:10.13021/ORC2020/XXLVXM
+  DATAFILE_API_ROOT: https://dataverse.orc.gmu.edu/api/access/datafile
+  PYTHONHASHSEED: "0"
+  PYTHONUNBUFFERED: "1"
+  PYTHONDONTWRITEBYTECODE: "1"
+  OMP_NUM_THREADS: "1"
+  OPENBLAS_NUM_THREADS: "1"
+  MKL_NUM_THREADS: "1"
+  NUMEXPR_NUM_THREADS: "1"
+
+jobs:
+  contract:
+    name: Validate frozen gpuserver6000 control plane
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out exact reviewed revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+          clean: true
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Validate unchanged science and operational custody
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install -e ".[dev]"
+          python -m pip check
+          python -m ruff check \
+            scripts/science/materialize_verified_dot_archives.py \
+            tests/test_dot_rope_query_selective_gpuserver6000_v3_workflow.py \
+            tests/test_materialize_verified_dot_archives.py
+          python -m ruff format --check \
+            scripts/science/materialize_verified_dot_archives.py \
+            tests/test_dot_rope_query_selective_gpuserver6000_v3_workflow.py \
+            tests/test_materialize_verified_dot_archives.py
+          python -m pytest -q \
+            tests/test_dot_rope_query_selective_gpuserver6000_v3_workflow.py \
+            tests/test_materialize_verified_dot_archives.py \
+            tests/test_dot_rope_query_selective_heldout.py \
+            tests/test_dot_rope_query_selective_heldout_workflow.py \
+            tests/test_trusted_self_hosted_validation_policy.py \
+            tests/test_github_action_pins.py
+          python -m compileall -q \
+            scripts/science/materialize_verified_dot_archives.py \
+            scripts/science/run_dot_rope_query_selective_heldout.py
+
+  authorize:
+    name: Authorize one immutable strong-prerequisite request
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      request_id: ${{ steps.request.outputs.request_id }}
+      head_sha: ${{ steps.request.outputs.head_sha }}
+      protocol_git_blob_sha: ${{ steps.request.outputs.protocol_git_blob_sha }}
+      prerequisite_run_id: ${{ steps.request.outputs.prerequisite_run_id }}
+      prerequisite_artifact_id: ${{ steps.request.outputs.prerequisite_artifact_id }}
+      prerequisite_artifact_name: ${{ steps.request.outputs.prerequisite_artifact_name }}
+      prerequisite_artifact_digest: ${{ steps.request.outputs.prerequisite_artifact_digest }}
+      prerequisite_evaluation_id: ${{ steps.request.outputs.prerequisite_evaluation_id }}
+      prerequisite_marker_support_id: ${{ steps.request.outputs.prerequisite_marker_support_id }}
+    steps:
+      - name: Check out exact merged revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 2
+          persist-credentials: false
+          clean: true
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Require exactly one non-forced request-file change
+        id: request
+        shell: bash
+        env:
+          EVENT_REF: ${{ github.ref }}
+          EVENT_BEFORE: ${{ github.event.before }}
+          EVENT_AFTER: ${{ github.event.after }}
+          EVENT_FORCED: ${{ github.event.forced }}
+          EVENT_DELETED: ${{ github.event.deleted }}
+        run: |
+          set -euo pipefail
+          test "$EVENT_REF" = "refs/heads/main"
+          test "$EVENT_AFTER" = "$(git rev-parse HEAD)"
+          test "$EVENT_FORCED" = "false"
+          test "$EVENT_DELETED" = "false"
+          test "$EVENT_BEFORE" != "0000000000000000000000000000000000000000"
+          mapfile -t changed < <(git diff --name-only "$EVENT_BEFORE" "$EVENT_AFTER" | sort)
+          if [[ ${#changed[@]} -ne 1 || "${changed[0]}" != "$REQUEST_PATH" ]]; then
+            printf 'Expected only %s; changed paths were:\n' "$REQUEST_PATH" >&2
+            printf '  %s\n' "${changed[@]}" >&2
+            exit 2
+          fi
+          protocol_blob=$(git rev-parse "$EVENT_AFTER:$PROTOCOL_PATH")
+          python -m pip install -e .
+          validation=$(
+            python scripts/science/run_dot_rope_query_selective_heldout.py \
+              validate-request \
+              --request "$REQUEST_PATH" \
+              --protocol "$PROTOCOL_PATH" \
+              --protocol-git-blob-sha "$protocol_blob"
+          )
+          VALIDATION="$validation" REQUEST_PATH="$REQUEST_PATH" \
+            PROTOCOL_BLOB="$protocol_blob" EVENT_AFTER="$EVENT_AFTER" \
+            python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          value = json.loads(os.environ["VALIDATION"])
+          request = json.loads(Path(os.environ["REQUEST_PATH"]).read_text(encoding="utf-8"))
+          prerequisite = request["prerequisite"]
+          outputs = {
+              "request_id": value["request_id"],
+              "head_sha": os.environ["EVENT_AFTER"],
+              "protocol_git_blob_sha": os.environ["PROTOCOL_BLOB"],
+              "prerequisite_run_id": prerequisite["run_id"],
+              "prerequisite_artifact_id": prerequisite["artifact_id"],
+              "prerequisite_artifact_name": prerequisite["artifact_name"],
+              "prerequisite_artifact_digest": prerequisite["artifact_digest"],
+              "prerequisite_evaluation_id": prerequisite["evaluation_id"],
+              "prerequisite_marker_support_id": prerequisite["marker_support_id"],
+          }
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              for key, item in outputs.items():
+                  output.write(f"{key}={item}\n")
+          PY
+
+  prerequisite:
+    name: Verify exact R04-R10 strong-positive prerequisite
+    if: github.event_name == 'push'
+    needs: authorize
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      decision: ${{ steps.verify.outputs.decision }}
+      result_id: ${{ steps.verify.outputs.result_id }}
+    steps:
+      - name: Check out exact authorized revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.authorize.outputs.head_sha }}
+          persist-credentials: false
+          clean: true
+      - name: Verify exact prerequisite artifact metadata
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARTIFACT_ID: ${{ needs.authorize.outputs.prerequisite_artifact_id }}
+          EXPECTED_NAME: ${{ needs.authorize.outputs.prerequisite_artifact_name }}
+          EXPECTED_DIGEST: ${{ needs.authorize.outputs.prerequisite_artifact_digest }}
+          EXPECTED_RUN_ID: ${{ needs.authorize.outputs.prerequisite_run_id }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          import urllib.request
+
+          url = (
+              f"{os.environ['GITHUB_API_URL']}/repos/{os.environ['GITHUB_REPOSITORY']}"
+              f"/actions/artifacts/{os.environ['ARTIFACT_ID']}"
+          )
+          request = urllib.request.Request(
+              url,
+              headers={
+                  "Accept": "application/vnd.github+json",
+                  "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
+                  "User-Agent": "Prob4D-DOT-query-selective-gpuserver6000/3",
+                  "X-GitHub-Api-Version": "2022-11-28",
+              },
+          )
+          with urllib.request.urlopen(request, timeout=60) as response:
+              value = json.load(response)
+          if int(value["id"]) != int(os.environ["ARTIFACT_ID"]):
+              raise SystemExit("prerequisite artifact ID changed")
+          if value["name"] != os.environ["EXPECTED_NAME"]:
+              raise SystemExit("prerequisite artifact name changed")
+          if value.get("digest") != os.environ["EXPECTED_DIGEST"]:
+              raise SystemExit("prerequisite artifact digest changed")
+          if value.get("expired") is not False:
+              raise SystemExit("prerequisite artifact expired")
+          workflow = value.get("workflow_run") or {}
+          if int(workflow.get("id", -1)) != int(os.environ["EXPECTED_RUN_ID"]):
+              raise SystemExit("prerequisite workflow run changed")
+          PY
+      - name: Download exact prerequisite evidence
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ${{ needs.authorize.outputs.prerequisite_artifact_name }}
+          path: ${{ runner.temp }}/dot-prerequisite
+          github-token: ${{ github.token }}
+          repository: ${{ github.repository }}
+          run-id: ${{ needs.authorize.outputs.prerequisite_run_id }}
+      - name: Independently verify scientific decision and identities
+        id: verify
+        shell: bash
+        env:
+          EXPECTED_EVALUATION_ID: ${{ needs.authorize.outputs.prerequisite_evaluation_id }}
+          EXPECTED_SUPPORT_ID: ${{ needs.authorize.outputs.prerequisite_marker_support_id }}
+        run: |
+          set -euo pipefail
+          result="$RUNNER_TEMP/dot-prerequisite/result/result.json"
+          support="$RUNNER_TEMP/dot-prerequisite/result/marker-support.json"
+          test -f "$result"
+          test -f "$support"
+          verification=$(
+            python scripts/science/verify_dot_rope_cut3r_heldout_result.py \
+              "$result" --marker-support "$support"
+          )
+          VERIFICATION="$verification" EXPECTED_EVALUATION_ID="$EXPECTED_EVALUATION_ID" \
+            EXPECTED_SUPPORT_ID="$EXPECTED_SUPPORT_ID" SUPPORT="$support" \
+            python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          verified = json.loads(os.environ["VERIFICATION"])
+          support = json.loads(Path(os.environ["SUPPORT"]).read_text(encoding="utf-8"))
+          if verified["decision"] != "heldout-strong-positive":
+              raise SystemExit("R04-R10 prerequisite is not strong-positive")
+          if verified["result_id"] != os.environ["EXPECTED_EVALUATION_ID"]:
+              raise SystemExit("prerequisite evaluation identity changed")
+          if support["support_id"] != os.environ["EXPECTED_SUPPORT_ID"]:
+              raise SystemExit("prerequisite marker-support identity changed")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"decision={verified['decision']}\n")
+              output.write(f"result_id={verified['result_id']}\n")
+          PY
+
+  provider:
+    name: Seal marker-free R11-R30 CUT3R point maps on gpuserver6000
+    if: github.event_name == 'push'
+    needs: [authorize, prerequisite]
+    environment: trusted-self-hosted-validation
+    runs-on: [self-hosted, gpuserver6000]
+    timeout-minutes: 720
+    permissions:
+      contents: read
+    outputs:
+      decision: ${{ steps.result.outputs.decision }}
+      provider_bundle_id: ${{ steps.result.outputs.provider_bundle_id }}
+    steps:
+      - name: Bind intended runner and initialize isolated workspace
+        id: workspace
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$RUNNER_NAME" = "workstation2"
+          test "$RUNNER_OS" = "Linux"
+          test "$RUNNER_ARCH" = "X64"
+          command -v nvidia-smi >/dev/null 2>&1
+          root="${RUNNER_TEMP}/prob4d-dot-query-provider-v3-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          rm -rf -- "$root"
+          mkdir -p "$root/provider" "$root/home" "$root/cache" "$root/tmp" "$root/CUT3R"
+          echo "root=$root" >> "$GITHUB_OUTPUT"
+          {
+            echo "HOME=$root/home"
+            echo "XDG_CACHE_HOME=$root/cache"
+            echo "TMPDIR=$root/tmp"
+            echo "TORCH_EXTENSIONS_DIR=$root/cache/torch-extensions"
+            echo "WANDB_MODE=disabled"
+            echo "WANDB_DISABLED=true"
+          } >> "$GITHUB_ENV"
+          nvidia-smi --query-gpu=name,driver_version,memory.total --format=csv,noheader
+      - name: Check out exact authorized revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.authorize.outputs.head_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+          clean: true
+      - name: Verify exact prewarmed runtime and unopened archives
+        id: runtime
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -d "$RUNTIME_ROOT"
+          test ! -L "$RUNTIME_ROOT"
+          test -x "$RUNTIME_ROOT/venv/bin/python"
+          test -d "$RUNTIME_ROOT/CUT3R/.git"
+          test -f "$RUNTIME_ROOT/cut3r_512_dpt_4_64.pth"
+          test -f "$RUNTIME_ROOT/bootstrap-manifest.json"
+          test "$(git -C "$RUNTIME_ROOT/CUT3R" rev-parse HEAD)" = "$CUT3R_REVISION"
+          test "$(sha256sum "$RUNTIME_ROOT/cut3r_512_dpt_4_64.pth" | awk '{print $1}')" = \
+            "$CUT3R_CHECKPOINT_SHA256"
+          test -d "$ARCHIVE_ROOT"
+          test ! -L "$ARCHIVE_ROOT"
+          printf '%s  %s\n' "$R11_MD5" "$ARCHIVE_ROOT/$R11_ARCHIVE" | md5sum --check --strict
+          printf '%s  %s\n' "$R21_MD5" "$ARCHIVE_ROOT/$R21_ARCHIVE" | md5sum --check --strict
+          MANIFEST="$RUNTIME_ROOT/bootstrap-manifest.json" \
+            EXPECTED_PYTHON="$RUNTIME_ROOT/venv/bin/python" \
+            python - <<'PY'
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          value = json.loads(Path(os.environ["MANIFEST"]).read_text(encoding="utf-8"))
+          if value.get("schema") != "prob4d.dot-cut3r-gpuserver6000-runtime-prewarm":
+              raise SystemExit("runtime prewarm schema changed")
+          if value.get("schema_version") != 1:
+              raise SystemExit("runtime prewarm version changed")
+          if value.get("runner_name") != "workstation2":
+              raise SystemExit("runtime was not built on the intended runner")
+          if value.get("cut3r_revision") != os.environ["CUT3R_REVISION"]:
+              raise SystemExit("runtime CUT3R revision changed")
+          if value.get("checkpoint_sha256") != os.environ["CUT3R_CHECKPOINT_SHA256"]:
+              raise SystemExit("runtime checkpoint changed")
+          if value.get("runtime_python") != os.environ["EXPECTED_PYTHON"]:
+              raise SystemExit("runtime interpreter changed")
+          if value.get("dot_dataset_accessed") is not False:
+              raise SystemExit("runtime prewarm crossed the DOT boundary")
+          if value.get("archives_opened") is not False:
+              raise SystemExit("prewarm opened a target archive")
+          native_id = value.get("native_rope_artifact_id", "")
+          if re.fullmatch(r"[0-9a-f]{64}", native_id) is None:
+              raise SystemExit("runtime native RoPE identity is invalid")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"native_rope_artifact_id={native_id}\n")
+          PY
+          "$RUNTIME_ROOT/venv/bin/python" - <<'PY'
+          import torch
+          if not torch.cuda.is_available():
+              raise SystemExit("prewarmed runtime has no CUDA device")
+          print(torch.__version__, torch.version.cuda, torch.cuda.get_device_name(0))
+          PY
+      - name: Copy and attest native CUT3R runtime without opening DOT
+        shell: bash
+        env:
+          NATIVE_ROPE_ARTIFACT_ID: ${{ steps.runtime.outputs.native_rope_artifact_id }}
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          cp -a "$RUNTIME_ROOT/CUT3R/." "$root/CUT3R/"
+          REQUEST_PATH=__dot_query_selective_gpuserver6000_runtime_verification__ \
+            PYTHONPATH="$GITHUB_WORKSPACE/src" \
+            "$RUNTIME_ROOT/venv/bin/python" scripts/science/prepare_cut3r_runtime.py \
+              --cut3r-checkout "$root/CUT3R" \
+              --expected-artifact-id "$NATIVE_ROPE_ARTIFACT_ID" \
+              --output "$root/provider/runtime-receipt.json"
+      - name: Enable exact hash-bound legacy checkpoint load in isolated copy
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          CHECKOUT="$root/CUT3R" CHECKPOINT="$RUNTIME_ROOT/cut3r_512_dpt_4_64.pth" \
+            EXPECTED_CHECKPOINT="$CUT3R_CHECKPOINT_SHA256" \
+            "$RUNTIME_ROOT/venv/bin/python" - <<'PY'
+          import hashlib
+          import os
+          from pathlib import Path
+
+          checkout = Path(os.environ["CHECKOUT"]).resolve(strict=True)
+          checkpoint = Path(os.environ["CHECKPOINT"]).resolve(strict=True)
+          digest = hashlib.sha256(checkpoint.read_bytes()).hexdigest()
+          if digest != os.environ["EXPECTED_CHECKPOINT"]:
+              raise SystemExit("query-selective checkpoint bytes changed")
+          model = checkout / "src/dust3r/model.py"
+          source = model.read_bytes()
+          header = f"blob {len(source)}\0".encode("ascii")
+          blob = hashlib.sha1(header + source, usedforsecurity=False).hexdigest()
+          if blob != "7ed9f6106fb063686990c874ede99876ebc939ab":
+              raise SystemExit("query-selective CUT3R model source changed")
+          original = '    ckpt = torch.load(model_path, map_location="cpu")\n'
+          patched = '    ckpt = torch.load(model_path, map_location="cpu", weights_only=False)\n'
+          text = source.decode("utf-8")
+          if text.count(original) != 1 or patched in text:
+              raise SystemExit("query-selective CUT3R load call changed")
+          model.write_text(text.replace(original, patched, 1), encoding="utf-8")
+          PY
+      - name: Predict R11-R30 from normal-view images only
+        id: execute
+        continue-on-error: true
+        shell: bash
+        env:
+          REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
+          EXPECTED_HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          PYTHONPATH="$GITHUB_WORKSPACE/src:$GITHUB_WORKSPACE/scripts/science" \
+            "$RUNTIME_ROOT/venv/bin/python" \
+            scripts/science/run_dot_rope_query_selective_heldout.py \
+              predict \
+              --protocol "$PROTOCOL_PATH" \
+              --request-id "$REQUEST_ID" \
+              --prob4d-revision "$EXPECTED_HEAD_SHA" \
+              --dataset-root "$ARCHIVE_ROOT" \
+              --cut3r-checkout "$root/CUT3R" \
+              --checkpoint "$RUNTIME_ROOT/cut3r_512_dpt_4_64.pth" \
+              --runtime-receipt "$root/provider/runtime-receipt.json" \
+              --output-dir "$root/provider/bundle"
+      - name: Read sealed provider result
+        id: result
+        if: always()
+        shell: bash
+        env:
+          EXECUTION_OUTCOME: ${{ steps.execute.outcome }}
+        run: |
+          set -euo pipefail
+          manifest="${{ steps.workspace.outputs.root }}/provider/bundle/manifest.json"
+          if [[ "$EXECUTION_OUTCOME" != "success" || ! -f "$manifest" ]]; then
+            echo "decision=technical-failure" >> "$GITHUB_OUTPUT"
+            echo "provider_bundle_id=unavailable" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          MANIFEST="$manifest" python - <<'PY'
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          value = json.loads(Path(os.environ["MANIFEST"]).read_text(encoding="utf-8"))
+          if value.get("decision") != "sealed-r11-r30-provider-predictions":
+              raise SystemExit("R11-R30 provider did not seal predictions")
+          bundle_id = value.get("provider_bundle_id", "")
+          if re.fullmatch(r"[0-9a-f]{64}", bundle_id) is None:
+              raise SystemExit("R11-R30 provider bundle identity is invalid")
+          boundary = value.get("information_boundary") or {}
+          if boundary.get("two_dimensional_markers_opened") is not False:
+              raise SystemExit("provider opened 2-D markers")
+          if boundary.get("three_dimensional_markers_opened") is not False:
+              raise SystemExit("provider opened 3-D markers")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write("decision=sealed-r11-r30-provider-predictions\n")
+              output.write(f"provider_bundle_id={bundle_id}\n")
+          PY
+      - name: Upload immutable R11-R30 provider bundle
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: dot-rope-query-selective-gpuserver6000-v3-provider-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.workspace.outputs.root }}/provider/
+          if-no-files-found: error
+          retention-days: 30
+      - name: Require sealed provider predictions
+        if: always()
+        shell: bash
+        env:
+          DECISION: ${{ steps.result.outputs.decision }}
+        run: |
+          set -euo pipefail
+          test "$DECISION" = "sealed-r11-r30-provider-predictions"
+      - name: Remove isolated provider workspace
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          test "$root" = "${RUNNER_TEMP}/prob4d-dot-query-provider-v3-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          rm -rf -- "$root"
+
+  seal:
+    name: Seal factors and query decisions from 2-D markers only
+    if: github.event_name == 'push'
+    needs: [authorize, provider]
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      seal_id: ${{ steps.result.outputs.seal_id }}
+      supported_sequences: ${{ steps.result.outputs.supported_sequences }}
+    steps:
+      - name: Initialize isolated factor-seal workspace
+        id: workspace
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="$RUNNER_TEMP/prob4d-dot-query-seal-v3-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          rm -rf -- "$root"
+          mkdir -p "$root/provider" "$root/dataset" "$root/seal" "$root/receipts"
+          echo "root=$root" >> "$GITHUB_OUTPUT"
+      - name: Check out exact authorized revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.authorize.outputs.head_sha }}
+          persist-credentials: false
+          clean: true
+      - name: Set up scientific Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install exact repository package
+        run: |
+          python -m pip install -e .
+          python -m pip check
+      - name: Download exact provider bundle from this run
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: dot-rope-query-selective-gpuserver6000-v3-provider-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.workspace.outputs.root }}/provider
+      - name: Materialize exact official target archives
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          python scripts/science/materialize_verified_dot_archives.py \
+            --dataset-api "$DATASET_API" \
+            --datafile-api-root "$DATAFILE_API_ROOT" \
+            --output-dir "$root/dataset" \
+            --entry "$R11_ARCHIVE=$R11_MD5" \
+            --entry "$R21_ARCHIVE=$R21_MD5" \
+            --receipt "$root/receipts/archive-materialization.json"
+      - name: Seal factor fits, admission, and predictions without 3-D access
+        shell: bash
+        env:
+          REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
+          EXPECTED_HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          PYTHONPATH="$GITHUB_WORKSPACE/src:$GITHUB_WORKSPACE/scripts/science" \
+            python scripts/science/run_dot_rope_query_selective_heldout.py \
+              seal \
+              --protocol "$PROTOCOL_PATH" \
+              --request-id "$REQUEST_ID" \
+              --prob4d-revision "$EXPECTED_HEAD_SHA" \
+              --dataset-root "$root/dataset" \
+              --provider-bundle "$root/provider/bundle" \
+              --output-dir "$root/seal/predictions"
+      - name: Validate immutable prediction seal
+        id: result
+        shell: bash
+        run: |
+          set -euo pipefail
+          seal="${{ steps.workspace.outputs.root }}/seal/predictions/prediction-seal.json"
+          SEAL="$seal" python - <<'PY'
+          import hashlib
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          path = Path(os.environ["SEAL"])
+          value = json.loads(path.read_text(encoding="utf-8"))
+          supplied = value["seal_id"]
+          unsigned = dict(value)
+          unsigned.pop("seal_id")
+          canonical = json.dumps(
+              unsigned,
+              sort_keys=True,
+              separators=(",", ":"),
+              ensure_ascii=False,
+              allow_nan=False,
+          ).encode("utf-8")
+          if hashlib.sha256(canonical).hexdigest() != supplied:
+              raise SystemExit("prediction seal identity mismatch")
+          if re.fullmatch(r"[0-9a-f]{64}", supplied) is None:
+              raise SystemExit("prediction seal ID is invalid")
+          boundary = value.get("information_boundary") or {}
+          if boundary.get("three_dimensional_markers_opened") is not False:
+              raise SystemExit("factor stage opened 3-D markers")
+          if boundary.get("predictions_and_admission_complete") is not True:
+              raise SystemExit("factor stage did not complete predictions")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"seal_id={supplied}\n")
+              output.write(f"supported_sequences={len(value['supported_sequences'])}\n")
+          PY
+          chmod a-w "$seal"
+      - name: Upload content-addressed prediction seal
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: dot-rope-query-selective-gpuserver6000-v3-seal-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.workspace.outputs.root }}/seal/
+          if-no-files-found: error
+          retention-days: 30
+
+  evaluate:
+    name: Open R11-R30 3-D outcomes and score frozen predictions once
+    if: github.event_name == 'push'
+    needs: [authorize, provider, seal]
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    permissions:
+      contents: read
+      actions: read
+    outputs:
+      decision: ${{ steps.result.outputs.decision }}
+      result_id: ${{ steps.result.outputs.result_id }}
+    steps:
+      - name: Initialize isolated outcome workspace
+        id: workspace
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="$RUNNER_TEMP/prob4d-dot-query-evaluate-v3-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          rm -rf -- "$root"
+          mkdir -p "$root/provider" "$root/seal" "$root/dataset" "$root/evidence" "$root/receipts"
+          echo "root=$root" >> "$GITHUB_OUTPUT"
+      - name: Check out exact authorized revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.authorize.outputs.head_sha }}
+          persist-credentials: false
+          clean: true
+      - name: Set up scientific Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install exact repository package
+        run: |
+          python -m pip install -e .
+          python -m pip check
+      - name: Download exact provider and prediction seal
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: dot-rope-query-selective-gpuserver6000-v3-*
+          path: ${{ steps.workspace.outputs.root }}/artifacts
+          merge-multiple: false
+      - name: Stage exact artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          cp -a "$root/artifacts/dot-rope-query-selective-gpuserver6000-v3-provider-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}/." "$root/provider/"
+          cp -a "$root/artifacts/dot-rope-query-selective-gpuserver6000-v3-seal-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}/." "$root/seal/"
+          test -f "$root/provider/bundle/manifest.json"
+          test -f "$root/seal/predictions/prediction-seal.json"
+      - name: Materialize exact official target archives
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          python scripts/science/materialize_verified_dot_archives.py \
+            --dataset-api "$DATASET_API" \
+            --datafile-api-root "$DATAFILE_API_ROOT" \
+            --output-dir "$root/dataset" \
+            --entry "$R11_ARCHIVE=$R11_MD5" \
+            --entry "$R21_ARCHIVE=$R21_MD5" \
+            --receipt "$root/receipts/archive-materialization.json"
+      - name: Score already sealed predictions against 3-D outcomes
+        id: execute
+        continue-on-error: true
+        shell: bash
+        env:
+          REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
+          EXPECTED_HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          PYTHONPATH="$GITHUB_WORKSPACE/src:$GITHUB_WORKSPACE/scripts/science" \
+            python scripts/science/run_dot_rope_query_selective_heldout.py \
+              evaluate \
+              --protocol "$PROTOCOL_PATH" \
+              --request-id "$REQUEST_ID" \
+              --prob4d-revision "$EXPECTED_HEAD_SHA" \
+              --dataset-root "$root/dataset" \
+              --provider-bundle "$root/provider/bundle" \
+              --prediction-seal "$root/seal/predictions/prediction-seal.json" \
+              --output-dir "$root/evidence/result"
+      - name: Read bounded terminal outcome
+        id: result
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}/evidence/result"
+          ROOT="$root" python - <<'PY'
+          import json
+          import os
+          import re
+          from pathlib import Path
+
+          root = Path(os.environ["ROOT"])
+          complete = root / "result.json"
+          failed = root / "failure.json"
+          if complete.is_file():
+              value = json.loads(complete.read_text(encoding="utf-8"))
+              decision = value["decision"]
+              result_id = value["result_id"]
+          elif failed.is_file():
+              value = json.loads(failed.read_text(encoding="utf-8"))
+              decision = value["decision"]
+              result_id = value["result_id"]
+          else:
+              raise SystemExit("query-selective evaluation emitted no bounded result")
+          allowed = {
+              "query-selective-strong-positive",
+              "query-selective-bounded-positive",
+              "query-selective-mixed-negative-or-insufficient-support",
+              "technical-failure",
+          }
+          if decision not in allowed:
+              raise SystemExit("query-selective decision is unsupported")
+          if re.fullmatch(r"[0-9a-f]{64}", result_id) is None:
+              raise SystemExit("query-selective result identity is invalid")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"decision={decision}\n")
+              output.write(f"result_id={result_id}\n")
+          PY
+      - name: Upload content-addressed terminal evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: dot-rope-query-selective-gpuserver6000-v3-result-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.workspace.outputs.root }}/evidence/
+          if-no-files-found: error
+          retention-days: 30
+      - name: Require a scientific terminal result
+        if: always()
+        shell: bash
+        env:
+          DECISION: ${{ steps.result.outputs.decision }}
+        run: |
+          set -euo pipefail
+          case "$DECISION" in
+            query-selective-strong-positive|query-selective-bounded-positive|query-selective-mixed-negative-or-insufficient-support)
+              ;;
+            *)
+              exit 2
+              ;;
+          esac
+
+  publish:
+    name: Publish frozen R11-R30 terminal decision
+    if: always() && github.event_name == 'push'
+    needs: [prerequisite, provider, seal, evaluate]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Write run summary
+        shell: bash
+        env:
+          PREREQUISITE_DECISION: ${{ needs.prerequisite.outputs.decision }}
+          PROVIDER_RESULT: ${{ needs.provider.result }}
+          PROVIDER_DECISION: ${{ needs.provider.outputs.decision }}
+          SEAL_ID: ${{ needs.seal.outputs.seal_id }}
+          SUPPORTED: ${{ needs.seal.outputs.supported_sequences }}
+          EVALUATION_RESULT: ${{ needs.evaluate.result }}
+          DECISION: ${{ needs.evaluate.outputs.decision }}
+          RESULT_ID: ${{ needs.evaluate.outputs.result_id }}
+        run: |
+          {
+            echo "## DOT R11-R30 query-selective CUT3R experiment on gpuserver6000"
+            echo
+            echo "- R04-R10 prerequisite: \`$PREREQUISITE_DECISION\`"
+            echo "- provider job: \`$PROVIDER_RESULT\`"
+            echo "- provider decision: \`$PROVIDER_DECISION\`"
+            echo "- prediction seal: \`$SEAL_ID\`"
+            echo "- supported sequences at seal: \`$SUPPORTED/20\`"
+            echo "- evaluation job: \`$EVALUATION_RESULT\`"
+            echo "- terminal decision: \`$DECISION\`"
+            echo "- result ID: \`$RESULT_ID\`"
+            echo
+            echo "R31-R70 remained unopened. No target-side tuning, BayesianPhysTwin, or Causal4D execution was authorized."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.d/dot-query-selective-gpuserver6000-v3.md
+++ b/CHANGELOG.d/dot-query-selective-gpuserver6000-v3.md
@@ -1,0 +1,5 @@
+# Frozen DOT R11–R30 execution on gpuserver6000
+
+Add a corrected, fail-closed control plane for the already frozen DOT R11–R30 query-selective CUT3R experiment. The learned-provider job is moved to `gpuserver6000` / `workstation2` and consumes a separately attested persistent runtime plus publisher-verified compressed archives.
+
+The protocol, R04–R10 strong-positive prerequisite, target cohort, R31–R70 reserve, provider identity, methods, observability gate, query definitions, exact fallback, sequence-level inference, comparators, bootstrap, terminal criteria, and prediction-before-outcome information order remain unchanged. No target-side tuning, BayesianPhysTwin execution, or Causal4D execution is authorized.

--- a/scripts/science/materialize_verified_dot_archives.py
+++ b/scripts/science/materialize_verified_dot_archives.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Materialize exact official DOT archives without opening their contents."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+
+_MD5 = re.compile(r"[0-9a-f]{32}")
+
+
+def _parse_entry(raw: str) -> tuple[str, str]:
+    try:
+        name, digest = raw.split("=", 1)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("entry must be NAME=MD5") from exc
+    if not name or name != Path(name).name or "/" in name or "\\" in name:
+        raise argparse.ArgumentTypeError("archive name must be a plain filename")
+    digest = digest.lower()
+    if _MD5.fullmatch(digest) is None:
+        raise argparse.ArgumentTypeError("archive digest must be a lowercase MD5")
+    return name, digest
+
+
+def _md5(path: Path) -> str:
+    digest = hashlib.md5(usedforsecurity=False)
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _metadata(url: str) -> dict[str, Any]:
+    request = urllib.request.Request(
+        url,
+        headers={"User-Agent": "Prob4D-verified-DOT-archive-materializer/1"},
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
+        value = json.load(response)
+    if value.get("status") != "OK":
+        raise RuntimeError("DOT metadata endpoint did not return status OK")
+    return value
+
+
+def _resolve(
+    metadata: dict[str, Any], entries: list[tuple[str, str]]
+) -> list[dict[str, Any]]:
+    files = metadata["data"]["latestVersion"]["files"]
+    by_name: dict[str, list[dict[str, Any]]] = {}
+    for entry in files:
+        data_file = entry["dataFile"]
+        by_name.setdefault(str(data_file["filename"]), []).append(data_file)
+
+    resolved: list[dict[str, Any]] = []
+    for name, expected_md5 in entries:
+        matches = by_name.get(name, [])
+        if len(matches) != 1:
+            raise RuntimeError(f"official DOT archive identity is ambiguous for {name}")
+        data_file = matches[0]
+        checksum = data_file.get("checksum") or {}
+        if checksum.get("type") != "MD5":
+            raise RuntimeError(f"official checksum type changed for {name}")
+        if str(checksum.get("value", "")).lower() != expected_md5:
+            raise RuntimeError(f"official checksum changed for {name}")
+        byte_count = int(data_file["filesize"])
+        if byte_count <= 0:
+            raise RuntimeError(f"official byte count is invalid for {name}")
+        resolved.append(
+            {
+                "name": name,
+                "md5": expected_md5,
+                "bytes": byte_count,
+                "datafile_id": int(data_file["id"]),
+            }
+        )
+    return resolved
+
+
+def _materialize(
+    *, output_dir: Path, datafile_api_root: str, value: dict[str, Any]
+) -> dict[str, Any]:
+    name = str(value["name"])
+    expected_md5 = str(value["md5"])
+    expected_bytes = int(value["bytes"])
+    destination = output_dir / name
+
+    valid = (
+        destination.is_file()
+        and destination.stat().st_size == expected_bytes
+        and _md5(destination) == expected_md5
+    )
+    if not valid:
+        part = output_dir / f"{name}.part"
+        part.touch(exist_ok=True)
+        subprocess.run(
+            [
+                "curl",
+                "--fail",
+                "--location",
+                "--retry",
+                "12",
+                "--retry-all-errors",
+                "--connect-timeout",
+                "30",
+                "--continue-at",
+                "-",
+                "--output",
+                os.fspath(part),
+                f"{datafile_api_root.rstrip('/')}/{value['datafile_id']}",
+            ],
+            check=True,
+        )
+        if part.stat().st_size != expected_bytes:
+            raise RuntimeError(f"downloaded byte count mismatch for {name}")
+        measured = _md5(part)
+        if measured != expected_md5:
+            raise RuntimeError(f"downloaded checksum mismatch for {name}")
+        os.replace(part, destination)
+
+    measured = _md5(destination)
+    if destination.stat().st_size != expected_bytes or measured != expected_md5:
+        raise RuntimeError(f"materialized archive verification failed for {name}")
+    return {
+        **value,
+        "path": os.fspath(destination),
+        "measured_md5": measured,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset-api", required=True)
+    parser.add_argument("--datafile-api-root", required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--entry", action="append", type=_parse_entry, required=True)
+    parser.add_argument("--receipt", type=Path, required=True)
+    args = parser.parse_args()
+
+    entries = list(args.entry)
+    if len({name for name, _ in entries}) != len(entries):
+        raise RuntimeError("duplicate DOT archive entry")
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    if args.output_dir.is_symlink():
+        raise RuntimeError("archive output directory must not be a symlink")
+
+    resolved = _resolve(_metadata(args.dataset_api), entries)
+    materialized = [
+        _materialize(
+            output_dir=args.output_dir,
+            datafile_api_root=args.datafile_api_root,
+            value=value,
+        )
+        for value in resolved
+    ]
+    receipt = {
+        "schema": "prob4d.verified-dot-archive-materialization",
+        "schema_version": 1,
+        "archives": materialized,
+        "information_boundary": {
+            "compressed_archive_bytes_read_for_hashing": True,
+            "archive_members_enumerated": False,
+            "archives_extracted": False,
+            "normal_view_images_opened": False,
+            "two_dimensional_markers_opened": False,
+            "three_dimensional_markers_opened": False,
+        },
+    }
+    args.receipt.parent.mkdir(parents=True, exist_ok=True)
+    args.receipt.write_text(
+        json.dumps(receipt, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_dot_rope_query_selective_gpuserver6000_v3_workflow.py
+++ b/tests/test_dot_rope_query_selective_gpuserver6000_v3_workflow.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github/workflows/dot-rope-query-selective-heldout-gpuserver6000-v3.yml"
+REQUEST = (
+    "protocols/execution_requests/"
+    "dot_rope_query_selective_heldout_gpuserver6000_v3.json"
+)
+PROTOCOL = "protocols/dot-rope-query-selective-heldout-v1.json"
+
+
+def _load() -> tuple[dict, str]:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    value = yaml.safe_load(text)
+    assert isinstance(value, dict)
+    return value, text
+
+
+def test_workflow_retains_frozen_protocol_and_one_file_trigger() -> None:
+    value, text = _load()
+    triggers = value.get("on", value.get(True))
+    assert triggers["push"] == {"branches": ["main"], "paths": [REQUEST]}
+    assert value["env"]["PROTOCOL_PATH"] == PROTOCOL
+    assert value["permissions"] == {"contents": "read"}
+    assert value["concurrency"]["cancel-in-progress"] is False
+    assert 'if [[ ${#changed[@]} -ne 1 || "${changed[0]}" != "$REQUEST_PATH" ]]' in text
+    assert 'test "$EVENT_FORCED" = "false"' in text
+    assert 'test "$EVENT_DELETED" = "false"' in text
+
+
+def test_provider_only_moves_execution_lane_to_gpuserver6000() -> None:
+    value, text = _load()
+    provider = value["jobs"]["provider"]
+    assert provider["runs-on"] == ["self-hosted", "gpuserver6000"]
+    assert provider["environment"] == "trusted-self-hosted-validation"
+    assert provider["permissions"] == {"contents": "read"}
+    assert 'test "$RUNNER_NAME" = "workstation2"' in text
+    assert (
+        value["env"]["RUNTIME_ROOT"]
+        == "/home/github-runner/.cache/prob4d/dot-r11-r30-cut3r-gpuserver6000-v1"
+    )
+    assert (
+        value["env"]["ARCHIVE_ROOT"]
+        == "/home/github-runner/.cache/prob4d/dot-r11-r30-archives-v29"
+    )
+    assert "prob4d.dot-cut3r-gpuserver6000-runtime-prewarm" in text
+    assert "gpuserver4090" not in text
+    assert "workstation1" not in text
+
+
+def test_provider_and_archives_keep_exact_frozen_identities() -> None:
+    value, text = _load()
+    env = value["env"]
+    assert env["CUT3R_REVISION"] == "8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf"
+    assert (
+        env["CUT3R_CHECKPOINT_SHA256"]
+        == "45f7e98a0a64dbeb54901ae2b878cd8cd125f20a4497316483f0bd6f109f8103"
+    )
+    assert env["R11_ARCHIVE"] == "R11-20.zip"
+    assert env["R11_MD5"] == "23ce3e7067465d3edabe20b4c7cfa388"
+    assert env["R21_ARCHIVE"] == "R21-30.zip"
+    assert env["R21_MD5"] == "8aee77f79d1aff6e1f3fd21886b251a0"
+    assert "doi:10.13021/ORC2020/XXLVXM" in text
+    assert '"reserved_sequences": "R31-R70"' in text
+
+
+def test_prediction_first_information_order_is_explicit() -> None:
+    _, text = _load()
+    provider_index = text.index("  provider:")
+    seal_index = text.index("  seal:")
+    evaluate_index = text.index("  evaluate:")
+    assert provider_index < seal_index < evaluate_index
+    provider_text = text[provider_index:seal_index]
+    assert "Predict R11-R30 from normal-view images only" in provider_text
+    assert "two_dimensional_markers_opened" in provider_text
+    assert "three_dimensional_markers_opened" in provider_text
+    assert "Seal factors and query decisions from 2-D markers only" in text
+    assert "Open R11-R30 3-D outcomes and score frozen predictions once" in text
+
+
+def test_strong_prerequisite_and_terminal_classes_are_unchanged() -> None:
+    _, text = _load()
+    assert 'verified["decision"] != "heldout-strong-positive"' in text
+    for decision in (
+        "query-selective-strong-positive",
+        "query-selective-bounded-positive",
+        "query-selective-mixed-negative-or-insufficient-support",
+        "technical-failure",
+    ):
+        assert decision in text
+    assert "run_dot_rope_query_selective_heldout.py" in text
+    assert "verify_dot_rope_cut3r_heldout_result.py" in text
+
+
+def test_no_target_side_optimization_or_downstream_execution() -> None:
+    _, text = _load()
+    lowered = text.lower()
+    for forbidden in (
+        "optuna",
+        "--tune",
+        "scripts/run_bayesian_phystwin",
+        "scripts/run_causal4d",
+    ):
+        assert forbidden not in lowered
+    assert (
+        "R31-R70 remained unopened. No target-side tuning, BayesianPhysTwin, "
+        "or Causal4D execution was authorized."
+    ) in text
+
+
+def test_hosted_archive_materialization_is_checksum_bound_and_nonextracting() -> None:
+    _, text = _load()
+    assert text.count("materialize_verified_dot_archives.py") >= 3
+    assert "--entry \"$R11_ARCHIVE=$R11_MD5\"" in text
+    assert "--entry \"$R21_ARCHIVE=$R21_MD5\"" in text
+    for forbidden in ("unzip ", "extractall", "zipfile"):
+        assert forbidden not in text.lower()

--- a/tests/test_materialize_verified_dot_archives.py
+++ b/tests/test_materialize_verified_dot_archives.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from scripts.science.materialize_verified_dot_archives import (
+    _materialize,
+    _parse_entry,
+    _resolve,
+)
+
+
+def _md5(payload: bytes) -> str:
+    return hashlib.md5(payload, usedforsecurity=False).hexdigest()
+
+
+def test_parse_entry_accepts_plain_filename_and_lowercase_md5() -> None:
+    digest = "0123456789abcdef0123456789abcdef"
+    assert _parse_entry(f"R11-20.zip={digest}") == ("R11-20.zip", digest)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "missing-separator",
+        "../R11-20.zip=0123456789abcdef0123456789abcdef",
+        "folder/R11-20.zip=0123456789abcdef0123456789abcdef",
+        "R11-20.zip=not-an-md5",
+    ],
+)
+def test_parse_entry_rejects_ambiguous_or_unsafe_values(raw: str) -> None:
+    with pytest.raises(Exception):
+        _parse_entry(raw)
+
+
+def test_resolve_requires_exact_publisher_checksum() -> None:
+    digest = "0123456789abcdef0123456789abcdef"
+    metadata = {
+        "data": {
+            "latestVersion": {
+                "files": [
+                    {
+                        "dataFile": {
+                            "filename": "R11-20.zip",
+                            "id": 123,
+                            "filesize": 456,
+                            "checksum": {"type": "MD5", "value": digest},
+                        }
+                    }
+                ]
+            }
+        }
+    }
+    assert _resolve(metadata, [("R11-20.zip", digest)]) == [
+        {
+            "name": "R11-20.zip",
+            "md5": digest,
+            "bytes": 456,
+            "datafile_id": 123,
+        }
+    ]
+    with pytest.raises(RuntimeError, match="checksum changed"):
+        _resolve(metadata, [("R11-20.zip", "f" * 32)])
+
+
+def test_materialize_reuses_only_size_and_hash_verified_archive(tmp_path: Path) -> None:
+    payload = b"compressed archive bytes are opaque to this helper"
+    digest = _md5(payload)
+    archive = tmp_path / "R11-20.zip"
+    archive.write_bytes(payload)
+    value = {
+        "name": archive.name,
+        "md5": digest,
+        "bytes": len(payload),
+        "datafile_id": 123,
+    }
+    result = _materialize(
+        output_dir=tmp_path,
+        datafile_api_root="https://example.invalid/api/access/datafile",
+        value=value,
+    )
+    assert result == {
+        **value,
+        "path": str(archive),
+        "measured_md5": digest,
+    }
+    assert archive.read_bytes() == payload
+
+
+def test_resolve_rejects_duplicate_publisher_filename() -> None:
+    digest = "0123456789abcdef0123456789abcdef"
+    data_file = {
+        "filename": "R11-20.zip",
+        "id": 123,
+        "filesize": 456,
+        "checksum": {"type": "MD5", "value": digest},
+    }
+    metadata = {
+        "data": {
+            "latestVersion": {
+                "files": [{"dataFile": data_file}, {"dataFile": dict(data_file)}]
+            }
+        }
+    }
+    with pytest.raises(RuntimeError, match="ambiguous"):
+        _resolve(metadata, [("R11-20.zip", digest)])


### PR DESCRIPTION
## Purpose

Replace the first operational draft with a corrected, testable control plane for executing the already frozen DOT R11–R30 query-selective CUT3R experiment on `gpuserver6000`.

## Scientific invariants

The existing protocol and evaluator remain authoritative. This change preserves the R04–R10 strong-positive prerequisite, R11–R30 target cohort, R31–R70 reserve, provider identity, query gate, methods, exact fallback, sequence-level bootstrap, negative control, terminal criteria, and prediction-first information order.

## Operational changes

- bind the learned-provider job to `[self-hosted, gpuserver6000]` / `workstation2`;
- require the separately attested prewarmed CUT3R runtime and unopened compressed archives;
- use a checksum-bound archive materializer for the two hosted stages, without enumerating or extracting archive members;
- retain separate provider, 2-D factor/prediction-seal, and 3-D outcome-scoring jobs.

## Corrections relative to the abandoned draft

- remove an unregistered assumption about validator output fields;
- remove a contradictory test assertion while preserving the prohibition on target-side optimization;
- add focused unit coverage for publisher metadata resolution, checksum verification, unsafe path rejection, and archive reuse.

No request file is included, so this PR cannot open R11–R30 or run the scientific experiment.