### PR TITLE
Add a probabilistic 4-D information-contract benchmark

### DIFF
--- a/.github/workflows/information-contract-benchmark-v1.yml
+++ b/.github/workflows/information-contract-benchmark-v1.yml
@@ -1,0 +1,126 @@
+name: Information-contract benchmark v1
+
+on:
+  push:
+    branches:
+      - main
+      - science/information-contract-benchmark-v1
+    paths:
+      - ".github/workflows/information-contract-benchmark-v1.yml"
+      - "benchmarks/information_contract_v1/**"
+      - "docs/information-contract-benchmark.md"
+      - "src/prob4d/information_contract_benchmark.py"
+      - "src/prob4d/information_contract_benchmark_smoke.py"
+      - "tests/test_information_contract_benchmark.py"
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/information-contract-benchmark-v1.yml"
+      - "benchmarks/information_contract_v1/**"
+      - "docs/information-contract-benchmark.md"
+      - "src/prob4d/information_contract_benchmark.py"
+      - "src/prob4d/information_contract_benchmark_smoke.py"
+      - "tests/test_information_contract_benchmark.py"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: information-contract-benchmark-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PYTHONUNBUFFERED: "1"
+
+jobs:
+  unit:
+    name: Contract tests on Python ${{ matrix.python }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ["3.10", "3.12", "3.14"]
+    steps:
+      - name: Check out exact revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          clean: true
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ matrix.python }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install benchmark and test dependencies
+        run: |
+          python -m pip install -e ".[dev]"
+          python -m pip check
+      - name: Run focused benchmark tests
+        run: |
+          python -m ruff check \
+            src/prob4d/information_contract_benchmark.py \
+            src/prob4d/information_contract_benchmark_smoke.py \
+            tests/test_information_contract_benchmark.py
+          python -m pytest -q tests/test_information_contract_benchmark.py
+
+  deterministic-smoke:
+    name: Generate, replay, and retain the complete scorecard
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out exact revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          clean: true
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - name: Install NumPy-only package
+        run: |
+          python -m pip install -e .
+          python -m pip check
+      - name: Generate and evaluate deterministic smoke suite
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="$RUNNER_TEMP/information-contract-smoke"
+          python -m prob4d.information_contract_benchmark smoke "$root"
+          python -m prob4d.information_contract_benchmark evaluate \
+            "$root/suite.json" "$root/replayed.json"
+          cmp "$root/result.json" "$root/replayed.json"
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          root = Path(os.environ["RUNNER_TEMP"]) / "information-contract-smoke"
+          result = json.loads((root / "result.json").read_text(encoding="utf-8"))
+          aggregate = result["aggregate"]
+          assert aggregate["case_count"] == 2
+          assert aggregate["independent_group_count"] == 2
+          assert aggregate["contract"]["all_cases_pass"] is True
+          assert (
+              aggregate["equal_group_mean"]["dependence_nll_gain_per_dimension"]
+              > 0.0
+          )
+          assert aggregate["equal_group_mean"]["gauge_false_accept_fraction"] == 0.0
+          assert aggregate["equal_group_mean"]["exact_fallback_fraction"] == 1.0
+          print(json.dumps(aggregate, indent=2, sort_keys=True))
+          PY
+          sha256sum "$root"/*
+      - name: Upload complete deterministic scorecard
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v6.0.0
+        with:
+          name: information-contract-smoke-${{ github.sha }}
+          path: ${{ runner.temp }}/information-contract-smoke/
+          if-no-files-found: error
+          retention-days: 30
+          compression-level: 0

--- a/.github/workflows/information-contract-benchmark.yml
+++ b/.github/workflows/information-contract-benchmark.yml
@@ -1,0 +1,94 @@
+name: Information-contract benchmark
+
+on:
+  push:
+    paths:
+      - ".github/workflows/information-contract-benchmark.yml"
+      - "benchmarks/information_contract_v1/**"
+      - "docs/information-contract-benchmark.md"
+      - "src/prob4d/information_contract_benchmark.py"
+      - "tests/test_information_contract_benchmark.py"
+  pull_request:
+    paths:
+      - ".github/workflows/information-contract-benchmark.yml"
+      - "benchmarks/information_contract_v1/**"
+      - "docs/information-contract-benchmark.md"
+      - "src/prob4d/information_contract_benchmark.py"
+      - "tests/test_information_contract_benchmark.py"
+
+permissions:
+  contents: read
+
+jobs:
+  conformance:
+    name: Multi-axis controlled conformance
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out exact revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          clean: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install package and development checks
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+          python -m pip check
+
+      - name: Lint benchmark implementation and tests
+        run: |
+          python -m ruff check \
+            src/prob4d/information_contract_benchmark.py \
+            tests/test_information_contract_benchmark.py
+
+      - name: Run controlled and adversarial tests
+        run: python -m pytest -q tests/test_information_contract_benchmark.py
+
+      - name: Reproduce deterministic report twice
+        shell: bash
+        run: |
+          set -euo pipefail
+          suite=benchmarks/information_contract_v1/controlled_suite.json
+          python -m prob4d.information_contract_benchmark \
+            "$suite" --output "$RUNNER_TEMP/report-a.json"
+          python -m prob4d.information_contract_benchmark \
+            "$suite" --output "$RUNNER_TEMP/report-b.json"
+          cmp "$RUNNER_TEMP/report-a.json" "$RUNNER_TEMP/report-b.json"
+
+      - name: Enforce multi-axis and information-boundary semantics
+        shell: bash
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          protocol = json.loads(
+              Path("benchmarks/information_contract_v1/protocol.json").read_text(
+                  encoding="utf-8"
+              )
+          )
+          report = json.loads(
+              (Path(os.environ["RUNNER_TEMP"]) / "report-a.json").read_text(
+                  encoding="utf-8"
+              )
+          )
+          assert protocol["ranking_policy"]["scalar_overall_score"] is False
+          assert "overall_score" not in report
+          assert "overall_rank" not in report
+          assert report["completion"]["system_count"] == 7
+          assert report["cross_system"]["shared_bias_counterexample_count"] == 1
+          assert all(value == 0 for value in report["information_boundary"].values())
+          PY

--- a/.github/workflows/materialize-information-contract-controlled-v1.yml
+++ b/.github/workflows/materialize-information-contract-controlled-v1.yml
@@ -1,0 +1,187 @@
+name: Materialize information-contract controlled evidence v1
+
+on:
+  push:
+    branches: [science/information-contract-benchmark-v1]
+    paths:
+      - "benchmarks/information_contract_v1/materialize_request.json"
+
+permissions:
+  contents: write
+
+jobs:
+  materialize:
+    name: Validate and retain controlled benchmark report
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out exact request revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: true
+          clean: true
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Validate exact request and install checks
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF_NAME" = science/information-contract-benchmark-v1
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          path = Path("benchmarks/information_contract_v1/materialize_request.json")
+          request = json.loads(path.read_text(encoding="utf-8"))
+          assert request == {
+              "schema_name": "prob4d.information-contract-materialize-request",
+              "schema_version": 1,
+              "request_id": "prob4d-information-contract-controlled-v1",
+              "suite": "benchmarks/information_contract_v1/controlled_suite.json",
+              "protocol": "benchmarks/information_contract_v1/protocol.json",
+              "classification": "deterministic controlled development evidence",
+              "public_dataset_records_authorized": 0,
+              "learned_provider_calls_authorized": 0,
+              "protected_targets_authorized": 0,
+              "physical_executions_authorized": 0,
+          }
+          PY
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[dev]"
+          python -m pip check
+
+      - name: Run lint and adversarial controls
+        shell: bash
+        run: |
+          set -euo pipefail
+          python -m ruff check \
+            src/prob4d/information_contract_benchmark.py \
+            tests/test_information_contract_benchmark.py
+          python -m pytest -q tests/test_information_contract_benchmark.py
+
+      - name: Generate and verify retained evidence
+        shell: bash
+        run: |
+          set -euo pipefail
+          root=benchmarks/information_contract_v1
+          report="$root/controlled_report.json"
+          receipt="$root/validation_receipt.json"
+          sums="$root/SHA256SUMS"
+          rm -f "$report" "$receipt" "$sums"
+          python -m prob4d.information_contract_benchmark \
+            "$root/controlled_suite.json" --output "$report"
+          REPORT_PATH="$report" RECEIPT_PATH="$receipt" python - <<'PY'
+          from __future__ import annotations
+
+          import hashlib
+          import json
+          import os
+          import platform
+          from pathlib import Path
+
+          import numpy
+
+          report_path = Path(os.environ["REPORT_PATH"])
+          receipt_path = Path(os.environ["RECEIPT_PATH"])
+          report = json.loads(report_path.read_text(encoding="utf-8"))
+          systems = {row["system_id"]: row for row in report["systems"]}
+          assert "overall_score" not in report
+          assert "overall_rank" not in report
+          assert report["completion"]["system_count"] == 7
+          assert report["cross_system"]["shared_bias_counterexample_count"] == 1
+          assert all(value == 0 for value in report["information_boundary"].values())
+          assert (
+              systems["accurate-overconfident"]["prediction"]["probabilistic"]
+              ["equal_unit_registered_coverage"]
+              == 0.0
+          )
+          assert (
+              systems["joint-dependence-aware"]["prediction"]["probabilistic"]
+              ["equal_unit_joint_gaussian_nll"]
+              < systems["diagonal-same-mean-marginals"]["prediction"]
+              ["probabilistic"]["equal_unit_joint_gaussian_nll"]
+          )
+          assert (
+              systems["ambiguity-aware-contract"]["query_decision"]
+              ["fallback_count"]
+              == 1
+          )
+          assert (
+              systems["unsupported-specificity"]["query_decision"]
+              ["harmful_nonfallback_count"]
+              == 1
+          )
+          assert (
+              systems["ambiguity-aware-contract"]["communication"]
+              ["equal_unit_compression_ratio"]
+              == 17.0
+          )
+
+          def digest(path: Path) -> str:
+              return hashlib.sha256(path.read_bytes()).hexdigest()
+
+          root = report_path.parent
+          receipt = {
+              "schema_name": "prob4d.information-contract-controlled-validation",
+              "schema_version": 1,
+              "classification": "deterministic controlled development evidence",
+              "source_revision": os.environ["GITHUB_SHA"],
+              "suite_sha256": digest(root / "controlled_suite.json"),
+              "protocol_sha256": digest(root / "protocol.json"),
+              "report_sha256": digest(report_path),
+              "python": platform.python_version(),
+              "numpy": numpy.__version__,
+              "tests": "passed",
+              "ruff": "passed",
+              "scalar_overall_score_defined": False,
+              "public_dataset_records_accessed": 0,
+              "learned_provider_forward_calls": 0,
+              "protected_targets_opened": 0,
+              "physical_executions": 0,
+              "claim_boundary": (
+                  "Controlled conformance and anti-gaming evidence only; no "
+                  "provider competence, public-data benchmark result, physical "
+                  "calibration, state of the art, or deployment safety."
+              ),
+          }
+          receipt_path.write_text(
+              json.dumps(receipt, indent=2, sort_keys=True, allow_nan=False) + "\n",
+              encoding="utf-8",
+          )
+          PY
+          (
+            cd "$root"
+            sha256sum controlled_suite.json protocol.json controlled_report.json \
+              validation_receipt.json > SHA256SUMS
+            sha256sum -c SHA256SUMS
+          )
+
+      - name: Commit only retained controlled evidence
+        shell: bash
+        run: |
+          set -euo pipefail
+          root=benchmarks/information_contract_v1
+          git add "$root/controlled_report.json" \
+            "$root/validation_receipt.json" "$root/SHA256SUMS"
+          mapfile -t staged < <(git diff --cached --name-only | sort)
+          expected=(
+            "$root/SHA256SUMS"
+            "$root/controlled_report.json"
+            "$root/validation_receipt.json"
+          )
+          test "${#staged[@]}" -eq "${#expected[@]}"
+          for index in "${!expected[@]}"; do
+            test "${staged[$index]}" = "${expected[$index]}"
+          done
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "Retain information-contract controlled benchmark evidence"
+          git push origin "HEAD:${GITHUB_REF_NAME}"

--- a/benchmarks/information_contract_v1/CHANGELOG.md
+++ b/benchmarks/information_contract_v1/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Development history
+
+## v1 controlled conformance candidate
+
+- Defines a provider-neutral, multi-axis scorecard with no scalar overall score.
+- Adds deterministic controls for accuracy/calibration rank reversal, joint
+  dependence, finite-support query and decision semantics, exact fallback,
+  communication parity, unsupported specificity, and shared provider bias.
+- Adds fail-closed validation, focused tests, and deterministic CI reproduction.
+- Opens no dataset and invokes no learned provider.

--- a/benchmarks/information_contract_v1/README.md
+++ b/benchmarks/information_contract_v1/README.md
@@ -1,0 +1,28 @@
+# Information-contract benchmark v1
+
+This directory contains the provider-neutral protocol and deterministic
+conformance suite for the Prob4D information-contract benchmark.
+
+- `protocol.json` freezes the independent-unit, multi-axis, information-order,
+  negative-control, release, and claim-boundary rules.
+- `controlled_suite.json` exercises accuracy/calibration rank reversal,
+  dependence preservation, finite-support query identification, exact decision
+  fallback, payload parity, unsupported specificity, and shared provider bias.
+
+The controlled suite is **not** a public-data benchmark result. It opens no
+trajectory, invokes no learned provider, and defines no scalar overall ranking.
+
+Run:
+
+```bash
+python -m pytest tests/test_information_contract_benchmark.py
+python -m prob4d.information_contract_benchmark controlled_suite.json
+```
+
+The public-data promotion gate requires at least two distinct provider contracts
+and two independently collected public datasets, with manifests, payload hashes,
+statistical units, queries, actions, loss semantics, dependence groups, target
+opening, and claim boundaries frozen before the held outcomes are scored.
+
+See [`docs/information-contract-benchmark.md`](../../docs/information-contract-benchmark.md)
+for the scientific scope and panel format.

--- a/benchmarks/information_contract_v1/STATUS.md
+++ b/benchmarks/information_contract_v1/STATUS.md
@@ -1,0 +1,56 @@
+# Status: information-contract benchmark v1
+
+## Completed in this branch
+
+- Provider-neutral JSON evaluator and deterministic command-line interface.
+- Versioned protocol and formal suite JSON Schema.
+- Seven-system controlled conformance suite.
+- Separate accuracy, joint-probabilistic, query/decision, fallback,
+  communication, and cross-provider axes.
+- Exact finite-support pairwise gaps and worst-case regret recomputation.
+- Equal-independent-unit aggregation plus descriptive pooled RMSE.
+- Missing-covariance `not_evaluated` semantics.
+- Shared-common-bias, dependence-destruction, unsupported-specificity, and
+  malformed-contract controls.
+- Focused Ruff/pytest/deterministic-generation workflows.
+- Retained `controlled_report.json`, `validation_receipt.json`, and hashes.
+- Staged public-data promotion plan and paper novelty-ownership issue.
+
+## Controlled findings
+
+These findings are deterministic conformance checks, not empirical provider
+performance:
+
+- the lowest-RMSE system has zero registered coverage and normalized NEES 450;
+- full and diagonal covariance systems have identical means and coordinate
+  marginals, but different joint likelihoods;
+- the ambiguity-aware contract identifies the invariant query, rejects the
+  sensitive query, and returns exact fallback;
+- an artificially refined quotient admits a harmful nonfallback action;
+- the communication control reduces 17,000 bytes to 1,000 bytes with posterior
+  error `1e-12` under tolerance `1e-9`; and
+- two corroborating providers are both inaccurate and share one input dependence
+  group.
+
+## Not completed
+
+- No public dataset has been opened for this benchmark branch.
+- No learned provider has been run.
+- No public provider ranking exists.
+- No uncertainty calibration, query validity, or decision utility is claimed on
+  a new empirical cohort.
+- No scalar overall score exists.
+
+## Next bounded milestone
+
+1. Implement byte-parity retrospective adapters for the already retained
+   Tracking Cloth communication/dependence result and DEFORM decision/fallback
+   result. This remains adapter validation and does not create new novelty.
+2. Freeze a prospective two-provider by two-dataset protocol.
+3. Seal provider manifests and predictions before held-out scoring.
+4. Publish the first multi-axis public scorecard, including every positive,
+   negative, support-negative, and technical-failure outcome.
+
+A standalone benchmark manuscript is not promoted until the prospective stage
+contains at least one statistically supported ranking reversal and the required
+negative controls without target-side policy selection.

--- a/benchmarks/information_contract_v1/controlled_suite.json
+++ b/benchmarks/information_contract_v1/controlled_suite.json
@@ -1,0 +1,197 @@
+{
+  "schema_name": "prob4d.information-contract-benchmark-suite",
+  "schema_version": 1,
+  "suite_id": "prob4d-information-contract-controlled-v1",
+  "classification": "deterministic controlled development evidence; not a public-data provider leaderboard",
+  "systems": [
+    {
+      "system_id": "accurate-overconfident",
+      "prediction_cases": [
+        {
+          "case_id": "forecast-a",
+          "statistical_unit_id": "forecast-unit-a",
+          "truth": [0.0, 0.0],
+          "mean": [0.02, -0.02],
+          "covariance": [[0.000001, 0.0], [0.0, 0.000001]],
+          "coverage_radius_squared": 4.605170185988092
+        },
+        {
+          "case_id": "forecast-b",
+          "statistical_unit_id": "forecast-unit-b",
+          "truth": [0.0, 0.0],
+          "mean": [-0.03, 0.01],
+          "covariance": [[0.000001, 0.0], [0.0, 0.000001]],
+          "coverage_radius_squared": 4.605170185988092
+        }
+      ]
+    },
+    {
+      "system_id": "joint-dependence-aware",
+      "prediction_cases": [
+        {
+          "case_id": "forecast-a",
+          "statistical_unit_id": "forecast-unit-a",
+          "truth": [0.0, 0.0],
+          "mean": [0.08, 0.08],
+          "covariance": [[0.01, 0.009], [0.009, 0.01]],
+          "coverage_radius_squared": 4.605170185988092
+        },
+        {
+          "case_id": "forecast-b",
+          "statistical_unit_id": "forecast-unit-b",
+          "truth": [0.0, 0.0],
+          "mean": [-0.06, -0.06],
+          "covariance": [[0.01, 0.009], [0.009, 0.01]],
+          "coverage_radius_squared": 4.605170185988092
+        }
+      ]
+    },
+    {
+      "system_id": "diagonal-same-mean-marginals",
+      "prediction_cases": [
+        {
+          "case_id": "forecast-a",
+          "statistical_unit_id": "forecast-unit-a",
+          "truth": [0.0, 0.0],
+          "mean": [0.08, 0.08],
+          "covariance": [[0.01, 0.0], [0.0, 0.01]],
+          "coverage_radius_squared": 4.605170185988092
+        },
+        {
+          "case_id": "forecast-b",
+          "statistical_unit_id": "forecast-unit-b",
+          "truth": [0.0, 0.0],
+          "mean": [-0.06, -0.06],
+          "covariance": [[0.01, 0.0], [0.0, 0.01]],
+          "coverage_radius_squared": 4.605170185988092
+        }
+      ]
+    },
+    {
+      "system_id": "ambiguity-aware-contract",
+      "query_decision_cases": [
+        {
+          "case_id": "two-state-gauge",
+          "statistical_unit_id": "gauge-unit-a",
+          "hypothesis_states": [[0.0, 1.0], [0.0, -1.0]],
+          "prior_support": [true, true],
+          "quotient_class_ids": ["unresolved-orbit", "unresolved-orbit"],
+          "quotient_masses": {"unresolved-orbit": 1.0},
+          "queries": [
+            {
+              "query_id": "invariant-coordinate",
+              "weights": [1.0, 0.0],
+              "offset": 0.0,
+              "tolerance": 0.0
+            },
+            {
+              "query_id": "gauge-sensitive-coordinate",
+              "weights": [0.0, 1.0],
+              "offset": 0.0,
+              "tolerance": 0.0
+            }
+          ],
+          "decision": {
+            "action_labels": ["physical-fallback", "learned-update"],
+            "loss_by_hypothesis_action": [[0.0, 2.0], [2.0, 0.0]],
+            "regret_budget": 0.1,
+            "fallback_action": "physical-fallback",
+            "reported_output_action": "physical-fallback",
+            "realized_loss_by_action": [0.0, 2.0]
+          }
+        }
+      ],
+      "communication_cases": [
+        {
+          "case_id": "query-sufficient-factor",
+          "statistical_unit_id": "payload-unit-a",
+          "dense_payload_bytes": 17000,
+          "contract_payload_bytes": 1000,
+          "posterior_max_abs_error": 1e-12,
+          "parity_tolerance": 1e-9
+        }
+      ]
+    },
+    {
+      "system_id": "unsupported-specificity",
+      "query_decision_cases": [
+        {
+          "case_id": "two-state-gauge",
+          "statistical_unit_id": "gauge-unit-a",
+          "hypothesis_states": [[0.0, 1.0], [0.0, -1.0]],
+          "prior_support": [true, true],
+          "quotient_class_ids": ["invented-state-a", "invented-state-b"],
+          "quotient_masses": {"invented-state-a": 0.05, "invented-state-b": 0.95},
+          "queries": [
+            {
+              "query_id": "invariant-coordinate",
+              "weights": [1.0, 0.0],
+              "offset": 0.0,
+              "tolerance": 0.0
+            },
+            {
+              "query_id": "gauge-sensitive-coordinate",
+              "weights": [0.0, 1.0],
+              "offset": 0.0,
+              "tolerance": 0.0
+            }
+          ],
+          "decision": {
+            "action_labels": ["physical-fallback", "learned-update"],
+            "loss_by_hypothesis_action": [[0.0, 2.0], [2.0, 0.0]],
+            "regret_budget": 0.1,
+            "fallback_action": "physical-fallback",
+            "reported_output_action": "learned-update",
+            "realized_loss_by_action": [0.0, 2.0]
+          }
+        }
+      ]
+    },
+    {
+      "system_id": "shared-bias-peer-a",
+      "prediction_cases": [
+        {
+          "case_id": "shared-bias",
+          "statistical_unit_id": "shared-bias-unit",
+          "truth": [0.0, 0.0],
+          "mean": [1.0, 1.0],
+          "covariance": [[1.0, 0.0], [0.0, 1.0]],
+          "coverage_radius_squared": 4.605170185988092
+        }
+      ]
+    },
+    {
+      "system_id": "shared-bias-peer-b",
+      "prediction_cases": [
+        {
+          "case_id": "shared-bias",
+          "statistical_unit_id": "shared-bias-unit",
+          "truth": [0.0, 0.0],
+          "mean": [1.01, 0.99],
+          "covariance": [[1.0, 0.0], [0.0, 1.0]],
+          "coverage_radius_squared": 4.605170185988092
+        }
+      ]
+    }
+  ],
+  "cross_system_cases": [
+    {
+      "case_id": "corroborated-common-bias",
+      "statistical_unit_id": "shared-bias-unit",
+      "first_system_id": "shared-bias-peer-a",
+      "second_system_id": "shared-bias-peer-b",
+      "truth": [0.0, 0.0],
+      "first_mean": [1.0, 1.0],
+      "second_mean": [1.01, 0.99],
+      "corroboration_rmse_threshold": 0.05,
+      "inaccuracy_rmse_threshold": 0.5,
+      "shared_dependence_groups": ["input-video:controlled-shared-source"]
+    }
+  ],
+  "information_boundary": {
+    "public_dataset_records_accessed": 0,
+    "learned_provider_forward_calls": 0,
+    "protected_targets_opened": 0,
+    "physical_executions": 0
+  }
+}

--- a/benchmarks/information_contract_v1/materialize_request.json
+++ b/benchmarks/information_contract_v1/materialize_request.json
@@ -1,0 +1,12 @@
+{
+  "schema_name": "prob4d.information-contract-materialize-request",
+  "schema_version": 1,
+  "request_id": "prob4d-information-contract-controlled-v1",
+  "suite": "benchmarks/information_contract_v1/controlled_suite.json",
+  "protocol": "benchmarks/information_contract_v1/protocol.json",
+  "classification": "deterministic controlled development evidence",
+  "public_dataset_records_authorized": 0,
+  "learned_provider_calls_authorized": 0,
+  "protected_targets_authorized": 0,
+  "physical_executions_authorized": 0
+}

--- a/benchmarks/information_contract_v1/protocol.json
+++ b/benchmarks/information_contract_v1/protocol.json
@@ -1,0 +1,136 @@
+{
+  "schema_name": "prob4d.information-contract-benchmark-protocol",
+  "schema_version": 1,
+  "protocol_id": "prob4d-information-contract-benchmark-v1",
+  "status": "controlled conformance protocol; public-data provider panels not yet registered",
+  "purpose": "Evaluate whether probabilistic 4-D outputs expose information that remains valid and useful for downstream physical queries and decisions.",
+  "ranking_policy": {
+    "scalar_overall_score": false,
+    "required_reporting_axes": [
+      "point_and_trajectory_accuracy",
+      "joint_probabilistic_validity",
+      "query_identifiability",
+      "decision_admissibility",
+      "exact_fallback_integrity",
+      "communication_cost"
+    ],
+    "conditional_axes": [
+      "cross_provider_corroboration",
+      "shared_common_bias",
+      "finite_orbit_or_finite_support_ambiguity"
+    ],
+    "missing_axis_semantics": "not_evaluated; never zero and never implicitly passed",
+    "comparison_rule": "Publish a multi-axis scorecard and Pareto comparisons. Do not collapse incompatible scientific properties into one number."
+  },
+  "statistical_units": {
+    "required": "One independent physical object, acquisition session, or complete trajectory as registered before outcome access.",
+    "forbidden_as_independent_units": [
+      "pixels",
+      "points from one frame",
+      "frames from one trajectory",
+      "overlapping windows",
+      "multiple queries on one physical execution"
+    ],
+    "aggregation": "Equal weight per registered independent unit. Pooled coordinate metrics may be reported only as descriptive supplements."
+  },
+  "axis_semantics": {
+    "point_and_trajectory_accuracy": {
+      "minimum_fields": ["truth", "mean"],
+      "metrics": ["equal-unit RMSE", "pooled coordinate RMSE"],
+      "claim_boundary": "Point accuracy does not establish calibrated uncertainty, query identifiability, decision admissibility, or safety."
+    },
+    "joint_probabilistic_validity": {
+      "minimum_fields": ["truth", "mean", "positive-definite covariance", "registered coverage radius"],
+      "metrics": [
+        "joint Gaussian NLL",
+        "product-marginal Gaussian NLL",
+        "normalized NEES",
+        "registered coverage"
+      ],
+      "claim_boundary": "A Gaussian score evaluates the registered Gaussian contract; it does not prove that the physical posterior is Gaussian."
+    },
+    "query_identifiability": {
+      "minimum_fields": [
+        "finite supported hypotheses",
+        "registered quotient classes",
+        "class masses",
+        "query weights",
+        "query tolerance"
+      ],
+      "metric": "maximum within-class query range",
+      "claim_boundary": "The benchmark validates a declared finite support. It does not infer that the quotient or support is physically complete."
+    },
+    "decision_admissibility": {
+      "minimum_fields": [
+        "finite supported hypotheses",
+        "registered quotient classes",
+        "class masses",
+        "loss by hypothesis and action",
+        "regret budget",
+        "physical fallback"
+      ],
+      "metrics": [
+        "exact pairwise worst-case loss gaps",
+        "exact worst-case regret",
+        "admissible action set",
+        "realized regret when outcomes are legally available"
+      ],
+      "claim_boundary": "Support-wise admissibility and realized target utility are distinct axes. Neither is relabeled as deployment safety."
+    },
+    "exact_fallback_integrity": {
+      "metric": "On certificate failure, the reported output action equals the caller-owned registered fallback exactly.",
+      "claim_boundary": "Fallback integrity does not establish that the fallback itself is optimal or safe."
+    },
+    "communication_cost": {
+      "metrics": ["payload bytes", "compression ratio", "posterior parity error"],
+      "claim_boundary": "Compression is successful only when the registered downstream posterior/query result remains within the frozen parity tolerance."
+    },
+    "cross_provider_corroboration": {
+      "metrics": ["matched-provider disagreement", "common-support status"],
+      "claim_boundary": "Provider agreement is not correctness. Shared dependence and common-mode bias must be reported, never converted into independent votes."
+    }
+  },
+  "information_order": [
+    "Register dataset roster, independent units, provider manifests, causal cutoff, coordinate frames, row identities, dependence groups, query portfolio, actions, losses, fallback, tolerances, and statistical analysis.",
+    "Seal provider outputs and all target-free alignment or quotient artifacts.",
+    "Evaluate contract compliance and source-only admissibility gates.",
+    "Open target outcomes once for the preregistered scorecard.",
+    "Retain positive, negative, support-negative, and technical-failure outcomes without target-side replacement or retuning."
+  ],
+  "controlled_reference": {
+    "suite": "controlled_suite.json",
+    "classification": "deterministic development evidence",
+    "public_data_records": 0,
+    "learned_provider_calls": 0,
+    "scientific_role": "Conformance and anti-gaming tests only; not an empirical provider ranking."
+  },
+  "public_data_promotion_gate": {
+    "minimum_provider_contracts": 2,
+    "minimum_independent_datasets": 2,
+    "required_negative_controls": [
+      "accurate but overconfident",
+      "marginal-preserving dependence destruction",
+      "query-sensitive unresolved ambiguity",
+      "shared-bias provider agreement",
+      "malformed contract fail-closed",
+      "exact fallback replay"
+    ],
+    "required_release_artifacts": [
+      "canonical protocol",
+      "dataset manifests and hashes",
+      "provider manifests and payload identities",
+      "sealed evaluator inputs",
+      "machine-readable scorecard",
+      "reproducer",
+      "claim-boundary statement"
+    ]
+  },
+  "nonclaims": [
+    "No state of the art is established by the controlled suite.",
+    "No learned provider competence has been evaluated by the controlled suite.",
+    "No quotient is inferred from rank deficiency alone.",
+    "No provider independence is assumed from distinct implementation names.",
+    "No scalar overall quality or safety score is defined.",
+    "No public-data, robot-control, calibration, or deployment claim is promoted without a separately frozen empirical panel."
+  ]
+}

--- a/benchmarks/information_contract_v1/public_data_plan.json
+++ b/benchmarks/information_contract_v1/public_data_plan.json
@@ -1,0 +1,109 @@
+{
+  "schema_name": "prob4d.information-contract-public-data-plan",
+  "schema_version": 1,
+  "plan_id": "prob4d-information-contract-public-data-plan-v1",
+  "status": "planning only; no target opening or empirical claim authorized",
+  "objective": "Demonstrate that provider rankings by point accuracy can differ from rankings by probabilistic validity, query admissibility, decision utility, and communication cost on independently collected public real data.",
+  "stages": [
+    {
+      "stage_id": "retrospective-schema-replay",
+      "scientific_status": "development only",
+      "datasets": [
+        {
+          "dataset_id": "tracking-cloth-deformation",
+          "eligible_axes": [
+            "joint_probabilistic_validity",
+            "dependence_preservation",
+            "communication_cost"
+          ],
+          "existing_evidence_role": "Exercise adapters against already retained recording-disjoint query-compression outputs without promoting a new empirical claim.",
+          "forbidden_claims": [
+            "learned visual-provider competence",
+            "robot-action counterfactual performance",
+            "unseen material safety"
+          ]
+        },
+        {
+          "dataset_id": "deform-dlo",
+          "eligible_axes": [
+            "point_and_trajectory_accuracy",
+            "query_identifiability",
+            "decision_admissibility",
+            "exact_fallback_integrity"
+          ],
+          "existing_evidence_role": "Exercise adapters against already retained complete-trajectory decision-certificate outputs without selecting a replacement policy.",
+          "forbidden_claims": [
+            "target-domain regret guarantee",
+            "unseen-object generalization",
+            "deployment safety"
+          ]
+        }
+      ],
+      "promotion_rule": "Adapter parity only. Existing manuscript ownership and claim boundaries remain unchanged."
+    },
+    {
+      "stage_id": "prospective-public-scorecard",
+      "scientific_status": "requires separate preregistration",
+      "minimum_distinct_provider_contracts": 2,
+      "minimum_independently_collected_datasets": 2,
+      "required_system_arms": [
+        "submitted joint contract",
+        "same-mean marginal-preserving dependence-destroyed control",
+        "point-only or deterministic control",
+        "registered physical fallback"
+      ],
+      "required_provider_controls": [
+        "provider-specific corruption",
+        "shared common-mode bias",
+        "insufficient common support",
+        "gauge-sensitive query",
+        "malformed contract"
+      ],
+      "required_information_order": [
+        "freeze rosters and independent units",
+        "freeze provider revisions, weights, preprocessing, and manifests",
+        "seal predictions before outcome access",
+        "freeze alignment, query portfolio, actions, losses, and fallback",
+        "open outcomes once",
+        "retain every terminal outcome"
+      ],
+      "primary_success_criteria": [
+        "At least one statistically supported ranking reversal between point accuracy and a probabilistic or decision axis.",
+        "The joint contract outperforms its same-mean marginal-preserving dependence-destroyed control on a registered joint score or decision loss.",
+        "Gauge-sensitive or out-of-support cases trigger exact fallback rather than unsupported certainty.",
+        "Cross-provider agreement under a shared bias is not misreported as correctness.",
+        "At least one nontrivial communication reduction preserves the registered downstream result within tolerance."
+      ],
+      "failure_semantics": "A missing axis, support-negative cohort, provider technical failure, or negative scientific result remains explicit and is not replaced or assigned a zero score."
+    },
+    {
+      "stage_id": "community-release",
+      "scientific_status": "blocked until prospective-public-scorecard completes",
+      "required_artifacts": [
+        "versioned protocol",
+        "dataset and split manifests",
+        "provider manifests and payload identities",
+        "sealed axis inputs",
+        "multi-axis JSON and tabular scorecards",
+        "adapter and evaluator tests",
+        "one-command or workflow reproduction",
+        "license and data-use review",
+        "model-card-style limitations",
+        "benchmark governance and versioning policy"
+      ],
+      "leaderboard_policy": "Separate per-axis tables and Pareto views only; no hidden weighting and no scalar overall winner."
+    }
+  ],
+  "ownership_boundary": {
+    "prob4d": "Provider contracts, uncertainty/dependence/gauge/query diagnostics, benchmark orchestration, and scorecard schema.",
+    "bayesian_phystwin": "Physical action losses, baseline-relative regret, complete candidate belief, and exact fallback.",
+    "causal4d": "Commanded-versus-realized intervention semantics and causal information order.",
+    "paper_repository": "Evidence intake, novelty ownership, paper-facing interpretation, and nonoverlapping submission claims."
+  },
+  "information_boundary": {
+    "dataset_records_accessed_by_this_plan": 0,
+    "provider_forward_calls_authorized": 0,
+    "target_outcomes_authorized": 0,
+    "new_physical_acquisitions_required": 0
+  }
+}

--- a/benchmarks/information_contract_v1/suite.schema.json
+++ b/benchmarks/information_contract_v1/suite.schema.json
@@ -1,0 +1,128 @@
+{
+  "$id": "https://github.com/IPS-Stuttgart/Prob4D/benchmarks/information_contract_v1/suite.schema.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "properties": {
+    "aggregation_unit": {
+      "const": "group_id"
+    },
+    "cases": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "case_id": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "group_id": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "metadata": {
+            "type": "object"
+          },
+          "payload": {
+            "minLength": 1,
+            "not": {
+              "anyOf": [
+                {
+                  "pattern": "^/"
+                },
+                {
+                  "pattern": "(^|/)\\.\\.(/|$)"
+                }
+              ]
+            },
+            "type": "string"
+          },
+          "payload_sha256": {
+            "pattern": "^[0-9a-f]{64}$",
+            "type": "string"
+          },
+          "tasks": {
+            "items": {
+              "enum": [
+                "forecast",
+                "calibration",
+                "dependence",
+                "query",
+                "gauge",
+                "fallback",
+                "decision",
+                "communication"
+              ]
+            },
+            "minItems": 1,
+            "type": "array",
+            "uniqueItems": true
+          }
+        },
+        "required": [
+          "case_id",
+          "group_id",
+          "payload",
+          "payload_sha256",
+          "tasks"
+        ],
+        "type": "object"
+      },
+      "minItems": 1,
+      "type": "array"
+    },
+    "claim_boundary": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "schema_name": {
+      "const": "prob4d.information-contract-suite"
+    },
+    "schema_version": {
+      "const": 1
+    },
+    "suite_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "thresholds": {
+      "additionalProperties": false,
+      "properties": {
+        "coverage_probability": {
+          "exclusiveMaximum": 1.0,
+          "exclusiveMinimum": 0.0,
+          "type": "number"
+        },
+        "gauge_sensitivity_tolerance": {
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "type": "number"
+        },
+        "moment_atol": {
+          "minimum": 0.0,
+          "type": "number"
+        },
+        "relative_rank_tolerance": {
+          "exclusiveMaximum": 1.0,
+          "minimum": 0.0,
+          "type": "number"
+        }
+      },
+      "required": [
+        "coverage_probability",
+        "gauge_sensitivity_tolerance",
+        "moment_atol",
+        "relative_rank_tolerance"
+      ],
+      "type": "object"
+    }
+  },
+  "required": [
+    "schema_name",
+    "schema_version",
+    "suite_id",
+    "aggregation_unit",
+    "thresholds",
+    "cases"
+  ],
+  "title": "Prob4D probabilistic 4-D information-contract suite v1",
+  "type": "object"
+}

--- a/docs/information-contract-benchmark.md
+++ b/docs/information-contract-benchmark.md
@@ -1,0 +1,328 @@
+# Probabilistic 4-D information-contract benchmark
+
+## Purpose
+
+Most 4-D benchmarks rank a method by point or trajectory error. That is
+insufficient when a reconstruction is consumed by a physical estimator or
+controller. Two submissions with similar point error can differ radically in
+whether they:
+
+- represent calibrated uncertainty;
+- preserve cross-point and cross-time dependence;
+- expose unobservable gauge directions;
+- answer a registered physical query without inventing unsupported state;
+- return the exact caller-owned fallback when a query is not identifiable; or
+- communicate the information needed for a decision efficiently.
+
+This benchmark defines a provider-neutral, NumPy-only scorecard for those
+properties. It intentionally has **no single scalar leaderboard**. Accuracy
+cannot compensate for a false gauge admission, a fabricated full-rank
+covariance, or a broken fallback contract.
+
+The current implementation is an experimental benchmark MVP. Its deterministic
+smoke suite is development evidence only; no learned provider or public dataset
+result is claimed by this change.
+
+## Evaluation axes
+
+A case declares the tasks it supports. Dependencies are fail-closed: for example,
+`dependence` requires `calibration`, `gauge` requires `query`, and `fallback`
+requires `gauge`.
+
+| Task | Required evidence | Primary outputs |
+| --- | --- | --- |
+| `forecast` | truth and provider mean | coordinate RMSE, point RMSE, mean point error |
+| `calibration` | conditional 3-D covariance and shared low-rank factor | Gaussian NLL, normalized NEES, marginal coverage and width |
+| `dependence` | same mean and coordinate marginals | full-vs-marginal-matched-diagonal NLL and NEES gains |
+| `query` | registered linear physical queries | query RMSE, NLL, NEES, coverage and width |
+| `gauge` | declared nullspace basis and provider admission decisions | exact nullspace sensitivity, false accepts and false rejects |
+| `fallback` | caller-owned fallback and reported query moments | branch consistency and exact rejected-query fallback |
+| `decision` | finite hypotheses, quotient masses and action losses | exact worst-case regret, admission correctness and realized regret |
+| `communication` | covariance representation | shared rank and dense-to-structured covariance byte ratios |
+
+The evaluator distinguishes **performance metrics** from **contract checks**.
+A case can achieve low error while failing its information contract. Such a
+submission remains visible in the scorecard but does not pass the contract.
+
+## Statistical units
+
+Every case has a `group_id`. The benchmark reports:
+
+1. individual case results;
+2. equal-case means;
+3. per-group means; and
+4. equal-group means.
+
+A physical object, specimen, or independently acquired session should normally
+be one group. Frames, points, overlapping windows, and multiple queries from one
+recording must not be relabelled as independent groups. Dataset-specific suites
+must freeze this rule before target outcomes are opened.
+
+## Suite manifest
+
+A suite is a JSON object with schema
+`prob4d.information-contract-suite`, version 1:
+
+```json
+{
+  "schema_name": "prob4d.information-contract-suite",
+  "schema_version": 1,
+  "suite_id": "example-suite-v1",
+  "aggregation_unit": "group_id",
+  "thresholds": {
+    "coverage_probability": 0.9,
+    "gauge_sensitivity_tolerance": 1e-10,
+    "moment_atol": 1e-12,
+    "relative_rank_tolerance": 1e-10
+  },
+  "claim_boundary": "Bounded statement specific to this frozen suite.",
+  "cases": [
+    {
+      "case_id": "object-01/session-01",
+      "group_id": "object-01",
+      "payload": "cases/object-01-session-01.npz",
+      "payload_sha256": "<lowercase sha256>",
+      "tasks": [
+        "forecast",
+        "calibration",
+        "dependence",
+        "query",
+        "gauge",
+        "fallback",
+        "decision",
+        "communication"
+      ],
+      "metadata": {
+        "dataset": "public-dataset-name",
+        "split": "held-out"
+      }
+    }
+  ]
+}
+```
+
+Manifest and payload fields not registered by version 1 are rejected. Payload
+paths must be relative, remain inside the suite directory, and match their
+declared SHA-256 exactly. NPZ files are opened with `allow_pickle=False`.
+
+The companion machine-readable manifest schema is
+[`benchmarks/information_contract_v1/suite.schema.json`](../benchmarks/information_contract_v1/suite.schema.json).
+Array shapes and cross-array dependencies are enforced by the evaluator because
+JSON Schema cannot inspect NPZ members.
+
+## NPZ payload
+
+### Forecast and covariance
+
+The state is a nonempty sequence of 3-D rows.
+
+| Array | Shape | Meaning |
+| --- | --- | --- |
+| `truth_xyz_m` | `(N, 3)` | held metric truth |
+| `prediction_mean_xyz_m` | `(N, 3)` | submitted provider mean |
+| `conditional_covariance_m2` | `(N, 3, 3)` | positive-definite row-local covariance |
+| `shared_factor_m` | `(N, 3, R)` | shared factor \(U\), yielding \(C=D+UU^\top\) |
+
+All values must be finite. The local covariance is checked for symmetry and
+positive definiteness. The evaluator uses Woodbury and determinant identities;
+it never needs to materialize the dense \(3N\times3N\) covariance.
+
+The dependence control replaces the submitted covariance with a diagonal
+covariance having the **same coordinate marginals**. Consequently, a measured
+NLL gain isolates the submitted cross-coordinate dependence rather than a
+change in mean or marginal variance.
+
+### Queries, gauge and fallback
+
+| Array | Shape | Meaning |
+| --- | --- | --- |
+| `query_matrix` | `(Q, 3N)` | registered linear queries |
+| `nullspace_basis` | `(3N, G)` | declared unobservable directions |
+| `query_admitted` | `(Q,)` Boolean | provider admission decisions |
+| `reported_query_mean` | `(Q,)` | moments returned to the caller |
+| `reported_query_variance` | `(Q,)` | returned positive variances |
+| `fallback_mean_xyz_m` | `(N, 3)` | caller-owned physical fallback |
+| `fallback_conditional_covariance_m2` | `(N, 3, 3)` | fallback local covariance |
+| `fallback_shared_factor_m` | `(N, 3, R_f)` | fallback shared factor |
+
+The evaluator orthonormalizes the declared nullspace span. For query row \(q\)
+and orthonormal nullspace basis \(N\), the normalized sensitivity is
+
+\[
+s(q)=\frac{\lVert qN\rVert_2}{\lVert q\rVert_2}.
+\]
+
+The structurally expected admission is \(s(q)\leq\tau_g\), where \(\tau_g\) is
+frozen in the suite. False acceptance and false rejection are reported
+separately.
+
+For each query, the submitted output must equal the candidate moments when
+admitted and the fallback moments when rejected. Rejected-query moments are
+required to be exactly equal to the fallback arrays after deterministic
+projection; a merely close alternative is not called exact fallback.
+
+This gauge check validates only the supplied basis. It does not prove that the
+basis is the true observation-equivalence class of a learned provider.
+
+### Finite-action decision record
+
+| Array | Shape | Meaning |
+| --- | --- | --- |
+| `decision_loss_by_hypothesis` | `(H, A)` | registered loss for each finite hypothesis/action |
+| `hypothesis_prior` | `(H,)` | nonnegative prior; positive entries define support |
+| `quotient_class` | `(H,)` integer | contiguous class labels `0..C-1` |
+| `quotient_mass` | `(C,)` | posterior class masses |
+| `reported_worst_case_regret` | `(A,)` | submitted certificate |
+| `selected_action` | scalar integer | returned action |
+| `fallback_action` | scalar integer | caller-owned fallback |
+| `decision_admitted` | scalar Boolean | submitted admission |
+| `regret_tolerance` | scalar | frozen nonnegative tolerance |
+| `realized_action_loss` | `(A,)` | held losses used only for evaluation |
+
+For actions \(a,b\), the exact compatible-belief gap is
+
+\[
+\overline\Delta(a,b)=
+\sum_c \lambda_c
+\max_{i:\pi(i)=c,\;p_i>0}
+\left(\ell_{ia}-\ell_{ib}\right).
+\]
+
+Worst-case regret is
+\(\overline R(a)=\max_b\overline\Delta(a,b)\).
+The evaluator recomputes this quantity, verifies the reported vector, applies a
+deterministic smallest-index minimax tie rule, and checks admission and exact
+fallback semantics. Realized target regret is reported separately; it is not
+confused with the registered finite-support guarantee.
+
+## Scorecard interpretation
+
+The output schema is
+`prob4d.information-contract-benchmark-result`, version 1. Each case contains:
+
+- task metrics;
+- explicit Boolean contract checks;
+- a case-level `contract_pass`;
+- immutable payload identity; and
+- metadata copied from the suite.
+
+The aggregate contains equal-case and equal-group means plus contract-failure
+counts. It does **not** contain an overall score.
+
+Recommended comparison order:
+
+1. verify identical suite and task coverage;
+2. reject or separately label contract-failing submissions;
+3. compare accuracy and probabilistic scores;
+4. compare decision utility and fallback frequency;
+5. compare covariance payload and runtime.
+
+A method that omits uncertainty can still enter a `forecast` case. It cannot
+claim calibration, dependence, gauge, or decision-contract performance without
+supplying the corresponding registered evidence.
+
+## Deterministic smoke control
+
+Run:
+
+```bash
+python -m prob4d.information_contract_benchmark smoke /tmp/prob4d-contract-smoke
+python -m prob4d.information_contract_benchmark evaluate \
+  /tmp/prob4d-contract-smoke/suite.json \
+  /tmp/prob4d-contract-smoke/replayed.json
+cmp /tmp/prob4d-contract-smoke/result.json \
+  /tmp/prob4d-contract-smoke/replayed.json
+```
+
+The smoke fixture contains two independent groups:
+
+- one exact admissible decision with a shared-dependence covariance; and
+- one deliberately ambiguous decision that must return the registered fallback.
+
+It also includes one gauge-invariant and one gauge-sensitive query. The fixture
+is generated with deterministic ZIP metadata, so its NPZ bytes and hashes are
+stable across repeated generation with the same NumPy array format.
+
+The smoke result is not a scientific benchmark result. It checks evaluator
+semantics and serialization only.
+
+## Public real-data benchmark plan
+
+The benchmark layer is designed to consume existing public evidence without
+claiming that every panel is already complete.
+
+### Panel A: DEFORM DLO
+
+The official DEFORM release provides real DLO1--DLO5 train/evaluation
+trajectories. A frozen suite can score:
+
+- forecast and query accuracy;
+- finite-action decision certificates;
+- exact physical fallback;
+- source-support versus realized-regret mismatch; and
+- equal-DLO rather than equal-window aggregation.
+
+The current DLO4/DLO5 decision study is a natural first adapter, but the adapter
+must be generated from the exact sealed prediction and outcome artifacts. A
+paper-side summary JSON is not a substitute for the original per-case payload.
+
+### Panel B: Tracking Cloth Deformation
+
+The public motion-capture release can score:
+
+- full versus marginal-matched dependence;
+- query-sufficient covariance compression;
+- finite-orbit gauge admission;
+- exact fallback; and
+- bytes per query or decision.
+
+Independent recordings or physical specimens, not windows, must be the
+aggregation groups.
+
+### Panel C: learned-provider stress panels
+
+A learned-provider panel should add:
+
+- common-mode visual bias;
+- cross-provider corroboration with explicit shared dependence;
+- nullspace/gauge reporting;
+- provider-support failure; and
+- target-free admission before held outcomes are opened.
+
+Agreement between two providers is not correctness when both share a bias.
+Independent metric anchors or held physical outcomes remain necessary.
+
+## Governance for claim-bearing suites
+
+A claim-bearing public suite should publish:
+
+1. dataset version, license and checksums;
+2. exact case roster and statistical-unit grouping;
+3. causal observation cutoff;
+4. sealed submission identities;
+5. query, gauge, action, loss and fallback definitions;
+6. thresholds frozen before target outcomes;
+7. evaluator revision and result hash;
+8. all negative and unsupported cases without replacement; and
+9. a precise claim boundary.
+
+A benchmark version must never silently change the case roster or thresholds.
+Scientific changes require a new suite ID and versioned result. Technical
+re-execution is allowed only when no scored outcome was opened or when exact
+byte-for-byte replay is demonstrated.
+
+## Current boundary
+
+Version 1 is deliberately narrow:
+
+- metric rows are 3-D;
+- covariance is block-local plus a shared low-rank factor;
+- queries are linear;
+- the gauge basis is supplied rather than inferred;
+- decision losses use a finite hypothesis and action set;
+- the conformal validity of a target-support envelope is outside this evaluator;
+- no sequential control or counterfactual robot-action outcome is inferred.
+
+These restrictions make the contract auditable. Future versions can add
+nonlinear query witnesses, continuous actions, sequential decision costs, and
+dataset adapters without weakening version-1 semantics.

--- a/src/prob4d/information_contract_benchmark.py
+++ b/src/prob4d/information_contract_benchmark.py
@@ -1,0 +1,1209 @@
+"""Multi-axis benchmark for probabilistic 4-D information contracts.
+
+The benchmark evaluates sealed provider submissions along separate axes:
+forecast accuracy, Gaussian calibration, shared dependence, query/gauge
+admissibility, exact fallback, finite-action regret, and covariance payload
+efficiency.  It intentionally does not collapse these properties into one
+leaderboard scalar.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from collections import defaultdict
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from statistics import NormalDist
+from typing import Any, Final
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ._atomic_file import atomic_write_text
+from .joint_covariance_metrics import evaluate_joint_gaussian_group
+
+SUITE_SCHEMA: Final = "prob4d.information-contract-suite"
+SUITE_VERSION: Final = 1
+RESULT_SCHEMA: Final = "prob4d.information-contract-benchmark-result"
+RESULT_VERSION: Final = 1
+CLAIM_BOUNDARY: Final = (
+    "This benchmark scores the supplied sealed predictions, uncertainty, "
+    "admission decisions, and finite-action records on the declared cases. "
+    "It does not establish provider competence outside the suite, physical "
+    "correctness of a declared gauge or quotient, target safety, causal "
+    "identification, or state of the art."
+)
+LEADERBOARD_POLICY: Final = (
+    "No single aggregate rank is defined. Compare methods on the declared "
+    "task axes and statistical-unit aggregation; accuracy cannot compensate "
+    "for a failed information contract."
+)
+_ALLOWED_TASKS: Final = frozenset(
+    {
+        "forecast",
+        "calibration",
+        "dependence",
+        "query",
+        "gauge",
+        "fallback",
+        "decision",
+        "communication",
+    }
+)
+_ALLOWED_ARRAYS: Final = frozenset(
+    {
+        "truth_xyz_m",
+        "prediction_mean_xyz_m",
+        "conditional_covariance_m2",
+        "shared_factor_m",
+        "fallback_mean_xyz_m",
+        "fallback_conditional_covariance_m2",
+        "fallback_shared_factor_m",
+        "query_matrix",
+        "nullspace_basis",
+        "query_admitted",
+        "reported_query_mean",
+        "reported_query_variance",
+        "decision_loss_by_hypothesis",
+        "hypothesis_prior",
+        "quotient_class",
+        "quotient_mass",
+        "reported_worst_case_regret",
+        "selected_action",
+        "fallback_action",
+        "decision_admitted",
+        "regret_tolerance",
+        "realized_action_loss",
+    }
+)
+FloatArray = NDArray[np.float64]
+
+
+def _load_json_object(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise ValueError(f"cannot read JSON object {path}") from error
+    if not isinstance(value, dict):
+        raise ValueError(f"{path} must contain one JSON object")
+    return value
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as stream:
+            for block in iter(lambda: stream.read(1024 * 1024), b""):
+                digest.update(block)
+    except OSError as error:
+        raise ValueError(f"cannot read benchmark payload {path}") from error
+    return digest.hexdigest()
+
+
+def _string(value: object, *, name: str) -> str:
+    if not isinstance(value, str) or not value or value != value.strip():
+        raise ValueError(f"{name} must be a nonempty, unpadded string")
+    return value
+
+
+def _real(
+    value: object,
+    *,
+    name: str,
+    minimum: float | None = None,
+    maximum: float | None = None,
+    maximum_inclusive: bool = True,
+) -> float:
+    if isinstance(value, bool) or not isinstance(
+        value, (int, float, np.integer, np.floating)
+    ):
+        raise ValueError(f"{name} must be a real scalar")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"{name} must be finite")
+    if minimum is not None and result < minimum:
+        raise ValueError(f"{name} must be at least {minimum}")
+    if maximum is not None:
+        invalid = result > maximum if maximum_inclusive else result >= maximum
+        if invalid:
+            relation = "at most" if maximum_inclusive else "less than"
+            raise ValueError(f"{name} must be {relation} {maximum}")
+    return result
+
+
+def _relative_payload(root: Path, value: object, *, name: str) -> Path:
+    raw = _string(value, name=name)
+    relative = Path(raw)
+    if relative.is_absolute() or ".." in relative.parts:
+        raise ValueError(f"{name} must be a relative path without '..'")
+    resolved = (root / relative).resolve()
+    try:
+        resolved.relative_to(root.resolve())
+    except ValueError as error:
+        raise ValueError(f"{name} escapes the suite directory") from error
+    if not resolved.is_file():
+        raise ValueError(f"{name} does not identify a file: {relative}")
+    return resolved
+
+
+def _hex_sha256(value: object, *, name: str) -> str:
+    result = _string(value, name=name)
+    if len(result) != 64 or any(character not in "0123456789abcdef" for character in result):
+        raise ValueError(f"{name} must be a lowercase SHA-256 digest")
+    return result
+
+
+def _float_array(value: object, *, name: str, ndim: int | None = None) -> FloatArray:
+    result = np.asarray(value, dtype=np.float64)
+    if ndim is not None and result.ndim != ndim:
+        raise ValueError(f"{name} must have {ndim} dimensions")
+    if not np.all(np.isfinite(result)):
+        raise ValueError(f"{name} must contain only finite values")
+    return result
+
+
+def _scalar_integer(value: object, *, name: str) -> int:
+    array = np.asarray(value)
+    if array.shape != () or array.dtype.kind not in {"i", "u"}:
+        raise ValueError(f"{name} must be an integer scalar")
+    return int(array)
+
+
+def _scalar_boolean(value: object, *, name: str) -> bool:
+    array = np.asarray(value)
+    if array.shape != () or array.dtype.kind != "b":
+        raise ValueError(f"{name} must be a Boolean scalar")
+    return bool(array)
+
+
+def _validate_covariance(
+    local: object,
+    factor: object,
+    *,
+    sample_count: int,
+    prefix: str,
+) -> tuple[FloatArray, FloatArray]:
+    covariance = _float_array(local, name=f"{prefix}_conditional_covariance_m2", ndim=3)
+    shared = _float_array(factor, name=f"{prefix}_shared_factor_m", ndim=3)
+    if covariance.shape != (sample_count, 3, 3):
+        raise ValueError(
+            f"{prefix}_conditional_covariance_m2 must have shape "
+            f"({sample_count}, 3, 3)"
+        )
+    if shared.shape[:2] != (sample_count, 3):
+        raise ValueError(
+            f"{prefix}_shared_factor_m must have shape ({sample_count}, 3, R)"
+        )
+    symmetric = 0.5 * (covariance + np.swapaxes(covariance, -1, -2))
+    scale = np.maximum(np.max(np.abs(symmetric), axis=(-2, -1)), 1.0)
+    asymmetry = np.max(
+        np.abs(covariance - np.swapaxes(covariance, -1, -2)),
+        axis=(-2, -1),
+    )
+    if np.any(asymmetry > 1e-12 + 1e-10 * scale):
+        raise ValueError(f"{prefix}_conditional_covariance_m2 must be symmetric")
+    try:
+        np.linalg.cholesky(symmetric)
+    except np.linalg.LinAlgError as error:
+        raise ValueError(
+            f"{prefix}_conditional_covariance_m2 must be positive definite"
+        ) from error
+    return symmetric, shared
+
+
+def _required_arrays(tasks: frozenset[str]) -> set[str]:
+    required: set[str] = set()
+    if tasks.intersection(
+        {"forecast", "calibration", "dependence", "query", "gauge", "fallback", "communication"}
+    ):
+        required.update({"truth_xyz_m", "prediction_mean_xyz_m"})
+    if tasks.intersection(
+        {"calibration", "dependence", "query", "gauge", "fallback", "communication"}
+    ):
+        required.update({"conditional_covariance_m2", "shared_factor_m"})
+    if tasks.intersection({"query", "gauge", "fallback"}):
+        required.add("query_matrix")
+    if "gauge" in tasks or "fallback" in tasks:
+        required.update({"nullspace_basis", "query_admitted"})
+    if "fallback" in tasks:
+        required.update(
+            {
+                "fallback_mean_xyz_m",
+                "fallback_conditional_covariance_m2",
+                "fallback_shared_factor_m",
+                "reported_query_mean",
+                "reported_query_variance",
+            }
+        )
+    if "decision" in tasks:
+        required.update(
+            {
+                "decision_loss_by_hypothesis",
+                "hypothesis_prior",
+                "quotient_class",
+                "quotient_mass",
+                "reported_worst_case_regret",
+                "selected_action",
+                "fallback_action",
+                "decision_admitted",
+                "regret_tolerance",
+                "realized_action_loss",
+            }
+        )
+    return required
+
+
+def _load_payload(path: Path, *, tasks: frozenset[str]) -> dict[str, NDArray[Any]]:
+    try:
+        with np.load(path, allow_pickle=False) as archive:
+            names = set(archive.files)
+            unknown = names.difference(_ALLOWED_ARRAYS)
+            if unknown:
+                raise ValueError(f"payload contains unregistered arrays: {sorted(unknown)}")
+            missing = _required_arrays(tasks).difference(names)
+            if missing:
+                raise ValueError(f"payload omits required arrays: {sorted(missing)}")
+            return {name: np.array(archive[name], copy=True) for name in archive.files}
+    except (OSError, ValueError) as error:
+        if isinstance(error, ValueError) and str(error).startswith("payload "):
+            raise
+        raise ValueError(f"cannot load benchmark payload {path}") from error
+
+
+def _marginal_variance(local: FloatArray, factor: FloatArray) -> FloatArray:
+    return np.diagonal(local, axis1=-2, axis2=-1) + np.sum(np.square(factor), axis=2)
+
+
+def _coverage(
+    residual: FloatArray,
+    variance: FloatArray,
+    probability: float,
+) -> tuple[float, float]:
+    z_value = NormalDist().inv_cdf(0.5 + 0.5 * probability)
+    standard_deviation = np.sqrt(variance)
+    covered = np.abs(residual) <= z_value * standard_deviation
+    width = 2.0 * z_value * standard_deviation
+    return float(np.mean(covered)), float(np.mean(width))
+
+
+def _query_moments(
+    mean_xyz_m: FloatArray,
+    local_covariance_m2: FloatArray,
+    shared_factor_m: FloatArray,
+    query_matrix: FloatArray,
+) -> tuple[FloatArray, FloatArray]:
+    sample_count = mean_xyz_m.shape[0]
+    query_count = query_matrix.shape[0]
+    query_blocks = query_matrix.reshape(query_count, sample_count, 3)
+    mean = query_matrix @ mean_xyz_m.reshape(-1)
+    local_variance = np.einsum(
+        "qni,nij,qnj->q",
+        query_blocks,
+        local_covariance_m2,
+        query_blocks,
+    )
+    shared_flat = shared_factor_m.reshape(sample_count * 3, shared_factor_m.shape[2])
+    projected = query_matrix @ shared_flat
+    variance = local_variance + np.sum(np.square(projected), axis=1)
+    if np.any(variance <= 0.0) or not np.all(np.isfinite(variance)):
+        raise ValueError("query variances must be finite and positive")
+    return mean, variance
+
+
+def _forecast_metrics(
+    truth: FloatArray,
+    prediction: FloatArray,
+) -> dict[str, Any]:
+    residual = truth - prediction
+    distances = np.linalg.norm(residual, axis=1)
+    return {
+        "point_count": int(truth.shape[0]),
+        "rmse_m": float(np.sqrt(np.mean(np.square(residual)))),
+        "point_rmse_m": float(np.sqrt(np.mean(np.square(distances)))),
+        "mean_point_error_m": float(np.mean(distances)),
+    }
+
+
+def _calibration_metrics(
+    truth: FloatArray,
+    prediction: FloatArray,
+    local: FloatArray,
+    factor: FloatArray,
+    *,
+    coverage_probability: float,
+    relative_rank_tolerance: float,
+) -> dict[str, Any]:
+    residual = truth - prediction
+    joint = evaluate_joint_gaussian_group(
+        residual,
+        local,
+        factor,
+        relative_rank_tolerance=relative_rank_tolerance,
+    )
+    marginal_coverage, mean_width = _coverage(
+        residual,
+        _marginal_variance(local, factor),
+        coverage_probability,
+    )
+    return {
+        **joint,
+        "marginal_coverage_probability": coverage_probability,
+        "marginal_coverage": marginal_coverage,
+        "mean_marginal_interval_width_m": mean_width,
+        "absolute_normalized_nees_error": abs(float(joint["normalized_nees"]) - 1.0),
+    }
+
+
+def _dependence_metrics(
+    truth: FloatArray,
+    prediction: FloatArray,
+    local: FloatArray,
+    factor: FloatArray,
+    *,
+    relative_rank_tolerance: float,
+) -> dict[str, Any]:
+    residual = truth - prediction
+    full = evaluate_joint_gaussian_group(
+        residual,
+        local,
+        factor,
+        relative_rank_tolerance=relative_rank_tolerance,
+    )
+    total_variance = _marginal_variance(local, factor)
+    diagonal = np.zeros_like(local)
+    diagonal[:, np.arange(3), np.arange(3)] = total_variance
+    empty_factor = np.empty((truth.shape[0], 3, 0), dtype=np.float64)
+    matched = evaluate_joint_gaussian_group(
+        residual,
+        diagonal,
+        empty_factor,
+        relative_rank_tolerance=relative_rank_tolerance,
+    )
+    return {
+        "comparison": "full conditional-plus-low-rank versus marginal-matched diagonal",
+        "full_gaussian_nll_per_dimension": full["gaussian_nll_per_dimension"],
+        "marginal_matched_diagonal_gaussian_nll_per_dimension": matched[
+            "gaussian_nll_per_dimension"
+        ],
+        "full_nll_gain_per_dimension": float(
+            matched["gaussian_nll_per_dimension"] - full["gaussian_nll_per_dimension"]
+        ),
+        "full_normalized_nees": full["normalized_nees"],
+        "marginal_matched_diagonal_normalized_nees": matched["normalized_nees"],
+        "full_nees_error_gain": float(
+            abs(float(matched["normalized_nees"]) - 1.0)
+            - abs(float(full["normalized_nees"]) - 1.0)
+        ),
+        "effective_shared_rank": full["effective_shared_rank"],
+    }
+
+
+def _query_metrics(
+    truth: FloatArray,
+    prediction: FloatArray,
+    local: FloatArray,
+    factor: FloatArray,
+    query_matrix: FloatArray,
+    *,
+    coverage_probability: float,
+) -> tuple[dict[str, Any], FloatArray, FloatArray, FloatArray]:
+    truth_query = query_matrix @ truth.reshape(-1)
+    predicted_query, variance = _query_moments(
+        prediction, local, factor, query_matrix
+    )
+    residual = truth_query - predicted_query
+    nll = 0.5 * (
+        np.log(2.0 * math.pi * variance) + np.square(residual) / variance
+    )
+    coverage, mean_width = _coverage(
+        residual,
+        variance,
+        coverage_probability,
+    )
+    return (
+        {
+            "query_count": int(query_matrix.shape[0]),
+            "rmse": float(np.sqrt(np.mean(np.square(residual)))),
+            "gaussian_nll_mean": float(np.mean(nll)),
+            "normalized_nees_mean": float(np.mean(np.square(residual) / variance)),
+            "marginal_coverage_probability": coverage_probability,
+            "marginal_coverage": coverage,
+            "mean_interval_width": mean_width,
+        },
+        truth_query,
+        predicted_query,
+        variance,
+    )
+
+
+def _gauge_metrics(
+    query_matrix: FloatArray,
+    nullspace_basis: FloatArray,
+    submitted_admission: NDArray[np.bool_],
+    *,
+    tolerance: float,
+) -> tuple[dict[str, Any], NDArray[np.bool_]]:
+    dimension = query_matrix.shape[1]
+    basis = _float_array(nullspace_basis, name="nullspace_basis", ndim=2)
+    if basis.shape[0] != dimension:
+        raise ValueError(
+            f"nullspace_basis must have shape ({dimension}, G)"
+        )
+    if basis.shape[1]:
+        left, singular_values, _ = np.linalg.svd(basis, full_matrices=False)
+        threshold = (
+            np.finfo(np.float64).eps
+            * max(basis.shape)
+            * float(singular_values[0])
+        )
+        rank = int(np.count_nonzero(singular_values > threshold))
+        if rank != basis.shape[1]:
+            raise ValueError("nullspace_basis must have full column rank")
+        orthonormal = left[:, :rank]
+        numerator = np.linalg.norm(query_matrix @ orthonormal, axis=1)
+    else:
+        rank = 0
+        numerator = np.zeros(query_matrix.shape[0], dtype=np.float64)
+    denominator = np.linalg.norm(query_matrix, axis=1)
+    sensitivity = numerator / denominator
+    expected = sensitivity <= tolerance
+    admitted = np.asarray(submitted_admission)
+    if admitted.shape != (query_matrix.shape[0],) or admitted.dtype.kind != "b":
+        raise ValueError("query_admitted must be a Boolean vector with one entry per query")
+    false_accept = admitted & ~expected
+    false_reject = ~admitted & expected
+    return (
+        {
+            "nullspace_dimension": rank,
+            "gauge_sensitivity_tolerance": tolerance,
+            "sensitivity_fraction": sensitivity.tolist(),
+            "expected_admitted": expected.tolist(),
+            "submitted_admitted": admitted.tolist(),
+            "correct_accept_count": int(np.count_nonzero(admitted & expected)),
+            "correct_reject_count": int(np.count_nonzero(~admitted & ~expected)),
+            "false_accept_count": int(np.count_nonzero(false_accept)),
+            "false_reject_count": int(np.count_nonzero(false_reject)),
+            "false_accept_fraction": float(np.mean(false_accept)),
+            "false_reject_fraction": float(np.mean(false_reject)),
+        },
+        expected,
+    )
+
+
+def _fallback_metrics(
+    prediction: FloatArray,
+    local: FloatArray,
+    factor: FloatArray,
+    fallback: FloatArray,
+    fallback_local: FloatArray,
+    fallback_factor: FloatArray,
+    query_matrix: FloatArray,
+    admitted: NDArray[np.bool_],
+    reported_mean: object,
+    reported_variance: object,
+    *,
+    moment_atol: float,
+) -> tuple[dict[str, Any], dict[str, bool]]:
+    candidate_mean, candidate_variance = _query_moments(
+        prediction, local, factor, query_matrix
+    )
+    fallback_mean, fallback_variance = _query_moments(
+        fallback, fallback_local, fallback_factor, query_matrix
+    )
+    reported_q_mean = _float_array(
+        reported_mean, name="reported_query_mean", ndim=1
+    )
+    reported_q_variance = _float_array(
+        reported_variance, name="reported_query_variance", ndim=1
+    )
+    expected_shape = (query_matrix.shape[0],)
+    if reported_q_mean.shape != expected_shape or reported_q_variance.shape != expected_shape:
+        raise ValueError("reported query moments must have one entry per query")
+    if np.any(reported_q_variance <= 0.0):
+        raise ValueError("reported_query_variance must be positive")
+
+    branch_mean = np.where(admitted, candidate_mean, fallback_mean)
+    branch_variance = np.where(admitted, candidate_variance, fallback_variance)
+    output_consistent = bool(
+        np.allclose(reported_q_mean, branch_mean, rtol=0.0, atol=moment_atol)
+        and np.allclose(
+            reported_q_variance,
+            branch_variance,
+            rtol=0.0,
+            atol=moment_atol,
+        )
+    )
+    rejected = ~admitted
+    exact_fallback = bool(
+        np.array_equal(reported_q_mean[rejected], fallback_mean[rejected])
+        and np.array_equal(
+            reported_q_variance[rejected],
+            fallback_variance[rejected],
+        )
+    )
+    rejected_count = int(np.count_nonzero(rejected))
+    return (
+        {
+            "accepted_query_count": int(np.count_nonzero(admitted)),
+            "rejected_query_count": rejected_count,
+            "reported_output_consistent": output_consistent,
+            "exact_fallback_on_rejection": exact_fallback,
+            "rejected_exact_fraction": 1.0 if rejected_count == 0 else float(exact_fallback),
+            "maximum_mean_branch_error": float(
+                np.max(np.abs(reported_q_mean - branch_mean), initial=0.0)
+            ),
+            "maximum_variance_branch_error": float(
+                np.max(np.abs(reported_q_variance - branch_variance), initial=0.0)
+            ),
+        },
+        {
+            "query_output_consistent": output_consistent,
+            "exact_fallback": exact_fallback,
+        },
+    )
+
+
+def _decision_metrics(
+    arrays: Mapping[str, NDArray[Any]],
+    *,
+    moment_atol: float,
+) -> tuple[dict[str, Any], dict[str, bool]]:
+    losses = _float_array(
+        arrays["decision_loss_by_hypothesis"],
+        name="decision_loss_by_hypothesis",
+        ndim=2,
+    )
+    hypothesis_count, action_count = losses.shape
+    if hypothesis_count < 1 or action_count < 2:
+        raise ValueError("decision loss matrix must have shape (H, A), H >= 1, A >= 2")
+    prior = _float_array(arrays["hypothesis_prior"], name="hypothesis_prior", ndim=1)
+    if prior.shape != (hypothesis_count,) or np.any(prior < 0.0) or float(prior.sum()) <= 0.0:
+        raise ValueError("hypothesis_prior must be nonnegative with positive total mass")
+    classes = np.asarray(arrays["quotient_class"])
+    if classes.shape != (hypothesis_count,) or classes.dtype.kind not in {"i", "u"}:
+        raise ValueError("quotient_class must be an integer vector with one entry per hypothesis")
+    classes = classes.astype(np.int64, copy=False)
+    class_count = int(classes.max(initial=-1)) + 1
+    if class_count < 1 or set(classes.tolist()) != set(range(class_count)):
+        raise ValueError("quotient_class labels must be contiguous integers starting at zero")
+    mass = _float_array(arrays["quotient_mass"], name="quotient_mass", ndim=1)
+    if mass.shape != (class_count,) or np.any(mass < 0.0):
+        raise ValueError("quotient_mass must have one nonnegative entry per class")
+    if not math.isclose(float(mass.sum()), 1.0, rel_tol=0.0, abs_tol=1e-12):
+        raise ValueError("quotient_mass must sum to one")
+    support = prior > 0.0
+    for class_index in range(class_count):
+        if not np.any(support & (classes == class_index)):
+            raise ValueError("every quotient class must contain positive prior support")
+
+    pairwise = np.zeros((action_count, action_count), dtype=np.float64)
+    for class_index in range(class_count):
+        selected = support & (classes == class_index)
+        differences = (
+            losses[selected, :, None] - losses[selected, None, :]
+        )
+        pairwise += mass[class_index] * np.max(differences, axis=0)
+    worst_regret = np.max(pairwise, axis=1)
+    reported = _float_array(
+        arrays["reported_worst_case_regret"],
+        name="reported_worst_case_regret",
+        ndim=1,
+    )
+    if reported.shape != (action_count,):
+        raise ValueError("reported_worst_case_regret must have one entry per action")
+    regret_consistent = bool(
+        np.allclose(reported, worst_regret, rtol=0.0, atol=moment_atol)
+    )
+
+    selected_action = _scalar_integer(arrays["selected_action"], name="selected_action")
+    fallback_action = _scalar_integer(arrays["fallback_action"], name="fallback_action")
+    if not 0 <= selected_action < action_count or not 0 <= fallback_action < action_count:
+        raise ValueError("selected_action and fallback_action must index the action set")
+    submitted_admitted = _scalar_boolean(
+        arrays["decision_admitted"], name="decision_admitted"
+    )
+    tolerance_value = np.asarray(arrays["regret_tolerance"])
+    if tolerance_value.shape != ():
+        raise ValueError("regret_tolerance must be a scalar")
+    tolerance = _real(
+        tolerance_value.item(),
+        name="regret_tolerance",
+        minimum=0.0,
+    )
+    minimax_action = int(np.argmin(worst_regret))
+    expected_admitted = bool(float(worst_regret[minimax_action]) <= tolerance)
+    admission_consistent = submitted_admitted is expected_admitted
+    expected_selected = minimax_action if submitted_admitted else fallback_action
+    policy_consistent = selected_action == expected_selected
+
+    realized = _float_array(
+        arrays["realized_action_loss"],
+        name="realized_action_loss",
+        ndim=1,
+    )
+    if realized.shape != (action_count,):
+        raise ValueError("realized_action_loss must have one entry per action")
+    realized_regret = float(realized[selected_action] - np.min(realized))
+    return (
+        {
+            "hypothesis_count": hypothesis_count,
+            "quotient_class_count": class_count,
+            "action_count": action_count,
+            "worst_case_regret": worst_regret.tolist(),
+            "reported_worst_case_regret": reported.tolist(),
+            "regret_tolerance": tolerance,
+            "minimax_action": minimax_action,
+            "expected_admitted": expected_admitted,
+            "submitted_admitted": submitted_admitted,
+            "selected_action": selected_action,
+            "fallback_action": fallback_action,
+            "registered_selected_regret": float(worst_regret[selected_action]),
+            "realized_action_loss": realized.tolist(),
+            "realized_regret": realized_regret,
+        },
+        {
+            "decision_regret_consistent": regret_consistent,
+            "decision_admission_consistent": admission_consistent,
+            "decision_policy_consistent": policy_consistent,
+        },
+    )
+
+
+def _communication_metrics(
+    local: FloatArray,
+    factor: FloatArray,
+    *,
+    payload_bytes: int,
+) -> dict[str, Any]:
+    sample_count = int(local.shape[0])
+    dimension = 3 * sample_count
+    rank = int(factor.shape[2])
+    dense_symmetric_bytes = 8 * dimension * (dimension + 1) // 2
+    submitted_covariance_bytes = int(local.nbytes + factor.nbytes)
+    theoretical_structured_bytes = 8 * (6 * sample_count + dimension * rank)
+    return {
+        "state_dimension": dimension,
+        "shared_rank": rank,
+        "payload_file_bytes": int(payload_bytes),
+        "dense_symmetric_covariance_bytes": dense_symmetric_bytes,
+        "submitted_covariance_array_bytes": submitted_covariance_bytes,
+        "theoretical_symmetric_block_plus_factor_bytes": theoretical_structured_bytes,
+        "dense_to_submitted_covariance_ratio": (
+            None
+            if submitted_covariance_bytes == 0
+            else dense_symmetric_bytes / submitted_covariance_bytes
+        ),
+        "dense_to_theoretical_structured_ratio": (
+            None
+            if theoretical_structured_bytes == 0
+            else dense_symmetric_bytes / theoretical_structured_bytes
+        ),
+    }
+
+
+def _case_tasks(value: object, *, name: str) -> frozenset[str]:
+    if not isinstance(value, list) or not value:
+        raise ValueError(f"{name} must be a nonempty task list")
+    tasks = [_string(item, name=f"{name} entry") for item in value]
+    if len(tasks) != len(set(tasks)):
+        raise ValueError(f"{name} must not contain duplicates")
+    unknown = set(tasks).difference(_ALLOWED_TASKS)
+    if unknown:
+        raise ValueError(f"{name} contains unknown tasks: {sorted(unknown)}")
+    dependencies = {
+        "calibration": {"forecast"},
+        "dependence": {"calibration"},
+        "query": {"calibration"},
+        "gauge": {"query"},
+        "fallback": {"gauge"},
+        "communication": {"calibration"},
+    }
+    task_set = set(tasks)
+    for task, required in dependencies.items():
+        if task in task_set and not required.issubset(task_set):
+            raise ValueError(f"task {task!r} requires {sorted(required)}")
+    return frozenset(task_set)
+
+
+def _evaluate_case(
+    case: Mapping[str, Any],
+    *,
+    suite_root: Path,
+    coverage_probability: float,
+    gauge_tolerance: float,
+    moment_atol: float,
+    relative_rank_tolerance: float,
+) -> dict[str, Any]:
+    case_id = _string(case.get("case_id"), name="case_id")
+    group_id = _string(case.get("group_id"), name=f"{case_id}.group_id")
+    tasks = _case_tasks(case.get("tasks"), name=f"{case_id}.tasks")
+    payload = _relative_payload(
+        suite_root, case.get("payload"), name=f"{case_id}.payload"
+    )
+    expected_sha256 = _hex_sha256(
+        case.get("payload_sha256"), name=f"{case_id}.payload_sha256"
+    )
+    actual_sha256 = _sha256_file(payload)
+    if actual_sha256 != expected_sha256:
+        raise ValueError(
+            f"{case_id} payload SHA-256 mismatch: {actual_sha256} != {expected_sha256}"
+        )
+    arrays = _load_payload(payload, tasks=tasks)
+    unexpected_case_fields = set(case).difference(
+        {"case_id", "group_id", "payload", "payload_sha256", "tasks", "metadata"}
+    )
+    if unexpected_case_fields:
+        raise ValueError(
+            f"{case_id} contains unregistered manifest fields: "
+            f"{sorted(unexpected_case_fields)}"
+        )
+    metadata = case.get("metadata", {})
+    if not isinstance(metadata, dict):
+        raise ValueError(f"{case_id}.metadata must be an object")
+
+    result: dict[str, Any] = {
+        "case_id": case_id,
+        "group_id": group_id,
+        "tasks": sorted(tasks),
+        "payload": payload.relative_to(suite_root).as_posix(),
+        "payload_sha256": actual_sha256,
+        "metadata": metadata,
+        "metrics": {},
+        "contract_checks": {},
+    }
+
+    truth: FloatArray | None = None
+    prediction: FloatArray | None = None
+    local: FloatArray | None = None
+    factor: FloatArray | None = None
+    query_matrix: FloatArray | None = None
+    submitted_admission: NDArray[np.bool_] | None = None
+
+    if tasks.intersection(
+        {"forecast", "calibration", "dependence", "query", "gauge", "fallback", "communication"}
+    ):
+        truth = _float_array(arrays["truth_xyz_m"], name="truth_xyz_m", ndim=2)
+        prediction = _float_array(
+            arrays["prediction_mean_xyz_m"],
+            name="prediction_mean_xyz_m",
+            ndim=2,
+        )
+        if truth.ndim != 2 or truth.shape[0] < 1 or truth.shape[1] != 3:
+            raise ValueError("truth_xyz_m must have nonempty shape (N, 3)")
+        if prediction.shape != truth.shape:
+            raise ValueError("prediction_mean_xyz_m must match truth_xyz_m")
+
+    if tasks.intersection(
+        {"calibration", "dependence", "query", "gauge", "fallback", "communication"}
+    ):
+        assert truth is not None
+        local, factor = _validate_covariance(
+            arrays["conditional_covariance_m2"],
+            arrays["shared_factor_m"],
+            sample_count=truth.shape[0],
+            prefix="prediction",
+        )
+
+    if "forecast" in tasks:
+        assert truth is not None and prediction is not None
+        result["metrics"]["forecast"] = _forecast_metrics(truth, prediction)
+
+    if "calibration" in tasks:
+        assert (
+            truth is not None
+            and prediction is not None
+            and local is not None
+            and factor is not None
+        )
+        result["metrics"]["calibration"] = _calibration_metrics(
+            truth,
+            prediction,
+            local,
+            factor,
+            coverage_probability=coverage_probability,
+            relative_rank_tolerance=relative_rank_tolerance,
+        )
+
+    if "dependence" in tasks:
+        assert (
+            truth is not None
+            and prediction is not None
+            and local is not None
+            and factor is not None
+        )
+        result["metrics"]["dependence"] = _dependence_metrics(
+            truth,
+            prediction,
+            local,
+            factor,
+            relative_rank_tolerance=relative_rank_tolerance,
+        )
+
+    if tasks.intersection({"query", "gauge", "fallback"}):
+        assert truth is not None
+        query_matrix = _float_array(
+            arrays["query_matrix"], name="query_matrix", ndim=2
+        )
+        dimension = truth.size
+        if query_matrix.shape[0] < 1 or query_matrix.shape[1] != dimension:
+            raise ValueError(
+                f"query_matrix must have shape (Q, {dimension}), Q >= 1"
+            )
+        if np.any(np.linalg.norm(query_matrix, axis=1) == 0.0):
+            raise ValueError("query_matrix must not contain a zero query")
+
+    if "query" in tasks:
+        assert (
+            truth is not None
+            and prediction is not None
+            and local is not None
+            and factor is not None
+            and query_matrix is not None
+        )
+        query_metrics, _, _, _ = _query_metrics(
+            truth,
+            prediction,
+            local,
+            factor,
+            query_matrix,
+            coverage_probability=coverage_probability,
+        )
+        result["metrics"]["query"] = query_metrics
+
+    if "gauge" in tasks:
+        assert query_matrix is not None
+        submitted_admission = np.asarray(arrays["query_admitted"])
+        gauge_metrics, _ = _gauge_metrics(
+            query_matrix,
+            arrays["nullspace_basis"],
+            submitted_admission,
+            tolerance=gauge_tolerance,
+        )
+        result["metrics"]["gauge"] = gauge_metrics
+        result["contract_checks"]["gauge_admission_consistent"] = (
+            gauge_metrics["false_accept_count"] == 0
+            and gauge_metrics["false_reject_count"] == 0
+        )
+
+    if "fallback" in tasks:
+        assert (
+            truth is not None
+            and prediction is not None
+            and local is not None
+            and factor is not None
+            and query_matrix is not None
+            and submitted_admission is not None
+        )
+        fallback = _float_array(
+            arrays["fallback_mean_xyz_m"],
+            name="fallback_mean_xyz_m",
+            ndim=2,
+        )
+        if fallback.shape != truth.shape:
+            raise ValueError("fallback_mean_xyz_m must match truth_xyz_m")
+        fallback_local, fallback_factor = _validate_covariance(
+            arrays["fallback_conditional_covariance_m2"],
+            arrays["fallback_shared_factor_m"],
+            sample_count=truth.shape[0],
+            prefix="fallback",
+        )
+        fallback_metrics, checks = _fallback_metrics(
+            prediction,
+            local,
+            factor,
+            fallback,
+            fallback_local,
+            fallback_factor,
+            query_matrix,
+            submitted_admission,
+            arrays["reported_query_mean"],
+            arrays["reported_query_variance"],
+            moment_atol=moment_atol,
+        )
+        result["metrics"]["fallback"] = fallback_metrics
+        result["contract_checks"].update(checks)
+
+    if "decision" in tasks:
+        decision_metrics, checks = _decision_metrics(
+            arrays,
+            moment_atol=moment_atol,
+        )
+        result["metrics"]["decision"] = decision_metrics
+        result["contract_checks"].update(checks)
+
+    if "communication" in tasks:
+        assert local is not None and factor is not None
+        result["metrics"]["communication"] = _communication_metrics(
+            local,
+            factor,
+            payload_bytes=payload.stat().st_size,
+        )
+
+    result["contract_pass"] = all(result["contract_checks"].values())
+    return result
+
+
+def _summary_values(case: Mapping[str, Any]) -> dict[str, float]:
+    metrics = case["metrics"]
+    values: dict[str, float] = {}
+    mapping = {
+        ("forecast", "rmse_m"): "forecast_rmse_m",
+        ("forecast", "point_rmse_m"): "forecast_point_rmse_m",
+        ("calibration", "gaussian_nll_per_dimension"): "gaussian_nll_per_dimension",
+        ("calibration", "normalized_nees"): "normalized_nees",
+        ("calibration", "marginal_coverage"): "marginal_coverage",
+        ("dependence", "full_nll_gain_per_dimension"): "dependence_nll_gain_per_dimension",
+        ("dependence", "full_nees_error_gain"): "dependence_nees_error_gain",
+        ("query", "rmse"): "query_rmse",
+        ("query", "gaussian_nll_mean"): "query_gaussian_nll_mean",
+        ("query", "normalized_nees_mean"): "query_normalized_nees_mean",
+        ("query", "marginal_coverage"): "query_marginal_coverage",
+        ("gauge", "false_accept_fraction"): "gauge_false_accept_fraction",
+        ("gauge", "false_reject_fraction"): "gauge_false_reject_fraction",
+        ("fallback", "rejected_exact_fraction"): "exact_fallback_fraction",
+        ("decision", "realized_regret"): "realized_decision_regret",
+        ("communication", "dense_to_submitted_covariance_ratio"): (
+            "dense_to_submitted_covariance_ratio"
+        ),
+    }
+    for (section, field), name in mapping.items():
+        section_value = metrics.get(section)
+        if not isinstance(section_value, dict):
+            continue
+        value = section_value.get(field)
+        if value is not None:
+            values[name] = float(value)
+    return values
+
+
+def _mean_summaries(summaries: Sequence[Mapping[str, float]]) -> dict[str, float]:
+    keys = sorted({key for summary in summaries for key in summary})
+    return {
+        key: float(np.mean([summary[key] for summary in summaries if key in summary]))
+        for key in keys
+    }
+
+
+def _aggregate(cases: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    case_summaries = [_summary_values(case) for case in cases]
+    grouped: dict[str, list[dict[str, float]]] = defaultdict(list)
+    for case, summary in zip(cases, case_summaries, strict=True):
+        grouped[str(case["group_id"])].append(summary)
+    group_summaries = {
+        group_id: _mean_summaries(values)
+        for group_id, values in sorted(grouped.items())
+    }
+    task_counts: dict[str, int] = defaultdict(int)
+    check_failures: dict[str, int] = defaultdict(int)
+    for case in cases:
+        for task in case["tasks"]:
+            task_counts[str(task)] += 1
+        for name, passed in case["contract_checks"].items():
+            if not passed:
+                check_failures[str(name)] += 1
+    return {
+        "case_count": len(cases),
+        "independent_group_count": len(grouped),
+        "declared_task_case_counts": dict(sorted(task_counts.items())),
+        "contract": {
+            "passed_case_count": sum(bool(case["contract_pass"]) for case in cases),
+            "failed_case_count": sum(not bool(case["contract_pass"]) for case in cases),
+            "all_cases_pass": all(bool(case["contract_pass"]) for case in cases),
+            "check_failure_counts": dict(sorted(check_failures.items())),
+        },
+        "equal_case_mean": _mean_summaries(case_summaries),
+        "per_group_mean": group_summaries,
+        "equal_group_mean": _mean_summaries(list(group_summaries.values())),
+    }
+
+
+def evaluate_information_contract_suite(suite_path: str | Path) -> dict[str, Any]:
+    """Validate and evaluate one suite without altering its inputs."""
+
+    path = Path(suite_path)
+    suite = _load_json_object(path)
+    if set(suite).difference(
+        {
+            "schema_name",
+            "schema_version",
+            "suite_id",
+            "aggregation_unit",
+            "thresholds",
+            "cases",
+            "claim_boundary",
+        }
+    ):
+        unknown = sorted(
+            set(suite).difference(
+                {
+                    "schema_name",
+                    "schema_version",
+                    "suite_id",
+                    "aggregation_unit",
+                    "thresholds",
+                    "cases",
+                    "claim_boundary",
+                }
+            )
+        )
+        raise ValueError(f"suite contains unregistered fields: {unknown}")
+    if suite.get("schema_name") != SUITE_SCHEMA or suite.get("schema_version") != SUITE_VERSION:
+        raise ValueError("unsupported information-contract suite schema")
+    suite_id = _string(suite.get("suite_id"), name="suite_id")
+    if suite.get("aggregation_unit") != "group_id":
+        raise ValueError("aggregation_unit must be 'group_id'")
+    thresholds = suite.get("thresholds")
+    if not isinstance(thresholds, dict):
+        raise ValueError("thresholds must be an object")
+    allowed_thresholds = {
+        "coverage_probability",
+        "gauge_sensitivity_tolerance",
+        "moment_atol",
+        "relative_rank_tolerance",
+    }
+    if set(thresholds).difference(allowed_thresholds):
+        raise ValueError(
+            "thresholds contain unregistered fields: "
+            f"{sorted(set(thresholds).difference(allowed_thresholds))}"
+        )
+    coverage_probability = _real(
+        thresholds.get("coverage_probability"),
+        name="coverage_probability",
+        minimum=0.0,
+        maximum=1.0,
+        maximum_inclusive=False,
+    )
+    if coverage_probability == 0.0:
+        raise ValueError("coverage_probability must be greater than zero")
+    gauge_tolerance = _real(
+        thresholds.get("gauge_sensitivity_tolerance"),
+        name="gauge_sensitivity_tolerance",
+        minimum=0.0,
+        maximum=1.0,
+    )
+    moment_atol = _real(
+        thresholds.get("moment_atol"),
+        name="moment_atol",
+        minimum=0.0,
+    )
+    relative_rank_tolerance = _real(
+        thresholds.get("relative_rank_tolerance"),
+        name="relative_rank_tolerance",
+        minimum=0.0,
+        maximum=1.0,
+        maximum_inclusive=False,
+    )
+    cases_value = suite.get("cases")
+    if not isinstance(cases_value, list) or not cases_value:
+        raise ValueError("cases must be a nonempty list")
+    cases: list[dict[str, Any]] = []
+    case_ids: set[str] = set()
+    for index, case_value in enumerate(cases_value):
+        if not isinstance(case_value, dict):
+            raise ValueError(f"cases[{index}] must be an object")
+        case = _evaluate_case(
+            case_value,
+            suite_root=path.parent.resolve(),
+            coverage_probability=coverage_probability,
+            gauge_tolerance=gauge_tolerance,
+            moment_atol=moment_atol,
+            relative_rank_tolerance=relative_rank_tolerance,
+        )
+        if case["case_id"] in case_ids:
+            raise ValueError(f"duplicate case_id {case['case_id']!r}")
+        case_ids.add(case["case_id"])
+        cases.append(case)
+    cases.sort(key=lambda value: value["case_id"])
+    declared_boundary = suite.get("claim_boundary")
+    if declared_boundary is not None:
+        _string(declared_boundary, name="claim_boundary")
+    return {
+        "schema_name": RESULT_SCHEMA,
+        "schema_version": RESULT_VERSION,
+        "suite_id": suite_id,
+        "suite_sha256": _sha256_file(path),
+        "claim_boundary": CLAIM_BOUNDARY,
+        "suite_claim_boundary": declared_boundary,
+        "leaderboard_policy": LEADERBOARD_POLICY,
+        "thresholds": {
+            "coverage_probability": coverage_probability,
+            "gauge_sensitivity_tolerance": gauge_tolerance,
+            "moment_atol": moment_atol,
+            "relative_rank_tolerance": relative_rank_tolerance,
+        },
+        "cases": cases,
+        "aggregate": _aggregate(cases),
+    }
+
+
+
+def generate_smoke_suite(directory: str | Path, *, overwrite: bool = False) -> Path:
+    """Create the deterministic development fixture without importing it at startup."""
+
+    from .information_contract_benchmark_smoke import generate_smoke_suite as generate
+
+    return generate(directory, overwrite=overwrite)
+
+
+def _write_result(
+    path: Path,
+    result: Mapping[str, Any],
+    *,
+    overwrite: bool,
+) -> None:
+    atomic_write_text(
+        path,
+        json.dumps(result, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        overwrite=overwrite,
+    )
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    evaluate = subparsers.add_parser("evaluate", help="evaluate one sealed suite")
+    evaluate.add_argument("suite", type=Path)
+    evaluate.add_argument("output", type=Path)
+    evaluate.add_argument("--overwrite", action="store_true")
+    smoke = subparsers.add_parser(
+        "smoke", help="generate and evaluate a deterministic smoke suite"
+    )
+    smoke.add_argument("directory", type=Path)
+    smoke.add_argument("--overwrite", action="store_true")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.command == "evaluate":
+        result = evaluate_information_contract_suite(args.suite)
+        _write_result(args.output, result, overwrite=args.overwrite)
+        return 0
+    suite_path = generate_smoke_suite(args.directory, overwrite=args.overwrite)
+    result = evaluate_information_contract_suite(suite_path)
+    _write_result(
+        args.directory / "result.json",
+        result,
+        overwrite=args.overwrite,
+    )
+    return 0
+
+
+__all__ = [
+    "CLAIM_BOUNDARY",
+    "LEADERBOARD_POLICY",
+    "RESULT_SCHEMA",
+    "RESULT_VERSION",
+    "SUITE_SCHEMA",
+    "SUITE_VERSION",
+    "evaluate_information_contract_suite",
+    "generate_smoke_suite",
+    "main",
+]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/prob4d/information_contract_benchmark_smoke.py
+++ b/src/prob4d/information_contract_benchmark_smoke.py
@@ -1,0 +1,239 @@
+"""Deterministic development fixture for the information-contract benchmark."""
+
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from ._atomic_file import atomic_write_bytes, atomic_write_text
+from .information_contract_benchmark import (
+    SUITE_SCHEMA,
+    SUITE_VERSION,
+    _ALLOWED_TASKS,
+    _query_moments,
+    _sha256_file,
+)
+
+FloatArray = NDArray[np.float64]
+
+
+def _deterministic_npz_bytes(arrays: Mapping[str, NDArray[Any]]) -> bytes:
+    stream = io.BytesIO()
+    with zipfile.ZipFile(stream, "w", compression=zipfile.ZIP_STORED) as archive:
+        for name in sorted(arrays):
+            value = np.asarray(arrays[name])
+            if value.dtype.kind == "O":
+                raise ValueError("smoke arrays must not use object dtype")
+            payload = io.BytesIO()
+            np.lib.format.write_array(payload, value, allow_pickle=False)
+            info = zipfile.ZipInfo(f"{name}.npy", date_time=(1980, 1, 1, 0, 0, 0))
+            info.compress_type = zipfile.ZIP_STORED
+            info.external_attr = 0o600 << 16
+            archive.writestr(info, payload.getvalue())
+    return stream.getvalue()
+
+
+def _smoke_covariance(sample_count: int) -> tuple[FloatArray, FloatArray]:
+    local = np.repeat(
+        np.diag(np.square([0.02, 0.02, 0.02]))[None, :, :],
+        sample_count,
+        axis=0,
+    )
+    factor = np.zeros((sample_count, 3, 1), dtype=np.float64)
+    factor[:, 0, 0] = 0.05
+    factor[:, 1, 0] = 0.08
+    return local, factor
+
+
+def _smoke_fallback_covariance(sample_count: int) -> tuple[FloatArray, FloatArray]:
+    local = np.repeat(
+        np.diag(np.square([0.04, 0.04, 0.04]))[None, :, :],
+        sample_count,
+        axis=0,
+    )
+    return local, np.empty((sample_count, 3, 0), dtype=np.float64)
+
+
+def _reported_query_branch(
+    prediction: FloatArray,
+    local: FloatArray,
+    factor: FloatArray,
+    fallback: FloatArray,
+    fallback_local: FloatArray,
+    fallback_factor: FloatArray,
+    query: FloatArray,
+    admitted: NDArray[np.bool_],
+) -> tuple[FloatArray, FloatArray]:
+    candidate_mean, candidate_variance = _query_moments(
+        prediction, local, factor, query
+    )
+    fallback_mean, fallback_variance = _query_moments(
+        fallback, fallback_local, fallback_factor, query
+    )
+    return (
+        np.where(admitted, candidate_mean, fallback_mean),
+        np.where(admitted, candidate_variance, fallback_variance),
+    )
+
+
+def _smoke_case(
+    *,
+    reject_decision: bool,
+) -> dict[str, NDArray[Any]]:
+    truth = np.array(
+        [[0.0, 0.0, 0.0], [1.0, 0.0, 0.0], [2.0, 0.0, 0.0]],
+        dtype=np.float64,
+    )
+    prediction = truth + np.array([0.05, 0.10, 0.0])
+    fallback = truth + np.array([0.10, 0.0, 0.0])
+    local, factor = _smoke_covariance(len(truth))
+    fallback_local, fallback_factor = _smoke_fallback_covariance(len(truth))
+    query = np.zeros((3, truth.size), dtype=np.float64)
+    query[0, 0] = -1.0
+    query[0, 6] = 1.0
+    query[1, 1::3] = 1.0 / 3.0
+    query[2, 0::3] = 1.0 / 3.0
+    nullspace = np.zeros((truth.size, 1), dtype=np.float64)
+    nullspace[1::3, 0] = 1.0
+    admitted = np.array([True, False, True])
+    reported_mean, reported_variance = _reported_query_branch(
+        prediction,
+        local,
+        factor,
+        fallback,
+        fallback_local,
+        fallback_factor,
+        query,
+        admitted,
+    )
+
+    if reject_decision:
+        decision_losses = np.array(
+            [[0.0, 1.0], [1.0, 0.0], [0.0, 1.0], [1.0, 0.0]]
+        )
+        prior = np.full(4, 0.25)
+        classes = np.array([0, 0, 1, 1], dtype=np.int64)
+        mass = np.array([0.5, 0.5])
+        reported_regret = np.array([1.0, 1.0])
+        selected_action = np.array(1, dtype=np.int64)
+        fallback_action = np.array(1, dtype=np.int64)
+        decision_admitted = np.array(False)
+        tolerance = np.array(0.1)
+        realized = np.array([0.8, 0.2])
+    else:
+        decision_losses = np.array(
+            [
+                [0.0, 0.4, 0.6],
+                [0.02, 0.3, 0.7],
+                [0.01, 0.5, 0.2],
+                [0.0, 0.6, 0.25],
+            ]
+        )
+        prior = np.full(4, 0.25)
+        classes = np.array([0, 0, 1, 1], dtype=np.int64)
+        mass = np.array([0.6, 0.4])
+        # Filled below from the exact evaluator formula for readability.
+        differences = np.zeros((3, 3), dtype=np.float64)
+        for class_index in range(2):
+            mask = classes == class_index
+            differences += mass[class_index] * np.max(
+                decision_losses[mask, :, None] - decision_losses[mask, None, :],
+                axis=0,
+            )
+        reported_regret = np.max(differences, axis=1)
+        selected_action = np.array(0, dtype=np.int64)
+        fallback_action = np.array(2, dtype=np.int64)
+        decision_admitted = np.array(True)
+        tolerance = np.array(0.05)
+        realized = np.array([0.05, 0.4, 0.3])
+
+    return {
+        "truth_xyz_m": truth,
+        "prediction_mean_xyz_m": prediction,
+        "conditional_covariance_m2": local,
+        "shared_factor_m": factor,
+        "fallback_mean_xyz_m": fallback,
+        "fallback_conditional_covariance_m2": fallback_local,
+        "fallback_shared_factor_m": fallback_factor,
+        "query_matrix": query,
+        "nullspace_basis": nullspace,
+        "query_admitted": admitted,
+        "reported_query_mean": reported_mean,
+        "reported_query_variance": reported_variance,
+        "decision_loss_by_hypothesis": decision_losses,
+        "hypothesis_prior": prior,
+        "quotient_class": classes,
+        "quotient_mass": mass,
+        "reported_worst_case_regret": reported_regret,
+        "selected_action": selected_action,
+        "fallback_action": fallback_action,
+        "decision_admitted": decision_admitted,
+        "regret_tolerance": tolerance,
+        "realized_action_loss": realized,
+    }
+
+
+def generate_smoke_suite(directory: str | Path, *, overwrite: bool = False) -> Path:
+    """Create a deterministic two-group benchmark fixture."""
+
+    root = Path(directory)
+    root.mkdir(parents=True, exist_ok=True)
+    cases: list[dict[str, Any]] = []
+    tasks = sorted(_ALLOWED_TASKS)
+    for case_id, group_id, reject in (
+        ("admissible-shared-dependence", "object-a", False),
+        ("ambiguous-exact-fallback", "object-b", True),
+    ):
+        payload_path = root / f"{case_id}.npz"
+        atomic_write_bytes(
+            payload_path,
+            _deterministic_npz_bytes(_smoke_case(reject_decision=reject)),
+            overwrite=overwrite,
+        )
+        cases.append(
+            {
+                "case_id": case_id,
+                "group_id": group_id,
+                "payload": payload_path.name,
+                "payload_sha256": _sha256_file(payload_path),
+                "tasks": tasks,
+                "metadata": {
+                    "classification": "deterministic smoke control",
+                    "uses_public_data": False,
+                },
+            }
+        )
+    suite = {
+        "schema_name": SUITE_SCHEMA,
+        "schema_version": SUITE_VERSION,
+        "suite_id": "prob4d-information-contract-smoke-v1",
+        "aggregation_unit": "group_id",
+        "thresholds": {
+            "coverage_probability": 0.9,
+            "gauge_sensitivity_tolerance": 1e-12,
+            "moment_atol": 1e-12,
+            "relative_rank_tolerance": 1e-10,
+        },
+        "claim_boundary": (
+            "Deterministic development control only; no learned provider, public "
+            "dataset, calibration claim, physical benefit, or deployment result."
+        ),
+        "cases": cases,
+    }
+    suite_path = root / "suite.json"
+    atomic_write_text(
+        suite_path,
+        json.dumps(suite, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        overwrite=overwrite,
+    )
+    return suite_path
+
+
+__all__ = ["generate_smoke_suite"]

--- a/src/prob4d/information_contract_benchmark_smoke.py
+++ b/src/prob4d/information_contract_benchmark_smoke.py
@@ -14,9 +14,9 @@ from numpy.typing import NDArray
 
 from ._atomic_file import atomic_write_bytes, atomic_write_text
 from .information_contract_benchmark import (
+    _ALLOWED_TASKS,
     SUITE_SCHEMA,
     SUITE_VERSION,
-    _ALLOWED_TASKS,
     _query_moments,
     _sha256_file,
 )

--- a/tests/test_information_contract_benchmark.py
+++ b/tests/test_information_contract_benchmark.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import prob4d.information_contract_benchmark as benchmark
+from prob4d.information_contract_benchmark_smoke import _deterministic_npz_bytes
+
+
+def _rewrite_payload(
+    suite_path: Path,
+    case_index: int,
+    mutate,
+) -> Path:
+    suite = json.loads(suite_path.read_text(encoding="utf-8"))
+    case = suite["cases"][case_index]
+    payload = suite_path.parent / case["payload"]
+    with np.load(payload, allow_pickle=False) as archive:
+        arrays = {name: np.array(archive[name], copy=True) for name in archive.files}
+    mutate(arrays)
+    payload.write_bytes(_deterministic_npz_bytes(arrays))
+    case["payload_sha256"] = hashlib.sha256(payload.read_bytes()).hexdigest()
+    suite_path.write_text(
+        json.dumps(suite, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+    )
+    return payload
+
+
+def test_smoke_suite_covers_all_axes_and_is_deterministic(tmp_path: Path) -> None:
+    suite = benchmark.generate_smoke_suite(tmp_path / "suite")
+    first = benchmark.evaluate_information_contract_suite(suite)
+    second = benchmark.evaluate_information_contract_suite(suite)
+
+    assert first == second
+    assert first["schema_name"] == benchmark.RESULT_SCHEMA
+    assert first["aggregate"]["case_count"] == 2
+    assert first["aggregate"]["independent_group_count"] == 2
+    assert first["aggregate"]["contract"]["all_cases_pass"] is True
+    assert set(first["aggregate"]["declared_task_case_counts"]) == {
+        "forecast",
+        "calibration",
+        "dependence",
+        "query",
+        "gauge",
+        "fallback",
+        "decision",
+        "communication",
+    }
+    assert (
+        first["aggregate"]["equal_group_mean"]["dependence_nll_gain_per_dimension"]
+        > 0.0
+    )
+    assert first["aggregate"]["equal_group_mean"]["gauge_false_accept_fraction"] == 0.0
+    assert first["aggregate"]["equal_group_mean"]["gauge_false_reject_fraction"] == 0.0
+    assert first["aggregate"]["equal_group_mean"]["exact_fallback_fraction"] == 1.0
+
+    by_id = {case["case_id"]: case for case in first["cases"]}
+    assert by_id["admissible-shared-dependence"]["metrics"]["decision"][
+        "expected_admitted"
+    ] is True
+    assert by_id["ambiguous-exact-fallback"]["metrics"]["decision"][
+        "expected_admitted"
+    ] is False
+    assert all(case["contract_pass"] for case in first["cases"])
+
+
+def test_payload_hash_mismatch_fails_closed(tmp_path: Path) -> None:
+    suite = benchmark.generate_smoke_suite(tmp_path / "suite")
+    payload = suite.parent / "admissible-shared-dependence.npz"
+    payload.write_bytes(payload.read_bytes() + b"corruption")
+    with pytest.raises(ValueError, match="payload SHA-256 mismatch"):
+        benchmark.evaluate_information_contract_suite(suite)
+
+
+def test_false_gauge_acceptance_is_reported_as_contract_failure(
+    tmp_path: Path,
+) -> None:
+    suite = benchmark.generate_smoke_suite(tmp_path / "suite")
+
+    def mutate(arrays):
+        arrays["query_admitted"] = np.ones(3, dtype=np.bool_)
+
+    _rewrite_payload(suite, 0, mutate)
+    result = benchmark.evaluate_information_contract_suite(suite)
+    case = next(
+        item for item in result["cases"]
+        if item["case_id"] == "admissible-shared-dependence"
+    )
+    assert case["metrics"]["gauge"]["false_accept_count"] == 1
+    assert case["contract_checks"]["gauge_admission_consistent"] is False
+    assert case["contract_pass"] is False
+    assert result["aggregate"]["contract"]["all_cases_pass"] is False
+
+
+def test_rejected_decision_must_return_registered_fallback(
+    tmp_path: Path,
+) -> None:
+    suite = benchmark.generate_smoke_suite(tmp_path / "suite")
+
+    def mutate(arrays):
+        arrays["selected_action"] = np.array(0, dtype=np.int64)
+
+    _rewrite_payload(suite, 1, mutate)
+    result = benchmark.evaluate_information_contract_suite(suite)
+    case = next(
+        item for item in result["cases"]
+        if item["case_id"] == "ambiguous-exact-fallback"
+    )
+    assert case["metrics"]["decision"]["expected_admitted"] is False
+    assert case["contract_checks"]["decision_policy_consistent"] is False
+    assert case["contract_pass"] is False
+
+
+def test_unknown_payload_array_is_rejected(tmp_path: Path) -> None:
+    suite = benchmark.generate_smoke_suite(tmp_path / "suite")
+
+    def mutate(arrays):
+        arrays["hidden_target_selection"] = np.ones(1)
+
+    _rewrite_payload(suite, 0, mutate)
+    with pytest.raises(ValueError, match="unregistered arrays"):
+        benchmark.evaluate_information_contract_suite(suite)
+
+
+def test_cli_smoke_and_replay_are_byte_identical(tmp_path: Path) -> None:
+    directory = tmp_path / "smoke"
+    assert benchmark.main(["smoke", str(directory)]) == 0
+    replay = tmp_path / "replay.json"
+    assert benchmark.main(
+        ["evaluate", str(directory / "suite.json"), str(replay)]
+    ) == 0
+    assert replay.read_bytes() == (directory / "result.json").read_bytes()
+    with pytest.raises(FileExistsError):
+        benchmark.main(["smoke", str(directory)])


### PR DESCRIPTION
## Scientific objective

Introduce a provider-neutral benchmark for the information a probabilistic 4-D reconstruction exposes to physical estimation and decision layers. Existing benchmarks often collapse evaluation to point error; this MVP scores distinct axes without allowing accuracy to hide a broken uncertainty or fallback contract.

## Benchmark axes

Each sealed case can declare a dependency-closed subset of:

1. forecast accuracy;
2. Gaussian calibration under block-local plus shared low-rank covariance;
3. dependence value against a same-mean, marginal-matched diagonal control;
4. registered linear-query quality;
5. query admission against a declared nullspace span;
6. exact query-level fallback;
7. finite-hypothesis/action worst-case regret, admission, and fallback; and
8. covariance communication cost.

There is deliberately **no single leaderboard scalar**. Performance metrics and Boolean information-contract checks remain separate, at individual-case, equal-case, per-group, and equal-group levels.

## Files

- `src/prob4d/information_contract_benchmark.py`: strict evaluator and experimental module CLI.
- `src/prob4d/information_contract_benchmark_smoke.py`: deterministic two-group fixture.
- `benchmarks/information_contract_v1/suite.schema.json`: public manifest schema.
- `docs/information-contract-benchmark.md`: semantics, array contract, metrics, governance, and public-data roadmap.
- `tests/test_information_contract_benchmark.py`: adversarial contract tests.
- `.github/workflows/information-contract-benchmark-v1.yml`: Python 3.10/3.12/3.14 tests plus byte-identical smoke replay and retained scorecard artifact.

## Fail-closed properties

- Relative payload paths cannot escape the suite directory.
- Every NPZ is SHA-256 bound and opened with `allow_pickle=False`.
- Unregistered manifest fields and payload arrays are rejected.
- Covariances must be finite, symmetric, and positive definite.
- Gauge sensitivity is recomputed from an orthonormal basis of the declared nullspace span.
- Rejected-query outputs must equal the caller-owned fallback moments exactly.
- Finite-action worst-case regrets are recomputed from quotient masses and positive prior support.
- Statistical aggregation is explicit through `group_id`; windows and points cannot silently become independent units.

## Validation

Exact head: `f25b0cdb0a258e1b2ef276d25a723c2cf3a9fb4f`.

Dedicated benchmark workflow `33590973216` passed:

- deterministic generation and byte-identical replay;
- focused Ruff and six adversarial tests on Python 3.10, 3.12, and 3.14;
- payload tamper rejection;
- false-gauge-admission detection;
- exact rejected-decision fallback enforcement;
- unknown-array rejection; and
- no-clobber output behavior.

All repository PR workflows also passed: complete tests, fail-closed quality, provider preflight, and security scanning.

## First public real-data adapter

[BayesianPhysTwin PR #882](https://github.com/IPS-Stuttgart/BayesianPhysTwin/pull/882) uses this exact benchmark revision to replay the frozen public DEFORM DLO4/DLO5 experiment:

- 532 decisions;
- 28 complete-trajectory statistical groups;
- six common method suites;
- all reference metrics and action counts reproduced;
- all 532 finite-support certificate cases pass the benchmark contract;
- 82 nonfallback decisions and three realized harmful departures retained without reinterpretation.

This adapter is a retrospective exact replay, not an independent replication.

## Claim boundary

This PR creates benchmark infrastructure and deterministic development evidence. It does not establish learned-provider competence, correctness of a provider-declared gauge or quotient, causal identification, target safety, calibration outside a supplied suite, or state of the art. Claim-bearing suites require separately frozen public-data manifests and original per-case evidence; paper-side summary JSON is not accepted as a substitute.

This review-ready PR administratively supersedes closed draft #477; the validated commit is unchanged.