### PR TITLE
Fix authenticated DOT evaluator log redirect

### DIFF
--- a/.github/workflows/dot-r04-r10-evaluation-recovery-v2.yml
+++ b/.github/workflows/dot-r04-r10-evaluation-recovery-v2.yml
@@ -186,6 +186,7 @@ jobs:
           import json
           import os
           import re
+          import urllib.parse
           import urllib.request
           import zipfile
           from pathlib import Path
@@ -204,6 +205,28 @@ jobs:
               request = urllib.request.Request(f"{api}/repos/{repo}{path}", headers=headers)
               with urllib.request.urlopen(request, timeout=60) as response:
                   return json.load(response)
+
+          class CrossOriginSafeRedirectHandler(urllib.request.HTTPRedirectHandler):
+              def redirect_request(self, req, fp, code, msg, response_headers, newurl):
+                  redirected = super().redirect_request(
+                      req, fp, code, msg, response_headers, newurl
+                  )
+                  if redirected is None:
+                      return None
+                  source = urllib.parse.urlsplit(req.full_url)
+                  target = urllib.parse.urlsplit(newurl)
+                  if target.scheme != "https":
+                      raise SystemExit("refusing non-HTTPS evaluator log redirect")
+                  if (source.scheme, source.netloc) != (target.scheme, target.netloc):
+                      sensitive = {
+                          "authorization",
+                          "accept",
+                          "x-github-api-version",
+                      }
+                      for key in list(redirected.headers):
+                          if key.lower() in sensitive:
+                              redirected.remove_header(key)
+                  return redirected
 
           run_id = int(os.environ["TARGET_RUN_ID"])
           run = get_json(f"/actions/runs/{run_id}")
@@ -301,7 +324,8 @@ jobs:
               f"{api}/repos/{repo}/actions/jobs/{os.environ['EVALUATION_JOB_ID']}/logs",
               headers=headers,
           )
-          with urllib.request.urlopen(log_request, timeout=120) as response:
+          log_opener = urllib.request.build_opener(CrossOriginSafeRedirectHandler())
+          with log_opener.open(log_request, timeout=120) as response:
               raw = response.read()
           try:
               log_text = raw.decode("utf-8", errors="replace")

--- a/tests/test_dot_r04_r10_evaluation_recovery_v2.py
+++ b/tests/test_dot_r04_r10_evaluation_recovery_v2.py
@@ -132,3 +132,20 @@ def test_recovery_authorization_checkout_fetches_base_commit() -> None:
     assert "fetch-depth: 0" in checkout
     assert "BASE_SHA: ${{ github.event.before }}" in inspect
     assert 'git diff-tree --no-commit-id --name-only -r "$BASE_SHA" "$HEAD_SHA"' in inspect
+
+
+def test_recovery_log_redirect_does_not_forward_github_credentials() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    inspect = text[text.index("\n  inspect:") : text.index("\n  recover:")]
+
+    assert "import urllib.parse" in inspect
+    assert "class CrossOriginSafeRedirectHandler" in inspect
+    assert 'if target.scheme != "https":' in inspect
+    assert '"authorization"' in inspect
+    assert '"x-github-api-version"' in inspect
+    assert "if key.lower() in sensitive:" in inspect
+    assert "redirected.remove_header(key)" in inspect
+    assert (
+        "urllib.request.build_opener(CrossOriginSafeRedirectHandler())" in inspect
+    )
+    assert "urllib.request.urlopen(log_request, timeout=120)" not in inspect

--- a/tests/test_dot_r04_r10_evaluation_recovery_v2.py
+++ b/tests/test_dot_r04_r10_evaluation_recovery_v2.py
@@ -145,7 +145,5 @@ def test_recovery_log_redirect_does_not_forward_github_credentials() -> None:
     assert '"x-github-api-version"' in inspect
     assert "if key.lower() in sensitive:" in inspect
     assert "redirected.remove_header(key)" in inspect
-    assert (
-        "urllib.request.build_opener(CrossOriginSafeRedirectHandler())" in inspect
-    )
+    assert "urllib.request.build_opener(CrossOriginSafeRedirectHandler())" in inspect
     assert "urllib.request.urlopen(log_request, timeout=120)" not in inspect


### PR DESCRIPTION
The hosted R04–R10 recovery authorization failed while downloading the frozen evaluator job log. Python's default redirect handler forwarded the GitHub bearer header to the cross-origin signed Azure URL, which rejected it with HTTP 401.

This change:
- keeps authentication on GitHub API requests;
- strips GitHub-specific headers on cross-origin redirects;
- rejects non-HTTPS log redirects;
- adds regression coverage for the redirect boundary.

The sealed provider artifact, frozen evaluator revision, scientific parameters, cohort, and decision mapping remain unchanged.