### PR TITLE
Audit DOT R04-R10 multiview marker support

### DIFF
--- a/.github/workflows/dot-r04-r10-camera-support-audit-v1.yml
+++ b/.github/workflows/dot-r04-r10-camera-support-audit-v1.yml
@@ -1,0 +1,213 @@
+name: DOT R04-R10 camera support audit v1
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/dot-r04-r10-camera-support-audit-v1.yml"
+      - "scripts/science/audit_dot_r04_r10_camera_support.py"
+  push:
+    branches: [main]
+    paths:
+      - "protocols/execution_requests/dot_r04_r10_camera_support_audit_v1.json"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dot-r04-r10-camera-support-audit-v1-${{ github.ref }}-${{ github.sha }}
+  cancel-in-progress: false
+
+env:
+  REQUEST_PATH: protocols/execution_requests/dot_r04_r10_camera_support_audit_v1.json
+  DATASET_ROOT: /mnt/seagate10tb/florianpfaff/datasets/dot
+  ARCHIVE_NAME: R01-10.zip
+  ARCHIVE_MD5: ca546ff5f22c0279123ccb18509858ee
+
+jobs:
+  contract:
+    name: Validate R04-R10 camera audit control plane
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out reviewed revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+          clean: true
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Validate bounded diagnostic implementation
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m py_compile scripts/science/audit_dot_r04_r10_camera_support.py
+          python - <<'PY'
+          from pathlib import Path
+          text = Path("scripts/science/audit_dot_r04_r10_camera_support.py").read_text(encoding="utf-8")
+          required = [
+              'SEQUENCES = [f"R{i:02d}" for i in range(4, 11)]',
+              'ARCHIVE = "R01-10.zip"',
+              '"r11_r70_opened": False',
+              '"performance_metrics_computed": False',
+              '"frozen_r04_r10_result_reinterpreted": False',
+          ]
+          for needle in required:
+              if needle not in text:
+                  raise SystemExit(f"missing boundary: {needle}")
+          for forbidden in ("R11-20.zip", "R21-30.zip", "R31-40.zip", "R41-50.zip", "R51-60.zip", "R61-70.zip"):
+              if forbidden in text:
+                  raise SystemExit(f"target archive leaked into diagnostic: {forbidden}")
+          PY
+
+  authorize:
+    name: Authorize one immutable R04-R10 diagnostic request
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      head_sha: ${{ steps.request.outputs.head_sha }}
+      request_id: ${{ steps.request.outputs.request_id }}
+    steps:
+      - name: Check out exact merged revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 2
+          persist-credentials: false
+          clean: true
+      - name: Require exactly one bounded request-file change
+        id: request
+        shell: bash
+        env:
+          EVENT_REF: ${{ github.ref }}
+          EVENT_BEFORE: ${{ github.event.before }}
+          EVENT_AFTER: ${{ github.event.after }}
+          EVENT_FORCED: ${{ github.event.forced }}
+          EVENT_DELETED: ${{ github.event.deleted }}
+        run: |
+          set -euo pipefail
+          test "$EVENT_REF" = "refs/heads/main"
+          test "$EVENT_AFTER" = "$(git rev-parse HEAD)"
+          test "$EVENT_FORCED" = "false"
+          test "$EVENT_DELETED" = "false"
+          test "$EVENT_BEFORE" != "0000000000000000000000000000000000000000"
+          mapfile -t changed < <(git diff --name-only "$EVENT_BEFORE" "$EVENT_AFTER" | sort)
+          if [[ ${#changed[@]} -ne 1 || "${changed[0]}" != "$REQUEST_PATH" ]]; then
+            printf 'Expected only %s; changed paths were:\n' "$REQUEST_PATH" >&2
+            printf '  %s\n' "${changed[@]}" >&2
+            exit 2
+          fi
+          REQUEST="$REQUEST_PATH" EVENT_AFTER="$EVENT_AFTER" python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          path = Path(os.environ["REQUEST"])
+          value = json.loads(path.read_text(encoding="utf-8"))
+          expected = {
+              "schema",
+              "schema_version",
+              "request_id",
+              "sequences",
+              "archive",
+              "r11_r70_opened",
+              "performance_metrics_computed",
+              "frozen_r04_r10_result_reinterpreted",
+          }
+          if set(value) != expected:
+              raise SystemExit("diagnostic request fields changed")
+          if value["schema"] != "prob4d.dot-r04-r10-camera-support-audit-request" or value["schema_version"] != 1:
+              raise SystemExit("diagnostic request schema changed")
+          if value["sequences"] != [f"R{i:02d}" for i in range(4, 11)]:
+              raise SystemExit("diagnostic sequence boundary changed")
+          if value["archive"] != "R01-10.zip":
+              raise SystemExit("diagnostic archive changed")
+          for key in (
+              "r11_r70_opened",
+              "performance_metrics_computed",
+              "frozen_r04_r10_result_reinterpreted",
+          ):
+              if value[key] is not False:
+                  raise SystemExit(f"{key} exceeds the diagnostic boundary")
+          unsigned = dict(value)
+          request_id = unsigned.pop("request_id")
+          encoded = json.dumps(unsigned, sort_keys=True, separators=(",", ":")).encode()
+          if hashlib.sha256(encoded).hexdigest() != request_id:
+              raise SystemExit("diagnostic request identity mismatch")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"head_sha={os.environ['EVENT_AFTER']}\n")
+              output.write(f"request_id={request_id}\n")
+          PY
+
+  audit:
+    name: Audit already-open R04-R10 camera visibility support
+    if: github.event_name == 'push'
+    needs: authorize
+    environment: trusted-self-hosted-validation
+    runs-on: [self-hosted, Linux, X64, gpuserver4090]
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Require intended runner and official R01-R10 archive only
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$RUNNER_NAME" = "workstation1"
+          test "$RUNNER_OS" = "Linux"
+          test "$RUNNER_ARCH" = "X64"
+          test -d "$DATASET_ROOT"
+          test ! -L "$DATASET_ROOT"
+          test -f "$DATASET_ROOT/$ARCHIVE_NAME"
+          printf '%s  %s\n' "$ARCHIVE_MD5" "$DATASET_ROOT/$ARCHIVE_NAME" | md5sum --check --strict
+      - name: Check out exact authorized revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.authorize.outputs.head_sha }}
+          persist-credentials: false
+          clean: true
+      - name: Run support-only multiview diagnostic
+        id: audit
+        shell: bash
+        run: |
+          set -euo pipefail
+          out="$RUNNER_TEMP/dot-r04-r10-camera-support-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}.json"
+          summary=$(python scripts/science/audit_dot_r04_r10_camera_support.py \
+            --dataset-root "$DATASET_ROOT" \
+            --output "$out")
+          echo "$summary"
+          RESULT="$out" python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          value = json.loads(Path(os.environ["RESULT"]).read_text(encoding="utf-8"))
+          boundary = value["scientific_boundary"]
+          if boundary["r11_r70_opened"] is not False:
+              raise SystemExit("diagnostic crossed R11-R70 boundary")
+          if boundary["performance_metrics_computed"] is not False:
+              raise SystemExit("diagnostic computed performance")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"result={os.environ['RESULT']}\n")
+              output.write(f"decision={value['decision']}\n")
+              output.write(f"audit_id={value['audit_id']}\n")
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as summary_file:
+              summary_file.write(f"Decision: `{value['decision']}`\n\n")
+              summary_file.write(f"Audit ID: `{value['audit_id']}`\n\n")
+              summary_file.write(f"Cameras: `{value['dataset']['cameras_present_on_every_sequence']}`\n\n")
+              summary_file.write(f"Fixed-camera feasible: `{value['fixed_camera_feasible_candidates']}`\n\n")
+              summary_file.write(f"Multiview feasible modes: `{value['multiview_feasible_coordinate_modes']}`\n")
+          PY
+      - name: Upload bounded support audit
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4.6.2
+        with:
+          name: dot-r04-r10-camera-support-${{ needs.authorize.outputs.request_id }}
+          path: ${{ steps.audit.outputs.result }}
+          if-no-files-found: error
+          retention-days: 90

