### PR TITLE
Retain terminal DOT/CUT3R R04–R10 support-negative evidence

### DIFF
--- a/CHANGELOG.d/dot-cut3r-r04-r10-heldout-negative-v1.md
+++ b/CHANGELOG.d/dot-cut3r-r04-r10-heldout-negative-v1.md
@@ -1,0 +1,8 @@
+### Evidence
+
+- Retain the terminal DOT/CUT3R R04--R10 held-out support-negative result from
+  the exact sealed provider and frozen evaluator.
+- Record that the registered probabilistic comparison could not proceed because
+  pooled provider/truth support was below its frozen minimum.
+- Preserve the R11--R70 unopened boundary, no-retuning status, and absence of
+  BayesianPhysTwin or Causal4D execution.

--- a/docs/dot-cut3r-r04-r10-heldout-negative-v1.md
+++ b/docs/dot-cut3r-r04-r10-heldout-negative-v1.md
@@ -1,0 +1,27 @@
+# Terminal DOT/CUT3R confirmation result: support negative
+
+The source-frozen DOT/CUT3R confirmation on sequences R04--R10 is now
+terminal. The exact sealed provider artifact and exact frozen evaluator were
+successfully recovered and executed in GitHub Actions run `33550572437`.
+
+The result is **held-out support-negative**. Evaluation terminated before the
+registered NLL comparison because pooled provider/truth support was below its
+predeclared minimum. Thus the source-selected shared-dependence value
+`alpha=0.85` is not supported as a held-out result.
+
+This is an important evidential boundary:
+
+- the provider itself completed and was sealed before marker access;
+- the negative is not caused by the prior packaging failure;
+- no provider rerun, confirmation retuning, or scientific-input change occurred;
+- R11--R70 remained unopened by this experiment;
+- no BayesianPhysTwin or Causal4D outcome was computed.
+
+The paper-facing conclusion should be that the registered CUT3R route did not
+supply enough qualified correspondence support for the intended held-out
+probabilistic comparison. It should not be reported as a failed NLL result, and
+it should not be rescued by changing the support rule after target access.
+
+Evidence is retained under
+`evidence/dot-cut3r-r04-r10-heldout-negative-v1/`, result ID
+`efe88e93985e88d42efd8375e24af40b04cfe8bf18bc1352cd83cf2b893861d0`.

--- a/evidence/dot-cut3r-r04-r10-heldout-negative-v1/README.md
+++ b/evidence/dot-cut3r-r04-r10-heldout-negative-v1/README.md
@@ -1,0 +1,46 @@
+# DOT/CUT3R R04--R10 held-out support-negative evidence
+
+This directory records the terminal outcome of the independently frozen
+DOT/CUT3R R04--R10 confirmation. The marker-free CUT3R provider artifact was
+sealed before confirmation marker access. A hosted recovery reused that exact
+provider artifact and the exact frozen evaluator after repairing only the
+output-directory packaging path.
+
+## Terminal decision
+
+`heldout-support-negative`
+
+The evaluator stopped because:
+
+> pooled provider/truth support is below its registered minimum
+
+This is a scientific support negative, not a technical failure and not an NLL
+comparison. The registered source-frozen dependence value `alpha=0.85` was
+therefore not promoted on the held-out cohort.
+
+## Custody and immutability
+
+- confirmation sequences opened once: R04--R10;
+- R11--R70 remained unopened by this evaluation;
+- provider predictions were not rerun;
+- no confirmation-side threshold, coordinate rule, window, mean, comparator,
+  or dependence parameter changed;
+- BayesianPhysTwin and Causal4D were not executed;
+- recovery workflow run: `33550572437`;
+- recovered-evaluation job: `99998900477`;
+- artifact: `9817282504`;
+- artifact SHA-256: `3207766f8b48c11e667cf90f61e86c0026a0de024727293d5495cc2214304685`;
+- terminal result ID: `efe88e93985e88d42efd8375e24af40b04cfe8bf18bc1352cd83cf2b893861d0`.
+
+The four compact retained JSON payloads are copied byte-for-byte from the
+immutable Actions artifact. `manifest.json` binds those files and the source
+identities; it also records the SHA-256 of the larger `marker-support.json`
+payload retained in the Actions artifact. No images, marker coordinates, point
+maps, or raw dataset payloads are retained here.
+
+## Claim boundary
+
+The result rejects the registered held-out CUT3R dependence claim because the
+frozen metric-support requirement was not met. It does not establish that CUT3R
+is generally incapable, nor does it establish BayesianPhysTwin or Causal4D
+benefit, deployment safety, or state of the art.

