### PR TITLE
[Closed: lower expected value] Qualify DOT source camera routing with learned CUT3R factors

### DIFF
--- a/.github/workflows/dot-r11-r20-camera-routing-provider-rank-v1.yml
+++ b/.github/workflows/dot-r11-r20-camera-routing-provider-rank-v1.yml
@@ -1,0 +1,583 @@
+name: DOT R11-R20 camera-routing provider-rank v1
+
+on:
+  push:
+    branches: [science/dot-r11-r20-camera-routing-source-v1]
+    paths:
+      - "ops/requests/dot_r11_r20_camera_routing_provider_rank_v1.json"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dot-r11-r20-camera-routing-provider-rank-v1
+  cancel-in-progress: false
+
+env:
+  REQUEST_PATH: ops/requests/dot_r11_r20_camera_routing_provider_rank_v1.json
+  PROTOCOL_PATH: protocols/dot-rope-query-selective-camera-routing-source-v3.json
+  BASE_V2_PROTOCOL: protocols/dot-rope-query-selective-source-support-v2.json
+  DATASET_ROOT: /home/github-runner/.cache/prob4d/dot-r11-r30-archives-v29
+  SOURCE_ARCHIVE: R11-20.zip
+  SOURCE_MD5: 23ce3e7067465d3edabe20b4c7cfa388
+  CUT3R_REVISION: 8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf
+  CUT3R_CHECKPOINT_SHA256: 45f7e98a0a64dbeb54901ae2b878cd8cd125f20a4497316483f0bd6f109f8103
+  CUT3R_CHECKPOINT_GDRIVE_ID: 1Asz-ZB3FfpzZYwunhQvNPZEUA8XUNAYD
+  RETAINED_CUT3R_CHECKOUT: /mnt/corsair/prob4d-cut3r-source-freeze-v2-inputs/CUT3R
+  RETAINED_CUT3R_CHECKPOINT: /mnt/corsair/prob4d-cut3r-source-freeze-v2-inputs/cut3r_512_dpt_4_64.pth
+  EXPECTED_PROTOCOL_ID: cd57cb81d1aa52707f26bb0f39829e848d15d0a67b064b390b24caf545923690
+  EXPECTED_RAW_AUDIT_ID: 66724cb78840f4b9ef3becf97e5765924094cf8db6eca2d892c44cfa7edb19b3
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONHASHSEED: "0"
+  PYTHONUNBUFFERED: "1"
+  PYTHONDONTWRITEBYTECODE: "1"
+  OMP_NUM_THREADS: "1"
+  OPENBLAS_NUM_THREADS: "1"
+  MKL_NUM_THREADS: "1"
+  NUMEXPR_NUM_THREADS: "1"
+
+jobs:
+  authorize:
+    name: Authorize exact routed source-provider rank request
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      head_sha: ${{ steps.request.outputs.head_sha }}
+      request_id: ${{ steps.request.outputs.request_id }}
+      protocol_git_blob_sha: ${{ steps.request.outputs.protocol_git_blob_sha }}
+    steps:
+      - name: Check out exact request revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 2
+          persist-credentials: false
+          clean: true
+      - name: Require exactly one content-addressed request change
+        id: request
+        shell: bash
+        env:
+          EVENT_REF: ${{ github.ref }}
+          EVENT_BEFORE: ${{ github.event.before }}
+          EVENT_AFTER: ${{ github.event.after }}
+          EVENT_FORCED: ${{ github.event.forced }}
+          EVENT_DELETED: ${{ github.event.deleted }}
+        run: |
+          set -euo pipefail
+          test "$EVENT_REF" = "refs/heads/science/dot-r11-r20-camera-routing-source-v1"
+          test "$EVENT_AFTER" = "$(git rev-parse HEAD)"
+          test "$EVENT_FORCED" = "false"
+          test "$EVENT_DELETED" = "false"
+          test "$EVENT_BEFORE" != "0000000000000000000000000000000000000000"
+          mapfile -t changed < <(git diff --name-only "$EVENT_BEFORE" "$EVENT_AFTER" | sort)
+          if [[ ${#changed[@]} -ne 1 || "${changed[0]}" != "$REQUEST_PATH" ]]; then
+            printf 'Expected only %s; changed paths were:\n' "$REQUEST_PATH" >&2
+            printf '  %s\n' "${changed[@]}" >&2
+            exit 2
+          fi
+          REQUEST="$REQUEST_PATH" python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          def content_id(value):
+              return hashlib.sha256(json.dumps(
+                  value, sort_keys=True, separators=(",", ":"),
+                  ensure_ascii=False, allow_nan=False,
+              ).encode("utf-8")).hexdigest()
+
+          request = json.loads(Path(os.environ["REQUEST"]).read_text(encoding="utf-8"))
+          unsigned = dict(request)
+          request_id = unsigned.pop("request_id", None)
+          if content_id(unsigned) != request_id:
+              raise SystemExit("provider-rank request identity mismatch")
+          expected = {
+              "schema": "prob4d.dot-r11-r20-camera-routing-provider-rank-request",
+              "schema_version": 1,
+              "protocol_path": os.environ["PROTOCOL_PATH"],
+              "protocol_git_blob_sha": request["protocol_git_blob_sha"],
+              "protocol_id": os.environ["EXPECTED_PROTOCOL_ID"],
+              "raw_routing_audit_id": os.environ["EXPECTED_RAW_AUDIT_ID"],
+              "source_sequences": [f"R{i:02d}" for i in range(11, 21)],
+              "confirmation_sequences": [f"R{i:02d}" for i in range(21, 31)],
+              "reserved_sequences": "R31-R70",
+              "routed_marker_free_provider_authorized": True,
+              "source_factor_rank_qualification_authorized": True,
+              "source_reconstruction_error_authorized": False,
+              "source_proper_score_authorized": False,
+              "confirmation_payload_access_authorized": False,
+              "post_source_retuning_authorized": False,
+          }
+          comparable = dict(request)
+          comparable.pop("request_id")
+          if comparable != expected:
+              raise SystemExit("provider-rank request content changed")
+          blob = os.popen(f"git rev-parse HEAD:{os.environ['PROTOCOL_PATH']}").read().strip()
+          if blob != request["protocol_git_blob_sha"]:
+              raise SystemExit("request does not bind the exact protocol blob")
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output:
+              output.write(f"head_sha={os.environ['EVENT_AFTER']}\n")
+              output.write(f"request_id={request_id}\n")
+              output.write(f"protocol_git_blob_sha={blob}\n")
+          PY
+      - name: Validate source-only helpers without DOT access
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m py_compile \
+            scripts/science/run_dot_rope_source_support_camera_component_v1.py \
+            scripts/science/materialize_dot_rope_source_camera_components_v1.py \
+            scripts/science/combine_dot_rope_source_camera_components_v1.py
+          tmp=$(mktemp -d)
+          trap 'rm -rf "$tmp"' EXIT
+          python scripts/science/materialize_dot_rope_source_camera_components_v1.py \
+            --protocol "$PROTOCOL_PATH" \
+            --base-v2-protocol "$BASE_V2_PROTOCOL" \
+            --output-dir "$tmp/components"
+          python - <<'PY'
+          import json
+          from pathlib import Path
+          root = Path("$tmp/components")
+          PY
+
+  source_rank:
+    name: Seal routed CUT3R source provider then qualify rank on gpuserver6000
+    needs: authorize
+    environment: trusted-self-hosted-validation
+    runs-on: [self-hosted, gpuserver6000]
+    timeout-minutes: 720
+    permissions:
+      contents: read
+    outputs:
+      decision: ${{ steps.result.outputs.decision }}
+      result_id: ${{ steps.result.outputs.result_id }}
+      supported_sequences: ${{ steps.result.outputs.supported_sequences }}
+      provider_seal_id: ${{ steps.seal.outputs.provider_seal_id }}
+    steps:
+      - name: Bind intended GPU runner and source archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$RUNNER_NAME" = "workstation2"
+          test "$RUNNER_OS" = "Linux"
+          test "$RUNNER_ARCH" = "X64"
+          command -v nvidia-smi >/dev/null 2>&1
+          command -v c++ >/dev/null 2>&1
+          command -v md5sum >/dev/null 2>&1
+          test -f "$DATASET_ROOT/$SOURCE_ARCHIVE"
+          test ! -L "$DATASET_ROOT/$SOURCE_ARCHIVE"
+          printf '%s  %s\n' "$SOURCE_MD5" "$DATASET_ROOT/$SOURCE_ARCHIVE" | md5sum --check --strict
+          nvidia-smi --query-gpu=name,driver_version,memory.total --format=csv,noheader
+
+      - name: Initialize isolated source-provider workspace
+        id: workspace
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${RUNNER_TEMP}/dot-r11-r20-camera-rank-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          rm -rf -- "$root"
+          mkdir -p \
+            "$root/home" "$root/cache" "$root/tmp" \
+            "$root/evidence" "$root/components" "$root/providers" "$root/results"
+          echo "root=$root" >> "$GITHUB_OUTPUT"
+          {
+            echo "HOME=$root/home"
+            echo "XDG_CACHE_HOME=$root/cache"
+            echo "PIP_CACHE_DIR=$root/cache/pip"
+            echo "HF_HOME=$root/cache/huggingface"
+            echo "TMPDIR=$root/tmp"
+            echo "TORCH_EXTENSIONS_DIR=$root/cache/torch-extensions"
+            echo "WANDB_MODE=disabled"
+            echo "WANDB_DISABLED=true"
+          } >> "$GITHUB_ENV"
+
+      - name: Check out exact authorized Prob4D revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.authorize.outputs.head_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+          clean: true
+
+      - name: Verify exact protocol and clean checkout
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "${{ needs.authorize.outputs.head_sha }}"
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+          test "$(git rev-parse HEAD:$PROTOCOL_PATH)" = "${{ needs.authorize.outputs.protocol_git_blob_sha }}"
+
+      - name: Check out exact public CUT3R revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: CUT3R/CUT3R
+          ref: 8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf
+          path: external/CUT3R
+          fetch-depth: 1
+          persist-credentials: false
+          clean: true
+
+      - name: Set up bootstrap Python 3.11
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.11"
+
+      - name: Select or bootstrap CUDA CUT3R interpreter
+        id: runtime
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          candidates=(
+            "$RETAINED_CUT3R_CHECKOUT/.venv/bin/python"
+            /home/florianpfaff/conda_envs/cut3r/bin/python
+            /home/florianpfaff/miniconda3/envs/cut3r/bin/python
+            /home/github-runner/.conda/envs/cut3r/bin/python
+            /opt/conda/envs/cut3r/bin/python
+          )
+          usable=""
+          for candidate in "${candidates[@]}"; do
+            [[ -x "$candidate" ]] || continue
+            if "$candidate" - <<'PY' >/dev/null 2>&1
+          import accelerate, cv2, einops, h5py, hydra, lpips
+          import numpy, PIL, roma, scipy, sklearn, torch, torchvision, transformers
+          assert torch.cuda.is_available()
+          PY
+            then
+              usable="$candidate"
+              break
+            fi
+          done
+          if [[ -z "$usable" ]]; then
+            venv="$root/venv"
+            python -m venv "$venv"
+            usable="$venv/bin/python"
+            "$usable" -m pip install "pip==25.2" "setuptools==80.9.0" "wheel==0.45.1"
+            "$usable" -m pip install torch==2.11.0 torchvision==0.26.0 \
+              --index-url https://download.pytorch.org/whl/cu126
+            filtered="$root/cut3r-requirements.txt"
+            python - external/CUT3R/requirements.txt "$filtered" <<'PY'
+          import re, sys
+          from pathlib import Path
+          kept=[]
+          for line in Path(sys.argv[1]).read_text(encoding="utf-8").splitlines():
+              if re.match(r"^(torch|torchvision)(?:\s|[<>=!~].*)?$", line.strip(), flags=re.I):
+                  continue
+              kept.append(line)
+          Path(sys.argv[2]).write_text("\n".join(kept)+"\n", encoding="utf-8")
+          PY
+            "$usable" -m pip install -r "$filtered" gdown==5.2.0
+            "$usable" -m pip check
+          fi
+          "$usable" - <<'PY'
+          import torch
+          assert torch.cuda.is_available()
+          print(torch.__version__, torch.version.cuda, torch.cuda.get_device_name(0))
+          PY
+          echo "python=$usable" >> "$GITHUB_OUTPUT"
+
+      - name: Acquire exact frozen CUT3R checkpoint
+        id: checkpoint
+        shell: bash
+        env:
+          RUNTIME_PYTHON: ${{ steps.runtime.outputs.python }}
+        run: |
+          set -euo pipefail
+          selected="$RETAINED_CUT3R_CHECKPOINT"
+          if [[ ! -f "$selected" || "$(sha256sum "$selected" | awk '{print $1}')" != "$CUT3R_CHECKPOINT_SHA256" ]]; then
+            selected="${{ steps.workspace.outputs.root }}/cut3r_512_dpt_4_64.pth"
+            "$RUNTIME_PYTHON" -m pip install gdown==5.2.0
+            OUTPUT="$selected" "$RUNTIME_PYTHON" - <<'PY'
+          import gdown, os
+          value=gdown.download(id=os.environ["CUT3R_CHECKPOINT_GDRIVE_ID"], output=os.environ["OUTPUT"], quiet=False)
+          if value is None:
+              raise SystemExit("CUT3R checkpoint download failed")
+          PY
+          fi
+          test "$(sha256sum "$selected" | awk '{print $1}')" = "$CUT3R_CHECKPOINT_SHA256"
+          echo "path=$selected" >> "$GITHUB_OUTPUT"
+
+      - name: Build hash-pinned native CUT3R RoPE compatibility runtime
+        id: rope
+        shell: bash
+        env:
+          RUNTIME_PYTHON: ${{ steps.runtime.outputs.python }}
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          checkout="$root/CUT3R"
+          mkdir -p "$checkout"
+          cp -a external/CUT3R/. "$checkout/"
+          test "$(git -C "$checkout" rev-parse HEAD)" = "$CUT3R_REVISION"
+          patch=.github/patches/cut3r-curope-torch211-cu126.patch
+          test "$(sha256sum "$patch" | awk '{print $1}')" = \
+            "9778ec434a6e2d9ae8be162295d60e06d86bf0fbadbb66d516eb46c666ab547d"
+          git -C "$checkout" apply --check "$GITHUB_WORKSPACE/$patch"
+          git -C "$checkout" apply "$GITHUB_WORKSPACE/$patch"
+          git -C "$checkout" diff --check
+          nvcc="$(command -v nvcc || true)"
+          [[ -x "$nvcc" ]] || nvcc=/usr/local/cuda/bin/nvcc
+          test -x "$nvcc"
+          cuda_home=$(dirname "$(dirname "$nvcc")")
+          arch=$("$RUNTIME_PYTHON" - <<'PY'
+          import torch
+          major,minor=torch.cuda.get_device_capability(0)
+          print(f"{major}.{minor}")
+          PY
+          )
+          CUDA_HOME="$cuda_home" TORCH_CUDA_ARCH_LIST="$arch" MAX_JOBS=4 \
+            PYTHONPATH="$GITHUB_WORKSPACE/src:$checkout:$checkout/src" \
+            "$RUNTIME_PYTHON" scripts/science/prepare_cut3r_runtime.py \
+              --cut3r-checkout "$checkout" --build \
+              --output "$root/evidence/runtime-receipt.json"
+          CHECKOUT="$checkout" CHECKPOINT="${{ steps.checkpoint.outputs.path }}" \
+            "$RUNTIME_PYTHON" - <<'PY'
+          import hashlib, os
+          from pathlib import Path
+          checkpoint=Path(os.environ["CHECKPOINT"])
+          if hashlib.sha256(checkpoint.read_bytes()).hexdigest()!=os.environ["CUT3R_CHECKPOINT_SHA256"]:
+              raise SystemExit("checkpoint digest changed")
+          path=Path(os.environ["CHECKOUT"])/"src/dust3r/model.py"
+          source=path.read_bytes()
+          framed=f"blob {len(source)}\0".encode("ascii")+source
+          blob=hashlib.sha1(framed, usedforsecurity=False).hexdigest()
+          if blob!="7ed9f6106fb063686990c874ede99876ebc939ab":
+              raise SystemExit("CUT3R model source changed")
+          old='    ckpt = torch.load(model_path, map_location="cpu")\n'
+          new='    ckpt = torch.load(model_path, map_location="cpu", weights_only=False)\n'
+          text=source.decode("utf-8")
+          if text.count(old)!=1:
+              raise SystemExit("legacy checkpoint loader shape changed")
+          path.write_text(text.replace(old,new,1), encoding="utf-8")
+          PY
+          echo "checkout=$checkout" >> "$GITHUB_OUTPUT"
+
+      - name: Materialize exact routed-camera component protocols
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          "${{ steps.runtime.outputs.python }}" \
+            scripts/science/materialize_dot_rope_source_camera_components_v1.py \
+              --protocol "$PROTOCOL_PATH" \
+              --base-v2-protocol "$BASE_V2_PROTOCOL" \
+              --output-dir "$root/components/protocols"
+
+      - name: Run target-closed synthetic runtime smoke
+        shell: bash
+        env:
+          REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
+          RUNTIME_PYTHON: ${{ steps.runtime.outputs.python }}
+          CHECKPOINT: ${{ steps.checkpoint.outputs.path }}
+          CUT3R_CHECKOUT: ${{ steps.rope.outputs.checkout }}
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          PYTHONPATH="$GITHUB_WORKSPACE/src:$GITHUB_WORKSPACE/scripts/science" \
+            "$RUNTIME_PYTHON" scripts/science/run_dot_rope_source_support_camera_component_v1.py \
+              --camera cam001 \
+              --source-sequences-json '["R13","R14","R15","R16","R18","R19"]' \
+              runtime-smoke \
+              --protocol "$root/components/protocols/component-cam001.json" \
+              --request-id "$REQUEST_ID" \
+              --prob4d-revision "${{ needs.authorize.outputs.head_sha }}" \
+              --cut3r-checkout "$CUT3R_CHECKOUT" \
+              --checkpoint "$CHECKPOINT" \
+              --runtime-receipt "$root/evidence/runtime-receipt.json" \
+              --output-dir "$root/evidence/smoke"
+
+      - name: Execute routed marker-free source predictions
+        shell: bash
+        env:
+          REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
+          RUNTIME_PYTHON: ${{ steps.runtime.outputs.python }}
+          CHECKPOINT: ${{ steps.checkpoint.outputs.path }}
+          CUT3R_CHECKOUT: ${{ steps.rope.outputs.checkout }}
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          MANIFEST="$root/components/protocols/manifest.json" "$RUNTIME_PYTHON" - <<'PY' > "$root/components/components.tsv"
+          import json, os
+          from pathlib import Path
+          value=json.loads(Path(os.environ["MANIFEST"]).read_text(encoding="utf-8"))
+          for item in value["components"]:
+              print(item["camera"], json.dumps(item["source_sequences"], separators=(",",":")), item["protocol_file"], sep="\t")
+          PY
+          while IFS=$'\t' read -r camera sequences protocol_file; do
+            destination="$root/providers/$camera/bundle"
+            mkdir -p "$(dirname "$destination")"
+            PYTHONPATH="$GITHUB_WORKSPACE/src:$GITHUB_WORKSPACE/scripts/science" \
+              "$RUNTIME_PYTHON" scripts/science/run_dot_rope_source_support_camera_component_v1.py \
+                --camera "$camera" --source-sequences-json "$sequences" \
+                predict \
+                --protocol "$root/components/protocols/$protocol_file" \
+                --request-id "$REQUEST_ID" \
+                --prob4d-revision "${{ needs.authorize.outputs.head_sha }}" \
+                --dataset-root "$DATASET_ROOT" \
+                --cut3r-checkout "$CUT3R_CHECKOUT" \
+                --checkpoint "$CHECKPOINT" \
+                --runtime-receipt "$root/evidence/runtime-receipt.json" \
+                --output-dir "$destination"
+          done < "$root/components/components.tsv"
+
+      - name: Seal all routed provider components before source marker qualification
+        id: seal
+        shell: bash
+        env:
+          RUNTIME_PYTHON: ${{ steps.runtime.outputs.python }}
+          REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          ROOT="$root" "$RUNTIME_PYTHON" - <<'PY'
+          import hashlib, json, os
+          from pathlib import Path
+          root=Path(os.environ["ROOT"])
+          manifest=json.loads((root/"components/protocols/manifest.json").read_text(encoding="utf-8"))
+          components=[]
+          for item in manifest["components"]:
+              camera=item["camera"]
+              provider=root/"providers"/camera/"bundle"/"manifest.json"
+              value=json.loads(provider.read_text(encoding="utf-8"))
+              if value["decision"]!="sealed-provider-predictions":
+                  raise SystemExit(f"{camera} provider is not sealed")
+              boundary=value["information_boundary"]
+              for key in ("two_dimensional_markers_opened","three_dimensional_markers_opened","target_payloads_opened"):
+                  if boundary.get(key) is not False:
+                      raise SystemExit(f"{camera} provider crossed information boundary")
+              components.append({
+                  "camera":camera,
+                  "source_sequences":item["source_sequences"],
+                  "provider_bundle_id":value["provider_bundle_id"],
+                  "manifest_sha256":hashlib.sha256(provider.read_bytes()).hexdigest(),
+              })
+          seal={
+              "schema":"prob4d.dot-r11-r20-routed-provider-seal",
+              "schema_version":1,
+              "request_id":os.environ["REQUEST_ID"],
+              "parent_protocol_id":os.environ["EXPECTED_PROTOCOL_ID"],
+              "raw_routing_audit_id":os.environ["EXPECTED_RAW_AUDIT_ID"],
+              "components":components,
+              "source_marker_payloads_opened":False,
+              "confirmation_payloads_opened":False,
+          }
+          encoded=json.dumps(seal,sort_keys=True,separators=(",",":")).encode()
+          seal["provider_seal_id"]=hashlib.sha256(encoded).hexdigest()
+          (root/"providers"/"provider-seal.json").write_text(json.dumps(seal,indent=2,sort_keys=True)+"\n",encoding="utf-8")
+          print(seal["provider_seal_id"])
+          with open(os.environ["GITHUB_OUTPUT"],"a",encoding="utf-8") as output:
+              output.write(f"provider_seal_id={seal['provider_seal_id']}\n")
+          PY
+          chmod -R a-w "$root/providers"
+
+      - name: Upload immutable routed source provider before marker access
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: dot-r11-r20-routed-provider-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            ${{ steps.workspace.outputs.root }}/providers/
+            ${{ steps.workspace.outputs.root }}/components/protocols/
+            ${{ steps.workspace.outputs.root }}/evidence/runtime-receipt.json
+          if-no-files-found: error
+          retention-days: 90
+          compression-level: 6
+
+      - name: Qualify frozen routed cameras using source support and rank only
+        shell: bash
+        env:
+          REQUEST_ID: ${{ needs.authorize.outputs.request_id }}
+          RUNTIME_PYTHON: ${{ steps.runtime.outputs.python }}
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          while IFS=$'\t' read -r camera sequences protocol_file; do
+            mkdir -p "$root/results/$camera"
+            PYTHONPATH="$GITHUB_WORKSPACE/src:$GITHUB_WORKSPACE/scripts/science" \
+              "$RUNTIME_PYTHON" scripts/science/run_dot_rope_source_support_camera_component_v1.py \
+                --camera "$camera" --source-sequences-json "$sequences" \
+                qualify \
+                --protocol "$root/components/protocols/$protocol_file" \
+                --request-id "$REQUEST_ID" \
+                --prob4d-revision "${{ needs.authorize.outputs.head_sha }}" \
+                --dataset-root "$DATASET_ROOT" \
+                --provider-bundle "$root/providers/$camera/bundle" \
+                --output "$root/results/$camera/result.json"
+          done < "$root/components/components.tsv"
+          "$RUNTIME_PYTHON" scripts/science/combine_dot_rope_source_camera_components_v1.py \
+            --component-manifest "$root/components/protocols/manifest.json" \
+            --results-root "$root/results" \
+            --output "$root/results/result.json"
+
+      - name: Verify and publish routed provider-rank source decision
+        id: result
+        shell: bash
+        env:
+          RUNTIME_PYTHON: ${{ steps.runtime.outputs.python }}
+        run: |
+          set -euo pipefail
+          root="${{ steps.workspace.outputs.root }}"
+          RESULT="$root/results/result.json" "$RUNTIME_PYTHON" - <<'PY'
+          import json, os
+          from pathlib import Path
+          value=json.loads(Path(os.environ["RESULT"]).read_text(encoding="utf-8"))
+          if value["decision"] not in {"camera-routing-provider-rank-qualified","camera-routing-provider-rank-negative"}:
+              raise SystemExit("unexpected source rank decision")
+          boundary=value["information_boundary"]
+          assert boundary["source_reconstruction_error_computed"] is False
+          assert boundary["source_proper_score_computed"] is False
+          assert boundary["r21_r30_payloads_opened"] is False
+          assert boundary["r31_r70_payloads_opened"] is False
+          with open(os.environ["GITHUB_OUTPUT"],"a",encoding="utf-8") as output:
+              output.write(f"decision={value['decision']}\n")
+              output.write(f"result_id={value['result_id']}\n")
+              output.write(f"supported_sequences={value['supported_source_sequences']}\n")
+          with open(os.environ["GITHUB_STEP_SUMMARY"],"a",encoding="utf-8") as output:
+              output.write("## DOT R11-R20 routed CUT3R provider-rank gate\n\n")
+              output.write(f"- decision: **{value['decision']}**\n")
+              output.write(f"- supported source sequences: **{value['supported_source_sequences']}/10**\n")
+              output.write(f"- minimum supported condition ratio: `{value['minimum_supported_condition_ratio']}`\n")
+              output.write(f"- minimum supported support margin: `{value['minimum_supported_margin']}`\n")
+              output.write(f"- result ID: `{value['result_id']}`\n")
+              output.write("- R21-R70 remained unopened; no source error or proper score was computed.\n")
+          PY
+
+      - name: Upload immutable source provider-rank evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: dot-r11-r20-routed-provider-rank-result-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.workspace.outputs.root }}/results/
+          if-no-files-found: error
+          retention-days: 90
+
+      - name: Remove isolated provider workspace
+        if: always()
+        shell: bash
+        run: |
+          root="${{ steps.workspace.outputs.root }}"
+          chmod -R u+w "$root" 2>/dev/null || true
+          rm -rf -- "$root"
+
+  summary:
+    name: Publish camera-routing source rank summary
+    if: always()
+    needs: [authorize, source_rank]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Write bounded summary
+        shell: bash
+        env:
+          DECISION: ${{ needs.source_rank.outputs.decision }}
+          RESULT_ID: ${{ needs.source_rank.outputs.result_id }}
+          SUPPORTED: ${{ needs.source_rank.outputs.supported_sequences }}
+          PROVIDER_SEAL_ID: ${{ needs.source_rank.outputs.provider_seal_id }}
+        run: |
+          {
+            echo "## DOT camera-routing source provider-rank v1"
+            echo
+            echo "- provider seal: \`${PROVIDER_SEAL_ID:-unavailable}\`"
+            echo "- source decision: **${DECISION:-unavailable}**"
+            echo "- supported R11-R20 sequences: \`${SUPPORTED:-unavailable}/10\`"
+            echo "- result ID: \`${RESULT_ID:-unavailable}\`"
+            echo "- R21-R30 and R31-R70 remained unopened"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/dot-r11-r20-camera-routing-source-v1.yml
+++ b/.github/workflows/dot-r11-r20-camera-routing-source-v1.yml
@@ -1,0 +1,167 @@
+name: DOT R11-R20 camera-routing source audit v1
+
+on:
+  push:
+    branches: [science/dot-r11-r20-camera-routing-source-v1]
+    paths:
+      - "ops/requests/dot_r11_r20_camera_routing_source_v1.json"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dot-r11-r20-camera-routing-source-v1
+  cancel-in-progress: false
+
+env:
+  REQUEST_PATH: ops/requests/dot_r11_r20_camera_routing_source_v1.json
+  DATASET_ROOT: /home/github-runner/.cache/prob4d/dot-r11-r30-archives-v29
+  ARCHIVE: R11-20.zip
+  ARCHIVE_MD5: 23ce3e7067465d3edabe20b4c7cfa388
+
+jobs:
+  authorize:
+    name: Authorize source-only camera-routing audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      head_sha: ${{ steps.request.outputs.head_sha }}
+    steps:
+      - name: Check out exact request revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 2
+          persist-credentials: false
+          clean: true
+      - name: Require exactly one non-forced request change
+        id: request
+        shell: bash
+        env:
+          EVENT_REF: ${{ github.ref }}
+          EVENT_BEFORE: ${{ github.event.before }}
+          EVENT_AFTER: ${{ github.event.after }}
+          EVENT_FORCED: ${{ github.event.forced }}
+          EVENT_DELETED: ${{ github.event.deleted }}
+        run: |
+          set -euo pipefail
+          test "$EVENT_REF" = "refs/heads/science/dot-r11-r20-camera-routing-source-v1"
+          test "$EVENT_AFTER" = "$(git rev-parse HEAD)"
+          test "$EVENT_FORCED" = "false"
+          test "$EVENT_DELETED" = "false"
+          test "$EVENT_BEFORE" != "0000000000000000000000000000000000000000"
+          mapfile -t changed < <(git diff --name-only "$EVENT_BEFORE" "$EVENT_AFTER" | sort)
+          if [[ ${#changed[@]} -ne 1 || "${changed[0]}" != "$REQUEST_PATH" ]]; then
+            printf 'Expected only %s; changed paths were:\n' "$REQUEST_PATH" >&2
+            printf '  %s\n' "${changed[@]}" >&2
+            exit 2
+          fi
+          REQUEST="$REQUEST_PATH" python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          value = json.loads(Path(os.environ["REQUEST"]).read_text(encoding="utf-8"))
+          expected = {
+              "schema": "prob4d.dot-r11-r20-camera-routing-source-audit-request",
+              "schema_version": 1,
+              "source_sequences": "R11-R20",
+              "confirmation_sequences": "R21-R30",
+              "reserve_sequences": "R31-R70",
+              "runner_label": "gpuserver6000",
+              "source_performance_metrics_allowed": False,
+              "confirmation_payload_access_allowed": False,
+              "provider_execution_allowed": False,
+          }
+          if value != expected:
+              raise SystemExit("source camera-routing request content changed")
+          PY
+          echo "head_sha=$EVENT_AFTER" >> "$GITHUB_OUTPUT"
+
+  audit:
+    name: Audit R11-R20 camera routing on gpuserver6000
+    needs: authorize
+    environment: trusted-self-hosted-validation
+    runs-on: [self-hosted, gpuserver6000]
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      - name: Bind runner and exact source archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$RUNNER_NAME" = "workstation2"
+          test "$RUNNER_OS" = "Linux"
+          test "$RUNNER_ARCH" = "X64"
+          test -x /usr/bin/python3
+          test -f "$DATASET_ROOT/$ARCHIVE"
+          test ! -L "$DATASET_ROOT/$ARCHIVE"
+          printf '%s  %s\n' "$ARCHIVE_MD5" "$DATASET_ROOT/$ARCHIVE" | md5sum --check --strict
+      - name: Initialize isolated evidence workspace
+        id: workspace
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="$RUNNER_TEMP/dot-r11-r20-camera-routing-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          rm -rf -- "$root"
+          mkdir -p "$root/evidence"
+          echo "root=$root" >> "$GITHUB_OUTPUT"
+      - name: Check out exact authorized revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.authorize.outputs.head_sha }}
+          persist-credentials: false
+          clean: true
+      - name: Run outcome-blind source camera-routing audit
+        shell: bash
+        run: |
+          set -euo pipefail
+          /usr/bin/python3 scripts/science/audit_dot_r11_r20_camera_routing_support_v1.py \
+            --dataset-root "$DATASET_ROOT" \
+            --output "${{ steps.workspace.outputs.root }}/evidence/result.json"
+      - name: Verify information boundary and summarize
+        shell: bash
+        run: |
+          set -euo pipefail
+          RESULT="${{ steps.workspace.outputs.root }}/evidence/result.json" /usr/bin/python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          value = json.loads(Path(os.environ["RESULT"]).read_text(encoding="utf-8"))
+          assert value["decision"] in {
+              "camera-routing-source-support-eligible",
+              "camera-routing-source-support-negative",
+          }
+          boundary = value["information_boundary"]
+          assert boundary["source_reconstruction_error_computed"] is False
+          assert boundary["source_proper_score_computed"] is False
+          assert boundary["r21_r30_payloads_opened"] is False
+          assert boundary["r31_r70_payloads_opened"] is False
+          assert boundary["provider_predictions_computed"] is False
+          summary = {
+              "decision": value["decision"],
+              "audit_id": value["audit_id"],
+              "candidate": value["selected_candidate"]["candidate_id"],
+              "supported_sequences": value["selected_candidate"]["supported_sequences"],
+              "routing": value["selected_camera_routing"],
+          }
+          print(json.dumps(summary, indent=2, sort_keys=True))
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as output:
+              output.write("## DOT R11-R20 camera-routing source audit\n\n```json\n")
+              output.write(json.dumps(summary, indent=2, sort_keys=True))
+              output.write("\n```\n\nR21-R70 remained unopened. No performance metric or provider prediction was computed.\n")
+          PY
+      - name: Upload bounded source audit evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: dot-r11-r20-camera-routing-source-v1-${{ github.run_id }}
+          path: ${{ steps.workspace.outputs.root }}/evidence/result.json
+          if-no-files-found: error
+          retention-days: 90
+      - name: Remove isolated evidence workspace
+        if: always()
+        shell: bash
+        run: |
+          rm -rf -- "${{ steps.workspace.outputs.root }}"

--- a/docs/dot-r11-r20-camera-routing-source-v3.md
+++ b/docs/dot-r11-r20-camera-routing-source-v3.md
@@ -1,0 +1,11 @@
+# DOT R11-R20 camera-routing source v3
+
+This source-development lane follows the terminal fixed-camera R04-R10 `heldout-support-negative` result without retuning or reinterpreting it.
+
+The source split is R11-R20. R21-R30 remains a one-shot confirmation cohort and R31-R70 remains reserve.
+
+A source-only raw marker audit on run `33527652881` found that the frozen `expanded__overlap-345` geometry supports all 10 R11-R20 sequences when a deterministic per-sequence single-camera rule is allowed. The rule chooses the lexicographically smallest camera that meets the frozen pixel-zero-based 2-D support thresholds. It selected `cam005` for R11, R12, and R20; `cam002` for R17; and `cam001` for the remaining six sequences. The minimum selected-camera support margin was 1.125 times the registered threshold. No provider prediction, reconstruction error, NLL, or proper score entered that routing decision.
+
+The next registered gate runs the unchanged CUT3R revision and checkpoint only on those routed source cameras. Provider outputs are sealed and uploaded before source marker qualification. Source qualification may use marker support and the rank-six observable-factor mechanism, but not reconstruction error or proper scores. Promotion requires at least 9 of 10 routed source sequences to support the fixed `expanded__overlap-345` geometry with factor rank six.
+
+If the source provider-rank gate qualifies, a separate future protocol/request may open R21-R30 exactly once. That confirmation must predict all five normal-view cameras before target marker access, choose the lexicographically smallest camera meeting the frozen raw 2-D support rule, refuse camera switching after a factor-rank failure, seal all query decisions/predictions before 3-D outcome access, and retain R31-R70 unopened.

--- a/ops/requests/dot_r11_r20_camera_routing_provider_rank_v1.json
+++ b/ops/requests/dot_r11_r20_camera_routing_provider_rank_v1.json
@@ -1,0 +1,40 @@
+{
+  "schema": "prob4d.dot-r11-r20-camera-routing-provider-rank-request",
+  "schema_version": 1,
+  "protocol_path": "protocols/dot-rope-query-selective-camera-routing-source-v3.json",
+  "protocol_git_blob_sha": "f5c7992ee508ea5371dc282dc864bca189a750aa",
+  "protocol_id": "cd57cb81d1aa52707f26bb0f39829e848d15d0a67b064b390b24caf545923690",
+  "raw_routing_audit_id": "66724cb78840f4b9ef3becf97e5765924094cf8db6eca2d892c44cfa7edb19b3",
+  "source_sequences": [
+    "R11",
+    "R12",
+    "R13",
+    "R14",
+    "R15",
+    "R16",
+    "R17",
+    "R18",
+    "R19",
+    "R20"
+  ],
+  "confirmation_sequences": [
+    "R21",
+    "R22",
+    "R23",
+    "R24",
+    "R25",
+    "R26",
+    "R27",
+    "R28",
+    "R29",
+    "R30"
+  ],
+  "reserved_sequences": "R31-R70",
+  "routed_marker_free_provider_authorized": true,
+  "source_factor_rank_qualification_authorized": true,
+  "source_reconstruction_error_authorized": false,
+  "source_proper_score_authorized": false,
+  "confirmation_payload_access_authorized": false,
+  "post_source_retuning_authorized": false,
+  "request_id": "75e9cac8d776dac0575dc29d922b1468542cf3bf0ad9949810fc18441341863d"
+}

--- a/ops/requests/dot_r11_r20_camera_routing_source_v1.json
+++ b/ops/requests/dot_r11_r20_camera_routing_source_v1.json
@@ -1,0 +1,11 @@
+{
+  "schema": "prob4d.dot-r11-r20-camera-routing-source-audit-request",
+  "schema_version": 1,
+  "source_sequences": "R11-R20",
+  "confirmation_sequences": "R21-R30",
+  "reserve_sequences": "R31-R70",
+  "runner_label": "gpuserver6000",
+  "source_performance_metrics_allowed": false,
+  "confirmation_payload_access_allowed": false,
+  "provider_execution_allowed": false
+}

--- a/protocols/dot-rope-query-selective-camera-routing-confirmation-v1.json
+++ b/protocols/dot-rope-query-selective-camera-routing-confirmation-v1.json
@@ -6,7 +6,9 @@
     "source_protocol_id": "cd57cb81d1aa52707f26bb0f39829e848d15d0a67b064b390b24caf545923690",
     "required_decision": "camera-routing-provider-rank-qualified",
     "minimum_supported_source_sequences": 9,
-    "raw_routing_audit_id": "66724cb78840f4b9ef3becf97e5765924094cf8db6eca2d892c44cfa7edb19b3"
+    "raw_routing_audit_id": "66724cb78840f4b9ef3becf97e5765924094cf8db6eca2d892c44cfa7edb19b3",
+    "source_calibration_id": "943339ac864fda04cc59081bc81a605576b3c90bf0aa996aea00b00335cfc0c7",
+    "selected_dependence_alpha": 0.85
   },
   "target_archive": {
     "name": "R21-30.zip",
@@ -68,6 +70,7 @@
   "factor": {
     "expected_rank": 6,
     "rank_threshold": 0.01,
+    "selected_dependence_alpha": 0.85,
     "prior_standard_deviations_local": [0.05, 0.2, 0.2, 0.2, 0.15, 0.15, 0.15],
     "query_gate": {
       "minimum_direct_observability_fraction": 0.9,
@@ -122,5 +125,5 @@
     "target_side_retuning_allowed": false
   },
   "claim_boundary": "One-shot DOT R21-R30 learned-CUT3R camera-routed query-selective confirmation after source-only R11-R20 rank qualification. It does not authorize target-side retuning, post-outcome camera switching, R31-R70 access, BayesianPhysTwin/Causal4D execution, deployment-safety claims, or state-of-the-art claims.",
-  "protocol_id": "6cfa652c6e5d419dda2b81ccd88ff25f7180a2abc2d3f749d6c8b3e9c1ad1195"
+  "protocol_id": "b9267992484516a88d73637c813ae463f27e4a7b2586f805d394bea45e5f537c"
 }

--- a/protocols/dot-rope-query-selective-camera-routing-confirmation-v1.json
+++ b/protocols/dot-rope-query-selective-camera-routing-confirmation-v1.json
@@ -1,0 +1,126 @@
+{
+  "schema": "prob4d.dot-rope-query-selective-camera-routing-confirmation-protocol",
+  "schema_version": 1,
+  "dataset_doi": "10.13021/ORC2020/XXLVXM",
+  "prerequisite": {
+    "source_protocol_id": "cd57cb81d1aa52707f26bb0f39829e848d15d0a67b064b390b24caf545923690",
+    "required_decision": "camera-routing-provider-rank-qualified",
+    "minimum_supported_source_sequences": 9,
+    "raw_routing_audit_id": "66724cb78840f4b9ef3becf97e5765924094cf8db6eca2d892c44cfa7edb19b3"
+  },
+  "target_archive": {
+    "name": "R21-30.zip",
+    "md5": "8aee77f79d1aff6e1f3fd21886b251a0"
+  },
+  "target_sequences": [
+    "R21",
+    "R22",
+    "R23",
+    "R24",
+    "R25",
+    "R26",
+    "R27",
+    "R28",
+    "R29",
+    "R30"
+  ],
+  "reserved_sequences": "R31-R70",
+  "camera_roster": [
+    "cam001",
+    "cam002",
+    "cam003",
+    "cam004",
+    "cam005"
+  ],
+  "frames": [1, 2, 3, 4, 5, 6, 7],
+  "windows": {
+    "continuous": [1, 2, 3, 4, 5, 6, 7],
+    "window_a": [1, 2, 3, 4, 5],
+    "window_b": [3, 4, 5, 6, 7]
+  },
+  "provider": {
+    "name": "CUT3R",
+    "cut3r_revision": "8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf",
+    "checkpoint_sha256": "45f7e98a0a64dbeb54901ae2b878cd8cd125f20a4497316483f0bd6f109f8103",
+    "device": "cuda",
+    "image_size": 512,
+    "random_seed": 42,
+    "revisit": 1,
+    "update": true,
+    "native_rope_required": true
+  },
+  "coordinate_convention": {
+    "columns": [0, 1],
+    "mode": "pixel-zero-based",
+    "preprocessing_transform": "cut3r-long-edge-resize-512-center-crop-multiple-of-16-pixel-centers",
+    "shared_3d_camera_label": "cam001"
+  },
+  "routing": {
+    "fit_a_frames": [1, 2, 3],
+    "fit_b_frames": [5, 6, 7],
+    "overlap_frames": [3, 4, 5],
+    "minimum_metric_fit_markers": 6,
+    "minimum_overlap_common_markers": 8,
+    "minimum_overlap_nonempty_frames": 2,
+    "rule": "After all five camera providers are sealed, open target 2-D markers only and choose the lexicographically smallest camera satisfying the frozen raw-support thresholds. If that camera's learned-provider factor is not rank six, mark the sequence unsupported and do not switch cameras.",
+    "camera_switch_after_factor_rank_failure": false
+  },
+  "factor": {
+    "expected_rank": 6,
+    "rank_threshold": 0.01,
+    "prior_standard_deviations_local": [0.05, 0.2, 0.2, 0.2, 0.15, 0.15, 0.15],
+    "query_gate": {
+      "minimum_direct_observability_fraction": 0.9,
+      "maximum_worst_supported_variance_ratio": 1.0,
+      "minimum_metric_variance_reduction_fraction": 0.0
+    },
+    "invalid_nullspace_precision_ratio": 1.0,
+    "observation_noise_fraction": 0.02
+  },
+  "methods": [
+    "physical_fallback",
+    "full_rank_only",
+    "observable_subspace_unconditional",
+    "query_aware",
+    "invalid_full_rank_completion"
+  ],
+  "queries": {
+    "centerline_centroid": {
+      "definition": "selected-camera provider-window-B overlap centroid",
+      "expected_relation_to_axial_nullspace": "locally invariant"
+    },
+    "off_axis_probe": {
+      "definition": "selected-camera provider-window-B centroid plus one cloud-scale deterministic normal",
+      "expected_relation_to_axial_nullspace": "sensitive"
+    }
+  },
+  "statistics": {
+    "independent_unit": "complete_sequence",
+    "primary_method": "query_aware",
+    "primary_comparator": "physical_fallback",
+    "primary_point_metric": "rmse_fraction_of_provider_span",
+    "primary_proper_score": "normalized_joint_gaussian_nll_per_dimension",
+    "paired_bootstrap_replicates": 20000,
+    "paired_bootstrap_seed": 20260901,
+    "minimum_supported_target_sequences": 9,
+    "minimum_centroid_acceptance_fraction": 0.9,
+    "minimum_off_axis_rejection_fraction": 0.9,
+    "outcome_oracle_is_diagnostic_only": true
+  },
+  "terminal_rules": {
+    "strong_positive": "minimum support passes; centroid acceptance and off-axis rejection pass; paired bootstrap lower 95% bounds for both RMSE improvement and NLL improvement over physical fallback are positive",
+    "directional_positive": "support and query-routing gates pass but one registered lower confidence bound is nonpositive",
+    "mixed_or_negative": "completed target evaluation not satisfying a positive class",
+    "support_negative": "fewer than 9 target sequences support the frozen routed factor"
+  },
+  "information_order": {
+    "all_five_camera_provider_predictions_sealed_before_target_marker_access": true,
+    "target_2d_opened_only_after_provider_seal": true,
+    "camera_routing_and_factor_query_predictions_sealed_before_target_3d": true,
+    "target_3d_opened_once_for_scoring": true,
+    "r31_r70_payloads_opened": false,
+    "target_side_retuning_allowed": false
+  },
+  "claim_boundary": "One-shot DOT R21-R30 learned-CUT3R camera-routed query-selective confirmation after source-only R11-R20 rank qualification. It does not authorize target-side retuning, post-outcome camera switching, R31-R70 access, BayesianPhysTwin/Causal4D execution, deployment-safety claims, or state-of-the-art claims.",
+  "protocol_id": "6cfa652c6e5d419dda2b81ccd88ff25f7180a2abc2d3f749d6c8b3e9c1ad1195"
+}

--- a/protocols/dot-rope-query-selective-camera-routing-source-v3.json
+++ b/protocols/dot-rope-query-selective-camera-routing-source-v3.json
@@ -1,0 +1,171 @@
+{
+  "schema": "prob4d.dot-rope-query-selective-camera-routing-source-protocol",
+  "schema_version": 3,
+  "dataset_doi": "10.13021/ORC2020/XXLVXM",
+  "source_archive": {
+    "name": "R11-20.zip",
+    "md5": "23ce3e7067465d3edabe20b4c7cfa388"
+  },
+  "source_sequences": [
+    "R11",
+    "R12",
+    "R13",
+    "R14",
+    "R15",
+    "R16",
+    "R17",
+    "R18",
+    "R19",
+    "R20"
+  ],
+  "confirmation_sequences": [
+    "R21",
+    "R22",
+    "R23",
+    "R24",
+    "R25",
+    "R26",
+    "R27",
+    "R28",
+    "R29",
+    "R30"
+  ],
+  "reserved_sequences": "R31-R70",
+  "camera_roster": [
+    "cam001",
+    "cam002",
+    "cam003",
+    "cam004",
+    "cam005"
+  ],
+  "frames": [1, 2, 3, 4, 5, 6, 7],
+  "windows": {
+    "continuous": [1, 2, 3, 4, 5, 6, 7],
+    "window_a": [1, 2, 3, 4, 5],
+    "window_b": [3, 4, 5, 6, 7]
+  },
+  "routing_development": {
+    "source_audit_run_id": 33527652881,
+    "source_audit_head_sha": "8aa0d3d643dcb3d72f930c25846353dd9d5b6c40",
+    "source_audit_artifact_id": 9808467255,
+    "source_audit_artifact_digest": "sha256:1b3abc1405583bb81532ebda15110c196b5d03808883244e9e18282fd5b6323e",
+    "source_audit_id": "66724cb78840f4b9ef3becf97e5765924094cf8db6eca2d892c44cfa7edb19b3",
+    "decision": "camera-routing-source-support-eligible",
+    "selected_candidate": "expanded__overlap-345",
+    "metric_fit_a_frames": [1, 2, 3],
+    "metric_fit_b_frames": [5, 6, 7],
+    "overlap_frames": [3, 4, 5],
+    "supported_source_sequences": 10,
+    "worst_selected_camera_support_margin": 1.125,
+    "selected_camera_routing": {
+      "R11": "cam005",
+      "R12": "cam005",
+      "R13": "cam001",
+      "R14": "cam001",
+      "R15": "cam001",
+      "R16": "cam001",
+      "R17": "cam002",
+      "R18": "cam001",
+      "R19": "cam001",
+      "R20": "cam005"
+    },
+    "provider_execution_cameras": ["cam001", "cam002", "cam005"],
+    "selection_rule": "For each source sequence, choose the lexicographically smallest normal-view camera meeting the frozen pixel-zero-based 2-D support thresholds under the selected frame geometry. No reconstruction error, NLL, proper score, or provider prediction entered this routing decision."
+  },
+  "provider": {
+    "name": "CUT3R",
+    "cut3r_revision": "8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf",
+    "checkpoint_sha256": "45f7e98a0a64dbeb54901ae2b878cd8cd125f20a4497316483f0bd6f109f8103",
+    "device": "cuda",
+    "image_size": 512,
+    "random_seed": 42,
+    "revisit": 1,
+    "update": true,
+    "native_rope_required": true
+  },
+  "coordinate_convention": {
+    "columns": [0, 1],
+    "mode": "pixel-zero-based",
+    "preprocessing_transform": "cut3r-long-edge-resize-512-center-crop-multiple-of-16-pixel-centers",
+    "frozen_from": "R01-R03 source development before R04-R10 access"
+  },
+  "provider_rank_gate": {
+    "metric_fit_a_frames": [1, 2, 3],
+    "metric_fit_b_frames": [5, 6, 7],
+    "overlap_frames": [3, 4, 5],
+    "minimum_metric_fit_markers": 6,
+    "minimum_overlap_common_markers": 8,
+    "minimum_overlap_nonempty_frames": 2,
+    "expected_factor_rank": 6,
+    "rank_threshold": 0.01,
+    "minimum_source_supported_sequences_for_promotion": 9,
+    "camera_fallback_after_rank_failure": false,
+    "outcome_metrics_used": false
+  },
+  "confirmation_camera_rule": {
+    "provider_prediction_camera_roster": ["cam001", "cam002", "cam003", "cam004", "cam005"],
+    "provider_seal_before_target_marker_access": true,
+    "after_provider_seal_open_only_2d_for_routing_and_factor": true,
+    "routing_rule": "Choose the lexicographically smallest camera meeting the frozen raw 2-D support thresholds under expanded/overlap-345. If its learned-provider overlap factor is not rank six, mark that target sequence unsupported; do not switch cameras based on factor rank or outcomes.",
+    "three_dimensional_outcomes_opened_only_after_prediction_seal": true
+  },
+  "downstream_frozen_config": {
+    "methods": [
+      "physical_fallback",
+      "full_rank_only",
+      "observable_subspace_unconditional",
+      "query_aware",
+      "invalid_full_rank_completion"
+    ],
+    "prior_standard_deviations_local": [0.05, 0.2, 0.2, 0.2, 0.15, 0.15, 0.15],
+    "query_gate": {
+      "minimum_direct_observability_fraction": 0.9,
+      "maximum_worst_supported_variance_ratio": 1.0,
+      "minimum_metric_variance_reduction_fraction": 0.0
+    },
+    "queries": {
+      "centerline_centroid": {
+        "definition": "provider-window-B overlap centroid",
+        "expected_relation_to_axial_nullspace": "locally invariant"
+      },
+      "off_axis_probe": {
+        "definition": "provider-window-B centroid plus one cloud-scale deterministic normal",
+        "expected_relation_to_axial_nullspace": "sensitive"
+      }
+    },
+    "invalid_nullspace_precision_ratio": 1.0,
+    "observation_noise_fraction": 0.02,
+    "exact_fallback_required": true
+  },
+  "confirmation_statistics": {
+    "independent_unit": "complete_sequence",
+    "primary_method": "query_aware",
+    "primary_comparator": "physical_fallback",
+    "primary_point_metric": "rmse_fraction_of_provider_span",
+    "primary_proper_score": "normalized_joint_gaussian_nll_per_dimension",
+    "paired_bootstrap_replicates": 20000,
+    "paired_bootstrap_seed": 20260901,
+    "minimum_supported_confirmation_sequences": 9,
+    "minimum_centroid_acceptance_fraction": 0.9,
+    "minimum_off_axis_rejection_fraction": 0.9,
+    "outcome_oracle_is_diagnostic_only": true
+  },
+  "information_boundary": {
+    "r04_r10_reused_for_tuning": false,
+    "r11_r20_is_source_development": true,
+    "source_reconstruction_error_used_for_routing_or_rank_gate": false,
+    "source_proper_score_used_for_routing_or_rank_gate": false,
+    "r21_r30_payloads_opened": false,
+    "r31_r70_payloads_opened": false,
+    "bayesian_phystwin_executed": false,
+    "causal4d_executed": false,
+    "dataset_modified": false,
+    "target_side_retuning_allowed": false
+  },
+  "promotion": {
+    "on_provider_rank_qualified": "freeze this routing and factor rule and materialize a separate R21-R30 one-shot confirmation request",
+    "on_provider_rank_negative": "terminate camera-routing CUT3R provider version without opening R21-R70"
+  },
+  "claim_boundary": "R11-R20 is source development only. The source camera rule may use raw marker support and provider-factor rank but no reconstruction error or proper score. R21-R30 remains a one-shot confirmation and R31-R70 remains reserve. A later positive result would establish only learned-CUT3R marker-localized query-selective factor use on DOT rope.",
+  "protocol_id": "cd57cb81d1aa52707f26bb0f39829e848d15d0a67b064b390b24caf545923690"
+}

--- a/scripts/science/audit_dot_r11_r20_camera_routing_support_v1.py
+++ b/scripts/science/audit_dot_r11_r20_camera_routing_support_v1.py
@@ -1,0 +1,309 @@
+#!/usr/bin/env python3
+"""Audit outcome-blind per-sequence camera routing support on DOT R11-R20."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import re
+import zipfile
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+SEQUENCES = [f"R{i:02d}" for i in range(11, 21)]
+FRAMES = list(range(1, 8))
+ARCHIVE = "R11-20.zip"
+ARCHIVE_MD5 = "23ce3e7067465d3edabe20b4c7cfa388"
+SHARED_3D_CAMERA = "cam001"
+CAMERA_RE = re.compile(
+    r"^(R(?:1[1-9]|20))/images/normal_view/frame(\d{6})_(cam\d+)\.jpg$"
+)
+NUMBER = re.compile(r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][-+]?\d+)?")
+FIT_PROFILES = [
+    {"id": "compact", "fit_a": [1, 2], "fit_b": [6, 7]},
+    {"id": "expanded", "fit_a": [1, 2, 3], "fit_b": [5, 6, 7]},
+    {"id": "full-window", "fit_a": [1, 2, 3, 4, 5], "fit_b": [3, 4, 5, 6, 7]},
+]
+OVERLAP_GROUPS = [
+    {"id": "overlap-34", "frames": [3, 4]},
+    {"id": "overlap-45", "frames": [4, 5]},
+    {"id": "overlap-345", "frames": [3, 4, 5]},
+]
+MIN_FIT = 6
+MIN_OVERLAP = 8
+MIN_NONEMPTY = 2
+PROMOTION_MINIMUM = 9
+
+
+def numeric_rows(text: str) -> list[list[float]]:
+    rows: list[list[float]] = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        values = [float(match.group(0)) for match in NUMBER.finditer(line)]
+        if values:
+            rows.append(values)
+    return rows
+
+
+def jpeg_size(blob: bytes) -> tuple[int, int]:
+    if len(blob) < 4 or blob[:2] != b"\xff\xd8":
+        raise ValueError("normal-view payload is not a JPEG")
+    offset = 2
+    sof = {0xC0, 0xC1, 0xC2, 0xC3, 0xC5, 0xC6, 0xC7, 0xC9, 0xCA, 0xCB, 0xCD, 0xCE, 0xCF}
+    while offset + 4 <= len(blob):
+        if blob[offset] != 0xFF:
+            offset += 1
+            continue
+        while offset < len(blob) and blob[offset] == 0xFF:
+            offset += 1
+        if offset >= len(blob):
+            break
+        marker = blob[offset]
+        offset += 1
+        if marker in {0xD8, 0xD9} or 0xD0 <= marker <= 0xD7:
+            continue
+        if offset + 2 > len(blob):
+            break
+        length = int.from_bytes(blob[offset : offset + 2], "big")
+        if length < 2 or offset + length > len(blob):
+            raise ValueError("malformed JPEG segment")
+        if marker in sof:
+            if length < 7:
+                raise ValueError("malformed JPEG SOF")
+            height = int.from_bytes(blob[offset + 3 : offset + 5], "big")
+            width = int.from_bytes(blob[offset + 5 : offset + 7], "big")
+            if width <= 0 or height <= 0:
+                raise ValueError("invalid JPEG dimensions")
+            return width, height
+        offset += length
+    raise ValueError("JPEG dimensions unavailable")
+
+
+def md5(path: Path) -> str:
+    digest = hashlib.md5(usedforsecurity=False)
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def image_member(sequence: str, frame: int, camera: str) -> str:
+    return f"{sequence}/images/normal_view/frame{frame:06d}_{camera}.jpg"
+
+
+def coordinate_member(sequence: str, dimension: int, frame: int, camera: str) -> str:
+    return f"{sequence}/coordinates/{dimension}d/frame{frame:06d}_{camera}.txt"
+
+
+def valid_indices(rows: list[list[float]], width: int, height: int) -> set[int]:
+    result: set[int] = set()
+    for index, row in enumerate(rows):
+        if len(row) < 2:
+            continue
+        x, y = float(row[-2]), float(row[-1])
+        if math.isfinite(x) and math.isfinite(y) and 0.0 <= x <= width - 1.0 and 0.0 <= y <= height - 1.0:
+            result.add(index)
+    return result
+
+
+def audit(dataset_root: Path) -> dict[str, Any]:
+    root = dataset_root.expanduser().resolve(strict=True)
+    archive_path = (root / ARCHIVE).resolve(strict=True)
+    archive_path.relative_to(root)
+    if archive_path.is_symlink() or not archive_path.is_file():
+        raise ValueError("official R11-20 archive unavailable")
+    if md5(archive_path) != ARCHIVE_MD5:
+        raise ValueError("R11-20 archive checksum mismatch")
+
+    support: dict[str, dict[str, dict[int, set[int]]]] = {}
+    cameras_by_sequence = {sequence: set() for sequence in SEQUENCES}
+    row_count_pairs = 0
+    with zipfile.ZipFile(archive_path, "r") as archive:
+        names = set(archive.namelist())
+        for name in names:
+            match = CAMERA_RE.match(name)
+            if match and int(match.group(2)) in FRAMES:
+                cameras_by_sequence[match.group(1)].add(match.group(3))
+        cameras = sorted(set.intersection(*(value for value in cameras_by_sequence.values())))
+        if not cameras:
+            raise ValueError("no common normal-view camera across R11-R20")
+        for sequence in SEQUENCES:
+            support[sequence] = {}
+            for camera in cameras:
+                support[sequence][camera] = {}
+                for frame in FRAMES:
+                    image = image_member(sequence, frame, camera)
+                    two_d = coordinate_member(sequence, 2, frame, camera)
+                    three_d = coordinate_member(sequence, 3, frame, SHARED_3D_CAMERA)
+                    for member in (image, two_d, three_d):
+                        pure = PurePosixPath(member)
+                        if pure.is_absolute() or ".." in pure.parts or member not in names:
+                            raise ValueError(f"registered source member missing: {member}")
+                    width, height = jpeg_size(archive.read(image))
+                    rows_2d = numeric_rows(archive.read(two_d).decode("utf-8", errors="replace"))
+                    rows_3d = numeric_rows(archive.read(three_d).decode("utf-8", errors="replace"))
+                    if len(rows_2d) != len(rows_3d):
+                        raise ValueError(
+                            "camera-specific 2-D and shared 3-D row counts differ: "
+                            f"{sequence}:{camera}:{frame}:{len(rows_2d)}!={len(rows_3d)}"
+                        )
+                    row_count_pairs += 1
+                    support[sequence][camera][frame] = valid_indices(rows_2d, width, height)
+
+    candidate_summaries: list[dict[str, Any]] = []
+    for fit in FIT_PROFILES:
+        for overlap in OVERLAP_GROUPS:
+            candidate_id = f"{fit['id']}__{overlap['id']}"
+            per_sequence = []
+            supported_sequences = 0
+            worst_margin = float("inf")
+            for sequence in SEQUENCES:
+                eligible = []
+                per_camera = []
+                for camera in cameras:
+                    counts = {frame: len(support[sequence][camera][frame]) for frame in FRAMES}
+                    fit_a = sum(counts[frame] for frame in fit["fit_a"])
+                    fit_b = sum(counts[frame] for frame in fit["fit_b"])
+                    overlap_values = [counts[frame] for frame in overlap["frames"]]
+                    overlap_total = sum(overlap_values)
+                    overlap_nonempty = sum(value > 0 for value in overlap_values)
+                    margin = min(fit_a / MIN_FIT, fit_b / MIN_FIT, overlap_total / MIN_OVERLAP)
+                    feasible = (
+                        fit_a >= MIN_FIT
+                        and fit_b >= MIN_FIT
+                        and overlap_total >= MIN_OVERLAP
+                        and overlap_nonempty >= MIN_NONEMPTY
+                    )
+                    if feasible:
+                        eligible.append(camera)
+                    per_camera.append(
+                        {
+                            "camera": camera,
+                            "feasible": feasible,
+                            "fit_a_total": fit_a,
+                            "fit_b_total": fit_b,
+                            "overlap_total": overlap_total,
+                            "overlap_nonempty_frames": overlap_nonempty,
+                            "normalized_support_margin": margin,
+                        }
+                    )
+                selected_camera = min(eligible) if eligible else None
+                if selected_camera is not None:
+                    supported_sequences += 1
+                    selected_row = next(row for row in per_camera if row["camera"] == selected_camera)
+                    worst_margin = min(worst_margin, float(selected_row["normalized_support_margin"]))
+                per_sequence.append(
+                    {
+                        "sequence": sequence,
+                        "eligible_cameras": eligible,
+                        "selected_camera": selected_camera,
+                        "per_camera": per_camera,
+                    }
+                )
+            candidate_summaries.append(
+                {
+                    "candidate_id": candidate_id,
+                    "fit_a_frames": fit["fit_a"],
+                    "fit_b_frames": fit["fit_b"],
+                    "overlap_frames": overlap["frames"],
+                    "supported_sequences": supported_sequences,
+                    "worst_selected_camera_support_margin": 0.0 if worst_margin == float("inf") else worst_margin,
+                    "selected_frame_count": len(fit["fit_a"]) + len(fit["fit_b"]) + len(overlap["frames"]),
+                    "per_sequence": per_sequence,
+                }
+            )
+
+    selected = sorted(
+        candidate_summaries,
+        key=lambda row: (
+            -int(row["supported_sequences"]),
+            -float(row["worst_selected_camera_support_margin"]),
+            int(row["selected_frame_count"]),
+            str(row["candidate_id"]),
+        ),
+    )[0]
+    decision = (
+        "camera-routing-source-support-eligible"
+        if int(selected["supported_sequences"]) >= PROMOTION_MINIMUM
+        else "camera-routing-source-support-negative"
+    )
+    routing = {
+        row["sequence"]: row["selected_camera"]
+        for row in selected["per_sequence"]
+        if row["selected_camera"] is not None
+    }
+    result: dict[str, Any] = {
+        "schema": "prob4d.dot-r11-r20-camera-routing-support-v1",
+        "schema_version": 1,
+        "decision": decision,
+        "source_archive": {"name": ARCHIVE, "md5": ARCHIVE_MD5},
+        "source_sequences": SEQUENCES,
+        "confirmation_sequences": [f"R{i:02d}" for i in range(21, 31)],
+        "reserved_sequences": "R31-R70",
+        "cameras_present_on_every_source_sequence": cameras,
+        "coordinate_mode": "pixel-zero-based",
+        "shared_3d_camera_label": SHARED_3D_CAMERA,
+        "selection": {
+            "minimum_metric_fit_markers": MIN_FIT,
+            "minimum_overlap_common_markers": MIN_OVERLAP,
+            "minimum_overlap_nonempty_frames": MIN_NONEMPTY,
+            "minimum_source_supported_sequences_for_promotion": PROMOTION_MINIMUM,
+            "camera_tie_break": "lexicographically-smallest-eligible-camera",
+            "outcome_metrics_used": False,
+        },
+        "selected_candidate": selected,
+        "selected_camera_routing": routing,
+        "candidate_summaries": candidate_summaries,
+        "row_count_pairs_verified": row_count_pairs,
+        "information_boundary": {
+            "r11_r20_source_images_opened": True,
+            "r11_r20_source_2d_markers_opened": True,
+            "r11_r20_source_3d_carriers_opened_for_layout_consistency_only": True,
+            "source_reconstruction_error_computed": False,
+            "source_proper_score_computed": False,
+            "r21_r30_payloads_opened": False,
+            "r31_r70_payloads_opened": False,
+            "provider_predictions_computed": False,
+            "bayesian_phystwin_executed": False,
+            "causal4d_executed": False,
+        },
+        "claim_boundary": (
+            "Outcome-blind raw-marker camera-routing feasibility on DOT R11-R20 source data only. "
+            "This audit does not establish CUT3R/provider overlap, rank-six factors, prediction benefit, "
+            "or confirmation performance. R21-R70 remain closed."
+        ),
+    }
+    encoded = json.dumps(result, sort_keys=True, separators=(",", ":"), allow_nan=False).encode()
+    result["audit_id"] = hashlib.sha256(encoded).hexdigest()
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dataset-root", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    result = audit(args.dataset_root)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(
+        json.dumps(
+            {
+                "decision": result["decision"],
+                "audit_id": result["audit_id"],
+                "selected_candidate": result["selected_candidate"]["candidate_id"],
+                "supported_sequences": result["selected_candidate"]["supported_sequences"],
+                "routing": result["selected_camera_routing"],
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/science/combine_dot_rope_source_camera_components_v1.py
+++ b/scripts/science/combine_dot_rope_source_camera_components_v1.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Combine fixed routed-camera source-support components into one DOT v3 rank gate."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+EXPECTED_PARENT = "cd57cb81d1aa52707f26bb0f39829e848d15d0a67b064b390b24caf545923690"
+EXPECTED_AUDIT = "66724cb78840f4b9ef3becf97e5765924094cf8db6eca2d892c44cfa7edb19b3"
+EXPECTED_CANDIDATE = "expanded__overlap-345"
+EXPECTED_SEQUENCES = [f"R{index:02d}" for index in range(11, 21)]
+MINIMUM_PROMOTION = 9
+EXPECTED_RANK = 6
+
+
+def content_id(value: object) -> str:
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if type(value) is not dict:
+        raise ValueError(f"{path.name} must contain one object")
+    return value
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--component-manifest", type=Path, required=True)
+    parser.add_argument("--results-root", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    manifest = load_json(args.component_manifest)
+    unsigned_manifest = dict(manifest)
+    manifest_id = unsigned_manifest.pop("manifest_id", None)
+    if content_id(unsigned_manifest) != manifest_id:
+        raise ValueError("component manifest identity mismatch")
+    if manifest.get("parent_protocol_id") != EXPECTED_PARENT:
+        raise ValueError("parent protocol changed")
+    if manifest.get("raw_routing_audit_id") != EXPECTED_AUDIT:
+        raise ValueError("raw routing audit changed")
+    if manifest.get("fixed_candidate") != EXPECTED_CANDIDATE:
+        raise ValueError("source support geometry changed")
+
+    rows: list[dict[str, Any]] = []
+    component_results = []
+    seen: set[str] = set()
+    for component in manifest["components"]:
+        camera = str(component["camera"])
+        result_path = args.results_root / camera / "result.json"
+        result = load_json(result_path)
+        summaries = [
+            item for item in result.get("candidate_summaries", [])
+            if item.get("candidate_id") == EXPECTED_CANDIDATE
+        ]
+        if len(summaries) != 1:
+            raise ValueError(f"{camera} lacks the frozen candidate")
+        summary = summaries[0]
+        expected_component_sequences = list(component["source_sequences"])
+        per_sequence = list(summary.get("per_sequence", []))
+        if sorted(item.get("sequence") for item in per_sequence) != sorted(expected_component_sequences):
+            raise ValueError(f"{camera} result sequence roster changed")
+        for item in per_sequence:
+            sequence = str(item["sequence"])
+            if sequence in seen:
+                raise ValueError("source sequence appears in multiple camera components")
+            seen.add(sequence)
+            rank = int(item.get("factor_rank", 0))
+            supported = bool(item.get("supported", False)) and rank == EXPECTED_RANK
+            condition = float(item.get("observable_condition_ratio", 0.0))
+            if not math.isfinite(condition) or condition < 0.0:
+                raise ValueError("invalid observable condition ratio")
+            rows.append(
+                {
+                    "sequence": sequence,
+                    "camera": camera,
+                    "supported": supported,
+                    "factor_rank": rank,
+                    "fit_a_total": int(item.get("fit_a_total", 0)),
+                    "fit_b_total": int(item.get("fit_b_total", 0)),
+                    "overlap_common_total": int(item.get("overlap_common_total", 0)),
+                    "overlap_nonempty_frames": int(item.get("overlap_nonempty_frames", 0)),
+                    "normalized_support_margin": float(item.get("normalized_support_margin", 0.0)),
+                    "observable_condition_ratio": condition,
+                    "factor_error": item.get("factor_error"),
+                }
+            )
+        component_results.append(
+            {
+                "camera": camera,
+                "protocol_id": component["protocol_id"],
+                "provider_bundle_id": result.get("provider_bundle_id"),
+                "component_result_id": result.get("result_id"),
+                "component_decision": result.get("decision"),
+            }
+        )
+
+    if sorted(seen) != EXPECTED_SEQUENCES:
+        raise ValueError("combined components do not cover R11-R20 exactly")
+    rows.sort(key=lambda item: item["sequence"])
+    supported = [item for item in rows if item["supported"]]
+    decision = (
+        "camera-routing-provider-rank-qualified"
+        if len(supported) >= MINIMUM_PROMOTION
+        else "camera-routing-provider-rank-negative"
+    )
+    result: dict[str, Any] = {
+        "schema": "prob4d.dot-r11-r20-camera-routing-provider-rank-result",
+        "schema_version": 1,
+        "decision": decision,
+        "parent_protocol_id": EXPECTED_PARENT,
+        "raw_routing_audit_id": EXPECTED_AUDIT,
+        "fixed_candidate": EXPECTED_CANDIDATE,
+        "minimum_supported_sequences_for_promotion": MINIMUM_PROMOTION,
+        "expected_factor_rank": EXPECTED_RANK,
+        "supported_source_sequences": len(supported),
+        "source_sequence_count": len(rows),
+        "minimum_supported_condition_ratio": min(
+            (item["observable_condition_ratio"] for item in supported), default=0.0
+        ),
+        "minimum_supported_margin": min(
+            (item["normalized_support_margin"] for item in supported), default=0.0
+        ),
+        "per_sequence": rows,
+        "component_results": component_results,
+        "information_boundary": {
+            "source_reconstruction_error_computed": False,
+            "source_proper_score_computed": False,
+            "r21_r30_payloads_opened": False,
+            "r31_r70_payloads_opened": False,
+            "bayesian_phystwin_executed": False,
+            "causal4d_executed": False,
+        },
+    }
+    result["result_id"] = content_id(result)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(result, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(
+        json.dumps(
+            {
+                "decision": decision,
+                "result_id": result["result_id"],
+                "supported_source_sequences": len(supported),
+                "minimum_supported_condition_ratio": result["minimum_supported_condition_ratio"],
+                "minimum_supported_margin": result["minimum_supported_margin"],
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/science/materialize_dot_rope_camera_routing_confirmation_request_v1.py
+++ b/scripts/science/materialize_dot_rope_camera_routing_confirmation_request_v1.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Materialize the DOT R21-R30 camera-routing one-shot request from qualified source evidence.
+
+This helper opens no DOT payload. It accepts only the registered R11-R20 provider-rank
+positive result plus exact GitHub artifact metadata and the immutable routed-provider
+seal. It fails closed for any negative/technical source result and never overwrites an
+existing target request.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+PROTOCOL_SCHEMA = "prob4d.dot-rope-query-selective-camera-routing-confirmation-protocol"
+PROTOCOL_ID = "6cfa652c6e5d419dda2b81ccd88ff25f7180a2abc2d3f749d6c8b3e9c1ad1195"
+SOURCE_PROTOCOL_ID = "cd57cb81d1aa52707f26bb0f39829e848d15d0a67b064b390b24caf545923690"
+RAW_AUDIT_ID = "66724cb78840f4b9ef3becf97e5765924094cf8db6eca2d892c44cfa7edb19b3"
+SOURCE_DECISION = "camera-routing-provider-rank-qualified"
+SOURCE_RESULT_SCHEMA = "prob4d.dot-r11-r20-camera-routing-provider-rank-result"
+PROVIDER_SEAL_SCHEMA = "prob4d.dot-r11-r20-routed-provider-seal"
+REQUEST_SCHEMA = "prob4d.dot-rope-camera-routing-confirmation-request"
+PROTOCOL_PATH = "protocols/dot-rope-query-selective-camera-routing-confirmation-v1.json"
+DEFAULT_OUTPUT = "protocols/execution_requests/dot_rope_camera_routing_confirmation_v1.json"
+
+
+def canonical_json(value: object) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+
+
+def content_id(value: object) -> str:
+    return hashlib.sha256(canonical_json(value)).hexdigest()
+
+
+def read_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if type(value) is not dict:
+        raise ValueError(f"{path.name} must contain one JSON object")
+    return value
+
+
+def require_hex(value: object, *, name: str, length: int) -> str:
+    if not isinstance(value, str) or len(value) != length:
+        raise ValueError(f"{name} must contain {length} lowercase hexadecimal characters")
+    if any(character not in "0123456789abcdef" for character in value):
+        raise ValueError(f"{name} must contain {length} lowercase hexadecimal characters")
+    return value
+
+
+def verify_protocol(value: Mapping[str, Any]) -> dict[str, Any]:
+    protocol = dict(value)
+    if protocol.get("schema") != PROTOCOL_SCHEMA or protocol.get("schema_version") != 1:
+        raise ValueError("unsupported confirmation protocol")
+    unsigned = dict(protocol)
+    protocol_id = unsigned.pop("protocol_id", None)
+    if protocol_id != PROTOCOL_ID or content_id(unsigned) != protocol_id:
+        raise ValueError("confirmation protocol identity mismatch")
+    prerequisite = protocol.get("prerequisite") or {}
+    if prerequisite.get("source_protocol_id") != SOURCE_PROTOCOL_ID:
+        raise ValueError("source prerequisite changed")
+    if prerequisite.get("required_decision") != SOURCE_DECISION:
+        raise ValueError("source prerequisite decision changed")
+    if prerequisite.get("minimum_supported_source_sequences") != 9:
+        raise ValueError("source support threshold changed")
+    if prerequisite.get("raw_routing_audit_id") != RAW_AUDIT_ID:
+        raise ValueError("raw routing audit prerequisite changed")
+    if protocol.get("target_sequences") != [f"R{i:02d}" for i in range(21, 31)]:
+        raise ValueError("target sequence roster changed")
+    if protocol.get("reserved_sequences") != "R31-R70":
+        raise ValueError("reserve boundary changed")
+    order = protocol.get("information_order") or {}
+    if order.get("all_five_camera_provider_predictions_sealed_before_target_marker_access") is not True:
+        raise ValueError("provider-before-marker order changed")
+    if order.get("camera_routing_and_factor_query_predictions_sealed_before_target_3d") is not True:
+        raise ValueError("prediction-before-outcome order changed")
+    if order.get("r31_r70_payloads_opened") is not False:
+        raise ValueError("reserve boundary changed")
+    return protocol
+
+
+def verify_source_result(value: Mapping[str, Any]) -> dict[str, Any]:
+    result = dict(value)
+    if result.get("schema") != SOURCE_RESULT_SCHEMA or result.get("schema_version") != 1:
+        raise ValueError("source provider-rank result schema changed")
+    unsigned = dict(result)
+    result_id = unsigned.pop("result_id", None)
+    require_hex(result_id, name="source result_id", length=64)
+    if content_id(unsigned) != result_id:
+        raise ValueError("source provider-rank result identity mismatch")
+    if result.get("decision") != SOURCE_DECISION:
+        raise ValueError("source provider-rank prerequisite is not qualified")
+    if result.get("parent_protocol_id") != SOURCE_PROTOCOL_ID:
+        raise ValueError("source provider-rank protocol changed")
+    if result.get("raw_routing_audit_id") != RAW_AUDIT_ID:
+        raise ValueError("source raw routing audit changed")
+    supported = result.get("supported_source_sequences")
+    if not isinstance(supported, int) or supported < 9 or supported > 10:
+        raise ValueError("source provider-rank support is below the registered threshold")
+    boundary = result.get("information_boundary") or {}
+    for key in (
+        "source_reconstruction_error_computed",
+        "source_proper_score_computed",
+        "r21_r30_payloads_opened",
+        "r31_r70_payloads_opened",
+        "bayesian_phystwin_executed",
+        "causal4d_executed",
+    ):
+        if boundary.get(key) is not False:
+            raise ValueError(f"source information boundary changed: {key}")
+    return result
+
+
+def verify_provider_seal(value: Mapping[str, Any]) -> dict[str, Any]:
+    seal = dict(value)
+    if seal.get("schema") != PROVIDER_SEAL_SCHEMA or seal.get("schema_version") != 1:
+        raise ValueError("source routed-provider seal schema changed")
+    unsigned = dict(seal)
+    seal_id = unsigned.pop("provider_seal_id", None)
+    require_hex(seal_id, name="provider_seal_id", length=64)
+    if content_id(unsigned) != seal_id:
+        raise ValueError("source routed-provider seal identity mismatch")
+    if seal.get("parent_protocol_id") != SOURCE_PROTOCOL_ID:
+        raise ValueError("source provider seal protocol changed")
+    if seal.get("raw_routing_audit_id") != RAW_AUDIT_ID:
+        raise ValueError("source provider seal raw audit changed")
+    if seal.get("source_marker_payloads_opened") is not False:
+        raise ValueError("source provider was not sealed before source marker access")
+    if seal.get("confirmation_payloads_opened") is not False:
+        raise ValueError("source provider seal indicates confirmation access")
+    components = seal.get("components")
+    if not isinstance(components, list) or sorted(item.get("camera") for item in components) != [
+        "cam001", "cam002", "cam005"
+    ]:
+        raise ValueError("source routed-provider component roster changed")
+    return seal
+
+
+def verify_artifact(value: Mapping[str, Any], *, label: str) -> dict[str, Any]:
+    artifact = dict(value)
+    if not isinstance(artifact.get("id"), int) or artifact["id"] <= 0:
+        raise ValueError(f"{label} artifact id must be positive")
+    if not isinstance(artifact.get("name"), str) or not artifact["name"]:
+        raise ValueError(f"{label} artifact name must be nonempty")
+    digest = artifact.get("digest")
+    if not isinstance(digest, str) or not digest.startswith("sha256:"):
+        raise ValueError(f"{label} artifact digest must be SHA-256")
+    require_hex(digest.removeprefix("sha256:"), name=f"{label} artifact digest", length=64)
+    if artifact.get("expired") is not False:
+        raise ValueError(f"{label} artifact must be unexpired")
+    workflow = artifact.get("workflow_run")
+    if not isinstance(workflow, dict) or not isinstance(workflow.get("id"), int) or workflow["id"] <= 0:
+        raise ValueError(f"{label} workflow_run.id must be positive")
+    return artifact
+
+
+def build_request(
+    *,
+    protocol: Mapping[str, Any],
+    protocol_git_blob_sha: str,
+    source_result: Mapping[str, Any],
+    provider_seal: Mapping[str, Any],
+    source_result_artifact: Mapping[str, Any],
+    source_provider_artifact: Mapping[str, Any],
+) -> dict[str, Any]:
+    frozen = verify_protocol(protocol)
+    result = verify_source_result(source_result)
+    seal = verify_provider_seal(provider_seal)
+    result_artifact = verify_artifact(source_result_artifact, label="source result")
+    provider_artifact = verify_artifact(source_provider_artifact, label="source provider")
+    require_hex(protocol_git_blob_sha, name="confirmation protocol Git blob", length=40)
+    if result_artifact["workflow_run"]["id"] != provider_artifact["workflow_run"]["id"]:
+        raise ValueError("source result/provider artifacts came from different workflow runs")
+    if seal["request_id"] != source_result.get("component_results", [{}])[0].get("request_id", seal["request_id"]):
+        # Older component-result schema does not duplicate the request id; the seal remains authoritative.
+        raise ValueError("source provider request identity changed")
+    unsigned: dict[str, Any] = {
+        "schema": REQUEST_SCHEMA,
+        "schema_version": 1,
+        "protocol_path": PROTOCOL_PATH,
+        "protocol_git_blob_sha": protocol_git_blob_sha,
+        "protocol_id": frozen["protocol_id"],
+        "target_sequences": list(frozen["target_sequences"]),
+        "reserved_sequences": frozen["reserved_sequences"],
+        "source_prerequisite": {
+            "source_protocol_id": SOURCE_PROTOCOL_ID,
+            "raw_routing_audit_id": RAW_AUDIT_ID,
+            "run_id": result_artifact["workflow_run"]["id"],
+            "result_artifact_id": result_artifact["id"],
+            "result_artifact_name": result_artifact["name"],
+            "result_artifact_digest": result_artifact["digest"],
+            "provider_artifact_id": provider_artifact["id"],
+            "provider_artifact_name": provider_artifact["name"],
+            "provider_artifact_digest": provider_artifact["digest"],
+            "source_result_id": result["result_id"],
+            "source_provider_seal_id": seal["provider_seal_id"],
+            "decision": result["decision"],
+            "supported_source_sequences": result["supported_source_sequences"],
+        },
+        "all_five_camera_prediction_authorized": True,
+        "target_2d_routing_and_factor_authorized": True,
+        "target_3d_one_shot_scoring_authorized": True,
+        "post_open_tuning_authorized": False,
+        "post_rank_camera_switch_authorized": False,
+        "r31_r70_access_authorized": False,
+        "bayesian_phystwin_executed": False,
+        "causal4d_executed": False,
+        "claim_boundary": frozen["claim_boundary"],
+    }
+    return {**unsigned, "request_id": content_id(unsigned)}
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--protocol", type=Path, default=Path(PROTOCOL_PATH))
+    parser.add_argument("--protocol-git-blob-sha", required=True)
+    parser.add_argument("--source-result", type=Path, required=True)
+    parser.add_argument("--source-provider-seal", type=Path, required=True)
+    parser.add_argument("--source-result-artifact-metadata", type=Path, required=True)
+    parser.add_argument("--source-provider-artifact-metadata", type=Path, required=True)
+    parser.add_argument("--output", type=Path, default=Path(DEFAULT_OUTPUT))
+    args = parser.parse_args()
+    if args.output.exists():
+        raise FileExistsError(f"refusing to overwrite {args.output}")
+    request = build_request(
+        protocol=read_json(args.protocol),
+        protocol_git_blob_sha=args.protocol_git_blob_sha,
+        source_result=read_json(args.source_result),
+        provider_seal=read_json(args.source_provider_seal),
+        source_result_artifact=read_json(args.source_result_artifact_metadata),
+        source_provider_artifact=read_json(args.source_provider_artifact_metadata),
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(request, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps({
+        "output": str(args.output),
+        "request_id": request["request_id"],
+        "source_run_id": request["source_prerequisite"]["run_id"],
+        "source_result_id": request["source_prerequisite"]["source_result_id"],
+        "supported_source_sequences": request["source_prerequisite"]["supported_source_sequences"],
+    }, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/science/materialize_dot_rope_camera_routing_confirmation_request_v2.py
+++ b/scripts/science/materialize_dot_rope_camera_routing_confirmation_request_v2.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Invoke the camera-routing confirmation materializer with the final frozen calibration binding."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+DELEGATE = Path(__file__).with_name(
+    "materialize_dot_rope_camera_routing_confirmation_request_v1.py"
+)
+PROTOCOL = Path("protocols/dot-rope-query-selective-camera-routing-confirmation-v1.json")
+PROTOCOL_ID = "b9267992484516a88d73637c813ae463f27e4a7b2586f805d394bea45e5f537c"
+SOURCE_CALIBRATION_ID = "943339ac864fda04cc59081bc81a605576b3c90bf0aa996aea00b00335cfc0c7"
+DEPENDENCE_ALPHA = 0.85
+
+
+def main() -> int:
+    value = json.loads(PROTOCOL.read_text(encoding="utf-8"))
+    if value.get("protocol_id") != PROTOCOL_ID:
+        raise ValueError("final confirmation protocol identity changed")
+    prerequisite = value.get("prerequisite") or {}
+    if prerequisite.get("source_calibration_id") != SOURCE_CALIBRATION_ID:
+        raise ValueError("source calibration identity changed")
+    if float(prerequisite.get("selected_dependence_alpha")) != DEPENDENCE_ALPHA:
+        raise ValueError("source-selected dependence alpha changed")
+    if float((value.get("factor") or {}).get("selected_dependence_alpha")) != DEPENDENCE_ALPHA:
+        raise ValueError("factor dependence alpha changed")
+
+    spec = importlib.util.spec_from_file_location("camera_routing_request_v1", DELEGATE)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("cannot load confirmation request materializer")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.PROTOCOL_ID = PROTOCOL_ID
+    return int(module.main())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/science/materialize_dot_rope_source_camera_components_v1.py
+++ b/scripts/science/materialize_dot_rope_source_camera_components_v1.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Materialize fixed-camera component protocols from the frozen DOT camera-routing source v3 protocol."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+V3_SCHEMA = "prob4d.dot-rope-query-selective-camera-routing-source-protocol"
+V2_SCHEMA = "prob4d.dot-rope-query-selective-source-support-protocol"
+EXPECTED_V3_ID = "cd57cb81d1aa52707f26bb0f39829e848d15d0a67b064b390b24caf545923690"
+EXPECTED_RAW_AUDIT_ID = "66724cb78840f4b9ef3becf97e5765924094cf8db6eca2d892c44cfa7edb19b3"
+EXPECTED_CANDIDATE = "expanded__overlap-345"
+EXPECTED_ROUTING = {
+    "R11": "cam005",
+    "R12": "cam005",
+    "R13": "cam001",
+    "R14": "cam001",
+    "R15": "cam001",
+    "R16": "cam001",
+    "R17": "cam002",
+    "R18": "cam001",
+    "R19": "cam001",
+    "R20": "cam005",
+}
+
+
+def content_id(value: object) -> str:
+    encoded = json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if type(value) is not dict:
+        raise ValueError(f"{path.name} must contain one object")
+    return value
+
+
+def verify_v3(value: dict[str, Any]) -> None:
+    if value.get("schema") != V3_SCHEMA or value.get("schema_version") != 3:
+        raise ValueError("camera-routing source protocol schema changed")
+    unsigned = dict(value)
+    protocol_id = unsigned.pop("protocol_id", None)
+    if protocol_id != EXPECTED_V3_ID or content_id(unsigned) != protocol_id:
+        raise ValueError("camera-routing source protocol identity changed")
+    routing = value.get("routing_development") or {}
+    if routing.get("source_audit_id") != EXPECTED_RAW_AUDIT_ID:
+        raise ValueError("raw routing audit identity changed")
+    if routing.get("selected_candidate") != EXPECTED_CANDIDATE:
+        raise ValueError("raw routing support geometry changed")
+    if routing.get("selected_camera_routing") != EXPECTED_ROUTING:
+        raise ValueError("source camera routing changed")
+    if (value.get("information_boundary") or {}).get("r21_r30_payloads_opened") is not False:
+        raise ValueError("R21-R30 boundary changed")
+
+
+def materialize(v3: dict[str, Any], base: dict[str, Any], output: Path) -> dict[str, Any]:
+    if base.get("schema") != V2_SCHEMA or base.get("schema_version") != 2:
+        raise ValueError("base source-support v2 protocol changed")
+    groups: dict[str, list[str]] = defaultdict(list)
+    for sequence, camera in EXPECTED_ROUTING.items():
+        groups[camera].append(sequence)
+    if sorted(groups) != ["cam001", "cam002", "cam005"]:
+        raise ValueError("provider camera group roster changed")
+
+    output.mkdir(parents=True, exist_ok=False)
+    components = []
+    for camera in sorted(groups):
+        sequences = sorted(groups[camera])
+        component = json.loads(json.dumps(base))
+        component.pop("protocol_id", None)
+        component["camera"] = camera
+        component["source_sequences"] = sequences
+        component["support_selection"]["fit_frame_profiles"] = [
+            {
+                "id": "expanded",
+                "metric_fit_a_frames": [1, 2, 3],
+                "metric_fit_b_frames": [5, 6, 7],
+            }
+        ]
+        component["support_selection"]["overlap_groups"] = [
+            {"id": "overlap-345", "frames": [3, 4, 5]}
+        ]
+        component["support_selection"]["minimum_source_supported_sequences_for_promotion"] = len(sequences)
+        component["support_selection"]["selection_objective"] = [
+            "fixed by source raw-support routing audit 66724cb78840f4b9ef3becf97e5765924094cf8db6eca2d892c44cfa7edb19b3"
+        ]
+        component["claim_boundary"] = (
+            f"Source-only routed-camera factor qualification for {camera} on {','.join(sequences)}. "
+            "The camera/sequence routing and expanded/overlap-345 geometry were frozen before this provider run. "
+            "No reconstruction error or proper score may be used; R21-R70 remain closed."
+        )
+        component["protocol_id"] = content_id(component)
+        filename = f"component-{camera}.json"
+        path = output / filename
+        path.write_text(json.dumps(component, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        components.append(
+            {
+                "camera": camera,
+                "source_sequences": sequences,
+                "protocol_file": filename,
+                "protocol_id": component["protocol_id"],
+            }
+        )
+
+    manifest: dict[str, Any] = {
+        "schema": "prob4d.dot-r11-r20-camera-routing-component-manifest",
+        "schema_version": 1,
+        "parent_protocol_id": v3["protocol_id"],
+        "raw_routing_audit_id": EXPECTED_RAW_AUDIT_ID,
+        "fixed_candidate": EXPECTED_CANDIDATE,
+        "components": components,
+        "source_sequence_count": sum(len(item["source_sequences"]) for item in components),
+        "confirmation_payloads_opened": False,
+        "source_performance_metrics_used": False,
+    }
+    if manifest["source_sequence_count"] != 10:
+        raise ValueError("component roster does not cover R11-R20 exactly")
+    manifest["manifest_id"] = content_id(manifest)
+    (output / "manifest.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return manifest
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--protocol", type=Path, required=True)
+    parser.add_argument("--base-v2-protocol", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    args = parser.parse_args()
+    v3 = load_json(args.protocol)
+    verify_v3(v3)
+    manifest = materialize(v3, load_json(args.base_v2_protocol), args.output_dir)
+    print(json.dumps(manifest, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/science/run_dot_rope_source_support_camera_component_v1.py
+++ b/scripts/science/run_dot_rope_source_support_camera_component_v1.py
@@ -12,6 +12,7 @@ from pathlib import Path
 SOURCE = Path(__file__).with_name("run_dot_rope_query_selective_source_support_v2.py")
 CAMERAS = {"cam001", "cam002", "cam003", "cam004", "cam005"}
 ALL_SOURCE = {f"R{index:02d}" for index in range(11, 21)}
+SHARED_3D_CAMERA = "cam001"
 
 
 def _load():
@@ -37,9 +38,27 @@ def main() -> int:
         raise ValueError("source component sequence list contains duplicates")
     if any(sequence not in ALL_SOURCE for sequence in source_sequences):
         raise ValueError("source component escaped R11-R20")
+
     module = _load()
     module.CAMERA = known.camera
     module.SOURCE_SEQUENCES = list(source_sequences)
+
+    original_load_script = module._load_script
+
+    def load_script(filename: str, name: str, expected_blob: str):
+        loaded = original_load_script(filename, name, expected_blob)
+        if filename == "audit_dot_rope_marker_support.py":
+            def coordinate_member(sequence: str, dimension: int, frame: int) -> str:
+                camera = known.camera if dimension == 2 else SHARED_3D_CAMERA
+                return (
+                    f"{sequence}/coordinates/{dimension}d/"
+                    f"frame{frame:06d}_{camera}.txt"
+                )
+
+            loaded._coordinate_member = coordinate_member
+        return loaded
+
+    module._load_script = load_script
     sys.argv = [SOURCE.name, *remainder]
     return int(module.main())
 

--- a/scripts/science/run_dot_rope_source_support_camera_component_v1.py
+++ b/scripts/science/run_dot_rope_source_support_camera_component_v1.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Run one routed-camera component through the frozen DOT source-support v2 code."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+SOURCE = Path(__file__).with_name("run_dot_rope_query_selective_source_support_v2.py")
+CAMERAS = {"cam001", "cam002", "cam003", "cam004", "cam005"}
+ALL_SOURCE = {f"R{index:02d}" for index in range(11, 21)}
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("dot_source_support_component_delegate", SOURCE)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("cannot load source-support v2 delegate")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, add_help=False)
+    parser.add_argument("--camera", required=True)
+    parser.add_argument("--source-sequences-json", required=True)
+    known, remainder = parser.parse_known_args()
+    if known.camera not in CAMERAS:
+        raise ValueError("camera is outside the frozen DOT roster")
+    source_sequences = json.loads(known.source_sequences_json)
+    if not isinstance(source_sequences, list) or not source_sequences:
+        raise ValueError("source component requires a nonempty sequence list")
+    if len(source_sequences) != len(set(source_sequences)):
+        raise ValueError("source component sequence list contains duplicates")
+    if any(sequence not in ALL_SOURCE for sequence in source_sequences):
+        raise ValueError("source component escaped R11-R20")
+    module = _load()
+    module.CAMERA = known.camera
+    module.SOURCE_SEQUENCES = list(source_sequences)
+    sys.argv = [SOURCE.name, *remainder]
+    return int(module.main())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Closed scientific direction

This source-only camera-routing continuation is retired without merge.

The frozen R04-R10 learned-provider confirmation is already terminal as `heldout-support-negative`; no valid seven-sequence NLL comparison was produced. This branch subsequently reached the exact CUT3R runtime and native-extension build but failed its target-closed synthetic smoke before any R11-R20 provider prediction or marker qualification. R21-R30 remained unopened.

The paper-critical effort has moved to the stronger completed evidence now merged in Prob4D #464 and BayesianPhysTwin-Paper #158:

- held-out DEFORM DLO4/DLO5 selective query admission with exact fallback;
- held-out Tracking Cloth finite-orbit validation on 15 recordings and 1,803 cases;
- zero harmful finite-orbit-accepted radial updates versus approximately 65.1% harmful local-gate admissions;
- explicit retention of DOT/CUT3R and broad Deform360 negative/support boundaries.

Closing this PR changes no scientific result, protocol, target custody, or dataset reservation. The branch remains available for historical inspection, but CUT3R provider competence is no longer a submission dependency and no further DOT cohort is authorized from this branch.