--- a/scripts/science/audit_dot_r04_r10_camera_support.py
+++ b/scripts/science/audit_dot_r04_r10_camera_support.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+"""Audit camera/visibility support on already-open DOT R04-R10 only."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import re
+import zipfile
+from collections import Counter
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+SEQUENCES = [f"R{i:02d}" for i in range(4, 11)]
+FRAMES = list(range(1, 8))
+ARCHIVE = "R01-10.zip"
+ARCHIVE_MD5 = "ca546ff5f22c0279123ccb18509858ee"
+CAMERA_RE = re.compile(
+    r"^(R(?:0[4-9]|10))/images/normal_view/frame(\d{6})_(cam\d+)\.jpg$"
+)
+NUMBER = re.compile(r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?")
+
+
+def numeric_rows(text: str) -> list[list[float]]:
+    rows: list[list[float]] = []
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        values = [float(match.group(0)) for match in NUMBER.finditer(line)]
+        if values:
+            rows.append(values)
+    return rows
+
+
+def jpeg_size(blob: bytes) -> tuple[int, int]:
+    if len(blob) < 4 or blob[:2] != b"\xff\xd8":
+        raise ValueError("normal-view payload is not a JPEG")
+    offset = 2
+    sof = {
+        0xC0,
+        0xC1,
+        0xC2,
+        0xC3,
+        0xC5,
+        0xC6,
+        0xC7,
+        0xC9,
+        0xCA,
+        0xCB,
+        0xCD,
+        0xCE,
+        0xCF,
+    }
+    while offset + 4 <= len(blob):
+        if blob[offset] != 0xFF:
+            offset += 1
+            continue
+        while offset < len(blob) and blob[offset] == 0xFF:
+            offset += 1
+        if offset >= len(blob):
+            break
+        marker = blob[offset]
+        offset += 1
+        if marker in {0xD8, 0xD9} or 0xD0 <= marker <= 0xD7:
+            continue
+        if offset + 2 > len(blob):
+            break
+        length = int.from_bytes(blob[offset : offset + 2], "big")
+        if length < 2 or offset + length > len(blob):
+            raise ValueError("malformed JPEG segment")
+        if marker in sof:
+            if length < 7:
+                raise ValueError("malformed JPEG SOF")
+            height = int.from_bytes(blob[offset + 3 : offset + 5], "big")
+            width = int.from_bytes(blob[offset + 5 : offset + 7], "big")
+            if width <= 0 or height <= 0:
+                raise ValueError("invalid JPEG dimensions")
+            return width, height
+        offset += length
+    raise ValueError("JPEG dimensions unavailable")
+
+
+def md5(path: Path) -> str:
+    digest = hashlib.md5(usedforsecurity=False)
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def member(sequence: str, dimension: int, frame: int, camera: str) -> str:
+    return f"{sequence}/coordinates/{dimension}d/frame{frame:06d}_{camera}.txt"
+
+
+def image_member(sequence: str, frame: int, camera: str) -> str:
+    return f"{sequence}/images/normal_view/frame{frame:06d}_{camera}.jpg"
+
+
+def finite_pair(row: list[float]) -> tuple[float, float] | None:
+    if len(row) < 2:
+        return None
+    x, y = float(row[-2]), float(row[-1])
+    if not (math.isfinite(x) and math.isfinite(y)):
+        return None
+    return x, y
+
+
+def valid_indices(rows: list[list[float]], width: int, height: int, mode: str) -> set[int]:
+    result: set[int] = set()
+    for idx, row in enumerate(rows):
+        pair = finite_pair(row)
+        if pair is None:
+            continue
+        x, y = pair
+        if mode == "pixel-zero-based":
+            valid = 0.0 <= x <= width - 1.0 and 0.0 <= y <= height - 1.0
+        elif mode == "pixel-one-based":
+            valid = 1.0 <= x <= width and 1.0 <= y <= height
+        elif mode == "swapped-pixel-zero-based":
+            valid = 0.0 <= y <= width - 1.0 and 0.0 <= x <= height - 1.0
+        elif mode == "swapped-pixel-one-based":
+            valid = 1.0 <= y <= width and 1.0 <= x <= height
+        elif mode == "unit-normalized":
+            valid = 0.0 <= x <= 1.0 and 0.0 <= y <= 1.0
+        elif mode == "percent-normalized":
+            valid = 0.0 <= x <= 100.0 and 0.0 <= y <= 100.0
+        else:
+            raise ValueError(mode)
+        if valid:
+            result.add(idx)
+    return result
+
+
+def compact_pair(pair: tuple[float, float]) -> str:
+    return f"{pair[0]:.6g},{pair[1]:.6g}"
+
+
+def readme_evidence(dataset_root: Path) -> dict[str, Any]:
+    candidates = [dataset_root / "A_Read_Me.txt", dataset_root / "A_Readme.txt"]
+    for path in candidates:
+        if path.is_file() and not path.is_symlink():
+            raw = path.read_bytes()
+            text = raw.decode("utf-8", errors="replace")
+            terms = ("marker", "coordinate", "camera", "visible", "visibility", "2d", "image")
+            lines = [
+                line.strip()
+                for line in text.splitlines()
+                if any(term in line.lower() for term in terms)
+            ][:80]
+            return {
+                "present": True,
+                "path": path.name,
+                "sha256": hashlib.sha256(raw).hexdigest(),
+                "relevant_lines": lines,
+            }
+    return {"present": False, "relevant_lines": []}
+
+
+def pooled(counts: dict[int, int]) -> dict[str, int | bool]:
+    overlap = [counts.get(frame, 0) for frame in (3, 4, 5)]
+    fit_a = [counts.get(frame, 0) for frame in (1, 2)]
+    fit_b = [counts.get(frame, 0) for frame in (6, 7)]
+    out: dict[str, int | bool] = {
+        "overlap_total": sum(overlap),
+        "overlap_nonempty_frames": sum(value > 0 for value in overlap),
+        "fit_a_total": sum(fit_a),
+        "fit_b_total": sum(fit_b),
+    }
+    out["registered_support_feasible"] = bool(
+        int(out["overlap_total"]) >= 6
+        and int(out["overlap_nonempty_frames"]) >= 2
+        and int(out["fit_a_total"]) >= 6
+        and int(out["fit_b_total"]) >= 6
+    )
+    return out
+
+
+def audit(dataset_root: Path) -> dict[str, Any]:
+    root = dataset_root.expanduser().resolve(strict=True)
+    if root.is_symlink() or not root.is_dir():
+        raise ValueError("dataset root must be a real directory")
+    archive_path = (root / ARCHIVE).resolve(strict=True)
+    archive_path.relative_to(root)
+    if archive_path.is_symlink() or not archive_path.is_file():
+        raise ValueError("official R01-10 archive unavailable")
+    if md5(archive_path) != ARCHIVE_MD5:
+        raise ValueError("R01-10 archive checksum mismatch")
+
+    modes = (
+        "pixel-zero-based",
+        "pixel-one-based",
+        "swapped-pixel-zero-based",
+        "swapped-pixel-one-based",
+        "unit-normalized",
+        "percent-normalized",
+    )
+    per_frame: dict[str, Any] = {}
+    support: dict[str, dict[str, dict[str, dict[int, set[int]]]]] = {}
+    cameras_by_sequence: dict[str, set[str]] = {sequence: set() for sequence in SEQUENCES}
+    three_d_hashes: dict[str, dict[int, dict[str, str]]] = {
+        sequence: {frame: {} for frame in FRAMES} for sequence in SEQUENCES
+    }
+
+    with zipfile.ZipFile(archive_path, "r") as archive:
+        names = set(archive.namelist())
+        for name in names:
+            match = CAMERA_RE.match(name)
+            if match:
+                sequence, frame_text, camera = match.groups()
+                if int(frame_text) in FRAMES:
+                    cameras_by_sequence[sequence].add(camera)
+
+        common_cameras = set.intersection(*(value for value in cameras_by_sequence.values()))
+        if not common_cameras:
+            raise ValueError("no camera is present across R04-R10")
+        cameras = sorted(common_cameras)
+
+        for sequence in SEQUENCES:
+            support[sequence] = {}
+            for camera in cameras:
+                support[sequence][camera] = {mode: {} for mode in modes}
+                for frame in FRAMES:
+                    image_name = image_member(sequence, frame, camera)
+                    two_name = member(sequence, 2, frame, camera)
+                    three_name = member(sequence, 3, frame, camera)
+                    for path in (image_name, two_name, three_name):
+                        pure = PurePosixPath(path)
+                        if pure.is_absolute() or ".." in pure.parts or path not in names:
+                            raise ValueError(f"registered payload missing: {path}")
+                    width, height = jpeg_size(archive.read(image_name))
+                    raw_2d = archive.read(two_name)
+                    raw_3d = archive.read(three_name)
+                    rows_2d = numeric_rows(raw_2d.decode("utf-8", errors="replace"))
+                    rows_3d = numeric_rows(raw_3d.decode("utf-8", errors="replace"))
+                    count = min(len(rows_2d), len(rows_3d))
+                    rows_2d = rows_2d[:count]
+                    rows_3d = rows_3d[:count]
+                    three_d_hashes[sequence][frame][camera] = hashlib.sha256(raw_3d).hexdigest()
+                    counts: dict[str, int] = {}
+                    for mode in modes:
+                        indices = valid_indices(rows_2d, width, height, mode)
+                        support[sequence][camera][mode][frame] = indices
+                        counts[mode] = len(indices)
+                    finite_pairs = [pair for row in rows_2d if (pair := finite_pair(row)) is not None]
+                    repeated = Counter(compact_pair(pair) for pair in finite_pairs)
+                    sentinels = [
+                        {"value": value, "count": occurrences}
+                        for value, occurrences in repeated.most_common(8)
+                        if occurrences >= 2
+                    ]
+                    per_frame[f"{sequence}:{camera}:{frame:06d}"] = {
+                        "image_size": [width, height],
+                        "rows_2d": len(rows_2d),
+                        "rows_3d": len(rows_3d),
+                        "paired_rows": count,
+                        "support_by_coordinate_hypothesis": counts,
+                        "repeated_coordinate_pairs": sentinels,
+                        "x_range": (
+                            [min(pair[0] for pair in finite_pairs), max(pair[0] for pair in finite_pairs)]
+                            if finite_pairs
+                            else None
+                        ),
+                        "y_range": (
+                            [min(pair[1] for pair in finite_pairs), max(pair[1] for pair in finite_pairs)]
+                            if finite_pairs
+                            else None
+                        ),
+                    }
+
+    cameras = sorted(set.intersection(*(value for value in cameras_by_sequence.values())))
+    camera_summary: dict[str, Any] = {}
+    for camera in cameras:
+        mode_summary: dict[str, Any] = {}
+        for mode in modes:
+            sequence_summary = {}
+            for sequence in SEQUENCES:
+                counts = {frame: len(support[sequence][camera][mode][frame]) for frame in FRAMES}
+                sequence_summary[sequence] = {
+                    "per_frame": {str(frame): counts[frame] for frame in FRAMES},
+                    "pooled": pooled(counts),
+                }
+            mode_summary[mode] = {
+                "all_sequences_feasible": all(
+                    value["pooled"]["registered_support_feasible"]
+                    for value in sequence_summary.values()
+                ),
+                "minimum_fit_a_total": min(
+                    int(value["pooled"]["fit_a_total"]) for value in sequence_summary.values()
+                ),
+                "minimum_fit_b_total": min(
+                    int(value["pooled"]["fit_b_total"]) for value in sequence_summary.values()
+                ),
+                "sequences": sequence_summary,
+            }
+        camera_summary[camera] = mode_summary
+
+    multiview: dict[str, Any] = {}
+    for mode in modes:
+        sequence_summary = {}
+        for sequence in SEQUENCES:
+            counts: dict[int, int] = {}
+            for frame in FRAMES:
+                union: set[int] = set()
+                for camera in cameras:
+                    union |= support[sequence][camera][mode][frame]
+                counts[frame] = len(union)
+            sequence_summary[sequence] = {
+                "per_frame_union": {str(frame): counts[frame] for frame in FRAMES},
+                "pooled": pooled(counts),
+            }
+        multiview[mode] = {
+            "all_sequences_feasible": all(
+                value["pooled"]["registered_support_feasible"]
+                for value in sequence_summary.values()
+            ),
+            "sequences": sequence_summary,
+        }
+
+    three_d_consistency = {
+        sequence: {
+            str(frame): len(set(three_d_hashes[sequence][frame].values())) == 1
+            for frame in FRAMES
+        }
+        for sequence in SEQUENCES
+    }
+    fixed = [
+        {"camera": camera, "mode": mode}
+        for camera in cameras
+        for mode in modes
+        if camera_summary[camera][mode]["all_sequences_feasible"]
+    ]
+    multiview_feasible = [mode for mode in modes if multiview[mode]["all_sequences_feasible"]]
+    cam001_pixel0 = (
+        camera_summary.get("cam001", {})
+        .get("pixel-zero-based", {})
+        .get("all_sequences_feasible", False)
+    )
+    if fixed:
+        decision = "fixed-camera-support-available"
+    elif multiview_feasible:
+        decision = "multiview-support-available"
+    elif not cam001_pixel0 and any(
+        camera_summary.get("cam001", {}).get(mode, {}).get("all_sequences_feasible", False)
+        for mode in modes
+        if mode != "pixel-zero-based"
+    ):
+        decision = "cam001-coordinate-semantics-mismatch"
+    else:
+        decision = "support-remains-insufficient-or-ambiguous"
+
+    result = {
+        "schema": "prob4d.dot-r04-r10-camera-support-audit",
+        "schema_version": 1,
+        "decision": decision,
+        "scientific_boundary": {
+            "sequences_opened": SEQUENCES,
+            "r11_r70_opened": False,
+            "performance_metrics_computed": False,
+            "frozen_r04_r10_result_reinterpreted": False,
+        },
+        "dataset": {
+            "archive": ARCHIVE,
+            "archive_md5": ARCHIVE_MD5,
+            "cameras_present_on_every_sequence": cameras,
+        },
+        "readme": readme_evidence(root),
+        "cross_camera_3d_payload_identical": three_d_consistency,
+        "fixed_camera_feasible_candidates": fixed,
+        "multiview_feasible_coordinate_modes": multiview_feasible,
+        "camera_summary": camera_summary,
+        "multiview_union_summary": multiview,
+        "per_frame_diagnostics": per_frame,
+    }
+    encoded = json.dumps(result, sort_keys=True, separators=(",", ":"), allow_nan=False).encode()
+    result["audit_id"] = hashlib.sha256(encoded).hexdigest()
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dataset-root", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    result = audit(args.dataset_root)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(result, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+    print(
+        json.dumps(
+            {
+                "decision": result["decision"],
+                "audit_id": result["audit_id"],
+                "cameras": result["dataset"]["cameras_present_on_every_sequence"],
+                "fixed_camera_feasible_candidates": result["fixed_camera_feasible_candidates"],
+                "multiview_feasible_coordinate_modes": result[
+                    "multiview_feasible_coordinate_modes"
+                ],
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/science/audit_dot_r04_r10_camera_support.py
+++ b/scripts/science/audit_dot_r04_r10_camera_support.py
@@ -244,7 +244,9 @@ def audit(dataset_root: Path) -> dict[str, Any]:
                         indices = valid_indices(rows_2d, width, height, mode)
                         support[sequence][camera][mode][frame] = indices
                         counts[mode] = len(indices)
-                    finite_pairs = [pair for row in rows_2d if (pair := finite_pair(row)) is not None]
+                    finite_pairs = [
+                        pair for row in rows_2d if (pair := finite_pair(row)) is not None
+                    ]
                     repeated = Counter(compact_pair(pair) for pair in finite_pairs)
                     sentinels = [
                         {"value": value, "count": occurrences}
@@ -259,12 +261,18 @@ def audit(dataset_root: Path) -> dict[str, Any]:
                         "support_by_coordinate_hypothesis": counts,
                         "repeated_coordinate_pairs": sentinels,
                         "x_range": (
-                            [min(pair[0] for pair in finite_pairs), max(pair[0] for pair in finite_pairs)]
+                            [
+                                min(pair[0] for pair in finite_pairs),
+                                max(pair[0] for pair in finite_pairs),
+                            ]
                             if finite_pairs
                             else None
                         ),
                         "y_range": (
-                            [min(pair[1] for pair in finite_pairs), max(pair[1] for pair in finite_pairs)]
+                            [
+                                min(pair[1] for pair in finite_pairs),
+                                max(pair[1] for pair in finite_pairs),
+                            ]
                             if finite_pairs
                             else None
                         ),

--- a/tests/test_trusted_self_hosted_validation_policy.py
+++ b/tests/test_trusted_self_hosted_validation_policy.py
@@ -2,8 +2,8 @@
 
 The historical policy implementation is retained byte-for-byte in the adjacent
 non-test module. This wrapper adds the separately reviewed DOT R11--R30,
-DOT R04--R10 recovery/relay, and Tracking-Cloth query-portfolio workflows
-before exposing the original test functions to pytest.
+DOT R04--R10 recovery/relay/camera-audit, and Tracking-Cloth query-portfolio
+workflows before exposing the original test functions to pytest.
 """
 
 from __future__ import annotations