--- a/evidence/dot-cut3r-r04-r10-heldout-negative-v1/failure.json
+++ b/evidence/dot-cut3r-r04-r10-heldout-negative-v1/failure.json
@@ -1,0 +1,44 @@
+{
+  "claim_boundary": "Independent held-out DOT rope confirmation on R04-R10 for the source-frozen alpha=0.85 shared-dependence model. R11-R70 remain unopened. No parameter, provider, coordinate convention, support rule, window, mean, comparator, or threshold may be changed after confirmation access. The result can establish only the registered held-out CUT3R query-uncertainty/dependence claim; it does not establish BayesianPhysTwin benefit, Causal4D benefit, deployment safety, or state of the art.",
+  "decision": "heldout-support-negative",
+  "failure": "ValueError: pooled provider/truth support is below its registered minimum",
+  "information_boundary": {
+    "bayesian_phystwin_executed": false,
+    "causal4d_executed": false,
+    "confirmation_2d_markers_opened_after_provider_seal": true,
+    "confirmation_3d_markers_opened_after_provider_seal": true,
+    "opened_sequences": [
+      "R04",
+      "R05",
+      "R06",
+      "R07",
+      "R08",
+      "R09",
+      "R10"
+    ],
+    "reserved_sequences": "R11-R70",
+    "sealed_confirmation_provider_predictions_opened": true
+  },
+  "marker_support_id": "a2c32a395eaa334238cf19368b14eebf5a5af70f8368e9a01ed8dfc4f616e46a",
+  "repository_revision": "b85dd8e8adb68ffb289868731222151968940317",
+  "request_id": "62d64df1b1b72f2b2aff0b17cf4c7aad245150f9fa1ff67712eedc0f4e109ce6",
+  "result_id": "efe88e93985e88d42efd8375e24af40b04cfe8bf18bc1352cd83cf2b893861d0",
+  "schema": "prob4d.dot-rope-cut3r-heldout-failure",
+  "schema_version": 1,
+  "selected_dependence_alpha": 0.85,
+  "source_calibration_id": "943339ac864fda04cc59081bc81a605576b3c90bf0aa996aea00b00335cfc0c7",
+  "traceback_tail": [
+    "Traceback (most recent call last):",
+    "  File \"/home/runner/work/Prob4D/Prob4D/frozen/scripts/science/run_dot_rope_cut3r_heldout_confirmation.py\", line 427, in evaluate",
+    "    base.evaluate(",
+    "  File \"/home/runner/work/Prob4D/Prob4D/frozen/scripts/science/run_dot_rope_cut3r_native_provider.py\", line 944, in evaluate",
+    "    sequence_result, rows = _sequence_evaluation(",
+    "                            ^^^^^^^^^^^^^^^^^^^^^",
+    "  File \"/home/runner/work/Prob4D/Prob4D/frozen/scripts/science/run_dot_rope_cut3r_native_provider.py\", line 769, in _sequence_evaluation",
+    "    a_source, a_truth = _collect_provider_truth(runs[\"window_a\"], frame_payloads, fit_a_frames)",
+    "                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^",
+    "  File \"/home/runner/work/Prob4D/Prob4D/frozen/scripts/science/evaluate_dot_rope_cut3r_pooled.py\", line 514, in _collect_provider_truth",
+    "    raise ValueError(\"pooled provider/truth support is below its registered minimum\")",
+    "ValueError: pooled provider/truth support is below its registered minimum"
+  ]
+}

--- a/evidence/dot-cut3r-r04-r10-heldout-negative-v1/independent-verification.json
+++ b/evidence/dot-cut3r-r04-r10-heldout-negative-v1/independent-verification.json
@@ -1,0 +1,1 @@
+{"confirmation_sequence_count": 7, "decision": "heldout-support-negative", "result_id": "efe88e93985e88d42efd8375e24af40b04cfe8bf18bc1352cd83cf2b893861d0", "selected_alpha": 0.85}

