### PR TITLE
Repair frozen DOT R04–R10 CUT3R native runtime

### DIFF
--- a/CHANGELOG.d/dot-r04-r10-curope-torch211-v1.md
+++ b/CHANGELOG.d/dot-r04-r10-curope-torch211-v1.md
@@ -1,0 +1,3 @@
+# Fixed
+
+- Bind the existing reviewed CUT3R curope PyTorch 2.11/SM89 compatibility patch to the frozen DOT R04–R10 `gpuserver6000` recovery request. The repair verifies the exact request path, CUT3R revision, checkpoint digest, patch blob, and original curope source blobs before changing only the removed dispatch API and native build target. It emits an immutable compatibility receipt and does not alter any scientific protocol setting or open marker outcomes.

--- a/scripts/science/prepare_cut3r_runtime.py
+++ b/scripts/science/prepare_cut3r_runtime.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Build or verify CUT3R's native RoPE kernel and emit an immutable receipt."""
+"""Build or verify CUT3R's native RoPE kernel and emit immutable receipts."""
 
 from __future__ import annotations
 
@@ -16,10 +16,26 @@ from prob4d.cut3r_runtime_contract import require_compiled_cut3r_rope
 _TRUSTED_REQUEST_PATH = (
     "protocols/execution_requests/dot_rope_cut3r_sealed_runtime_v1.json"
 )
+_TRUSTED_HELDOUT_RECOVERY_REQUEST_PATH = (
+    "protocols/execution_requests/"
+    "dot_rope_cut3r_heldout_confirmation_gpuserver6000_v1.json"
+)
 _TRUSTED_CUT3R_REVISION = "8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf"
 _TRUSTED_CHECKPOINT_SHA256 = (
     "45f7e98a0a64dbeb54901ae2b878cd8cd125f20a4497316483f0bd6f109f8103"
 )
+_TRUSTED_CUROPE_PATCH_RELATIVE_PATH = Path(
+    ".github/patches/cut3r-curope-torch211-cu126.patch"
+)
+_TRUSTED_CUROPE_PATCH_GIT_BLOB_SHA1 = "9127464c77b571b9586144cabe24a4eed8667db0"
+_TRUSTED_CUROPE_KERNELS_RELATIVE_PATH = Path("src/croco/models/curope/kernels.cu")
+_TRUSTED_CUROPE_KERNELS_GIT_BLOB_SHA1 = "7156cd1bb935cb1f0be45e58add53f9c21505c20"
+_TRUSTED_CUROPE_SETUP_RELATIVE_PATH = Path("src/croco/models/curope/setup.py")
+_TRUSTED_CUROPE_SETUP_GIT_BLOB_SHA1 = "02ddb0912370a67a49fd2bb91164cf2f1da8648e"
+_PATCHED_DISPATCH_CALL = (
+    'AT_DISPATCH_FLOATING_TYPES_AND_HALF(tokens.scalar_type(), "rope_2d_cuda"'
+)
+_PATCHED_SM89_TARGET = 'all_cuda_archs = ["-gencode", "arch=compute_89,code=sm_89"]'
 _TRUSTED_MODEL_RELATIVE_PATH = Path("src/dust3r/model.py")
 _TRUSTED_MODEL_GIT_BLOB_SHA1 = "7ed9f6106fb063686990c874ede99876ebc939ab"
 _ORIGINAL_LOAD_CALL = '    ckpt = torch.load(model_path, map_location="cpu")\n'
@@ -93,11 +109,133 @@ def _trusted_request_selected() -> bool:
     return os.environ.get("REQUEST_PATH") == _TRUSTED_REQUEST_PATH
 
 
+def _trusted_heldout_recovery_selected() -> bool:
+    return os.environ.get("REQUEST_PATH") == _TRUSTED_HELDOUT_RECOVERY_REQUEST_PATH
+
+
 def _require_trusted_runtime_identity() -> None:
     if os.environ.get("CUT3R_REVISION") != _TRUSTED_CUT3R_REVISION:
         raise RuntimeError("trusted CUT3R compatibility revision changed")
     if os.environ.get("CUT3R_CHECKPOINT_SHA256") != _TRUSTED_CHECKPOINT_SHA256:
         raise RuntimeError("trusted CUT3R compatibility checkpoint digest changed")
