### PR TITLE
Record terminal DOT R11–R20 camera-routing source-rank result

### DIFF
--- a/evidence/dot/r11-r20-camera-routing-provider-rank-v1/RESULT.md
+++ b/evidence/dot/r11-r20-camera-routing-provider-rank-v1/RESULT.md
@@ -1,0 +1,44 @@
+# DOT R11–R20 camera-routing CUT3R source-rank result
+
+## Outcome
+
+**Decision:** `camera-routing-provider-rank-negative`
+
+The corrected routed-camera experiment completed successfully on `gpuserver4090` (`workstation1`) in GitHub Actions run `33552798863`. The target-closed synthetic CUT3R smoke passed, all R11–R20 marker-free predictions were sealed, and the source-only rank gate was evaluated.
+
+Only **1 of 10** source sequences passed the fixed rank/support criterion; the promotion threshold was **9 of 10**. The only supported sequence was `R18` on `cam001`:
+
+- factor rank: `6` (expected `6`)
+- observable condition ratio: `0.9984359824719174`
+- normalized support margin: `3.375`
+- fit-A / fit-B / common overlap support: `27 / 27 / 27`
+
+The remaining nine sequences produced full-rank (`7`) factors rather than the required one-dimensional gauge defect. Camera routing therefore did not recover a broadly applicable rank-6 ambiguity class for the fixed candidate `expanded__overlap-345`.
+
+## Reproducibility identities
+
+- evaluated commit: `c64765ea766e667a566e1b565e8ed01ffd734e53`
+- result ID: `a1fc018dc7fb504b35f6fbfc422e7a59edaeb71009c6f29c512019d42f949ced`
+- provider seal ID: `38ea78e8bf44cbeaedeeadaee862af3cc6369d35d7e3b5a2b5fac0f020c7145b`
+- provider artifact: `dot-r11-r20-routed-provider-fast-33552798863-1`
+- provider artifact ID: `9818146750`
+- provider artifact SHA-256: `70c2cec1cf33b65ae6653a3839fb4f74d57023d1d49cced6c61e6948f4d7b8a6`
+- rank-result artifact: `dot-r11-r20-routed-provider-rank-fast-33552798863-1`
+- rank-result artifact ID: `9818149548`
+- rank-result artifact SHA-256: `d6f81bbb2fbe8af7cf574fe4bdad313fe0ac05d2882a3673c832b2ce2e79add0`
+
+The three routed provider components were:
+
+| Camera | Sequences | Provider bundle ID |
+|---|---|---|
+| `cam001` | R13, R14, R15, R16, R18, R19 | `14d78d100a62e11e0e51d76491e72f9bb34d30e141a8a510d9bdb69bacb35dff` |
+| `cam002` | R17 | `e0c476a039e9610a2849c6dba3996936fbf7f648b68b61d93bc0519fff389dae` |
+| `cam005` | R11, R12, R20 | `60c56f8c1cc2b07e418d67b01d81c3dc7dd7b369dbeaac9899f029af8f79b818` |
+
+## Scientific interpretation
+
+This is a valid negative source-feasibility result. The learned provider and camera routing worked technically, but the intended rank-deficient ambiguity structure was present in only one sequence. Consequently, this fixed DOT route should not be promoted to R21–R30 confirmation or used as the flagship positive paper result.
+
+The result points to a different formulation: treat the prevalent full-rank cross-window uncertainty as a general correlated belief and test query-level value directly, rather than requiring a rank-6 gauge factor in every sequence. That is a new experiment and should not be represented as a rescue of this fixed rank-gate result.
+
+No BayesianPhysTwin or Causal4D run was executed, and no R21–R70 payload was opened by this experiment.

