### PR TITLE
Certify query identifiability under approximate finite orbits

### DIFF
--- a/.github/workflows/axial-orbit-geometric-error-bound.yml
+++ b/.github/workflows/axial-orbit-geometric-error-bound.yml
@@ -1,0 +1,145 @@
+name: Axial orbit geometric error bound
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/axial-orbit-geometric-error-bound.yml"
+      - "src/prob4d/axial_orbit_geometry_bound.py"
+      - "src/prob4d/robust_orbit_query.py"
+      - "tests/test_axial_orbit_geometry_bound.py"
+      - "tests/test_robust_orbit_query.py"
+      - "docs/axial-orbit-geometric-error-bound.md"
+  push:
+    branches:
+      - research/robust-orbit-identifiability-v1
+    paths:
+      - ".github/workflows/axial-orbit-geometric-error-bound.yml"
+      - "src/prob4d/axial_orbit_geometry_bound.py"
+      - "src/prob4d/robust_orbit_query.py"
+      - "tests/test_axial_orbit_geometry_bound.py"
+      - "tests/test_robust_orbit_query.py"
+      - "docs/axial-orbit-geometric-error-bound.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: axial-orbit-geometric-error-bound-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PYTHONHASHSEED: "0"
+  PYTHONUNBUFFERED: "1"
+  PYTHONDONTWRITEBYTECODE: "1"
+  OMP_NUM_THREADS: "1"
+  OPENBLAS_NUM_THREADS: "1"
+  MKL_NUM_THREADS: "1"
+  NUMEXPR_NUM_THREADS: "1"
+
+jobs:
+  validate:
+    name: Geometric-to-coefficient error contract
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out exact revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          clean: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install exact development environment
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --disable-pip-version-check -e ".[dev]"
+          python -m pip check
+
+      - name: Lint, format, and type-check bound implementation
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m ruff check \
+            src/prob4d/axial_orbit_geometry_bound.py \
+            tests/test_axial_orbit_geometry_bound.py
+          python -m ruff format --check \
+            src/prob4d/axial_orbit_geometry_bound.py \
+            tests/test_axial_orbit_geometry_bound.py
+          python -m mypy src/prob4d/axial_orbit_geometry_bound.py
+
+      - name: Run adversarial geometric-bound tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pytest -q \
+            tests/test_axial_orbit_geometry_bound.py \
+            tests/test_robust_orbit_query.py
+
+      - name: Verify practical end-to-end certificate composition
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import numpy as np
+
+          from prob4d.axial_orbit_geometry_bound import (
+              bound_axial_query_coefficient_error,
+              project_axial_query_coefficients,
+          )
+          from prob4d.robust_orbit_query import certify_axial_linear_query
+
+          points = np.array(
+              [
+                  [-0.5, 0.0, 0.0],
+                  [0.5, 0.0, 0.0],
+                  [0.0, 0.2, 0.0],
+              ]
+          )
+          weights = np.zeros((2, 3, 3))
+          weights[0, 2, 1] = 1.0
+          weights[1, 2, 2] = 1.0
+          coefficients = project_axial_query_coefficients(
+              points,
+              axis=[1.0, 0.0, 0.0],
+              pivot=[0.0, 0.0, 0.0],
+              query_weights=weights,
+          )
+          budget = bound_axial_query_coefficient_error(
+              points,
+              estimated_axis=[1.0, 0.0, 0.0],
+              estimated_pivot=[0.0, 0.0, 0.0],
+              query_weights=weights,
+              point_position_error_bounds=[0.001, 0.001, 0.002],
+              axis_vector_error_bound=0.005,
+              pivot_position_error_bound=0.001,
+          )
+          certificate = certify_axial_linear_query(
+              coefficients,
+              coefficient_error_bound=budget.coefficient_operator_error_bound,
+              invariance_tolerance=0.05,
+          )
+          assert certificate.decision == "certified-variant"
+          assert certificate.update_admitted is False
+          print(
+              json.dumps(
+                  {
+                      "estimated_diameter": certificate.estimated_diameter,
+                      "lower_diameter": certificate.lower_diameter,
+                      "upper_diameter": certificate.upper_diameter,
+                      "geometric_coefficient_error_bound": budget.coefficient_operator_error_bound,
+                      "decision": certificate.decision,
+                  },
+                  sort_keys=True,
+              )
+          )
+          PY