+
+
+def _resolved_regular_member(root: Path, relative: Path, *, name: str) -> Path:
+    candidate = root / relative
+    if candidate.is_symlink():
+        raise RuntimeError(f"trusted {name} must not be a symbolic link")
+    resolved = candidate.resolve(strict=True)
+    try:
+        resolved.relative_to(root)
+    except ValueError as error:
+        raise RuntimeError(f"trusted {name} escapes its root") from error
+    if not resolved.is_file():
+        raise RuntimeError(f"trusted {name} is not a regular file")
+    return resolved
+
+
+def _prepare_trusted_curope_compatibility(
+    checkout: Path,
+    repository_root: Path,
+) -> dict[str, object] | None:
+    """Apply the exact reviewed PyTorch 2.11/SM89 curope compatibility patch."""
+
+    if not _trusted_heldout_recovery_selected():
+        return None
+    _require_trusted_runtime_identity()
+
+    checkout = checkout.expanduser().resolve(strict=True)
+    repository_root = repository_root.expanduser().resolve(strict=True)
+    patch_path = _resolved_regular_member(
+        repository_root,
+        _TRUSTED_CUROPE_PATCH_RELATIVE_PATH,
+        name="curope compatibility patch",
+    )
+    patch_bytes = patch_path.read_bytes()
+    patch_blob = _git_blob_sha1(patch_bytes)
+    if patch_blob != _TRUSTED_CUROPE_PATCH_GIT_BLOB_SHA1:
+        raise RuntimeError("trusted curope compatibility patch bytes changed")
+
+    source_members = (
+        (
+            "kernels",
+            _TRUSTED_CUROPE_KERNELS_RELATIVE_PATH,
+            _TRUSTED_CUROPE_KERNELS_GIT_BLOB_SHA1,
+        ),
+        (
+            "setup",
+            _TRUSTED_CUROPE_SETUP_RELATIVE_PATH,
+            _TRUSTED_CUROPE_SETUP_GIT_BLOB_SHA1,
+        ),
+    )
+    before: dict[str, dict[str, str]] = {}
+    resolved_members: dict[str, Path] = {}
+    for name, relative, expected_blob in source_members:
+        member = _resolved_regular_member(checkout, relative, name=f"curope {name} source")
+        source = member.read_bytes()
+        source_blob = _git_blob_sha1(source)
+        if source_blob != expected_blob:
+            raise RuntimeError(f"trusted curope {name} source bytes changed")
+        before[name] = {
+            "path": relative.as_posix(),
+            "git_blob_sha1": source_blob,
+            "sha256": hashlib.sha256(source).hexdigest(),
+        }
+        resolved_members[name] = member
+
+    subprocess.run(
+        ["git", "apply", "--check", str(patch_path)],
+        cwd=checkout,
+        check=True,
+    )
+    subprocess.run(
+        ["git", "apply", str(patch_path)],
+        cwd=checkout,
+        check=True,
+    )
+
+    kernels = resolved_members["kernels"].read_text(encoding="utf-8")
+    setup = resolved_members["setup"].read_text(encoding="utf-8")
+    if _PATCHED_DISPATCH_CALL not in kernels or "tokens.type()" in kernels:
+        raise RuntimeError("trusted curope dispatch compatibility was not applied")
+    if _PATCHED_SM89_TARGET not in setup or "cuda.get_gencode_flags()" in setup:
+        raise RuntimeError("trusted curope SM89 build target was not applied")
+
+    after = {
+        name: {
+            "path": relative.as_posix(),
+            "git_blob_sha1": _git_blob_sha1(resolved_members[name].read_bytes()),
+            "sha256": _sha256(resolved_members[name]),
+        }
+        for name, relative, _ in source_members
+    }
+    record: dict[str, object] = {
+        "schema": "prob4d.cut3r-curope-pytorch211-sm89-compatibility",
+        "schema_version": 1,
+        "status": "trusted-curope-pytorch211-sm89-patch-applied",
+        "request_path": _TRUSTED_HELDOUT_RECOVERY_REQUEST_PATH,
+        "cut3r_revision": _TRUSTED_CUT3R_REVISION,
+        "checkpoint_sha256": _TRUSTED_CHECKPOINT_SHA256,
+        "patch": {
+            "path": _TRUSTED_CUROPE_PATCH_RELATIVE_PATH.as_posix(),
+            "git_blob_sha1": patch_blob,
+            "sha256": hashlib.sha256(patch_bytes).hexdigest(),
+        },
+        "members_before": before,
+        "members_after": after,
+        "compatibility_scope": (
+            "Replace the removed Tensor.type() dispatch API and compile CUT3R curope "
+            "only for the registered NVIDIA Ada SM89 provider device."
+        ),
+        "scientific_boundary": (
+            "The patch changes only native extension compilation compatibility; it "
+            "does not change the checkpoint, provider weights, images, source "
+            "calibration, alpha, query definition, cohort, comparator, statistic, or "
+            "decision rule."
+        ),
+    }
+    record["artifact_id"] = _content_id(record)
+    return record
 
 
 def _prepare_trusted_checkpoint_compatibility(
@@ -223,7 +361,18 @@ def _prepare_trusted_smoke_workspace_compatibility(
 def main() -> int:
     args = _parser().parse_args()
     checkout = args.cut3r_checkout.expanduser().resolve(strict=True)
+    repository_root = Path(__file__).resolve().parents[2]
     curope_root = checkout / "src/croco/models/curope"
+
+    curope_compatibility = _prepare_trusted_curope_compatibility(
+        checkout,
+        repository_root,
+    )
+    if curope_compatibility is not None:
+        _write_no_clobber(
+            args.output.with_name("curope-compatibility.json"),
+            curope_compatibility,
+        )
 
     if args.build:
         subprocess.run(
@@ -241,9 +390,7 @@ def main() -> int:
             "verified CUT3R runtime receipt differs from the frozen artifact ID"
         )
     checkpoint_compatibility = _prepare_trusted_checkpoint_compatibility(checkout)
-    smoke_compatibility = _prepare_trusted_smoke_workspace_compatibility(
-        Path(__file__).resolve().parents[2]
-    )
+    smoke_compatibility = _prepare_trusted_smoke_workspace_compatibility(repository_root)
     _write_no_clobber(args.output, receipt)
     if checkpoint_compatibility is not None:
         _write_no_clobber(

--- a/tests/test_dot_rope_cut3r_heldout_confirmation_workflow.py
+++ b/tests/test_dot_rope_cut3r_heldout_confirmation_workflow.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "dot-rope-cut3r-heldout-confirmation-v1.yml"
+PREPARE_RUNTIME = ROOT / "scripts/science" / "prepare_cut3r_runtime.py"
 
 
 def test_confirmation_workflow_is_single_request_triggered_and_stage_sealed() -> None:
@@ -48,6 +49,22 @@ def test_confirmation_provider_is_read_only_and_bound_to_gpuserver6000() -> None
     assert provider.index("Predict from marker-free normal-view images only") < provider.index(
         "Upload immutable provider seal before marker evaluation"
     )
+
+
+def test_confirmation_runtime_applies_only_the_hash_bound_curope_repair() -> None:
+    text = PREPARE_RUNTIME.read_text(encoding="utf-8")
+
+    assert "_TRUSTED_HELDOUT_RECOVERY_REQUEST_PATH" in text
+    assert "dot_rope_cut3r_heldout_confirmation_gpuserver6000_v1.json" in text
+    assert "cut3r-curope-torch211-cu126.patch" in text
+    assert "9127464c77b571b9586144cabe24a4eed8667db0" in text
+    assert "7156cd1bb935cb1f0be45e58add53f9c21505c20" in text
+    assert "02ddb0912370a67a49fd2bb91164cf2f1da8648e" in text
+    assert '["git", "apply", "--check", str(patch_path)]' in text
+    assert '["git", "apply", str(patch_path)]' in text
+    assert "tokens.scalar_type()" in text
+    assert "arch=compute_89,code=sm_89" in text
+    assert "scientific_boundary" in text
 
 
 def test_confirmation_marker_evaluation_is_hosted_and_frozen() -> None:

--- a/tests/test_prepare_cut3r_runtime.py
+++ b/tests/test_prepare_cut3r_runtime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import importlib.util
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -73,6 +74,84 @@ def _configure_smoke_fixture(
         module._TRUSTED_CHECKPOINT_SHA256,
     )
     return repository_root, source_path, source
+
+
+def _configure_curope_fixture(
+    monkeypatch,
+    module,
+    tmp_path: Path,
+) -> tuple[Path, Path, Path, Path]:
+    repository_root = tmp_path / "repository"
+    patch_path = repository_root / module._TRUSTED_CUROPE_PATCH_RELATIVE_PATH
+    patch_path.parent.mkdir(parents=True)
+
+    checkout = tmp_path / "CUT3R"
+    kernels_path = checkout / module._TRUSTED_CUROPE_KERNELS_RELATIVE_PATH
+    setup_path = checkout / module._TRUSTED_CUROPE_SETUP_RELATIVE_PATH
+    kernels_path.parent.mkdir(parents=True)
+    kernels_source = (
+        b'AT_DISPATCH_FLOATING_TYPES_AND_HALF(tokens.type(), "rope_2d_cuda", ([&] {\n'
+        b"    launch();\n"
+        b"}));\n"
+    )
+    setup_source = (
+        b"from setuptools import setup\n"
+        b"from torch import cuda\n"
+        b"from torch.utils.cpp_extension import BuildExtension, CUDAExtension\n"
+        b'all_cuda_archs = cuda.get_gencode_flags().replace("compute=", "arch=").split()\n'
+    )
+    kernels_path.write_bytes(kernels_source)
+    setup_path.write_bytes(setup_source)
+
+    patch = (
+        b"diff --git a/src/croco/models/curope/kernels.cu "
+        b"b/src/croco/models/curope/kernels.cu\n"
+        b"--- a/src/croco/models/curope/kernels.cu\n"
+        b"+++ b/src/croco/models/curope/kernels.cu\n"
+        b"@@ -1,3 +1,3 @@\n"
+        b'-AT_DISPATCH_FLOATING_TYPES_AND_HALF(tokens.type(), "rope_2d_cuda", ([&] {\n'
+        b'+AT_DISPATCH_FLOATING_TYPES_AND_HALF(tokens.scalar_type(), "rope_2d_cuda", ([&] {\n'
+        b"     launch();\n"
+        b" }));\n"
+        b"diff --git a/src/croco/models/curope/setup.py "
+        b"b/src/croco/models/curope/setup.py\n"
+        b"--- a/src/croco/models/curope/setup.py\n"
+        b"+++ b/src/croco/models/curope/setup.py\n"
+        b"@@ -1,4 +1,3 @@\n"
+        b" from setuptools import setup\n"
+        b"-from torch import cuda\n"
+        b" from torch.utils.cpp_extension import BuildExtension, CUDAExtension\n"
+        b'-all_cuda_archs = cuda.get_gencode_flags().replace("compute=", "arch=").split()\n'
+        b'+all_cuda_archs = ["-gencode", "arch=compute_89,code=sm_89"]\n'
+    )
+    patch_path.write_bytes(patch)
+    subprocess.run(["git", "init", "-q"], cwd=checkout, check=True)
+
+    monkeypatch.setattr(
+        module,
+        "_TRUSTED_CUROPE_PATCH_GIT_BLOB_SHA1",
+        module._git_blob_sha1(patch),
+    )
+    monkeypatch.setattr(
+        module,
+        "_TRUSTED_CUROPE_KERNELS_GIT_BLOB_SHA1",
+        module._git_blob_sha1(kernels_source),
+    )
+    monkeypatch.setattr(
+        module,
+        "_TRUSTED_CUROPE_SETUP_GIT_BLOB_SHA1",
+        module._git_blob_sha1(setup_source),
+    )
+    monkeypatch.setenv(
+        "REQUEST_PATH",
+        module._TRUSTED_HELDOUT_RECOVERY_REQUEST_PATH,
+    )
+    monkeypatch.setenv("CUT3R_REVISION", module._TRUSTED_CUT3R_REVISION)
+    monkeypatch.setenv(
+        "CUT3R_CHECKPOINT_SHA256",
+        module._TRUSTED_CHECKPOINT_SHA256,
+    )
+    return repository_root, checkout, kernels_path, setup_path
 
 
 def test_trusted_checkpoint_compatibility_is_hash_bound(
@@ -147,9 +226,62 @@ def test_trusted_smoke_workspace_compatibility_rejects_source_drift(
         module._prepare_trusted_smoke_workspace_compatibility(repository_root)
 
 
+def test_trusted_heldout_curope_compatibility_is_hash_bound(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_script()
+    repository_root, checkout, kernels_path, setup_path = _configure_curope_fixture(
+        monkeypatch,
+        module,
+        tmp_path,
+    )
+
+    record = module._prepare_trusted_curope_compatibility(
+        checkout.resolve(),
+        repository_root.resolve(),
+    )
+
+    assert record is not None
+    assert record["status"] == "trusted-curope-pytorch211-sm89-patch-applied"
+    assert "tokens.scalar_type()" in kernels_path.read_text(encoding="utf-8")
+    assert "tokens.type()" not in kernels_path.read_text(encoding="utf-8")
+    assert "arch=compute_89,code=sm_89" in setup_path.read_text(encoding="utf-8")
+    assert "cuda.get_gencode_flags()" not in setup_path.read_text(encoding="utf-8")
+    unsigned = dict(record)
+    artifact_id = unsigned.pop("artifact_id")
+    assert artifact_id == module._content_id(unsigned)
+
+
+def test_trusted_heldout_curope_compatibility_rejects_source_drift(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    module = _load_script()
+    repository_root, checkout, kernels_path, _ = _configure_curope_fixture(
+        monkeypatch,
+        module,
+        tmp_path,
+    )
+    kernels_path.write_text("unexpected source\n", encoding="utf-8")
+
+    with pytest.raises(RuntimeError, match="kernels source bytes changed"):
+        module._prepare_trusted_curope_compatibility(
+            checkout.resolve(),
+            repository_root.resolve(),
+        )
+
+
 def test_unrelated_runtime_does_not_patch(monkeypatch, tmp_path: Path) -> None:
     module = _load_script()
     monkeypatch.delenv("REQUEST_PATH", raising=False)
 
     assert module._prepare_trusted_checkpoint_compatibility(tmp_path.resolve()) is None
     assert module._prepare_trusted_smoke_workspace_compatibility(tmp_path.resolve()) is None
+    assert (
+        module._prepare_trusted_curope_compatibility(
+            tmp_path.resolve(),
+            tmp_path.resolve(),
+        )
+        is None
+    )


### PR DESCRIPTION
## Purpose

Repair the sole operational blocker in the already frozen DOT R04–R10 held-out confirmation: CUT3R's native `curope` extension still used the removed `Tensor.type()` dispatch API under PyTorch 2.11 and attempted obsolete CUDA architectures.

## Scope

This PR does not change the scientific protocol, checkpoint, CUT3R revision, source calibration, selected alpha, image/marker custody, confirmation cohort, reserved cohort, queries, comparators, bootstrap procedure, or decision rule.

It binds the existing reviewed patch `.github/patches/cut3r-curope-torch211-cu126.patch` only to the exact `gpuserver6000` held-out recovery request. Before application, the runtime helper verifies:

- request path `protocols/execution_requests/dot_rope_cut3r_heldout_confirmation_gpuserver6000_v1.json`;
- CUT3R revision `8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf`;
- checkpoint SHA-256 `45f7e98a0a64dbeb54901ae2b878cd8cd125f20a4497316483f0bd6f109f8103`;
- patch Git blob `9127464c77b571b9586144cabe24a4eed8667db0`;
- original `kernels.cu` blob `7156cd1bb935cb1f0be45e58add53f9c21505c20`;
- original `setup.py` blob `02ddb0912370a67a49fd2bb91164cf2f1da8648e`.

The patch changes only:

1. `tokens.type()` to `tokens.scalar_type()` for the PyTorch dispatch macro; and
2. the native build target to the registered NVIDIA Ada SM89 architecture.

An immutable compatibility receipt is written before compilation so a subsequent failure remains diagnosable.

## Validation

- Added unit tests for successful hash-bound patching and fail-closed source drift.
- Extended the held-out workflow contract to require the exact patch identities and application path.
- Local focused test fixture: 7/7 tests passed.

After this PR is green and merged, a separate one-file request update will re-trigger the unchanged held-out confirmation on `gpuserver6000`; R11–R70 remain unopened.