### PR TITLE
Repair stalled DOT R11-R20 source-support runtime

### DIFF
--- a/.github/workflows/repair-dot-source-support-runtime-v3.yml
+++ b/.github/workflows/repair-dot-source-support-runtime-v3.yml
@@ -1,0 +1,258 @@
+name: Repair stalled DOT source-support runtime v3
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "protocols/execution_requests/repair_dot_source_support_runtime_v3.json"
+
+permissions:
+  contents: write
+  actions: write
+
+concurrency:
+  group: repair-dot-source-support-runtime-v3
+  cancel-in-progress: false
+
+env:
+  REQUEST_PATH: protocols/execution_requests/repair_dot_source_support_runtime_v3.json
+  TARGET_RUN_ID: "33535549040"
+  TARGET_HEAD_SHA: 0bccd72f6e01d7722c82914c92aed43bbf3f49b2
+  TARGET_JOB_ID: "99949034542"
+  TARGET_WORKFLOW_PATH: .github/workflows/dot-rope-query-selective-source-support-v2-gpuserver6000-recovery.yml
+  TARGET_JOB_NAME: Seal frozen R11-R20 provider on gpuserver6000
+
+jobs:
+  repair:
+    name: Cancel the unopened stalled run and switch to an isolated runtime
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - name: Check out exact merged repair request
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 2
+          persist-credentials: true
+          clean: true
+
+      - name: Validate the single content-addressed repair request
+        shell: bash
+        env:
+          EVENT_REF: ${{ github.ref }}
+          EVENT_BEFORE: ${{ github.event.before }}
+          EVENT_AFTER: ${{ github.event.after }}
+          EVENT_FORCED: ${{ github.event.forced }}
+          EVENT_DELETED: ${{ github.event.deleted }}
+        run: |
+          set -euo pipefail
+          test "$EVENT_REF" = "refs/heads/main"
+          test "$EVENT_AFTER" = "$(git rev-parse HEAD)"
+          test "$EVENT_FORCED" = "false"
+          test "$EVENT_DELETED" = "false"
+          test "$EVENT_BEFORE" != "0000000000000000000000000000000000000000"
+          mapfile -t changed < <(git diff --name-only "$EVENT_BEFORE" "$EVENT_AFTER" | sort)
+          if [[ ${#changed[@]} -ne 1 || "${changed[0]}" != "$REQUEST_PATH" ]]; then
+            printf 'Expected only %s; changed paths were:\n' "$REQUEST_PATH" >&2
+            printf '  %s\n' "${changed[@]}" >&2
+            exit 2
+          fi
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          path = Path(os.environ["REQUEST_PATH"])
+          value = json.loads(path.read_text(encoding="utf-8"))
+          expected_fields = {
+              "schema",
+              "schema_version",
+              "request_id",
+              "target_run_id",
+              "target_head_sha",
+              "target_job_id",
+              "target_workflow_path",
+              "reason",
+          }
+          if set(value) != expected_fields:
+              raise SystemExit("repair request fields changed")
+          if value["schema"] != "prob4d.dot-source-support-runtime-repair-request":
+              raise SystemExit("repair request schema changed")
+          if value["schema_version"] != 3:
+              raise SystemExit("repair request schema version changed")
+          if value["target_run_id"] != int(os.environ["TARGET_RUN_ID"]):
+              raise SystemExit("repair target run changed")
+          if value["target_head_sha"] != os.environ["TARGET_HEAD_SHA"]:
+              raise SystemExit("repair target head changed")
+          if value["target_job_id"] != int(os.environ["TARGET_JOB_ID"]):
+              raise SystemExit("repair target job changed")
+          if value["target_workflow_path"] != os.environ["TARGET_WORKFLOW_PATH"]:
+              raise SystemExit("repair target workflow changed")
+          unsigned = dict(value)
+          supplied = unsigned.pop("request_id")
+          encoded = json.dumps(unsigned, sort_keys=True, separators=(",", ":")).encode()
+          measured = hashlib.sha256(encoded).hexdigest()
+          if supplied != measured:
+              raise SystemExit("repair request identity mismatch")
+          print(json.dumps({"request_id": supplied}, sort_keys=True))
+          PY
+
+      - name: Prove no DOT payload was opened and cancel the stalled run
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from __future__ import annotations
+
+          import json
+          import os
+          import time
+          import urllib.error
+          import urllib.request
+
+          api = os.environ["GITHUB_API_URL"].rstrip("/")
+          repository = os.environ["GITHUB_REPOSITORY"]
+          run_id = int(os.environ["TARGET_RUN_ID"])
+          job_id = int(os.environ["TARGET_JOB_ID"])
+          headers = {
+              "Accept": "application/vnd.github+json",
+              "Authorization": f"Bearer {os.environ['GH_TOKEN']}",
+              "User-Agent": "Prob4D-DOT-source-runtime-repair/3",
+              "X-GitHub-Api-Version": "2022-11-28",
+          }
+
+          def request(path: str, *, method: str = "GET"):
+              item = urllib.request.Request(
+                  f"{api}/repos/{repository}{path}",
+                  method=method,
+                  headers=headers,
+              )
+              try:
+                  with urllib.request.urlopen(item, timeout=60) as response:
+                      raw = response.read()
+              except urllib.error.HTTPError as error:
+                  raise SystemExit(
+                      f"GitHub API {method} {path} failed with {error.code}"
+                  ) from error
+              return json.loads(raw) if raw else None
+
+          run = request(f"/actions/runs/{run_id}")
+          expected_run = {
+              "head_sha": os.environ["TARGET_HEAD_SHA"],
+              "path": os.environ["TARGET_WORKFLOW_PATH"],
+              "event": "push",
+              "head_branch": "main",
+          }
+          for key, expected in expected_run.items():
+              if run.get(key) != expected:
+                  raise SystemExit(f"stalled-run identity changed: {key}")
+
+          jobs = request(f"/actions/runs/{run_id}/jobs?per_page=100").get("jobs", [])
+          matches = [job for job in jobs if int(job.get("id", -1)) == job_id]
+          if len(matches) != 1:
+              raise SystemExit("stalled provider job is unavailable")
+          job = matches[0]
+          if job.get("name") != os.environ["TARGET_JOB_NAME"]:
+              raise SystemExit("stalled provider job name changed")
+          if job.get("status") != "in_progress" or job.get("conclusion") is not None:
+              raise SystemExit("provider is no longer at the recoverable in-progress state")
+          steps = {step.get("name"): step for step in job.get("steps") or []}
+          if (steps.get("Select or bootstrap a CUDA CUT3R interpreter") or {}).get(
+              "status"
+          ) != "in_progress":
+              raise SystemExit("provider is no longer stalled in runtime bootstrap")
+          forbidden_started = (
+              "Acquire exact CUT3R checkpoint without opening DOT",
+              "Materialize only the official R11-R20 archive",
+              "Apply audited native-RoPE compatibility and build",
+              "Run repaired target-closed synthetic smoke",
+              "Execute frozen marker-free R11-R20 predictions",
+              "Read sealed provider identity",
+              "Upload immutable sealed provider",
+          )
+          for name in forbidden_started:
+              step = steps.get(name) or {}
+              if step.get("status") not in (None, "pending"):
+                  raise SystemExit(f"source data boundary may have been crossed: {name}")
+          artifacts = request(f"/actions/runs/{run_id}/artifacts?per_page=100")
+          if int(artifacts.get("total_count", -1)) != 0:
+              raise SystemExit("stalled run unexpectedly has artifacts")
+
+          request(f"/actions/runs/{run_id}/cancel", method="POST")
+          for _ in range(90):
+              time.sleep(2)
+              run = request(f"/actions/runs/{run_id}")
+              if run.get("status") == "completed":
+                  break
+          if run.get("status") != "completed" or run.get("conclusion") != "cancelled":
+              raise SystemExit("stalled run did not become a bounded cancellation")
+          print(
+              json.dumps(
+                  {
+                      "cancelled_run_id": run_id,
+                      "conclusion": run["conclusion"],
+                      "dot_payload_opened": False,
+                      "provider_artifacts": 0,
+                  },
+                  sort_keys=True,
+              )
+          )
+          PY
+
+      - name: Patch only the isolated runtime and concurrency behavior
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          from pathlib import Path
+
+          path = Path(
+              ".github/workflows/"
+              "dot-rope-query-selective-source-support-v2-gpuserver6000-recovery.yml"
+          )
+          text = path.read_text(encoding="utf-8")
+          replacements = {
+              "  cancel-in-progress: false\n": "  cancel-in-progress: true\n",
+              '            venv="$RUNTIME_CACHE_ROOT/venv"\n': (
+                  '            # The previous persistent venv could be left locked by an '\
+                  'interrupted pip process. Use the same isolated, per-run runtime strategy '\
+                  'that completed the R04-R10 provider.\n'
+                  '            venv="$root/venv"\n'
+              ),
+          }
+          for old, new in replacements.items():
+              if text.count(old) != 1:
+                  raise SystemExit(f"expected exactly one patch site: {old!r}")
+              text = text.replace(old, new, 1)
+          path.write_text(text, encoding="utf-8", newline="\n")
+          PY
+          git diff --check
+          changed=$(git diff --name-only)
+          test "$changed" = "$TARGET_WORKFLOW_PATH"
+
+      - name: Remove the one-shot repair control plane and publish the patch
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -- "$REQUEST_PATH" ".github/workflows/repair-dot-source-support-runtime-v3.yml"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -- "$TARGET_WORKFLOW_PATH" "$REQUEST_PATH" \
+            ".github/workflows/repair-dot-source-support-runtime-v3.yml"
+          git diff --cached --check
+          mapfile -t changed < <(git diff --cached --name-only | sort)
+          expected=(
+            ".github/workflows/dot-rope-query-selective-source-support-v2-gpuserver6000-recovery.yml"
+            ".github/workflows/repair-dot-source-support-runtime-v3.yml"
+            "protocols/execution_requests/repair_dot_source_support_runtime_v3.json"
+          )
+          if [[ "${changed[*]}" != "${expected[*]}" ]]; then
+            printf 'Unexpected staged paths:\n' >&2
+            printf '  %s\n' "${changed[@]}" >&2
+            exit 2
+          fi
+          git commit -m "Use isolated runtime for DOT R11-R20 source support"
+          git push origin HEAD:main


### PR DESCRIPTION
## Purpose

Unblock the prospectively clean DOT R11–R20 source/support qualification without opening any DOT payload or changing a scientific input.

Run `33535549040` is stalled in the `Select or bootstrap a CUDA CUT3R interpreter` step of provider job `99949034542`. The checkpoint, archive, marker, prediction, and artifact steps have not started, and the run has no artifacts.

## Bounded repair

This one-shot hosted workflow:

1. verifies the exact stalled run, head, workflow path, job ID, and step state;
2. proves that no DOT archive, normal-view image, marker payload, provider prediction, or artifact has been opened or produced;
3. cancels that exact stalled run;
4. changes only the runtime bootstrap from a persistent cache venv to the per-run isolated venv strategy that already completed the R04–R10 provider;
5. enables cancellation of a superseded source-support execution; and
6. deletes the repair workflow and its content-addressed request after publishing the bounded patch.

## Scientific invariants

Unchanged:

- R11–R20 source/support cohort;
- R21–R30 currently closed by source protocol v2;
- all R31–R70 payloads closed;
- CUT3R revision and checkpoint;
- camera, frames, windows, marker coordinate convention, support candidates, rank threshold, and source selection objective;
- prohibition on reconstruction-error or proper-score selection;
- no BayesianPhysTwin or Causal4D execution.

No repair request is included in this PR, so merging the PR alone cannot cancel the run or open data.