### PR TITLE
Certify finite-orbit query gating under uncertain geometry

### DIFF
--- a/.github/workflows/bounded-axial-orbit.yml
+++ b/.github/workflows/bounded-axial-orbit.yml
@@ -1,0 +1,80 @@
+name: Bounded axial-orbit certificates
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/bounded-axial-orbit.yml"
+      - "src/prob4d/bounded_axial_orbit.py"
+      - "protocols/tracking-cloth-bounded-orbit-robustness-v1.json"
+      - "scripts/science/run_tracking_cloth_bounded_orbit_robustness_v1.py"
+      - "tests/test_bounded_axial_orbit.py"
+      - "tests/test_tracking_cloth_bounded_orbit_robustness_v1.py"
+      - "src/prob4d/motive_csv.py"
+      - "tests/test_motive_csv.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bounded-axial-orbit-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract:
+    name: Analytic bound, protocol, and parser contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install development environment
+        run: |
+          python -m pip install --disable-pip-version-check -e ".[dev]"
+          python -m pip install --disable-pip-version-check "numpy==2.3.5"
+          python -m pip check
+      - name: Lint and format check
+        run: |
+          python -m ruff check \
+            src/prob4d/bounded_axial_orbit.py \
+            scripts/science/run_tracking_cloth_bounded_orbit_robustness_v1.py \
+            tests/test_bounded_axial_orbit.py \
+            tests/test_tracking_cloth_bounded_orbit_robustness_v1.py
+          python -m ruff format --check \
+            src/prob4d/bounded_axial_orbit.py \
+            scripts/science/run_tracking_cloth_bounded_orbit_robustness_v1.py \
+            tests/test_bounded_axial_orbit.py \
+            tests/test_tracking_cloth_bounded_orbit_robustness_v1.py
+      - name: Type check analytic kernel
+        run: python -m mypy src/prob4d/bounded_axial_orbit.py
+      - name: Verify analytic, protocol, and parser tests
+        run: |
+          python -m pytest -q \
+            tests/test_bounded_axial_orbit.py \
+            tests/test_tracking_cloth_bounded_orbit_robustness_v1.py \
+            tests/test_motive_csv.py
+      - name: Verify frozen protocol identity
+        run: |
+          python - <<'PY'
+          import hashlib
+          import json
+          from pathlib import Path
+
+          path = Path("protocols/tracking-cloth-bounded-orbit-robustness-v1.json")
+          value = json.loads(path.read_text(encoding="utf-8"))
+          supplied = value.pop("protocol_id")
+          encoded = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+          assert supplied == (
+              "6b372b78329a809aee508a68ffd51abeb945fc941c0db29ca996459ddf52f711"
+          )
+          assert hashlib.sha256(encoded).hexdigest() == supplied
+          PY

--- a/docs/tracking-cloth-bounded-orbit-robustness-v1.md
+++ b/docs/tracking-cloth-bounded-orbit-robustness-v1.md
@@ -1,0 +1,62 @@
+# Bounded finite-orbit certificates under uncertain geometry
+
+Status: **secondary robustness evidence** on the 15 public real-trajectory recordings already used by the primary Tracking Cloth experiment. This is not a second independent confirmation and does not use a learned visual provider.
+
+## Why this experiment matters
+
+The primary result used exact motion-capture anchors to instantiate the controlled hidden SO(2) orbit. A practical system estimates those anchors. Simply inserting their point estimates into the orbit can be optimistic: an incorrectly oriented or displaced line can make the computed orbit too small and admit a query that is not identifiable for the unknown true geometry.
+
+This experiment replaces that plug-in assumption with a deterministic outer certificate.
+
+## Guarantee
+
+For observed anchors \(\hat a,\hat b\) and probe \(\hat p\), suppose each true point lies inside a Euclidean ball of radius \(\epsilon\). Let \(\hat d=\|\hat b-\hat a\|\), \(\hat t\) be the observed axial coordinate, and \(\hat r\) the observed probe-to-line radius. When \(\hat d>2\epsilon\), normalized-vector perturbation and the triangle inequality give
+
+\[
+r \leq \hat r + 2\epsilon + |\hat t|\min\left(2,\frac{4\epsilon}{\hat d-2\epsilon}\right).
+\]
+
+If \(\hat d\leq2\epsilon\), the axis direction is not certified and the implementation fails closed with an infinite orbit-width bound. Consequently, any query accepted using this outer orbit is also accepted on the unknown true orbit, conditional on the declared point-error balls being valid.
+
+`src/prob4d/bounded_axial_orbit.py` implements this bound without fitting to target outcomes. The tests include 2,048 randomized adversarial point perturbations, exact zero-error recovery, similarity equivariance, a plug-in underestimation counterexample, and the uninformative-anchor failure case.
+
+## Public real-trajectory stress test
+
+The error radius was swept from 0% to 10% of the true anchor separation. Sixteen deterministic boundary perturbations were evaluated for each of 1,803 cases from 15 recordings, giving 28,848 perturbation cases per error level. Decision thresholds were the 25th, 50th, and 75th percentiles of full radial-orbit width computed from 273 valid source cases in 24 shake/twist recordings. The recording file remained the bootstrap unit.
+
+| Point error / anchor span | Plug-in containment | Certified containment | Certified width / truth | q50 plug-in false accept | q50 certified false accept | q50 certified false reject |
+|---:|---:|---:|---:|---:|---:|---:|
+| 0.0% | 1.0000 | 1.0000 | 1.000 | 0.0000 | 0.0000 | 0.0000 |
+| 0.5% | 0.5055 | 1.0000 | 1.064 | 0.0490 | 0.0000 | 0.1030 |
+| 1.0% | 0.5057 | 1.0000 | 1.128 | 0.0890 | 0.0000 | 0.2851 |
+| 2.0% | 0.5080 | 1.0000 | 1.261 | 0.1286 | 0.0000 | 0.4050 |
+| 5.0% | 0.5259 | 1.0000 | 1.680 | 0.1507 | 0.0000 | 0.4493 |
+| 10.0% | 0.5481 | 1.0000 | 2.470 | 0.1585 | 0.0000 | 0.4992 |
+
+At every nonzero error level, the plug-in orbit contains the true orbit only about half the time. At 2% point error, it falsely accepts 12.86% of cases relative to the source-median width threshold. The certified outer orbit retains 100% containment and zero false acceptance across the complete sweep.
+
+The guarantee is not free: at 2% error, the outer interval is 1.261 times as wide as the true interval on average and rejects 40.50% of cases that the oracle orbit would accept at the source-median threshold. At 10% error, mean width inflation reaches 2.470 and false rejection reaches 49.92%. This is the intended fail-closed tradeoff: transparent conservatism instead of hidden false acceptance.
+
+The 95% recording-bootstrap interval for plug-in containment at 2% error is [0.5006, 0.5166]; for width inflation it is [1.2102, 1.3204]; and for q50 plug-in false acceptance it is [0.0612, 0.1990]. Certified containment and false acceptance remain exactly 1 and 0, respectively, because they follow from the valid error-ball construction rather than an empirical calibration claim.
+
+## Unsupported second cohort
+
+A separate header-only audit examined the 27 untouched Self-collision recordings without parsing trajectory values. No source/target marker-identity namespace shared three cloth markers. Those recordings were therefore not forced into an invalid correspondence-based replication and remain outcome-unopened.
+
+This negative support finding prevents an apparently broader but scientifically invalid experiment. It does not count as evidence against finite-orbit gating.
+
+## Interpretation and limits
+
+The combined result addresses a central reviewer concern about the primary real-trajectory experiment: the orbit need not be known exactly. When its generator is uncertain but enclosed by declared point-error balls, an outer-orbit certificate preserves sound acceptance and fails closed when the axis is not identifiable.
+
+The study remains controlled. Motion-capture trajectories provide the real geometry, while bounded perturbations model an imperfect upstream estimate. The method does not infer \(\epsilon\) from images, establish learned-provider competence, identify the full physical cloth state, or demonstrate BayesianPhysTwin task benefit. A learned provider must supply a defensible point-error bound before this certificate can be used operationally.
+
+## Provenance
+
+- Protocol: `6b372b78329a809aee508a68ffd51abeb945fc941c0db29ca996459ddf52f711`
+- Result: `5afbb2ae23ab34f8cb1944ed39d9517c8d7233096de8ae2e07b822d0e7299552`
+- Source seal: `2f85bfa0b31eb62af5eaff36c3cc9c0e1bb4c91f79d43e14dbda8e28a9959afc`
+- Workflow run: `33564072262`
+- Artifact: `9822421238`
+- Artifact digest: `sha256:7d6ed4e938361f4cde0f4e3cbfcb12bba4036863934222e04730089925917868`
+- Self-collision header audit: `8e062f5ac4a8521b51cf616986331614f1bc91b5ca1d4971ed7647a5c4bc2ed9`