@@ -29,6 +29,9 @@ DOT_ROPE_R04_R10_ARCHIVE_RECOVERY_V2_WORKFLOW = (
 DOT_ROPE_R04_R10_HOSTED_ARCHIVE_RELAY_WORKFLOW = (
     POLICY.WORKFLOW_ROOT / "relay-dot-r04-r10-archive-v1.yml"
 )
+DOT_R04_R10_CAMERA_SUPPORT_AUDIT_WORKFLOW = (
+    POLICY.WORKFLOW_ROOT / "dot-r04-r10-camera-support-audit-v1.yml"
+)
 TRACKING_CLOTH_QUERY_PORTFOLIO_WORKFLOW = (
     POLICY.WORKFLOW_ROOT / "tracking-cloth-query-portfolio-v1.yml"
 )
@@ -37,6 +40,7 @@ POLICY.TRUSTED_SELF_HOSTED_WORKFLOWS = (
     DOT_ROPE_QUERY_SELECTIVE_HELDOUT_WORKFLOW,
     DOT_ROPE_R04_R10_ARCHIVE_RECOVERY_V2_WORKFLOW,
     DOT_ROPE_R04_R10_HOSTED_ARCHIVE_RELAY_WORKFLOW,
+    DOT_R04_R10_CAMERA_SUPPORT_AUDIT_WORKFLOW,
     TRACKING_CLOTH_QUERY_PORTFOLIO_WORKFLOW,
 )
 


### PR DESCRIPTION
## Objective

Explain the registered R04-R10 `heldout-support-negative` result without rerunning, relaxing, or reinterpreting that frozen scientific experiment.

The diagnostic asks whether the support bottleneck is specific to the frozen `cam001` view, a simple coordinate convention mismatch, or persists even under a support-only multiview union.

## Scientific boundary

- opens only already-open R04-R10 payloads from the checksum-bound official `R01-10.zip`;
- does not open R11-R70;
- computes no tracking/reconstruction performance metric;
- does not rerun CUT3R or alter the frozen R04-R10 result;
- does not select target-side hyperparameters;
- execution is main-only through a later one-file request commit;
- self-hosted execution requires `[self-hosted, Linux, X64, gpuserver4090]` and runner name `workstation1`.

## Diagnostic

For every camera present in all R04-R10 sequences and frames 1-7, the audit reads normal-view JPEG dimensions and corresponding 2-D/3-D marker rows. It reports support under frozen/finite coordinate hypotheses, repeated sentinel-like coordinate pairs, fixed-camera pooled support, and a row-identity multiview union. It also checks whether per-camera 3-D payloads are identical and records relevant local dataset README lines when available.

A fixed camera or multiview support-positive result motivates a *new* held-out protocol; it does not rescue the already terminal confirmation.
