### PR TITLE
Add prior-anchored query messages for unknown-dependence fusion

### DIFF
--- a/CHANGELOG.d/query-message-ci.md
+++ b/CHANGELOG.d/query-message-ci.md
@@ -1,0 +1,9 @@
+### Added
+
+- Add prior-anchored Gaussian query messages that exactly reproduce a fixed
+  correlation-aware query posterior.
+- Add covariance-intersection composition that counts the common prior once,
+  remains idempotent for duplicated messages, and fails closed for incompatible
+  query/prior identities or invalid weights.
+- Add deterministic pairwise log-determinant/trace weight selection, focused
+  algebraic tests, and the source-only DOT evaluation boundary.

--- a/docs/query-message-fusion.md
+++ b/docs/query-message-fusion.md
@@ -1,0 +1,238 @@
+# Prior-anchored query messages and unknown-dependence fusion
+
+Prob4D can already condition a fixed Gaussian query directly through a structured
+innovation operator, and it can reduce one shared covariance factor while
+preserving that posterior. This module adds the downstream representation needed
+when several overlapping prediction windows produce query posteriors whose
+cross-window dependence is not known well enough to justify information
+addition.
+
+The implementation is in `src/prob4d/query_message.py`.
+
+## Exact query message
+
+Let a fixed registered query have anchor prior
+
+\[
+q \sim \mathcal N(m_0,P_0)
+\]
+
+and let one full, correlation-aware update produce
+
+\[
+q\mid y \sim \mathcal N(m_1,P_1).
+\]
+
+Assume the query coordinates have been reduced to an independent basis, so
+\(P_0\) and \(P_1\) are positive definite. Define the prior-relative natural
+parameter increment
+
+\[
+\Lambda = P_1^{-1}-P_0^{-1},\qquad
+\eta = P_1^{-1}m_1-P_0^{-1}m_0.
+\]
+
+Then applying the anchor prior once gives
+
+\[
+P_{\mathrm{msg}} =
+  \left(P_0^{-1}+\Lambda\right)^{-1}=P_1,
+\]
+
+\[
+m_{\mathrm{msg}} =
+  P_{\mathrm{msg}}\left(P_0^{-1}m_0+\eta\right)=m_1.
+\]
+
+`compress_gaussian_query_posterior` constructs this message from
+`GaussianQueryPosterior` and independently reconstructs the posterior before
+returning it. The retained payload is one \(Q\times Q\) symmetric information
+increment and one \(Q\)-vector. The explicit anchor adds one prior covariance and
+mean.
+
+The message is deliberately prior-bound and query-bound. Applying it to another
+prior would generally be wrong because nuisance variables eliminated by the
+full update can couple the observation to the query through the original prior.
+The implementation therefore stores the anchor and rejects a supplied prior
+unless its float64 arrays are byte-identical.
+
+## Covariance intersection in message coordinates
+
+Suppose messages \(i=1,\ldots,M\) share the same anchor and query but their
+cross-message dependence is unknown. Each component posterior has
+
+\[
+J_i=P_i^{-1}=J_0+\Lambda_i,\qquad
+h_i=J_i m_i=h_0+\eta_i,
+\]
+
+where \(J_0=P_0^{-1}\) and \(h_0=J_0m_0\).
+
+For nonnegative weights \(w_i\) with \(\sum_i w_i\leq 1\), assign the remaining
+weight
+
+\[
+w_0=1-\sum_i w_i
+\]
+
+to the unchanged anchor prior. Covariance intersection over the component
+posteriors and the prior gives
+
+\[
+J_{\mathrm{CI}}
+  = w_0J_0+\sum_i w_iJ_i
+  = J_0+\sum_i w_i\Lambda_i,
+\]
+
+\[
+h_{\mathrm{CI}}
+  = w_0h_0+\sum_i w_ih_i
+  = h_0+\sum_i w_i\eta_i.
+\]
+
+Thus the common prior is counted exactly once. No high-dimensional state,
+measurement covariance, or nuisance block must be reconstructed after the
+individual query messages have been formed.
+
+An important idempotence check follows immediately. If all component messages
+are byte-identical and the message weights sum to one, the fused posterior is
+exactly the single-message posterior. Repeating one overlapping-window result
+cannot create additional confidence. In contrast, adding the message
+information twice produces
+
+\[
+J_{\mathrm{naive}}=J_0+2\Lambda,
+\]
+
+which is spuriously more precise unless \(\Lambda=0\).
+
+`fuse_gaussian_query_messages_covariance_intersection` implements caller-supplied
+weights. `select_pairwise_covariance_intersection` provides a deterministic
+grid search minimizing query-covariance log determinant or trace. Weight
+selection is part of the scientific protocol; target outcomes must not be used
+to tune it.
+
+## Example
+
+```python
+from prob4d.query_message import (
+    apply_gaussian_query_message,
+    compress_gaussian_query_posterior,
+    fuse_gaussian_query_messages_covariance_intersection,
+)
+from prob4d.query_posterior import condition_gaussian_query
+
+first_posterior = condition_gaussian_query(...)
+second_posterior = condition_gaussian_query(...)
+
+first = compress_gaussian_query_posterior(
+    first_posterior,
+    query_id="rope-endpoint-at-horizon-8",
+    prior_id="physical-prior-frame-120",
+    evidence_ids=("cut3r-window-112-120",),
+)
+second = compress_gaussian_query_posterior(
+    second_posterior,
+    query_id="rope-endpoint-at-horizon-8",
+    prior_id="physical-prior-frame-120",
+    evidence_ids=("cut3r-window-116-120",),
+)
+
+fused = fuse_gaussian_query_messages_covariance_intersection(
+    (first, second),
+    weights=(0.5, 0.5),
+)
+query_belief = apply_gaussian_query_message(fused)
+```
+
+The two windows may overlap completely, partially, or not at all. The CI call
+does not assert independence. A scientifically justified independence model
+could be sharper, but it must be represented and validated separately rather
+than inferred from distinct window identifiers.
+
+## Relationship to shared-factor compression
+
+The existing `posterior_preserving_compression` module answers a different
+interface question:
+
+- keep all measurement rows;
+- keep the structured Woodbury consumer;
+- replace one shared factor \(U\) by a lower-rank \(UV\);
+- preserve one fixed query posterior.
+
+A query message is preferable when the downstream consumer needs only that
+fixed query and does not need to re-score the observation, change the query, or
+reuse the factor under another prior. It is smaller and cheaper online because
+the structured solve has already been completed.
+
+A compressed shared factor is preferable when the factor interface itself must
+remain resident, several compatible operations still consume it, or the query
+may change within the factor's registered validity boundary.
+
+The two operations compose:
+
+1. use the exact or posterior-preserving structured factor to obtain
+   `GaussianQueryPosterior`;
+2. convert the result into a prior-anchored query message;
+3. fuse overlapping-window messages with registered CI weights.
+
+## Complexity and storage
+
+For query dimension \(Q\) and \(M\) messages:
+
+- message payload: \(Q^2+Q\) float64 values;
+- explicit anchor: another \(Q^2+Q\) values;
+- message application: \(O(Q^3)\);
+- fixed-weight CI construction: \(O(MQ^2)\) plus one \(O(Q^3)\) application;
+- pairwise grid selection with \(G\) weights: \(O(GQ^3)\).
+
+The expensive full correlation-aware conditioning is still performed once per
+source message. This layer compresses and composes its query consequence; it
+does not make the provider covariance free.
+
+## Claim boundary
+
+This implementation establishes Gaussian algebra only.
+
+It does not establish:
+
+- correctness or calibration of the provider covariance;
+- unbiasedness required for a statistical covariance-intersection guarantee;
+- that a chosen query is sufficient for another query or action;
+- preservation of the observation marginal likelihood;
+- conditional independence between messages;
+- validity under a different prior, row identity, linearization, or robust
+  weighting;
+- nonlinear-query accuracy beyond the supplied local Gaussian approximation;
+- robot safety or state-of-the-art prediction.
+
+Singular or duplicated query coordinates must first be reduced to an independent
+basis. Invalid anchors, negative information increments, incompatible query
+identities, incompatible priors, and weights summing above one fail closed.
+
+## Source-only DOT experiment to register next
+
+The terminal routed-camera study found the intended rank-6 structure in only
+one of ten R11--R20 source sequences. The next experiment should therefore not
+condition eligibility on a fixed rank defect.
+
+R11--R20 are already opened and may be used for source development. A new
+protocol should:
+
+1. form full-rank correlation-aware endpoint, centroid, and local-tangent query
+   posteriors from the sealed routed CUT3R predictions;
+2. convert each overlapping window to a prior-anchored message;
+3. compare dense known-dependence fusion where available, naive independent
+   addition, diagonal fusion, factor truncation, query-space CI, and exact
+   fallback;
+4. freeze query definitions, source-selected CI policy, support rules, and all
+   thresholds before any new confirmation access;
+5. require parity to the dense per-window query posterior, no duplicate-window
+   confidence gain, proper-score and coverage reporting, harmful accepted-update
+   accounting, and measured bytes/latency;
+6. keep R21--R30 closed until the source gate passes and reserve R31--R70.
+
+The positive paper target is not “rank 6 occurs.” It is that a fixed
+query-message interface retains useful decision-relevant uncertainty across
+changing factor ranks while avoiding the overconfidence caused by overlapping
+evidence.