--- a/evidence/dot-cut3r-r04-r10-heldout-negative-v1/manifest.json
+++ b/evidence/dot-cut3r-r04-r10-heldout-negative-v1/manifest.json
@@ -1,0 +1,45 @@
+{
+  "artifact_files_sha256": {
+    "failure.json": "85dcbc249db06f42f36745e0d9649d1bb14db3778116a2b4fb93dd1e1874b18e",
+    "independent-verification.json": "66e856d75b24b092555bb5946a7037a7ef550d6a462662c36d8d475d09f14db0",
+    "marker-support.json": "14a2f744f344046bbd169acb68f028c390434196bcf806a6db35abab1a7b3dca",
+    "recovery-receipt.json": "ea593fe13f358a3c23061cb4d561b7678a395c1cf79ed52aa3223df5a644d862",
+    "recovery-request.json": "6e451b4f2426cdac94eb4b3a6dfde82c7ebdb20d872c37b36d56f8403fef2696"
+  },
+  "artifact_id": 9817282504,
+  "artifact_name": "dot-rope-cut3r-heldout-evaluation-recovered-v2-5f60d7494dbc67b694b0d011283a0b5bc3093b190c3f1e7fd1978549f48f1051",
+  "artifact_sha256": "3207766f8b48c11e667cf90f61e86c0026a0de024727293d5495cc2214304685",
+  "bayesian_phystwin_executed": false,
+  "causal4d_executed": false,
+  "confirmation_retuning_performed": false,
+  "confirmation_sequences": [
+    "R04",
+    "R05",
+    "R06",
+    "R07",
+    "R08",
+    "R09",
+    "R10"
+  ],
+  "decision": "heldout-support-negative",
+  "frozen_evaluator_revision": "b85dd8e8adb68ffb289868731222151968940317",
+  "marker_support_id": "a2c32a395eaa334238cf19368b14eebf5a5af70f8368e9a01ed8dfc4f616e46a",
+  "marker_support_retained_in_actions_artifact_only": true,
+  "provider_artifact_id": 9797527843,
+  "provider_artifact_sha256": "45cccd5b6f7b7d671cfc86fbcb27232d29faf5dafdeee8d0ea5a9c45ce42ae7c",
+  "provider_rerun": false,
+  "recovery_control_revision": "9d827ffbac97e5cace28ddb7fb023453b8c4c6ba",
+  "reserved_sequences": "R11-R70",
+  "result_id": "efe88e93985e88d42efd8375e24af40b04cfe8bf18bc1352cd83cf2b893861d0",
+  "retained_payloads": [
+    "failure.json",
+    "independent-verification.json",
+    "recovery-receipt.json",
+    "recovery-request.json"
+  ],
+  "schema": "prob4d.dot-cut3r-r04-r10-heldout-negative-evidence.v1",
+  "scientific_inputs_changed": false,
+  "selected_dependence_alpha": 0.85,
+  "workflow_job_id": 99998900477,
+  "workflow_run_id": 33550572437
+}

--- a/evidence/dot-cut3r-r04-r10-heldout-negative-v1/recovery-receipt.json
+++ b/evidence/dot-cut3r-r04-r10-heldout-negative-v1/recovery-receipt.json
@@ -1,0 +1,21 @@
+{
+  "bayesian_phystwin_executed": false,
+  "causal4d_executed": false,
+  "confirmation_retuning_performed": false,
+  "decision": "heldout-support-negative",
+  "evaluator_exit_status": 4,
+  "provider_artifact_digest": "sha256:45cccd5b6f7b7d671cfc86fbcb27232d29faf5dafdeee8d0ea5a9c45ce42ae7c",
+  "provider_artifact_id": 9797527843,
+  "provider_bundle_id": "57dc11d9e39258a2f620d67e39f1176cafe74252173ead8cb4ba2f76083499ec",
+  "provider_job_id": 99831732392,
+  "provider_rerun": false,
+  "r11_r70_opened": false,
+  "recovery_id": "65ea99495e469989029f330b15b7022ac32d0b55e5066f3d1d1fca7babf59833",
+  "recovery_request_id": "5f60d7494dbc67b694b0d011283a0b5bc3093b190c3f1e7fd1978549f48f1051",
+  "result_id": "efe88e93985e88d42efd8375e24af40b04cfe8bf18bc1352cd83cf2b893861d0",
+  "schema": "prob4d.dot-r04-r10-evaluation-recovery-receipt",
+  "schema_version": 2,
+  "scientific_inputs_changed": false,
+  "target_head_sha": "b85dd8e8adb68ffb289868731222151968940317",
+  "target_run_id": 33500239597
+}