--- a/evidence/dot/r11-r20-camera-routing-provider-rank-v1/result.json
+++ b/evidence/dot/r11-r20-camera-routing-provider-rank-v1/result.json
@@ -1,0 +1,178 @@
+{
+  "component_results": [
+    {
+      "camera": "cam001",
+      "component_decision": "source-support-negative",
+      "component_result_id": "e5668d6c125499fdaf65b76c800657d6aded6e8629c396f86736712e07d7e236",
+      "protocol_id": "0ff98eb668cd91df8f240a50d3c2ed792615a40de27958ea774711f270cbe71f",
+      "provider_bundle_id": "14d78d100a62e11e0e51d76491e72f9bb34d30e141a8a510d9bdb69bacb35dff"
+    },
+    {
+      "camera": "cam002",
+      "component_decision": "source-support-negative",
+      "component_result_id": "ffcc09b54bf8a3952f3df4df3bef7b52741ee05139d64c4590332bc9a2149959",
+      "protocol_id": "1dbbaa051fb5061efbd87f2a9841ed7153fbe94cbfe6db004b639c9bb8fedfb2",
+      "provider_bundle_id": "e0c476a039e9610a2849c6dba3996936fbf7f648b68b61d93bc0519fff389dae"
+    },
+    {
+      "camera": "cam005",
+      "component_decision": "source-support-negative",
+      "component_result_id": "2a6334add22b79d4c93809a8cfe7fec7f9754e11c4bc3176f4e96dcb5d0d7996",
+      "protocol_id": "9478b46a16cbe649b50dd59c1ef4ebbea4e8fec128f62da873b24ede3d72ea0e",
+      "provider_bundle_id": "60c56f8c1cc2b07e418d67b01d81c3dc7dd7b369dbeaac9899f029af8f79b818"
+    }
+  ],
+  "decision": "camera-routing-provider-rank-negative",
+  "expected_factor_rank": 6,
+  "fixed_candidate": "expanded__overlap-345",
+  "information_boundary": {
+    "bayesian_phystwin_executed": false,
+    "causal4d_executed": false,
+    "r21_r30_payloads_opened": false,
+    "r31_r70_payloads_opened": false,
+    "source_proper_score_computed": false,
+    "source_reconstruction_error_computed": false
+  },
+  "minimum_supported_condition_ratio": 0.9984359824719174,
+  "minimum_supported_margin": 3.375,
+  "minimum_supported_sequences_for_promotion": 9,
+  "parent_protocol_id": "cd57cb81d1aa52707f26bb0f39829e848d15d0a67b064b390b24caf545923690",
+  "per_sequence": [
+    {
+      "camera": "cam005",
+      "factor_error": null,
+      "factor_rank": 7,
+      "fit_a_total": 12,
+      "fit_b_total": 12,
+      "normalized_support_margin": 1.5,
+      "observable_condition_ratio": 0.34698364274467036,
+      "overlap_common_total": 12,
+      "overlap_nonempty_frames": 3,
+      "sequence": "R11",
+      "supported": false
+    },
+    {
+      "camera": "cam005",
+      "factor_error": null,
+      "factor_rank": 7,
+      "fit_a_total": 19,
+      "fit_b_total": 18,
+      "normalized_support_margin": 2.25,
+      "observable_condition_ratio": 0.03211153247603247,
+      "overlap_common_total": 18,
+      "overlap_nonempty_frames": 3,
+      "sequence": "R12",
+      "supported": false
+    },
+    {
+      "camera": "cam001",
+      "factor_error": null,
+      "factor_rank": 7,
+      "fit_a_total": 21,
+      "fit_b_total": 29,
+      "normalized_support_margin": 3.0,
+      "observable_condition_ratio": 0.04064632630091962,
+      "overlap_common_total": 24,
+      "overlap_nonempty_frames": 3,
+      "sequence": "R13",
+      "supported": false
+    },
+    {
+      "camera": "cam001",
+      "factor_error": null,
+      "factor_rank": 7,
+      "fit_a_total": 9,
+      "fit_b_total": 12,
+      "normalized_support_margin": 1.25,
+      "observable_condition_ratio": 0.16131668405882282,
+      "overlap_common_total": 10,
+      "overlap_nonempty_frames": 3,
+      "sequence": "R14",
+      "supported": false
+    },
+    {
+      "camera": "cam001",
+      "factor_error": null,
+      "factor_rank": 7,
+      "fit_a_total": 9,
+      "fit_b_total": 9,
+      "normalized_support_margin": 1.125,
+      "observable_condition_ratio": 0.020675137764448154,
+      "overlap_common_total": 9,
+      "overlap_nonempty_frames": 3,
+      "sequence": "R15",
+      "supported": false
+    },
+    {
+      "camera": "cam001",
+      "factor_error": null,
+      "factor_rank": 7,
+      "fit_a_total": 9,
+      "fit_b_total": 9,
+      "normalized_support_margin": 1.125,
+      "observable_condition_ratio": 0.103566896569927,
+      "overlap_common_total": 9,
+      "overlap_nonempty_frames": 3,
+      "sequence": "R16",
+      "supported": false
+    },
+    {
+      "camera": "cam002",
+      "factor_error": null,
+      "factor_rank": 7,
+      "fit_a_total": 15,
+      "fit_b_total": 15,
+      "normalized_support_margin": 1.875,
+      "observable_condition_ratio": 0.0967263072510241,
+      "overlap_common_total": 15,
+      "overlap_nonempty_frames": 3,
+      "sequence": "R17",
+      "supported": false
+    },
+    {
+      "camera": "cam001",
+      "factor_error": null,
+      "factor_rank": 6,
+      "fit_a_total": 27,
+      "fit_b_total": 27,
+      "normalized_support_margin": 3.375,
+      "observable_condition_ratio": 0.9984359824719174,
+      "overlap_common_total": 27,
+      "overlap_nonempty_frames": 3,
+      "sequence": "R18",
+      "supported": true
+    },
+    {
+      "camera": "cam001",
+      "factor_error": null,
+      "factor_rank": 7,
+      "fit_a_total": 9,
+      "fit_b_total": 9,
+      "normalized_support_margin": 1.125,
+      "observable_condition_ratio": 0.2610844397680334,
+      "overlap_common_total": 9,
+      "overlap_nonempty_frames": 3,
+      "sequence": "R19",
+      "supported": false
+    },
+    {
+      "camera": "cam005",
+      "factor_error": null,
+      "factor_rank": 7,
+      "fit_a_total": 21,
+      "fit_b_total": 21,
+      "normalized_support_margin": 2.625,
+      "observable_condition_ratio": 0.01681081929186926,
+      "overlap_common_total": 21,
+      "overlap_nonempty_frames": 3,
+      "sequence": "R20",
+      "supported": false
+    }
+  ],
+  "raw_routing_audit_id": "66724cb78840f4b9ef3becf97e5765924094cf8db6eca2d892c44cfa7edb19b3",
+  "result_id": "a1fc018dc7fb504b35f6fbfc422e7a59edaeb71009c6f29c512019d42f949ced",
+  "schema": "prob4d.dot-r11-r20-camera-routing-provider-rank-result",
+  "schema_version": 1,
+  "source_sequence_count": 10,
+  "supported_source_sequences": 1
+}


### PR DESCRIPTION
## Result

Records the completed source-only DOT R11–R20 camera-routing CUT3R experiment from Actions run `33552798863`.

- corrected synthetic CUT3R smoke: passed
- all routed marker-free predictions: completed and sealed
- source-rank decision: `camera-routing-provider-rank-negative`
- supported source sequences: `1/10` (`R18` only)
- required for promotion: `9/10`
- result ID: `a1fc018dc7fb504b35f6fbfc422e7a59edaeb71009c6f29c512019d42f949ced`

This PR adds only the retained result and a concise interpretation. It does not launch another experiment or alter the method.