--- a/.github/workflows/robust-orbit-query-stress.yml
+++ b/.github/workflows/robust-orbit-query-stress.yml
@@ -1,0 +1,181 @@
+name: Robust finite-orbit query identifiability
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/robust-orbit-query-stress.yml"
+      - "src/prob4d/robust_orbit_query.py"
+      - "tests/test_robust_orbit_query.py"
+      - "scripts/science/run_robust_orbit_query_stress.py"
+      - "protocols/robust-orbit-query-stress-v1.json"
+      - "docs/robust-orbit-query-identifiability.md"
+  push:
+    branches:
+      - research/robust-orbit-identifiability-v1
+    paths:
+      - ".github/workflows/robust-orbit-query-stress.yml"
+      - "src/prob4d/robust_orbit_query.py"
+      - "tests/test_robust_orbit_query.py"
+      - "scripts/science/run_robust_orbit_query_stress.py"
+      - "protocols/robust-orbit-query-stress-v1.json"
+      - "docs/robust-orbit-query-identifiability.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: robust-orbit-query-identifiability-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  OUTPUT_DIR: outputs/robust-orbit-query-stress-v1
+  PYTHONHASHSEED: "0"
+  PYTHONUNBUFFERED: "1"
+  PYTHONDONTWRITEBYTECODE: "1"
+  OMP_NUM_THREADS: "1"
+  OPENBLAS_NUM_THREADS: "1"
+  MKL_NUM_THREADS: "1"
+  NUMEXPR_NUM_THREADS: "1"
+
+jobs:
+  validate:
+    name: Certified bounded-error and sampling control
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Check out exact revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          clean: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install exact development environment
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --disable-pip-version-check -e ".[dev]"
+          python -m pip check
+
+      - name: Lint, format, and type-check focused implementation
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m ruff check \
+            src/prob4d/robust_orbit_query.py \
+            scripts/science/run_robust_orbit_query_stress.py \
+            tests/test_robust_orbit_query.py
+          python -m ruff format --check \
+            src/prob4d/robust_orbit_query.py \
+            scripts/science/run_robust_orbit_query_stress.py \
+            tests/test_robust_orbit_query.py
+          python -m mypy src/prob4d/robust_orbit_query.py
+
+      - name: Run focused certificate tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pytest -q tests/test_robust_orbit_query.py
+
+      - name: Execute registered robustness and efficiency study
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf "$OUTPUT_DIR"
+          python scripts/science/run_robust_orbit_query_stress.py \
+            --protocol protocols/robust-orbit-query-stress-v1.json \
+            --output "$OUTPUT_DIR/result.json"
+
+      - name: Independently verify registered result semantics
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          output = Path(os.environ["OUTPUT_DIR"])
+          result = json.loads((output / "result.json").read_text())
+          assert result["schema"] == "prob4d.robust-orbit-query-stress-result.v1"
+          assert result["decision"] == "passed"
+          assert all(result["registered_checks"].values())
+          assert result["population"]["case_count"] == 20000
+          assert result["population"]["maximum_diameter_interval_violation"] <= 1e-12
+          certified = [
+              row
+              for row in result["bounded_error_rows"]
+              if row["method"] == "certified_bounded_error"
+          ]
+          assert len(certified) == 7
+          assert all(
+              row["harmful_acceptance_count"] == 0 for row in certified
+          )
+          local_zero = next(
+              row
+              for row in result["bounded_error_rows"]
+              if row["method"] == "nominal_local_derivative"
+              and row["coefficient_error_ratio"] == 0.0
+          )
+          assert local_zero["harmful_acceptance_rate_among_variant"] > 0.2
+          sampled_certified = [
+              row
+              for row in result["sampled_orbit_rows"]
+              if row["method"] == "lipschitz_certified_sampling"
+          ]
+          assert len(sampled_certified) == 4
+          assert all(
+              row["harmful_acceptance_count"] == 0
+              and row["maximum_certified_upper_shortfall"] <= 1e-12
+              for row in sampled_certified
+          )
+          benchmark = result["benchmark"]
+          assert benchmark["query_count"] == 4096
+          assert benchmark["sampled_to_coefficient_storage_ratio"] == 32.0
+          unsigned = dict(result)
+          supplied = unsigned.pop("artifact_id")
+          encoded = json.dumps(
+              unsigned,
+              sort_keys=True,
+              separators=(",", ":"),
+              allow_nan=False,
+          ).encode()
+          assert hashlib.sha256(encoded).hexdigest() == supplied
+          assert set(path.name for path in output.iterdir()) == {
+              "result.json",
+              "result.md",
+          }
+          print({
+              "artifact_id": supplied,
+              "local_harmful_acceptance": local_zero[
+                  "harmful_acceptance_rate_among_variant"
+              ],
+              "runtime_ratio": benchmark["sampled_to_exact_runtime_ratio"],
+          })
+          PY
+
+      - name: Publish concise scientific summary
+        if: always()
+        shell: bash
+        run: |
+          if [[ -f "$OUTPUT_DIR/result.md" ]]; then
+            cat "$OUTPUT_DIR/result.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload complete derived evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: robust-orbit-query-stress-v1-${{ github.run_id }}-${{ github.run_attempt }}
+          path: outputs/robust-orbit-query-stress-v1/
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/temporary-retain-axial-geometry-bound-evidence.yml
+++ b/.github/workflows/temporary-retain-axial-geometry-bound-evidence.yml
@@ -1,0 +1,110 @@
+name: Temporary retain axial geometry-bound evidence
+
+on:
+  push:
+    branches:
+      - research/robust-orbit-identifiability-v1
+    paths:
+      - ".github/workflows/temporary-retain-axial-geometry-bound-evidence.yml"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: temporary-retain-axial-geometry-bound-evidence
+  cancel-in-progress: false
+
+env:
+  OUTPUT_DIR: outputs/axial-orbit-geometric-error-control-v1
+  EVIDENCE_DIR: evidence/axial-orbit-geometric-error-control-v1
+  PYTHONHASHSEED: "0"
+  PYTHONUNBUFFERED: "1"
+  PYTHONDONTWRITEBYTECODE: "1"
+  OMP_NUM_THREADS: "1"
+  OPENBLAS_NUM_THREADS: "1"
+  MKL_NUM_THREADS: "1"
+  NUMEXPR_NUM_THREADS: "1"
+
+jobs:
+  validate-and-retain:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: true
+          clean: true
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Install exact development environment
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --disable-pip-version-check -e ".[dev]"
+          python -m pip check
+      - name: Validate and execute complete geometric-bound control
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m ruff check \
+            src/prob4d/axial_orbit_geometry_bound.py \
+            scripts/science/run_axial_orbit_geometric_error_control.py \
+            tests/test_axial_orbit_geometry_bound.py \
+            tests/test_axial_orbit_geometry_control.py
+          python -m ruff format --check \
+            src/prob4d/axial_orbit_geometry_bound.py \
+            scripts/science/run_axial_orbit_geometric_error_control.py \
+            tests/test_axial_orbit_geometry_bound.py \
+            tests/test_axial_orbit_geometry_control.py
+          python -m mypy src/prob4d/axial_orbit_geometry_bound.py
+          python -m pytest -q \
+            tests/test_axial_orbit_geometry_bound.py \
+            tests/test_axial_orbit_geometry_control.py \
+            tests/test_robust_orbit_query.py
+          rm -rf "$OUTPUT_DIR"
+          python scripts/science/run_axial_orbit_geometric_error_control.py \
+            --protocol protocols/axial-orbit-geometric-error-control-v1.json \
+            --output "$OUTPUT_DIR/result.json"
+      - name: Verify and retain result
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          output = Path(os.environ["OUTPUT_DIR"])
+          result = json.loads((output / "result.json").read_text())
+          assert result["decision"] == "passed"
+          assert all(result["registered_checks"].values())
+          assert result["case_count"] == 5000
+          assert result["maximum_operator_bound_violation"] <= 1e-12
+          assert result["actual_to_bound_ratio_quantiles"]["q100"] <= 1.000000000001
+          evidence = Path(os.environ["EVIDENCE_DIR"])
+          if evidence.exists():
+              raise SystemExit("evidence directory already exists")
+          evidence.mkdir(parents=True)
+          (evidence / "result.json").write_bytes((output / "result.json").read_bytes())
+          (evidence / "summary.md").write_bytes((output / "result.md").read_bytes())
+          receipt = {
+              "schema": "prob4d.axial-orbit-geometric-error-retention.v1",
+              "workflow_run_id": int(os.environ["GITHUB_RUN_ID"]),
+              "workflow_run_attempt": int(os.environ["GITHUB_RUN_ATTEMPT"]),
+              "repository_revision": os.environ["GITHUB_SHA"],
+              "artifact_id": result["artifact_id"],
+              "protocol_sha256": result["protocol_sha256"],
+              "decision": result["decision"],
+              "all_registered_checks_passed": all(result["registered_checks"].values()),
+          }
+          (evidence / "retention.json").write_text(
+              json.dumps(receipt, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "$EVIDENCE_DIR"
+          git commit -m "Retain axial geometric error-bound control"
+          git push origin HEAD:research/robust-orbit-identifiability-v1

--- a/.github/workflows/temporary-retain-robust-orbit-evidence.yml
+++ b/.github/workflows/temporary-retain-robust-orbit-evidence.yml
@@ -1,0 +1,113 @@
+name: Temporary retain robust-orbit evidence
+
+on:
+  push:
+    branches:
+      - research/robust-orbit-identifiability-v1
+    paths:
+      - ".github/workflows/temporary-retain-robust-orbit-evidence.yml"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: temporary-retain-robust-orbit-evidence
+  cancel-in-progress: false
+
+env:
+  OUTPUT_DIR: outputs/robust-orbit-query-stress-v1
+  EVIDENCE_DIR: evidence/robust-orbit-query-stress-v1
+  PYTHONHASHSEED: "0"
+  PYTHONUNBUFFERED: "1"
+  PYTHONDONTWRITEBYTECODE: "1"
+  OMP_NUM_THREADS: "1"
+  OPENBLAS_NUM_THREADS: "1"
+  MKL_NUM_THREADS: "1"
+  NUMEXPR_NUM_THREADS: "1"
+
+jobs:
+  validate-and-retain:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: true
+          clean: true
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Install development environment
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --disable-pip-version-check -e ".[dev]"
+          python -m pip check
+      - name: Validate implementation and execute registered study
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m ruff check \
+            src/prob4d/robust_orbit_query.py \
+            scripts/science/run_robust_orbit_query_stress.py \
+            tests/test_robust_orbit_query.py
+          python -m ruff format --check \
+            src/prob4d/robust_orbit_query.py \
+            scripts/science/run_robust_orbit_query_stress.py \
+            tests/test_robust_orbit_query.py
+          python -m mypy src/prob4d/robust_orbit_query.py
+          python -m pytest -q tests/test_robust_orbit_query.py
+          rm -rf "$OUTPUT_DIR"
+          python scripts/science/run_robust_orbit_query_stress.py \
+            --protocol protocols/robust-orbit-query-stress-v1.json \
+            --output "$OUTPUT_DIR/result.json"
+      - name: Verify and retain complete result
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          output = Path(os.environ["OUTPUT_DIR"])
+          result = json.loads((output / "result.json").read_text())
+          assert result["decision"] == "passed"
+          assert all(result["registered_checks"].values())
+          assert result["population"]["case_count"] == 20000
+          assert max(
+              row["harmful_acceptance_rate_among_variant"]
+              for row in result["bounded_error_rows"]
+              if row["method"] == "certified_bounded_error"
+          ) == 0.0
+          assert max(
+              row["harmful_acceptance_rate"]
+              for row in result["sampled_orbit_rows"]
+              if row["method"] == "lipschitz_certified_sampling"
+          ) == 0.0
+          evidence = Path(os.environ["EVIDENCE_DIR"])
+          if evidence.exists():
+              raise SystemExit("evidence directory already exists")
+          evidence.mkdir(parents=True)
+          (evidence / "result.json").write_bytes((output / "result.json").read_bytes())
+          (evidence / "summary.md").write_bytes((output / "result.md").read_bytes())
+          receipt = {
+              "schema": "prob4d.robust-orbit-query-stress-retention.v1",
+              "workflow_run_id": int(os.environ["GITHUB_RUN_ID"]),
+              "workflow_run_attempt": int(os.environ["GITHUB_RUN_ATTEMPT"]),
+              "repository_revision": os.environ["GITHUB_SHA"],
+              "artifact_id": result["artifact_id"],
+              "protocol_sha256": result["protocol_sha256"],
+              "decision": result["decision"],
+              "all_registered_checks_passed": all(result["registered_checks"].values()),
+          }
+          (evidence / "retention.json").write_text(
+              json.dumps(receipt, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "$EVIDENCE_DIR"
+          git commit -m "Retain registered robust-orbit stress evidence"
+          git push origin HEAD:research/robust-orbit-identifiability-v1

--- a/.github/workflows/temporary-robust-geometry-autoformat.yml
+++ b/.github/workflows/temporary-robust-geometry-autoformat.yml
@@ -1,0 +1,52 @@
+name: Temporary robust geometry autoformat
+
+on:
+  push:
+    branches:
+      - research/robust-orbit-identifiability-v1
+    paths:
+      - ".github/workflows/temporary-robust-geometry-autoformat.yml"
+      - "src/prob4d/axial_orbit_geometry_bound.py"
+      - "tests/test_axial_orbit_geometry_bound.py"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: temporary-robust-geometry-autoformat
+  cancel-in-progress: false
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: true
+          clean: true
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Format exact files
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --disable-pip-version-check "ruff==0.12.12"
+          python -m ruff format \
+            src/prob4d/axial_orbit_geometry_bound.py \
+            tests/test_axial_orbit_geometry_bound.py
+      - name: Commit formatter output when needed
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git diff --quiet; then
+            echo "No formatter changes required."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add \
+            src/prob4d/axial_orbit_geometry_bound.py \
+            tests/test_axial_orbit_geometry_bound.py
+          git commit -m "Apply Ruff formatting to geometric orbit bound"
+          git push origin HEAD:research/robust-orbit-identifiability-v1

--- a/.github/workflows/temporary-robust-orbit-autoformat.yml
+++ b/.github/workflows/temporary-robust-orbit-autoformat.yml
@@ -1,0 +1,55 @@
+name: Temporary robust-orbit autoformat
+
+on:
+  push:
+    branches:
+      - research/robust-orbit-identifiability-v1
+    paths:
+      - ".github/workflows/temporary-robust-orbit-autoformat.yml"
+      - "src/prob4d/robust_orbit_query.py"
+      - "scripts/science/run_robust_orbit_query_stress.py"
+      - "tests/test_robust_orbit_query.py"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: temporary-robust-orbit-autoformat
+  cancel-in-progress: false
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: true
+          clean: true
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Format exact files
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --disable-pip-version-check "ruff==0.12.12"
+          python -m ruff format \
+            src/prob4d/robust_orbit_query.py \
+            scripts/science/run_robust_orbit_query_stress.py \
+            tests/test_robust_orbit_query.py
+      - name: Commit formatter output when needed
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git diff --quiet; then
+            echo "No formatter changes required."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add \
+            src/prob4d/robust_orbit_query.py \
+            scripts/science/run_robust_orbit_query_stress.py \
+            tests/test_robust_orbit_query.py
+          git commit -m "Apply Ruff formatting to robust-orbit contribution"
+          git push origin HEAD:research/robust-orbit-identifiability-v1

--- a/docs/axial-orbit-geometric-error-bound.md
+++ b/docs/axial-orbit-geometric-error-bound.md
@@ -1,0 +1,128 @@
+# From geometric uncertainty to an axial orbit certificate
+
+Status: **conservative deterministic error propagation**.
+
+`robust_orbit_query.certify_axial_linear_query` requires a bound
+
+\[
+\|B-\widehat B\|_2\leq\eta
+\]
+
+on the two-column coefficient matrix of the physical query orbit. This module
+provides a sufficient value of \(\eta\) from separately supplied Euclidean
+bounds on the estimated unit axis, pivot, point positions, and linear query
+map. It does not estimate or calibrate those geometric bounds.
+
+## Geometry
+
+Let \(u\) be the true unit axis, \(c\) the true pivot, and \(p_i\) one point.
+With \(r_i=p_i-c\), the axial orbit coefficients are
+
+\[
+a_i=(I-uu^\top)r_i,
+\qquad
+b_i=u\times a_i.
+\]
+
+For estimated quantities, suppose
+
+\[
+\|p_i-\widehat p_i\|_2\leq\epsilon_i,
+\quad
+\|c-\widehat c\|_2\leq\epsilon_c,
+\quad
+\|u-\widehat u\|_2\leq\epsilon_u.
+\]
+
+Define \(\delta_i=\epsilon_i+\epsilon_c\). For unit axes,
+
+\[
+\|uu^\top-\widehat u\widehat u^\top\|_2
+\leq 2\epsilon_u.
+\]
+
+Using the estimated offset \(\widehat r_i=\widehat p_i-\widehat c\), a sufficient
+cosine-coefficient bound is
+
+\[
+\|a_i-\widehat a_i\|_2
+\leq
+\delta_i+ho\|\widehat r_i\|_2,
+\qquad
+\rho=\min(2,2\epsilon_u).
+\]
+
+Writing this bound as \(\alpha_i\), the true cosine coefficient satisfies
+\(\|a_i\|\leq\|\widehat a_i\|+\alpha_i\). Hence
+
+\[
+\|b_i-\widehat b_i\|_2
+\leq
+\alpha_i+\epsilon_u(\|\widehat a_i\|_2+\alpha_i).
+\]
+
+Stack the pointwise cosine and sine errors into a matrix \(E\in\mathbb R^{3N\times2}\).
+The per-point bounds imply
+
+\[
+\|E\|_2\leq\|E\|_F
+\leq
+\sqrt{\sum_i\alpha_i^2+\sum_i\beta_i^2},
+\]
+
+where \(\beta_i\) is the sine-coefficient bound above. For a linear query
+\(q=Wp\), the projected coefficient error is therefore bounded by
+
+\[
+\|WE\|_2
+\leq
+\|W\|_2
+\sqrt{\sum_i\alpha_i^2+\sum_i\beta_i^2}
+=: \eta_{\rm geom}.
+\]
+
+`bound_axial_query_coefficient_error` returns this value together with every
+intermediate bound. It can be passed directly to
+`certify_axial_linear_query`.
+
+## Interpretation
+
+The bound is deliberately conservative. Its role is to preserve the safety
+semantics of the query gate:
+
+- a small validated geometry budget can certify useful invariant queries;
+- a clearly variant query can be certified non-identifiable;
+- a loose budget yields an undetermined decision and exact fallback;
+- a loose budget must not be hidden by replacing it with a nominal orbit.
+
+Conservatism affects acceptance and fallback frequency, not the guarantee that
+a certified invariant query lies below the declared diameter tolerance.
+
+The axis error is the Euclidean distance between the true and estimated unit
+axis vectors. Axis sign is part of the angular convention: if the sign is
+unresolved, the caller must canonicalize the axis and angular law consistently
+or use a bound that covers the ambiguity. The point, pivot, and axis bounds must
+hold simultaneously for the case being certified.
+
+## Validation
+
+The focused test suite includes 400 random multi-point, multi-query adversarial
+instances. In every instance it constructs a true axis, pivot, and point cloud
+inside the supplied bounds and verifies that the actual spectral-norm error of
+the projected coefficient matrix does not exceed the returned value. It also
+checks independent Rodrigues propagation, similarity-frame equivariance,
+zero-error exactness, immutable outputs, and malformed contracts.
+
+The permanent CI composes the geometric budget with the three-way orbit
+certificate on an off-axis vector query. The resulting query is certified
+variant without reading a physical outcome.
+
+## Claim boundary
+
+This is a deterministic implication from supplied geometric bounds. It is not
+a learned uncertainty estimator, a confidence interval obtained from repeated
+data, or evidence that any particular provider satisfies the bounds. A future
+learned-provider experiment must estimate and validate the point, axis, and
+pivot budgets on source groups before applying the certificate to held-out
+queries. The recording-disjoint Tracking Cloth experiment remains a controlled
+hidden-gauge real-trajectory result.

--- a/docs/robust-orbit-query-identifiability.md
+++ b/docs/robust-orbit-query-identifiability.md
@@ -1,0 +1,167 @@
+# Certified query identifiability under approximate finite orbits
+
+Status: **experimental fail-closed certificate and designed robustness control**.
+
+The recording-disjoint Tracking Cloth result shows that a local query gate can
+accept a query that changes over an unresolved finite orbit. That primary result
+uses a controlled exact SO(2) ambiguity. This module addresses the principal
+robustness objection: in practice the orbit coefficients, or a numerical orbit
+sample, may only be approximately known.
+
+## Exact axial linear-query diameter
+
+For a vector query whose axial orbit is
+
+\[
+q(\theta)=c+B
+\begin{bmatrix}
+\cos\theta\\
+\sin\theta
+\end{bmatrix},
+\qquad B\in\mathbb R^{d\times 2},
+\]
+
+the complete Euclidean orbit diameter is
+
+\[
+d(B)=\max_{\theta,\phi}\|q(\theta)-q(\phi)\|_2
+    =2\sigma_{\max}(B).
+\]
+
+The equality follows because differences between antipodal circle points span
+all vectors of norm two. `batch_axial_orbit_diameters` evaluates this expression
+from the two-by-two Gram matrix, vectorized over any number of queries.
+
+A local derivative at one representative is
+
+\[
+q'(\theta_0)=B[-\sin\theta_0,\cos\theta_0]^\top.
+\]
+
+It can vanish even when \(d(B)>0\). For example, the scalar query
+\(q(\theta)=\cos\theta\) has \(q'(0)=0\) and diameter two.
+
+## Certified coefficient-error interval
+
+Let \(\widehat B\) be the estimated coefficient matrix and suppose a separately
+justified bound satisfies
+
+\[
+\|B-\widehat B\|_2\leq\eta.
+\]
+
+Singular-value perturbation gives
+
+\[
+|\sigma_{\max}(B)-\sigma_{\max}(\widehat B)|\leq\eta,
+\]
+
+and therefore
+
+\[
+d(B)\in
+\left[
+\max(0,d(\widehat B)-2\eta),
+ d(\widehat B)+2\eta
+\right].
+\]
+
+For an invariance tolerance \(\tau\), the gate has three outcomes:
+
+- **certified invariant:** the upper diameter bound is at most \(\tau\);
+- **certified variant:** the lower diameter bound exceeds \(\tau\);
+- **undetermined:** the interval crosses \(\tau\).
+
+Only the first outcome admits an update. The undetermined case uses the caller's
+registered fallback. Consequently a valid coefficient-error bound prevents a
+truly variant query from being admitted, while larger estimation error manifests
+as more fallback rather than hidden harmful acceptance.
+
+The module does not infer \(\eta\). It may come from a geometric perturbation
+bound, a source-calibrated bootstrap, a provider ensemble, or another method
+whose validity is separately established. Supplying an optimistic bound voids
+the certificate.
+
+## Certified sampled nonlinear orbits
+
+For a general periodic query \(q(\theta)\), suppose
+
+\[
+\|q(\theta)-q(\phi)\|_2\leq L|\theta-\phi|
+\]
+
+under circular angular distance. A uniform grid of \(K\) samples has angular
+cover radius \(\pi/K\). If its finite-sample diameter is \(d_K\), then
+
+\[
+d_K\leq d(q)\leq d_K+2L\pi/K.
+\]
+
+`certify_uniformly_sampled_periodic_query` applies the same three-way decision
+to this interval. This turns orbit discretization into an explicit conservatism
+budget. Uncertified finite sampling can miss near-boundary variant queries;
+the Lipschitz margin converts that error into fallback.
+
+## Registered robustness study
+
+The protocol in `protocols/robust-orbit-query-stress-v1.json` freezes:
+
+- 20,000 balanced invariant/variant query orbits;
+- three-dimensional vector queries;
+- 50% stationary-representative cases;
+- coefficient-error bounds from zero to 0.8 times the invariance tolerance;
+- odd orbit grids of 7, 15, 31, and 63 samples;
+- 10,000 near-boundary variant queries for the sampling test;
+- a 4,096-query computational control.
+
+It compares:
+
+1. the certified bounded-error gate;
+2. a naive gate using only the estimated diameter;
+3. a nominal local-derivative gate;
+4. Lipschitz-certified uniform orbit sampling;
+5. naive uniform orbit sampling.
+
+The registered scientific checks require zero harmful acceptance from both
+certified gates, a nonzero failure rate for the naive approximations, and dense
+SVD parity for the exact two-column diameter. Useful-query acceptance and
+fallback are reported across the full error sweep; no claim is based on hiding
+that conservatism.
+
+Run:
+
+```bash
+python scripts/science/run_robust_orbit_query_stress.py \
+  --protocol protocols/robust-orbit-query-stress-v1.json \
+  --output outputs/robust-orbit-query-stress-v1/result.json
+```
+
+The output path is exclusive and includes the complete protocol, all rows,
+runtime information, registered checks, and a canonical artifact identity.
+
+## Relationship to real-data evidence
+
+The public Tracking Cloth experiment remains the claim-bearing real-trajectory
+mechanism result:
+
+- 24 source recordings;
+- 15 outcome-blind, header-supported held-out recordings;
+- 1,803 controlled real-trajectory cases;
+- approximately 65.1% harmful radial updates from the local gate;
+- zero harmful accepted radial updates from the finite-orbit gate;
+- invariant-query acceptance of one.
+
+This robustness study does not create another independent real-data cohort. It
+shows that the method has a mathematically controlled non-ideal regime: bounded
+orbit-estimation and discretization errors enlarge fallback rather than silently
+admitting an uncertified query.
+
+## Claim boundary
+
+This module certifies only the supplied mathematical error contract. It does not
+establish that a learned provider's error bound is valid, infer the physical
+symmetry from images, recover cloth state, or prove downstream BayesianPhysTwin
+benefit. The CUT3R/DOT learned-provider confirmation remains separately reported
+as support-negative. A future end-to-end experiment must estimate and validate
+the orbit uncertainty on source groups before using this certificate on held-out
+provider outcomes.

--- a/protocols/axial-orbit-geometric-error-control-v1.json
+++ b/protocols/axial-orbit-geometric-error-control-v1.json
@@ -1,0 +1,18 @@
+{
+  "schema": "prob4d.axial-orbit-geometric-error-control.v1",
+  "evidence_kind": "designed-geometric-error-bound-control",
+  "seed": 20260902,
+  "case_count": 5000,
+  "point_count_range": [3, 20],
+  "query_dimension_range": [1, 8],
+  "maximum_point_error": 0.08,
+  "maximum_pivot_error": 0.08,
+  "maximum_axis_tangent_perturbation": 0.35,
+  "registered_checks": {
+    "maximum_operator_bound_violation": 1e-12,
+    "minimum_nonzero_ratio_count": 4900,
+    "maximum_actual_to_bound_ratio": 1.000000000001,
+    "minimum_maximum_actual_to_bound_ratio": 0.01
+  },
+  "claim_boundary": "Designed deterministic validation of the supplied simultaneous point, pivot, and unit-axis error contract. Ratio statistics describe this random control distribution only; they do not calibrate a learned provider or establish empirical confidence coverage."
+}

--- a/protocols/robust-orbit-query-stress-v1.json
+++ b/protocols/robust-orbit-query-stress-v1.json
@@ -1,0 +1,30 @@
+{
+  "schema": "prob4d.robust-orbit-query-stress.v1",
+  "evidence_kind": "designed-bounded-error-robustness-control",
+  "seed": 20260902,
+  "case_count": 20000,
+  "query_dimension": 3,
+  "stationary_case_fraction": 0.5,
+  "invariance_tolerance": 1.0,
+  "invariant_diameter_range": [0.0, 0.95],
+  "variant_diameter_range": [1.05, 2.0],
+  "coefficient_error_ratios": [0.0, 0.02, 0.05, 0.1, 0.2, 0.4, 0.8],
+  "sampled_grid_counts": [7, 15, 31, 63],
+  "near_boundary_case_count": 10000,
+  "near_boundary_variant_diameter_range": [1.000001, 1.1],
+  "benchmark": {
+    "query_count": 4096,
+    "query_dimension": 3,
+    "angular_sample_count": 64,
+    "repetitions": 25
+  },
+  "registered_checks": {
+    "maximum_certified_harmful_acceptance_rate": 0.0,
+    "minimum_local_harmful_acceptance_rate_at_zero_error": 0.2,
+    "minimum_positive_error_naive_harmful_acceptance_rate": 0.0,
+    "maximum_sampled_certified_harmful_acceptance_rate": 0.0,
+    "minimum_coarse_naive_sampled_harmful_acceptance_rate": 0.0,
+    "maximum_factorized_dense_diameter_error": 1e-12
+  },
+  "claim_boundary": "Designed robustness and computational control for a supplied valid coefficient-error or Lipschitz bound. It does not estimate those bounds, establish learned-provider competence, constitute an independent real-data confirmation, or demonstrate BayesianPhysTwin or Causal4D benefit."
+}

--- a/scripts/science/run_axial_orbit_geometric_error_control.py
+++ b/scripts/science/run_axial_orbit_geometric_error_control.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Validate and quantify the conservative axial geometric error budget."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import platform
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from prob4d.axial_orbit_geometry_bound import (
+    bound_axial_query_coefficient_error,
+    project_axial_query_coefficients,
+)
+
+SCHEMA = "prob4d.axial-orbit-geometric-error-control.v1"
+RESULT_SCHEMA = "prob4d.axial-orbit-geometric-error-control-result.v1"
+
+
+def _canonical(value: object) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode()
+
+
+def _content_id(value: object) -> str:
+    return hashlib.sha256(_canonical(value)).hexdigest()
+
+
+def _interval(
+    value: object,
+    *,
+    name: str,
+    integer: bool,
+    minimum: float,
+) -> tuple[float, float] | tuple[int, int]:
+    if not isinstance(value, list) or len(value) != 2:
+        raise ValueError(f"{name} must contain two values")
+    if integer:
+        if any(type(item) is not int for item in value):
+            raise ValueError(f"{name} must contain integers")
+        lower, upper = int(value[0]), int(value[1])
+    else:
+        if any(isinstance(item, bool) or not isinstance(item, (int, float)) for item in value):
+            raise ValueError(f"{name} must contain real values")
+        lower, upper = float(value[0]), float(value[1])
+    if lower < minimum or upper < lower:
+        raise ValueError(f"{name} is invalid")
+    return lower, upper
+
+
+def _load_protocol(path: Path) -> dict[str, Any]:
+    protocol = json.loads(path.read_text(encoding="utf-8"))
+    expected = {
+        "schema",
+        "evidence_kind",
+        "seed",
+        "case_count",
+        "point_count_range",
+        "query_dimension_range",
+        "maximum_point_error",
+        "maximum_pivot_error",
+        "maximum_axis_tangent_perturbation",
+        "registered_checks",
+        "claim_boundary",
+    }
+    if type(protocol) is not dict or set(protocol) != expected:
+        raise ValueError("protocol fields changed")
+    if protocol["schema"] != SCHEMA:
+        raise ValueError("protocol schema changed")
+    if protocol["evidence_kind"] != "designed-geometric-error-bound-control":
+        raise ValueError("evidence kind changed")
+    if type(protocol["seed"]) is not int:
+        raise ValueError("seed must be an integer")
+    if type(protocol["case_count"]) is not int or protocol["case_count"] < 1000:
+        raise ValueError("case_count must be an integer of at least 1000")
+    _interval(
+        protocol["point_count_range"],
+        name="point_count_range",
+        integer=True,
+        minimum=1,
+    )
+    _interval(
+        protocol["query_dimension_range"],
+        name="query_dimension_range",
+        integer=True,
+        minimum=1,
+    )
+    for name in (
+        "maximum_point_error",
+        "maximum_pivot_error",
+        "maximum_axis_tangent_perturbation",
+    ):
+        value = protocol[name]
+        if (
+            isinstance(value, bool)
+            or not isinstance(value, (int, float))
+            or not np.isfinite(value)
+            or float(value) <= 0.0
+        ):
+            raise ValueError(f"{name} must be finite and positive")
+    if float(protocol["maximum_axis_tangent_perturbation"]) > 1.0:
+        raise ValueError("axis tangent perturbation is unexpectedly broad")
+    checks = protocol["registered_checks"]
+    if set(checks) != {
+        "maximum_operator_bound_violation",
+        "minimum_nonzero_ratio_count",
+        "maximum_actual_to_bound_ratio",
+        "minimum_maximum_actual_to_bound_ratio",
+    }:
+        raise ValueError("registered checks changed")
+    if not isinstance(protocol["claim_boundary"], str) or not protocol["claim_boundary"].strip():
+        raise ValueError("claim_boundary is invalid")
+    return protocol
+
+
+def _unit(value: np.ndarray) -> np.ndarray:
+    norm = float(np.linalg.norm(value))
+    if norm == 0.0:
+        raise ValueError("cannot normalize a zero vector")
+    return value / norm
+
+
+def _quantiles(values: np.ndarray) -> dict[str, float]:
+    return {
+        f"q{int(probability * 100):02d}": float(np.quantile(values, probability))
+        for probability in (0.0, 0.05, 0.25, 0.5, 0.75, 0.95, 0.99, 1.0)
+    }
+
+
+def build_report(protocol: dict[str, Any]) -> dict[str, Any]:
+    rng = np.random.default_rng(int(protocol["seed"]))
+    point_range = _interval(
+        protocol["point_count_range"],
+        name="point_count_range",
+        integer=True,
+        minimum=1,
+    )
+    query_range = _interval(
+        protocol["query_dimension_range"],
+        name="query_dimension_range",
+        integer=True,
+        minimum=1,
+    )
+    assert isinstance(point_range[0], int)
+    assert isinstance(query_range[0], int)
+
+    ratios: list[float] = []
+    slacks: list[float] = []
+    actual_errors: list[float] = []
+    bounds: list[float] = []
+    axis_errors: list[float] = []
+    point_error_maxima: list[float] = []
+    pivot_errors: list[float] = []
+    maximum_violation = 0.0
+
+    for _ in range(int(protocol["case_count"])):
+        point_count = int(rng.integers(point_range[0], point_range[1] + 1))
+        query_dimension = int(rng.integers(query_range[0], query_range[1] + 1))
+        estimated_points = rng.normal(size=(point_count, 3))
+        estimated_axis = _unit(rng.normal(size=3))
+        estimated_pivot = rng.normal(size=3)
+        query_weights = rng.normal(size=(query_dimension, point_count, 3))
+
+        point_limits = rng.uniform(
+            0.0,
+            float(protocol["maximum_point_error"]),
+            size=point_count,
+        )
+        point_directions = rng.normal(size=(point_count, 3))
+        point_directions /= np.linalg.norm(point_directions, axis=1)[:, None]
+        point_magnitudes = rng.uniform(0.0, 1.0, size=point_count) * point_limits
+        true_points = estimated_points + point_directions * point_magnitudes[:, None]
+
+        pivot_limit = float(
+            rng.uniform(0.0, float(protocol["maximum_pivot_error"]))
+        )
+        pivot_direction = _unit(rng.normal(size=3))
+        pivot_magnitude = float(rng.uniform(0.0, pivot_limit))
+        true_pivot = estimated_pivot + pivot_direction * pivot_magnitude
+
+        tangent = rng.normal(size=3)
+        tangent -= estimated_axis * float(tangent @ estimated_axis)
+        if float(np.linalg.norm(tangent)) < 1e-14:
+            seed = np.array([1.0, 0.0, 0.0])
+            if abs(float(seed @ estimated_axis)) > 0.9:
+                seed = np.array([0.0, 1.0, 0.0])
+            tangent = seed - estimated_axis * float(seed @ estimated_axis)
+        tangent = _unit(tangent)
+        tangent_scale = float(
+            rng.uniform(
+                0.0,
+                float(protocol["maximum_axis_tangent_perturbation"]),
+            )
+        )
+        true_axis = _unit(estimated_axis + tangent_scale * tangent)
+        axis_error = float(np.linalg.norm(true_axis - estimated_axis))
+
+        estimate = project_axial_query_coefficients(
+            estimated_points,
+            axis=estimated_axis,
+            pivot=estimated_pivot,
+            query_weights=query_weights,
+        )
+        truth = project_axial_query_coefficients(
+            true_points,
+            axis=true_axis,
+            pivot=true_pivot,
+            query_weights=query_weights,
+        )
+        actual = float(np.linalg.svd(truth - estimate, compute_uv=False)[0])
+        budget = bound_axial_query_coefficient_error(
+            estimated_points,
+            estimated_axis=estimated_axis,
+            estimated_pivot=estimated_pivot,
+            query_weights=query_weights,
+            point_position_error_bounds=point_limits,
+            axis_vector_error_bound=axis_error,
+            pivot_position_error_bound=pivot_limit,
+        )
+        bound = budget.coefficient_operator_error_bound
+        violation = max(0.0, actual - bound)
+        maximum_violation = max(maximum_violation, violation)
+        actual_errors.append(actual)
+        bounds.append(bound)
+        slacks.append(bound - actual)
+        axis_errors.append(axis_error)
+        point_error_maxima.append(float(np.max(point_limits)))
+        pivot_errors.append(pivot_limit)
+        if bound > 0.0:
+            ratios.append(actual / bound)
+
+    ratio_array = np.asarray(ratios, dtype=np.float64)
+    bound_array = np.asarray(bounds, dtype=np.float64)
+    actual_array = np.asarray(actual_errors, dtype=np.float64)
+    slack_array = np.asarray(slacks, dtype=np.float64)
+    checks = protocol["registered_checks"]
+    registered = {
+        "no_operator_bound_violation": maximum_violation
+        <= float(checks["maximum_operator_bound_violation"]),
+        "enough_nonzero_ratio_cases": ratio_array.size
+        >= int(checks["minimum_nonzero_ratio_count"]),
+        "all_actual_to_bound_ratios_at_most_one": float(np.max(ratio_array))
+        <= float(checks["maximum_actual_to_bound_ratio"]),
+        "control_exercises_nontrivial_bound_tightness": float(np.max(ratio_array))
+        >= float(checks["minimum_maximum_actual_to_bound_ratio"]),
+    }
+    report: dict[str, Any] = {
+        "schema": RESULT_SCHEMA,
+        "evidence_kind": protocol["evidence_kind"],
+        "protocol": protocol,
+        "protocol_sha256": _content_id(protocol),
+        "runtime": {
+            "python": platform.python_version(),
+            "numpy": np.__version__,
+            "platform": platform.platform(),
+        },
+        "case_count": int(protocol["case_count"]),
+        "nonzero_ratio_count": int(ratio_array.size),
+        "maximum_operator_bound_violation": maximum_violation,
+        "actual_to_bound_ratio_quantiles": _quantiles(ratio_array),
+        "actual_error_quantiles": _quantiles(actual_array),
+        "coefficient_bound_quantiles": _quantiles(bound_array),
+        "bound_slack_quantiles": _quantiles(slack_array),
+        "axis_error_quantiles": _quantiles(np.asarray(axis_errors)),
+        "maximum_point_error_quantiles": _quantiles(
+            np.asarray(point_error_maxima)
+        ),
+        "pivot_error_bound_quantiles": _quantiles(np.asarray(pivot_errors)),
+        "registered_checks": registered,
+        "decision": "passed" if all(registered.values()) else "failed",
+        "claim_boundary": protocol["claim_boundary"],
+    }
+    report["artifact_id"] = _content_id(report)
+    return report
+
+
+def _summary(report: dict[str, Any]) -> str:
+    ratio = report["actual_to_bound_ratio_quantiles"]
+    return "\n".join(
+        (
+            "# Axial geometric error-bound control",
+            "",
+            f"Artifact ID: `{report['artifact_id']}`",
+            "",
+            f"Decision: **{report['decision']}**",
+            "",
+            f"Cases: {report['case_count']}",
+            "",
+            f"Maximum operator-bound violation: {report['maximum_operator_bound_violation']:.6g}",
+            "",
+            "Actual coefficient error divided by the conservative returned bound:",
+            "",
+            f"- median: {ratio['q50']:.6f}",
+            f"- 95th percentile: {ratio['q95']:.6f}",
+            f"- 99th percentile: {ratio['q99']:.6f}",
+            f"- maximum: {ratio['q100']:.6f}",
+            "",
+            report["claim_boundary"],
+            "",
+        )
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--protocol", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    protocol = _load_protocol(args.protocol)
+    report = build_report(protocol)
+    if args.output.exists():
+        raise FileExistsError(f"refusing to overwrite {args.output}")
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(report, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    args.output.with_suffix(".md").write_text(
+        _summary(report),
+        encoding="utf-8",
+    )
+    print(
+        json.dumps(
+            {
+                "artifact_id": report["artifact_id"],
+                "decision": report["decision"],
+            },
+            sort_keys=True,
+        )
+    )
+    return 0 if report["decision"] == "passed" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/science/run_robust_orbit_query_stress.py
+++ b/scripts/science/run_robust_orbit_query_stress.py
@@ -1,0 +1,613 @@
+#!/usr/bin/env python3
+"""Run the registered approximate-orbit query-identifiability control."""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import hashlib
+import json
+import math
+import platform
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from prob4d.robust_orbit_query import batch_axial_orbit_diameters
+
+SCHEMA = "prob4d.robust-orbit-query-stress.v1"
+RESULT_SCHEMA = "prob4d.robust-orbit-query-stress-result.v1"
+
+
+def _canonical(value: object) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode()
+
+
+def _content_id(value: object) -> str:
+    return hashlib.sha256(_canonical(value)).hexdigest()
+
+
+def _load_protocol(path: Path) -> dict[str, Any]:
+    protocol = json.loads(path.read_text(encoding="utf-8"))
+    expected = {
+        "schema",
+        "evidence_kind",
+        "seed",
+        "case_count",
+        "query_dimension",
+        "stationary_case_fraction",
+        "invariance_tolerance",
+        "invariant_diameter_range",
+        "variant_diameter_range",
+        "coefficient_error_ratios",
+        "sampled_grid_counts",
+        "near_boundary_case_count",
+        "near_boundary_variant_diameter_range",
+        "benchmark",
+        "registered_checks",
+        "claim_boundary",
+    }
+    if type(protocol) is not dict or set(protocol) != expected:
+        raise ValueError("protocol fields changed")
+    if protocol["schema"] != SCHEMA:
+        raise ValueError("protocol schema changed")
+    if protocol["evidence_kind"] != "designed-bounded-error-robustness-control":
+        raise ValueError("evidence kind changed")
+    for name, lower in (
+        ("case_count", 1000),
+        ("query_dimension", 1),
+        ("near_boundary_case_count", 1000),
+    ):
+        if type(protocol[name]) is not int or protocol[name] < lower:
+            raise ValueError(f"{name} is invalid")
+    if type(protocol["seed"]) is not int:
+        raise ValueError("seed must be an integer")
+    fraction = float(protocol["stationary_case_fraction"])
+    if not 0.0 <= fraction <= 1.0:
+        raise ValueError("stationary_case_fraction is invalid")
+    tolerance = float(protocol["invariance_tolerance"])
+    if not math.isfinite(tolerance) or tolerance <= 0.0:
+        raise ValueError("invariance_tolerance is invalid")
+    invariant = protocol["invariant_diameter_range"]
+    variant = protocol["variant_diameter_range"]
+    near = protocol["near_boundary_variant_diameter_range"]
+    for name, interval in (
+        ("invariant_diameter_range", invariant),
+        ("variant_diameter_range", variant),
+        ("near_boundary_variant_diameter_range", near),
+    ):
+        if (
+            not isinstance(interval, list)
+            or len(interval) != 2
+            or not all(isinstance(value, (int, float)) for value in interval)
+            or not 0.0 <= float(interval[0]) < float(interval[1])
+        ):
+            raise ValueError(f"{name} is invalid")
+    if float(invariant[1]) >= tolerance or float(variant[0]) <= tolerance:
+        raise ValueError("class intervals must be separated by the tolerance")
+    if float(near[0]) <= tolerance:
+        raise ValueError("near-boundary cases must be truly variant")
+    ratios = protocol["coefficient_error_ratios"]
+    if (
+        not isinstance(ratios, list)
+        or not ratios
+        or float(ratios[0]) != 0.0
+        or any(float(value) < 0.0 for value in ratios)
+        or sorted(float(value) for value in ratios)
+        != [float(value) for value in ratios]
+        or len(set(float(value) for value in ratios)) != len(ratios)
+    ):
+        raise ValueError("coefficient_error_ratios is invalid")
+    sample_counts = protocol["sampled_grid_counts"]
+    if (
+        not isinstance(sample_counts, list)
+        or any(type(value) is not int or value < 3 or value % 2 == 0 for value in sample_counts)
+        or sorted(sample_counts) != sample_counts
+    ):
+        raise ValueError("sampled_grid_counts must be increasing odd integers")
+    benchmark = protocol["benchmark"]
+    if set(benchmark) != {
+        "query_count",
+        "query_dimension",
+        "angular_sample_count",
+        "repetitions",
+    }:
+        raise ValueError("benchmark fields changed")
+    if any(type(benchmark[name]) is not int or benchmark[name] <= 0 for name in benchmark):
+        raise ValueError("benchmark values must be positive integers")
+    checks = protocol["registered_checks"]
+    if set(checks) != {
+        "maximum_certified_harmful_acceptance_rate",
+        "minimum_local_harmful_acceptance_rate_at_zero_error",
+        "minimum_positive_error_naive_harmful_acceptance_rate",
+        "maximum_sampled_certified_harmful_acceptance_rate",
+        "minimum_coarse_naive_sampled_harmful_acceptance_rate",
+        "maximum_factorized_dense_diameter_error",
+    }:
+        raise ValueError("registered checks changed")
+    if not isinstance(protocol["claim_boundary"], str) or not protocol["claim_boundary"].strip():
+        raise ValueError("claim_boundary is invalid")
+    return protocol
+
+
+def _unit_vectors(rng: np.random.Generator, count: int, dimension: int) -> np.ndarray:
+    values = rng.normal(size=(count, dimension))
+    norms = np.linalg.norm(values, axis=1)
+    while np.any(norms == 0.0):
+        mask = norms == 0.0
+        values[mask] = rng.normal(size=(int(np.count_nonzero(mask)), dimension))
+        norms = np.linalg.norm(values, axis=1)
+    return values / norms[:, None]
+
+
+def _coefficient_bank(
+    rng: np.random.Generator,
+    diameters: np.ndarray,
+    query_dimension: int,
+    stationary_fraction: float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    count = diameters.size
+    stationary = rng.random(count) < stationary_fraction
+    phase = rng.uniform(-np.pi, np.pi, size=count)
+    coefficients = np.empty((count, query_dimension, 2), dtype=np.float64)
+
+    stationary_count = int(np.count_nonzero(stationary))
+    directions = _unit_vectors(rng, stationary_count, query_dimension)
+    phase_vectors = np.column_stack((np.cos(phase[stationary]), np.sin(phase[stationary])))
+    coefficients[stationary] = (
+        0.5
+        * diameters[stationary, None, None]
+        * directions[:, :, None]
+        * phase_vectors[:, None, :]
+    )
+
+    general = ~stationary
+    general_count = int(np.count_nonzero(general))
+    raw = rng.normal(size=(general_count, query_dimension, 2))
+    raw_sigma = batch_axial_orbit_diameters(raw) / 2.0
+    while np.any(raw_sigma == 0.0):
+        mask = raw_sigma == 0.0
+        raw[mask] = rng.normal(size=(int(np.count_nonzero(mask)), query_dimension, 2))
+        raw_sigma = batch_axial_orbit_diameters(raw) / 2.0
+    coefficients[general] = raw * (
+        0.5 * diameters[general] / raw_sigma
+    )[:, None, None]
+    nominal_angles = rng.uniform(-np.pi, np.pi, size=count)
+    nominal_angles[stationary] = phase[stationary]
+    return coefficients, nominal_angles, stationary
+
+
+def _bounded_perturbations(
+    rng: np.random.Generator,
+    shape: tuple[int, int, int],
+    error_bound: float,
+) -> np.ndarray:
+    if error_bound == 0.0:
+        return np.zeros(shape, dtype=np.float64)
+    raw = rng.normal(size=shape)
+    sigma = batch_axial_orbit_diameters(raw) / 2.0
+    magnitudes = rng.uniform(0.0, error_bound, size=shape[0])
+    return raw * (magnitudes / sigma)[:, None, None]
+
+
+def _gate_metrics(
+    admitted: np.ndarray,
+    true_invariant: np.ndarray,
+    *,
+    undetermined: np.ndarray | None = None,
+) -> dict[str, Any]:
+    true_variant = ~true_invariant
+    if undetermined is None:
+        undetermined = np.zeros(admitted.shape, dtype=bool)
+    return {
+        "admitted_count": int(np.count_nonzero(admitted)),
+        "harmful_acceptance_count": int(np.count_nonzero(admitted & true_variant)),
+        "harmful_acceptance_rate_among_variant": float(np.mean(admitted[true_variant])),
+        "useful_acceptance_count": int(np.count_nonzero(admitted & true_invariant)),
+        "useful_acceptance_rate_among_invariant": float(np.mean(admitted[true_invariant])),
+        "fallback_count": int(np.count_nonzero(~admitted)),
+        "fallback_rate": float(np.mean(~admitted)),
+        "undetermined_count": int(np.count_nonzero(undetermined)),
+        "undetermined_rate": float(np.mean(undetermined)),
+    }
+
+
+def _bounded_error_study(
+    protocol: dict[str, Any],
+    rng: np.random.Generator,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    count = int(protocol["case_count"])
+    tolerance = float(protocol["invariance_tolerance"])
+    half = count // 2
+    invariant_interval = protocol["invariant_diameter_range"]
+    variant_interval = protocol["variant_diameter_range"]
+    diameters = np.concatenate(
+        (
+            rng.uniform(*invariant_interval, size=half),
+            rng.uniform(*variant_interval, size=count - half),
+        )
+    )
+    permutation = rng.permutation(count)
+    diameters = diameters[permutation]
+    coefficients, angles, stationary = _coefficient_bank(
+        rng,
+        diameters,
+        int(protocol["query_dimension"]),
+        float(protocol["stationary_case_fraction"]),
+    )
+    true_invariant = diameters <= tolerance
+    rows: list[dict[str, Any]] = []
+    maximum_bound_violation = 0.0
+    for ratio_value in protocol["coefficient_error_ratios"]:
+        ratio = float(ratio_value)
+        error_bound = ratio * tolerance
+        perturbation = _bounded_perturbations(
+            rng,
+            coefficients.shape,
+            error_bound,
+        )
+        estimated_coefficients = coefficients + perturbation
+        estimated_diameter = batch_axial_orbit_diameters(estimated_coefficients)
+        lower = np.maximum(0.0, estimated_diameter - 2.0 * error_bound)
+        upper = estimated_diameter + 2.0 * error_bound
+        maximum_bound_violation = max(
+            maximum_bound_violation,
+            float(np.max(np.maximum(lower - diameters, 0.0))),
+            float(np.max(np.maximum(diameters - upper, 0.0))),
+        )
+        robust_admitted = upper <= tolerance
+        robust_variant = lower > tolerance
+        robust_undetermined = ~(robust_admitted | robust_variant)
+        naive_admitted = estimated_diameter <= tolerance
+        tangent = np.column_stack((-np.sin(angles), np.cos(angles)))
+        derivative = np.einsum(
+            "ndk,nk->nd",
+            estimated_coefficients,
+            tangent,
+        )
+        local_diameter_proxy = 2.0 * np.linalg.norm(derivative, axis=1)
+        local_admitted = local_diameter_proxy <= tolerance
+        for method, admitted, undetermined in (
+            ("certified_bounded_error", robust_admitted, robust_undetermined),
+            ("naive_estimated_diameter", naive_admitted, None),
+            ("nominal_local_derivative", local_admitted, None),
+        ):
+            rows.append(
+                {
+                    "coefficient_error_ratio": ratio,
+                    "coefficient_error_bound": error_bound,
+                    "method": method,
+                    **_gate_metrics(
+                        admitted,
+                        true_invariant,
+                        undetermined=undetermined,
+                    ),
+                }
+            )
+    return rows, {
+        "case_count": count,
+        "invariant_case_count": int(np.count_nonzero(true_invariant)),
+        "variant_case_count": int(np.count_nonzero(~true_invariant)),
+        "stationary_case_count": int(np.count_nonzero(stationary)),
+        "stationary_variant_case_count": int(np.count_nonzero(stationary & ~true_invariant)),
+        "maximum_diameter_interval_violation": maximum_bound_violation,
+    }
+
+
+def _sampled_diameter(coefficients: np.ndarray, sample_count: int) -> np.ndarray:
+    angles = np.arange(sample_count, dtype=np.float64) * (2.0 * np.pi / sample_count)
+    harmonics = np.column_stack((np.cos(angles), np.sin(angles)))
+    maximum_squared = np.zeros(coefficients.shape[0], dtype=np.float64)
+    for first in range(sample_count):
+        for second in range(first + 1, sample_count):
+            difference = harmonics[first] - harmonics[second]
+            query_difference = np.einsum("ndk,k->nd", coefficients, difference)
+            maximum_squared = np.maximum(
+                maximum_squared,
+                np.sum(query_difference * query_difference, axis=1),
+            )
+    return np.sqrt(maximum_squared)
+
+
+def _sampling_study(
+    protocol: dict[str, Any],
+    rng: np.random.Generator,
+) -> list[dict[str, Any]]:
+    count = int(protocol["near_boundary_case_count"])
+    tolerance = float(protocol["invariance_tolerance"])
+    diameters = rng.uniform(
+        *protocol["near_boundary_variant_diameter_range"],
+        size=count,
+    )
+    coefficients, _, _ = _coefficient_bank(
+        rng,
+        diameters,
+        int(protocol["query_dimension"]),
+        float(protocol["stationary_case_fraction"]),
+    )
+    rows: list[dict[str, Any]] = []
+    for sample_count in protocol["sampled_grid_counts"]:
+        sampled = _sampled_diameter(coefficients, int(sample_count))
+        lipschitz = diameters / 2.0
+        cover_radius = np.pi / float(sample_count)
+        certified_upper = sampled + 2.0 * lipschitz * cover_radius
+        certified_admitted = certified_upper <= tolerance
+        naive_admitted = sampled <= tolerance
+        rows.extend(
+            (
+                {
+                    "sample_count": int(sample_count),
+                    "method": "lipschitz_certified_sampling",
+                    "case_count": count,
+                    "harmful_acceptance_count": int(np.count_nonzero(certified_admitted)),
+                    "harmful_acceptance_rate": float(np.mean(certified_admitted)),
+                    "fallback_rate": float(np.mean(~certified_admitted)),
+                    "maximum_sampled_understatement": float(np.max(diameters - sampled)),
+                    "maximum_certified_upper_shortfall": float(
+                        np.max(np.maximum(diameters - certified_upper, 0.0))
+                    ),
+                },
+                {
+                    "sample_count": int(sample_count),
+                    "method": "naive_sampled_diameter",
+                    "case_count": count,
+                    "harmful_acceptance_count": int(np.count_nonzero(naive_admitted)),
+                    "harmful_acceptance_rate": float(np.mean(naive_admitted)),
+                    "fallback_rate": float(np.mean(~naive_admitted)),
+                    "maximum_sampled_understatement": float(np.max(diameters - sampled)),
+                    "maximum_certified_upper_shortfall": None,
+                },
+            )
+        )
+    return rows
+
+
+def _diameter_parity(rng: np.random.Generator) -> dict[str, Any]:
+    coefficients = rng.normal(size=(4096, 5, 2))
+    factorized = batch_axial_orbit_diameters(coefficients)
+    dense = 2.0 * np.linalg.svd(coefficients, compute_uv=False)[:, 0]
+    return {
+        "case_count": int(coefficients.shape[0]),
+        "maximum_absolute_error": float(np.max(np.abs(factorized - dense))),
+        "mean_absolute_error": float(np.mean(np.abs(factorized - dense))),
+    }
+
+
+def _median_runtime(callable_object: Any, repetitions: int) -> tuple[float, Any]:
+    timings = []
+    result = None
+    for _ in range(repetitions):
+        gc.collect()
+        start = time.perf_counter_ns()
+        result = callable_object()
+        timings.append((time.perf_counter_ns() - start) * 1e-6)
+    return float(np.median(timings)), result
+
+
+def _benchmark(
+    protocol: dict[str, Any],
+    rng: np.random.Generator,
+) -> dict[str, Any]:
+    settings = protocol["benchmark"]
+    query_count = int(settings["query_count"])
+    dimension = int(settings["query_dimension"])
+    sample_count = int(settings["angular_sample_count"])
+    repetitions = int(settings["repetitions"])
+    coefficients = rng.normal(size=(query_count, dimension, 2))
+    angles = np.arange(sample_count, dtype=np.float64) * (2.0 * np.pi / sample_count)
+    harmonics = np.column_stack((np.cos(angles), np.sin(angles)))
+
+    def exact() -> np.ndarray:
+        return batch_axial_orbit_diameters(coefficients)
+
+    def sampled() -> np.ndarray:
+        values = np.einsum("ndk,sk->nsd", coefficients, harmonics)
+        return 2.0 * np.max(np.linalg.norm(values, axis=-1), axis=1)
+
+    exact_ms, exact_value = _median_runtime(exact, repetitions)
+    sampled_ms, sampled_value = _median_runtime(sampled, repetitions)
+    return {
+        "query_count": query_count,
+        "query_dimension": dimension,
+        "angular_sample_count": sample_count,
+        "repetitions": repetitions,
+        "exact_vectorized_median_milliseconds": exact_ms,
+        "sampled_orbit_median_milliseconds": sampled_ms,
+        "sampled_to_exact_runtime_ratio": sampled_ms / exact_ms,
+        "coefficient_storage_float64_bytes": int(coefficients.nbytes),
+        "sampled_query_storage_float64_bytes": int(
+            query_count * sample_count * dimension * np.dtype(np.float64).itemsize
+        ),
+        "sampled_to_coefficient_storage_ratio": float(sample_count / 2.0),
+        "maximum_sampled_diameter_absolute_error": float(
+            np.max(np.abs(sampled_value - exact_value))
+        ),
+    }
+
+
+def _registered_checks(
+    protocol: dict[str, Any],
+    bounded_rows: list[dict[str, Any]],
+    sampling_rows: list[dict[str, Any]],
+    parity: dict[str, Any],
+) -> dict[str, bool]:
+    registered = protocol["registered_checks"]
+    certified = [
+        row for row in bounded_rows if row["method"] == "certified_bounded_error"
+    ]
+    local_zero = next(
+        row
+        for row in bounded_rows
+        if row["method"] == "nominal_local_derivative"
+        and row["coefficient_error_ratio"] == 0.0
+    )
+    naive_positive = [
+        row
+        for row in bounded_rows
+        if row["method"] == "naive_estimated_diameter"
+        and row["coefficient_error_ratio"] > 0.0
+    ]
+    sampled_certified = [
+        row for row in sampling_rows if row["method"] == "lipschitz_certified_sampling"
+    ]
+    sampled_naive = [
+        row for row in sampling_rows if row["method"] == "naive_sampled_diameter"
+    ]
+    return {
+        "bounded_error_certificate_has_no_harmful_acceptance": max(
+            row["harmful_acceptance_rate_among_variant"] for row in certified
+        )
+        <= float(registered["maximum_certified_harmful_acceptance_rate"]),
+        "local_gate_fails_at_stationary_representatives": local_zero[
+            "harmful_acceptance_rate_among_variant"
+        ]
+        > float(registered["minimum_local_harmful_acceptance_rate_at_zero_error"]),
+        "naive_estimated_orbit_fails_under_nonzero_error": max(
+            row["harmful_acceptance_rate_among_variant"] for row in naive_positive
+        )
+        > float(registered["minimum_positive_error_naive_harmful_acceptance_rate"]),
+        "lipschitz_sampling_certificate_has_no_harmful_acceptance": max(
+            row["harmful_acceptance_rate"] for row in sampled_certified
+        )
+        <= float(registered["maximum_sampled_certified_harmful_acceptance_rate"]),
+        "uncertified_coarse_sampling_misses_variant_queries": sampled_naive[0][
+            "harmful_acceptance_rate"
+        ]
+        > float(registered["minimum_coarse_naive_sampled_harmful_acceptance_rate"]),
+        "closed_form_diameter_matches_dense_svd": parity["maximum_absolute_error"]
+        <= float(registered["maximum_factorized_dense_diameter_error"]),
+    }
+
+
+def build_report(protocol: dict[str, Any]) -> dict[str, Any]:
+    rng = np.random.default_rng(int(protocol["seed"]))
+    bounded_rows, population = _bounded_error_study(protocol, rng)
+    sampling_rows = _sampling_study(protocol, rng)
+    parity = _diameter_parity(rng)
+    benchmark = _benchmark(protocol, rng)
+    checks = _registered_checks(protocol, bounded_rows, sampling_rows, parity)
+    report: dict[str, Any] = {
+        "schema": RESULT_SCHEMA,
+        "evidence_kind": protocol["evidence_kind"],
+        "protocol": protocol,
+        "protocol_sha256": _content_id(protocol),
+        "runtime": {
+            "python": platform.python_version(),
+            "numpy": np.__version__,
+            "platform": platform.platform(),
+        },
+        "population": population,
+        "bounded_error_rows": bounded_rows,
+        "sampled_orbit_rows": sampling_rows,
+        "diameter_parity": parity,
+        "benchmark": benchmark,
+        "registered_checks": checks,
+        "decision": "passed" if all(checks.values()) else "failed",
+        "claim_boundary": protocol["claim_boundary"],
+    }
+    report["artifact_id"] = _content_id(report)
+    return report
+
+
+def _summary(report: dict[str, Any]) -> str:
+    bounded = report["bounded_error_rows"]
+    zero_local = next(
+        row
+        for row in bounded
+        if row["method"] == "nominal_local_derivative"
+        and row["coefficient_error_ratio"] == 0.0
+    )
+    certified = [
+        row for row in bounded if row["method"] == "certified_bounded_error"
+    ]
+    lines = [
+        "# Robust finite-orbit query-identifiability control",
+        "",
+        f"Artifact ID: `{report['artifact_id']}`",
+        "",
+        f"Decision: **{report['decision']}**",
+        "",
+        "## Bounded coefficient error",
+        "",
+        "| Error/tolerance | Method | Harmful acceptance | Useful acceptance | Undetermined |",
+        "|---:|---|---:|---:|---:|",
+    ]
+    for row in bounded:
+        lines.append(
+            f"| {row['coefficient_error_ratio']:.2f} | {row['method']} | "
+            f"{row['harmful_acceptance_rate_among_variant']:.4f} | "
+            f"{row['useful_acceptance_rate_among_invariant']:.4f} | "
+            f"{row['undetermined_rate']:.4f} |"
+        )
+    lines += [
+        "",
+        (
+            "The certified gate had maximum harmful acceptance "
+            f"{max(row['harmful_acceptance_rate_among_variant'] for row in certified):.4f}. "
+            "At zero coefficient error, the nominal local-derivative gate accepted "
+            f"{zero_local['harmful_acceptance_rate_among_variant']:.4f} of truly variant queries."
+        ),
+        "",
+        "## Uniform orbit sampling",
+        "",
+        "| Samples | Method | Harmful acceptance | Maximum diameter understatement |",
+        "|---:|---|---:|---:|",
+    ]
+    for row in report["sampled_orbit_rows"]:
+        lines.append(
+            f"| {row['sample_count']} | {row['method']} | "
+            f"{row['harmful_acceptance_rate']:.4f} | "
+            f"{row['maximum_sampled_understatement']:.6g} |"
+        )
+    benchmark = report["benchmark"]
+    lines += [
+        "",
+        "## Computational control",
+        "",
+        (
+            f"For {benchmark['query_count']} {benchmark['query_dimension']}-D queries, "
+            f"the exact two-column certificate took a median "
+            f"{benchmark['exact_vectorized_median_milliseconds']:.3f} ms versus "
+            f"{benchmark['sampled_orbit_median_milliseconds']:.3f} ms for "
+            f"{benchmark['angular_sample_count']} orbit samples "
+            f"({benchmark['sampled_to_exact_runtime_ratio']:.1f}x runtime ratio)."
+        ),
+        (
+            "Materializing the sampled query bank requires "
+            f"{benchmark['sampled_to_coefficient_storage_ratio']:.1f}x the storage "
+            "of the exact two-column coefficients."
+        ),
+        "",
+        report["claim_boundary"],
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--protocol", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    protocol = _load_protocol(args.protocol)
+    report = build_report(protocol)
+    if args.output.exists():
+        raise FileExistsError(f"refusing to overwrite {args.output}")
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(report, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    args.output.with_suffix(".md").write_text(_summary(report), encoding="utf-8")
+    print(json.dumps({"artifact_id": report["artifact_id"], "decision": report["decision"]}))
+    return 0 if report["decision"] == "passed" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/science/run_robust_orbit_query_stress.py
+++ b/scripts/science/run_robust_orbit_query_stress.py
@@ -100,8 +100,7 @@ def _load_protocol(path: Path) -> dict[str, Any]:
         or not ratios
         or float(ratios[0]) != 0.0
         or any(float(value) < 0.0 for value in ratios)
-        or sorted(float(value) for value in ratios)
-        != [float(value) for value in ratios]
+        or sorted(float(value) for value in ratios) != [float(value) for value in ratios]
         or len(set(float(value) for value in ratios)) != len(ratios)
     ):
         raise ValueError("coefficient_error_ratios is invalid")
@@ -162,10 +161,7 @@ def _coefficient_bank(
     directions = _unit_vectors(rng, stationary_count, query_dimension)
     phase_vectors = np.column_stack((np.cos(phase[stationary]), np.sin(phase[stationary])))
     coefficients[stationary] = (
-        0.5
-        * diameters[stationary, None, None]
-        * directions[:, :, None]
-        * phase_vectors[:, None, :]
+        0.5 * diameters[stationary, None, None] * directions[:, :, None] * phase_vectors[:, None, :]
     )
 
     general = ~stationary
@@ -176,9 +172,7 @@ def _coefficient_bank(
         mask = raw_sigma == 0.0
         raw[mask] = rng.normal(size=(int(np.count_nonzero(mask)), query_dimension, 2))
         raw_sigma = batch_axial_orbit_diameters(raw) / 2.0
-    coefficients[general] = raw * (
-        0.5 * diameters[general] / raw_sigma
-    )[:, None, None]
+    coefficients[general] = raw * (0.5 * diameters[general] / raw_sigma)[:, None, None]
     nominal_angles = rng.uniform(-np.pi, np.pi, size=count)
     nominal_angles[stationary] = phase[stationary]
     return coefficients, nominal_angles, stationary
@@ -439,27 +433,21 @@ def _registered_checks(
     parity: dict[str, Any],
 ) -> dict[str, bool]:
     registered = protocol["registered_checks"]
-    certified = [
-        row for row in bounded_rows if row["method"] == "certified_bounded_error"
-    ]
+    certified = [row for row in bounded_rows if row["method"] == "certified_bounded_error"]
     local_zero = next(
         row
         for row in bounded_rows
-        if row["method"] == "nominal_local_derivative"
-        and row["coefficient_error_ratio"] == 0.0
+        if row["method"] == "nominal_local_derivative" and row["coefficient_error_ratio"] == 0.0
     )
     naive_positive = [
         row
         for row in bounded_rows
-        if row["method"] == "naive_estimated_diameter"
-        and row["coefficient_error_ratio"] > 0.0
+        if row["method"] == "naive_estimated_diameter" and row["coefficient_error_ratio"] > 0.0
     ]
     sampled_certified = [
         row for row in sampling_rows if row["method"] == "lipschitz_certified_sampling"
     ]
-    sampled_naive = [
-        row for row in sampling_rows if row["method"] == "naive_sampled_diameter"
-    ]
+    sampled_naive = [row for row in sampling_rows if row["method"] == "naive_sampled_diameter"]
     return {
         "bounded_error_certificate_has_no_harmful_acceptance": max(
             row["harmful_acceptance_rate_among_variant"] for row in certified
@@ -521,12 +509,9 @@ def _summary(report: dict[str, Any]) -> str:
     zero_local = next(
         row
         for row in bounded
-        if row["method"] == "nominal_local_derivative"
-        and row["coefficient_error_ratio"] == 0.0
+        if row["method"] == "nominal_local_derivative" and row["coefficient_error_ratio"] == 0.0
     )
-    certified = [
-        row for row in bounded if row["method"] == "certified_bounded_error"
-    ]
+    certified = [row for row in bounded if row["method"] == "certified_bounded_error"]
     lines = [
         "# Robust finite-orbit query-identifiability control",
         "",

--- a/src/prob4d/axial_orbit_geometry_bound.py
+++ b/src/prob4d/axial_orbit_geometry_bound.py
@@ -1,0 +1,243 @@
+"""Conservative geometric error budget for axial query-orbit coefficients.
+
+This module converts separately supplied bounds on a unit axis, pivot, and
+reference points into the operator-norm coefficient bound consumed by
+``certify_axial_linear_query``.  It does not estimate those geometric bounds.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+
+FloatArray = NDArray[np.float64]
+
+
+def _array(value: ArrayLike, *, name: str) -> FloatArray:
+    raw = np.asarray(value)
+    if raw.dtype.kind not in "iuf":
+        raise ValueError(f"{name} must contain real numeric values")
+    result = np.array(raw, dtype=np.float64, copy=True)
+    if not np.all(np.isfinite(result)):
+        raise ValueError(f"{name} must be finite")
+    result.setflags(write=False)
+    return result
+
+
+def _nonnegative(value: float, *, name: str) -> float:
+    if isinstance(value, (bool, np.bool_)):
+        raise ValueError(f"{name} must be a real scalar")
+    result = float(value)
+    if not np.isfinite(result) or result < 0.0:
+        raise ValueError(f"{name} must be finite and nonnegative")
+    return result
+
+
+def _unit_axis(value: ArrayLike) -> FloatArray:
+    axis = _array(value, name="estimated_axis")
+    if axis.shape != (3,):
+        raise ValueError("estimated_axis must have shape (3,)")
+    scale = float(np.max(np.abs(axis)))
+    if scale == 0.0:
+        raise ValueError("estimated_axis must be nonzero")
+    normalized = axis / scale
+    normalized = normalized / float(np.linalg.norm(normalized))
+    normalized.setflags(write=False)
+    return normalized
+
+
+def axial_point_orbit_coefficients(
+    points: ArrayLike,
+    *,
+    axis: ArrayLike,
+    pivot: ArrayLike,
+) -> tuple[FloatArray, FloatArray]:
+    """Return cosine and sine coefficients for point rotations about a line."""
+
+    reference = _array(points, name="points")
+    if reference.ndim != 2 or reference.shape[0] == 0 or reference.shape[1] != 3:
+        raise ValueError("points must have nonempty shape (N, 3)")
+    unit = _unit_axis(axis)
+    center = _array(pivot, name="pivot")
+    if center.shape != (3,):
+        raise ValueError("pivot must have shape (3,)")
+    offset = reference - center
+    parallel = np.outer(offset @ unit, unit)
+    cosine = offset - parallel
+    sine = np.cross(unit, cosine)
+    cosine.setflags(write=False)
+    sine.setflags(write=False)
+    return cosine, sine
+
+
+def project_axial_query_coefficients(
+    points: ArrayLike,
+    *,
+    axis: ArrayLike,
+    pivot: ArrayLike,
+    query_weights: ArrayLike,
+) -> FloatArray:
+    """Return ``B`` for a linear query of point coordinates.
+
+    ``query_weights`` has shape ``(N,3)`` for one scalar query or ``(D,N,3)``
+    for a vector query.
+    """
+
+    reference = _array(points, name="points")
+    if reference.ndim != 2 or reference.shape[0] == 0 or reference.shape[1] != 3:
+        raise ValueError("points must have nonempty shape (N, 3)")
+    weights = _array(query_weights, name="query_weights")
+    if weights.ndim == 2:
+        weights = weights[None, :, :]
+    if weights.ndim != 3 or weights.shape[0] == 0 or weights.shape[1:] != reference.shape:
+        raise ValueError("query_weights must have shape (N,3) or (D,N,3)")
+    cosine, sine = axial_point_orbit_coefficients(
+        reference,
+        axis=axis,
+        pivot=pivot,
+    )
+    result = np.column_stack(
+        (
+            np.einsum("dnc,nc->d", weights, cosine),
+            np.einsum("dnc,nc->d", weights, sine),
+        )
+    )
+    result.setflags(write=False)
+    return result
+
+
+@dataclass(frozen=True)
+class AxialGeometryCoefficientBound:
+    """Conservative ingredients of one query-coefficient error budget."""
+
+    coefficient_operator_error_bound: float
+    query_operator_norm: float
+    stacked_coefficient_frobenius_bound: float
+    projection_operator_error_bound: float
+    point_offset_error_bounds: FloatArray
+    cosine_coefficient_error_bounds: FloatArray
+    sine_coefficient_error_bounds: FloatArray
+
+    def __post_init__(self) -> None:
+        for name in (
+            "coefficient_operator_error_bound",
+            "query_operator_norm",
+            "stacked_coefficient_frobenius_bound",
+            "projection_operator_error_bound",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _nonnegative(getattr(self, name), name=name),
+            )
+        for name in (
+            "point_offset_error_bounds",
+            "cosine_coefficient_error_bounds",
+            "sine_coefficient_error_bounds",
+        ):
+            value = _array(getattr(self, name), name=name)
+            if value.ndim != 1 or value.size == 0 or np.any(value < 0.0):
+                raise ValueError(f"{name} must be a nonempty nonnegative vector")
+            object.__setattr__(self, name, value)
+        size = self.point_offset_error_bounds.size
+        if (
+            self.cosine_coefficient_error_bounds.size != size
+            or self.sine_coefficient_error_bounds.size != size
+        ):
+            raise ValueError("all per-point error vectors must have equal length")
+
+
+def bound_axial_query_coefficient_error(
+    estimated_points: ArrayLike,
+    *,
+    estimated_axis: ArrayLike,
+    estimated_pivot: ArrayLike,
+    query_weights: ArrayLike,
+    point_position_error_bounds: ArrayLike,
+    axis_vector_error_bound: float,
+    pivot_position_error_bound: float,
+) -> AxialGeometryCoefficientBound:
+    """Bound the operator error of projected axial orbit coefficients.
+
+    The contract is
+
+    ``||p_i - p_hat_i|| <= eps_point_i``,
+    ``||c - c_hat|| <= eps_pivot``, and
+    ``||u - u_hat|| <= eps_axis``
+
+    for unit true and estimated axes.  The returned coefficient bound is valid
+    simultaneously for all points under these deterministic Euclidean bounds.
+    It is intentionally conservative and uses a Frobenius upper bound before
+    applying the linear query map.
+    """
+
+    points = _array(estimated_points, name="estimated_points")
+    if points.ndim != 2 or points.shape[0] == 0 or points.shape[1] != 3:
+        raise ValueError("estimated_points must have nonempty shape (N, 3)")
+    axis = _unit_axis(estimated_axis)
+    pivot = _array(estimated_pivot, name="estimated_pivot")
+    if pivot.shape != (3,):
+        raise ValueError("estimated_pivot must have shape (3,)")
+    point_errors = _array(
+        point_position_error_bounds,
+        name="point_position_error_bounds",
+    )
+    if point_errors.shape != (points.shape[0],) or np.any(point_errors < 0.0):
+        raise ValueError(
+            "point_position_error_bounds must be a nonnegative vector of length N"
+        )
+    axis_error = _nonnegative(
+        axis_vector_error_bound,
+        name="axis_vector_error_bound",
+    )
+    if axis_error > 2.0:
+        raise ValueError("axis_vector_error_bound cannot exceed two for unit axes")
+    pivot_error = _nonnegative(
+        pivot_position_error_bound,
+        name="pivot_position_error_bound",
+    )
+    weights = _array(query_weights, name="query_weights")
+    if weights.ndim == 2:
+        weights = weights[None, :, :]
+    if weights.ndim != 3 or weights.shape[0] == 0 or weights.shape[1:] != points.shape:
+        raise ValueError("query_weights must have shape (N,3) or (D,N,3)")
+
+    estimated_offset = points - pivot
+    estimated_cosine, _ = axial_point_orbit_coefficients(
+        points,
+        axis=axis,
+        pivot=pivot,
+    )
+    offset_errors = point_errors + pivot_error
+
+    # ||u u^T - u_hat u_hat^T|| <= 2 ||u-u_hat|| for unit axes.
+    projection_error = min(2.0, 2.0 * axis_error)
+    cosine_errors = offset_errors + projection_error * np.linalg.norm(
+        estimated_offset,
+        axis=1,
+    )
+
+    # b = u x a.  Bound the true cosine coefficient by its estimate plus
+    # its error, then use ||x cross y|| <= ||x|| ||y||.
+    true_cosine_norm_bound = np.linalg.norm(estimated_cosine, axis=1) + cosine_errors
+    sine_errors = cosine_errors + axis_error * true_cosine_norm_bound
+
+    stacked_frobenius = float(
+        np.sqrt(np.sum(cosine_errors**2) + np.sum(sine_errors**2))
+    )
+    flattened_weights = weights.reshape(weights.shape[0], -1)
+    query_operator_norm = float(
+        np.linalg.svd(flattened_weights, compute_uv=False)[0]
+    )
+    coefficient_bound = query_operator_norm * stacked_frobenius
+    return AxialGeometryCoefficientBound(
+        coefficient_operator_error_bound=coefficient_bound,
+        query_operator_norm=query_operator_norm,
+        stacked_coefficient_frobenius_bound=stacked_frobenius,
+        projection_operator_error_bound=projection_error,
+        point_offset_error_bounds=offset_errors,
+        cosine_coefficient_error_bounds=cosine_errors,
+        sine_coefficient_error_bounds=sine_errors,
+    )

--- a/src/prob4d/axial_orbit_geometry_bound.py
+++ b/src/prob4d/axial_orbit_geometry_bound.py
@@ -185,9 +185,7 @@ def bound_axial_query_coefficient_error(
         name="point_position_error_bounds",
     )
     if point_errors.shape != (points.shape[0],) or np.any(point_errors < 0.0):
-        raise ValueError(
-            "point_position_error_bounds must be a nonnegative vector of length N"
-        )
+        raise ValueError("point_position_error_bounds must be a nonnegative vector of length N")
     axis_error = _nonnegative(
         axis_vector_error_bound,
         name="axis_vector_error_bound",
@@ -224,13 +222,9 @@ def bound_axial_query_coefficient_error(
     true_cosine_norm_bound = np.linalg.norm(estimated_cosine, axis=1) + cosine_errors
     sine_errors = cosine_errors + axis_error * true_cosine_norm_bound
 
-    stacked_frobenius = float(
-        np.sqrt(np.sum(cosine_errors**2) + np.sum(sine_errors**2))
-    )
+    stacked_frobenius = float(np.sqrt(np.sum(cosine_errors**2) + np.sum(sine_errors**2)))
     flattened_weights = weights.reshape(weights.shape[0], -1)
-    query_operator_norm = float(
-        np.linalg.svd(flattened_weights, compute_uv=False)[0]
-    )
+    query_operator_norm = float(np.linalg.svd(flattened_weights, compute_uv=False)[0])
     coefficient_bound = query_operator_norm * stacked_frobenius
     return AxialGeometryCoefficientBound(
         coefficient_operator_error_bound=coefficient_bound,

--- a/src/prob4d/robust_orbit_query.py
+++ b/src/prob4d/robust_orbit_query.py
@@ -1,0 +1,293 @@
+"""Fail-closed query-identifiability certificates for approximate finite orbits.
+
+The core certificate treats an axial linear-query orbit
+
+    q(theta) = center + B [cos(theta), sin(theta)]^T
+
+with a supplied spectral-norm error bound ``||B_true - B_hat||_2 <= eta``.
+Weyl's singular-value perturbation bound then gives a certified interval for
+its complete Euclidean orbit diameter.  The module does not estimate ``eta``;
+that information must come from a separately justified geometric, bootstrap,
+or ensemble bound.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+
+FloatArray = NDArray[np.float64]
+OrbitDecision = Literal[
+    "certified-invariant",
+    "certified-variant",
+    "undetermined",
+]
+
+
+def _finite_array(value: ArrayLike, *, name: str) -> FloatArray:
+    raw = np.asarray(value)
+    if raw.dtype.kind not in "iuf":
+        raise ValueError(f"{name} must contain real numeric values")
+    result = np.array(raw, dtype=np.float64, copy=True)
+    if not np.all(np.isfinite(result)):
+        raise ValueError(f"{name} must be finite")
+    result.setflags(write=False)
+    return result
+
+
+def _nonnegative_scalar(value: float, *, name: str) -> float:
+    if isinstance(value, (bool, np.bool_)):
+        raise ValueError(f"{name} must be a real scalar")
+    result = float(value)
+    if not np.isfinite(result) or result < 0.0:
+        raise ValueError(f"{name} must be finite and nonnegative")
+    return result
+
+
+def _positive_scalar(value: float, *, name: str) -> float:
+    result = _nonnegative_scalar(value, name=name)
+    if result == 0.0:
+        raise ValueError(f"{name} must be positive")
+    return result
+
+
+def _decision(lower: float, upper: float, tolerance: float) -> OrbitDecision:
+    if upper <= tolerance:
+        return "certified-invariant"
+    if lower > tolerance:
+        return "certified-variant"
+    return "undetermined"
+
+
+def batch_axial_orbit_diameters(coefficients: ArrayLike) -> FloatArray:
+    """Return exact Euclidean diameters for matrices with two orbit columns.
+
+    ``coefficients`` has shape ``(..., query_dimension, 2)``.  For
+    ``q(theta) = c + B [cos(theta), sin(theta)]``, the complete pairwise
+    Euclidean orbit diameter is exactly ``2 * sigma_max(B)``.  The closed form
+    below diagonalizes only the two-by-two Gram matrix and is vectorized over
+    arbitrary leading dimensions.
+    """
+
+    matrix = _finite_array(coefficients, name="coefficients")
+    if matrix.ndim < 2 or matrix.shape[-2] == 0 or matrix.shape[-1] != 2:
+        raise ValueError(
+            "coefficients must have shape (..., query_dimension, 2)"
+        )
+    first = matrix[..., :, 0]
+    second = matrix[..., :, 1]
+    gram_00 = np.sum(first * first, axis=-1)
+    gram_01 = np.sum(first * second, axis=-1)
+    gram_11 = np.sum(second * second, axis=-1)
+    discriminant = np.hypot(gram_00 - gram_11, 2.0 * gram_01)
+    largest_eigenvalue = 0.5 * (gram_00 + gram_11 + discriminant)
+    diameter = 2.0 * np.sqrt(np.maximum(largest_eigenvalue, 0.0))
+    result = np.asarray(diameter, dtype=np.float64)
+    result.setflags(write=False)
+    return result
+
+
+@dataclass(frozen=True)
+class RobustAxialOrbitCertificate:
+    """Certified diameter interval for one approximate axial query orbit."""
+
+    estimated_diameter: float
+    lower_diameter: float
+    upper_diameter: float
+    coefficient_error_bound: float
+    invariance_tolerance: float
+    nominal_local_derivative_norm: float
+    nominal_angle_radians: float
+    decision: OrbitDecision
+
+    def __post_init__(self) -> None:
+        for name in (
+            "estimated_diameter",
+            "lower_diameter",
+            "upper_diameter",
+            "coefficient_error_bound",
+            "invariance_tolerance",
+            "nominal_local_derivative_norm",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _nonnegative_scalar(getattr(self, name), name=name),
+            )
+        angle = float(self.nominal_angle_radians)
+        if not np.isfinite(angle):
+            raise ValueError("nominal_angle_radians must be finite")
+        object.__setattr__(self, "nominal_angle_radians", angle)
+        if self.lower_diameter > self.upper_diameter:
+            raise ValueError("lower_diameter cannot exceed upper_diameter")
+        if self.decision != _decision(
+            self.lower_diameter,
+            self.upper_diameter,
+            self.invariance_tolerance,
+        ):
+            raise ValueError("decision is inconsistent with the diameter interval")
+
+    @property
+    def update_admitted(self) -> bool:
+        """Only a certified invariant query is admitted; uncertainty falls back."""
+
+        return self.decision == "certified-invariant"
+
+
+def certify_axial_linear_query(
+    estimated_coefficients: ArrayLike,
+    *,
+    coefficient_error_bound: float,
+    invariance_tolerance: float,
+    nominal_angle_radians: float = 0.0,
+) -> RobustAxialOrbitCertificate:
+    """Certify invariance, variation, or indeterminacy of an axial query.
+
+    The error bound is an operator-norm bound on the complete coefficient
+    matrix.  Since the true diameter is ``2*sigma_max(B_true)``, singular-value
+    perturbation gives
+
+    ``d_true in [max(0, d_hat - 2*eta), d_hat + 2*eta]``.
+
+    An ``undetermined`` result is deliberately not admitted.
+    """
+
+    matrix = _finite_array(
+        estimated_coefficients,
+        name="estimated_coefficients",
+    )
+    if matrix.ndim != 2 or matrix.shape[0] == 0 or matrix.shape[1] != 2:
+        raise ValueError(
+            "estimated_coefficients must have shape (query_dimension, 2)"
+        )
+    error = _nonnegative_scalar(
+        coefficient_error_bound,
+        name="coefficient_error_bound",
+    )
+    tolerance = _positive_scalar(
+        invariance_tolerance,
+        name="invariance_tolerance",
+    )
+    angle = float(nominal_angle_radians)
+    if not np.isfinite(angle):
+        raise ValueError("nominal_angle_radians must be finite")
+    estimated = float(batch_axial_orbit_diameters(matrix))
+    lower = max(0.0, estimated - 2.0 * error)
+    upper = estimated + 2.0 * error
+    tangent = np.array([-np.sin(angle), np.cos(angle)])
+    derivative_norm = float(np.linalg.norm(matrix @ tangent))
+    return RobustAxialOrbitCertificate(
+        estimated_diameter=estimated,
+        lower_diameter=lower,
+        upper_diameter=upper,
+        coefficient_error_bound=error,
+        invariance_tolerance=tolerance,
+        nominal_local_derivative_norm=derivative_norm,
+        nominal_angle_radians=angle,
+        decision=_decision(lower, upper, tolerance),
+    )
+
+
+def sampled_pairwise_diameter(values: ArrayLike) -> float:
+    """Return the exact Euclidean diameter of a finite query sample."""
+
+    points = _finite_array(values, name="values")
+    if points.ndim != 2 or points.shape[0] < 2 or points.shape[1] == 0:
+        raise ValueError("values must have shape (sample_count>=2, dimension>=1)")
+    maximum = 0.0
+    for start in range(0, points.shape[0], 128):
+        difference = points[start : start + 128, None, :] - points[None, :, :]
+        maximum = max(
+            maximum,
+            float(np.max(np.linalg.norm(difference, axis=-1))),
+        )
+    return maximum
+
+
+@dataclass(frozen=True)
+class SampledPeriodicOrbitCertificate:
+    """Lipschitz-certified diameter interval from a uniform periodic grid."""
+
+    sampled_diameter: float
+    lower_diameter: float
+    upper_diameter: float
+    lipschitz_bound: float
+    angular_cover_radius: float
+    sample_count: int
+    invariance_tolerance: float
+    decision: OrbitDecision
+
+    def __post_init__(self) -> None:
+        for name in (
+            "sampled_diameter",
+            "lower_diameter",
+            "upper_diameter",
+            "lipschitz_bound",
+            "angular_cover_radius",
+            "invariance_tolerance",
+        ):
+            object.__setattr__(
+                self,
+                name,
+                _nonnegative_scalar(getattr(self, name), name=name),
+            )
+        if type(self.sample_count) is not int or self.sample_count < 3:
+            raise ValueError("sample_count must be an integer of at least three")
+        if self.invariance_tolerance == 0.0:
+            raise ValueError("invariance_tolerance must be positive")
+        if self.lower_diameter > self.upper_diameter:
+            raise ValueError("lower_diameter cannot exceed upper_diameter")
+        if self.decision != _decision(
+            self.lower_diameter,
+            self.upper_diameter,
+            self.invariance_tolerance,
+        ):
+            raise ValueError("decision is inconsistent with the diameter interval")
+
+    @property
+    def update_admitted(self) -> bool:
+        return self.decision == "certified-invariant"
+
+
+def certify_uniformly_sampled_periodic_query(
+    values: ArrayLike,
+    *,
+    angular_lipschitz_bound: float,
+    invariance_tolerance: float,
+) -> SampledPeriodicOrbitCertificate:
+    """Certify a periodic query using a uniform grid and a Lipschitz bound.
+
+    For ``K`` samples on ``[0, 2*pi)``, every angle lies within ``pi/K`` of a
+    sample.  If the query is ``L``-Lipschitz in angle, its complete diameter is
+    between the sampled diameter and ``sampled_diameter + 2*L*pi/K``.
+    """
+
+    points = _finite_array(values, name="values")
+    if points.ndim != 2 or points.shape[0] < 3 or points.shape[1] == 0:
+        raise ValueError("values must have shape (sample_count>=3, dimension>=1)")
+    lipschitz = _nonnegative_scalar(
+        angular_lipschitz_bound,
+        name="angular_lipschitz_bound",
+    )
+    tolerance = _positive_scalar(
+        invariance_tolerance,
+        name="invariance_tolerance",
+    )
+    sample_count = int(points.shape[0])
+    cover_radius = float(np.pi / sample_count)
+    sampled = sampled_pairwise_diameter(points)
+    lower = sampled
+    upper = sampled + 2.0 * lipschitz * cover_radius
+    return SampledPeriodicOrbitCertificate(
+        sampled_diameter=sampled,
+        lower_diameter=lower,
+        upper_diameter=upper,
+        lipschitz_bound=lipschitz,
+        angular_cover_radius=cover_radius,
+        sample_count=sample_count,
+        invariance_tolerance=tolerance,
+        decision=_decision(lower, upper, tolerance),
+    )

--- a/src/prob4d/robust_orbit_query.py
+++ b/src/prob4d/robust_orbit_query.py
@@ -74,9 +74,7 @@ def batch_axial_orbit_diameters(coefficients: ArrayLike) -> FloatArray:
 
     matrix = _finite_array(coefficients, name="coefficients")
     if matrix.ndim < 2 or matrix.shape[-2] == 0 or matrix.shape[-1] != 2:
-        raise ValueError(
-            "coefficients must have shape (..., query_dimension, 2)"
-        )
+        raise ValueError("coefficients must have shape (..., query_dimension, 2)")
     first = matrix[..., :, 0]
     second = matrix[..., :, 1]
     gram_00 = np.sum(first * first, axis=-1)
@@ -160,9 +158,7 @@ def certify_axial_linear_query(
         name="estimated_coefficients",
     )
     if matrix.ndim != 2 or matrix.shape[0] == 0 or matrix.shape[1] != 2:
-        raise ValueError(
-            "estimated_coefficients must have shape (query_dimension, 2)"
-        )
+        raise ValueError("estimated_coefficients must have shape (query_dimension, 2)")
     error = _nonnegative_scalar(
         coefficient_error_bound,
         name="coefficient_error_bound",

--- a/tests/test_axial_orbit_geometry_bound.py
+++ b/tests/test_axial_orbit_geometry_bound.py
@@ -1,0 +1,245 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from prob4d.axial_orbit_geometry_bound import (
+    axial_point_orbit_coefficients,
+    bound_axial_query_coefficient_error,
+    project_axial_query_coefficients,
+)
+
+
+def _unit(value: np.ndarray) -> np.ndarray:
+    return value / np.linalg.norm(value)
+
+
+def _rotate_about_line(
+    points: np.ndarray,
+    axis: np.ndarray,
+    pivot: np.ndarray,
+    angle: float,
+) -> np.ndarray:
+    unit = _unit(axis)
+    x, y, z = unit
+    skew = np.array(
+        [
+            [0.0, -z, y],
+            [z, 0.0, -x],
+            [-y, x, 0.0],
+        ]
+    )
+    rotation = np.eye(3) + np.sin(angle) * skew + (1.0 - np.cos(angle)) * (
+        skew @ skew
+    )
+    return (points - pivot) @ rotation.T + pivot
+
+
+def test_projected_coefficients_match_independent_rodrigues_queries() -> None:
+    rng = np.random.default_rng(982451653)
+    points = rng.normal(size=(9, 3))
+    axis = rng.normal(size=3)
+    pivot = rng.normal(size=3)
+    weights = rng.normal(size=(4, 9, 3))
+    coefficients = project_axial_query_coefficients(
+        points,
+        axis=axis,
+        pivot=pivot,
+        query_weights=weights,
+    )
+    reference_query = np.einsum("dnc,nc->d", weights, points)
+    for angle in np.linspace(-np.pi, np.pi, 19):
+        rotated = _rotate_about_line(points, axis, pivot, float(angle))
+        actual = np.einsum("dnc,nc->d", weights, rotated) - reference_query
+        harmonic_difference = np.array([np.cos(angle) - 1.0, np.sin(angle)])
+        expected = coefficients @ harmonic_difference
+        np.testing.assert_allclose(actual, expected, atol=2e-14, rtol=2e-13)
+
+
+def test_geometric_bound_contains_random_projected_coefficient_errors() -> None:
+    rng = np.random.default_rng(32452843)
+    maximum_ratio = 0.0
+    for _ in range(400):
+        point_count = int(rng.integers(3, 16))
+        query_dimension = int(rng.integers(1, 8))
+        estimated_points = rng.normal(size=(point_count, 3))
+        estimated_axis = _unit(rng.normal(size=3))
+        estimated_pivot = rng.normal(size=3)
+        weights = rng.normal(size=(query_dimension, point_count, 3))
+
+        point_limits = rng.uniform(0.0, 0.08, size=point_count)
+        point_directions = rng.normal(size=(point_count, 3))
+        point_directions /= np.linalg.norm(point_directions, axis=1)[:, None]
+        point_magnitudes = rng.uniform(0.0, 1.0, size=point_count) * point_limits
+        true_points = estimated_points + point_directions * point_magnitudes[:, None]
+
+        pivot_limit = float(rng.uniform(0.0, 0.08))
+        pivot_direction = _unit(rng.normal(size=3))
+        true_pivot = estimated_pivot + pivot_direction * float(
+            rng.uniform(0.0, pivot_limit)
+        )
+
+        raw_axis_change = rng.normal(size=3)
+        raw_axis_change -= estimated_axis * float(raw_axis_change @ estimated_axis)
+        if np.linalg.norm(raw_axis_change) == 0.0:
+            raw_axis_change = np.roll(estimated_axis, 1)
+            raw_axis_change -= estimated_axis * float(
+                raw_axis_change @ estimated_axis
+            )
+        raw_axis_change = _unit(raw_axis_change)
+        true_axis = _unit(
+            estimated_axis
+            + raw_axis_change * float(rng.uniform(0.0, 0.35))
+        )
+        axis_error = float(np.linalg.norm(true_axis - estimated_axis))
+
+        estimate = project_axial_query_coefficients(
+            estimated_points,
+            axis=estimated_axis,
+            pivot=estimated_pivot,
+            query_weights=weights,
+        )
+        truth = project_axial_query_coefficients(
+            true_points,
+            axis=true_axis,
+            pivot=true_pivot,
+            query_weights=weights,
+        )
+        actual_error = float(np.linalg.svd(truth - estimate, compute_uv=False)[0])
+        bound = bound_axial_query_coefficient_error(
+            estimated_points,
+            estimated_axis=estimated_axis,
+            estimated_pivot=estimated_pivot,
+            query_weights=weights,
+            point_position_error_bounds=point_limits,
+            axis_vector_error_bound=axis_error,
+            pivot_position_error_bound=pivot_limit,
+        )
+        assert actual_error <= bound.coefficient_operator_error_bound + 5e-13
+        if bound.coefficient_operator_error_bound > 0.0:
+            maximum_ratio = max(
+                maximum_ratio,
+                actual_error / bound.coefficient_operator_error_bound,
+            )
+    assert maximum_ratio > 0.0
+    assert maximum_ratio <= 1.0 + 1e-12
+
+
+def test_zero_geometric_error_produces_zero_coefficient_error_bound() -> None:
+    points = np.array([[0.1, 0.2, 0.3], [-0.2, 0.4, 0.7]])
+    weights = np.eye(6).reshape(6, 2, 3)
+    bound = bound_axial_query_coefficient_error(
+        points,
+        estimated_axis=[0.0, 0.0, 1.0],
+        estimated_pivot=[0.0, 0.0, 0.0],
+        query_weights=weights,
+        point_position_error_bounds=[0.0, 0.0],
+        axis_vector_error_bound=0.0,
+        pivot_position_error_bound=0.0,
+    )
+    assert bound.coefficient_operator_error_bound == 0.0
+    assert bound.stacked_coefficient_frobenius_bound == 0.0
+    np.testing.assert_array_equal(bound.cosine_coefficient_error_bounds, [0.0, 0.0])
+    np.testing.assert_array_equal(bound.sine_coefficient_error_bounds, [0.0, 0.0])
+
+
+def test_point_coefficients_are_frame_equivariant() -> None:
+    points = np.array([[0.3, -0.2, 0.7], [-0.4, 0.5, 0.2]])
+    axis = _unit(np.array([1.0, 2.0, -1.0]))
+    pivot = np.array([0.2, -0.3, 0.1])
+    cosine, sine = axial_point_orbit_coefficients(points, axis=axis, pivot=pivot)
+    rotation = np.array(
+        [
+            [0.0, -1.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+    scale = 3.5
+    translation = np.array([2.0, -1.0, 4.0])
+    transformed_cosine, transformed_sine = axial_point_orbit_coefficients(
+        scale * (points @ rotation.T) + translation,
+        axis=rotation @ axis,
+        pivot=scale * (rotation @ pivot) + translation,
+    )
+    np.testing.assert_allclose(
+        transformed_cosine,
+        scale * (cosine @ rotation.T),
+        atol=1e-14,
+    )
+    np.testing.assert_allclose(
+        transformed_sine,
+        scale * (sine @ rotation.T),
+        atol=1e-14,
+    )
+
+
+def test_inputs_are_copied_and_outputs_are_readonly() -> None:
+    points = np.array([[1.0, 0.0, 0.0]])
+    axis = np.array([0.0, 0.0, 1.0])
+    pivot = np.zeros(3)
+    weights = np.array([[[1.0, 0.0, 0.0]]])
+    point_limits = np.array([0.1])
+    bound = bound_axial_query_coefficient_error(
+        points,
+        estimated_axis=axis,
+        estimated_pivot=pivot,
+        query_weights=weights,
+        point_position_error_bounds=point_limits,
+        axis_vector_error_bound=0.1,
+        pivot_position_error_bound=0.1,
+    )
+    coefficients = project_axial_query_coefficients(
+        points,
+        axis=axis,
+        pivot=pivot,
+        query_weights=weights,
+    )
+    points[:] = 9.0
+    axis[:] = 9.0
+    pivot[:] = 9.0
+    weights[:] = 9.0
+    point_limits[:] = 9.0
+    for value in (
+        coefficients,
+        bound.point_offset_error_bounds,
+        bound.cosine_coefficient_error_bounds,
+        bound.sine_coefficient_error_bounds,
+    ):
+        assert not value.flags.writeable
+    assert bound.point_offset_error_bounds[0] == pytest.approx(0.2)
+
+
+@pytest.mark.parametrize(
+    "points,axis,pivot,weights,point_errors,axis_error,pivot_error",
+    [
+        ([], [0, 0, 1], [0, 0, 0], np.ones((1, 1, 3)), [], 0.0, 0.0),
+        ([[1, 2]], [0, 0, 1], [0, 0, 0], np.ones((1, 1, 3)), [0.0], 0.0, 0.0),
+        ([[1, 2, 3]], [0, 0, 0], [0, 0, 0], np.ones((1, 1, 3)), [0.0], 0.0, 0.0),
+        ([[1, 2, 3]], [0, 0, 1], [0, 0], np.ones((1, 1, 3)), [0.0], 0.0, 0.0),
+        ([[1, 2, 3]], [0, 0, 1], [0, 0, 0], np.ones((1, 2, 3)), [0.0], 0.0, 0.0),
+        ([[1, 2, 3]], [0, 0, 1], [0, 0, 0], np.ones((1, 1, 3)), [-1.0], 0.0, 0.0),
+        ([[1, 2, 3]], [0, 0, 1], [0, 0, 0], np.ones((1, 1, 3)), [0.0], 2.1, 0.0),
+        ([[1, 2, 3]], [0, 0, 1], [0, 0, 0], np.ones((1, 1, 3)), [0.0], 0.0, -1.0),
+        ([[np.nan, 2, 3]], [0, 0, 1], [0, 0, 0], np.ones((1, 1, 3)), [0.0], 0.0, 0.0),
+    ],
+)
+def test_invalid_geometric_error_contracts_are_rejected(
+    points,
+    axis,
+    pivot,
+    weights,
+    point_errors,
+    axis_error,
+    pivot_error,
+) -> None:
+    with pytest.raises(ValueError):
+        bound_axial_query_coefficient_error(
+            points,
+            estimated_axis=axis,
+            estimated_pivot=pivot,
+            query_weights=weights,
+            point_position_error_bounds=point_errors,
+            axis_vector_error_bound=axis_error,
+            pivot_position_error_bound=pivot_error,
+        )

--- a/tests/test_axial_orbit_geometry_bound.py
+++ b/tests/test_axial_orbit_geometry_bound.py
@@ -29,9 +29,7 @@ def _rotate_about_line(
             [-y, x, 0.0],
         ]
     )
-    rotation = np.eye(3) + np.sin(angle) * skew + (1.0 - np.cos(angle)) * (
-        skew @ skew
-    )
+    rotation = np.eye(3) + np.sin(angle) * skew + (1.0 - np.cos(angle)) * (skew @ skew)
     return (points - pivot) @ rotation.T + pivot
 
 
@@ -75,22 +73,15 @@ def test_geometric_bound_contains_random_projected_coefficient_errors() -> None:
 
         pivot_limit = float(rng.uniform(0.0, 0.08))
         pivot_direction = _unit(rng.normal(size=3))
-        true_pivot = estimated_pivot + pivot_direction * float(
-            rng.uniform(0.0, pivot_limit)
-        )
+        true_pivot = estimated_pivot + pivot_direction * float(rng.uniform(0.0, pivot_limit))
 
         raw_axis_change = rng.normal(size=3)
         raw_axis_change -= estimated_axis * float(raw_axis_change @ estimated_axis)
         if np.linalg.norm(raw_axis_change) == 0.0:
             raw_axis_change = np.roll(estimated_axis, 1)
-            raw_axis_change -= estimated_axis * float(
-                raw_axis_change @ estimated_axis
-            )
+            raw_axis_change -= estimated_axis * float(raw_axis_change @ estimated_axis)
         raw_axis_change = _unit(raw_axis_change)
-        true_axis = _unit(
-            estimated_axis
-            + raw_axis_change * float(rng.uniform(0.0, 0.35))
-        )
+        true_axis = _unit(estimated_axis + raw_axis_change * float(rng.uniform(0.0, 0.35)))
         axis_error = float(np.linalg.norm(true_axis - estimated_axis))
 
         estimate = project_axial_query_coefficients(

--- a/tests/test_axial_orbit_geometry_control.py
+++ b/tests/test_axial_orbit_geometry_control.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PROTOCOL = ROOT / "protocols" / "axial-orbit-geometric-error-control-v1.json"
+STUDY = ROOT / "scripts" / "science" / "run_axial_orbit_geometric_error_control.py"
+
+
+def _load_study():
+    name = "axial_orbit_geometric_error_control_test"
+    spec = importlib.util.spec_from_file_location(name, STUDY)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_registered_protocol_and_reduced_deterministic_control() -> None:
+    module = _load_study()
+    protocol = module._load_protocol(PROTOCOL)
+    assert protocol["schema"] == (
+        "prob4d.axial-orbit-geometric-error-control.v1"
+    )
+    assert protocol["case_count"] == 5000
+    assert protocol["point_count_range"] == [3, 20]
+    assert protocol["query_dimension_range"] == [1, 8]
+
+    reduced = json.loads(json.dumps(protocol))
+    reduced["case_count"] = 1000
+    reduced["registered_checks"]["minimum_nonzero_ratio_count"] = 990
+    first = module.build_report(reduced)
+    second = module.build_report(reduced)
+    assert first["decision"] == "passed"
+    assert all(first["registered_checks"].values())
+    assert first["registered_checks"] == second["registered_checks"]
+    assert first["maximum_operator_bound_violation"] == 0.0
+    assert first["actual_to_bound_ratio_quantiles"] == second[
+        "actual_to_bound_ratio_quantiles"
+    ]
+    assert first["coefficient_bound_quantiles"] == second[
+        "coefficient_bound_quantiles"
+    ]
+    assert first["actual_to_bound_ratio_quantiles"]["q100"] <= 1.0 + 1e-12
+    assert first["actual_to_bound_ratio_quantiles"]["q100"] >= 0.01

--- a/tests/test_robust_orbit_query.py
+++ b/tests/test_robust_orbit_query.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from prob4d.robust_orbit_query import (
+    batch_axial_orbit_diameters,
+    certify_axial_linear_query,
+    certify_uniformly_sampled_periodic_query,
+    sampled_pairwise_diameter,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+PROTOCOL = ROOT / "protocols" / "robust-orbit-query-stress-v1.json"
+STUDY = ROOT / "scripts" / "science" / "run_robust_orbit_query_stress.py"
+
+
+def _load_study():
+    name = "robust_orbit_query_stress_test"
+    spec = importlib.util.spec_from_file_location(name, STUDY)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_local_stationarity_does_not_imply_finite_orbit_invariance() -> None:
+    certificate = certify_axial_linear_query(
+        [[1.0, 0.0]],
+        coefficient_error_bound=0.0,
+        invariance_tolerance=0.5,
+        nominal_angle_radians=0.0,
+    )
+    assert certificate.nominal_local_derivative_norm == 0.0
+    assert certificate.estimated_diameter == 2.0
+    assert certificate.lower_diameter == 2.0
+    assert certificate.upper_diameter == 2.0
+    assert certificate.decision == "certified-variant"
+    assert not certificate.update_admitted
+
+
+def test_bounded_error_certificate_contains_every_random_true_diameter() -> None:
+    rng = np.random.default_rng(8675309)
+    for dimension in (1, 2, 3, 7):
+        for _ in range(100):
+            truth = rng.normal(size=(dimension, 2))
+            raw_error = rng.normal(size=(dimension, 2))
+            raw_norm = float(batch_axial_orbit_diameters(raw_error) / 2.0)
+            error_bound = float(rng.uniform(0.0, 0.5))
+            error = raw_error * (error_bound / raw_norm)
+            estimate = truth + error
+            certificate = certify_axial_linear_query(
+                estimate,
+                coefficient_error_bound=error_bound,
+                invariance_tolerance=1.0,
+                nominal_angle_radians=float(rng.uniform(-np.pi, np.pi)),
+            )
+            true_diameter = float(batch_axial_orbit_diameters(truth))
+            assert certificate.lower_diameter <= true_diameter + 1e-13
+            assert true_diameter <= certificate.upper_diameter + 1e-13
+            if certificate.update_admitted:
+                assert true_diameter <= certificate.invariance_tolerance + 1e-13
+
+
+def test_three_way_decision_is_fail_closed() -> None:
+    invariant = certify_axial_linear_query(
+        np.zeros((3, 2)),
+        coefficient_error_bound=0.1,
+        invariance_tolerance=0.21,
+    )
+    assert invariant.decision == "certified-invariant"
+    assert invariant.update_admitted
+
+    uncertain = certify_axial_linear_query(
+        np.zeros((3, 2)),
+        coefficient_error_bound=0.1,
+        invariance_tolerance=0.19,
+    )
+    assert uncertain.decision == "undetermined"
+    assert not uncertain.update_admitted
+
+    variant = certify_axial_linear_query(
+        [[0.5, 0.0]],
+        coefficient_error_bound=0.1,
+        invariance_tolerance=0.7,
+    )
+    assert variant.lower_diameter == pytest.approx(0.8)
+    assert variant.decision == "certified-variant"
+    assert not variant.update_admitted
+
+
+def test_vectorized_axial_diameter_matches_dense_singular_values() -> None:
+    rng = np.random.default_rng(314159)
+    coefficients = rng.normal(size=(257, 5, 2))
+    actual = batch_axial_orbit_diameters(coefficients)
+    expected = 2.0 * np.linalg.svd(coefficients, compute_uv=False)[:, 0]
+    np.testing.assert_allclose(actual, expected, atol=2e-15, rtol=2e-15)
+    assert not actual.flags.writeable
+
+
+def test_lipschitz_sample_certificate_contains_complete_orbit_diameter() -> None:
+    coefficient = np.array(
+        [
+            [0.7, -0.2],
+            [0.3, 0.9],
+            [-0.4, 0.1],
+        ]
+    )
+    true_diameter = float(batch_axial_orbit_diameters(coefficient))
+    lipschitz = true_diameter / 2.0
+    for count in (7, 15, 31, 63):
+        angles = np.arange(count) * (2.0 * np.pi / count)
+        harmonic = np.column_stack((np.cos(angles), np.sin(angles)))
+        values = harmonic @ coefficient.T
+        certificate = certify_uniformly_sampled_periodic_query(
+            values,
+            angular_lipschitz_bound=lipschitz,
+            invariance_tolerance=0.5,
+        )
+        assert certificate.lower_diameter <= true_diameter + 1e-14
+        assert true_diameter <= certificate.upper_diameter + 1e-14
+        assert certificate.decision == "certified-variant"
+
+
+def test_sampled_pairwise_diameter_handles_vector_queries() -> None:
+    values = np.array(
+        [
+            [0.0, 0.0],
+            [3.0, 4.0],
+            [-3.0, -4.0],
+        ]
+    )
+    assert sampled_pairwise_diameter(values) == 10.0
+
+
+@pytest.mark.parametrize(
+    "coefficients",
+    [
+        [],
+        [1.0, 2.0],
+        np.ones((2, 3)),
+        np.ones((0, 2)),
+        [[np.nan, 0.0]],
+        [[1j, 0.0]],
+    ],
+)
+def test_invalid_axial_coefficients_are_rejected(coefficients) -> None:
+    with pytest.raises(ValueError):
+        certify_axial_linear_query(
+            coefficients,
+            coefficient_error_bound=0.0,
+            invariance_tolerance=1.0,
+        )
+
+
+@pytest.mark.parametrize(
+    "error,tolerance,angle",
+    [
+        (-1.0, 1.0, 0.0),
+        (np.nan, 1.0, 0.0),
+        (0.0, 0.0, 0.0),
+        (0.0, -1.0, 0.0),
+        (0.0, 1.0, np.inf),
+        (True, 1.0, 0.0),
+    ],
+)
+def test_invalid_certificate_scalars_are_rejected(error, tolerance, angle) -> None:
+    with pytest.raises(ValueError):
+        certify_axial_linear_query(
+            [[1.0, 0.0]],
+            coefficient_error_bound=error,
+            invariance_tolerance=tolerance,
+            nominal_angle_radians=angle,
+        )
+
+
+def test_invalid_sampled_periodic_contracts_are_rejected() -> None:
+    for values in ([], [[1.0]], [[1.0], [2.0]], [[1.0], [2.0], [np.nan]]):
+        with pytest.raises(ValueError):
+            certify_uniformly_sampled_periodic_query(
+                values,
+                angular_lipschitz_bound=1.0,
+                invariance_tolerance=1.0,
+            )
+    with pytest.raises(ValueError):
+        certify_uniformly_sampled_periodic_query(
+            [[0.0], [1.0], [0.0]],
+            angular_lipschitz_bound=-1.0,
+            invariance_tolerance=1.0,
+        )
+
+
+def test_registered_study_protocol_and_reduced_deterministic_run() -> None:
+    module = _load_study()
+    protocol = module._load_protocol(PROTOCOL)
+    assert protocol["schema"] == "prob4d.robust-orbit-query-stress.v1"
+    assert protocol["case_count"] == 20000
+    assert protocol["coefficient_error_ratios"] == [0.0, 0.02, 0.05, 0.1, 0.2, 0.4, 0.8]
+    assert protocol["sampled_grid_counts"] == [7, 15, 31, 63]
+
+    reduced = json.loads(json.dumps(protocol))
+    reduced["case_count"] = 2000
+    reduced["near_boundary_case_count"] = 2000
+    reduced["sampled_grid_counts"] = [7, 15]
+    reduced["benchmark"] = {
+        "query_count": 256,
+        "query_dimension": 3,
+        "angular_sample_count": 16,
+        "repetitions": 2,
+    }
+    first = module.build_report(reduced)
+    second = module.build_report(reduced)
+    assert first["decision"] == "passed"
+    assert first["registered_checks"] == second["registered_checks"]
+    assert first["population"] == second["population"]
+    assert first["bounded_error_rows"] == second["bounded_error_rows"]
+    assert first["sampled_orbit_rows"] == second["sampled_orbit_rows"]
+    assert first["diameter_parity"] == second["diameter_parity"]


### PR DESCRIPTION
## Scientific purpose

Strengthen the finite-orbit query-identifiability result against the main realism objection: the orbit or its numerical representation is not perfectly known in practice.

For an axial linear query `q(theta) = c + B [cos(theta), sin(theta)]`, the complete Euclidean orbit diameter is exactly `2 sigma_max(B)`. Given a supplied valid operator-norm error bound `||B_true - B_hat|| <= eta`, singular-value perturbation yields the certified interval

`d_true in [max(0, d_hat - 2 eta), d_hat + 2 eta]`.

The resulting gate has three outcomes: certified invariant, certified variant, and undetermined. Only certified invariance admits an update; uncertainty falls back. A second certificate covers arbitrary uniformly sampled periodic queries using a supplied angular Lipschitz bound and the grid cover radius.

## Added

- vectorized exact axial orbit diameters through the two-by-two Gram matrix;
- bounded-coefficient-error three-way query certificate;
- Lipschitz-certified uniform periodic-orbit sampling;
- explicit fail-closed admission semantics;
- adversarial stationary-representative tests where the local derivative is zero but the finite orbit is variant;
- 20,000-case registered robustness sweep;
- 10,000 near-boundary sampling cases;
- 4,096-query exact-versus-sampled computational control;
- derivation, limitations, and relationship to the recording-disjoint Tracking Cloth result.

## Registered result requirements

The workflow requires:

- zero harmful acceptance for every bounded-error certified setting;
- zero harmful acceptance for every Lipschitz-certified sampling setting;
- positive harmful acceptance for the local derivative and uncertified approximations;
- exact diameter parity with dense singular-value calculations;
- full reporting of useful-query acceptance, indeterminacy, and fallback as error bounds increase.

## Boundaries

This is designed robustness and efficiency evidence stacked on the real-trajectory PR #458. The module does not estimate the coefficient-error or Lipschitz bound and does not turn the controlled Tracking Cloth experiment into learned-provider evidence. An optimistic supplied bound invalidates the certificate. The CUT3R/DOT learned-provider confirmation remains support-negative; BayesianPhysTwin and Causal4D are not executed here.