### PR TITLE
Qualify untouched DOT reserve support before learned-provider confirmation

### DIFF
--- a/.github/workflows/temporary-dot-reserve-support-audit.yml
+++ b/.github/workflows/temporary-dot-reserve-support-audit.yml
@@ -1,0 +1,322 @@
+name: Temporary DOT R11-R70 outcome-blind support audit
+
+on:
+  push:
+    branches:
+      - research/dot-rope-reserve-support-audit-v1
+    paths:
+      - ".github/workflows/temporary-dot-reserve-support-audit.yml"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: temporary-dot-reserve-support-audit
+  cancel-in-progress: false
+
+env:
+  DATASET_API: https://dataverse.orc.gmu.edu/api/datasets/:persistentId/?persistentId=doi:10.13021/ORC2020/XXLVXM
+  DATAFILE_API_ROOT: https://dataverse.orc.gmu.edu/api/access/datafile
+  PROTOCOL_PATH: protocols/dot-rope-reserve-support-audit-v1.json
+  OUTPUT_DIR: outputs/dot-rope-reserve-support-audit-v1
+  EVIDENCE_DIR: evidence/dot-rope-reserve-support-audit-v1
+  PYTHONHASHSEED: "0"
+  PYTHONUNBUFFERED: "1"
+  PYTHONDONTWRITEBYTECODE: "1"
+
+jobs:
+  support-audit:
+    name: Freeze R11-R70 cameras without 3-D outcomes
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    steps:
+      - name: Check out exact audit revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: true
+          clean: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install exact development environment and validate audit
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --disable-pip-version-check -e ".[dev]"
+          python -m pip check
+          python -m ruff check \
+            scripts/science/audit_dot_rope_reserve_support.py \
+            tests/test_dot_rope_reserve_support_audit.py
+          python -m ruff format --check \
+            scripts/science/audit_dot_rope_reserve_support.py \
+            tests/test_dot_rope_reserve_support_audit.py
+          python -m pytest -q tests/test_dot_rope_reserve_support_audit.py
+          python scripts/science/audit_dot_rope_reserve_support.py \
+            validate-protocol --protocol "$PROTOCOL_PATH"
+
+      - name: Initialize isolated dataset workspace
+        id: workspace
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="$RUNNER_TEMP/dot-reserve-support-$GITHUB_RUN_ID-$GITHUB_RUN_ATTEMPT"
+          rm -rf -- "$root" "$OUTPUT_DIR"
+          mkdir -p "$root/dataset" "$root/custody"
+          {
+            echo "WORK_ROOT=$root"
+            echo "DATASET_ROOT=$root/dataset"
+            echo "OFFICIAL_METADATA=$root/custody/official-metadata.json"
+          } >> "$GITHUB_ENV"
+          echo "root=$root" >> "$GITHUB_OUTPUT"
+          df -h . "$RUNNER_TEMP"
+
+      - name: Resolve the exact official reserve archives
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          import urllib.request
+          from pathlib import Path
+
+          expected = [
+              "R11-20.zip",
+              "R21-30.zip",
+              "R31-40.zip",
+              "R41-50.zip",
+              "R51-60.zip",
+              "R61-70.zip",
+          ]
+          request = urllib.request.Request(
+              os.environ["DATASET_API"],
+              headers={"User-Agent": "Prob4D-DOT-reserve-support/1"},
+          )
+          with urllib.request.urlopen(request, timeout=90) as response:
+              metadata = json.load(response)
+          if metadata.get("status") != "OK":
+              raise SystemExit("Dataverse metadata request did not return OK")
+          latest = metadata["data"]["latestVersion"]
+          files = latest["files"]
+          selected = []
+          for filename in expected:
+              matches = [
+                  row["dataFile"]
+                  for row in files
+                  if row.get("dataFile", {}).get("filename") == filename
+              ]
+              if len(matches) != 1:
+                  raise SystemExit(f"expected one official {filename}")
+              data_file = matches[0]
+              checksum = data_file.get("checksum", {})
+              if checksum.get("type") != "MD5":
+                  raise SystemExit(f"{filename} lacks an MD5 checksum")
+              selected.append(
+                  {
+                      "filename": filename,
+                      "datafile_id": int(data_file["id"]),
+                      "byte_count": int(data_file["filesize"]),
+                      "md5": str(checksum["value"]).lower(),
+                  }
+              )
+          receipt = {
+              "dataset_persistent_id": "doi:10.13021/ORC2020/XXLVXM",
+              "dataset_version_number": latest.get("versionNumber"),
+              "dataset_version_minor_number": latest.get("versionMinorNumber"),
+              "dataset_version_state": latest.get("versionState"),
+              "files": selected,
+          }
+          path = Path(os.environ["OFFICIAL_METADATA"])
+          path.write_text(
+              json.dumps(receipt, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          with Path(os.environ["WORK_ROOT"], "downloads.tsv").open(
+              "w",
+              encoding="utf-8",
+          ) as stream:
+              for row in selected:
+                  stream.write(
+                      f"{row['filename']}\t{row['datafile_id']}\t"
+                      f"{row['byte_count']}\t{row['md5']}\n"
+                  )
+          print(receipt)
+          PY
+
+      - name: Download and verify all six reserve archives
+        shell: bash
+        run: |
+          set -euo pipefail
+          while IFS=$'\t' read -r name file_id byte_count md5; do
+            destination="$DATASET_ROOT/$name"
+            echo "Downloading $name ($byte_count bytes)"
+            curl --fail --location --retry 8 --retry-all-errors \
+              --connect-timeout 30 --max-time 5400 \
+              --output "$destination" \
+              "$DATAFILE_API_ROOT/$file_id"
+            test "$(stat -c %s "$destination")" = "$byte_count"
+            printf '%s  %s\n' "$md5" "$destination" \
+              | md5sum --check --strict
+            df -h "$DATASET_ROOT"
+          done < "$WORK_ROOT/downloads.tsv"
+
+      - name: Execute the frozen support audit once
+        shell: bash
+        run: |
+          set -euo pipefail
+          python scripts/science/audit_dot_rope_reserve_support.py audit \
+            --protocol "$PROTOCOL_PATH" \
+            --dataset-root "$DATASET_ROOT" \
+            --official-metadata "$OFFICIAL_METADATA" \
+            --output-dir "$OUTPUT_DIR" \
+            --repository-revision "$(git rev-parse HEAD)"
+
+      - name: Independently verify information custody and result identity
+        id: result
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          output = Path(os.environ["OUTPUT_DIR"])
+          if (output / "technical-failure.json").exists():
+              raise SystemExit((output / "technical-failure.json").read_text())
+          result = json.loads((output / "result.json").read_text())
+          custody = json.loads((output / "accessed-members.json").read_text())
+          assert result["schema"] == (
+              "prob4d.dot-rope-reserve-support-audit-result.v1"
+          )
+          assert len(result["selected_cameras"]) == 60
+          assert result["camera_row_count"] == 600
+          assert result["accessed_member_count"] == 4200
+          assert len(result["qualified_sequences"]) + len(
+              result["unsupported_sequences"]
+          ) == 60
+          assert sorted(
+              result["qualified_sequences"] + result["unsupported_sequences"]
+          ) == [f"R{index:02d}" for index in range(11, 71)]
+          assert len(custody["members"]) == 4200
+          assert custody["three_dimensional_coordinate_values_opened"] is False
+          assert custody["normal_or_uv_images_opened"] is False
+          assert all(
+              "/coordinates/2d/" in row["member"]
+              and "/coordinates/3d/" not in row["member"]
+              for row in custody["members"]
+          )
+          boundary = result["information_boundary"]
+          assert boundary["two_dimensional_coordinate_values_opened"] is True
+          assert boundary["three_dimensional_coordinate_values_opened"] is False
+          assert boundary["normal_view_images_opened"] is False
+          assert boundary["uv_view_images_opened"] is False
+          assert boundary["learned_provider_executed"] is False
+          assert boundary["provider_residuals_or_uncertainty_scores_opened"] is False
+          unsigned = dict(result)
+          supplied = unsigned.pop("support_id")
+          encoded = json.dumps(
+              unsigned,
+              sort_keys=True,
+              separators=(",", ":"),
+              allow_nan=False,
+          ).encode()
+          assert hashlib.sha256(encoded).hexdigest() == supplied
+          ledger_sha = hashlib.sha256(
+              (output / "accessed-members.json").read_bytes()
+          ).hexdigest()
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as stream:
+              stream.write(f"support_id={supplied}\n")
+              stream.write(
+                  f"qualified_sequence_count={len(result['qualified_sequences'])}\n"
+              )
+              stream.write(
+                  f"unsupported_sequence_count={len(result['unsupported_sequences'])}\n"
+              )
+              stream.write(f"access_ledger_sha256={ledger_sha}\n")
+          print(
+              {
+                  "support_id": supplied,
+                  "qualified_sequences": len(result["qualified_sequences"]),
+                  "unsupported_sequences": len(result["unsupported_sequences"]),
+                  "access_ledger_sha256": ledger_sha,
+              }
+          )
+          PY
+
+      - name: Remove downloaded archives before evidence publication
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf -- "$DATASET_ROOT"
+          test ! -e "$DATASET_ROOT"
+
+      - name: Retain compact support result on the audit branch
+        shell: bash
+        env:
+          SUPPORT_ID: ${{ steps.result.outputs.support_id }}
+          QUALIFIED_COUNT: ${{ steps.result.outputs.qualified_sequence_count }}
+          UNSUPPORTED_COUNT: ${{ steps.result.outputs.unsupported_sequence_count }}
+          LEDGER_SHA256: ${{ steps.result.outputs.access_ledger_sha256 }}
+        run: |
+          set -euo pipefail
+          test ! -e "$EVIDENCE_DIR"
+          mkdir -p "$EVIDENCE_DIR"
+          cp "$OUTPUT_DIR/result.json" "$EVIDENCE_DIR/result.json"
+          cp "$OUTPUT_DIR/summary.md" "$EVIDENCE_DIR/summary.md"
+          cp "$OUTPUT_DIR/selected-cameras.csv" "$EVIDENCE_DIR/selected-cameras.csv"
+          cp "$OFFICIAL_METADATA" "$EVIDENCE_DIR/official-metadata.json"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          receipt = {
+              "schema": "prob4d.dot-rope-reserve-support-retention.v1",
+              "workflow_run_id": int(os.environ["GITHUB_RUN_ID"]),
+              "workflow_run_attempt": int(os.environ["GITHUB_RUN_ATTEMPT"]),
+              "repository_revision": os.environ["GITHUB_SHA"],
+              "support_id": os.environ["SUPPORT_ID"],
+              "qualified_sequence_count": int(os.environ["QUALIFIED_COUNT"]),
+              "unsupported_sequence_count": int(os.environ["UNSUPPORTED_COUNT"]),
+              "accessed_member_count": 4200,
+              "access_ledger_sha256": os.environ["LEDGER_SHA256"],
+              "three_dimensional_truth_opened": False,
+              "learned_provider_executed": False,
+          }
+          Path(os.environ["EVIDENCE_DIR"], "retention.json").write_text(
+              json.dumps(receipt, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          PY
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add "$EVIDENCE_DIR"
+          git commit -m "Retain outcome-blind DOT reserve support qualification"
+          git push origin HEAD:research/dot-rope-reserve-support-audit-v1
+
+      - name: Publish support summary
+        if: always()
+        shell: bash
+        run: |
+          if [[ -f "$OUTPUT_DIR/summary.md" ]]; then
+            cat "$OUTPUT_DIR/summary.md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload complete support evidence and access ledger
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: dot-rope-reserve-support-audit-v1-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            outputs/dot-rope-reserve-support-audit-v1/
+            ${{ env.OFFICIAL_METADATA }}
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/temporary-dot-reserve-support-autoformat.yml
+++ b/.github/workflows/temporary-dot-reserve-support-autoformat.yml
@@ -1,0 +1,52 @@
+name: Temporary DOT reserve support autoformat
+
+on:
+  push:
+    branches:
+      - research/dot-rope-reserve-support-audit-v1
+    paths:
+      - ".github/workflows/temporary-dot-reserve-support-autoformat.yml"
+      - "scripts/science/audit_dot_rope_reserve_support.py"
+      - "tests/test_dot_rope_reserve_support_audit.py"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: temporary-dot-reserve-support-autoformat
+  cancel-in-progress: false
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: true
+          clean: true
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+      - name: Format exact files
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --disable-pip-version-check "ruff==0.12.12"
+          python -m ruff format \
+            scripts/science/audit_dot_rope_reserve_support.py \
+            tests/test_dot_rope_reserve_support_audit.py
+      - name: Commit formatter output when needed
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git diff --quiet; then
+            echo "No formatter changes required."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add \
+            scripts/science/audit_dot_rope_reserve_support.py \
+            tests/test_dot_rope_reserve_support_audit.py
+          git commit -m "Apply Ruff formatting to DOT reserve support audit"
+          git push origin HEAD:research/dot-rope-reserve-support-audit-v1

--- a/.github/workflows/temporary-freeze-dot-provider-cohort.yml
+++ b/.github/workflows/temporary-freeze-dot-provider-cohort.yml
@@ -1,0 +1,126 @@
+name: Temporary freeze DOT learned-provider cohort
+
+on:
+  push:
+    branches:
+      - research/dot-rope-reserve-support-audit-v1
+    paths:
+      - ".github/workflows/temporary-freeze-dot-provider-cohort.yml"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: temporary-freeze-dot-provider-cohort
+  cancel-in-progress: false
+
+jobs:
+  freeze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: true
+          clean: true
+      - name: Select two fixed-camera sequences from each reserve archive
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          evidence = Path("evidence/dot-rope-reserve-support-audit-v1")
+          result = json.loads((evidence / "result.json").read_text())
+          assert len(result["qualified_sequences"]) == 60
+          assert result["unsupported_sequences"] == []
+          candidates = [
+              row
+              for row in result["selected_cameras"]
+              if row["qualified"] and row["selected_camera"] == "cam001"
+          ]
+          by_archive = {}
+          for row in candidates:
+              by_archive.setdefault(row["archive"], []).append(row)
+          assert sorted(by_archive) == [
+              "R11-20.zip",
+              "R21-30.zip",
+              "R31-40.zip",
+              "R41-50.zip",
+              "R51-60.zip",
+              "R61-70.zip",
+          ]
+          selected = []
+          for archive in sorted(by_archive):
+              ranked = sorted(
+                  by_archive[archive],
+                  key=lambda row: (
+                      hashlib.sha256(
+                          f"{result['support_id']}:{row['sequence']}".encode()
+                      ).hexdigest(),
+                      row["sequence"],
+                  ),
+              )
+              assert len(ranked) >= 2
+              selected.extend(ranked[:2])
+          selected_sequences = [row["sequence"] for row in selected]
+          reserve = [
+              sequence
+              for sequence in result["qualified_sequences"]
+              if sequence not in selected_sequences
+          ]
+          cohort = {
+              "schema": "prob4d.dot-rope-learned-provider-cohort.v1",
+              "support_id": result["support_id"],
+              "support_protocol_sha256": result["protocol_sha256"],
+              "support_branch_revision": result["repository_revision"],
+              "selection_rule": (
+                  "among support-qualified sequences whose deterministic selected "
+                  "camera is cam001, take the two smallest SHA256(support_id:sequence) "
+                  "per official reserve archive; break ties by sequence"
+              ),
+              "selected_sequence_count": 12,
+              "selected_sequences": selected_sequences,
+              "selected_camera_by_sequence": {
+                  row["sequence"]: row["selected_camera"] for row in selected
+              },
+              "selected_archive_by_sequence": {
+                  row["sequence"]: row["archive"] for row in selected
+              },
+              "reserve_sequence_count": len(reserve),
+              "reserve_sequences": reserve,
+              "information_order": {
+                  "three_dimensional_truth_opened_before_cohort_freeze": False,
+                  "normal_view_images_opened_before_cohort_freeze": False,
+                  "learned_provider_executed_before_cohort_freeze": False,
+                  "provider_outcomes_used_for_selection": False,
+                  "three_dimensional_outcomes_used_for_selection": False,
+              },
+              "next_stage": {
+                  "provider_checkpoint_and_code_must_remain_source_frozen": True,
+                  "provider_output_support_must_be_sealed_before_3d_truth": True,
+                  "target_side_retuning_allowed": False,
+                  "unsupported_provider_outputs_replaced": False,
+              },
+          }
+          unsigned = dict(cohort)
+          cohort["cohort_id"] = hashlib.sha256(
+              json.dumps(
+                  unsigned,
+                  sort_keys=True,
+                  separators=(",", ":"),
+              ).encode()
+          ).hexdigest()
+          (evidence / "provider-cohort.json").write_text(
+              json.dumps(cohort, indent=2, sort_keys=True) + "\n",
+              encoding="utf-8",
+          )
+          print(cohort)
+          PY
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add evidence/dot-rope-reserve-support-audit-v1/provider-cohort.json
+          git commit -m "Freeze outcome-blind DOT learned-provider cohort"
+          git push origin HEAD:research/dot-rope-reserve-support-audit-v1

--- a/docs/dot-rope-reserve-support-audit-v1.md
+++ b/docs/dot-rope-reserve-support-audit-v1.md
@@ -1,0 +1,76 @@
+# Outcome-blind DOT reserve support qualification
+
+Status: **completed support seal; no learned-provider or 3-D outcome result**.
+
+## Purpose
+
+The first CUT3R/DOT held-out confirmation terminated because one frozen
+sequence lacked the preregistered provider/truth support. That support-negative
+result remains terminal and is not reinterpreted. The untouched R11--R70
+reserve therefore received a new support-only qualification before any normal
+image, learned-provider prediction, or 3-D coordinate outcome was opened.
+
+## Frozen audit
+
+Protocol `protocols/dot-rope-reserve-support-audit-v1.json` registered:
+
+- sequences R11 through R70;
+- cameras `cam001` through `cam010`;
+- frames 1 through 7;
+- only publisher 2-D marker-coordinate files;
+- stable coordinate-row index as the support identity;
+- visibility requiring finite, nonnegative coordinates;
+- common support as the intersection across all seven frames;
+- deterministic camera selection by common count, minimum frame count, mean
+  frame count, and finally the lowest camera index;
+- qualification requiring at least eight common markers and at least eight
+  visible markers in every frame;
+- no replacement of unsupported sequences.
+
+All six official reserve archives were resolved through the publisher's
+Dataverse metadata, downloaded, and verified against their official byte counts
+and MD5 checksums. The audit read exactly 4,200 two-dimensional coordinate
+members: 60 sequences times 10 cameras times seven frames. It did not read a
+3-D coordinate value, normal or UV image, provider output, residual, covariance
+score, BayesianPhysTwin result, or Causal4D result.
+
+## Result
+
+All **60 of 60** reserve sequences satisfied the conservative support rule under
+their deterministically selected camera. The complete per-camera table, one
+selected camera per sequence, official archive receipts, exact information
+boundary, and content-addressed support result are retained in
+`evidence/dot-rope-reserve-support-audit-v1/`.
+
+This result says only that a feasible observation/evaluation interface exists.
+It does not imply that CUT3R will emit valid predictions at the marker support
+or that any uncertainty method will improve a held-out score.
+
+## Frozen learned-provider cohort
+
+Before opening images or running CUT3R, the audit result was used to freeze a
+computationally tractable 12-sequence cohort:
+
+1. retain only support-qualified sequences whose deterministic selected camera
+   is `cam001`;
+2. within each of the six reserve archives, rank sequences by
+   `SHA256(support_id:sequence)`;
+3. select the first two sequences per archive;
+4. reserve the remaining 48 sequences without replacement.
+
+The exact roster, camera map, archive map, selection rule, information order,
+and cohort identity are stored in
+`evidence/dot-rope-reserve-support-audit-v1/provider-cohort.json`.
+
+The next stage must retain the source-frozen CUT3R code, checkpoint, window
+construction, covariance family, and source-selected dependence strength. It
+must seal provider outputs and provider-side support before opening 3-D truth.
+No target-side tuning or replacement is permitted.
+
+## Claim boundary
+
+This is outcome-blind support qualification and cohort freezing. It is not a
+positive learned-provider result and is not part of the primary controlled
+Tracking Cloth claim. Its purpose is to make a valid end-to-end confirmation
+possible without changing the earlier support-negative outcome or selecting
+sequences from provider residuals or 3-D target errors.

--- a/protocols/dot-rope-reserve-support-audit-v1.json
+++ b/protocols/dot-rope-reserve-support-audit-v1.json
@@ -1,0 +1,74 @@
+{
+  "schema": "prob4d.dot-rope-reserve-support-audit.v1",
+  "evidence_kind": "outcome-blind-two-dimensional-support-qualification",
+  "dataset": {
+    "persistent_id": "doi:10.13021/ORC2020/XXLVXM",
+    "archive_names": [
+      "R11-20.zip",
+      "R21-30.zip",
+      "R31-40.zip",
+      "R41-50.zip",
+      "R51-60.zip",
+      "R61-70.zip"
+    ],
+    "sequence_start": 11,
+    "sequence_stop": 70,
+    "cameras": [
+      "cam001",
+      "cam002",
+      "cam003",
+      "cam004",
+      "cam005",
+      "cam006",
+      "cam007",
+      "cam008",
+      "cam009",
+      "cam010"
+    ],
+    "frames": [1, 2, 3, 4, 5, 6, 7],
+    "coordinate_member_template": "{sequence}/coordinates/2d/frame{frame:06d}_{camera}.txt",
+    "coordinate_columns": [0, 1]
+  },
+  "visibility_rule": {
+    "finite_coordinates_required": true,
+    "nonnegative_coordinates_required": true,
+    "identity_definition": "stable row index within publisher 2-D coordinate files",
+    "common_support_scope": "intersection across all seven registered frames"
+  },
+  "camera_selection_rule": {
+    "order": [
+      "maximum common visible marker count across all seven frames",
+      "maximum minimum per-frame visible marker count",
+      "maximum mean per-frame visible marker count",
+      "lowest camera index"
+    ],
+    "minimum_common_visible_markers": 8,
+    "minimum_per_frame_visible_markers": 8,
+    "unsupported_sequences_replaced": false
+  },
+  "next_stage_boundary": {
+    "camera_map_may_be_frozen_from_this_result": true,
+    "learned_provider_may_run_only_after_camera_map_freeze": true,
+    "provider_output_support_requires_a_separate_outcome_blind_seal": true,
+    "three_dimensional_truth_may_open_only_after_provider_support_freeze": true
+  },
+  "information_boundary": {
+    "zip_member_names_visible": true,
+    "two_dimensional_coordinate_values_opened": true,
+    "three_dimensional_coordinate_values_opened": false,
+    "normal_view_images_opened": false,
+    "uv_view_images_opened": false,
+    "learned_provider_executed": false,
+    "provider_residuals_or_uncertainty_scores_opened": false,
+    "bayesian_phystwin_executed": false,
+    "causal4d_executed": false
+  },
+  "registered_outputs": [
+    "all sequence-camera support rows",
+    "one deterministically selected camera per sequence",
+    "qualified and unsupported reserve sequence rosters",
+    "exact accessed 2-D member ledger",
+    "official archive metadata and checksums"
+  ],
+  "claim_boundary": "Support qualification only. Two-dimensional marker visibility is used to freeze a camera map and candidate sequence roster before learned-provider execution. No 3-D truth, normal or UV imagery, provider prediction, residual, covariance score, physical query outcome, BayesianPhysTwin result, or Causal4D result is opened. Qualification does not imply provider competence or a positive held-out result."
+}

--- a/scripts/science/audit_dot_rope_reserve_support.py
+++ b/scripts/science/audit_dot_rope_reserve_support.py
@@ -52,9 +52,7 @@ def _load_protocol(path: Path) -> dict[str, Any]:
     }
     if set(protocol) != expected or protocol["schema"] != SCHEMA:
         raise ValueError("protocol schema or fields changed")
-    if protocol["evidence_kind"] != (
-        "outcome-blind-two-dimensional-support-qualification"
-    ):
+    if protocol["evidence_kind"] != ("outcome-blind-two-dimensional-support-qualification"):
         raise ValueError("evidence kind changed")
     dataset = protocol["dataset"]
     if dataset != {
@@ -71,9 +69,7 @@ def _load_protocol(path: Path) -> dict[str, Any]:
         "sequence_stop": 70,
         "cameras": [f"cam{index:03d}" for index in range(1, 11)],
         "frames": list(range(1, 8)),
-        "coordinate_member_template": (
-            "{sequence}/coordinates/2d/frame{frame:06d}_{camera}.txt"
-        ),
+        "coordinate_member_template": ("{sequence}/coordinates/2d/frame{frame:06d}_{camera}.txt"),
         "coordinate_columns": [0, 1],
     }:
         raise ValueError("dataset contract changed")
@@ -109,9 +105,7 @@ def _load_protocol(path: Path) -> dict[str, Any]:
         "causal4d_executed": False,
     }:
         raise ValueError("information boundary changed")
-    if not isinstance(protocol["claim_boundary"], str) or not protocol[
-        "claim_boundary"
-    ].strip():
+    if not isinstance(protocol["claim_boundary"], str) or not protocol["claim_boundary"].strip():
         raise ValueError("claim boundary is empty")
     return protocol
 
@@ -135,9 +129,7 @@ def _parse_coordinates(raw: bytes, *, member: str) -> list[tuple[float, float]]:
             x = float(tokens[0])
             y = float(tokens[1])
         except ValueError as error:
-            raise ValueError(
-                f"{member}:{line_number} contains a nonnumeric coordinate"
-            ) from error
+            raise ValueError(f"{member}:{line_number} contains a nonnumeric coordinate") from error
         rows.append((x, y))
     if not rows:
         raise ValueError(f"{member} contains no coordinate rows")
@@ -174,9 +166,7 @@ def _verify_archives(
     protocol: dict[str, Any],
 ) -> tuple[dict[str, Path], list[dict[str, Any]]]:
     metadata = _load_json(metadata_path)
-    if metadata.get("dataset_persistent_id") != protocol["dataset"][
-        "persistent_id"
-    ]:
+    if metadata.get("dataset_persistent_id") != protocol["dataset"]["persistent_id"]:
         raise ValueError("metadata persistent identifier changed")
     files = metadata.get("files")
     if not isinstance(files, list):
@@ -267,27 +257,17 @@ def evaluate(args: argparse.Namespace) -> int:
             args.official_metadata,
             protocol,
         )
-        handles = {
-            name: zipfile.ZipFile(path)
-            for name, path in archives.items()
-        }
+        handles = {name: zipfile.ZipFile(path) for name, path in archives.items()}
         try:
-            name_sets = {
-                name: set(handle.namelist())
-                for name, handle in handles.items()
-            }
+            name_sets = {name: set(handle.namelist()) for name, handle in handles.items()}
             camera_rows: list[dict[str, Any]] = []
             selected_rows: list[dict[str, Any]] = []
             accessed_members: list[dict[str, Any]] = []
             minimum_common = int(
-                protocol["camera_selection_rule"][
-                    "minimum_common_visible_markers"
-                ]
+                protocol["camera_selection_rule"]["minimum_common_visible_markers"]
             )
             minimum_frame = int(
-                protocol["camera_selection_rule"][
-                    "minimum_per_frame_visible_markers"
-                ]
+                protocol["camera_selection_rule"]["minimum_per_frame_visible_markers"]
             )
             template = protocol["dataset"]["coordinate_member_template"]
             for sequence_number in range(
@@ -342,9 +322,7 @@ def evaluate(args: argparse.Namespace) -> int:
                         "maximum_frame_visible_marker_count": max(frame_counts),
                         "minimum_coordinate_row_count": min(marker_row_counts),
                         "maximum_coordinate_row_count": max(marker_row_counts),
-                        "common_marker_indices": ";".join(
-                            str(index) for index in sorted(common)
-                        ),
+                        "common_marker_indices": ";".join(str(index) for index in sorted(common)),
                     }
                     camera_rows.append(row)
                     sequence_camera_rows.append(row)
@@ -359,17 +337,14 @@ def evaluate(args: argparse.Namespace) -> int:
                 )
                 qualified = (
                     int(selected["common_visible_marker_count"]) >= minimum_common
-                    and int(selected["minimum_frame_visible_marker_count"])
-                    >= minimum_frame
+                    and int(selected["minimum_frame_visible_marker_count"]) >= minimum_frame
                 )
                 selected_rows.append(
                     {
                         "sequence": sequence,
                         "archive": archive_name,
                         "selected_camera": selected["camera"],
-                        "common_visible_marker_count": selected[
-                            "common_visible_marker_count"
-                        ],
+                        "common_visible_marker_count": selected["common_visible_marker_count"],
                         "minimum_frame_visible_marker_count": selected[
                             "minimum_frame_visible_marker_count"
                         ],
@@ -384,12 +359,8 @@ def evaluate(args: argparse.Namespace) -> int:
             for handle in handles.values():
                 handle.close()
 
-        qualified = [
-            row["sequence"] for row in selected_rows if row["qualified"]
-        ]
-        unsupported = [
-            row["sequence"] for row in selected_rows if not row["qualified"]
-        ]
+        qualified = [row["sequence"] for row in selected_rows if row["qualified"]]
+        unsupported = [row["sequence"] for row in selected_rows if not row["qualified"]]
         result: dict[str, Any] = {
             "schema": RESULT_SCHEMA,
             "evidence_kind": protocol["evidence_kind"],
@@ -438,9 +409,7 @@ def evaluate(args: argparse.Namespace) -> int:
             "protocol_sha256": _content_id(protocol),
             "repository_revision": args.repository_revision,
             "decision": "technical-failure",
-            "failure": (
-                f"{type(error).__name__}: {' '.join(str(error).split())}"
-            )[:2000],
+            "failure": (f"{type(error).__name__}: {' '.join(str(error).split())}")[:2000],
             "traceback_tail": traceback.format_exc().splitlines()[-30:],
             "information_boundary": protocol["information_boundary"],
             "claim_boundary": protocol["claim_boundary"],

--- a/scripts/science/audit_dot_rope_reserve_support.py
+++ b/scripts/science/audit_dot_rope_reserve_support.py
@@ -1,0 +1,474 @@
+#!/usr/bin/env python3
+"""Freeze a DOT R11-R70 camera map using only 2-D marker visibility."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+import traceback
+import zipfile
+from pathlib import Path
+from typing import Any
+
+SCHEMA = "prob4d.dot-rope-reserve-support-audit.v1"
+RESULT_SCHEMA = "prob4d.dot-rope-reserve-support-audit-result.v1"
+
+
+def _canonical(value: object) -> bytes:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    ).encode()
+
+
+def _content_id(value: object) -> str:
+    return hashlib.sha256(_canonical(value)).hexdigest()
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if type(value) is not dict:
+        raise ValueError(f"{path} must contain one JSON object")
+    return value
+
+
+def _load_protocol(path: Path) -> dict[str, Any]:
+    protocol = _load_json(path)
+    expected = {
+        "schema",
+        "evidence_kind",
+        "dataset",
+        "visibility_rule",
+        "camera_selection_rule",
+        "next_stage_boundary",
+        "information_boundary",
+        "registered_outputs",
+        "claim_boundary",
+    }
+    if set(protocol) != expected or protocol["schema"] != SCHEMA:
+        raise ValueError("protocol schema or fields changed")
+    if protocol["evidence_kind"] != (
+        "outcome-blind-two-dimensional-support-qualification"
+    ):
+        raise ValueError("evidence kind changed")
+    dataset = protocol["dataset"]
+    if dataset != {
+        "persistent_id": "doi:10.13021/ORC2020/XXLVXM",
+        "archive_names": [
+            "R11-20.zip",
+            "R21-30.zip",
+            "R31-40.zip",
+            "R41-50.zip",
+            "R51-60.zip",
+            "R61-70.zip",
+        ],
+        "sequence_start": 11,
+        "sequence_stop": 70,
+        "cameras": [f"cam{index:03d}" for index in range(1, 11)],
+        "frames": list(range(1, 8)),
+        "coordinate_member_template": (
+            "{sequence}/coordinates/2d/frame{frame:06d}_{camera}.txt"
+        ),
+        "coordinate_columns": [0, 1],
+    }:
+        raise ValueError("dataset contract changed")
+    if protocol["visibility_rule"] != {
+        "finite_coordinates_required": True,
+        "nonnegative_coordinates_required": True,
+        "identity_definition": "stable row index within publisher 2-D coordinate files",
+        "common_support_scope": "intersection across all seven registered frames",
+    }:
+        raise ValueError("visibility rule changed")
+    if protocol["camera_selection_rule"] != {
+        "order": [
+            "maximum common visible marker count across all seven frames",
+            "maximum minimum per-frame visible marker count",
+            "maximum mean per-frame visible marker count",
+            "lowest camera index",
+        ],
+        "minimum_common_visible_markers": 8,
+        "minimum_per_frame_visible_markers": 8,
+        "unsupported_sequences_replaced": False,
+    }:
+        raise ValueError("camera selection rule changed")
+    boundary = protocol["information_boundary"]
+    if boundary != {
+        "zip_member_names_visible": True,
+        "two_dimensional_coordinate_values_opened": True,
+        "three_dimensional_coordinate_values_opened": False,
+        "normal_view_images_opened": False,
+        "uv_view_images_opened": False,
+        "learned_provider_executed": False,
+        "provider_residuals_or_uncertainty_scores_opened": False,
+        "bayesian_phystwin_executed": False,
+        "causal4d_executed": False,
+    }:
+        raise ValueError("information boundary changed")
+    if not isinstance(protocol["claim_boundary"], str) or not protocol[
+        "claim_boundary"
+    ].strip():
+        raise ValueError("claim boundary is empty")
+    return protocol
+
+
+def _archive_for_sequence(sequence_number: int) -> str:
+    start = ((sequence_number - 1) // 10) * 10 + 1
+    return f"R{start:02d}-{start + 9:02d}.zip"
+
+
+def _parse_coordinates(raw: bytes, *, member: str) -> list[tuple[float, float]]:
+    text = raw.decode("utf-8-sig")
+    rows: list[tuple[float, float]] = []
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        tokens = stripped.replace(",", " ").split()
+        if len(tokens) < 2:
+            raise ValueError(f"{member}:{line_number} has fewer than two columns")
+        try:
+            x = float(tokens[0])
+            y = float(tokens[1])
+        except ValueError as error:
+            raise ValueError(
+                f"{member}:{line_number} contains a nonnumeric coordinate"
+            ) from error
+        rows.append((x, y))
+    if not rows:
+        raise ValueError(f"{member} contains no coordinate rows")
+    return rows
+
+
+def _visible_indices(rows: list[tuple[float, float]]) -> set[int]:
+    return {
+        index
+        for index, (x, y) in enumerate(rows)
+        if math.isfinite(x) and math.isfinite(y) and x >= 0.0 and y >= 0.0
+    }
+
+
+def _md5(path: Path) -> str:
+    digest = hashlib.md5(usedforsecurity=False)
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(8 * 1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(8 * 1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _verify_archives(
+    root: Path,
+    metadata_path: Path,
+    protocol: dict[str, Any],
+) -> tuple[dict[str, Path], list[dict[str, Any]]]:
+    metadata = _load_json(metadata_path)
+    if metadata.get("dataset_persistent_id") != protocol["dataset"][
+        "persistent_id"
+    ]:
+        raise ValueError("metadata persistent identifier changed")
+    files = metadata.get("files")
+    if not isinstance(files, list):
+        raise ValueError("metadata files are missing")
+    by_name = {
+        row.get("filename"): row
+        for row in files
+        if isinstance(row, dict) and isinstance(row.get("filename"), str)
+    }
+    expected = protocol["dataset"]["archive_names"]
+    if set(by_name) != set(expected):
+        raise ValueError("official archive metadata roster changed")
+    paths: dict[str, Path] = {}
+    receipts: list[dict[str, Any]] = []
+    for name in expected:
+        row = by_name[name]
+        path = root / name
+        if not path.is_file() or path.is_symlink():
+            raise ValueError(f"archive is missing or symlinked: {name}")
+        byte_count = int(row["byte_count"])
+        checksum = str(row["md5"]).lower()
+        if path.stat().st_size != byte_count or _md5(path) != checksum:
+            raise ValueError(f"archive identity changed: {name}")
+        paths[name] = path
+        receipts.append(
+            {
+                "filename": name,
+                "datafile_id": int(row["datafile_id"]),
+                "byte_count": byte_count,
+                "md5": checksum,
+                "sha256": _sha256(path),
+            }
+        )
+    return paths, receipts
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.write_text(
+        json.dumps(value, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+
+
+def _write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+    if not rows:
+        raise ValueError(f"cannot write an empty CSV: {path.name}")
+    with path.open("w", encoding="utf-8", newline="") as stream:
+        writer = csv.DictWriter(stream, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def _summary(result: dict[str, Any]) -> str:
+    lines = [
+        "# DOT R11-R70 outcome-blind support audit",
+        "",
+        f"Support ID: `{result['support_id']}`",
+        "",
+        f"Qualified sequences: **{len(result['qualified_sequences'])}/60**",
+        "",
+        f"Unsupported sequences: **{len(result['unsupported_sequences'])}/60**",
+        "",
+        "Only publisher 2-D marker-coordinate values were read. No 3-D truth, normal or UV image, provider prediction, residual, covariance score, or downstream outcome was opened.",
+        "",
+        "| Sequence | selected camera | common markers | minimum/frame | qualified |",
+        "|---|---:|---:|---:|---:|",
+    ]
+    for row in result["selected_cameras"]:
+        lines.append(
+            f"| {row['sequence']} | {row['selected_camera']} | "
+            f"{row['common_visible_marker_count']} | "
+            f"{row['minimum_frame_visible_marker_count']} | "
+            f"{str(row['qualified']).lower()} |"
+        )
+    lines += ["", result["claim_boundary"], ""]
+    return "\n".join(lines)
+
+
+def evaluate(args: argparse.Namespace) -> int:
+    protocol = _load_protocol(args.protocol)
+    output = args.output_dir
+    if output.exists():
+        raise ValueError("output directory already exists")
+    output.mkdir(parents=True)
+    try:
+        archives, archive_receipts = _verify_archives(
+            args.dataset_root,
+            args.official_metadata,
+            protocol,
+        )
+        handles = {
+            name: zipfile.ZipFile(path)
+            for name, path in archives.items()
+        }
+        try:
+            name_sets = {
+                name: set(handle.namelist())
+                for name, handle in handles.items()
+            }
+            camera_rows: list[dict[str, Any]] = []
+            selected_rows: list[dict[str, Any]] = []
+            accessed_members: list[dict[str, Any]] = []
+            minimum_common = int(
+                protocol["camera_selection_rule"][
+                    "minimum_common_visible_markers"
+                ]
+            )
+            minimum_frame = int(
+                protocol["camera_selection_rule"][
+                    "minimum_per_frame_visible_markers"
+                ]
+            )
+            template = protocol["dataset"]["coordinate_member_template"]
+            for sequence_number in range(
+                int(protocol["dataset"]["sequence_start"]),
+                int(protocol["dataset"]["sequence_stop"]) + 1,
+            ):
+                sequence = f"R{sequence_number:02d}"
+                archive_name = _archive_for_sequence(sequence_number)
+                archive = handles[archive_name]
+                names = name_sets[archive_name]
+                sequence_camera_rows: list[dict[str, Any]] = []
+                for camera in protocol["dataset"]["cameras"]:
+                    visible_by_frame: list[set[int]] = []
+                    frame_counts: list[int] = []
+                    marker_row_counts: list[int] = []
+                    for frame in protocol["dataset"]["frames"]:
+                        member = template.format(
+                            sequence=sequence,
+                            frame=int(frame),
+                            camera=camera,
+                        )
+                        if member not in names:
+                            raise ValueError(f"registered 2-D member is missing: {member}")
+                        raw = archive.read(member)
+                        rows = _parse_coordinates(raw, member=member)
+                        visible = _visible_indices(rows)
+                        visible_by_frame.append(visible)
+                        frame_counts.append(len(visible))
+                        marker_row_counts.append(len(rows))
+                        accessed_members.append(
+                            {
+                                "archive": archive_name,
+                                "sequence": sequence,
+                                "camera": camera,
+                                "frame": int(frame),
+                                "member": member,
+                                "byte_count": len(raw),
+                                "sha256": hashlib.sha256(raw).hexdigest(),
+                                "coordinate_row_count": len(rows),
+                                "visible_marker_count": len(visible),
+                            }
+                        )
+                    common = set.intersection(*visible_by_frame)
+                    row = {
+                        "sequence": sequence,
+                        "camera": camera,
+                        "common_visible_marker_count": len(common),
+                        "minimum_frame_visible_marker_count": min(frame_counts),
+                        "mean_frame_visible_marker_count": float(
+                            sum(frame_counts) / len(frame_counts)
+                        ),
+                        "maximum_frame_visible_marker_count": max(frame_counts),
+                        "minimum_coordinate_row_count": min(marker_row_counts),
+                        "maximum_coordinate_row_count": max(marker_row_counts),
+                        "common_marker_indices": ";".join(
+                            str(index) for index in sorted(common)
+                        ),
+                    }
+                    camera_rows.append(row)
+                    sequence_camera_rows.append(row)
+                selected = max(
+                    sequence_camera_rows,
+                    key=lambda row: (
+                        row["common_visible_marker_count"],
+                        row["minimum_frame_visible_marker_count"],
+                        row["mean_frame_visible_marker_count"],
+                        -int(str(row["camera"])[3:]),
+                    ),
+                )
+                qualified = (
+                    int(selected["common_visible_marker_count"]) >= minimum_common
+                    and int(selected["minimum_frame_visible_marker_count"])
+                    >= minimum_frame
+                )
+                selected_rows.append(
+                    {
+                        "sequence": sequence,
+                        "archive": archive_name,
+                        "selected_camera": selected["camera"],
+                        "common_visible_marker_count": selected[
+                            "common_visible_marker_count"
+                        ],
+                        "minimum_frame_visible_marker_count": selected[
+                            "minimum_frame_visible_marker_count"
+                        ],
+                        "mean_frame_visible_marker_count": selected[
+                            "mean_frame_visible_marker_count"
+                        ],
+                        "common_marker_indices": selected["common_marker_indices"],
+                        "qualified": qualified,
+                    }
+                )
+        finally:
+            for handle in handles.values():
+                handle.close()
+
+        qualified = [
+            row["sequence"] for row in selected_rows if row["qualified"]
+        ]
+        unsupported = [
+            row["sequence"] for row in selected_rows if not row["qualified"]
+        ]
+        result: dict[str, Any] = {
+            "schema": RESULT_SCHEMA,
+            "evidence_kind": protocol["evidence_kind"],
+            "protocol": protocol,
+            "protocol_sha256": _content_id(protocol),
+            "repository_revision": args.repository_revision,
+            "official_archives": archive_receipts,
+            "selected_cameras": selected_rows,
+            "qualified_sequences": qualified,
+            "unsupported_sequences": unsupported,
+            "camera_row_count": len(camera_rows),
+            "accessed_member_count": len(accessed_members),
+            "information_boundary": protocol["information_boundary"],
+            "next_stage_boundary": protocol["next_stage_boundary"],
+            "claim_boundary": protocol["claim_boundary"],
+        }
+        result["support_id"] = _content_id(result)
+        _write_json(output / "result.json", result)
+        _write_json(
+            output / "accessed-members.json",
+            {
+                "dataset_persistent_id": protocol["dataset"]["persistent_id"],
+                "members": accessed_members,
+                "three_dimensional_coordinate_values_opened": False,
+                "normal_or_uv_images_opened": False,
+            },
+        )
+        _write_csv(output / "camera-support.csv", camera_rows)
+        _write_csv(output / "selected-cameras.csv", selected_rows)
+        (output / "summary.md").write_text(_summary(result), encoding="utf-8")
+        print(
+            json.dumps(
+                {
+                    "support_id": result["support_id"],
+                    "qualified_sequence_count": len(qualified),
+                    "unsupported_sequence_count": len(unsupported),
+                    "accessed_member_count": len(accessed_members),
+                },
+                sort_keys=True,
+            )
+        )
+        return 0
+    except Exception as error:
+        failure = {
+            "schema": "prob4d.dot-rope-reserve-support-audit-technical-failure.v1",
+            "protocol_sha256": _content_id(protocol),
+            "repository_revision": args.repository_revision,
+            "decision": "technical-failure",
+            "failure": (
+                f"{type(error).__name__}: {' '.join(str(error).split())}"
+            )[:2000],
+            "traceback_tail": traceback.format_exc().splitlines()[-30:],
+            "information_boundary": protocol["information_boundary"],
+            "claim_boundary": protocol["claim_boundary"],
+        }
+        failure["technical_result_id"] = _content_id(failure)
+        _write_json(output / "technical-failure.json", failure)
+        print(json.dumps(failure, sort_keys=True))
+        return 3
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subcommands = parser.add_subparsers(dest="command", required=True)
+    validate = subcommands.add_parser("validate-protocol")
+    validate.add_argument("--protocol", type=Path, required=True)
+    audit = subcommands.add_parser("audit")
+    audit.add_argument("--protocol", type=Path, required=True)
+    audit.add_argument("--dataset-root", type=Path, required=True)
+    audit.add_argument("--official-metadata", type=Path, required=True)
+    audit.add_argument("--output-dir", type=Path, required=True)
+    audit.add_argument("--repository-revision", required=True)
+    args = parser.parse_args()
+    if args.command == "validate-protocol":
+        protocol = _load_protocol(args.protocol)
+        print(json.dumps({"protocol_sha256": _content_id(protocol)}))
+        return 0
+    return evaluate(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dot_rope_reserve_support_audit.py
+++ b/tests/test_dot_rope_reserve_support_audit.py
@@ -61,10 +61,7 @@ def _make_dataset(root: Path) -> Path:
                     if sequence == "R12":
                         visible = 7
                     for frame in range(1, 8):
-                        member = (
-                            f"{sequence}/coordinates/2d/"
-                            f"frame{frame:06d}_{camera}.txt"
-                        )
+                        member = f"{sequence}/coordinates/2d/frame{frame:06d}_{camera}.txt"
                         archive.writestr(member, _coordinate_rows(visible))
                 archive.writestr(
                     f"{sequence}/coordinates/3d/frame000001_cam001.txt",
@@ -95,9 +92,7 @@ def test_protocol_and_archive_mapping_are_frozen() -> None:
     protocol = module._load_protocol(PROTOCOL)
     assert protocol["dataset"]["sequence_start"] == 11
     assert protocol["dataset"]["sequence_stop"] == 70
-    assert protocol["camera_selection_rule"][
-        "minimum_common_visible_markers"
-    ] == 8
+    assert protocol["camera_selection_rule"]["minimum_common_visible_markers"] == 8
     assert module._archive_for_sequence(11) == "R11-20.zip"
     assert module._archive_for_sequence(20) == "R11-20.zip"
     assert module._archive_for_sequence(21) == "R21-30.zip"
@@ -136,9 +131,7 @@ def test_complete_synthetic_audit_is_deterministic_and_reads_only_2d(
         f"R{index:02d}" for index in range(11, 71) if index != 12
     ]
     assert result["unsupported_sequences"] == ["R12"]
-    selected = {
-        row["sequence"]: row for row in result["selected_cameras"]
-    }
+    selected = {row["sequence"]: row for row in result["selected_cameras"]}
     assert selected["R11"]["selected_camera"] == "cam003"
     assert selected["R11"]["common_visible_marker_count"] == 10
     assert selected["R12"]["selected_camera"] == "cam001"
@@ -163,9 +156,7 @@ def test_complete_synthetic_audit_is_deterministic_and_reads_only_2d(
 def test_protocol_rejects_an_expanded_information_boundary(tmp_path: Path) -> None:
     module = _load_module()
     protocol = json.loads(PROTOCOL.read_text())
-    protocol["information_boundary"][
-        "three_dimensional_coordinate_values_opened"
-    ] = True
+    protocol["information_boundary"]["three_dimensional_coordinate_values_opened"] = True
     path = tmp_path / "changed.json"
     path.write_text(json.dumps(protocol), encoding="utf-8")
     try:

--- a/tests/test_dot_rope_reserve_support_audit.py
+++ b/tests/test_dot_rope_reserve_support_audit.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import sys
+import zipfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "science" / "audit_dot_rope_reserve_support.py"
+PROTOCOL = ROOT / "protocols" / "dot-rope-reserve-support-audit-v1.json"
+
+
+def _load_module():
+    name = "dot_rope_reserve_support_audit_test"
+    spec = importlib.util.spec_from_file_location(name, SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _md5(path: Path) -> str:
+    digest = hashlib.md5(usedforsecurity=False)
+    digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def _archive_name(sequence_number: int) -> str:
+    start = ((sequence_number - 1) // 10) * 10 + 1
+    return f"R{start:02d}-{start + 9:02d}.zip"
+
+
+def _coordinate_rows(visible: int, total: int = 12) -> str:
+    rows = []
+    for index in range(total):
+        if index < visible:
+            rows.append(f"{10.0 + index:.3f} {20.0 + index:.3f}\n")
+        else:
+            rows.append("-1 -1\n")
+    return "".join(rows)
+
+
+def _make_dataset(root: Path) -> Path:
+    archive_paths: dict[str, Path] = {}
+    for start in range(11, 62, 10):
+        name = f"R{start:02d}-{start + 9:02d}.zip"
+        path = root / name
+        archive_paths[name] = path
+        with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+            for sequence_number in range(start, start + 10):
+                sequence = f"R{sequence_number:02d}"
+                for camera_index in range(1, 11):
+                    camera = f"cam{camera_index:03d}"
+                    visible = 8
+                    if sequence == "R11" and camera == "cam003":
+                        visible = 10
+                    if sequence == "R12":
+                        visible = 7
+                    for frame in range(1, 8):
+                        member = (
+                            f"{sequence}/coordinates/2d/"
+                            f"frame{frame:06d}_{camera}.txt"
+                        )
+                        archive.writestr(member, _coordinate_rows(visible))
+                archive.writestr(
+                    f"{sequence}/coordinates/3d/frame000001_cam001.txt",
+                    "this must never be parsed\n",
+                )
+    metadata = {
+        "dataset_persistent_id": "doi:10.13021/ORC2020/XXLVXM",
+        "files": [
+            {
+                "filename": name,
+                "datafile_id": 1000 + index,
+                "byte_count": path.stat().st_size,
+                "md5": _md5(path),
+            }
+            for index, (name, path) in enumerate(sorted(archive_paths.items()))
+        ],
+    }
+    metadata_path = root / "official-metadata.json"
+    metadata_path.write_text(
+        json.dumps(metadata, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return metadata_path
+
+
+def test_protocol_and_archive_mapping_are_frozen() -> None:
+    module = _load_module()
+    protocol = module._load_protocol(PROTOCOL)
+    assert protocol["dataset"]["sequence_start"] == 11
+    assert protocol["dataset"]["sequence_stop"] == 70
+    assert protocol["camera_selection_rule"][
+        "minimum_common_visible_markers"
+    ] == 8
+    assert module._archive_for_sequence(11) == "R11-20.zip"
+    assert module._archive_for_sequence(20) == "R11-20.zip"
+    assert module._archive_for_sequence(21) == "R21-30.zip"
+    assert module._archive_for_sequence(70) == "R61-70.zip"
+
+
+def test_coordinate_parser_preserves_row_identity_and_missing_markers() -> None:
+    module = _load_module()
+    rows = module._parse_coordinates(
+        b"1,2\n-1 -1\n3 4 99\n",
+        member="fixture.txt",
+    )
+    assert rows == [(1.0, 2.0), (-1.0, -1.0), (3.0, 4.0)]
+    assert module._visible_indices(rows) == {0, 2}
+
+
+def test_complete_synthetic_audit_is_deterministic_and_reads_only_2d(
+    tmp_path: Path,
+) -> None:
+    module = _load_module()
+    dataset = tmp_path / "dataset"
+    dataset.mkdir()
+    metadata = _make_dataset(dataset)
+    output = tmp_path / "output"
+    args = argparse.Namespace(
+        protocol=PROTOCOL,
+        dataset_root=dataset,
+        official_metadata=metadata,
+        output_dir=output,
+        repository_revision="a" * 40,
+    )
+    assert module.evaluate(args) == 0
+    result = json.loads((output / "result.json").read_text())
+    custody = json.loads((output / "accessed-members.json").read_text())
+    assert result["qualified_sequences"] == [
+        f"R{index:02d}" for index in range(11, 71) if index != 12
+    ]
+    assert result["unsupported_sequences"] == ["R12"]
+    selected = {
+        row["sequence"]: row for row in result["selected_cameras"]
+    }
+    assert selected["R11"]["selected_camera"] == "cam003"
+    assert selected["R11"]["common_visible_marker_count"] == 10
+    assert selected["R12"]["selected_camera"] == "cam001"
+    assert selected["R12"]["qualified"] is False
+    assert selected["R13"]["selected_camera"] == "cam001"
+    assert result["camera_row_count"] == 600
+    assert result["accessed_member_count"] == 4200
+    assert len(custody["members"]) == 4200
+    assert custody["three_dimensional_coordinate_values_opened"] is False
+    assert custody["normal_or_uv_images_opened"] is False
+    assert all("/coordinates/2d/" in row["member"] for row in custody["members"])
+    assert not any("/coordinates/3d/" in row["member"] for row in custody["members"])
+    assert set(path.name for path in output.iterdir()) == {
+        "accessed-members.json",
+        "camera-support.csv",
+        "result.json",
+        "selected-cameras.csv",
+        "summary.md",
+    }
+
+
+def test_protocol_rejects_an_expanded_information_boundary(tmp_path: Path) -> None:
+    module = _load_module()
+    protocol = json.loads(PROTOCOL.read_text())
+    protocol["information_boundary"][
+        "three_dimensional_coordinate_values_opened"
+    ] = True
+    path = tmp_path / "changed.json"
+    path.write_text(json.dumps(protocol), encoding="utf-8")
+    try:
+        module._load_protocol(path)
+    except ValueError as error:
+        assert "information boundary" in str(error)
+    else:
+        raise AssertionError("expanded information boundary was accepted")


### PR DESCRIPTION
## Purpose

Create an outcome-blind, support-feasible route to the missing learned-provider confirmation without revising the terminal R04-R10 support-negative result.

## Frozen support audit

Before opening any R11-R70 normal image, provider prediction, or 3-D coordinate outcome, the protocol fixed:

- all 60 reserve sequences R11-R70;
- ten cameras and frames 1-7;
- stable 2-D marker row identity;
- finite/nonnegative visibility;
- common support across all seven frames;
- deterministic camera selection by common count, minimum frame count, mean count, then lowest camera index;
- at least eight common markers and eight visible markers per frame;
- no replacement of unsupported sequences.

The one-shot audit resolved and checksum-verified all six official reserve archives, read exactly 4,200 two-dimensional coordinate members, and retained an exact access ledger. It did not read any 3-D coordinate value, normal or UV image, learned-provider output, residual, covariance score, BayesianPhysTwin result, or Causal4D result.

## Result

All **60/60** untouched reserve sequences passed the conservative support rule under their deterministically selected camera.

The branch retains:

- the immutable support protocol and audited implementation;
- synthetic custody and camera-selection tests;
- all per-camera support rows;
- one selected camera per sequence;
- official archive metadata and checksums;
- compact support result and access-ledger digest;
- a frozen 12-sequence learned-provider cohort.

## Frozen provider cohort

To make the next CUT3R stage computationally tractable without provider- or outcome-based selection, the cohort rule was frozen before image access:

1. retain support-qualified sequences whose selected camera is `cam001`;
2. rank by `SHA256(support_id:sequence)` within each reserve archive;
3. select two sequences per archive;
4. reserve the remaining 48 sequences without replacement.

The exact 12-sequence roster, archive map, camera map, support identity, and cohort identity are in `evidence/dot-rope-reserve-support-audit-v1/provider-cohort.json`.

## Next information boundary

The next stage must keep the source-frozen CUT3R code/checkpoint, windows, covariance comparators, and source-selected dependence strength. Provider outputs and provider-side support must be sealed before 3-D truth is opened. Target-side tuning and replacement remain prohibited.

## Claim boundary

This is support qualification only. It establishes that a feasible interface exists; it does not establish provider competence, calibration, an uncertainty improvement, a downstream physical-query benefit, deployment safety, or state of the art. The original R04-R10 support-negative result remains terminal and separately reported.