### PR TITLE
Recover frozen DOT R11–R20 source support on gpuserver6000

### DIFF
--- a/.github/workflows/dot-rope-query-selective-source-support-v2-gpuserver6000-recovery.yml
+++ b/.github/workflows/dot-rope-query-selective-source-support-v2-gpuserver6000-recovery.yml
@@ -1,0 +1,836 @@
+name: DOT rope source support v2 gpuserver6000 recovery
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/dot-rope-query-selective-source-support-v2-gpuserver6000-recovery.yml"
+      - "CHANGELOG.d/dot-r11-r20-source-support-gpuserver6000-recovery.md"
+      - "scripts/science/materialize_verified_dot_archives.py"
+      - "scripts/science/run_dot_rope_query_selective_source_support_v2_recovery.py"
+      - "tests/test_materialize_verified_dot_archives.py"
+      - "tests/test_dot_rope_query_selective_source_support_v2_recovery.py"
+      - "tests/test_trusted_self_hosted_validation_policy.py"
+  push:
+    branches: [main]
+    paths:
+      - "protocols/execution_requests/dot_rope_query_selective_source_support_v2_gpuserver6000.json"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dot-rope-source-support-v2-gpuserver6000-recovery
+  cancel-in-progress: false
+
+env:
+  REQUEST_PATH: protocols/execution_requests/dot_rope_query_selective_source_support_v2_gpuserver6000.json
+  PROTOCOL_PATH: protocols/dot-rope-query-selective-source-support-v2.json
+  SOURCE_ARCHIVE: R11-20.zip
+  SOURCE_MD5: 23ce3e7067465d3edabe20b4c7cfa388
+  DATASET_API: https://dataverse.orc.gmu.edu/api/datasets/:persistentId/?persistentId=doi:10.13021/ORC2020/XXLVXM
+  DATAFILE_API_ROOT: https://dataverse.orc.gmu.edu/api/access/datafile
+  DATASET_CACHE_ROOT: /home/github-runner/.cache/prob4d/dot-r11-r20-source-support-v2-gpuserver6000/dot-v29
+  RUNTIME_CACHE_ROOT: /home/github-runner/.cache/prob4d/dot-r11-r20-source-support-v2-gpuserver6000/runtime
+  CUT3R_REVISION: 8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf
+  CUT3R_CHECKPOINT_SHA256: 45f7e98a0a64dbeb54901ae2b878cd8cd125f20a4497316483f0bd6f109f8103
+  CUT3R_CHECKPOINT_GDRIVE_ID: 1Asz-ZB3FfpzZYwunhQvNPZEUA8XUNAYD
+  ORIGINAL_RUN_ID: "33522102387"
+  ORIGINAL_HEAD_SHA: d8df21b4902f18ec48701804364495ee7c167495
+  ORIGINAL_WORKFLOW_PATH: .github/workflows/dot-rope-query-selective-source-support-v2-execute.yml
+  ORIGINAL_PROVIDER_JOB: Seal marker-free R11-R20 CUT3R predictions
+  CUROPE_PATCH_BLOB: 9127464c77b571b9586144cabe24a4eed8667db0
+  CUROPE_PATCH_SHA256: 9778ec434a6e2d9ae8be162295d60e06d86bf0fbadbb66d516eb46c666ab547d
+  CUROPE_KERNELS_BLOB: 7156cd1bb935cb1f0be45e58add53f9c21505c20
+  CUROPE_SETUP_BLOB: 02ddb0912370a67a49fd2bb91164cf2f1da8648e
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONHASHSEED: "0"
+  PYTHONUNBUFFERED: "1"
+  PYTHONDONTWRITEBYTECODE: "1"
+  OMP_NUM_THREADS: "1"
+  OPENBLAS_NUM_THREADS: "1"
+  MKL_NUM_THREADS: "1"
+  NUMEXPR_NUM_THREADS: "1"
+
+jobs:
+  contract:
+    name: Validate source-support recovery control plane
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out exact reviewed revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+          clean: true
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Validate frozen science and operational recovery
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install -e ".[dev]"
+          python -m pip check
+          python -m ruff check \
+            scripts/science/materialize_verified_dot_archives.py \
+            scripts/science/run_dot_rope_query_selective_source_support_v2_recovery.py \
+            tests/test_materialize_verified_dot_archives.py \
+            tests/test_dot_rope_query_selective_source_support_v2_recovery.py \
+            tests/test_trusted_self_hosted_validation_policy.py
+          python -m ruff format --check \
+            scripts/science/materialize_verified_dot_archives.py \
+            scripts/science/run_dot_rope_query_selective_source_support_v2_recovery.py \
+            tests/test_materialize_verified_dot_archives.py \
+            tests/test_dot_rope_query_selective_source_support_v2_recovery.py \
+            tests/test_trusted_self_hosted_validation_policy.py
+          python -m pytest -q \
+            tests/test_materialize_verified_dot_archives.py \
+            tests/test_dot_rope_query_selective_source_support_v2.py \
+            tests/test_dot_rope_query_selective_source_support_v2_recovery.py \
+            tests/test_trusted_self_hosted_validation_policy.py \
+            tests/test_github_action_pins.py
+          python -m compileall -q \
+            scripts/science/materialize_verified_dot_archives.py \
+            scripts/science/run_dot_rope_query_selective_source_support_v2_recovery.py
+
+  authorize:
+    name: Authorize recovery and retire untouched predecessor
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      actions: write
+    outputs:
+      request_id: ${{ steps.request.outputs.request_id }}
+      head_sha: ${{ steps.request.outputs.head_sha }}
+      protocol_git_blob_sha: ${{ steps.request.outputs.protocol_git_blob_sha }}
+    steps:
+      - name: Check out exact merged revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 2
+          persist-credentials: false
+          clean: true
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Require one immutable recovery request
+        id: request
+        shell: bash
+        env:
+          EVENT_REF: ${{ github.ref }}
+          EVENT_BEFORE: ${{ github.event.before }}
+          EVENT_AFTER: ${{ github.event.after }}
+          EVENT_FORCED: ${{ github.event.forced }}
+          EVENT_DELETED: ${{ github.event.deleted }}
+        run: |
+          set -euo pipefail
+          test "$EVENT_REF" = "refs/heads/main"
+          test "$EVENT_AFTER" = "$(/usr/bin/git rev-parse HEAD)"
+          test "$EVENT_FORCED" = "false"
+          test "$EVENT_DELETED" = "false"
+          test "$EVENT_BEFORE" != "0000000000000000000000000000000000000000"
+          mapfile -t changed < <(
+            /usr/bin/git diff --name-only "$EVENT_BEFORE" "$EVENT_AFTER" | sort
+          )
+          if [[ ${#changed[@]} -ne 1 || "${changed[0]}" != "$REQUEST_PATH" ]]; then
+            printf 'Expected only %s; changed paths were:\n' "$REQUEST_PATH" >&2
+            printf '  %s\n' "${changed[@]}" >&2
+            exit 2
+          fi
+          protocol_blob=$(/usr/bin/git rev-parse "$EVENT_AFTER:$PROTOCOL_PATH")
+          python -m pip install -e .
+          validation=$(
+            python \
+              scripts/science/run_dot_rope_query_selective_source_support_v2_recovery.py \
+              validate-request \
+              --request "$REQUEST_PATH" \
+              --protocol "$PROTOCOL_PATH" \
+              --protocol-git-blob-sha "$protocol_blob"
+          )
+          VALIDATION="$validation" PROTOCOL_BLOB="$protocol_blob" \
+            EVENT_AFTER="$EVENT_AFTER" python - <<'PY'
+          import json
+          import os
+
+          value = json.loads(os.environ["VALIDATION"])
+          outputs = {
+              "request_id": value["request_id"],
+              "head_sha": os.environ["EVENT_AFTER"],
+              "protocol_git_blob_sha": os.environ["PROTOCOL_BLOB"],
+          }
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              for key, item in outputs.items():
+                  output.write(f"{key}={item}\n")
+          PY
+      - name: Prove old provider stayed unopened, then cancel it
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from __future__ import annotations
+
+          import json
+          import os
+          import time
+          import urllib.request
+
+          api = os.environ["GITHUB_API_URL"]
+          repository = os.environ["GITHUB_REPOSITORY"]
+          run_id = int(os.environ["ORIGINAL_RUN_ID"])
+          headers = {
+              "Accept": "application/vnd.github+json",
+              "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
+              "User-Agent": "Prob4D-DOT-source-support-recovery/1",
+              "X-GitHub-Api-Version": "2022-11-28",
+          }
+
+          def request(path: str, *, method: str = "GET"):
+              value = urllib.request.Request(
+                  f"{api}/repos/{repository}{path}",
+                  method=method,
+                  headers=headers,
+              )
+              with urllib.request.urlopen(value, timeout=30) as response:
+                  raw = response.read()
+              return json.loads(raw) if raw else None
+
+          def inspect():
+              run = request(f"/actions/runs/{run_id}")
+              if run["head_sha"] != os.environ["ORIGINAL_HEAD_SHA"]:
+                  raise SystemExit("predecessor head changed")
+              if run["path"] != os.environ["ORIGINAL_WORKFLOW_PATH"]:
+                  raise SystemExit("predecessor workflow changed")
+              if run["event"] != "push" or run["head_branch"] != "main":
+                  raise SystemExit("predecessor trigger changed")
+              jobs = request(f"/actions/runs/{run_id}/jobs?per_page=100")["jobs"]
+              matches = [
+                  job
+                  for job in jobs
+                  if job["name"] == os.environ["ORIGINAL_PROVIDER_JOB"]
+              ]
+              if len(matches) != 1:
+                  raise SystemExit("predecessor provider job is unavailable")
+              provider = matches[0]
+              artifacts = request(f"/actions/runs/{run_id}/artifacts?per_page=100")
+              untouched = (
+                  artifacts["total_count"] == 0
+                  and provider.get("conclusion") in (None, "cancelled")
+                  and provider.get("runner_id") in (None, 0)
+                  and not provider.get("runner_name")
+                  and not provider.get("steps")
+              )
+              if not untouched:
+                  raise SystemExit(
+                      "provider may have started; recovery is forbidden"
+                  )
+              return run, provider, artifacts
+
+          run, provider, artifacts = inspect()
+          if run["status"] in {"queued", "in_progress"}:
+              request(f"/actions/runs/{run_id}/cancel", method="POST")
+              for _ in range(60):
+                  time.sleep(2)
+                  run = request(f"/actions/runs/{run_id}")
+                  if run["status"] == "completed":
+                      break
+              else:
+                  raise SystemExit("predecessor did not cancel")
+          run, provider, artifacts = inspect()
+          if run["status"] != "completed" or run["conclusion"] != "cancelled":
+              raise SystemExit("predecessor is not an untouched cancellation")
+          print(
+              json.dumps(
+                  {
+                      "retired_run_id": run_id,
+                      "provider_steps": provider.get("steps") or [],
+                      "provider_runner_id": provider.get("runner_id"),
+                      "artifact_count": artifacts["total_count"],
+                  },
+                  sort_keys=True,
+              )
+          )
+          PY
+
+  provider:
+    name: Seal frozen R11-R20 provider on gpuserver6000
+    if: github.event_name == 'push'
+    needs: authorize
+    environment: trusted-self-hosted-validation
+    runs-on: [self-hosted, gpuserver6000]
+    timeout-minutes: 720
+    permissions:
+      contents: read
+    outputs:
+      provider_bundle_id: ${{ steps.identity.outputs.provider_bundle_id }}
+      provider_artifact_name: ${{ steps.identity.outputs.provider_artifact_name }}
+    steps:
+      - name: Bind intended GPU runner
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$RUNNER_NAME" = "workstation2"
+          test "$RUNNER_OS" = "Linux"
+          test "$RUNNER_ARCH" = "X64"
+          command -v nvidia-smi >/dev/null 2>&1
+          command -v c++ >/dev/null 2>&1
+          command -v curl >/dev/null 2>&1
+          nvidia-smi --query-gpu=name,driver_version,memory.total --format=csv,noheader
+      - name: Initialize isolated provider workspace
+        id: workspace
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${RUNNER_TEMP}/dot-source-v2-recovery-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          /usr/bin/rm -rf -- "$root"
+          /usr/bin/mkdir -p \
+            "$root/home" "$root/cache" "$root/tmp" "$root/evidence" \
+            "$root/provider"
+          echo "root=$root" >> "$GITHUB_OUTPUT"
+          {
+            echo "HOME=$root/home"
+            echo "XDG_CACHE_HOME=$root/cache"
+            echo "PIP_CACHE_DIR=$root/cache/pip"
+            echo "HF_HOME=$root/cache/huggingface"
+            echo "TMPDIR=$root/tmp"
+            echo "TORCH_EXTENSIONS_DIR=$root/cache/torch-extensions"
+            echo "WANDB_MODE=disabled"
+            echo "WANDB_DISABLED=true"
+          } >> "$GITHUB_ENV"
+      - name: Check out exact authorized Prob4D revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.authorize.outputs.head_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+          clean: true
+      - name: Verify clean exact Prob4D checkout
+        shell: bash
+        env:
+          EXPECTED_HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          test "$(/usr/bin/git rev-parse HEAD)" = "$EXPECTED_HEAD_SHA"
+          test -z "$(/usr/bin/git status --porcelain=v1 --untracked-files=all)"
+          test "$(/usr/bin/git rev-parse HEAD:$PROTOCOL_PATH)" = \
+            "${{ needs.authorize.outputs.protocol_git_blob_sha }}"
+      - name: Check out exact public CUT3R revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: CUT3R/CUT3R
+          ref: 8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf
+          path: external/CUT3R
+          fetch-depth: 1
+          persist-credentials: false
+          clean: true
+      - name: Set up bootstrap Python 3.11
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+      - name: Select or bootstrap a CUDA CUT3R interpreter
+        id: runtime
+        shell: bash
+        env:
+          RETAINED_CUT3R_CHECKOUT: ${{ vars.CUT3R_CHECKOUT }}
+          RETAINED_CUT3R_PYTHON: ${{ vars.CUT3R_PYTHON }}
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          candidates=("")
+          add_candidate() {
+            local candidate="${1:-}"
+            [[ -n "$candidate" ]] || return 0
+            local existing
+            for existing in "${candidates[@]}"; do
+              [[ "$existing" != "$candidate" ]] || return 0
+            done
+            candidates+=("$candidate")
+          }
+          add_candidate "${RETAINED_CUT3R_PYTHON:-}"
+          if [[ -n "${RETAINED_CUT3R_CHECKOUT:-}" ]]; then
+            add_candidate "$RETAINED_CUT3R_CHECKOUT/.venv/bin/python"
+          fi
+          add_candidate /home/florianpfaff/conda_envs/cut3r/bin/python
+          add_candidate /home/florianpfaff/miniconda3/envs/cut3r/bin/python
+          add_candidate /home/github-runner/.conda/envs/cut3r/bin/python
+          add_candidate /opt/conda/envs/cut3r/bin/python
+
+          usable=""
+          for candidate in "${candidates[@]}"; do
+            [[ -x "$candidate" ]] || continue
+            if "$candidate" - <<'PY'
+          import accelerate
+          import cv2
+          import einops
+          import h5py
+          import hydra
+          import lpips
+          import numpy
+          import PIL
+          import roma
+          import scipy
+          import sklearn
+          import torch
+          import torchvision
+          import transformers
+
+          if not torch.cuda.is_available():
+              raise SystemExit(1)
+          print(torch.__version__, torch.version.cuda, torch.cuda.get_device_name(0))
+          PY
+            then
+              usable="$candidate"
+              break
+            fi
+          done
+
+          if [[ -z "$usable" ]]; then
+            venv="$RUNTIME_CACHE_ROOT/venv"
+            /usr/bin/mkdir -p "$RUNTIME_CACHE_ROOT"
+            if [[ ! -x "$venv/bin/python" ]]; then
+              python -m venv "$venv"
+            fi
+            usable="$venv/bin/python"
+            "$usable" -m pip install \
+              "pip==25.2" "setuptools==80.9.0" "wheel==0.45.1"
+            "$usable" -m pip install \
+              torch==2.11.0 torchvision==0.26.0 \
+              --index-url https://download.pytorch.org/whl/cu126
+            filtered="$root/tmp/cut3r-requirements.txt"
+            python - external/CUT3R/requirements.txt "$filtered" <<'PY'
+          import re
+          import sys
+          from pathlib import Path
+
+          source = Path(sys.argv[1]).read_text(encoding="utf-8").splitlines()
+          kept = []
+          for line in source:
+              stripped = line.strip()
+              if re.match(
+                  r"^(torch|torchvision)(?:\s|[<>=!~].*)?$",
+                  stripped,
+                  flags=re.I,
+              ):
+                  continue
+              kept.append(line)
+          Path(sys.argv[2]).write_text("\n".join(kept) + "\n", encoding="utf-8")
+          PY
+            "$usable" -m pip install -r "$filtered" gdown==5.2.0
+            "$usable" -m pip check
+          fi
+          "$usable" - <<'PY'
+          import torch
+
+          if not torch.cuda.is_available():
+              raise SystemExit("selected CUT3R Python has no CUDA device")
+          print("selected_gpu", torch.cuda.get_device_name(0))
+          PY
+          echo "python=$usable" >> "$GITHUB_OUTPUT"
+      - name: Acquire exact CUT3R checkpoint without opening DOT
+        id: checkpoint
+        shell: bash
+        env:
+          RETAINED_CUT3R_CHECKPOINT: ${{ vars.CUT3R_CHECKPOINT }}
+        run: |
+          set -euo pipefail
+          /usr/bin/mkdir -p "$RUNTIME_CACHE_ROOT"
+          selected=""
+          if [[ -n "${RETAINED_CUT3R_CHECKPOINT:-}" \
+                && -f "$RETAINED_CUT3R_CHECKPOINT" ]]; then
+            measured=$(sha256sum "$RETAINED_CUT3R_CHECKPOINT" | awk '{print $1}')
+            if [[ "$measured" = "$CUT3R_CHECKPOINT_SHA256" ]]; then
+              selected="$RETAINED_CUT3R_CHECKPOINT"
+            fi
+          fi
+          if [[ -z "$selected" ]]; then
+            selected="$RUNTIME_CACHE_ROOT/cut3r_512_dpt_4_64.pth"
+            valid=false
+            if [[ -f "$selected" ]]; then
+              measured=$(sha256sum "$selected" | awk '{print $1}')
+              [[ "$measured" = "$CUT3R_CHECKPOINT_SHA256" ]] && valid=true
+            fi
+            if [[ "$valid" != true ]]; then
+              part="$selected.part-${GITHUB_RUN_ID}"
+              /usr/bin/rm -f -- "$part"
+              python -m pip install gdown==5.2.0
+              PART="$part" python - <<'PY'
+          import os
+          import gdown
+
+          result = gdown.download(
+              id=os.environ["CUT3R_CHECKPOINT_GDRIVE_ID"],
+              output=os.environ["PART"],
+              quiet=False,
+          )
+          if result is None:
+              raise SystemExit("gdown did not produce the frozen checkpoint")
+          PY
+              test "$(sha256sum "$part" | awk '{print $1}')" = \
+                "$CUT3R_CHECKPOINT_SHA256"
+              /usr/bin/mv -- "$part" "$selected"
+            fi
+          fi
+          test "$(sha256sum "$selected" | awk '{print $1}')" = \
+            "$CUT3R_CHECKPOINT_SHA256"
+          echo "path=$selected" >> "$GITHUB_OUTPUT"
+      - name: Materialize only the official R11-R20 archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          python scripts/science/materialize_verified_dot_archives.py \
+            --dataset-api "$DATASET_API" \
+            --datafile-api-root "$DATAFILE_API_ROOT" \
+            --output-dir "$DATASET_CACHE_ROOT" \
+            --entry "$SOURCE_ARCHIVE=$SOURCE_MD5" \
+            --receipt "$root/evidence/archive-materialization.json"
+          test -f "$DATASET_CACHE_ROOT/$SOURCE_ARCHIVE"
+          printf '%s  %s\n' "$SOURCE_MD5" \
+            "$DATASET_CACHE_ROOT/$SOURCE_ARCHIVE" | md5sum --check --strict
+      - name: Apply audited native-RoPE compatibility and build
+        id: rope
+        shell: bash
+        env:
+          RUNTIME_PYTHON: ${{ steps.runtime.outputs.python }}
+          CHECKPOINT_PATH: ${{ steps.checkpoint.outputs.path }}
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          checkout="$root/CUT3R"
+          /usr/bin/mkdir -p "$checkout"
+          /usr/bin/cp -a external/CUT3R/. "$checkout/"
+          test "$(/usr/bin/git -C "$checkout" rev-parse HEAD)" = "$CUT3R_REVISION"
+          patch="$GITHUB_WORKSPACE/.github/patches/cut3r-curope-torch211-cu126.patch"
+          test "$(/usr/bin/git hash-object "$patch")" = "$CUROPE_PATCH_BLOB"
+          test "$(sha256sum "$patch" | awk '{print $1}')" = "$CUROPE_PATCH_SHA256"
+          test "$(/usr/bin/git -C "$checkout" hash-object \
+            src/croco/models/curope/kernels.cu)" = "$CUROPE_KERNELS_BLOB"
+          test "$(/usr/bin/git -C "$checkout" hash-object \
+            src/croco/models/curope/setup.py)" = "$CUROPE_SETUP_BLOB"
+          /usr/bin/git -C "$checkout" apply --check "$patch"
+          /usr/bin/git -C "$checkout" apply "$patch"
+          mapfile -t changed < <(
+            /usr/bin/git -C "$checkout" diff --name-only | sort
+          )
+          expected=(
+            src/croco/models/curope/kernels.cu
+            src/croco/models/curope/setup.py
+          )
+          [[ "${changed[*]}" = "${expected[*]}" ]]
+          grep -F 'tokens.scalar_type()' \
+            "$checkout/src/croco/models/curope/kernels.cu"
+          grep -F 'arch=compute_89,code=sm_89' \
+            "$checkout/src/croco/models/curope/setup.py"
+
+          CHECKOUT="$checkout" CHECKPOINT="$CHECKPOINT_PATH" \
+            RECEIPT="$root/evidence/checkpoint-load-compatibility.json" \
+            python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          checkout = Path(os.environ["CHECKOUT"]).resolve(strict=True)
+          checkpoint = Path(os.environ["CHECKPOINT"]).resolve(strict=True)
+          expected_checkpoint = os.environ["CUT3R_CHECKPOINT_SHA256"]
+          if hashlib.sha256(checkpoint.read_bytes()).hexdigest() != expected_checkpoint:
+              raise SystemExit("checkpoint digest changed")
+          path = checkout / "src/dust3r/model.py"
+          source = path.read_bytes()
+          framed = f"blob {len(source)}\0".encode("ascii") + source
+          blob = hashlib.sha1(framed, usedforsecurity=False).hexdigest()
+          if blob != "7ed9f6106fb063686990c874ede99876ebc939ab":
+              raise SystemExit("CUT3R model source blob changed")
+          original = '    ckpt = torch.load(model_path, map_location="cpu")\n'
+          replacement = (
+              '    ckpt = torch.load(model_path, map_location="cpu", '
+              'weights_only=False)\n'
+          )
+          text = source.decode("utf-8")
+          if text.count(original) != 1 or replacement in text:
+              raise SystemExit("CUT3R checkpoint loader shape changed")
+          patched = text.replace(original, replacement, 1).encode("utf-8")
+          path.write_bytes(patched)
+          receipt = {
+              "schema": "prob4d.dot-source-v2-checkpoint-compatibility",
+              "schema_version": 1,
+              "cut3r_revision": os.environ["CUT3R_REVISION"],
+              "checkpoint_sha256": expected_checkpoint,
+              "source_git_blob_sha1": blob,
+              "source_sha256": hashlib.sha256(source).hexdigest(),
+              "patched_sha256": hashlib.sha256(patched).hexdigest(),
+              "torch_load_policy": "weights_only=False only at the pinned loader",
+          }
+          Path(os.environ["RECEIPT"]).write_text(
+              json.dumps(receipt, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
+
+          /usr/bin/find "$checkout/src/croco/models/curope" \
+            -maxdepth 1 -type f -name '*.so' -delete
+          /usr/bin/rm -rf -- "$checkout/src/croco/models/curope/build"
+          nvcc=$(command -v nvcc || true)
+          [[ -x "$nvcc" ]] || nvcc=/usr/local/cuda/bin/nvcc
+          test -x "$nvcc"
+          cuda_home=$(/usr/bin/dirname "$(/usr/bin/dirname "$nvcc")")
+          CUDA_HOME="$cuda_home" MAX_JOBS=4 \
+            PYTHONPATH="$GITHUB_WORKSPACE/src:$checkout:$checkout/src" \
+            "$RUNTIME_PYTHON" scripts/science/prepare_cut3r_runtime.py \
+              --cut3r-checkout "$checkout" \
+              --build \
+              --output "$root/evidence/runtime-receipt.json"
+          echo "checkout=$checkout" >> "$GITHUB_OUTPUT"
+      - name: Run repaired target-closed synthetic smoke
+        shell: bash
+        env:
+          RUNTIME_PYTHON: ${{ steps.runtime.outputs.python }}
+          CHECKPOINT_PATH: ${{ steps.checkpoint.outputs.path }}
+          CUT3R_CHECKOUT: ${{ steps.rope.outputs.checkout }}
+          REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
+          EXPECTED_HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          PYTHONPATH="$GITHUB_WORKSPACE/src:$GITHUB_WORKSPACE/scripts/science:$CUT3R_CHECKOUT:$CUT3R_CHECKOUT/src" \
+            "$RUNTIME_PYTHON" \
+            scripts/science/run_dot_rope_query_selective_source_support_v2_recovery.py \
+              runtime-smoke \
+              --protocol "$PROTOCOL_PATH" \
+              --request-id "$REQUEST_ID" \
+              --prob4d-revision "$EXPECTED_HEAD_SHA" \
+              --cut3r-checkout "$CUT3R_CHECKOUT" \
+              --checkpoint "$CHECKPOINT_PATH" \
+              --runtime-receipt "$root/evidence/runtime-receipt.json" \
+              --output-dir "$root/provider/smoke"
+      - name: Execute frozen marker-free R11-R20 predictions
+        shell: bash
+        env:
+          RUNTIME_PYTHON: ${{ steps.runtime.outputs.python }}
+          CHECKPOINT_PATH: ${{ steps.checkpoint.outputs.path }}
+          CUT3R_CHECKOUT: ${{ steps.rope.outputs.checkout }}
+          REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
+          EXPECTED_HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          PYTHONPATH="$GITHUB_WORKSPACE/src:$GITHUB_WORKSPACE/scripts/science:$CUT3R_CHECKOUT:$CUT3R_CHECKOUT/src" \
+            "$RUNTIME_PYTHON" \
+            scripts/science/run_dot_rope_query_selective_source_support_v2_recovery.py \
+              predict \
+              --protocol "$PROTOCOL_PATH" \
+              --request-id "$REQUEST_ID" \
+              --prob4d-revision "$EXPECTED_HEAD_SHA" \
+              --dataset-root "$DATASET_CACHE_ROOT" \
+              --cut3r-checkout "$CUT3R_CHECKOUT" \
+              --checkpoint "$CHECKPOINT_PATH" \
+              --runtime-receipt "$root/evidence/runtime-receipt.json" \
+              --output-dir "$root/provider/bundle"
+      - name: Read sealed provider identity
+        id: identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          ROOT="$root" python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          manifest = json.loads(
+              (Path(os.environ["ROOT"]) / "provider/bundle/manifest.json").read_text(
+                  encoding="utf-8"
+              )
+          )
+          if manifest["decision"] != "sealed-provider-predictions":
+              raise SystemExit("source provider did not seal")
+          name = (
+              "dot-query-source-v2-gpuserver6000-provider-"
+              f"{os.environ['GITHUB_RUN_ID']}-{os.environ['GITHUB_RUN_ATTEMPT']}"
+          )
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"provider_bundle_id={manifest['provider_bundle_id']}\n")
+              output.write(f"provider_artifact_name={name}\n")
+          PY
+      - name: Upload immutable sealed provider
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ steps.identity.outputs.provider_artifact_name }}
+          path: ${{ steps.workspace.outputs.root }}/provider/
+          if-no-files-found: error
+          retention-days: 90
+      - name: Upload bounded runtime receipts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dot-query-source-v2-gpuserver6000-runtime-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.workspace.outputs.root }}/evidence/
+          if-no-files-found: warn
+          retention-days: 30
+      - name: Remove isolated provider workspace
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          expected="${RUNNER_TEMP}/dot-source-v2-recovery-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          test "$root" = "$expected"
+          /usr/bin/chmod -R u+w "$root" 2>/dev/null || true
+          /usr/bin/rm -rf -- "$root"
+
+  qualify:
+    name: Select frozen source-only support geometry on gpuserver6000
+    if: github.event_name == 'push'
+    needs: [authorize, provider]
+    environment: trusted-self-hosted-validation
+    runs-on: [self-hosted, gpuserver6000]
+    timeout-minutes: 180
+    permissions:
+      contents: read
+    outputs:
+      decision: ${{ steps.identity.outputs.decision }}
+      result_id: ${{ steps.identity.outputs.result_id }}
+      selected_candidate: ${{ steps.identity.outputs.selected_candidate }}
+    steps:
+      - name: Bind intended runner and verified source archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$RUNNER_NAME" = "workstation2"
+          test "$RUNNER_OS" = "Linux"
+          test "$RUNNER_ARCH" = "X64"
+          test -f "$DATASET_CACHE_ROOT/$SOURCE_ARCHIVE"
+          printf '%s  %s\n' "$SOURCE_MD5" \
+            "$DATASET_CACHE_ROOT/$SOURCE_ARCHIVE" | md5sum --check --strict
+      - name: Initialize isolated qualification workspace
+        id: workspace
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${RUNNER_TEMP}/dot-source-v2-qualify-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          /usr/bin/rm -rf -- "$root"
+          /usr/bin/mkdir -p "$root/provider" "$root/result"
+          echo "root=$root" >> "$GITHUB_OUTPUT"
+      - name: Check out exact authorized revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.authorize.outputs.head_sha }}
+          persist-credentials: false
+          clean: true
+      - name: Set up scientific Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install exact repository package
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install -e .
+          python -m pip check
+      - name: Download exact sealed source provider
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ${{ needs.provider.outputs.provider_artifact_name }}
+          path: ${{ steps.workspace.outputs.root }}/provider
+      - name: Select support geometry without source error scoring
+        shell: bash
+        env:
+          REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
+          EXPECTED_HEAD_SHA: ${{ needs.authorize.outputs.head_sha }}
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          PYTHONPATH="$GITHUB_WORKSPACE/src:$GITHUB_WORKSPACE/scripts/science" \
+            python \
+            scripts/science/run_dot_rope_query_selective_source_support_v2_recovery.py \
+              qualify \
+              --protocol "$PROTOCOL_PATH" \
+              --request-id "$REQUEST_ID" \
+              --prob4d-revision "$EXPECTED_HEAD_SHA" \
+              --dataset-root "$DATASET_CACHE_ROOT" \
+              --provider-bundle "$root/provider/bundle" \
+              --output "$root/result/result.json"
+      - name: Read source-support decision
+        id: identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          ROOT="$root" python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          result = json.loads(
+              (Path(os.environ["ROOT"]) / "result/result.json").read_text(
+                  encoding="utf-8"
+              )
+          )
+          if result["decision"] not in {
+              "source-support-qualified",
+              "source-support-negative",
+          }:
+              raise SystemExit("source-support result is not scientific")
+          selected = result["selected_support_rule"]["candidate_id"]
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"decision={result['decision']}\n")
+              output.write(f"result_id={result['result_id']}\n")
+              output.write(f"selected_candidate={selected}\n")
+          PY
+      - name: Upload immutable source-support result
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dot-query-source-v2-gpuserver6000-result-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.workspace.outputs.root }}/result/
+          if-no-files-found: warn
+          retention-days: 90
+      - name: Remove isolated qualification workspace
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          expected="${RUNNER_TEMP}/dot-source-v2-qualify-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          test "$root" = "$expected"
+          /usr/bin/rm -rf -- "$root"
+
+  summary:
+    name: Publish source-only recovery summary
+    if: always()
+    needs: [authorize, provider, qualify]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write bounded summary
+        shell: bash
+        env:
+          PROVIDER_ID: ${{ needs.provider.outputs.provider_bundle_id }}
+          DECISION: ${{ needs.qualify.outputs.decision }}
+          RESULT_ID: ${{ needs.qualify.outputs.result_id }}
+          SELECTED: ${{ needs.qualify.outputs.selected_candidate }}
+        run: |
+          {
+            echo "## DOT query-selective source support v2 recovery"
+            echo
+            echo "- provider bundle: \`$PROVIDER_ID\`"
+            echo "- source decision: \`$DECISION\`"
+            echo "- result id: \`$RESULT_ID\`"
+            echo "- selected support geometry: \`$SELECTED\`"
+            echo "- R21-R30 confirmation payloads remain unopened"
+            echo "- R31-R70 remain unopened"
+            echo "- no source RMSE/NLL/proper score was used for selection"
+            echo "- no BayesianPhysTwin or Causal4D outcome was executed"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.d/dot-r11-r20-source-support-gpuserver6000-recovery.md
+++ b/CHANGELOG.d/dot-r11-r20-source-support-gpuserver6000-recovery.md
@@ -1,0 +1,9 @@
+### Changed
+
+- Add a fail-closed `gpuserver6000` recovery lane for the frozen DOT R11–R20
+  source-support qualification. It retires the untouched queued
+  `gpuserver4090` provider, materializes only the publisher-verified
+  `R11-20.zip`, applies the audited CUT3R runtime compatibility patch, and
+  repairs only the dataset-free smoke workspace. The protocol, request
+  identity, source-support objective, and unopened R21–R70 boundary are
+  unchanged.

--- a/scripts/science/materialize_verified_dot_archives.py
+++ b/scripts/science/materialize_verified_dot_archives.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Materialize exact official DOT archives without opening their contents."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import subprocess
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+_MD5 = re.compile(r"[0-9a-f]{32}")
+
+
+def _parse_entry(raw: str) -> tuple[str, str]:
+    try:
+        name, digest = raw.split("=", 1)
+    except ValueError as error:
+        raise argparse.ArgumentTypeError("entry must be NAME=MD5") from error
+    if not name or name != Path(name).name or "/" in name or "\\" in name:
+        raise argparse.ArgumentTypeError("archive name must be a plain filename")
+    digest = digest.lower()
+    if _MD5.fullmatch(digest) is None:
+        raise argparse.ArgumentTypeError("archive digest must be a lowercase MD5")
+    return name, digest
+
+
+def _md5(path: Path) -> str:
+    digest = hashlib.md5(usedforsecurity=False)
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _metadata(url: str) -> dict[str, Any]:
+    request = urllib.request.Request(
+        url,
+        headers={"User-Agent": "Prob4D-verified-DOT-archive-materializer/1"},
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
+        value = json.load(response)
+    if value.get("status") != "OK":
+        raise RuntimeError("DOT metadata endpoint did not return status OK")
+    return value
+
+
+def _resolve(metadata: dict[str, Any], entries: list[tuple[str, str]]) -> list[dict[str, Any]]:
+    files = metadata["data"]["latestVersion"]["files"]
+    by_name: dict[str, list[dict[str, Any]]] = {}
+    for entry in files:
+        data_file = entry["dataFile"]
+        by_name.setdefault(str(data_file["filename"]), []).append(data_file)
+
+    resolved: list[dict[str, Any]] = []
+    for name, expected_md5 in entries:
+        matches = by_name.get(name, [])
+        if len(matches) != 1:
+            raise RuntimeError(f"official DOT archive identity is ambiguous for {name}")
+        data_file = matches[0]
+        checksum = data_file.get("checksum") or {}
+        if checksum.get("type") != "MD5":
+            raise RuntimeError(f"official checksum type changed for {name}")
+        if str(checksum.get("value", "")).lower() != expected_md5:
+            raise RuntimeError(f"official checksum changed for {name}")
+        byte_count = int(data_file["filesize"])
+        if byte_count <= 0:
+            raise RuntimeError(f"official byte count is invalid for {name}")
+        resolved.append(
+            {
+                "name": name,
+                "md5": expected_md5,
+                "bytes": byte_count,
+                "datafile_id": int(data_file["id"]),
+            }
+        )
+    return resolved
+
+
+def _materialize(
+    *, output_dir: Path, datafile_api_root: str, value: dict[str, Any]
+) -> dict[str, Any]:
+    name = str(value["name"])
+    expected_md5 = str(value["md5"])
+    expected_bytes = int(value["bytes"])
+    destination = output_dir / name
+    if destination.is_symlink():
+        raise RuntimeError(f"archive destination must not be a symlink: {name}")
+
+    valid = (
+        destination.is_file()
+        and destination.stat().st_size == expected_bytes
+        and _md5(destination) == expected_md5
+    )
+    if not valid:
+        part = output_dir / f"{name}.part"
+        if part.is_symlink():
+            raise RuntimeError(f"partial archive must not be a symlink: {name}")
+        part.touch(exist_ok=True)
+        if part.stat().st_size > expected_bytes:
+            part.unlink()
+            part.touch()
+        subprocess.run(
+            [
+                "curl",
+                "--fail",
+                "--location",
+                "--retry",
+                "12",
+                "--retry-all-errors",
+                "--connect-timeout",
+                "30",
+                "--continue-at",
+                "-",
+                "--output",
+                os.fspath(part),
+                f"{datafile_api_root.rstrip('/')}/{value['datafile_id']}",
+            ],
+            check=True,
+        )
+        if part.stat().st_size != expected_bytes:
+            raise RuntimeError(f"downloaded byte count mismatch for {name}")
+        measured = _md5(part)
+        if measured != expected_md5:
+            raise RuntimeError(f"downloaded checksum mismatch for {name}")
+        os.replace(part, destination)
+
+    measured = _md5(destination)
+    if destination.stat().st_size != expected_bytes or measured != expected_md5:
+        raise RuntimeError(f"materialized archive verification failed for {name}")
+    return {
+        **value,
+        "path": os.fspath(destination),
+        "measured_md5": measured,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset-api", required=True)
+    parser.add_argument("--datafile-api-root", required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--entry", action="append", type=_parse_entry, required=True)
+    parser.add_argument("--receipt", type=Path, required=True)
+    args = parser.parse_args()
+
+    entries = list(args.entry)
+    if len({name for name, _ in entries}) != len(entries):
+        raise RuntimeError("duplicate DOT archive entry")
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    if args.output_dir.is_symlink():
+        raise RuntimeError("archive output directory must not be a symlink")
+
+    resolved = _resolve(_metadata(args.dataset_api), entries)
+    materialized = [
+        _materialize(
+            output_dir=args.output_dir,
+            datafile_api_root=args.datafile_api_root,
+            value=value,
+        )
+        for value in resolved
+    ]
+    receipt = {
+        "schema": "prob4d.verified-dot-archive-materialization",
+        "schema_version": 1,
+        "archives": materialized,
+        "information_boundary": {
+            "compressed_archive_bytes_read_for_hashing": True,
+            "archive_members_enumerated": False,
+            "archives_extracted": False,
+            "normal_view_images_opened": False,
+            "two_dimensional_markers_opened": False,
+            "three_dimensional_markers_opened": False,
+        },
+    }
+    args.receipt.parent.mkdir(parents=True, exist_ok=True)
+    args.receipt.write_text(
+        json.dumps(receipt, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/science/run_dot_rope_query_selective_source_support_v2_recovery.py
+++ b/scripts/science/run_dot_rope_query_selective_source_support_v2_recovery.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Run frozen DOT source-support v2 with one dataset-free smoke repair.
+
+The scientific implementation remains byte-pinned. This wrapper changes only
+its CUT3R smoke fixture: synthetic frames are written into a fresh child
+folder rather than into ``TemporaryDirectory``'s already-created root.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+_V2_PATH = Path(__file__).with_name("run_dot_rope_query_selective_source_support_v2.py")
+_V2_GIT_BLOB_SHA1 = "7d63f9d3b718f53b15036e55d538add2560e855a"
+
+
+def _git_blob_sha1(payload: bytes) -> str:
+    framed = f"blob {len(payload)}\0".encode("ascii") + payload
+    return hashlib.sha1(framed, usedforsecurity=False).hexdigest()
+
+
+def _load_v2() -> ModuleType:
+    source = _V2_PATH.read_bytes()
+    measured = _git_blob_sha1(source)
+    if measured != _V2_GIT_BLOB_SHA1:
+        raise RuntimeError("frozen source-support v2 implementation changed")
+    spec = importlib.util.spec_from_file_location(
+        "dot_rope_query_selective_source_support_v2_frozen",
+        _V2_PATH,
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError("cannot load frozen source-support v2 implementation")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _install_runtime_smoke_compatibility(v2: ModuleType) -> None:
+    original_run_base_provider = v2._run_base_provider
+
+    def run_base_provider(args: Any, command: str) -> int:
+        if command != "runtime-smoke":
+            return int(original_run_base_provider(args, command))
+
+        protocol = v2._load_protocol(args.protocol)
+        v2._require_execution_identity(args.request_id, args.prob4d_revision)
+        base = v2._load_script(
+            "run_dot_rope_cut3r_native_provider.py",
+            "dot_r11_r20_source_provider_recovery",
+            v2.BASE_PROVIDER_BLOB,
+        )
+        adapted = v2._adapted_provider_protocol(protocol)
+        base._load_protocol = lambda _path: adapted
+        original_make_frames = base._make_synthetic_frames
+
+        def make_frames(destination: Path, count: int) -> list[Path]:
+            return list(original_make_frames(destination / "frames", count))
+
+        base._make_synthetic_frames = make_frames
+        return int(base.runtime_smoke(args))
+
+    v2._run_base_provider = run_base_provider
+
+
+def main() -> int:
+    v2 = _load_v2()
+    _install_runtime_smoke_compatibility(v2)
+    return int(v2.main())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dot_rope_query_selective_source_support_v2_recovery.py
+++ b/tests/test_dot_rope_query_selective_source_support_v2_recovery.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WRAPPER = ROOT / "scripts/science/run_dot_rope_query_selective_source_support_v2_recovery.py"
+WORKFLOW = (
+    ROOT / ".github/workflows/dot-rope-query-selective-source-support-v2-gpuserver6000-recovery.yml"
+)
+
+
+def test_wrapper_is_syntax_valid_and_hash_pins_frozen_v2() -> None:
+    text = WRAPPER.read_text(encoding="utf-8")
+    ast.parse(text)
+    assert "7d63f9d3b718f53b15036e55d538add2560e855a" in text
+    assert 'destination / "frames"' in text
+    assert 'command != "runtime-smoke"' in text
+    assert "original_run_base_provider(args, command)" in text
+
+
+def test_recovery_is_request_only_and_retires_unopened_predecessor() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "pull_request:" in text
+    assert "push:" in text
+    assert "pull_request_target:" not in text
+    assert "dot_rope_query_selective_source_support_v2_gpuserver6000.json" in text
+    assert 'ORIGINAL_RUN_ID: "33522102387"' in text
+    assert "Seal marker-free R11-R20 CUT3R predictions" in text
+    assert "provider may have started; recovery is forbidden" in text
+    assert "actions: write" in text
+    assert "/cancel" in text
+
+
+def test_recovery_preserves_source_only_data_boundary() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "R11-20.zip" in text
+    assert "23ce3e7067465d3edabe20b4c7cfa388" in text
+    assert "R21-30.zip" not in text
+    assert "R31-R70 remain unopened" in text
+    assert "source RMSE/NLL/proper score" in text
+    assert "BayesianPhysTwin" in text
+    assert "Causal4D" in text
+
+
+def test_recovery_uses_reviewed_runtime_repairs_on_gpuserver6000() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "runs-on: [self-hosted, gpuserver6000]" in text
+    assert 'test "$RUNNER_NAME" = "workstation2"' in text
+    assert "run_dot_rope_query_selective_source_support_v2_recovery.py" in text
+    assert "9778ec434a6e2d9ae8be162295d60e06d86bf0fbadbb66d516eb46c666ab547d" in text
+    assert "tokens.scalar_type()" in text
+    assert "compute_89,code=sm_89" in text
+    assert "weights_only=False" in text
+    assert "environment: trusted-self-hosted-validation" in text
+    assert "secrets." not in text

--- a/tests/test_materialize_verified_dot_archives.py
+++ b/tests/test_materialize_verified_dot_archives.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+from pathlib import Path
+
+import pytest
+
+from scripts.science.materialize_verified_dot_archives import (
+    _materialize,
+    _parse_entry,
+    _resolve,
+)
+
+
+def _md5(payload: bytes) -> str:
+    return hashlib.md5(payload, usedforsecurity=False).hexdigest()
+
+
+def test_parse_entry_accepts_plain_filename_and_lowercase_md5() -> None:
+    digest = "0123456789abcdef0123456789abcdef"
+    assert _parse_entry(f"R11-20.zip={digest}") == ("R11-20.zip", digest)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        "missing-separator",
+        "../R11-20.zip=0123456789abcdef0123456789abcdef",
+        "folder/R11-20.zip=0123456789abcdef0123456789abcdef",
+        "R11-20.zip=not-an-md5",
+    ],
+)
+def test_parse_entry_rejects_ambiguous_or_unsafe_values(raw: str) -> None:
+    with pytest.raises(argparse.ArgumentTypeError):
+        _parse_entry(raw)
+
+
+def test_resolve_requires_exact_publisher_checksum() -> None:
+    digest = "0123456789abcdef0123456789abcdef"
+    metadata = {
+        "data": {
+            "latestVersion": {
+                "files": [
+                    {
+                        "dataFile": {
+                            "filename": "R11-20.zip",
+                            "id": 123,
+                            "filesize": 456,
+                            "checksum": {"type": "MD5", "value": digest},
+                        }
+                    }
+                ]
+            }
+        }
+    }
+    assert _resolve(metadata, [("R11-20.zip", digest)]) == [
+        {
+            "name": "R11-20.zip",
+            "md5": digest,
+            "bytes": 456,
+            "datafile_id": 123,
+        }
+    ]
+    with pytest.raises(RuntimeError, match="checksum changed"):
+        _resolve(metadata, [("R11-20.zip", "f" * 32)])
+
+
+def test_materialize_reuses_only_size_and_hash_verified_archive(
+    tmp_path: Path,
+) -> None:
+    payload = b"compressed archive bytes are opaque to this helper"
+    digest = _md5(payload)
+    archive = tmp_path / "R11-20.zip"
+    archive.write_bytes(payload)
+    value = {
+        "name": archive.name,
+        "md5": digest,
+        "bytes": len(payload),
+        "datafile_id": 123,
+    }
+    result = _materialize(
+        output_dir=tmp_path,
+        datafile_api_root="https://example.invalid/api/access/datafile",
+        value=value,
+    )
+    assert result == {
+        **value,
+        "path": str(archive),
+        "measured_md5": digest,
+    }
+    assert archive.read_bytes() == payload
+
+
+def test_resolve_rejects_duplicate_publisher_filename() -> None:
+    digest = "0123456789abcdef0123456789abcdef"
+    data_file = {
+        "filename": "R11-20.zip",
+        "id": 123,
+        "filesize": 456,
+        "checksum": {"type": "MD5", "value": digest},
+    }
+    metadata = {
+        "data": {
+            "latestVersion": {"files": [{"dataFile": data_file}, {"dataFile": dict(data_file)}]}
+        }
+    }
+    with pytest.raises(RuntimeError, match="ambiguous"):
+        _resolve(metadata, [("R11-20.zip", digest)])

--- a/tests/test_trusted_self_hosted_validation_policy.py
+++ b/tests/test_trusted_self_hosted_validation_policy.py
@@ -1,9 +1,10 @@
 """Load the unchanged self-hosted policy suite and extend its reviewed allowlist.
 
 The historical policy implementation is retained byte-for-byte in the adjacent
-non-test module. This wrapper adds separately reviewed DOT continuation and
-Tracking-Cloth query-portfolio workflows before exposing the original test
-functions to pytest.
+non-test module. This wrapper adds the separately reviewed DOT R11--R30,
+DOT R04--R10 recovery/relay/camera-audit, Tracking-Cloth query-portfolio,
+DOT R11--R20 source-support execution, and its fail-closed gpuserver6000
+recovery workflow before exposing the original test functions to pytest.
 """
 
 from __future__ import annotations
@@ -38,6 +39,9 @@ TRACKING_CLOTH_QUERY_PORTFOLIO_WORKFLOW = (
 DOT_ROPE_QUERY_SELECTIVE_SOURCE_SUPPORT_V2_EXECUTION_WORKFLOW = (
     POLICY.WORKFLOW_ROOT / "dot-rope-query-selective-source-support-v2-execute.yml"
 )
+DOT_ROPE_QUERY_SELECTIVE_SOURCE_SUPPORT_V2_RECOVERY_WORKFLOW = (
+    POLICY.WORKFLOW_ROOT / "dot-rope-query-selective-source-support-v2-gpuserver6000-recovery.yml"
+)
 POLICY.TRUSTED_SELF_HOSTED_WORKFLOWS = (
     *POLICY.TRUSTED_SELF_HOSTED_WORKFLOWS,
     DOT_ROPE_QUERY_SELECTIVE_HELDOUT_WORKFLOW,
@@ -46,6 +50,7 @@ POLICY.TRUSTED_SELF_HOSTED_WORKFLOWS = (
     DOT_R04_R10_CAMERA_SUPPORT_AUDIT_WORKFLOW,
     TRACKING_CLOTH_QUERY_PORTFOLIO_WORKFLOW,
     DOT_ROPE_QUERY_SELECTIVE_SOURCE_SUPPORT_V2_EXECUTION_WORKFLOW,
+    DOT_ROPE_QUERY_SELECTIVE_SOURCE_SUPPORT_V2_RECOVERY_WORKFLOW,
 )
 
 for _name, _value in vars(POLICY).items():


### PR DESCRIPTION
## Purpose

Execute the already frozen DOT R11–R20 source/support qualification after its `gpuserver4090` provider remained queued, unassigned, step-free, and artifact-free.

## Fail-closed predecessor retirement

The hosted authorization job binds original run `33522102387`, head `d8df21b4902f18ec48701804364495ee7c167495`, workflow path, and provider job name. Recovery proceeds only if the provider still has no assigned runner, no executable steps, no conclusion other than cancellation, and the run has zero artifacts. It then cancels the untouched predecessor and independently rechecks that state. Any evidence of provider execution forbids recovery.

## Operational repairs

- route both source provider and source qualification to `[self-hosted, gpuserver6000]` / `workstation2`;
- materialize only publisher-verified `R11-20.zip` through a resumable, MD5- and byte-count-bound helper that never enumerates or extracts archive members;
- apply the existing audited PyTorch 2.11 / CUDA 12.6 cuRoPE patch after exact upstream blob verification;
- enable legacy checkpoint loading only for the exact SHA-256-bound CUT3R checkpoint; and
- wrap the byte-pinned v2 implementation so only the dataset-free synthetic smoke writes into a fresh child directory rather than an already-created `TemporaryDirectory` root.

## Scientific invariants

Unchanged:

- source-support protocol ID `037df0507c8e98f6005955e4dfea457f764289058a698a797a3f1008e9dc0e5f`;
- request ID `ad0b04f536c9768705b7d3bfa451631e01574e7512a7d68d02b2151cc80f486a`;
- source cohort R11–R20;
- fixed `cam001` v2 observation rule;
- support candidate roster, rank-six criterion, deterministic support-first selection objective, and 9/10 promotion threshold;
- no source RMSE, NLL, or proper-score selection;
- R21–R30 confirmation and R31–R70 reserve remain unopened; and
- no BayesianPhysTwin or Causal4D outcome is authorized.

This PR contains no execution request. A separate one-file request addition is required after review and merge.