--- a/evidence/tracking-cloth-bounded-orbit-robustness-v1/summary.json
+++ b/evidence/tracking-cloth-bounded-orbit-robustness-v1/summary.json
@@ -1,0 +1,294 @@
+{
+  "artifact_digest": "sha256:7d6ed4e938361f4cde0f4e3cbfcb12bba4036863934222e04730089925917868",
+  "artifact_id": 9822421238,
+  "claim_boundary": {
+    "bayesian_phystwin_benefit": false,
+    "controlled_bounded_measurement_error": true,
+    "deployment_safety": false,
+    "learned_visual_provider": false,
+    "physical_state_identification": false,
+    "public_real_geometry": true,
+    "secondary_robustness_not_independent_confirmation": true,
+    "state_of_the_art": false
+  },
+  "error_sweep": [
+    {
+      "certified_outer_orbit_containment": {
+        "ci95_high": 1.0,
+        "ci95_low": 1.0,
+        "groups": 15,
+        "mean": 1.0
+      },
+      "certified_width_over_true_width": {
+        "ci95_high": 1.0,
+        "ci95_low": 1.0,
+        "groups": 15,
+        "mean": 1.0
+      },
+      "plugin_orbit_containment": {
+        "ci95_high": 1.0,
+        "ci95_low": 1.0,
+        "groups": 15,
+        "mean": 1.0
+      },
+      "point_error_fraction_of_anchor_span": 0.0,
+      "q50_certified_false_accept": {
+        "ci95_high": 0.0,
+        "ci95_low": 0.0,
+        "groups": 15,
+        "mean": 0.0
+      },
+      "q50_certified_false_reject": {
+        "ci95_high": 0.0,
+        "ci95_low": 0.0,
+        "groups": 15,
+        "mean": 0.0
+      },
+      "q50_plugin_false_accept": {
+        "ci95_high": 0.0,
+        "ci95_low": 0.0,
+        "groups": 15,
+        "mean": 0.0
+      }
+    },
+    {
+      "certified_outer_orbit_containment": {
+        "ci95_high": 1.0,
+        "ci95_low": 1.0,
+        "groups": 15,
+        "mean": 1.0
+      },
+      "certified_width_over_true_width": {
+        "ci95_high": 1.0782248032589314,
+        "ci95_low": 1.051765936720996,
+        "groups": 15,
+        "mean": 1.0640096725504955
+      },
+      "plugin_orbit_containment": {
+        "ci95_high": 0.512066156007196,
+        "ci95_low": 0.4994375206771343,
+        "groups": 15,
+        "mean": 0.5054772386372648
+      },
+      "point_error_fraction_of_anchor_span": 0.005,
+      "q50_certified_false_accept": {
+        "ci95_high": 0.0,
+        "ci95_low": 0.0,
+        "groups": 15,
+        "mean": 0.0
+      },
+      "q50_certified_false_reject": {
+        "ci95_high": 0.17231696331800445,
+        "ci95_low": 0.0436487098142322,
+        "groups": 15,
+        "mean": 0.10297193191767541
+      },
+      "q50_plugin_false_accept": {
+        "ci95_high": 0.09095607885091928,
+        "ci95_low": 0.016072713722575883,
+        "groups": 15,
+        "mean": 0.04904333483750631
+      }
+    },
+    {
+      "certified_outer_orbit_containment": {
+        "ci95_high": 1.0,
+        "ci95_low": 1.0,
+        "groups": 15,
+        "mean": 1.0
+      },
+      "certified_width_over_true_width": {
+        "ci95_high": 1.1558348881306295,
+        "ci95_low": 1.1040000120122588,
+        "groups": 15,
+        "mean": 1.1283707322385195
+      },
+      "plugin_orbit_containment": {
+        "ci95_high": 0.5086387928816187,
+        "ci95_low": 0.5029453099129081,
+        "groups": 15,
+        "mean": 0.5056729657401454
+      },
+      "point_error_fraction_of_anchor_span": 0.01,
+      "q50_certified_false_accept": {
+        "ci95_high": 0.0,
+        "ci95_low": 0.0,
+        "groups": 15,
+        "mean": 0.0
+      },
+      "q50_certified_false_reject": {
+        "ci95_high": 0.4706403961583998,
+        "ci95_low": 0.1269872091188958,
+        "groups": 15,
+        "mean": 0.28508519699838936
+      },
+      "q50_plugin_false_accept": {
+        "ci95_high": 0.14290111767940553,
+        "ci95_low": 0.04064735733638134,
+        "groups": 15,
+        "mean": 0.08895393160176243
+      }
+    },
+    {
+      "certified_outer_orbit_containment": {
+        "ci95_high": 1.0,
+        "ci95_low": 1.0,
+        "groups": 15,
+        "mean": 1.0
+      },
+      "certified_width_over_true_width": {
+        "ci95_high": 1.3204471885887301,
+        "ci95_low": 1.2102298803360687,
+        "groups": 15,
+        "mean": 1.2607970003038638
+      },
+      "plugin_orbit_containment": {
+        "ci95_high": 0.5165815254241477,
+        "ci95_low": 0.5006146671606366,
+        "groups": 15,
+        "mean": 0.5079718771979004
+      },
+      "point_error_fraction_of_anchor_span": 0.02,
+      "q50_certified_false_accept": {
+        "ci95_high": 0.0,
+        "ci95_low": 0.0,
+        "groups": 15,
+        "mean": 0.0
+      },
+      "q50_certified_false_reject": {
+        "ci95_high": 0.5981839661490529,
+        "ci95_low": 0.21834720421119988,
+        "groups": 15,
+        "mean": 0.40501866397990066
+      },
+      "q50_plugin_false_accept": {
+        "ci95_high": 0.19899133139383282,
+        "ci95_low": 0.061193011848626085,
+        "groups": 15,
+        "mean": 0.12859037382309954
+      }
+    },
+    {
+      "certified_outer_orbit_containment": {
+        "ci95_high": 1.0,
+        "ci95_low": 1.0,
+        "groups": 15,
+        "mean": 1.0
+      },
+      "certified_width_over_true_width": {
+        "ci95_high": 1.8293643652696507,
+        "ci95_low": 1.5462395710010928,
+        "groups": 15,
+        "mean": 1.6797078728313184
+      },
+      "plugin_orbit_containment": {
+        "ci95_high": 0.536386357077067,
+        "ci95_low": 0.5167673446404228,
+        "groups": 15,
+        "mean": 0.5259081542737732
+      },
+      "point_error_fraction_of_anchor_span": 0.05,
+      "q50_certified_false_accept": {
+        "ci95_high": 0.0,
+        "ci95_low": 0.0,
+        "groups": 15,
+        "mean": 0.0
+      },
+      "q50_certified_false_reject": {
+        "ci95_high": 0.6491961450271109,
+        "ci95_low": 0.25627194637322365,
+        "groups": 15,
+        "mean": 0.4493264088803638
+      },
+      "q50_plugin_false_accept": {
+        "ci95_high": 0.2276909509163045,
+        "ci95_low": 0.07417796804940398,
+        "groups": 15,
+        "mean": 0.15074482928118652
+      }
+    },
+    {
+      "certified_outer_orbit_containment": {
+        "ci95_high": 1.0,
+        "ci95_low": 1.0,
+        "groups": 15,
+        "mean": 1.0
+      },
+      "certified_width_over_true_width": {
+        "ci95_high": 2.7931266543551625,
+        "ci95_low": 2.182448988010332,
+        "groups": 15,
+        "mean": 2.4696507849887586
+      },
+      "plugin_orbit_containment": {
+        "ci95_high": 0.5763063124195758,
+        "ci95_low": 0.524716237209001,
+        "groups": 15,
+        "mean": 0.5481351897742184
+      },
+      "point_error_fraction_of_anchor_span": 0.1,
+      "q50_certified_false_accept": {
+        "ci95_high": 0.0,
+        "ci95_low": 0.0,
+        "groups": 15,
+        "mean": 0.0
+      },
+      "q50_certified_false_reject": {
+        "ci95_high": 0.6734825858669227,
+        "ci95_low": 0.3373009409926345,
+        "groups": 15,
+        "mean": 0.4992075667153987
+      },
+      "q50_plugin_false_accept": {
+        "ci95_high": 0.24487942358226764,
+        "ci95_low": 0.07712316060335297,
+        "groups": 15,
+        "mean": 0.15850461745987396
+      }
+    }
+  ],
+  "mathematical_checks": {
+    "all_outer_bounds_contained_true_orbits": true,
+    "all_outer_gates_had_zero_false_acceptance": true,
+    "maximum_outer_false_acceptance": 0.0,
+    "maximum_outer_width_violation_mm": 0.0,
+    "maximum_zero_error_discrepancy": 0.0,
+    "zero_error_matched_oracle": true
+  },
+  "parent_result_id": "1441a141a8eccc1ae3a503c701c72e8d702a0bcb17226238f3d32effa3e58111",
+  "protocol_id": "6b372b78329a809aee508a68ffd51abeb945fc941c0db29ca996459ddf52f711",
+  "result_id": "5afbb2ae23ab34f8cb1944ed39d9517c8d7233096de8ae2e07b822d0e7299552",
+  "schema": "prob4d.tracking-cloth-bounded-orbit-robustness-summary.v1",
+  "self_collision_header_audit": {
+    "artifact_digest": "sha256:c3632e85d574f70c655bf5eeb117f7c2cc498425b33364196b7da2d3556a5229",
+    "artifact_id": 9821603739,
+    "audit_id": "8e062f5ac4a8521b51cf616986331614f1bc91b5ca1d4971ed7647a5c4bc2ed9",
+    "compatible_source_target_namespace_pairs": 0,
+    "disposition": "not forced into the outcome study",
+    "target_trajectory_values_parsed": false,
+    "workflow_run_id": 33561974194
+  },
+  "source": {
+    "case_count": 273,
+    "recording_count": 24,
+    "thresholds_mm": {
+      "q25": 654.2727862820069,
+      "q50": 686.8740375634897,
+      "q75": 688.9281344851154
+    },
+    "width_summary_mm": {
+      "maximum": 752.8258444677153,
+      "median": 686.8740375634897,
+      "minimum": 651.4370665106693
+    }
+  },
+  "source_revision": "ae1f99e3bdd885c95c39b4388056c67da9a73d3f",
+  "source_seal_id": "2f85bfa0b31eb62af5eaff36c3cc9c0e1bb4c91f79d43e14dbda8e28a9959afc",
+  "target": {
+    "perturbation_cases_per_error_level": 28848,
+    "perturbation_replicates_per_case": 16,
+    "real_trajectory_case_count": 1803,
+    "recording_count": 15
+  },
+  "workflow_run_id": 33564072262
+}