--- a/docs/query-message-fusion.md
+++ b/docs/query-message-fusion.md
@@ -210,27 +210,37 @@ Singular or duplicated query coordinates must first be reduced to an independent
 basis. Invalid anchors, negative information increments, incompatible query
 identities, incompatible priors, and weights summing above one fail closed.
 
-## Source-only DOT experiment to register next
+## Registered source-only DOT protocol
 
 The terminal routed-camera study found the intended rank-6 structure in only
-one of ten R11--R20 source sequences. The next experiment should therefore not
+one of ten R11--R20 source sequences. The content-addressed development protocol
+`protocols/dot-r11-r20-query-message-ci-source-v1.json` therefore does not
 condition eligibility on a fixed rank defect.
 
-R11--R20 are already opened and may be used for source development. A new
-protocol should:
+The protocol binds:
 
-1. form full-rank correlation-aware endpoint, centroid, and local-tangent query
-   posteriors from the sealed routed CUT3R predictions;
-2. convert each overlapping window to a prior-anchored message;
-3. compare dense known-dependence fusion where available, naive independent
-   addition, diagonal fusion, factor truncation, query-space CI, and exact
-   fallback;
-4. freeze query definitions, source-selected CI policy, support rules, and all
-   thresholds before any new confirmation access;
-5. require parity to the dense per-window query posterior, no duplicate-window
-   confidence gain, proper-score and coverage reporting, harmful accepted-update
-   accounting, and measured bytes/latency;
-6. keep R21--R30 closed until the source gate passes and reserve R31--R70.
+- the exact sealed routed CUT3R provider artifact from run `33552798863`;
+- the already-open source cohort R11--R20 and the unchanged R11--R20 archive
+  checksum;
+- the two overlapping windows and their identity-bound common anchor prior;
+- a gauge-insensitive centroid query and a gauge-sensitive adverse query;
+- equal-weight query-space CI as the primary source method, selected without
+  source outcomes;
+- dense/continuous, single-window, naive-independent, diagonal, pairwise-CI,
+  and exact-fallback comparators;
+- complete sequence as the independent unit; and
+- posterior parity, duplicate idempotence, RMSE, joint NLL, coverage and width,
+  harmful-update, byte, latency, and factor-rank-stratified endpoints.
+
+Protocol ID:
+
+```text
+50feac697139ab4b61942df8b4e32611fc0f41da2d29884ed81753dd73e77706
+```
+
+The protocol contains no execution request. R21--R30 confirmation and R31--R70
+reserve remain closed. Source completion cannot authorize confirmation; a
+separate one-shot protocol must be frozen before any confirmation access.
 
 The positive paper target is not “rank 6 occurs.” It is that a fixed
 query-message interface retains useful decision-relevant uncertainty across

--- a/protocols/dot-r11-r20-query-message-ci-source-v1.json
+++ b/protocols/dot-r11-r20-query-message-ci-source-v1.json
@@ -1,0 +1,209 @@
+{
+  "schema": "prob4d.dot-r11-r20-query-message-ci-source-protocol",
+  "schema_version": 1,
+  "stage": "development-only-source",
+  "dataset": {
+    "name": "DOT V29 rope",
+    "doi": "10.13021/ORC2020/XXLVXM",
+    "source_archive": {
+      "name": "R11-20.zip",
+      "md5": "23ce3e7067465d3edabe20b4c7cfa388"
+    },
+    "source_sequences": [
+      "R11",
+      "R12",
+      "R13",
+      "R14",
+      "R15",
+      "R16",
+      "R17",
+      "R18",
+      "R19",
+      "R20"
+    ],
+    "confirmation_sequences": [
+      "R21",
+      "R22",
+      "R23",
+      "R24",
+      "R25",
+      "R26",
+      "R27",
+      "R28",
+      "R29",
+      "R30"
+    ],
+    "reserved_sequences": "R31-R70"
+  },
+  "sealed_provider": {
+    "workflow_run_id": 33552798863,
+    "execution_revision": "c64765ea766e667a566e1b565e8ed01ffd734e53",
+    "artifact_id": 9818146750,
+    "artifact_digest": "sha256:70c2cec1cf33b65ae6653a3839fb4f74d57023d1d49cced6c61e6948f4d7b8a6",
+    "provider_seal_id": "38ea78e8bf44cbeaedeeadaee862af3cc6369d35d7e3b5a2b5fac0f020c7145b",
+    "source_marker_payloads_opened_when_predictions_were_sealed": false,
+    "confirmation_payloads_opened": false,
+    "components": [
+      {
+        "camera": "cam001",
+        "sequences": [
+          "R13",
+          "R14",
+          "R15",
+          "R16",
+          "R18",
+          "R19"
+        ],
+        "provider_bundle_id": "14d78d100a62e11e0e51d76491e72f9bb34d30e141a8a510d9bdb69bacb35dff"
+      },
+      {
+        "camera": "cam002",
+        "sequences": [
+          "R17"
+        ],
+        "provider_bundle_id": "e0c476a039e9610a2849c6dba3996936fbf7f648b68b61d93bc0519fff389dae"
+      },
+      {
+        "camera": "cam005",
+        "sequences": [
+          "R11",
+          "R12",
+          "R20"
+        ],
+        "provider_bundle_id": "60c56f8c1cc2b07e418d67b01d81c3dc7dd7b369dbeaac9899f029af8f79b818"
+      }
+    ]
+  },
+  "terminal_rank_diagnostic": {
+    "artifact_id": 9818149548,
+    "artifact_digest": "sha256:d6f81bbb2fbe8af7cf574fe4bdad313fe0ac05d2882a3673c832b2ce2e79add0",
+    "result_id": "a1fc018dc7fb504b35f6fbfc422e7a59edaeb71009c6f29c512019d42f949ced",
+    "decision": "camera-routing-provider-rank-negative",
+    "fixed_candidate": "expanded__overlap-345",
+    "factor_rank_counts": {
+      "6": 1,
+      "7": 9
+    },
+    "supported_sequences": [
+      "R18"
+    ],
+    "interpretation": "motivation for rank-agnostic query messages; never a positive rank-six claim"
+  },
+  "windows": {
+    "continuous": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7
+    ],
+    "window_a": [
+      1,
+      2,
+      3,
+      4,
+      5
+    ],
+    "window_b": [
+      3,
+      4,
+      5,
+      6,
+      7
+    ],
+    "overlap": [
+      3,
+      4,
+      5
+    ],
+    "common_anchor": "identity-bound physical fallback query belief at overlap reference frame 5"
+  },
+  "queries": [
+    {
+      "id": "centerline_centroid",
+      "dimension": 3,
+      "definition": "provider-window overlap centroid in the registered local chart",
+      "role": "gauge-insensitive utility query"
+    },
+    {
+      "id": "off_axis_probe",
+      "dimension": 3,
+      "definition": "overlap centroid plus one deterministic cloud-scale normal in the same chart",
+      "role": "gauge-sensitive adverse query"
+    }
+  ],
+  "message_contract": {
+    "implementation": "prob4d.query_message",
+    "construction": "posterior-ratio-v1",
+    "same_query_required": true,
+    "byte_identical_anchor_required": true,
+    "negative_information_rejected": true,
+    "singular_query_coordinates": "reduce to an independent basis or fail closed",
+    "posterior_parity_relative_tolerance": 1e-09,
+    "duplicate_message_mean_relative_tolerance": 1e-12,
+    "duplicate_message_covariance_relative_tolerance": 1e-12,
+    "observation_likelihood_preserved": false
+  },
+  "source_methods": {
+    "primary": {
+      "id": "two_window_query_ci_equal",
+      "messages": [
+        "window_a",
+        "window_b"
+      ],
+      "weights": [
+        0.5,
+        0.5
+      ],
+      "prior_weight": 0.0,
+      "weight_selection_uses_source_outcomes": false
+    },
+    "comparators": [
+      "physical_fallback",
+      "window_a_only",
+      "window_b_only",
+      "continuous_provider_query",
+      "naive_independent_message_sum",
+      "diagonal_query_covariance",
+      "pairwise_logdet_ci_source_diagnostic"
+    ],
+    "duplicate_message_control": "repeat one byte-identical message twice at weights 0.5/0.5",
+    "naive_duplicate_control": "add the same information increment twice"
+  },
+  "source_endpoints": {
+    "independent_unit": "complete_sequence",
+    "required": [
+      "per-window posterior mean and covariance parity",
+      "duplicate-message idempotence",
+      "query RMSE",
+      "joint Gaussian NLL",
+      "nominal 90% query coverage and interval width",
+      "harmful accepted-update fraction versus physical fallback",
+      "message bytes and construction/application latency",
+      "results stratified by observed factor rank"
+    ],
+    "source_weighting": "equal sequence weight",
+    "outcome_use": "development-only; cannot support a confirmation or deployment claim"
+  },
+  "promotion": {
+    "automatic_confirmation_authorization": false,
+    "on_source_completion": "freeze a separate one-shot R21-R30 protocol before any confirmation access",
+    "on_source_negative": "retain the result and leave R21-R70 unopened",
+    "rank_six_required": false
+  },
+  "information_boundary": {
+    "source_sequences_previously_opened": true,
+    "source_provider_may_be_reused_without_rerun": true,
+    "confirmation_access_authorized": false,
+    "r21_r30_payloads_opened": false,
+    "r31_r70_payloads_opened": false,
+    "execution_request_present": false,
+    "target_side_retuning_allowed": false,
+    "bayesian_phystwin_executed": false,
+    "causal4d_executed": false
+  },
+  "claim_boundary": "Development-only source evaluation on already-open DOT R11-R20 using one exact sealed marker-free CUT3R provider artifact. It may establish Gaussian query-message parity, duplicate-evidence idempotence, and descriptive source utility across changing factor ranks. It cannot establish held-out performance, calibration, learned-provider competence, BayesianPhysTwin or Causal4D benefit, deployment safety, or state of the art. R21-R70 remain closed.",
+  "protocol_id": "50feac697139ab4b61942df8b4e32611fc0f41da2d29884ed81753dd73e77706"
+}

