### PR TITLE
Fetch full history for DOT recovery authorization

### DIFF
--- a/.github/workflows/dot-r04-r10-evaluation-recovery-v2.yml
+++ b/.github/workflows/dot-r04-r10-evaluation-recovery-v2.yml
@@ -11,6 +11,7 @@ on:
   push:
     branches: [main]
     paths:
+      - ".github/workflows/dot-r04-r10-evaluation-recovery-v2.yml"
       - "protocols/execution_requests/dot_r04_r10_evaluation_recovery_v2.json"
 
 permissions:
@@ -152,6 +153,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.sha }}
+          fetch-depth: 0
           persist-credentials: false
           clean: true
 


### PR DESCRIPTION
## Closed as superseded

This two-line checkout-history fix was technically correct, but a separate completed frozen run already produced and independently verified the terminal R04–R10 scientific outcome:

- run `33501330668`;
- decision `heldout-support-negative`;
- result ID `531272d64eee29f26321030b236db9bd6ae3aadb7e16a1f492ac8140afc801ee`;
- reason: pooled provider/truth support below the registered minimum.

PR #448 records that scientific outcome, and PRs #453/#454 establish the bounded multiview diagnosis and clean R11–R20 source-support continuation. Replaying the already terminal R04–R10 evaluator would add no scientific evidence, so this PR is closed without merge.

No provider rerun, marker download, evaluator execution, or scientific input change occurred through this hotfix branch.