--- a/protocols/tracking-cloth-bounded-orbit-robustness-v1.json
+++ b/protocols/tracking-cloth-bounded-orbit-robustness-v1.json
@@ -1,0 +1,100 @@
+{
+  "schema": "prob4d.tracking-cloth-bounded-orbit-robustness.v1",
+  "evidence_kind": "post-primary-bounded-generator-robustness-on-public-real-trajectories",
+  "parent_result": {
+    "protocol_path": "protocols/tracking-cloth-finite-orbit-real-v3.json",
+    "protocol_git_blob_sha1": "2b82734df4292d2c47328828e2307942347ca2a7",
+    "protocol_id": "9c0fb1a4191743a5038a2f26e521db1640fd5abfc3cac389e851485b7836a472",
+    "run_id": 33534703640,
+    "artifact_id": 9811148956,
+    "artifact_digest": "sha256:817c86588bc5673529fc4ae41196f88741a23dd36a7347caeeca5bd92d3a177d",
+    "result_id": "1441a141a8eccc1ae3a503c701c72e8d702a0bcb17226238f3d32effa3e58111",
+    "source_seal_id": "b6819675387890dd786b22168638f1c1ee33558f88d8d6fa6359a0f6df403e6d",
+    "support_id": "f9867227ef9e5a780c49fbbe3ce646205795d9fda504c13b535523d654ef8812",
+    "status": "evaluated-real-geometry-passed"
+  },
+  "dataset": {
+    "record_name": "Tracking Cloth Deformation",
+    "zenodo_record": "14644526",
+    "archive_filename": "tracking_dataset.zip",
+    "archive_md5": "b4868b702f8a42b2ea1069d0f1a3b8f6",
+    "expected_csv_files": 120,
+    "source_rule": "all A2 cotton, denim, and wool Free-hanging shake/twist recordings",
+    "source_recording_count": 24,
+    "target_roster": "exact target_relative_paths from the bound v3 protocol",
+    "target_recording_count": 15,
+    "selected_marker_triplet": [
+      "1",
+      "20",
+      "5"
+    ]
+  },
+  "bounded_error_model": {
+    "point_error_bound_fractions_of_true_anchor_distance": [
+      0.0,
+      0.005,
+      0.01,
+      0.02,
+      0.05,
+      0.1
+    ],
+    "replicates_per_frame": 16,
+    "perturbation": "independent deterministic-hash directions at exactly the declared Euclidean radius for each anchor and probe",
+    "seed": 20260902,
+    "outer_radius_bound": "r_hat + 2*epsilon + abs(t_hat)*min(2,4*epsilon/(d_hat-2*epsilon)); infinite if d_hat<=2*epsilon"
+  },
+  "sampling": {
+    "source_frames_per_recording": 12,
+    "target_frames_per_recording": 128,
+    "minimum_anchor_distance_mm": 20.0,
+    "minimum_probe_radius_mm": 5.0
+  },
+  "source_only_width_thresholds": {
+    "quantity": "true full radial orbit width 2r in millimetres",
+    "quantiles": [
+      0.25,
+      0.5,
+      0.75
+    ]
+  },
+  "methods": [
+    "oracle_true_orbit_width",
+    "plugin_observed_orbit_width",
+    "bounded_outer_orbit_width"
+  ],
+  "primary_endpoints": [
+    "full-orbit containment by plugin and bounded outer intervals",
+    "false acceptance relative to source-only width thresholds",
+    "false rejection relative to source-only width thresholds",
+    "outer-width inflation relative to the true full orbit"
+  ],
+  "inference": {
+    "group_unit": "recording-file",
+    "bootstrap_replicates": 5000,
+    "bootstrap_seed": 20260902
+  },
+  "mathematical_invariants": {
+    "zero_error_matches_oracle": true,
+    "bounded_outer_contains_true_orbit_when_error_bound_is_valid": true,
+    "bounded_outer_false_acceptance_is_zero_when_informative": true,
+    "uninformative_anchor_geometry_fails_closed": true
+  },
+  "information_order": {
+    "parent_target_outcomes_were_opened_before_this_secondary_study": true,
+    "threshold_values_are_computed_from_source_trajectories_only": true,
+    "target_side_retuning_allowed": false,
+    "self_collision_target_trajectories_opened": false,
+    "unsupported_self_collision_groups_replaced": false
+  },
+  "claim_boundary": {
+    "secondary_robustness_not_independent_confirmation": true,
+    "public_real_geometry": true,
+    "controlled_bounded_measurement_error": true,
+    "learned_visual_provider": false,
+    "physical_state_identification": false,
+    "bayesian_phystwin_benefit": false,
+    "deployment_safety": false,
+    "state_of_the_art": false
+  },
+  "protocol_id": "6b372b78329a809aee508a68ffd51abeb945fc941c0db29ca996459ddf52f711"
+}