--- a/src/prob4d/query_message.py
+++ b/src/prob4d/query_message.py
@@ -21,8 +21,9 @@ from __future__ import annotations
 
 import hashlib
 import math
+from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import Any, Iterable, Literal, TypeAlias, cast
+from typing import Any, Literal, TypeAlias, cast
 
 import numpy as np
 from numpy.typing import NDArray

--- a/src/prob4d/query_message.py
+++ b/src/prob4d/query_message.py
@@ -1,0 +1,612 @@
+"""Prior-anchored Gaussian query messages and dependence-safe fusion.
+
+A high-dimensional correlated update may be reduced, after exact query
+conditioning, to one Gaussian natural-parameter increment in query coordinates.
+For anchor prior ``N(m0, P0)`` and posterior ``N(m1, P1)`` the message is
+
+``Lambda = P1^{-1} - P0^{-1}``
+``eta = P1^{-1} m1 - P0^{-1} m0``.
+
+Applying the anchor prior once plus ``(Lambda, eta)`` reproduces the query
+posterior.  The message is query-bound and prior-bound; it is not a reusable
+observation factor for a different prior or query.
+
+Messages with unknown cross-correlation may be combined by nonnegative
+covariance-intersection weights whose sum is at most one.  The unused weight is
+assigned to the anchor prior, so the shared prior is counted exactly once.
+This is an algebraic dependence guard, not a calibration or safety guarantee.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from dataclasses import dataclass, field
+from typing import Any, Iterable, Literal, TypeAlias, cast
+
+import numpy as np
+from numpy.typing import NDArray
+
+from .query_posterior import GaussianQueryPosterior
+
+FloatArray: TypeAlias = NDArray[np.floating[Any]]
+
+
+def _identifier(value: object, *, name: str) -> str:
+    if type(value) is not str or not value.strip():
+        raise ValueError(f"{name} must be a nonempty string")
+    return value
+
+
+def _identifier_tuple(value: Iterable[str], *, name: str) -> tuple[str, ...]:
+    try:
+        values = tuple(value)
+    except TypeError as error:
+        raise TypeError(f"{name} must be an iterable of strings") from error
+    retained = tuple(sorted({_identifier(item, name=f"{name} item") for item in values}))
+    if not retained:
+        raise ValueError(f"{name} must contain at least one identifier")
+    return retained
+
+
+def _readonly_vector(value: object, *, name: str) -> FloatArray:
+    result = np.asarray(value, dtype=np.float64)
+    if result.ndim != 1 or result.shape[0] < 1:
+        raise ValueError(f"{name} must be a nonempty vector")
+    if not np.all(np.isfinite(result)):
+        raise ValueError(f"{name} must be finite")
+    copied = result.copy()
+    copied.setflags(write=False)
+    return cast(FloatArray, copied)
+
+
+def _readonly_symmetric(
+    value: object,
+    *,
+    name: str,
+    positive_definite: bool,
+) -> FloatArray:
+    result = np.asarray(value, dtype=np.float64)
+    if result.ndim != 2 or result.shape[0] < 1 or result.shape[0] != result.shape[1]:
+        raise ValueError(f"{name} must be a nonempty square matrix")
+    if not np.all(np.isfinite(result)):
+        raise ValueError(f"{name} must be finite")
+    symmetric = 0.5 * (result + result.T)
+    scale = max(float(np.max(np.abs(symmetric), initial=0.0)), 1.0)
+    if not np.allclose(result, symmetric, atol=1e-12 * scale, rtol=1e-10):
+        raise ValueError(f"{name} must be symmetric")
+    eigenvalues = np.linalg.eigvalsh(symmetric)
+    if positive_definite:
+        try:
+            np.linalg.cholesky(symmetric)
+        except np.linalg.LinAlgError as error:
+            raise ValueError(
+                f"{name} must be positive definite; reduce deterministic or "
+                "duplicated query coordinates first"
+            ) from error
+    elif float(eigenvalues[0]) < -1e-10 * scale:
+        raise ValueError(f"{name} must be positive semidefinite")
+    copied = symmetric.copy()
+    copied.setflags(write=False)
+    return cast(FloatArray, copied)
+
+
+def _positive_definite(value: object, *, name: str) -> FloatArray:
+    return _readonly_symmetric(value, name=name, positive_definite=True)
+
+
+def _positive_semidefinite(value: object, *, name: str) -> FloatArray:
+    return _readonly_symmetric(value, name=name, positive_definite=False)
+
+
+def _precision(covariance: FloatArray) -> FloatArray:
+    identity = np.eye(covariance.shape[0], dtype=np.float64)
+    result = np.linalg.solve(covariance, identity)
+    return cast(FloatArray, 0.5 * (result + result.T))
+
+
+def _fraction(value: object, *, name: str, include_one: bool = True) -> float:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(
+        value,
+        (int, float, np.integer, np.floating),
+    ):
+        raise TypeError(f"{name} must be a real scalar")
+    result = float(value)
+    upper_valid = result <= 1.0 if include_one else result < 1.0
+    if not math.isfinite(result) or result < 0.0 or not upper_valid:
+        interval = "[0, 1]" if include_one else "[0, 1)"
+        raise ValueError(f"{name} must lie in {interval}")
+    return result
+
+
+def _array_digest(hasher: Any, value: FloatArray) -> None:
+    array = np.ascontiguousarray(np.asarray(value, dtype="<f8"))
+    shape = ",".join(str(item) for item in array.shape).encode("ascii")
+    hasher.update(len(shape).to_bytes(4, "big"))
+    hasher.update(shape)
+    payload = array.tobytes(order="C")
+    hasher.update(len(payload).to_bytes(8, "big"))
+    hasher.update(payload)
+
+
+def _text_digest(hasher: Any, value: str) -> None:
+    payload = value.encode("utf-8")
+    hasher.update(len(payload).to_bytes(4, "big"))
+    hasher.update(payload)
+
+
+@dataclass(frozen=True, slots=True)
+class GaussianQueryBelief:
+    """One complete Gaussian belief for a registered query."""
+
+    query_id: str
+    prior_id: str
+    mean: FloatArray
+    covariance: FloatArray
+    source_message_id: str
+
+    def __post_init__(self) -> None:
+        query_id = _identifier(self.query_id, name="query_id")
+        prior_id = _identifier(self.prior_id, name="prior_id")
+        source_message_id = _identifier(
+            self.source_message_id,
+            name="source_message_id",
+        )
+        mean = _readonly_vector(self.mean, name="mean")
+        covariance = _positive_definite(self.covariance, name="covariance")
+        if covariance.shape != (mean.shape[0], mean.shape[0]):
+            raise ValueError("covariance shape must match mean")
+        object.__setattr__(self, "query_id", query_id)
+        object.__setattr__(self, "prior_id", prior_id)
+        object.__setattr__(self, "mean", mean)
+        object.__setattr__(self, "covariance", covariance)
+        object.__setattr__(self, "source_message_id", source_message_id)
+
+    @property
+    def query_dimension(self) -> int:
+        return int(self.mean.shape[0])
+
+
+@dataclass(frozen=True, slots=True)
+class GaussianQueryMessage:
+    """Prior-relative Gaussian information retained in query coordinates.
+
+    The message may be applied only to the byte-identical anchor prior.  A
+    covariance-intersection message records the positive-weight component
+    messages and the remaining anchor-prior weight.
+    """
+
+    query_id: str
+    prior_id: str
+    evidence_ids: tuple[str, ...]
+    anchor_prior_mean: FloatArray
+    anchor_prior_covariance: FloatArray
+    information_increment: FloatArray
+    natural_parameter_increment: FloatArray
+    construction_id: str = "posterior-ratio-v1"
+    component_message_ids: tuple[str, ...] = ()
+    component_weights: tuple[float, ...] = ()
+    prior_weight: float = 0.0
+    message_id: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        query_id = _identifier(self.query_id, name="query_id")
+        prior_id = _identifier(self.prior_id, name="prior_id")
+        construction_id = _identifier(self.construction_id, name="construction_id")
+        evidence_ids = _identifier_tuple(self.evidence_ids, name="evidence_ids")
+        prior_mean = _readonly_vector(
+            self.anchor_prior_mean,
+            name="anchor_prior_mean",
+        )
+        prior_covariance = _positive_definite(
+            self.anchor_prior_covariance,
+            name="anchor_prior_covariance",
+        )
+        information = _positive_semidefinite(
+            self.information_increment,
+            name="information_increment",
+        )
+        natural = _readonly_vector(
+            self.natural_parameter_increment,
+            name="natural_parameter_increment",
+        )
+        dimension = prior_mean.shape[0]
+        expected_matrix_shape = (dimension, dimension)
+        if prior_covariance.shape != expected_matrix_shape:
+            raise ValueError("anchor_prior_covariance shape must match anchor_prior_mean")
+        if information.shape != expected_matrix_shape:
+            raise ValueError("information_increment shape must match anchor prior")
+        if natural.shape != (dimension,):
+            raise ValueError("natural_parameter_increment shape must match anchor prior")
+
+        component_ids = tuple(
+            _identifier(item, name="component_message_ids item")
+            for item in self.component_message_ids
+        )
+        component_weights = tuple(
+            _fraction(item, name="component_weights item")
+            for item in self.component_weights
+        )
+        prior_weight = _fraction(self.prior_weight, name="prior_weight")
+        if len(component_ids) != len(component_weights):
+            raise ValueError("component_message_ids and component_weights must align")
+        if component_ids:
+            if any(weight <= 0.0 for weight in component_weights):
+                raise ValueError("retained component_weights must be positive")
+            if not math.isclose(
+                sum(component_weights) + prior_weight,
+                1.0,
+                rel_tol=0.0,
+                abs_tol=1e-12,
+            ):
+                raise ValueError(
+                    "component_weights plus prior_weight must sum to one"
+                )
+        elif component_weights or prior_weight != 0.0:
+            raise ValueError(
+                "uncomposed messages must not declare component or prior weights"
+            )
+
+        hasher = hashlib.sha256()
+        _text_digest(hasher, "prob4d.gaussian-query-message.v1")
+        for item in (query_id, prior_id, construction_id):
+            _text_digest(hasher, item)
+        for item in evidence_ids:
+            _text_digest(hasher, item)
+        for item in component_ids:
+            _text_digest(hasher, item)
+        for item in component_weights:
+            _array_digest(hasher, np.asarray([item], dtype=np.float64))
+        _array_digest(hasher, np.asarray([prior_weight], dtype=np.float64))
+        for item in (prior_mean, prior_covariance, information, natural):
+            _array_digest(hasher, item)
+
+        object.__setattr__(self, "query_id", query_id)
+        object.__setattr__(self, "prior_id", prior_id)
+        object.__setattr__(self, "construction_id", construction_id)
+        object.__setattr__(self, "evidence_ids", evidence_ids)
+        object.__setattr__(self, "anchor_prior_mean", prior_mean)
+        object.__setattr__(self, "anchor_prior_covariance", prior_covariance)
+        object.__setattr__(self, "information_increment", information)
+        object.__setattr__(self, "natural_parameter_increment", natural)
+        object.__setattr__(self, "component_message_ids", component_ids)
+        object.__setattr__(self, "component_weights", component_weights)
+        object.__setattr__(self, "prior_weight", prior_weight)
+        object.__setattr__(self, "message_id", hasher.hexdigest())
+
+    @property
+    def query_dimension(self) -> int:
+        return int(self.anchor_prior_mean.shape[0])
+
+    @property
+    def payload_nbytes(self) -> int:
+        """Bytes needed after the anchor prior is already resident."""
+
+        return int(
+            self.information_increment.nbytes
+            + self.natural_parameter_increment.nbytes
+        )
+
+    @property
+    def anchored_storage_nbytes(self) -> int:
+        """Bytes for the message plus its explicit anchor prior."""
+
+        return int(
+            self.payload_nbytes
+            + self.anchor_prior_mean.nbytes
+            + self.anchor_prior_covariance.nbytes
+        )
+
+    def summary(self) -> dict[str, object]:
+        return {
+            "schema": "prob4d.gaussian-query-message.v1",
+            "message_id": self.message_id,
+            "query_id": self.query_id,
+            "prior_id": self.prior_id,
+            "query_dimension": self.query_dimension,
+            "evidence_ids": list(self.evidence_ids),
+            "construction_id": self.construction_id,
+            "component_message_ids": list(self.component_message_ids),
+            "component_weights": list(self.component_weights),
+            "prior_weight": self.prior_weight,
+            "payload_nbytes": self.payload_nbytes,
+            "anchored_storage_nbytes": self.anchored_storage_nbytes,
+            "claim_boundary": (
+                "same-query same-anchor Gaussian posterior only; "
+                "not observation evidence or a calibration guarantee"
+            ),
+        }
+
+
+def apply_gaussian_query_message(
+    message: GaussianQueryMessage,
+    *,
+    prior_id: str | None = None,
+    prior_mean: object | None = None,
+    prior_covariance: object | None = None,
+) -> GaussianQueryBelief:
+    """Apply a query message to its byte-identical anchor prior.
+
+    Omitting all prior arguments uses the retained anchor.  Supplying a prior is
+    an explicit compatibility audit: all three fields are required and the
+    arrays must be byte-identical after float64 conversion.
+    """
+
+    if not isinstance(message, GaussianQueryMessage):
+        raise TypeError("message must be a GaussianQueryMessage")
+    supplied = (
+        prior_id is not None,
+        prior_mean is not None,
+        prior_covariance is not None,
+    )
+    if any(supplied) and not all(supplied):
+        raise ValueError(
+            "prior_id, prior_mean, and prior_covariance must be supplied together"
+        )
+    if all(supplied):
+        retained_prior_id = _identifier(prior_id, name="prior_id")
+        retained_mean = _readonly_vector(prior_mean, name="prior_mean")
+        retained_covariance = _positive_definite(
+            prior_covariance,
+            name="prior_covariance",
+        )
+        if retained_prior_id != message.prior_id:
+            raise ValueError("prior_id does not match the message anchor")
+        if not np.array_equal(retained_mean, message.anchor_prior_mean):
+            raise ValueError("prior_mean is not byte-identical to the message anchor")
+        if not np.array_equal(
+            retained_covariance,
+            message.anchor_prior_covariance,
+        ):
+            raise ValueError(
+                "prior_covariance is not byte-identical to the message anchor"
+            )
+    else:
+        retained_mean = message.anchor_prior_mean
+        retained_covariance = message.anchor_prior_covariance
+
+    prior_precision = _precision(retained_covariance)
+    posterior_precision = 0.5 * (
+        prior_precision
+        + message.information_increment
+        + (prior_precision + message.information_increment).T
+    )
+    posterior_precision = _positive_definite(
+        posterior_precision,
+        name="posterior_precision",
+    )
+    posterior_natural = (
+        prior_precision @ retained_mean
+        + message.natural_parameter_increment
+    )
+    posterior_covariance = _precision(posterior_precision)
+    posterior_mean = np.linalg.solve(posterior_precision, posterior_natural)
+    return GaussianQueryBelief(
+        query_id=message.query_id,
+        prior_id=message.prior_id,
+        mean=posterior_mean,
+        covariance=posterior_covariance,
+        source_message_id=message.message_id,
+    )
+
+
+def compress_gaussian_query_posterior(
+    posterior: GaussianQueryPosterior,
+    *,
+    query_id: str,
+    prior_id: str,
+    evidence_ids: Iterable[str],
+    parity_relative_tolerance: float = 1e-10,
+) -> GaussianQueryMessage:
+    """Compress one exact Gaussian query posterior to a prior-relative message."""
+
+    if not isinstance(posterior, GaussianQueryPosterior):
+        raise TypeError("posterior must be a GaussianQueryPosterior")
+    tolerance = _fraction(
+        parity_relative_tolerance,
+        name="parity_relative_tolerance",
+        include_one=False,
+    )
+    prior_covariance = _positive_definite(
+        posterior.prior_covariance,
+        name="posterior.prior_covariance",
+    )
+    posterior_covariance = _positive_definite(
+        posterior.posterior_covariance,
+        name="posterior.posterior_covariance",
+    )
+    prior_precision = _precision(prior_covariance)
+    posterior_precision = _precision(posterior_covariance)
+    information = 0.5 * (
+        posterior_precision
+        - prior_precision
+        + (posterior_precision - prior_precision).T
+    )
+    natural = (
+        posterior_precision @ posterior.posterior_mean
+        - prior_precision @ posterior.prior_mean
+    )
+    message = GaussianQueryMessage(
+        query_id=query_id,
+        prior_id=prior_id,
+        evidence_ids=tuple(evidence_ids),
+        anchor_prior_mean=posterior.prior_mean,
+        anchor_prior_covariance=prior_covariance,
+        information_increment=information,
+        natural_parameter_increment=natural,
+    )
+    reconstructed = apply_gaussian_query_message(message)
+    mean_scale = max(
+        float(np.linalg.norm(posterior.posterior_mean)),
+        1.0,
+    )
+    covariance_scale = max(
+        float(np.linalg.norm(posterior_covariance, ord="fro")),
+        1.0,
+    )
+    mean_error = float(
+        np.linalg.norm(reconstructed.mean - posterior.posterior_mean)
+        / mean_scale
+    )
+    covariance_error = float(
+        np.linalg.norm(
+            reconstructed.covariance - posterior_covariance,
+            ord="fro",
+        )
+        / covariance_scale
+    )
+    if mean_error > tolerance or covariance_error > tolerance:
+        raise RuntimeError(
+            "query-message reconstruction exceeded parity_relative_tolerance"
+        )
+    return message
+
+
+def _matching_anchor(messages: tuple[GaussianQueryMessage, ...]) -> None:
+    first = messages[0]
+    for message in messages[1:]:
+        if message.query_id != first.query_id:
+            raise ValueError("all messages must have the same query_id")
+        if message.prior_id != first.prior_id:
+            raise ValueError("all messages must have the same prior_id")
+        if not np.array_equal(
+            message.anchor_prior_mean,
+            first.anchor_prior_mean,
+        ):
+            raise ValueError("all messages must have the same anchor prior mean")
+        if not np.array_equal(
+            message.anchor_prior_covariance,
+            first.anchor_prior_covariance,
+        ):
+            raise ValueError("all messages must have the same anchor prior covariance")
+
+
+def fuse_gaussian_query_messages_covariance_intersection(
+    messages: Iterable[GaussianQueryMessage],
+    *,
+    weights: object,
+    construction_id: str = "query-ci-v1",
+) -> GaussianQueryMessage:
+    """Fuse prior-anchored messages without assuming cross-message independence.
+
+    If component weights sum to less than one, the remaining weight belongs to
+    the unchanged anchor prior.  Equivalently, the result is covariance
+    intersection over the component posteriors and the anchor prior.
+    """
+
+    retained = tuple(messages)
+    if not retained:
+        raise ValueError("messages must contain at least one message")
+    if any(not isinstance(item, GaussianQueryMessage) for item in retained):
+        raise TypeError("messages must contain only GaussianQueryMessage values")
+    _matching_anchor(retained)
+    raw_weights = np.asarray(weights, dtype=np.float64)
+    if raw_weights.shape != (len(retained),):
+        raise ValueError("weights must have one entry per message")
+    if not np.all(np.isfinite(raw_weights)):
+        raise ValueError("weights must be finite")
+    if np.any(raw_weights < 0.0):
+        raise ValueError("weights must be nonnegative")
+    total_weight = float(np.sum(raw_weights, dtype=np.float64))
+    if total_weight <= 0.0:
+        raise ValueError("at least one message weight must be positive")
+    if total_weight > 1.0:
+        raise ValueError("message weights must sum to at most one")
+
+    aggregate: dict[str, tuple[GaussianQueryMessage, float]] = {}
+    for message, weight in zip(retained, raw_weights, strict=True):
+        if weight == 0.0:
+            continue
+        if message.message_id in aggregate:
+            previous_message, previous_weight = aggregate[message.message_id]
+            aggregate[message.message_id] = (
+                previous_message,
+                previous_weight + float(weight),
+            )
+        else:
+            aggregate[message.message_id] = (message, float(weight))
+    ordered = tuple(aggregate[key] for key in sorted(aggregate))
+    first = retained[0]
+    information = np.zeros_like(first.information_increment)
+    natural = np.zeros_like(first.natural_parameter_increment)
+    evidence: set[str] = set()
+    component_ids: list[str] = []
+    component_weights: list[float] = []
+    for message, weight in ordered:
+        information += weight * message.information_increment
+        natural += weight * message.natural_parameter_increment
+        evidence.update(message.evidence_ids)
+        component_ids.append(message.message_id)
+        component_weights.append(weight)
+
+    prior_weight = 1.0 - total_weight
+    return GaussianQueryMessage(
+        query_id=first.query_id,
+        prior_id=first.prior_id,
+        evidence_ids=tuple(sorted(evidence)),
+        anchor_prior_mean=first.anchor_prior_mean,
+        anchor_prior_covariance=first.anchor_prior_covariance,
+        information_increment=information,
+        natural_parameter_increment=natural,
+        construction_id=construction_id,
+        component_message_ids=tuple(component_ids),
+        component_weights=tuple(component_weights),
+        prior_weight=prior_weight,
+    )
+
+
+def select_pairwise_covariance_intersection(
+    first: GaussianQueryMessage,
+    second: GaussianQueryMessage,
+    *,
+    grid_size: int = 1001,
+    objective: Literal["logdet", "trace"] = "logdet",
+) -> GaussianQueryMessage:
+    """Select a deterministic pairwise covariance-intersection weight."""
+
+    if not isinstance(first, GaussianQueryMessage) or not isinstance(
+        second,
+        GaussianQueryMessage,
+    ):
+        raise TypeError("first and second must be GaussianQueryMessage values")
+    if isinstance(grid_size, (bool, np.bool_)) or not isinstance(
+        grid_size,
+        (int, np.integer),
+    ):
+        raise TypeError("grid_size must be an integer")
+    if grid_size < 2:
+        raise ValueError("grid_size must be at least two")
+    if objective not in ("logdet", "trace"):
+        raise ValueError("objective must be 'logdet' or 'trace'")
+    ordered = tuple(sorted((first, second), key=lambda item: item.message_id))
+    _matching_anchor(ordered)
+    prior_precision = _precision(ordered[0].anchor_prior_covariance)
+    best_index = 0
+    best_value = math.inf
+    for index, weight in enumerate(np.linspace(0.0, 1.0, int(grid_size))):
+        information = (
+            weight * ordered[0].information_increment
+            + (1.0 - weight) * ordered[1].information_increment
+        )
+        covariance = _precision(
+            _positive_definite(
+                prior_precision + information,
+                name="candidate posterior precision",
+            )
+        )
+        if objective == "logdet":
+            sign, value = np.linalg.slogdet(covariance)
+            if sign <= 0.0:
+                raise RuntimeError("candidate posterior covariance is not positive definite")
+            score = float(value)
+        else:
+            score = float(np.trace(covariance))
+        if score < best_value:
+            best_index = index
+            best_value = score
+    selected = best_index / (int(grid_size) - 1)
+    return fuse_gaussian_query_messages_covariance_intersection(
+        ordered,
+        weights=np.asarray([selected, 1.0 - selected], dtype=np.float64),
+        construction_id=f"pairwise-{objective}-grid-{int(grid_size)}-v1",
+    )

--- a/tests/test_dot_r11_r20_query_message_ci_source_protocol.py
+++ b/tests/test_dot_r11_r20_query_message_ci_source_protocol.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PROTOCOL = ROOT / "protocols/dot-r11-r20-query-message-ci-source-v1.json"
+
+
+def _canonical_id(value: dict[str, object]) -> str:
+    payload = dict(value)
+    protocol_id = payload.pop("protocol_id")
+    assert isinstance(protocol_id, str)
+    canonical = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def test_dot_query_message_source_protocol_is_rank_agnostic_and_target_closed() -> None:
+    value = json.loads(PROTOCOL.read_text(encoding="utf-8"))
+
+    assert value["schema"] == "prob4d.dot-r11-r20-query-message-ci-source-protocol"
+    assert value["schema_version"] == 1
+    assert value["stage"] == "development-only-source"
+    assert value["protocol_id"] == _canonical_id(value)
+
+    dataset = value["dataset"]
+    assert dataset["source_sequences"] == [f"R{index:02d}" for index in range(11, 21)]
+    assert dataset["confirmation_sequences"] == [
+        f"R{index:02d}" for index in range(21, 31)
+    ]
+    assert dataset["reserved_sequences"] == "R31-R70"
+    assert dataset["source_archive"] == {
+        "name": "R11-20.zip",
+        "md5": "23ce3e7067465d3edabe20b4c7cfa388",
+    }
+
+    provider = value["sealed_provider"]
+    assert provider["workflow_run_id"] == 33552798863
+    assert provider["execution_revision"] == "c64765ea766e667a566e1b565e8ed01ffd734e53"
+    assert provider["artifact_id"] == 9818146750
+    assert (
+        provider["artifact_digest"]
+        == "sha256:70c2cec1cf33b65ae6653a3839fb4f74d57023d1d49cced6c61e6948f4d7b8a6"
+    )
+    assert (
+        provider["provider_seal_id"]
+        == "38ea78e8bf44cbeaedeeadaee862af3cc6369d35d7e3b5a2b5fac0f020c7145b"
+    )
+    assert provider["source_marker_payloads_opened_when_predictions_were_sealed"] is False
+    assert provider["confirmation_payloads_opened"] is False
+    routed = {
+        sequence: component["camera"]
+        for component in provider["components"]
+        for sequence in component["sequences"]
+    }
+    assert routed == {
+        "R11": "cam005",
+        "R12": "cam005",
+        "R13": "cam001",
+        "R14": "cam001",
+        "R15": "cam001",
+        "R16": "cam001",
+        "R17": "cam002",
+        "R18": "cam001",
+        "R19": "cam001",
+        "R20": "cam005",
+    }
+
+    diagnostic = value["terminal_rank_diagnostic"]
+    assert diagnostic["decision"] == "camera-routing-provider-rank-negative"
+    assert diagnostic["factor_rank_counts"] == {"6": 1, "7": 9}
+    assert diagnostic["supported_sequences"] == ["R18"]
+    assert value["promotion"]["rank_six_required"] is False
+    assert value["promotion"]["automatic_confirmation_authorization"] is False
+
+    contract = value["message_contract"]
+    assert contract["implementation"] == "prob4d.query_message"
+    assert contract["same_query_required"] is True
+    assert contract["byte_identical_anchor_required"] is True
+    assert contract["negative_information_rejected"] is True
+    assert contract["observation_likelihood_preserved"] is False
+    assert contract["posterior_parity_relative_tolerance"] <= 1e-9
+    assert contract["duplicate_message_mean_relative_tolerance"] <= 1e-12
+    assert contract["duplicate_message_covariance_relative_tolerance"] <= 1e-12
+
+    primary = value["source_methods"]["primary"]
+    assert primary["id"] == "two_window_query_ci_equal"
+    assert primary["messages"] == ["window_a", "window_b"]
+    assert primary["weights"] == [0.5, 0.5]
+    assert sum(primary["weights"]) + primary["prior_weight"] == 1.0
+    assert primary["weight_selection_uses_source_outcomes"] is False
+    assert "naive_independent_message_sum" in value["source_methods"]["comparators"]
+    assert "continuous_provider_query" in value["source_methods"]["comparators"]
+
+    boundary = value["information_boundary"]
+    assert boundary == {
+        "source_sequences_previously_opened": True,
+        "source_provider_may_be_reused_without_rerun": True,
+        "confirmation_access_authorized": False,
+        "r21_r30_payloads_opened": False,
+        "r31_r70_payloads_opened": False,
+        "execution_request_present": False,
+        "target_side_retuning_allowed": False,
+        "bayesian_phystwin_executed": False,
+        "causal4d_executed": False,
+    }

--- a/tests/test_query_message.py
+++ b/tests/test_query_message.py
@@ -1,0 +1,348 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from prob4d.query_message import (
+    GaussianQueryMessage,
+    apply_gaussian_query_message,
+    compress_gaussian_query_posterior,
+    fuse_gaussian_query_messages_covariance_intersection,
+    select_pairwise_covariance_intersection,
+)
+from prob4d.query_posterior import GaussianQueryPosterior
+
+
+def _posterior(
+    *,
+    prior_mean: np.ndarray,
+    prior_covariance: np.ndarray,
+    information_increment: np.ndarray,
+    natural_increment: np.ndarray,
+) -> GaussianQueryPosterior:
+    prior_precision = np.linalg.inv(prior_covariance)
+    posterior_precision = prior_precision + information_increment
+    posterior_covariance = np.linalg.inv(posterior_precision)
+    posterior_mean = posterior_covariance @ (
+        prior_precision @ prior_mean + natural_increment
+    )
+    reduction = 0.5 * (
+        prior_covariance - posterior_covariance
+        + (prior_covariance - posterior_covariance).T
+    )
+    return GaussianQueryPosterior(
+        prior_mean=prior_mean,
+        prior_covariance=prior_covariance,
+        mean_shift=posterior_mean - prior_mean,
+        covariance_reduction=reduction,
+        posterior_mean=posterior_mean,
+        posterior_covariance=posterior_covariance,
+        innovation_precision_quadratic=0.0,
+        innovation_log_determinant=0.0,
+        innovation_negative_log_likelihood=0.0,
+        observation_dimension=12,
+    )
+
+
+def _messages() -> tuple[GaussianQueryMessage, GaussianQueryMessage]:
+    prior_mean = np.asarray([0.3, -0.2, 0.5], dtype=np.float64)
+    prior_covariance = np.asarray(
+        [
+            [2.0, 0.3, -0.1],
+            [0.3, 1.5, 0.2],
+            [-0.1, 0.2, 1.2],
+        ],
+        dtype=np.float64,
+    )
+    first_root = np.asarray(
+        [[0.8, 0.1, -0.2], [0.0, 0.5, 0.1], [0.2, -0.1, 0.6]],
+        dtype=np.float64,
+    )
+    second_root = np.asarray(
+        [[0.3, -0.2, 0.1], [0.4, 0.7, -0.1], [-0.2, 0.1, 0.9]],
+        dtype=np.float64,
+    )
+    first = _posterior(
+        prior_mean=prior_mean,
+        prior_covariance=prior_covariance,
+        information_increment=first_root @ first_root.T,
+        natural_increment=np.asarray([0.2, -0.4, 0.1]),
+    )
+    second = _posterior(
+        prior_mean=prior_mean,
+        prior_covariance=prior_covariance,
+        information_increment=second_root @ second_root.T,
+        natural_increment=np.asarray([-0.3, 0.2, 0.5]),
+    )
+    return (
+        compress_gaussian_query_posterior(
+            first,
+            query_id="rope-endpoint",
+            prior_id="prior-17",
+            evidence_ids=("window-1",),
+        ),
+        compress_gaussian_query_posterior(
+            second,
+            query_id="rope-endpoint",
+            prior_id="prior-17",
+            evidence_ids=("window-2",),
+        ),
+    )
+
+
+def test_message_reproduces_query_posterior_and_is_immutable() -> None:
+    message, _ = _messages()
+    belief = apply_gaussian_query_message(message)
+    prior_precision = np.linalg.inv(message.anchor_prior_covariance)
+    expected_covariance = np.linalg.inv(
+        prior_precision + message.information_increment
+    )
+    expected_mean = expected_covariance @ (
+        prior_precision @ message.anchor_prior_mean
+        + message.natural_parameter_increment
+    )
+
+    np.testing.assert_allclose(belief.mean, expected_mean, atol=1e-12, rtol=1e-12)
+    np.testing.assert_allclose(
+        belief.covariance,
+        expected_covariance,
+        atol=1e-12,
+        rtol=1e-12,
+    )
+    assert message.query_dimension == 3
+    assert message.payload_nbytes == 12 * np.dtype(np.float64).itemsize
+    assert len(message.message_id) == 64
+    assert message.evidence_ids == ("window-1",)
+    assert not message.information_increment.flags.writeable
+    assert not belief.covariance.flags.writeable
+    with pytest.raises(ValueError):
+        message.information_increment[0, 0] = 0.0
+
+
+def test_explicit_anchor_must_be_complete_and_byte_identical() -> None:
+    message, _ = _messages()
+    explicit = apply_gaussian_query_message(
+        message,
+        prior_id=message.prior_id,
+        prior_mean=message.anchor_prior_mean.copy(),
+        prior_covariance=message.anchor_prior_covariance.copy(),
+    )
+    implicit = apply_gaussian_query_message(message)
+    np.testing.assert_array_equal(explicit.mean, implicit.mean)
+    with pytest.raises(ValueError, match="supplied together"):
+        apply_gaussian_query_message(message, prior_id=message.prior_id)
+    changed = message.anchor_prior_mean.copy()
+    changed[0] = np.nextafter(changed[0], np.inf)
+    with pytest.raises(ValueError, match="byte-identical"):
+        apply_gaussian_query_message(
+            message,
+            prior_id=message.prior_id,
+            prior_mean=changed,
+            prior_covariance=message.anchor_prior_covariance,
+        )
+
+
+def test_covariance_intersection_matches_weighted_component_posteriors() -> None:
+    first, second = _messages()
+    fused = fuse_gaussian_query_messages_covariance_intersection(
+        (first, second),
+        weights=np.asarray([0.25, 0.75]),
+    )
+    belief = apply_gaussian_query_message(fused)
+    first_belief = apply_gaussian_query_message(first)
+    second_belief = apply_gaussian_query_message(second)
+    expected_precision = (
+        0.25 * np.linalg.inv(first_belief.covariance)
+        + 0.75 * np.linalg.inv(second_belief.covariance)
+    )
+    expected_natural = (
+        0.25 * np.linalg.solve(first_belief.covariance, first_belief.mean)
+        + 0.75 * np.linalg.solve(second_belief.covariance, second_belief.mean)
+    )
+    expected_covariance = np.linalg.inv(expected_precision)
+    expected_mean = expected_covariance @ expected_natural
+
+    np.testing.assert_allclose(belief.covariance, expected_covariance)
+    np.testing.assert_allclose(belief.mean, expected_mean)
+    assert fused.prior_weight == 0.0
+    assert fused.evidence_ids == ("window-1", "window-2")
+    assert sum(fused.component_weights) == pytest.approx(1.0)
+
+
+def test_unused_weight_is_assigned_to_anchor_prior_once() -> None:
+    first, second = _messages()
+    fused = fuse_gaussian_query_messages_covariance_intersection(
+        (first, second),
+        weights=[0.2, 0.3],
+    )
+    belief = apply_gaussian_query_message(fused)
+    prior_precision = np.linalg.inv(first.anchor_prior_covariance)
+    first_belief = apply_gaussian_query_message(first)
+    second_belief = apply_gaussian_query_message(second)
+    expected_precision = (
+        0.5 * prior_precision
+        + 0.2 * np.linalg.inv(first_belief.covariance)
+        + 0.3 * np.linalg.inv(second_belief.covariance)
+    )
+    expected_natural = (
+        0.5 * prior_precision @ first.anchor_prior_mean
+        + 0.2 * np.linalg.solve(first_belief.covariance, first_belief.mean)
+        + 0.3 * np.linalg.solve(second_belief.covariance, second_belief.mean)
+    )
+
+    np.testing.assert_allclose(belief.covariance, np.linalg.inv(expected_precision))
+    np.testing.assert_allclose(
+        belief.mean,
+        np.linalg.solve(expected_precision, expected_natural),
+    )
+    assert fused.prior_weight == pytest.approx(0.5)
+
+
+def test_duplicate_message_cannot_create_additional_confidence() -> None:
+    message, _ = _messages()
+    duplicate = fuse_gaussian_query_messages_covariance_intersection(
+        (message, message),
+        weights=[0.5, 0.5],
+    )
+    reference = apply_gaussian_query_message(message)
+    actual = apply_gaussian_query_message(duplicate)
+    np.testing.assert_allclose(actual.mean, reference.mean, atol=1e-12, rtol=1e-12)
+    np.testing.assert_allclose(
+        actual.covariance,
+        reference.covariance,
+        atol=1e-12,
+        rtol=1e-12,
+    )
+    assert duplicate.component_message_ids == (message.message_id,)
+    assert duplicate.component_weights == pytest.approx((1.0,))
+
+    prior_precision = np.linalg.inv(message.anchor_prior_covariance)
+    naive_covariance = np.linalg.inv(
+        prior_precision + 2.0 * message.information_increment
+    )
+    assert np.linalg.det(naive_covariance) < np.linalg.det(reference.covariance)
+
+
+def test_fusion_is_canonical_under_input_reordering() -> None:
+    first, second = _messages()
+    forward = fuse_gaussian_query_messages_covariance_intersection(
+        (first, second),
+        weights=[0.4, 0.6],
+    )
+    reverse = fuse_gaussian_query_messages_covariance_intersection(
+        (second, first),
+        weights=[0.6, 0.4],
+    )
+    assert forward.message_id == reverse.message_id
+    np.testing.assert_array_equal(
+        forward.information_increment,
+        reverse.information_increment,
+    )
+    assert forward.component_message_ids == reverse.component_message_ids
+    assert forward.component_weights == reverse.component_weights
+
+
+def test_pairwise_selector_chooses_the_more_informative_dominating_message() -> None:
+    prior_mean = np.zeros(2, dtype=np.float64)
+    prior_covariance = np.eye(2, dtype=np.float64)
+    weak = _posterior(
+        prior_mean=prior_mean,
+        prior_covariance=prior_covariance,
+        information_increment=0.2 * np.eye(2),
+        natural_increment=np.asarray([0.1, -0.1]),
+    )
+    strong = _posterior(
+        prior_mean=prior_mean,
+        prior_covariance=prior_covariance,
+        information_increment=2.0 * np.eye(2),
+        natural_increment=np.asarray([0.2, -0.2]),
+    )
+    weak_message = compress_gaussian_query_posterior(
+        weak,
+        query_id="centroid",
+        prior_id="prior",
+        evidence_ids=("weak",),
+    )
+    strong_message = compress_gaussian_query_posterior(
+        strong,
+        query_id="centroid",
+        prior_id="prior",
+        evidence_ids=("strong",),
+    )
+    selected = select_pairwise_covariance_intersection(
+        weak_message,
+        strong_message,
+        grid_size=101,
+        objective="logdet",
+    )
+    selected_belief = apply_gaussian_query_message(selected)
+    strong_belief = apply_gaussian_query_message(strong_message)
+    np.testing.assert_allclose(selected_belief.covariance, strong_belief.covariance)
+    assert max(selected.component_weights) == pytest.approx(1.0)
+
+
+def test_fusion_fails_closed_for_incompatible_anchors_and_weights() -> None:
+    first, second = _messages()
+    incompatible = GaussianQueryMessage(
+        query_id="different-query",
+        prior_id=second.prior_id,
+        evidence_ids=second.evidence_ids,
+        anchor_prior_mean=second.anchor_prior_mean,
+        anchor_prior_covariance=second.anchor_prior_covariance,
+        information_increment=second.information_increment,
+        natural_parameter_increment=second.natural_parameter_increment,
+    )
+    with pytest.raises(ValueError, match="same query_id"):
+        fuse_gaussian_query_messages_covariance_intersection(
+            (first, incompatible),
+            weights=[0.5, 0.5],
+        )
+    with pytest.raises(ValueError, match="at most one"):
+        fuse_gaussian_query_messages_covariance_intersection(
+            (first, second),
+            weights=[0.7, 0.7],
+        )
+    with pytest.raises(ValueError, match="nonnegative"):
+        fuse_gaussian_query_messages_covariance_intersection(
+            (first, second),
+            weights=[-0.1, 0.5],
+        )
+    with pytest.raises(ValueError, match="one entry"):
+        fuse_gaussian_query_messages_covariance_intersection(
+            (first, second),
+            weights=[1.0],
+        )
+
+
+def test_singular_or_information_increasing_query_covariance_is_rejected() -> None:
+    prior_mean = np.zeros(2)
+    singular = GaussianQueryPosterior(
+        prior_mean=prior_mean,
+        prior_covariance=np.diag([1.0, 0.0]),
+        mean_shift=np.zeros(2),
+        covariance_reduction=np.zeros((2, 2)),
+        posterior_mean=prior_mean,
+        posterior_covariance=np.diag([1.0, 0.0]),
+        innovation_precision_quadratic=0.0,
+        innovation_log_determinant=0.0,
+        innovation_negative_log_likelihood=0.0,
+        observation_dimension=1,
+    )
+    with pytest.raises(ValueError, match="positive definite"):
+        compress_gaussian_query_posterior(
+            singular,
+            query_id="q",
+            prior_id="p",
+            evidence_ids=("e",),
+        )
+
+    with pytest.raises(ValueError, match="positive semidefinite"):
+        GaussianQueryMessage(
+            query_id="q",
+            prior_id="p",
+            evidence_ids=("e",),
+            anchor_prior_mean=prior_mean,
+            anchor_prior_covariance=np.eye(2),
+            information_increment=-0.5 * np.eye(2),
+            natural_parameter_increment=np.zeros(2),
+        )


### PR DESCRIPTION
## Direction

Begin the rank-agnostic Prob4D pivot after the terminal DOT camera-routing result showed the fixed rank-6 ambiguity in only `1/10` source sequences.

Prob4D already supports exact structured Gaussian query conditioning and query-preserving shared-factor compression. The missing operation was safe composition of several overlapping-window query posteriors when their cross-window dependence is not justified well enough for ordinary information addition.

## Exact query message

For one registered query with anchor prior `N(m0, P0)` and correlation-aware posterior `N(m1, P1)`, retain

```text
Lambda = inv(P1) - inv(P0)
eta    = inv(P1) m1 - inv(P0) m0
```

Applying the anchor once reproduces the complete query posterior. The message stores only query-dimensional parameters and is bound to the exact query and byte-identical anchor prior.

The implementation:

- stores immutable arrays and a deterministic content ID;
- requires positive-definite independent query coordinates;
- independently reconstructs the posterior before returning a compressed message; and
- rejects negative information or incompatible anchors rather than repairing them silently.

## Unknown-dependence fusion

For component messages with unknown cross-correlation, nonnegative weights `w_i` with `sum(w_i) <= 1` yield

```text
J_CI = J0 + sum_i w_i Lambda_i
h_CI = h0 + sum_i w_i eta_i
```

The unused weight belongs to the anchor prior. This is covariance intersection over the component posteriors plus the prior, so the shared prior is counted exactly once. Repeating one byte-identical message at weights `0.5/0.5` reproduces the single-message belief instead of inventing confidence.

A deterministic pairwise log-determinant/trace grid selector is included. Scientific weight selection remains protocol-owned.

## Validation added

Nine focused implementation tests cover:

- exact posterior reconstruction;
- array immutability and strict anchor identity;
- equivalence to weighted covariance intersection of component posteriors;
- optional retained prior weight;
- duplicate-message idempotence versus naive overconfident information addition;
- canonical results under input reordering;
- deterministic pairwise weight selection; and
- fail-closed query, prior, weight, singularity, and negative-information cases.

The repository additionally binds the source protocol invariants described below.

## Registered DOT source path

`protocols/dot-r11-r20-query-message-ci-source-v1.json` is a content-addressed **development-only** protocol over the already-open source cohort. It binds the exact routed CUT3R provider from run `33552798863`:

- provider artifact `9818146750`, digest `sha256:70c2cec1cf33b65ae6653a3839fb4f74d57023d1d49cced6c61e6948f4d7b8a6`;
- rank-result artifact `9818149548`, digest `sha256:d6f81bbb2fbe8af7cf574fe4bdad313fe0ac05d2882a3673c832b2ce2e79add0`;
- observed source ranks: rank 6 on `1/10` sequences and rank 7 on `9/10`;
- primary method: equal-weight query-space CI over the two overlapping windows;
- complete sequence as the independent unit; and
- parity, duplicate-idempotence, RMSE, joint NLL, coverage/width, harmful-update, byte, latency, and rank-stratified endpoints.

This PR contains **no execution request**. R21-R30 confirmation and R31-R70 reserve remain unopened and unauthorized. Source completion cannot automatically authorize confirmation; a separate one-shot protocol must be frozen first.

## Controlled companion result

Stacked PR #469 owns the first registered scientific study of this API. Its authoritative hosted run evaluates 393,216 complete linear-Gaussian cases across cross-window correlations from `0` to `0.99`. It demonstrates that naive independent addition becomes strongly undercovered as dependence grows, while query-space CI remains conservative and improves RMSE over either single window. That controlled result does not establish real-provider utility.

## Paper relationship

This complements rather than replaces the existing posterior-preserving shared-factor compression result:

- shared-factor compression reduces one structured factor while retaining the existing observation consumer;
- query-message compression removes the observation representation after conditioning; and
- query-message CI permits compact messages from overlapping windows to be combined without an independence assumption.

## Claim boundary

This PR establishes Gaussian representation and fusion algebra. It does not establish provider calibration, covariance-intersection consistency under biased component beliefs, observation-likelihood preservation, nonlinear-query validity, held-out DOT utility, learned-provider competence, BayesianPhysTwin or Causal4D benefit, robot safety, or state of the art. It launches no empirical workflow and opens no dataset payload.