### PR TITLE
Add factorized marginal-preserving shared dependence

### DIFF
--- a/.github/workflows/factorized-shared-dependence.yml
+++ b/.github/workflows/factorized-shared-dependence.yml
@@ -1,0 +1,137 @@
+name: Factorized shared dependence
+
+on:
+  push:
+    branches:
+      - research/factorized-shared-dependence-v1
+    paths:
+      - ".github/workflows/factorized-shared-dependence.yml"
+      - "src/prob4d/factorized_dependence.py"
+      - "tests/test_factorized_dependence.py"
+      - "scripts/science/run_factorized_shared_dependence_control.py"
+      - "protocols/factorized-shared-dependence-control-v1.json"
+      - "docs/factorized-shared-dependence.md"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/factorized-shared-dependence.yml"
+      - "src/prob4d/factorized_dependence.py"
+      - "tests/test_factorized_dependence.py"
+      - "scripts/science/run_factorized_shared_dependence_control.py"
+      - "protocols/factorized-shared-dependence-control-v1.json"
+      - "docs/factorized-shared-dependence.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: factorized-shared-dependence-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  factorized-gaussian-contract:
+    name: Dense parity, moments, and storage control
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out exact revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          clean: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install development environment
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install -e ".[dev]"
+          python -m pip check
+
+      - name: Lint, format, and type-check focused files
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m ruff check \
+            src/prob4d/factorized_dependence.py \
+            tests/test_factorized_dependence.py \
+            scripts/science/run_factorized_shared_dependence_control.py
+          python -m ruff format --check \
+            src/prob4d/factorized_dependence.py \
+            tests/test_factorized_dependence.py \
+            scripts/science/run_factorized_shared_dependence_control.py
+          python -m mypy src/prob4d/factorized_dependence.py
+
+      - name: Verify dense parity, sampling, and invalid-input behavior
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pytest -q tests/test_factorized_dependence.py
+
+      - name: Reproduce designed factorization control
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf outputs/factorized-shared-dependence-control-v1
+          python scripts/science/run_factorized_shared_dependence_control.py \
+            --protocol protocols/factorized-shared-dependence-control-v1.json \
+            --output outputs/factorized-shared-dependence-control-v1/result.json
+
+      - name: Enforce numerical parity and bounded interpretation
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          result = json.loads(
+              Path(
+                  "outputs/factorized-shared-dependence-control-v1/result.json"
+              ).read_text(encoding="utf-8")
+          )
+          assert result["schema"] == (
+              "prob4d.factorized-shared-dependence-result.v1"
+          )
+          parity = result["dense_parity"]
+          assert parity["maximum_solve_absolute_error"] < 1.0e-8
+          assert parity["log_determinant_absolute_error"] < 1.0e-8
+          assert parity["quadratic_form_absolute_error"] < 1.0e-7
+          assert parity["gaussian_nll_absolute_error"] < 1.0e-7
+          assert result["sampling_control"][
+              "relative_covariance_frobenius_error"
+          ] < 0.05
+          storage = result["paper_scale_storage"]
+          assert storage["factorized_float64_bytes"] == 491_520
+          assert storage["dense_float64_bytes"] == 301_989_888
+          assert storage["dense_to_factorized_storage_ratio"] == 614.4
+          assert result["information_boundary"] == {
+              "provider_predictions_opened": False,
+              "source_outcomes_opened": False,
+              "heldout_outcomes_opened": False,
+              "bayesian_phystwin_executed": False,
+              "causal4d_executed": False,
+          }
+          print({
+              "artifact_id": result["artifact_id"],
+              "dense_parity": parity,
+              "sampling": result["sampling_control"],
+              "paper_scale_storage": storage,
+          })
+          PY
+
+      - name: Upload designed-control evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: factorized-shared-dependence-control-v1-${{ github.run_id }}
+          path: outputs/factorized-shared-dependence-control-v1/
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/temporary-factorized-adapter-validation.yml
+++ b/.github/workflows/temporary-factorized-adapter-validation.yml
@@ -1,0 +1,107 @@
+name: Temporary factorized endpoint-adapter validation
+
+on:
+  push:
+    branches:
+      - research/factorized-shared-dependence-v1
+    paths:
+      - ".github/workflows/temporary-factorized-adapter-validation.yml"
+
+permissions:
+  contents: write
+
+jobs:
+  validate-adapter:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out branch head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: research/factorized-shared-dependence-v1
+          fetch-depth: 0
+          persist-credentials: true
+          clean: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Format and validate covariance model plus adapter
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install -e ".[dev]"
+          python -m pip check
+          files=(
+            src/prob4d/factorized_dependence.py
+            src/prob4d/factorized_dependence_adapters.py
+            tests/test_factorized_dependence.py
+            tests/test_factorized_dependence_adapters.py
+            scripts/science/run_factorized_shared_dependence_control.py
+          )
+          python -m ruff check --fix "${files[@]}"
+          python -m ruff format "${files[@]}"
+          python -m ruff check "${files[@]}"
+          python -m mypy \
+            src/prob4d/factorized_dependence.py \
+            src/prob4d/factorized_dependence_adapters.py
+          python -m pytest -q \
+            tests/test_factorized_dependence.py \
+            tests/test_factorized_dependence_adapters.py
+          python scripts/science/run_factorized_shared_dependence_control.py \
+            --protocol protocols/factorized-shared-dependence-control-v1.json \
+            --output "$RUNNER_TEMP/factorized-control.json"
+          mkdir -p evidence/factorized-shared-dependence-control-v1
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          evidence = {
+              "schema": "prob4d.factorized-endpoint-adapter-validation.v1",
+              "validated": True,
+              "dense_endpoint_requirements": {
+                  "local_endpoint_block_diagonal": True,
+                  "complete_marginal_blocks_match": True,
+                  "shared_endpoint_positive_semidefinite": True,
+                  "material_rank_truncation_rejected": True,
+              },
+              "focused_tests": [
+                  "tests/test_factorized_dependence.py",
+                  "tests/test_factorized_dependence_adapters.py",
+              ],
+              "workflow_run_id": int(os.environ["GITHUB_RUN_ID"]),
+              "trigger_revision": os.environ["GITHUB_SHA"],
+              "claim_boundary": (
+                  "Software/algebra validation only. Compatibility with any "
+                  "particular empirical covariance endpoints must be checked "
+                  "from those frozen endpoints; no held-out outcome was opened."
+              ),
+          }
+          Path(
+              "evidence/factorized-shared-dependence-control-v1/"
+              "endpoint-adapter-validation.json"
+          ).write_text(
+              json.dumps(evidence, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Retain validated adapter and remove temporary workflow
+        shell: bash
+        run: |
+          set -euo pipefail
+          git rm .github/workflows/temporary-factorized-adapter-validation.yml
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add \
+            src/prob4d/factorized_dependence.py \
+            src/prob4d/factorized_dependence_adapters.py \
+            tests/test_factorized_dependence.py \
+            tests/test_factorized_dependence_adapters.py \
+            scripts/science/run_factorized_shared_dependence_control.py \
+            evidence/factorized-shared-dependence-control-v1/endpoint-adapter-validation.json
+          git commit -m "Validate fail-closed factorized endpoint adapter"
+          git push origin HEAD:research/factorized-shared-dependence-v1

--- a/.github/workflows/temporary-factorized-autoformat.yml
+++ b/.github/workflows/temporary-factorized-autoformat.yml
@@ -1,0 +1,51 @@
+name: Temporary factorized-dependence autoformat
+
+on:
+  push:
+    branches:
+      - research/factorized-shared-dependence-v1
+    paths:
+      - ".github/workflows/temporary-factorized-autoformat.yml"
+
+permissions:
+  contents: write
+
+jobs:
+  format-once:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: research/factorized-shared-dependence-v1
+          persist-credentials: true
+          clean: true
+
+      - name: Install Ruff
+        run: python -m pip install "ruff==0.12.12"
+
+      - name: Format focused Python files and remove this temporary workflow
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m ruff check --fix \
+            src/prob4d/factorized_dependence.py \
+            tests/test_factorized_dependence.py \
+            scripts/science/run_factorized_shared_dependence_control.py
+          python -m ruff format \
+            src/prob4d/factorized_dependence.py \
+            tests/test_factorized_dependence.py \
+            scripts/science/run_factorized_shared_dependence_control.py
+          git rm .github/workflows/temporary-factorized-autoformat.yml
+          if git diff --quiet --exit-code; then
+            exit 0
+          fi
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add \
+            src/prob4d/factorized_dependence.py \
+            tests/test_factorized_dependence.py \
+            scripts/science/run_factorized_shared_dependence_control.py
+          git commit -m "Apply focused Ruff formatting [autoformat]"
+          git push origin HEAD:research/factorized-shared-dependence-v1

--- a/.github/workflows/temporary-factorized-validate-and-retain.yml
+++ b/.github/workflows/temporary-factorized-validate-and-retain.yml
@@ -1,0 +1,108 @@
+name: Temporary factorized-dependence validation and retention
+
+on:
+  push:
+    branches:
+      - research/factorized-shared-dependence-v1
+    paths:
+      - ".github/workflows/temporary-factorized-validate-and-retain.yml"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: temporary-factorized-dependence-finalization
+  cancel-in-progress: false
+
+jobs:
+  validate-and-retain:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out branch head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: research/factorized-shared-dependence-v1
+          fetch-depth: 0
+          persist-credentials: true
+          clean: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Format, test, type-check, and reproduce
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install -e ".[dev]"
+          python -m pip check
+          python -m ruff check --fix \
+            src/prob4d/factorized_dependence.py \
+            tests/test_factorized_dependence.py \
+            scripts/science/run_factorized_shared_dependence_control.py
+          python -m ruff format \
+            src/prob4d/factorized_dependence.py \
+            tests/test_factorized_dependence.py \
+            scripts/science/run_factorized_shared_dependence_control.py
+          python -m ruff check \
+            src/prob4d/factorized_dependence.py \
+            tests/test_factorized_dependence.py \
+            scripts/science/run_factorized_shared_dependence_control.py
+          python -m mypy src/prob4d/factorized_dependence.py
+          python -m pytest -q tests/test_factorized_dependence.py
+          rm -rf outputs/factorized-shared-dependence-control-v1
+          python scripts/science/run_factorized_shared_dependence_control.py \
+            --protocol protocols/factorized-shared-dependence-control-v1.json \
+            --output outputs/factorized-shared-dependence-control-v1/result.json
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          result_path = Path(
+              "outputs/factorized-shared-dependence-control-v1/result.json"
+          )
+          result = json.loads(result_path.read_text(encoding="utf-8"))
+          parity = result["dense_parity"]
+          assert parity["maximum_solve_absolute_error"] < 1.0e-8
+          assert parity["log_determinant_absolute_error"] < 1.0e-8
+          assert parity["quadratic_form_absolute_error"] < 1.0e-7
+          assert parity["gaussian_nll_absolute_error"] < 1.0e-7
+          assert result["sampling_control"][
+              "relative_covariance_frobenius_error"
+          ] < 0.05
+          storage = result["paper_scale_storage"]
+          assert storage["factorized_float64_bytes"] == 491_520
+          assert storage["dense_float64_bytes"] == 301_989_888
+          assert storage["dense_to_factorized_storage_ratio"] == 614.4
+          retained = Path(
+              "evidence/factorized-shared-dependence-control-v1/result.json"
+          )
+          retained.parent.mkdir(parents=True, exist_ok=True)
+          retained.write_bytes(result_path.read_bytes())
+          print({
+              "artifact_id": result["artifact_id"],
+              "dense_parity": parity,
+              "sampling_control": result["sampling_control"],
+              "storage": storage,
+          })
+          PY
+
+      - name: Commit formatted code and validated evidence, then remove temporary workflows
+        shell: bash
+        run: |
+          set -euo pipefail
+          git rm -f .github/workflows/temporary-factorized-autoformat.yml \
+            2>/dev/null || true
+          git rm -f \
+            .github/workflows/temporary-factorized-validate-and-retain.yml
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add \
+            src/prob4d/factorized_dependence.py \
+            tests/test_factorized_dependence.py \
+            scripts/science/run_factorized_shared_dependence_control.py \
+            evidence/factorized-shared-dependence-control-v1/result.json
+          git commit -m "Validate factorized shared dependence and retain control [factorized-validated]"
+          git push origin HEAD:research/factorized-shared-dependence-v1

--- a/.github/workflows/temporary-update-factorized-workflow.yml
+++ b/.github/workflows/temporary-update-factorized-workflow.yml
@@ -1,0 +1,180 @@
+name: Temporary update factorized-dependence CI
+
+on:
+  push:
+    branches:
+      - research/factorized-shared-dependence-v1
+    paths:
+      - ".github/workflows/temporary-update-factorized-workflow.yml"
+
+permissions:
+  contents: write
+
+jobs:
+  update-permanent-workflow:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out branch head
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: research/factorized-shared-dependence-v1
+          fetch-depth: 0
+          persist-credentials: true
+          clean: true
+
+      - name: Rewrite permanent focused workflow with adapter coverage
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > .github/workflows/factorized-shared-dependence.yml <<'YAML'
+          name: Factorized shared dependence
+
+          on:
+            push:
+              branches:
+                - research/factorized-shared-dependence-v1
+              paths:
+                - ".github/workflows/factorized-shared-dependence.yml"
+                - "src/prob4d/factorized_dependence.py"
+                - "src/prob4d/factorized_dependence_adapters.py"
+                - "tests/test_factorized_dependence.py"
+                - "tests/test_factorized_dependence_adapters.py"
+                - "scripts/science/run_factorized_shared_dependence_control.py"
+                - "protocols/factorized-shared-dependence-control-v1.json"
+                - "docs/factorized-shared-dependence.md"
+            pull_request:
+              branches: [main]
+              paths:
+                - ".github/workflows/factorized-shared-dependence.yml"
+                - "src/prob4d/factorized_dependence.py"
+                - "src/prob4d/factorized_dependence_adapters.py"
+                - "tests/test_factorized_dependence.py"
+                - "tests/test_factorized_dependence_adapters.py"
+                - "scripts/science/run_factorized_shared_dependence_control.py"
+                - "protocols/factorized-shared-dependence-control-v1.json"
+                - "docs/factorized-shared-dependence.md"
+            workflow_dispatch:
+
+          permissions:
+            contents: read
+
+          concurrency:
+            group: factorized-shared-dependence-${{ github.ref }}
+            cancel-in-progress: true
+
+          jobs:
+            factorized-gaussian-contract:
+              name: Dense parity, endpoint compatibility, moments, and storage
+              runs-on: ubuntu-latest
+              timeout-minutes: 20
+              steps:
+                - name: Check out exact revision
+                  uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+                  with:
+                    persist-credentials: false
+                    clean: true
+
+                - name: Set up Python 3.12
+                  uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+                  with:
+                    python-version: "3.12"
+                    cache: pip
+                    cache-dependency-path: pyproject.toml
+
+                - name: Install development environment
+                  shell: bash
+                  run: |
+                    set -euo pipefail
+                    python -m pip install -e ".[dev]"
+                    python -m pip check
+
+                - name: Lint, format, and type-check focused files
+                  shell: bash
+                  run: |
+                    set -euo pipefail
+                    files=(
+                      src/prob4d/factorized_dependence.py
+                      src/prob4d/factorized_dependence_adapters.py
+                      tests/test_factorized_dependence.py
+                      tests/test_factorized_dependence_adapters.py
+                      scripts/science/run_factorized_shared_dependence_control.py
+                    )
+                    python -m ruff check "${files[@]}"
+                    python -m ruff format --check "${files[@]}"
+                    python -m mypy \
+                      src/prob4d/factorized_dependence.py \
+                      src/prob4d/factorized_dependence_adapters.py
+
+                - name: Verify dense parity and fail-closed endpoint conversion
+                  shell: bash
+                  run: |
+                    set -euo pipefail
+                    python -m pytest -q \
+                      tests/test_factorized_dependence.py \
+                      tests/test_factorized_dependence_adapters.py
+
+                - name: Reproduce designed factorization control
+                  shell: bash
+                  run: |
+                    set -euo pipefail
+                    rm -rf outputs/factorized-shared-dependence-control-v1
+                    python scripts/science/run_factorized_shared_dependence_control.py \
+                      --protocol protocols/factorized-shared-dependence-control-v1.json \
+                      --output outputs/factorized-shared-dependence-control-v1/result.json
+
+                - name: Enforce numerical parity and bounded interpretation
+                  shell: bash
+                  run: |
+                    set -euo pipefail
+                    python - <<'PY'
+                    import json
+                    from pathlib import Path
+
+                    result = json.loads(
+                        Path(
+                            "outputs/factorized-shared-dependence-control-v1/result.json"
+                        ).read_text(encoding="utf-8")
+                    )
+                    parity = result["dense_parity"]
+                    assert parity["maximum_solve_absolute_error"] < 1.0e-8
+                    assert parity["log_determinant_absolute_error"] < 1.0e-8
+                    assert parity["quadratic_form_absolute_error"] < 1.0e-7
+                    assert parity["gaussian_nll_absolute_error"] < 1.0e-7
+                    assert result["sampling_control"][
+                        "relative_covariance_frobenius_error"
+                    ] < 0.05
+                    storage = result["paper_scale_storage"]
+                    assert storage["factorized_float64_bytes"] == 491_520
+                    assert storage["dense_float64_bytes"] == 301_989_888
+                    assert storage["dense_to_factorized_storage_ratio"] == 614.4
+                    assert result["information_boundary"] == {
+                        "provider_predictions_opened": False,
+                        "source_outcomes_opened": False,
+                        "heldout_outcomes_opened": False,
+                        "bayesian_phystwin_executed": False,
+                        "causal4d_executed": False,
+                    }
+                    print({
+                        "artifact_id": result["artifact_id"],
+                        "dense_parity": parity,
+                        "sampling": result["sampling_control"],
+                        "paper_scale_storage": storage,
+                    })
+                    PY
+
+                - name: Upload designed-control evidence
+                  if: always()
+                  uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+                  with:
+                    name: factorized-shared-dependence-control-v1-${{ github.run_id }}
+                    path: outputs/factorized-shared-dependence-control-v1/
+                    if-no-files-found: warn
+                    retention-days: 30
+          YAML
+          git rm .github/workflows/temporary-update-factorized-workflow.yml
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git add .github/workflows/factorized-shared-dependence.yml
+          git commit -m "Cover endpoint adapter in factorized dependence CI"
+          git push origin HEAD:research/factorized-shared-dependence-v1

--- a/docs/factorized-shared-dependence.md
+++ b/docs/factorized-shared-dependence.md
@@ -1,0 +1,160 @@
+# Factorized marginal-preserving shared dependence
+
+Status: **experimental covariance kernel and designed algebra control**. This
+module does not fit a dependence strength and does not change any frozen DOT
+confirmation protocol.
+
+## Motivation
+
+A learned 4-D provider may exhibit both local uncertainty and a shared restart,
+gauge, or representation effect. Treating all outputs as independent discards
+that dependence. Treating all uncertainty as one perfectly shared latent can be
+far too restrictive. The source-only DOT study therefore considered the family
+
+\[
+\Sigma_\alpha=(1-\alpha)\Sigma_{\mathrm{local}}+
+\alpha\Sigma_{\mathrm{shared}},\qquad 0\leq\alpha\leq 1,
+\]
+
+while holding the predictive mean and every marginal variance fixed. The
+source-frozen DOT candidate is \(\alpha=0.85\); its independent confirmation is
+separate from this implementation.
+
+`BlockSharedGaussianCovariance` gives this family a direct latent
+interpretation and avoids materializing a dense joint covariance.
+
+## Model
+
+Let output group \(i\) have dimension \(D\), local marginal covariance
+\(M_i\), and rows \(F_i\in\mathbb R^{D\times R}\) of a shared factor. The
+constructor requires
+
+\[
+F_iF_i^\top=M_i
+\]
+
+for every group. Define
+
+\[
+\varepsilon_i\sim\mathcal N(0,M_i),\qquad
+z\sim\mathcal N(0,I_R),
+\]
+
+with all \(\varepsilon_i\) independent of each other and of \(z\). Then
+
+\[
+x_i=\sqrt{1-\alpha}\,\varepsilon_i+
+\sqrt{\alpha}\,F_i z
+\]
+
+has joint covariance
+
+\[
+\operatorname{Cov}(x)=
+(1-\alpha)\operatorname{blockdiag}(M_1,\ldots,M_N)
++\alpha FF^\top.
+\]
+
+For every \(\alpha\),
+
+\[
+\operatorname{Cov}(x_i)=M_i.
+\]
+
+Only cross-group covariance changes:
+
+\[
+\operatorname{Cov}(x_i,x_j)=\alpha F_iF_j^\top,
+\qquad i\ne j.
+\]
+
+This is stronger than preserving scalar diagonal entries: complete vector-valued
+marginal covariance blocks are preserved exactly.
+
+## Stable solve and log determinant
+
+For \(\alpha<1\), let
+
+\[
+B=(1-\alpha)\operatorname{blockdiag}(M_i),\qquad
+U=\sqrt{\alpha}F.
+\]
+
+The implementation evaluates
+
+\[
+(B+UU^\top)^{-1}
+=B^{-1}-B^{-1}U(I+U^\top B^{-1}U)^{-1}U^\top B^{-1}
+\]
+
+and
+
+\[
+\log\det(B+UU^\top)
+=\log\det B+\log\det(I+U^\top B^{-1}U)
+\]
+
+using independent \(D\times D\) block solves and one \(R\times R\) core.
+This supports exact Gaussian quadratic forms and normalized joint NLL without a
+large dense matrix.
+
+The fully shared endpoint \(\alpha=1\) remains valid for covariance moments and
+sampling, but may be singular whenever \(R<ND\). Precision operations reject
+that case rather than silently adding jitter or changing the registered model.
+
+## Complexity and storage
+
+The retained arrays require
+
+\[
+O\!\left(ND(D+R)\right)
+\]
+
+storage. One solve requires block-local work plus a rank-sized core, rather than
+a dense \(O((ND)^3)\) factorization.
+
+For the paper-scale example \(N=2048\), \(D=3\), and \(R=7\):
+
+| Representation | Float64 storage |
+|---|---:|
+| Dense \(6144\times6144\) covariance | 301,989,888 bytes |
+| Marginal blocks plus shared factor | 491,520 bytes |
+| **Reduction** | **614.4×** |
+
+This is an algebraic storage comparison. It is not an end-to-end runtime claim;
+provider execution and query construction may dominate total cost.
+
+## Reproduction
+
+```bash
+python -m pytest -q tests/test_factorized_dependence.py
+python scripts/science/run_factorized_shared_dependence_control.py \
+  --protocol protocols/factorized-shared-dependence-control-v1.json \
+  --output outputs/factorized-shared-dependence-control-v1/result.json
+```
+
+The control compares factorized solves, log determinants, quadratic forms, and
+Gaussian NLL with an explicitly materialized dense covariance. It also checks
+Monte Carlo moments and reports the paper-scale storage calculation. The output
+is created exclusively and includes the protocol identity, source hash, runtime,
+and a content identity.
+
+## Integration boundary
+
+The caller must supply a scientifically justified shared factor and dependence
+strength. The factor may come from a finite gauge orbit, a shared latent model,
+or another covariance construction, but those semantics are not inferred here.
+A source-fitted \(\alpha\) must be frozen before held-out evaluation.
+
+Do not use this class to:
+
+- change a predictive mean;
+- retrofit dependence using held-out outcomes;
+- claim that provider restarts are independent observations;
+- replace a singular likelihood with fabricated information;
+- infer a safety decision from NLL alone.
+
+The current DOT evidence specifically rejected adding a predictable restart
+residual as a deterministic mean correction. That negative control motivates a
+covariance interpretation, but the R04-R10 confirmation is still required for a
+held-out empirical claim.

--- a/protocols/factorized-shared-dependence-control-v1.json
+++ b/protocols/factorized-shared-dependence-control-v1.json
@@ -1,0 +1,21 @@
+{
+  "schema": "prob4d.factorized-shared-dependence-control.v1",
+  "evidence_kind": "designed-linear-algebra-control",
+  "seed": 20260901,
+  "group_count": 32,
+  "block_dimension": 3,
+  "latent_rank": 7,
+  "strength": 0.85,
+  "factor_scale": 0.4,
+  "factor_diagonal_offset": 1.5,
+  "sample_count": 20000,
+  "paper_scale_group_count": 2048,
+  "information_boundary": {
+    "provider_predictions_opened": false,
+    "source_outcomes_opened": false,
+    "heldout_outcomes_opened": false,
+    "bayesian_phystwin_executed": false,
+    "causal4d_executed": false
+  },
+  "claim_boundary": "Deterministic algebra, Monte Carlo moment, and storage control for a caller-supplied dependence strength only. No learned-provider competence, empirical calibration, held-out transfer, downstream benefit, safety, or state-of-the-art claim."
+}

--- a/scripts/science/run_factorized_shared_dependence_control.py
+++ b/scripts/science/run_factorized_shared_dependence_control.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Reproduce dense parity, moment, and storage controls for shared dependence."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import platform
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from prob4d.factorized_dependence import BlockSharedGaussianCovariance
+
+SCHEMA = "prob4d.factorized-shared-dependence-control.v1"
+RESULT_SCHEMA = "prob4d.factorized-shared-dependence-result.v1"
+
+
+def _canonical(value: object) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def _content_id(value: object) -> str:
+    return hashlib.sha256(_canonical(value)).hexdigest()
+
+
+def _unique_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def _load_protocol(path: Path) -> dict[str, Any]:
+    protocol = json.loads(
+        path.read_text(encoding="utf-8"),
+        object_pairs_hook=_unique_object,
+    )
+    expected = {
+        "schema",
+        "evidence_kind",
+        "seed",
+        "group_count",
+        "block_dimension",
+        "latent_rank",
+        "strength",
+        "factor_scale",
+        "factor_diagonal_offset",
+        "sample_count",
+        "paper_scale_group_count",
+        "information_boundary",
+        "claim_boundary",
+    }
+    if type(protocol) is not dict or set(protocol) != expected:
+        raise ValueError("protocol field set changed")
+    if protocol["schema"] != SCHEMA:
+        raise ValueError("unsupported protocol schema")
+    if protocol["evidence_kind"] != "designed-linear-algebra-control":
+        raise ValueError("unsupported evidence kind")
+    for name in (
+        "seed",
+        "group_count",
+        "block_dimension",
+        "latent_rank",
+        "sample_count",
+        "paper_scale_group_count",
+    ):
+        if type(protocol[name]) is not int or protocol[name] <= 0:
+            raise ValueError(f"{name} must be a positive integer")
+    if protocol["latent_rank"] < protocol["block_dimension"]:
+        raise ValueError("latent_rank must be at least block_dimension")
+    for name in ("strength", "factor_scale", "factor_diagonal_offset"):
+        value = protocol[name]
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError(f"{name} must be numeric")
+        if not math.isfinite(float(value)):
+            raise ValueError(f"{name} must be finite")
+    if not 0.0 <= float(protocol["strength"]) < 1.0:
+        raise ValueError("strength must lie in [0, 1)")
+    if protocol["factor_scale"] <= 0.0 or protocol["factor_diagonal_offset"] <= 0.0:
+        raise ValueError("factor scale and offset must be positive")
+    expected_boundary = {
+        "provider_predictions_opened": False,
+        "source_outcomes_opened": False,
+        "heldout_outcomes_opened": False,
+        "bayesian_phystwin_executed": False,
+        "causal4d_executed": False,
+    }
+    if protocol["information_boundary"] != expected_boundary:
+        raise ValueError("information boundary changed")
+    if not isinstance(protocol["claim_boundary"], str) or not protocol["claim_boundary"].strip():
+        raise ValueError("claim_boundary must be nonempty")
+    return protocol
+
+
+def _build_model(protocol: dict[str, Any]) -> BlockSharedGaussianCovariance:
+    generator = np.random.default_rng(protocol["seed"])
+    groups = protocol["group_count"]
+    dimension = protocol["block_dimension"]
+    rank = protocol["latent_rank"]
+    factors = generator.normal(
+        scale=float(protocol["factor_scale"]),
+        size=(groups, dimension, rank),
+    )
+    factors[:, :, :dimension] += float(protocol["factor_diagonal_offset"]) * np.eye(
+        dimension
+    )[None, :, :]
+    blocks = np.einsum("idr,ier->ide", factors, factors)
+    return BlockSharedGaussianCovariance(
+        marginal_blocks=blocks,
+        shared_factors=factors,
+        strength=float(protocol["strength"]),
+    )
+
+
+def build_report(protocol: dict[str, Any]) -> dict[str, Any]:
+    model = _build_model(protocol)
+    generator = np.random.default_rng(protocol["seed"] + 1)
+    residual = generator.normal(size=model.dimension)
+    right = generator.normal(size=(model.dimension, 5))
+    dense = model.dense_covariance()
+    dense_solve = np.linalg.solve(dense, right)
+    dense_residual_solve = np.linalg.solve(dense, residual)
+    sign, dense_logdet = np.linalg.slogdet(dense)
+    if sign <= 0.0:
+        raise RuntimeError("designed dense covariance is not positive definite")
+    dense_quadratic = float(residual @ dense_residual_solve)
+    dense_nll = 0.5 * (
+        model.dimension * math.log(2.0 * math.pi)
+        + dense_logdet
+        + dense_quadratic
+    )
+
+    samples = model.sample(generator, protocol["sample_count"]).reshape(
+        protocol["sample_count"], model.dimension
+    )
+    empirical_mean = np.mean(samples, axis=0)
+    empirical_covariance = np.cov(samples, rowvar=False, bias=True)
+    sample_relative_frobenius_error = float(
+        np.linalg.norm(empirical_covariance - dense) / np.linalg.norm(dense)
+    )
+
+    paper_groups = protocol["paper_scale_group_count"]
+    dimension = protocol["block_dimension"]
+    rank = protocol["latent_rank"]
+    factorized_values = paper_groups * dimension * (dimension + rank)
+    dense_values = (paper_groups * dimension) ** 2
+    item_size = np.dtype(np.float64).itemsize
+
+    report: dict[str, Any] = {
+        "schema": RESULT_SCHEMA,
+        "evidence_kind": protocol["evidence_kind"],
+        "protocol": protocol,
+        "protocol_id": _content_id(protocol),
+        "runtime": {
+            "python": platform.python_version(),
+            "numpy": np.__version__,
+        },
+        "model": {
+            "dimension": model.dimension,
+            "group_count": model.group_count,
+            "block_dimension": model.block_dimension,
+            "latent_rank": model.latent_rank,
+            "strength": model.strength,
+        },
+        "dense_parity": {
+            "maximum_solve_absolute_error": float(
+                np.max(np.abs(model.solve(right) - dense_solve))
+            ),
+            "log_determinant_absolute_error": abs(
+                model.log_determinant() - float(dense_logdet)
+            ),
+            "quadratic_form_absolute_error": abs(
+                model.quadratic_form(residual) - dense_quadratic
+            ),
+            "gaussian_nll_absolute_error": abs(
+                model.gaussian_nll(residual) - dense_nll
+            ),
+        },
+        "sampling_control": {
+            "sample_count": protocol["sample_count"],
+            "maximum_empirical_mean_absolute_value": float(
+                np.max(np.abs(empirical_mean))
+            ),
+            "relative_covariance_frobenius_error": sample_relative_frobenius_error,
+        },
+        "paper_scale_storage": {
+            "group_count": paper_groups,
+            "dimension": paper_groups * dimension,
+            "factorized_float64_bytes": factorized_values * item_size,
+            "dense_float64_bytes": dense_values * item_size,
+            "dense_to_factorized_storage_ratio": dense_values / factorized_values,
+        },
+        "complexity": {
+            "storage": "O(N*D*(D+R))",
+            "solve": "O(N*D^3 + N*D^2*R + N*D*R^2 + R^3)",
+            "sample": "O(N*D*(D+R)) per draw",
+        },
+        "information_boundary": protocol["information_boundary"],
+        "claim_boundary": protocol["claim_boundary"],
+    }
+    source = Path(__file__)
+    report["source_sha256"] = hashlib.sha256(source.read_bytes()).hexdigest()
+    report["artifact_id"] = _content_id(report)
+    return report
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--protocol", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+    protocol = _load_protocol(args.protocol)
+    report = build_report(protocol)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("x", encoding="utf-8", newline="\n") as stream:
+        json.dump(report, stream, indent=2, sort_keys=True, allow_nan=False)
+        stream.write("\n")
+    print(
+        json.dumps(
+            {
+                "artifact_id": report["artifact_id"],
+                "storage_ratio": report["paper_scale_storage"][
+                    "dense_to_factorized_storage_ratio"
+                ],
+                "maximum_solve_absolute_error": report["dense_parity"][
+                    "maximum_solve_absolute_error"
+                ],
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/prob4d/factorized_dependence.py
+++ b/src/prob4d/factorized_dependence.py
@@ -1,0 +1,290 @@
+"""Factorized marginal-preserving Gaussian dependence.
+
+The covariance family implemented here separates block-local uncertainty from a
+shared low-rank latent effect while preserving every marginal covariance block.
+It is useful for correlated point/query predictions whose means and marginal
+uncertainties are already fixed.  The strength is supplied by the caller; this
+module does not fit it or attach a calibration claim to it.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import TypeAlias
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+
+FloatArray: TypeAlias = NDArray[np.float64]
+
+
+def _numeric_array(value: ArrayLike, *, name: str) -> FloatArray:
+    raw = np.asarray(value)
+    if raw.dtype.kind not in "iuf":
+        raise ValueError(f"{name} must contain real numeric values")
+    result = np.array(raw, dtype=np.float64, copy=True)
+    if not np.all(np.isfinite(result)):
+        raise ValueError(f"{name} must be finite")
+    return result
+
+
+def _strength(value: float) -> float:
+    if isinstance(value, (bool, np.bool_)):
+        raise ValueError("strength must be a real scalar")
+    result = float(value)
+    if not math.isfinite(result) or not 0.0 <= result <= 1.0:
+        raise ValueError("strength must be finite and lie in [0, 1]")
+    return result
+
+
+@dataclass(frozen=True)
+class BlockSharedGaussianCovariance:
+    """Block-local plus shared-low-rank covariance with fixed marginals.
+
+    Let ``M_i`` denote the covariance block for output group ``i`` and let
+    ``F_i`` be that group's rows of a shared factor.  Construction requires
+
+    ``F_i @ F_i.T == M_i``
+
+    up to the declared numerical tolerance.  For strength ``alpha`` the joint
+    covariance is
+
+    ``Sigma(alpha) = (1-alpha) blockdiag(M_i) + alpha F F.T``.
+
+    Consequently, every diagonal block equals ``M_i`` for every alpha.  Only
+    cross-group dependence changes.  For ``alpha < 1``, solves and log
+    determinants use block solves and a rank-sized Woodbury core; no dense
+    joint covariance is formed.  ``alpha == 1`` remains available for moments
+    and sampling, but precision operations may be singular and are rejected.
+    """
+
+    marginal_blocks: FloatArray
+    shared_factors: FloatArray
+    strength: float
+    matching_rtol: float = 1.0e-9
+    matching_atol: float = 1.0e-12
+
+    def __post_init__(self) -> None:
+        blocks = _numeric_array(self.marginal_blocks, name="marginal_blocks")
+        factors = _numeric_array(self.shared_factors, name="shared_factors")
+        alpha = _strength(self.strength)
+        if blocks.ndim != 3 or blocks.shape[0] == 0 or blocks.shape[1] != blocks.shape[2]:
+            raise ValueError("marginal_blocks must have nonempty shape (N, D, D)")
+        if factors.ndim != 3 or factors.shape[:2] != blocks.shape[:2] or factors.shape[2] == 0:
+            raise ValueError("shared_factors must have shape (N, D, R) with R > 0")
+        if not math.isfinite(self.matching_rtol) or self.matching_rtol < 0.0:
+            raise ValueError("matching_rtol must be finite and nonnegative")
+        if not math.isfinite(self.matching_atol) or self.matching_atol < 0.0:
+            raise ValueError("matching_atol must be finite and nonnegative")
+
+        scale = max(1.0, float(np.max(np.abs(blocks))))
+        tolerance = max(float(self.matching_atol), float(self.matching_rtol) * scale)
+        if not np.allclose(blocks, np.swapaxes(blocks, 1, 2), rtol=0.0, atol=tolerance):
+            raise ValueError("marginal covariance blocks must be symmetric")
+        blocks = 0.5 * (blocks + np.swapaxes(blocks, 1, 2))
+        eigenvalues = np.linalg.eigvalsh(blocks)
+        if float(np.min(eigenvalues)) < -tolerance:
+            raise ValueError("marginal covariance blocks must be positive semidefinite")
+        if alpha < 1.0 and float(np.min(eigenvalues)) <= 0.0:
+            raise ValueError("marginal covariance blocks must be positive definite when strength < 1")
+
+        shared_marginals = np.einsum("idr,ier->ide", factors, factors)
+        if not np.allclose(
+            shared_marginals,
+            blocks,
+            rtol=float(self.matching_rtol),
+            atol=float(self.matching_atol),
+        ):
+            maximum = float(np.max(np.abs(shared_marginals - blocks)))
+            raise ValueError(
+                "shared factors must reproduce every marginal covariance block; "
+                f"maximum absolute mismatch is {maximum:.6g}"
+            )
+
+        blocks.setflags(write=False)
+        factors.setflags(write=False)
+        object.__setattr__(self, "marginal_blocks", blocks)
+        object.__setattr__(self, "shared_factors", factors)
+        object.__setattr__(self, "strength", alpha)
+
+    @property
+    def group_count(self) -> int:
+        return int(self.marginal_blocks.shape[0])
+
+    @property
+    def block_dimension(self) -> int:
+        return int(self.marginal_blocks.shape[1])
+
+    @property
+    def latent_rank(self) -> int:
+        return int(self.shared_factors.shape[2])
+
+    @property
+    def dimension(self) -> int:
+        return self.group_count * self.block_dimension
+
+    @property
+    def storage_bytes(self) -> int:
+        """Bytes occupied by the two numerical arrays retained by the model."""
+        return int(self.marginal_blocks.nbytes + self.shared_factors.nbytes)
+
+    @property
+    def dense_storage_bytes(self) -> int:
+        """Bytes required by one float64 dense joint covariance."""
+        return self.dimension * self.dimension * np.dtype(np.float64).itemsize
+
+    @property
+    def storage_reduction_factor(self) -> float:
+        return self.dense_storage_bytes / self.storage_bytes
+
+    @property
+    def marginal_covariances(self) -> FloatArray:
+        result = np.array(self.marginal_blocks, copy=True)
+        result.setflags(write=False)
+        return result
+
+    def cross_covariance(self, first_group: int, second_group: int) -> FloatArray:
+        """Return one cross-group covariance block.
+
+        The diagonal case returns the preserved marginal exactly rather than a
+        numerically reconstructed copy.
+        """
+        for value, name in ((first_group, "first_group"), (second_group, "second_group")):
+            if isinstance(value, (bool, np.bool_)) or not 0 <= int(value) < self.group_count:
+                raise IndexError(f"{name} is outside the group range")
+        first = int(first_group)
+        second = int(second_group)
+        if first == second:
+            result = np.array(self.marginal_blocks[first], copy=True)
+        else:
+            result = self.strength * self.shared_factors[first] @ self.shared_factors[second].T
+        result.setflags(write=False)
+        return result
+
+    def dense_covariance(self) -> FloatArray:
+        """Materialize the joint covariance for validation or small problems."""
+        local = np.zeros((self.dimension, self.dimension), dtype=np.float64)
+        width = self.block_dimension
+        for index, block in enumerate(self.marginal_blocks):
+            start = index * width
+            local[start : start + width, start : start + width] = block
+        factor = self.shared_factors.reshape(self.dimension, self.latent_rank)
+        result = (1.0 - self.strength) * local + self.strength * (factor @ factor.T)
+        result = 0.5 * (result + result.T)
+        result.setflags(write=False)
+        return result
+
+    def _require_precision_form(self) -> float:
+        local_weight = 1.0 - self.strength
+        if local_weight <= 0.0:
+            raise np.linalg.LinAlgError(
+                "strength=1 has no positive block-local component; use an explicit "
+                "singular-Gaussian treatment or a strength below one"
+            )
+        return local_weight
+
+    def _solve_blocks(self, right_hand_side: FloatArray) -> FloatArray:
+        return np.linalg.solve(self.marginal_blocks, right_hand_side)
+
+    def solve(self, right_hand_side: ArrayLike) -> FloatArray:
+        """Apply the inverse covariance using the Woodbury identity.
+
+        ``right_hand_side`` may have shape ``(dimension,)`` or
+        ``(dimension, K)``.  The returned shape matches the input shape.
+        """
+        local_weight = self._require_precision_form()
+        right = _numeric_array(right_hand_side, name="right_hand_side")
+        vector = right.ndim == 1
+        if vector:
+            if right.shape != (self.dimension,):
+                raise ValueError("a vector right_hand_side must match the covariance dimension")
+            right = right[:, None]
+        elif right.ndim != 2 or right.shape[0] != self.dimension:
+            raise ValueError("right_hand_side must have shape (dimension,) or (dimension, K)")
+
+        columns = right.shape[1]
+        grouped = right.reshape(self.group_count, self.block_dimension, columns)
+        local_inverse_right = self._solve_blocks(grouped) / local_weight
+
+        factor = self.shared_factors
+        local_inverse_factor = self._solve_blocks(factor) / local_weight
+        core = np.eye(self.latent_rank) + self.strength * np.einsum(
+            "idr,ids->rs", factor, local_inverse_factor
+        )
+        projected = math.sqrt(self.strength) * np.einsum(
+            "idr,idk->rk", factor, local_inverse_right
+        )
+        correction_coefficients = np.linalg.solve(core, projected)
+        correction = math.sqrt(self.strength) * np.einsum(
+            "idr,rk->idk", local_inverse_factor, correction_coefficients
+        )
+        result = (local_inverse_right - correction).reshape(self.dimension, columns)
+        if vector:
+            result = result[:, 0]
+        result.setflags(write=False)
+        return result
+
+    def log_determinant(self) -> float:
+        """Return ``log(det(Sigma))`` without materializing ``Sigma``."""
+        local_weight = self._require_precision_form()
+        signs, block_log_determinants = np.linalg.slogdet(self.marginal_blocks)
+        if np.any(signs <= 0.0):
+            raise np.linalg.LinAlgError("marginal covariance block is not positive definite")
+        local_inverse_factor = self._solve_blocks(self.shared_factors) / local_weight
+        core = np.eye(self.latent_rank) + self.strength * np.einsum(
+            "idr,ids->rs", self.shared_factors, local_inverse_factor
+        )
+        core_sign, core_log_determinant = np.linalg.slogdet(core)
+        if core_sign <= 0.0:
+            raise np.linalg.LinAlgError("Woodbury core is not positive definite")
+        return float(
+            np.sum(block_log_determinants)
+            + self.dimension * math.log(local_weight)
+            + core_log_determinant
+        )
+
+    def quadratic_form(self, residual: ArrayLike) -> float:
+        vector = _numeric_array(residual, name="residual")
+        if vector.shape != (self.dimension,):
+            raise ValueError("residual must match the covariance dimension")
+        solved = self.solve(vector)
+        value = float(vector @ solved)
+        tolerance = 1.0e-10 * max(1.0, float(vector @ vector))
+        if value < -tolerance:
+            raise RuntimeError("computed a negative covariance quadratic form")
+        return max(value, 0.0)
+
+    def gaussian_nll(self, residual: ArrayLike, *, normalized: bool = False) -> float:
+        """Gaussian negative log likelihood for a zero-mean residual."""
+        value = 0.5 * (
+            self.dimension * math.log(2.0 * math.pi)
+            + self.log_determinant()
+            + self.quadratic_form(residual)
+        )
+        return value / self.dimension if normalized else value
+
+    def sample(
+        self,
+        random_generator: np.random.Generator,
+        sample_count: int,
+    ) -> FloatArray:
+        """Draw zero-mean samples with shape ``(sample_count, N, D)``."""
+        if not isinstance(random_generator, np.random.Generator):
+            raise TypeError("random_generator must be numpy.random.Generator")
+        if isinstance(sample_count, (bool, np.bool_)) or int(sample_count) != sample_count:
+            raise ValueError("sample_count must be a positive integer")
+        count = int(sample_count)
+        if count <= 0:
+            raise ValueError("sample_count must be a positive integer")
+
+        local_noise = random_generator.standard_normal(
+            (count, self.group_count, self.block_dimension)
+        )
+        shared_noise = random_generator.standard_normal((count, self.latent_rank))
+        local_roots = np.linalg.cholesky(self.marginal_blocks)
+        local = np.einsum("idj,sij->sid", local_roots, local_noise)
+        shared = np.einsum("idr,sr->sid", self.shared_factors, shared_noise)
+        result = math.sqrt(1.0 - self.strength) * local + math.sqrt(self.strength) * shared
+        result.setflags(write=False)
+        return result

--- a/src/prob4d/factorized_dependence_adapters.py
+++ b/src/prob4d/factorized_dependence_adapters.py
@@ -1,0 +1,139 @@
+"""Fail-closed adapters for factorized marginal-preserving dependence."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+from numpy.typing import ArrayLike
+
+from .factorized_dependence import BlockSharedGaussianCovariance, FloatArray
+
+
+def _matrix(value: ArrayLike, *, name: str) -> FloatArray:
+    raw = np.asarray(value)
+    if raw.dtype.kind not in "iuf":
+        raise ValueError(f"{name} must contain real numeric values")
+    result = np.array(raw, dtype=np.float64, copy=True)
+    if (
+        result.ndim != 2
+        or result.shape[0] == 0
+        or result.shape[0] != result.shape[1]
+    ):
+        raise ValueError(f"{name} must be a nonempty square matrix")
+    if not np.all(np.isfinite(result)):
+        raise ValueError(f"{name} must be finite")
+    return result
+
+
+def _positive_integer(value: int, *, name: str) -> int:
+    if isinstance(value, (bool, np.bool_)) or int(value) != value or int(value) <= 0:
+        raise ValueError(f"{name} must be a positive integer")
+    return int(value)
+
+
+def factorized_from_covariance_endpoints(
+    local_covariance: ArrayLike,
+    shared_covariance: ArrayLike,
+    block_dimension: int,
+    strength: float,
+    *,
+    covariance_rtol: float = 1.0e-9,
+    covariance_atol: float = 1.0e-12,
+    rank_rtol: float = 1.0e-10,
+    rank_atol: float = 1.0e-13,
+) -> BlockSharedGaussianCovariance:
+    """Convert compatible dense endpoints into a block/shared representation.
+
+    The local endpoint must be block diagonal.  Every complete diagonal block
+    of the shared endpoint must equal the corresponding local block.  These
+    requirements are deliberately stronger than equality of scalar variances.
+    A mismatch raises instead of changing either endpoint.
+
+    The shared endpoint is factored by a symmetric eigendecomposition.  Only
+    eigenvalues below the declared numerical rank threshold are discarded.
+    The reconstructed covariance must still match the supplied shared endpoint
+    within the covariance tolerance.
+    """
+
+    local = _matrix(local_covariance, name="local_covariance")
+    shared = _matrix(shared_covariance, name="shared_covariance")
+    width = _positive_integer(block_dimension, name="block_dimension")
+    if local.shape != shared.shape:
+        raise ValueError("covariance endpoints must have matching shape")
+    if local.shape[0] % width:
+        raise ValueError("joint covariance dimension must be divisible by block_dimension")
+    for value, name in (
+        (covariance_rtol, "covariance_rtol"),
+        (covariance_atol, "covariance_atol"),
+        (rank_rtol, "rank_rtol"),
+        (rank_atol, "rank_atol"),
+    ):
+        if not math.isfinite(value) or value < 0.0:
+            raise ValueError(f"{name} must be finite and nonnegative")
+
+    scale = max(1.0, float(np.max(np.abs(np.concatenate((local, shared))))))
+    tolerance = max(covariance_atol, covariance_rtol * scale)
+    for matrix, name in ((local, "local_covariance"), (shared, "shared_covariance")):
+        if not np.allclose(matrix, matrix.T, rtol=0.0, atol=tolerance):
+            raise ValueError(f"{name} must be symmetric")
+    local = 0.5 * (local + local.T)
+    shared = 0.5 * (shared + shared.T)
+
+    local_eigenvalues = np.linalg.eigvalsh(local)
+    shared_eigenvalues, shared_eigenvectors = np.linalg.eigh(shared)
+    if float(np.min(local_eigenvalues)) < -tolerance:
+        raise ValueError("local_covariance must be positive semidefinite")
+    if float(np.min(shared_eigenvalues)) < -tolerance:
+        raise ValueError("shared_covariance must be positive semidefinite")
+
+    group_count = local.shape[0] // width
+    blocks = np.empty((group_count, width, width), dtype=np.float64)
+    block_local = np.zeros_like(local)
+    for group in range(group_count):
+        start = group * width
+        stop = start + width
+        blocks[group] = local[start:stop, start:stop]
+        block_local[start:stop, start:stop] = blocks[group]
+        if not np.allclose(
+            shared[start:stop, start:stop],
+            blocks[group],
+            rtol=covariance_rtol,
+            atol=covariance_atol,
+        ):
+            raise ValueError(
+                "shared and local endpoints do not preserve the same complete "
+                f"marginal block for group {group}"
+            )
+    if not np.allclose(local, block_local, rtol=covariance_rtol, atol=covariance_atol):
+        maximum = float(np.max(np.abs(local - block_local)))
+        raise ValueError(
+            "local_covariance must be block diagonal; maximum off-block magnitude "
+            f"is {maximum:.6g}"
+        )
+
+    maximum_eigenvalue = max(0.0, float(np.max(shared_eigenvalues)))
+    threshold = max(rank_atol, rank_rtol * maximum_eigenvalue)
+    retained = shared_eigenvalues > threshold
+    if not np.any(retained):
+        raise ValueError("shared_covariance has zero numerical rank")
+    factor = shared_eigenvectors[:, retained] * np.sqrt(shared_eigenvalues[retained])
+    reconstructed = factor @ factor.T
+    if not np.allclose(
+        reconstructed,
+        shared,
+        rtol=covariance_rtol,
+        atol=covariance_atol,
+    ):
+        maximum = float(np.max(np.abs(reconstructed - shared)))
+        raise ValueError(
+            "rank truncation does not reproduce shared_covariance within tolerance; "
+            f"maximum absolute mismatch is {maximum:.6g}"
+        )
+    return BlockSharedGaussianCovariance(
+        marginal_blocks=blocks,
+        shared_factors=factor.reshape(group_count, width, -1),
+        strength=strength,
+        matching_rtol=covariance_rtol,
+        matching_atol=covariance_atol,
+    )

--- a/tests/test_factorized_dependence.py
+++ b/tests/test_factorized_dependence.py
@@ -1,0 +1,222 @@
+"""Tests for block-local plus shared-low-rank Gaussian dependence."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from prob4d.factorized_dependence import BlockSharedGaussianCovariance
+
+
+def _model(
+    *,
+    groups: int = 6,
+    dimension: int = 3,
+    rank: int = 5,
+    strength: float = 0.85,
+    seed: int = 20260901,
+) -> BlockSharedGaussianCovariance:
+    rng = np.random.default_rng(seed)
+    factors = rng.normal(scale=0.4, size=(groups, dimension, rank))
+    factors[:, :, :dimension] += 1.5 * np.eye(dimension)[None, :, :]
+    blocks = np.einsum("idr,ier->ide", factors, factors)
+    return BlockSharedGaussianCovariance(blocks, factors, strength)
+
+
+def test_dense_covariance_preserves_blocks_and_scales_cross_dependence():
+    model = _model(groups=4, dimension=2, rank=3, strength=0.35)
+    dense = model.dense_covariance()
+    width = model.block_dimension
+    for first in range(model.group_count):
+        first_slice = slice(first * width, (first + 1) * width)
+        np.testing.assert_allclose(
+            dense[first_slice, first_slice],
+            model.marginal_blocks[first],
+            atol=1.0e-14,
+            rtol=1.0e-14,
+        )
+        for second in range(model.group_count):
+            second_slice = slice(second * width, (second + 1) * width)
+            np.testing.assert_allclose(
+                dense[first_slice, second_slice],
+                model.cross_covariance(first, second),
+                atol=1.0e-14,
+                rtol=1.0e-14,
+            )
+
+
+def test_factorized_solve_logdet_quadratic_and_nll_match_dense_algebra():
+    model = _model()
+    rng = np.random.default_rng(71)
+    right = rng.normal(size=(model.dimension, 4))
+    residual = rng.normal(size=model.dimension)
+    dense = model.dense_covariance()
+
+    np.testing.assert_allclose(
+        model.solve(right),
+        np.linalg.solve(dense, right),
+        atol=2.0e-11,
+        rtol=2.0e-11,
+    )
+    np.testing.assert_allclose(
+        model.solve(residual),
+        np.linalg.solve(dense, residual),
+        atol=2.0e-11,
+        rtol=2.0e-11,
+    )
+    sign, dense_logdet = np.linalg.slogdet(dense)
+    assert sign > 0.0
+    np.testing.assert_allclose(
+        model.log_determinant(), dense_logdet, atol=2.0e-11, rtol=2.0e-11
+    )
+    dense_quadratic = float(residual @ np.linalg.solve(dense, residual))
+    np.testing.assert_allclose(
+        model.quadratic_form(residual),
+        dense_quadratic,
+        atol=2.0e-10,
+        rtol=2.0e-11,
+    )
+    dense_nll = 0.5 * (
+        model.dimension * np.log(2.0 * np.pi) + dense_logdet + dense_quadratic
+    )
+    np.testing.assert_allclose(model.gaussian_nll(residual), dense_nll, atol=2.0e-10)
+    np.testing.assert_allclose(
+        model.gaussian_nll(residual, normalized=True),
+        dense_nll / model.dimension,
+        atol=2.0e-11,
+    )
+
+
+def test_zero_strength_is_block_independent_and_exactly_solvable():
+    model = _model(strength=0.0)
+    dense = model.dense_covariance()
+    width = model.block_dimension
+    for first in range(model.group_count):
+        for second in range(model.group_count):
+            if first == second:
+                continue
+            first_slice = slice(first * width, (first + 1) * width)
+            second_slice = slice(second * width, (second + 1) * width)
+            np.testing.assert_array_equal(dense[first_slice, second_slice], 0.0)
+    residual = np.arange(model.dimension, dtype=np.float64) / model.dimension
+    np.testing.assert_allclose(
+        model.solve(residual),
+        np.linalg.solve(dense, residual),
+        atol=1.0e-13,
+        rtol=1.0e-13,
+    )
+
+
+def test_full_shared_endpoint_retains_marginals_but_rejects_precision_operations():
+    model = _model(strength=1.0)
+    factor = model.shared_factors.reshape(model.dimension, model.latent_rank)
+    np.testing.assert_allclose(model.dense_covariance(), factor @ factor.T, atol=1.0e-14)
+    with pytest.raises(np.linalg.LinAlgError, match="strength=1"):
+        model.log_determinant()
+    with pytest.raises(np.linalg.LinAlgError, match="strength=1"):
+        model.solve(np.zeros(model.dimension))
+
+
+def test_sampling_recovers_the_dense_covariance():
+    model = _model(groups=3, dimension=2, rank=4, strength=0.65, seed=18)
+    samples = model.sample(np.random.default_rng(9182), 60_000).reshape(60_000, -1)
+    empirical_mean = np.mean(samples, axis=0)
+    empirical_covariance = np.cov(samples, rowvar=False, bias=True)
+    dense = model.dense_covariance()
+    scale = float(np.sqrt(np.max(np.diag(dense))))
+    assert float(np.max(np.abs(empirical_mean))) < 0.025 * scale
+    relative_frobenius_error = float(
+        np.linalg.norm(empirical_covariance - dense) / np.linalg.norm(dense)
+    )
+    assert relative_frobenius_error < 0.025
+
+
+def test_storage_report_for_paper_scale_is_more_than_six_hundred_fold_smaller():
+    groups, dimension, rank = 2048, 3, 7
+    factors = np.zeros((groups, dimension, rank), dtype=np.float64)
+    factors[:, :, :dimension] = np.eye(dimension)[None, :, :]
+    blocks = np.einsum("idr,ier->ide", factors, factors)
+    model = BlockSharedGaussianCovariance(blocks, factors, 0.85)
+    assert model.storage_bytes == 491_520
+    assert model.dense_storage_bytes == 301_989_888
+    np.testing.assert_allclose(model.storage_reduction_factor, 614.4)
+
+
+def test_inputs_are_copied_and_outputs_are_read_only():
+    factors = np.zeros((2, 2, 2), dtype=np.float64)
+    factors[:, :, :] = np.eye(2)[None, :, :]
+    blocks = np.einsum("idr,ier->ide", factors, factors)
+    model = BlockSharedGaussianCovariance(blocks, factors, 0.5)
+    factors[:] = 12.0
+    blocks[:] = 12.0
+    np.testing.assert_array_equal(model.marginal_blocks, np.tile(np.eye(2), (2, 1, 1)))
+    np.testing.assert_array_equal(model.shared_factors, np.tile(np.eye(2), (2, 1, 1)))
+    for value in (
+        model.marginal_blocks,
+        model.shared_factors,
+        model.marginal_covariances,
+        model.dense_covariance(),
+        model.solve(np.ones(model.dimension)),
+        model.sample(np.random.default_rng(1), 2),
+    ):
+        assert not value.flags.writeable
+
+
+@pytest.mark.parametrize("strength", [-0.1, 1.1, np.nan, np.inf, True])
+def test_invalid_strength_rejected(strength):
+    factors = np.tile(np.eye(2)[None, :, :], (2, 1, 1))
+    blocks = np.einsum("idr,ier->ide", factors, factors)
+    with pytest.raises(ValueError):
+        BlockSharedGaussianCovariance(blocks, factors, strength)
+
+
+def test_mismatched_marginal_blocks_rejected():
+    factors = np.tile(np.eye(2)[None, :, :], (2, 1, 1))
+    blocks = np.einsum("idr,ier->ide", factors, factors)
+    blocks[1, 0, 0] += 0.1
+    with pytest.raises(ValueError, match="reproduce every marginal"):
+        BlockSharedGaussianCovariance(blocks, factors, 0.5)
+
+
+def test_nonsymmetric_negative_and_singular_local_blocks_rejected():
+    factors = np.tile(np.eye(2)[None, :, :], (2, 1, 1))
+    blocks = np.einsum("idr,ier->ide", factors, factors)
+
+    nonsymmetric = blocks.copy()
+    nonsymmetric[0, 0, 1] = 0.2
+    with pytest.raises(ValueError, match="symmetric"):
+        BlockSharedGaussianCovariance(nonsymmetric, factors, 0.5)
+
+    singular_factors = factors.copy()
+    singular_factors[:, 1, :] = 0.0
+    singular = np.einsum("idr,ier->ide", singular_factors, singular_factors)
+    with pytest.raises(ValueError, match="positive definite"):
+        BlockSharedGaussianCovariance(singular, singular_factors, 0.5)
+
+    negative = blocks.copy()
+    negative[0, 0, 0] = -1.0
+    with pytest.raises(ValueError):
+        BlockSharedGaussianCovariance(negative, factors, 1.0)
+
+
+def test_invalid_shapes_rhs_indices_and_sampling_rejected():
+    model = _model(groups=2, dimension=2, rank=3)
+    with pytest.raises(ValueError):
+        BlockSharedGaussianCovariance(np.eye(2), np.ones((2, 2, 3)), 0.5)
+    with pytest.raises(ValueError):
+        BlockSharedGaussianCovariance(np.tile(np.eye(2), (2, 1, 1)), np.ones((2, 3, 2)), 0.5)
+    with pytest.raises(ValueError):
+        model.solve(np.ones(model.dimension + 1))
+    with pytest.raises(ValueError):
+        model.solve(np.ones((model.dimension + 1, 2)))
+    with pytest.raises(ValueError):
+        model.quadratic_form(np.ones(model.dimension + 1))
+    with pytest.raises(IndexError):
+        model.cross_covariance(-1, 0)
+    with pytest.raises(IndexError):
+        model.cross_covariance(0, model.group_count)
+    with pytest.raises(TypeError):
+        model.sample("not-a-generator", 2)
+    for count in (0, -1, 1.5, True):
+        with pytest.raises(ValueError):
+            model.sample(np.random.default_rng(1), count)

--- a/tests/test_factorized_dependence_adapters.py
+++ b/tests/test_factorized_dependence_adapters.py
@@ -1,0 +1,159 @@
+"""Tests for dense-to-factorized covariance endpoint conversion."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from prob4d.factorized_dependence_adapters import (
+    factorized_from_covariance_endpoints,
+)
+
+
+def _compatible_endpoints(
+    *, groups: int = 5, dimension: int = 3, rank: int = 4, seed: int = 43
+):
+    rng = np.random.default_rng(seed)
+    factors = rng.normal(size=(groups, dimension, rank))
+    factors[:, :, :dimension] += 2.0 * np.eye(dimension)[None, :, :]
+    flat = factors.reshape(groups * dimension, rank)
+    shared = flat @ flat.T
+    local = np.zeros_like(shared)
+    for group in range(groups):
+        start = group * dimension
+        stop = start + dimension
+        local[start:stop, start:stop] = shared[start:stop, start:stop]
+    return local, shared
+
+
+def test_compatible_dense_endpoints_recover_covariance_and_dense_gaussian_algebra():
+    local, shared = _compatible_endpoints()
+    strength = 0.73
+    model = factorized_from_covariance_endpoints(local, shared, 3, strength)
+    expected = (1.0 - strength) * local + strength * shared
+    np.testing.assert_allclose(
+        model.dense_covariance(), expected, atol=2.0e-12, rtol=2.0e-12
+    )
+    residual = np.linspace(-0.4, 0.7, expected.shape[0])
+    np.testing.assert_allclose(
+        model.solve(residual),
+        np.linalg.solve(expected, residual),
+        atol=2.0e-10,
+        rtol=2.0e-10,
+    )
+    sign, logdet = np.linalg.slogdet(expected)
+    assert sign > 0.0
+    np.testing.assert_allclose(model.log_determinant(), logdet, atol=2.0e-10)
+
+
+def test_adapter_recovers_numerical_shared_rank():
+    local, shared = _compatible_endpoints(groups=7, dimension=2, rank=3)
+    model = factorized_from_covariance_endpoints(local, shared, 2, 0.85)
+    assert model.latent_rank == 3
+    assert model.group_count == 7
+    assert model.block_dimension == 2
+
+
+def test_scalar_diagonal_agreement_is_not_enough_for_block_preservation():
+    local, shared = _compatible_endpoints(groups=2, dimension=2, rank=3)
+    changed = shared.copy()
+    changed[0, 1] += 0.2
+    changed[1, 0] += 0.2
+    assert np.array_equal(np.diag(changed), np.diag(local))
+    with pytest.raises(ValueError, match="complete marginal block"):
+        factorized_from_covariance_endpoints(local, changed, 2, 0.5)
+
+
+def test_local_cross_group_dependence_is_rejected():
+    local, shared = _compatible_endpoints(groups=3, dimension=2, rank=3)
+    local[0, 2] = local[2, 0] = 0.01
+    with pytest.raises(ValueError, match="block diagonal"):
+        factorized_from_covariance_endpoints(local, shared, 2, 0.5)
+
+
+def test_material_rank_truncation_is_rejected():
+    local, shared = _compatible_endpoints(groups=3, dimension=2, rank=3)
+    with pytest.raises(ValueError, match="rank truncation"):
+        factorized_from_covariance_endpoints(
+            local,
+            shared,
+            2,
+            0.5,
+            rank_rtol=0.99,
+            rank_atol=0.0,
+        )
+
+
+@pytest.mark.parametrize(
+    "mutation,match",
+    [
+        ("shape", "matching shape"),
+        ("dimension", "divisible"),
+        ("local_nonsymmetric", "symmetric"),
+        ("shared_nonsymmetric", "symmetric"),
+        ("local_negative", "positive semidefinite"),
+        ("shared_negative", "positive semidefinite"),
+        ("zero_rank", "zero numerical rank"),
+    ],
+)
+def test_invalid_dense_endpoints_fail_closed(mutation, match):
+    local, shared = _compatible_endpoints(groups=3, dimension=2, rank=3)
+    block_dimension = 2
+    if mutation == "shape":
+        shared = shared[:-1, :-1]
+    elif mutation == "dimension":
+        block_dimension = 4
+    elif mutation == "local_nonsymmetric":
+        local[0, 1] += 0.5
+    elif mutation == "shared_nonsymmetric":
+        shared[0, 1] += 0.5
+    elif mutation == "local_negative":
+        local[0, 0] = -10.0
+    elif mutation == "shared_negative":
+        shared[0, 0] = -10.0
+    elif mutation == "zero_rank":
+        local[:] = 0.0
+        shared[:] = 0.0
+    else:
+        raise AssertionError(mutation)
+    with pytest.raises(ValueError, match=match):
+        factorized_from_covariance_endpoints(
+            local,
+            shared,
+            block_dimension,
+            1.0 if mutation == "zero_rank" else 0.5,
+        )
+
+
+@pytest.mark.parametrize("block_dimension", [0, -1, 1.5, True])
+def test_invalid_block_dimension_rejected(block_dimension):
+    local, shared = _compatible_endpoints(groups=2, dimension=2, rank=3)
+    with pytest.raises(ValueError, match="positive integer"):
+        factorized_from_covariance_endpoints(
+            local,
+            shared,
+            block_dimension,
+            0.5,
+        )
+
+
+@pytest.mark.parametrize(
+    "name,value",
+    [
+        ("covariance_rtol", -1.0),
+        ("covariance_atol", np.nan),
+        ("rank_rtol", np.inf),
+        ("rank_atol", -1.0),
+    ],
+)
+def test_invalid_tolerances_rejected(name, value):
+    local, shared = _compatible_endpoints(groups=2, dimension=2, rank=3)
+    keywords = {name: value}
+    with pytest.raises(ValueError, match=name):
+        factorized_from_covariance_endpoints(
+            local,
+            shared,
+            2,
+            0.5,
+            **keywords,
+        )


### PR DESCRIPTION
## Purpose

Turn the source-selected DOT covariance family into an explicit latent Gaussian model whose means and full vector-valued marginal covariance blocks remain fixed while only cross-output dependence changes.

For local covariance blocks `M_i`, shared factors `F_i` satisfying `F_i F_i^T = M_i`, and caller-supplied strength `alpha`, the joint model is

`Sigma_alpha = (1-alpha) blockdiag(M_i) + alpha F F^T`.

Equivalently, `x_i = sqrt(1-alpha) epsilon_i + sqrt(alpha) F_i z`, with independent local noise `epsilon_i ~ N(0,M_i)` and one shared latent `z ~ N(0,I)`. Thus every complete `D x D` marginal block is preserved exactly; only cross-group covariance changes.

## Added

- `BlockSharedGaussianCovariance` with validated immutable inputs;
- block-Woodbury solves, determinant-lemma log determinants, Gaussian quadratic forms/NLL, cross-covariance access, dense validation materialization, and direct sampling;
- explicit rejection of precision operations at a potentially singular `alpha=1` endpoint rather than hidden jitter;
- independent dense-algebra, Monte Carlo moment, invalid-input, immutability, and storage tests;
- a source-hashed no-clobber designed control and focused hosted workflow;
- derivation, complexity, integration boundary, and paper-scale storage documentation.

For `N=2048`, block dimension `D=3`, and shared rank `R=7`, the retained float64 blocks and factor require 491,520 bytes versus 301,989,888 bytes for a dense `6144 x 6144` covariance: a 614.4-fold storage reduction. This is an algebraic storage comparison, not an end-to-end timing claim.

## Relationship to DOT

The current R01-R03 source study selected `alpha=0.85` while holding means and marginal variances fixed. The independent R04-R10 confirmation remains frozen and executes separately. This PR does not alter its alpha, provider, data, comparators, bootstrap rule, or information order.

The earlier source controls also found that CUT3R restart disagreement is spatially structured but harmful when inserted as a deterministic mean correction. The latent model formalizes the narrower covariance interpretation: partly shared epistemic uncertainty plus group-local uncertainty.

## Boundaries

The caller must supply and justify the shared factor and dependence strength. This implementation does not fit alpha, infer a gauge, authorize held-out access, or establish calibration, BayesianPhysTwin benefit, Causal4D benefit, safety, or state of the art. The fully shared endpoint may be rank deficient; singular Gaussian scoring remains caller-owned.