--- a/scripts/science/run_tracking_cloth_bounded_orbit_robustness_v1.py
+++ b/scripts/science/run_tracking_cloth_bounded_orbit_robustness_v1.py
@@ -1,0 +1,660 @@
+#!/usr/bin/env python3
+"""Secondary robustness study for uncertain axial-orbit generators.
+
+The primary Tracking Cloth result used exact motion-capture anchor and probe
+positions to instantiate a controlled hidden SO(2) ambiguity.  This study keeps
+the same public real trajectories but perturbs every anchor and probe inside a
+declared Euclidean error ball.  It compares a plug-in orbit width with a
+fail-closed outer bound whose containment follows analytically from the error
+balls.
+
+This is a post-primary robustness analysis.  It is not an independent held-out
+confirmation and does not introduce a learned visual provider.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+import re
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from prob4d.bounded_axial_orbit import (
+    bounded_axial_radius,
+    point_to_line_coordinates,
+)
+from prob4d.motive_csv import read_motive_markers
+
+PROTOCOL_ID = "6b372b78329a809aee508a68ffd51abeb945fc941c0db29ca996459ddf52f711"
+PROTOCOL_SCHEMA = "prob4d.tracking-cloth-bounded-orbit-robustness.v1"
+RESULT_SCHEMA = "prob4d.tracking-cloth-bounded-orbit-robustness-result.v1"
+SOURCE_SEAL_SCHEMA = "prob4d.tracking-cloth-bounded-orbit-source-seal.v1"
+PARENT_PROTOCOL_ID = "9c0fb1a4191743a5038a2f26e521db1640fd5abfc3cac389e851485b7836a472"
+PARENT_PROTOCOL_BLOB = "2b82734df4292d2c47328828e2307942347ca2a7"
+PARENT_RESULT_ID = "1441a141a8eccc1ae3a503c701c72e8d702a0bcb17226238f3d32effa3e58111"
+MARKER_TRIPLET = ("1", "20", "5")
+SOURCE_PATTERN = re.compile(
+    r"^(cotton|denim|wool)_A2_(shake|twist)_(fast|slow)_(hands|hanger)[.]csv$"
+)
+
+
+def _canonical(value: object) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False).encode()
+
+
+def _content_id(value: object) -> str:
+    return hashlib.sha256(_canonical(value)).hexdigest()
+
+
+def _git_blob_sha1(value: bytes) -> str:
+    return hashlib.sha1(
+        f"blob {len(value)}\0".encode() + value,
+        usedforsecurity=False,
+    ).hexdigest()
+
+
+def _stable_id(value: str) -> str:
+    return hashlib.sha256(value.encode()).hexdigest()[:16]
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.write_text(
+        json.dumps(value, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _load_protocol(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if type(value) is not dict:
+        raise ValueError("robustness protocol must be one JSON object")
+    unsigned = dict(value)
+    supplied = unsigned.pop("protocol_id", None)
+    if supplied != PROTOCOL_ID or _content_id(unsigned) != supplied:
+        raise ValueError("robustness protocol identity changed")
+    if value.get("schema") != PROTOCOL_SCHEMA:
+        raise ValueError("robustness protocol schema changed")
+    parent = value.get("parent_result", {})
+    if (
+        parent.get("protocol_id") != PARENT_PROTOCOL_ID
+        or parent.get("protocol_git_blob_sha1") != PARENT_PROTOCOL_BLOB
+        or parent.get("result_id") != PARENT_RESULT_ID
+        or parent.get("status") != "evaluated-real-geometry-passed"
+    ):
+        raise ValueError("parent result binding changed")
+    dataset = value.get("dataset", {})
+    if dataset.get("source_recording_count") != 24:
+        raise ValueError("source recording count changed")
+    if dataset.get("target_recording_count") != 15:
+        raise ValueError("target recording count changed")
+    if dataset.get("selected_marker_triplet") != list(MARKER_TRIPLET):
+        raise ValueError("marker triplet changed")
+    error = value.get("bounded_error_model", {})
+    if error.get("point_error_bound_fractions_of_true_anchor_distance") != [
+        0.0,
+        0.005,
+        0.01,
+        0.02,
+        0.05,
+        0.1,
+    ]:
+        raise ValueError("point-error sweep changed")
+    if error.get("replicates_per_frame") != 16 or error.get("seed") != 20260902:
+        raise ValueError("perturbation replication changed")
+    source_thresholds = value.get("source_only_width_thresholds", {})
+    if source_thresholds.get("quantiles") != [0.25, 0.5, 0.75]:
+        raise ValueError("source threshold quantiles changed")
+    sampling = value.get("sampling", {})
+    if sampling != {
+        "source_frames_per_recording": 12,
+        "target_frames_per_recording": 128,
+        "minimum_anchor_distance_mm": 20.0,
+        "minimum_probe_radius_mm": 5.0,
+    }:
+        raise ValueError("sampling contract changed")
+    order = value.get("information_order", {})
+    if order.get("threshold_values_are_computed_from_source_trajectories_only") is not True:
+        raise ValueError("source-only threshold rule changed")
+    if order.get("target_side_retuning_allowed") is not False:
+        raise ValueError("target-side retuning was enabled")
+    if order.get("self_collision_target_trajectories_opened") is not False:
+        raise ValueError("unsupported self-collision outcomes were authorized")
+    return value
+
+
+def _load_parent_protocol(protocol: dict[str, Any]) -> dict[str, Any]:
+    path = Path(protocol["parent_result"]["protocol_path"])
+    content = path.read_bytes()
+    if _git_blob_sha1(content) != PARENT_PROTOCOL_BLOB:
+        raise ValueError("parent v3 protocol Git blob changed")
+    value = json.loads(content)
+    if value.get("protocol_id") != PARENT_PROTOCOL_ID:
+        raise ValueError("parent v3 protocol identity changed")
+    paths = value.get("dataset", {}).get("target_relative_paths")
+    if not isinstance(paths, list) or len(paths) != 15:
+        raise ValueError("parent target roster changed")
+    if any("/Self-collisions/" in path for path in paths):
+        raise ValueError("unsupported self-collision path entered the target roster")
+    return value
+
+
+def _sample_indices(length: int, maximum: int) -> np.ndarray:
+    if length <= 0 or maximum <= 0:
+        return np.empty(0, dtype=np.int64)
+    return np.unique(np.linspace(0, length - 1, num=min(length, maximum), dtype=np.int64))
+
+
+def _source_paths(dataset_root: Path) -> list[Path]:
+    free_hanging = dataset_root / "tracking_dataset" / "Free-hanging"
+    paths = sorted(
+        path for path in free_hanging.glob("*.csv") if SOURCE_PATTERN.fullmatch(path.name)
+    )
+    if len(paths) != 24:
+        raise ValueError(f"expected 24 source recordings, found {len(paths)}")
+    return paths
+
+
+def _target_paths(dataset_root: Path, parent: dict[str, Any]) -> list[Path]:
+    paths = [dataset_root / relative for relative in parent["dataset"]["target_relative_paths"]]
+    if len(paths) != 15 or not all(path.is_file() for path in paths):
+        raise ValueError("the exact 15-recording target roster is unavailable")
+    return paths
+
+
+def _recording_cases(
+    path: Path,
+    dataset_root: Path,
+    maximum_frames: int,
+    minimum_anchor: float,
+    minimum_radius: float,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    coordinates, scale, details = read_motive_markers(path, MARKER_TRIPLET)
+    cases: list[dict[str, Any]] = []
+    for frame_index in _sample_indices(coordinates.shape[0], maximum_frames):
+        frame = coordinates[int(frame_index)]
+        if not np.all(np.isfinite(frame)):
+            continue
+        anchor_distance = float(np.linalg.norm(frame[1] - frame[0]))
+        axial, radius = point_to_line_coordinates(frame[0], frame[1], frame[2])
+        if anchor_distance < minimum_anchor or radius < minimum_radius:
+            continue
+        cases.append(
+            {
+                "frame_index": int(frame_index),
+                "anchor_a": frame[0],
+                "anchor_b": frame[1],
+                "probe": frame[2],
+                "anchor_distance": anchor_distance,
+                "axial_coordinate": axial,
+                "radius": radius,
+                "true_width": 2.0 * radius,
+            }
+        )
+    relative = path.relative_to(dataset_root).as_posix()
+    return cases, {
+        "group_id": _stable_id(relative),
+        "relative_path": relative,
+        "available_rows": int(details["rows"]),
+        "sampled_case_count": len(cases),
+        "unit_scale_to_mm": scale,
+    }
+
+
+def _hash_direction(*parts: object) -> np.ndarray:
+    digest = hashlib.sha256("|".join(str(part) for part in parts).encode()).digest()
+    maximum = float((1 << 64) - 1)
+    vector = np.array(
+        [
+            2.0 * int.from_bytes(digest[8 * index : 8 * (index + 1)], "big") / maximum - 1.0
+            for index in range(3)
+        ],
+        dtype=np.float64,
+    )
+    norm = float(np.linalg.norm(vector))
+    if norm <= np.finfo(np.float64).tiny:
+        return np.array([1.0, 0.0, 0.0])
+    return vector / norm
+
+
+def _bootstrap(values: Iterable[float], replicates: int, seed: int) -> dict[str, float | int]:
+    array = np.asarray(list(values), dtype=np.float64)
+    if array.size == 0 or not np.all(np.isfinite(array)):
+        raise ValueError("bootstrap received empty or nonfinite values")
+    rng = np.random.default_rng(seed)
+    indices = rng.integers(0, array.size, size=(replicates, array.size))
+    draws = np.mean(array[indices], axis=1)
+    return {
+        "mean": float(np.mean(array)),
+        "ci95_low": float(np.quantile(draws, 0.025)),
+        "ci95_high": float(np.quantile(draws, 0.975)),
+        "groups": int(array.size),
+    }
+
+
+def _source_seal(
+    dataset_root: Path,
+    protocol: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, float]]:
+    sampling = protocol["sampling"]
+    widths: list[float] = []
+    groups: list[dict[str, Any]] = []
+    for path in _source_paths(dataset_root):
+        cases, metadata = _recording_cases(
+            path,
+            dataset_root,
+            int(sampling["source_frames_per_recording"]),
+            float(sampling["minimum_anchor_distance_mm"]),
+            float(sampling["minimum_probe_radius_mm"]),
+        )
+        if not cases:
+            raise ValueError(f"source recording produced no valid cases: {path.name}")
+        widths.extend(float(case["true_width"]) for case in cases)
+        groups.append(metadata)
+    quantiles = protocol["source_only_width_thresholds"]["quantiles"]
+    thresholds = {
+        f"q{int(round(100.0 * quantile)):02d}": float(np.quantile(widths, quantile))
+        for quantile in quantiles
+    }
+    value: dict[str, Any] = {
+        "schema": SOURCE_SEAL_SCHEMA,
+        "protocol_id": protocol["protocol_id"],
+        "source_group_count": len(groups),
+        "source_case_count": len(widths),
+        "source_group_ids": [row["group_id"] for row in groups],
+        "thresholds_mm": thresholds,
+        "width_summary_mm": {
+            "minimum": float(np.min(widths)),
+            "median": float(np.median(widths)),
+            "maximum": float(np.max(widths)),
+        },
+        "groups": groups,
+        "target_trajectory_values_opened_before_source_seal": False,
+    }
+    value["source_seal_id"] = _content_id(value)
+    return value, thresholds
+
+
+def _evaluate_group(
+    cases: list[dict[str, Any]],
+    metadata: dict[str, Any],
+    thresholds: dict[str, float],
+    protocol: dict[str, Any],
+) -> dict[str, Any]:
+    error_model = protocol["bounded_error_model"]
+    ratios = error_model["point_error_bound_fractions_of_true_anchor_distance"]
+    replicates = int(error_model["replicates_per_frame"])
+    seed = int(error_model["seed"])
+    noise_rows: list[dict[str, Any]] = []
+
+    for ratio in ratios:
+        total = 0
+        informative = 0
+        plugin_contains = 0
+        outer_contains = 0
+        plugin_width_ratios: list[float] = []
+        outer_width_ratios: list[float] = []
+        threshold_counts = {
+            name: {
+                "oracle_accept": 0,
+                "plugin_accept": 0,
+                "outer_accept": 0,
+                "plugin_false_accept": 0,
+                "outer_false_accept": 0,
+                "plugin_false_reject": 0,
+                "outer_false_reject": 0,
+            }
+            for name in thresholds
+        }
+        maximum_outer_violation = -math.inf
+
+        for case in cases:
+            true_width = float(case["true_width"])
+            epsilon = float(ratio) * float(case["anchor_distance"])
+            frame_index = int(case["frame_index"])
+            for replicate in range(replicates):
+                observed = []
+                for label, point in (
+                    ("anchor-a", case["anchor_a"]),
+                    ("anchor-b", case["anchor_b"]),
+                    ("probe", case["probe"]),
+                ):
+                    direction = _hash_direction(
+                        seed,
+                        metadata["group_id"],
+                        frame_index,
+                        ratio,
+                        replicate,
+                        label,
+                    )
+                    observed.append(np.asarray(point) + epsilon * direction)
+                bound = bounded_axial_radius(*observed, epsilon)
+                plugin_width = bound.observed_full_orbit_width
+                outer_width = bound.outer_full_orbit_width
+                total += 1
+                informative += int(bound.informative)
+                plugin_contains += int(plugin_width + 1e-10 >= true_width)
+                outer_contains += int(outer_width + 1e-10 >= true_width)
+                maximum_outer_violation = max(
+                    maximum_outer_violation,
+                    true_width - outer_width,
+                )
+                plugin_width_ratios.append(plugin_width / true_width)
+                if math.isfinite(outer_width):
+                    outer_width_ratios.append(outer_width / true_width)
+
+                for name, threshold in thresholds.items():
+                    oracle_accept = true_width <= threshold
+                    plugin_accept = plugin_width <= threshold
+                    outer_accept = bound.accepts_width(threshold)
+                    counts = threshold_counts[name]
+                    counts["oracle_accept"] += int(oracle_accept)
+                    counts["plugin_accept"] += int(plugin_accept)
+                    counts["outer_accept"] += int(outer_accept)
+                    counts["plugin_false_accept"] += int(plugin_accept and not oracle_accept)
+                    counts["outer_false_accept"] += int(outer_accept and not oracle_accept)
+                    counts["plugin_false_reject"] += int(not plugin_accept and oracle_accept)
+                    counts["outer_false_reject"] += int(not outer_accept and oracle_accept)
+
+        if total == 0:
+            raise ValueError(
+                f"target group produced no perturbation cases: {metadata['relative_path']}"
+            )
+        threshold_rows = []
+        for name, counts in threshold_counts.items():
+            threshold_rows.append(
+                {
+                    "threshold_name": name,
+                    "threshold_mm": thresholds[name],
+                    **{key: value / total for key, value in counts.items()},
+                }
+            )
+        noise_rows.append(
+            {
+                "point_error_fraction": float(ratio),
+                "perturbation_case_count": total,
+                "informative_fraction": informative / total,
+                "plugin_orbit_containment": plugin_contains / total,
+                "outer_orbit_containment": outer_contains / total,
+                "plugin_width_ratio_mean": float(np.mean(plugin_width_ratios)),
+                "plugin_width_ratio_median": float(np.median(plugin_width_ratios)),
+                "outer_width_ratio_mean": float(np.mean(outer_width_ratios)),
+                "outer_width_ratio_median": float(np.median(outer_width_ratios)),
+                "maximum_outer_width_violation_mm": maximum_outer_violation,
+                "thresholds": threshold_rows,
+            }
+        )
+    return {**metadata, "noise_levels": noise_rows}
+
+
+def _aggregate(
+    groups: list[dict[str, Any]],
+    protocol: dict[str, Any],
+) -> list[dict[str, Any]]:
+    error_ratios = protocol["bounded_error_model"][
+        "point_error_bound_fractions_of_true_anchor_distance"
+    ]
+    threshold_names = [
+        f"q{int(round(100.0 * quantile)):02d}"
+        for quantile in protocol["source_only_width_thresholds"]["quantiles"]
+    ]
+    replicates = int(protocol["inference"]["bootstrap_replicates"])
+    seed = int(protocol["inference"]["bootstrap_seed"])
+    result: list[dict[str, Any]] = []
+    scalar_metrics = (
+        "informative_fraction",
+        "plugin_orbit_containment",
+        "outer_orbit_containment",
+        "plugin_width_ratio_mean",
+        "outer_width_ratio_mean",
+    )
+    threshold_metrics = (
+        "oracle_accept",
+        "plugin_accept",
+        "outer_accept",
+        "plugin_false_accept",
+        "outer_false_accept",
+        "plugin_false_reject",
+        "outer_false_reject",
+    )
+
+    for ratio_index, ratio in enumerate(error_ratios):
+        rows = [group["noise_levels"][ratio_index] for group in groups]
+        aggregate = {
+            "point_error_fraction": float(ratio),
+            "recording_count": len(groups),
+            "total_perturbation_cases": sum(row["perturbation_case_count"] for row in rows),
+            "metrics": {
+                name: _bootstrap(
+                    [float(row[name]) for row in rows],
+                    replicates,
+                    seed + 1000 * ratio_index + index,
+                )
+                for index, name in enumerate(scalar_metrics)
+            },
+            "maximum_outer_width_violation_mm": max(
+                float(row["maximum_outer_width_violation_mm"]) for row in rows
+            ),
+            "thresholds": [],
+        }
+        for threshold_index, threshold_name in enumerate(threshold_names):
+            threshold_rows = [
+                next(item for item in row["thresholds"] if item["threshold_name"] == threshold_name)
+                for row in rows
+            ]
+            aggregate["thresholds"].append(
+                {
+                    "threshold_name": threshold_name,
+                    "threshold_mm": threshold_rows[0]["threshold_mm"],
+                    "metrics": {
+                        name: _bootstrap(
+                            [float(row[name]) for row in threshold_rows],
+                            replicates,
+                            seed + 1000 * ratio_index + 100 * threshold_index + index,
+                        )
+                        for index, name in enumerate(threshold_metrics)
+                    },
+                }
+            )
+        result.append(aggregate)
+    return result
+
+
+def _summary(result: dict[str, Any]) -> str:
+    lines = [
+        "# Tracking Cloth bounded-orbit robustness",
+        "",
+        f"Result ID: `{result['result_id']}`",
+        "",
+        (
+            "This secondary study perturbs both anchors and the probe within "
+            "exact Euclidean error balls on the 15 already evaluated public "
+            "real-trajectory recordings."
+        ),
+        "Thresholds are source-only quantiles of the true full radial-orbit width.",
+        "",
+        (
+            "| point error / anchor span | plug-in containment | outer "
+            "containment | outer width / true width | q50 plug-in false "
+            "accept | q50 outer false accept | q50 outer false reject |"
+        ),
+        "|---:|---:|---:|---:|---:|---:|---:|",
+    ]
+    for row in result["aggregate"]:
+        metrics = row["metrics"]
+        q50 = next(item for item in row["thresholds"] if item["threshold_name"] == "q50")
+        threshold = q50["metrics"]
+        lines.append(
+            "| {ratio:.1%} | {plugin:.4f} | {outer:.4f} | {inflation:.3f} | "
+            "{plugin_false:.4f} | {outer_false:.4f} | {outer_reject:.4f} |".format(
+                ratio=row["point_error_fraction"],
+                plugin=metrics["plugin_orbit_containment"]["mean"],
+                outer=metrics["outer_orbit_containment"]["mean"],
+                inflation=metrics["outer_width_ratio_mean"]["mean"],
+                plugin_false=threshold["plugin_false_accept"]["mean"],
+                outer_false=threshold["outer_false_accept"]["mean"],
+                outer_reject=threshold["outer_false_reject"]["mean"],
+            )
+        )
+    lines += [
+        "",
+        (
+            "The outer certificate is conditionally exact only when the "
+            "declared point-error balls contain the true points. Width "
+            "inflation quantifies its conservatism; it is not a learned-"
+            "provider accuracy result."
+        ),
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _write_csv(path: Path, result: dict[str, Any]) -> None:
+    fields = [
+        "point_error_fraction",
+        "threshold_name",
+        "threshold_mm",
+        "metric",
+        "mean",
+        "ci95_low",
+        "ci95_high",
+        "groups",
+    ]
+    with path.open("w", encoding="utf-8", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=fields)
+        writer.writeheader()
+        for aggregate in result["aggregate"]:
+            for name, value in aggregate["metrics"].items():
+                writer.writerow(
+                    {
+                        "point_error_fraction": aggregate["point_error_fraction"],
+                        "threshold_name": "",
+                        "threshold_mm": "",
+                        "metric": name,
+                        **value,
+                    }
+                )
+            for threshold in aggregate["thresholds"]:
+                for name, value in threshold["metrics"].items():
+                    writer.writerow(
+                        {
+                            "point_error_fraction": aggregate["point_error_fraction"],
+                            "threshold_name": threshold["threshold_name"],
+                            "threshold_mm": threshold["threshold_mm"],
+                            "metric": name,
+                            **value,
+                        }
+                    )
+
+
+def run(args: argparse.Namespace) -> int:
+    protocol_path = Path(args.protocol).resolve()
+    protocol = _load_protocol(protocol_path)
+    parent = _load_parent_protocol(protocol)
+    dataset_root = Path(args.dataset_root).resolve(strict=True)
+    output = Path(args.output_dir).resolve()
+    if output.exists():
+        raise ValueError("output directory already exists")
+    output.mkdir(parents=True)
+
+    source_seal, thresholds = _source_seal(dataset_root, protocol)
+    _write_json(output / "source_seal.json", source_seal)
+
+    sampling = protocol["sampling"]
+    groups = []
+    for path in _target_paths(dataset_root, parent):
+        cases, metadata = _recording_cases(
+            path,
+            dataset_root,
+            int(sampling["target_frames_per_recording"]),
+            float(sampling["minimum_anchor_distance_mm"]),
+            float(sampling["minimum_probe_radius_mm"]),
+        )
+        if not cases:
+            raise ValueError(f"target recording produced no valid cases: {path.name}")
+        groups.append(_evaluate_group(cases, metadata, thresholds, protocol))
+
+    aggregate = _aggregate(groups, protocol)
+    maximum_violation = max(float(row["maximum_outer_width_violation_mm"]) for row in aggregate)
+    outer_false_accept = max(
+        float(threshold["metrics"]["outer_false_accept"]["mean"])
+        for row in aggregate
+        for threshold in row["thresholds"]
+    )
+    zero_error = aggregate[0]
+    zero_plugin_error = max(
+        abs(float(zero_error["metrics"][name]["mean"]) - expected)
+        for name, expected in (
+            ("plugin_orbit_containment", 1.0),
+            ("outer_orbit_containment", 1.0),
+            ("plugin_width_ratio_mean", 1.0),
+            ("outer_width_ratio_mean", 1.0),
+        )
+    )
+    result: dict[str, Any] = {
+        "schema": RESULT_SCHEMA,
+        "protocol_id": protocol["protocol_id"],
+        "source_revision": str(args.source_revision),
+        "parent_result": protocol["parent_result"],
+        "source_seal_id": source_seal["source_seal_id"],
+        "source_thresholds_mm": thresholds,
+        "target_group_count": len(groups),
+        "target_case_count": sum(group["sampled_case_count"] for group in groups),
+        "groups": groups,
+        "aggregate": aggregate,
+        "mathematical_checks": {
+            "maximum_outer_width_violation_mm": maximum_violation,
+            "maximum_outer_false_acceptance": outer_false_accept,
+            "maximum_zero_error_discrepancy": zero_plugin_error,
+            "all_outer_bounds_contained_true_orbits": maximum_violation <= 1e-9,
+            "all_outer_gates_had_zero_false_acceptance": outer_false_accept == 0.0,
+            "zero_error_matched_oracle": zero_plugin_error <= 1e-12,
+        },
+        "self_collision_header_audit": {
+            "audit_id": "8e062f5ac4a8521b51cf616986331614f1bc91b5ca1d4971ed7647a5c4bc2ed9",
+            "target_trajectory_values_parsed": False,
+            "compatible_source_target_namespace_pairs": 0,
+            "disposition": "not forced into the outcome study",
+        },
+        "information_order": protocol["information_order"],
+        "claim_boundary": protocol["claim_boundary"],
+    }
+    result["result_id"] = _content_id(result)
+    _write_json(output / "result.json", result)
+    _write_csv(output / "aggregate.csv", result)
+    (output / "summary.md").write_text(_summary(result), encoding="utf-8")
+    print(
+        json.dumps(
+            {
+                "result_id": result["result_id"],
+                "source_seal_id": source_seal["source_seal_id"],
+                "target_groups": result["target_group_count"],
+                "target_cases": result["target_case_count"],
+                "checks": result["mathematical_checks"],
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dataset-root", required=True)
+    parser.add_argument("--protocol", required=True)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--source-revision", required=True)
+    return parser
+
+
+def main() -> int:
+    return run(build_parser().parse_args())
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/prob4d/bounded_axial_orbit.py
+++ b/src/prob4d/bounded_axial_orbit.py
@@ -1,0 +1,157 @@
+"""Fail-closed axial-orbit bounds under bounded point-position errors.
+
+The local finite-orbit examples use two anchor points to define a rotation axis
+and one probe point whose distance from that axis determines the full radial
+query orbit.  In practice those three points are estimated.  This module gives
+a deterministic outer bound on the true probe radius when every supplied point
+is known only within one Euclidean error ball.
+
+The result is conditional: the caller owns the point-error bound.  If the
+observed anchors are too close to identify a direction under that bound, the
+result is uninformative and its radius upper bound is infinite.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import TypeAlias
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+
+FloatArray: TypeAlias = NDArray[np.float64]
+
+
+def _vector(value: ArrayLike, *, name: str) -> FloatArray:
+    raw = np.asarray(value)
+    if raw.dtype.kind not in "iuf":
+        raise ValueError(f"{name} must contain real numeric values")
+    result = np.asarray(raw, dtype=np.float64)
+    if result.shape != (3,) or not np.all(np.isfinite(result)):
+        raise ValueError(f"{name} must be a finite vector with shape (3,)")
+    return result
+
+
+def _nonnegative_scalar(value: float, *, name: str) -> float:
+    if isinstance(value, (bool, np.bool_)):
+        raise ValueError(f"{name} must be a real scalar")
+    result = float(value)
+    if not math.isfinite(result) or result < 0.0:
+        raise ValueError(f"{name} must be finite and nonnegative")
+    return result
+
+
+@dataclass(frozen=True)
+class AxialRadiusBound:
+    """Observed line geometry and an outer bound on the true probe radius."""
+
+    anchor_distance: float
+    observed_axial_coordinate: float
+    observed_radius: float
+    point_error_bound: float
+    direction_difference_bound: float
+    radius_upper_bound: float
+    informative: bool
+
+    @property
+    def observed_full_orbit_width(self) -> float:
+        return 2.0 * self.observed_radius
+
+    @property
+    def outer_full_orbit_width(self) -> float:
+        return 2.0 * self.radius_upper_bound
+
+    def accepts_width(self, maximum_width: float) -> bool:
+        """Return whether the outer orbit is no wider than ``maximum_width``."""
+
+        threshold = _nonnegative_scalar(maximum_width, name="maximum_width")
+        return self.informative and self.outer_full_orbit_width <= threshold
+
+
+def point_to_line_coordinates(
+    anchor_a: ArrayLike,
+    anchor_b: ArrayLike,
+    probe: ArrayLike,
+) -> tuple[float, float]:
+    """Return axial coordinate and radius relative to an oriented anchor line."""
+
+    first = _vector(anchor_a, name="anchor_a")
+    second = _vector(anchor_b, name="anchor_b")
+    point = _vector(probe, name="probe")
+    delta = second - first
+    distance = float(np.linalg.norm(delta))
+    if distance <= 0.0:
+        raise ValueError("anchor points must be distinct")
+    axis = delta / distance
+    offset = point - first
+    axial = float(offset @ axis)
+    radial = offset - axial * axis
+    return axial, float(np.linalg.norm(radial))
+
+
+def bounded_axial_radius(
+    observed_anchor_a: ArrayLike,
+    observed_anchor_b: ArrayLike,
+    observed_probe: ArrayLike,
+    point_error_bound: float,
+) -> AxialRadiusBound:
+    """Bound the true probe-to-axis radius under equal point-error balls.
+
+    Let the unobserved true points ``a``, ``b`` and ``p`` lie within distance
+    ``epsilon`` of their observed counterparts.  If ``d_hat`` is the observed
+    anchor separation and ``d_hat > 2*epsilon``, normalized-vector perturbation
+    gives
+
+    ``||u - u_hat|| <= 4*epsilon / (d_hat - 2*epsilon)``.
+
+    Choosing the observed axial coordinate as a feasible point on the true line
+    then yields
+
+    ``r_true <= r_hat + 2*epsilon + |t_hat|*||u-u_hat||``.
+
+    The implementation caps the direction difference at its universal maximum
+    of two.  When the anchors cannot identify a direction under the declared
+    error bound, the method fails closed with an infinite upper bound.
+    """
+
+    first = _vector(observed_anchor_a, name="observed_anchor_a")
+    second = _vector(observed_anchor_b, name="observed_anchor_b")
+    point = _vector(observed_probe, name="observed_probe")
+    epsilon = _nonnegative_scalar(point_error_bound, name="point_error_bound")
+
+    delta = second - first
+    distance = float(np.linalg.norm(delta))
+    if distance <= 0.0:
+        raise ValueError("observed anchor points must be distinct")
+    axis = delta / distance
+    offset = point - first
+    axial = float(offset @ axis)
+    radius = float(np.linalg.norm(offset - axial * axis))
+
+    anchor_vector_error = 2.0 * epsilon
+    if distance <= anchor_vector_error:
+        return AxialRadiusBound(
+            anchor_distance=distance,
+            observed_axial_coordinate=axial,
+            observed_radius=radius,
+            point_error_bound=epsilon,
+            direction_difference_bound=2.0,
+            radius_upper_bound=math.inf,
+            informative=False,
+        )
+
+    direction_bound = min(
+        2.0,
+        2.0 * anchor_vector_error / (distance - anchor_vector_error),
+    )
+    upper = radius + 2.0 * epsilon + abs(axial) * direction_bound
+    return AxialRadiusBound(
+        anchor_distance=distance,
+        observed_axial_coordinate=axial,
+        observed_radius=radius,
+        point_error_bound=epsilon,
+        direction_difference_bound=direction_bound,
+        radius_upper_bound=upper,
+        informative=True,
+    )