--- a/evidence/dot-cut3r-r04-r10-heldout-negative-v1/recovery-request.json
+++ b/evidence/dot-cut3r-r04-r10-heldout-negative-v1/recovery-request.json
@@ -1,0 +1,56 @@
+{
+  "evaluation_job_id": 99832885343,
+  "failure_contract": {
+    "evaluation_conclusion": "failure",
+    "evaluator_output_created": false,
+    "exact_error_fragment": "FileExistsError: [Errno 17] File exists: '/home/runner/work/_temp/prob4d-dot-r04-r10-evaluation-33500239597-1/evaluation'",
+    "marker_archive_verified": true,
+    "provider_conclusion": "success",
+    "provider_seal_verified": true,
+    "scientific_result_emitted": false
+  },
+  "frozen_science": {
+    "checkpoint_sha256": "45f7e98a0a64dbeb54901ae2b878cd8cd125f20a4497316483f0bd6f109f8103",
+    "confirmation_sequences": [
+      "R04",
+      "R05",
+      "R06",
+      "R07",
+      "R08",
+      "R09",
+      "R10"
+    ],
+    "cut3r_revision": "8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf",
+    "dot_archive_md5": "ca546ff5f22c0279123ccb18509858ee",
+    "dot_archive_name": "R01-10.zip",
+    "original_request_id": "62d64df1b1b72f2b2aff0b17cf4c7aad245150f9fa1ff67712eedc0f4e109ce6",
+    "protocol_git_blob_sha": "3c15531e94e4df7de20089d806b3209789f3ee3e",
+    "protocol_id": "a83258295d5ecabd95017a775f334173bb48141918832fb1a065a1dff66d16ba",
+    "reserved_sequences": "R11-R70",
+    "selected_alpha": 0.85,
+    "source_calibration_id": "943339ac864fda04cc59081bc81a605576b3c90bf0aa996aea00b00335cfc0c7"
+  },
+  "information_boundary": {
+    "bayesian_phystwin_executed": false,
+    "causal4d_executed": false,
+    "confirmation_retuning_authorized": false,
+    "marker_evaluation_authorized": true,
+    "provider_rerun_authorized": false,
+    "r11_r70_opened": false,
+    "sealed_provider_predictions_reused": true
+  },
+  "provider_artifact": {
+    "digest": "sha256:45cccd5b6f7b7d671cfc86fbcb27232d29faf5dafdeee8d0ea5a9c45ce42ae7c",
+    "id": 9797527843,
+    "name": "dot-rope-cut3r-heldout-provider-gpuserver6000-62d64df1b1b72f2b2aff0b17cf4c7aad245150f9fa1ff67712eedc0f4e109ce6",
+    "provider_bundle_id": "57dc11d9e39258a2f620d67e39f1176cafe74252173ead8cb4ba2f76083499ec"
+  },
+  "provider_job_id": 99831732392,
+  "request_id": "5f60d7494dbc67b694b0d011283a0b5bc3093b190c3f1e7fd1978549f48f1051",
+  "schema": "prob4d.dot-r04-r10-evaluation-recovery-request",
+  "schema_version": 2,
+  "target_head_sha": "b85dd8e8adb68ffb289868731222151968940317",
+  "target_run_attempt": 1,
+  "target_run_id": 33500239597,
+  "target_workflow_path": ".github/workflows/dot-rope-cut3r-heldout-confirmation-v1.yml"
+}


### PR DESCRIPTION
## Purpose

Record the terminal outcome of the independently frozen DOT/CUT3R R04–R10 confirmation after the sealed-provider recovery completed successfully.

## Terminal result

- decision: `heldout-support-negative`;
- exact stopping condition: `pooled provider/truth support is below its registered minimum`;
- result ID: `efe88e93985e88d42efd8375e24af40b04cfe8bf18bc1352cd83cf2b893861d0`;
- source-frozen dependence value: `alpha=0.85`;
- workflow run: `33550572437`;
- exact evaluation job: `99998900477`;
- recovered evidence artifact: `9817282504`, SHA-256 `3207766f8b48c11e667cf90f61e86c0026a0de024727293d5495cc2214304685`.

The evaluator stopped before the registered NLL comparison, so this PR does not report or imply a held-out NLL result.

## Scientific and custody boundary

- the marker-free provider predictions were already sealed before marker access;
- the provider was not rerun;
- the exact frozen evaluator was reused;
- the recovery changed only the prior output-directory packaging failure;
- no threshold, support rule, coordinate convention, window, mean, comparator, or dependence parameter changed;
- R04–R10 were the only confirmation sequences opened;
- R11–R70 remained unopened by this evaluation;
- BayesianPhysTwin and Causal4D were not executed.

## Files

Adds compact byte-identical terminal payloads, a hash/provenance manifest, a custody README, bounded documentation, and a changelog entry. The larger marker-support record remains in the immutable Actions artifact and is hash-bound in the manifest. No images, marker coordinates, point maps, or raw DOT payloads are committed.

This is evidence retention only. It rejects the registered held-out CUT3R dependence claim; it does not establish general CUT3R incapability, deployment safety, or state of the art.