--- a/tests/test_bounded_axial_orbit.py
+++ b/tests/test_bounded_axial_orbit.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from prob4d.bounded_axial_orbit import (
+    bounded_axial_radius,
+    point_to_line_coordinates,
+)
+
+
+def _ball_error(rng: np.random.Generator, radius: float) -> np.ndarray:
+    direction = rng.normal(size=3)
+    direction /= np.linalg.norm(direction)
+    return radius * rng.random() ** (1.0 / 3.0) * direction
+
+
+def test_zero_error_bound_recovers_observed_radius_exactly() -> None:
+    first = np.array([0.2, -0.3, 0.4])
+    second = np.array([1.2, 0.1, -0.2])
+    probe = np.array([-0.4, 0.8, 1.7])
+    _, radius = point_to_line_coordinates(first, second, probe)
+    result = bounded_axial_radius(first, second, probe, 0.0)
+    assert result.informative
+    assert result.direction_difference_bound == 0.0
+    assert result.observed_radius == radius
+    assert result.radius_upper_bound == radius
+    assert result.outer_full_orbit_width == result.observed_full_orbit_width
+
+
+def test_outer_bound_contains_random_true_geometries() -> None:
+    rng = np.random.default_rng(20260902)
+    for _ in range(2048):
+        true_a = rng.normal(size=3)
+        direction = rng.normal(size=3)
+        direction /= np.linalg.norm(direction)
+        true_b = true_a + rng.uniform(0.5, 3.0) * direction
+        true_probe = true_a + rng.normal(size=3)
+        epsilon = rng.uniform(0.0, 0.08) * np.linalg.norm(true_b - true_a)
+        observed_a = true_a + _ball_error(rng, epsilon)
+        observed_b = true_b + _ball_error(rng, epsilon)
+        observed_probe = true_probe + _ball_error(rng, epsilon)
+        result = bounded_axial_radius(
+            observed_a,
+            observed_b,
+            observed_probe,
+            epsilon,
+        )
+        _, true_radius = point_to_line_coordinates(true_a, true_b, true_probe)
+        assert result.radius_upper_bound + 1e-12 >= true_radius
+
+
+def test_plugin_radius_can_underestimate_but_outer_bound_does_not() -> None:
+    true_a = np.array([0.0, 0.0, 0.0])
+    true_b = np.array([1.0, 0.0, 0.0])
+    true_probe = np.array([0.5, 1.0, 0.0])
+    epsilon = 0.1
+    observed_probe = np.array([0.5, 0.9, 0.0])
+    result = bounded_axial_radius(true_a, true_b, observed_probe, epsilon)
+    _, true_radius = point_to_line_coordinates(true_a, true_b, true_probe)
+    assert result.observed_radius < true_radius
+    assert result.radius_upper_bound >= true_radius
+    assert result.accepts_width(1.9) is False
+
+
+def test_ambiguous_anchor_direction_fails_closed() -> None:
+    result = bounded_axial_radius(
+        [0.0, 0.0, 0.0],
+        [0.1, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        0.05,
+    )
+    assert not result.informative
+    assert math.isinf(result.radius_upper_bound)
+    assert result.accepts_width(1e12) is False
+
+
+def test_similarity_scaling_preserves_dimensionless_bound() -> None:
+    first = np.array([0.2, -0.3, 0.4])
+    second = np.array([1.2, 0.1, -0.2])
+    probe = np.array([-0.4, 0.8, 1.7])
+    epsilon = 0.03
+    rotation = np.array(
+        [
+            [0.0, -1.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+    scale = 7.5
+    shift = np.array([4.0, -8.0, 2.0])
+    original = bounded_axial_radius(first, second, probe, epsilon)
+    transformed = bounded_axial_radius(
+        scale * (rotation @ first) + shift,
+        scale * (rotation @ second) + shift,
+        scale * (rotation @ probe) + shift,
+        scale * epsilon,
+    )
+    assert transformed.direction_difference_bound == pytest.approx(
+        original.direction_difference_bound
+    )
+    assert transformed.observed_radius == pytest.approx(scale * original.observed_radius)
+    assert transformed.radius_upper_bound == pytest.approx(scale * original.radius_upper_bound)
+
+
+@pytest.mark.parametrize(
+    "points,error",
+    [
+        (([0, 0, 0], [0, 0, 0], [1, 0, 0]), 0.0),
+        (([0, 0], [1, 0, 0], [0, 1, 0]), 0.0),
+        (([0, 0, 0], [1, 0, 0], [0, np.nan, 0]), 0.0),
+        (([0, 0, 0], [1, 0, 0], [0, 1, 0]), -1.0),
+        (([0, 0, 0], [1, 0, 0], [0, 1, 0]), math.inf),
+    ],
+)
+def test_invalid_inputs_are_rejected(points, error) -> None:
+    with pytest.raises(ValueError):
+        bounded_axial_radius(*points, error)

--- a/tests/test_tracking_cloth_bounded_orbit_robustness_v1.py
+++ b/tests/test_tracking_cloth_bounded_orbit_robustness_v1.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import numpy as np
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "science" / "run_tracking_cloth_bounded_orbit_robustness_v1.py"
+PROTOCOL = ROOT / "protocols" / "tracking-cloth-bounded-orbit-robustness-v1.json"
+
+
+def _load_module():
+    name = "tracking_cloth_bounded_orbit_robustness_v1_test"
+    spec = importlib.util.spec_from_file_location(name, SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_protocol_binds_parent_result_and_secondary_information_order() -> None:
+    module = _load_module()
+    protocol = module._load_protocol(PROTOCOL)
+    assert protocol["protocol_id"] == module.PROTOCOL_ID
+    assert protocol["parent_result"]["result_id"] == module.PARENT_RESULT_ID
+    assert protocol["information_order"][
+        "parent_target_outcomes_were_opened_before_this_secondary_study"
+    ]
+    assert protocol["information_order"]["target_side_retuning_allowed"] is False
+    assert protocol["information_order"]["self_collision_target_trajectories_opened"] is False
+
+
+def test_hash_direction_is_deterministic_and_unit_length() -> None:
+    module = _load_module()
+    first = module._hash_direction(1, "recording", 17, 0.02, 4, "probe")
+    second = module._hash_direction(1, "recording", 17, 0.02, 4, "probe")
+    np.testing.assert_array_equal(first, second)
+    np.testing.assert_allclose(np.linalg.norm(first), 1.0, atol=1e-15)
+
+
+def test_synthetic_group_preserves_outer_containment_and_zero_false_acceptance() -> None:
+    module = _load_module()
+    protocol = module._load_protocol(PROTOCOL)
+    cases = []
+    for frame_index, radius in enumerate((0.2, 0.5, 0.8, 1.1)):
+        cases.append(
+            {
+                "frame_index": frame_index,
+                "anchor_a": np.array([0.0, 0.0, 0.0]),
+                "anchor_b": np.array([2.0, 0.0, 0.0]),
+                "probe": np.array([0.7, radius, 0.0]),
+                "anchor_distance": 2.0,
+                "axial_coordinate": 0.7,
+                "radius": radius,
+                "true_width": 2.0 * radius,
+            }
+        )
+    metadata = {
+        "group_id": "synthetic",
+        "relative_path": "synthetic.csv",
+        "sampled_case_count": len(cases),
+        "available_rows": len(cases),
+        "unit_scale_to_mm": 1.0,
+    }
+    result = module._evaluate_group(
+        cases,
+        metadata,
+        {"q25": 0.6, "q50": 1.2, "q75": 1.8},
+        protocol,
+    )
+    for noise in result["noise_levels"]:
+        assert noise["outer_orbit_containment"] == 1.0
+        assert noise["maximum_outer_width_violation_mm"] <= 0.0
+        assert all(row["outer_false_accept"] == 0.0 for row in noise["thresholds"])
+    zero = result["noise_levels"][0]
+    assert zero["plugin_orbit_containment"] == 1.0
+    assert zero["plugin_width_ratio_mean"] == 1.0
+    assert zero["outer_width_ratio_mean"] == 1.0


### PR DESCRIPTION
## Scientific contribution

The existing finite-orbit result assumes that the orbit generator is known from exact anchor geometry. This PR removes that idealization for axial ambiguities: it derives and implements a fail-closed outer orbit when both anchors and the queried probe are known only within declared Euclidean error balls.

For observed anchors `a_hat`, `b_hat`, probe `p_hat`, common point-error bound `epsilon`, observed anchor separation `d_hat`, observed axial coordinate `t_hat`, and observed probe-to-line radius `r_hat`, the true radius satisfies

```text
r_true <= r_hat + 2 epsilon
          + |t_hat| min(2, 4 epsilon / (d_hat - 2 epsilon))
```

when `d_hat > 2 epsilon`. If `d_hat <= 2 epsilon`, the axis direction is not certified and the implementation fails closed with an infinite bound. Therefore an acceptance decision made using the outer orbit is sound for every true geometry inside the declared point-error balls.

## Public real-trajectory robustness result

A frozen secondary study perturbed both anchors and the probe on the exact 15-recording Tracking Cloth cohort from the primary result. The point-error radius was swept from 0% to 10% of the true anchor separation; 16 deterministic boundary perturbations were evaluated for each of 1,803 real-trajectory cases, giving 28,848 perturbation cases per level. Decision thresholds were the 25th, 50th, and 75th percentiles of full orbit width computed from 273 valid source cases in 24 shake/twist recordings.

| Point error / anchor span | Plug-in orbit contains truth | Certified orbit contains truth | Certified width / truth | q50 plug-in false accept | q50 certified false accept | q50 certified false reject |
|---:|---:|---:|---:|---:|---:|---:|
| 0.0% | 1.0000 | 1.0000 | 1.000 | 0.0000 | 0.0000 | 0.0000 |
| 0.5% | 0.5055 | 1.0000 | 1.064 | 0.0490 | 0.0000 | 0.1030 |
| 1.0% | 0.5057 | 1.0000 | 1.128 | 0.0890 | 0.0000 | 0.2851 |
| 2.0% | 0.5080 | 1.0000 | 1.261 | 0.1286 | 0.0000 | 0.4050 |
| 5.0% | 0.5259 | 1.0000 | 1.680 | 0.1507 | 0.0000 | 0.4493 |
| 10.0% | 0.5481 | 1.0000 | 2.470 | 0.1585 | 0.0000 | 0.4992 |

At 2% point error, the plug-in orbit contains the true orbit in only 50.80% of perturbations and falsely accepts 12.86% of cases at the source-median decision threshold. The certified outer orbit retains 100% containment and zero false acceptance, at the explicit cost of 1.261x mean width and 40.50% false rejection. This is the intended fail-closed tradeoff: transparent conservatism instead of hidden optimism.

Recording-bootstrap intervals are retained in the evidence JSON. For the 2% setting, plug-in containment is 0.5080 [0.5006, 0.5166], certified width inflation is 1.2608 [1.2102, 1.3204], and q50 plug-in false acceptance is 0.1286 [0.0612, 0.1990].

## Alternative cohort audit

A separate header-only audit examined the 27 untouched Self-collision recordings without parsing trajectory values. No source/target namespace shared three cloth-marker identities, so those recordings were not forced into an invalid correspondence-based replication. They remain outcome-unopened.

## Files

- `src/prob4d/bounded_axial_orbit.py`: analytic outer-radius bound and fail-closed decision object;
- `tests/test_bounded_axial_orbit.py`: zero-error, 2,048 randomized adversarial perturbations, underestimation counterexample, similarity equivariance, and failure cases;
- frozen robustness protocol, evaluator, and protocol tests;
- focused permanent CI workflow;
- retained machine-readable evidence and paper-facing derivation.

The branch is one commit ahead of current `main` and contains only these eight durable files.

## Provenance

- Protocol: `6b372b78329a809aee508a68ffd51abeb945fc941c0db29ca996459ddf52f711`
- Result: `5afbb2ae23ab34f8cb1944ed39d9517c8d7233096de8ae2e07b822d0e7299552`
- Source seal: `2f85bfa0b31eb62af5eaff36c3cc9c0e1bb4c91f79d43e14dbda8e28a9959afc`
- Successful run: `33564072262`
- Artifact: `9822421238`
- Artifact digest: `sha256:7d6ed4e938361f4cde0f4e3cbfcb12bba4036863934222e04730089925917868`
- Header-only audit: `8e062f5ac4a8521b51cf616986331614f1bc91b5ca1d4971ed7647a5c4bc2ed9`

## Claim boundary

This closes the principal robustness objection to the controlled finite-orbit experiment: exact orbit geometry is not required when a valid deterministic point-error bound is available. It does **not** estimate that bound from images, establish learned-provider competence, identify the full physical cloth state, demonstrate BayesianPhysTwin task benefit, prove deployment safety, or establish state of the art. The robustness sweep is secondary analysis on the already evaluated 15 recordings, not an independent confirmation.