### PR TITLE
Add prospective Tracking Cloth approximate-orbit calibration

### DIFF
--- a/.github/workflows/tracking-cloth-approximate-orbit-tube-v1.yml
+++ b/.github/workflows/tracking-cloth-approximate-orbit-tube-v1.yml
@@ -1,0 +1,390 @@
+name: Tracking Cloth approximate-orbit tube v1
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/tracking-cloth-approximate-orbit-tube-v1.yml"
+      - "src/prob4d/orbit_tube.py"
+      - "src/prob4d/_tracking_cloth_approximate_orbit_calibration.py"
+      - "src/prob4d/_tracking_cloth_approximate_orbit_data.py"
+      - "src/prob4d/_tracking_cloth_approximate_orbit_evaluation.py"
+      - "src/prob4d/_tracking_cloth_approximate_orbit_io.py"
+      - "src/prob4d/_tracking_cloth_approximate_orbit_target.py"
+      - "scripts/science/run_tracking_cloth_approximate_orbit_tube_v1.py"
+      - "protocols/tracking-cloth-approximate-orbit-tube-v1.json"
+      - "protocols/execution_requests/tracking_cloth_approximate_orbit_tube_v1.request.json"
+      - "tests/test_orbit_tube.py"
+      - "tests/test_tracking_cloth_approximate_orbit_tube_v1.py"
+  push:
+    branches: [main]
+    paths:
+      - "protocols/execution_requests/tracking_cloth_approximate_orbit_tube_v1.request.json"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tracking-cloth-approximate-orbit-tube-v1-${{ github.sha }}
+  cancel-in-progress: false
+
+env:
+  PROTOCOL_PATH: protocols/tracking-cloth-approximate-orbit-tube-v1.json
+  REQUEST_PATH: protocols/execution_requests/tracking_cloth_approximate_orbit_tube_v1.request.json
+  SCRIPT_PATH: scripts/science/run_tracking_cloth_approximate_orbit_tube_v1.py
+  MODULE_PATH: src/prob4d/orbit_tube.py
+  ZENODO_URL: https://zenodo.org/records/14644526/files/tracking_dataset.zip?download=1
+  ZENODO_MD5: b4868b702f8a42b2ea1069d0f1a3b8f6
+  PYTHONHASHSEED: "0"
+  PYTHONUNBUFFERED: "1"
+  PYTHONDONTWRITEBYTECODE: "1"
+  OMP_NUM_THREADS: "1"
+  OPENBLAS_NUM_THREADS: "1"
+  MKL_NUM_THREADS: "1"
+  NUMEXPR_NUM_THREADS: "1"
+
+jobs:
+  contract:
+    name: Validate approximate-orbit implementation and protocol
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Check out exact revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          clean: true
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.10"
+
+      - name: Install exact test surface
+        run: |
+          python -m pip install --disable-pip-version-check \
+            "numpy==2.2.6" "pytest==9.1.1" "ruff==0.12.12"
+          python -m pip install --disable-pip-version-check --no-deps -e .
+
+      - name: Run focused tests and style checks
+        run: |
+          pytest -q \
+            tests/test_orbit_tube.py \
+            tests/test_tracking_cloth_approximate_orbit_tube_v1.py
+          ruff check \
+            src/prob4d/orbit_tube.py \
+            src/prob4d/_tracking_cloth_approximate_orbit_calibration.py \
+            src/prob4d/_tracking_cloth_approximate_orbit_data.py \
+            src/prob4d/_tracking_cloth_approximate_orbit_evaluation.py \
+            src/prob4d/_tracking_cloth_approximate_orbit_io.py \
+            src/prob4d/_tracking_cloth_approximate_orbit_target.py \
+            scripts/science/run_tracking_cloth_approximate_orbit_tube_v1.py \
+            tests/test_orbit_tube.py \
+            tests/test_tracking_cloth_approximate_orbit_tube_v1.py
+
+      - name: Validate content-addressed protocol and optional request
+        shell: bash
+        run: |
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          protocol_path = Path(os.environ["PROTOCOL_PATH"])
+          protocol = json.loads(protocol_path.read_text(encoding="utf-8"))
+          supplied = protocol.pop("protocol_id")
+          encoded = json.dumps(protocol, sort_keys=True, separators=(",", ":")).encode()
+          assert hashlib.sha256(encoded).hexdigest() == supplied
+          assert protocol["split"]["expected_calibration_groups"] == 18
+          assert protocol["split"]["expected_target_groups"] == 9
+          assert protocol["information_order"]["target_values_may_be_read_during_calibration"] is False
+          assert protocol["information_order"]["target_side_retuning_allowed"] is False
+          assert protocol["claim_boundary"]["estimated_orbit"] is True
+          assert protocol["claim_boundary"]["learned_visual_provider"] is False
+
+          request_path = Path(os.environ["REQUEST_PATH"])
+          if request_path.exists():
+              request = json.loads(request_path.read_text(encoding="utf-8"))
+              request_id = request.pop("request_id")
+              encoded = json.dumps(request, sort_keys=True, separators=(",", ":")).encode()
+              assert hashlib.sha256(encoded).hexdigest() == request_id
+              assert request["protocol_id"] == supplied
+              assert request["target_trajectory_values_opened_before_request"] is False
+              for path, expected in request["implementation_git_blobs"].items():
+                  import subprocess
+
+                  actual = subprocess.check_output(
+                      ["git", "hash-object", path], text=True
+                  ).strip()
+                  assert actual == expected, (path, actual, expected)
+          PY
+
+  calibrate:
+    name: Seal 18-recording approximate-orbit calibration
+    if: github.event_name == 'push'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    outputs:
+      calibrated: ${{ steps.result.outputs.calibrated }}
+      calibration_id: ${{ steps.result.outputs.calibration_id }}
+    steps:
+      - name: Check out exact request revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          clean: true
+
+      - name: Verify request and frozen implementation identities
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f "$REQUEST_PATH"
+          python - <<'PY'
+          import hashlib
+          import json
+          import os
+          import subprocess
+          from pathlib import Path
+
+          request = json.loads(Path(os.environ["REQUEST_PATH"]).read_text(encoding="utf-8"))
+          request_id = request.pop("request_id")
+          encoded = json.dumps(request, sort_keys=True, separators=(",", ":")).encode()
+          assert hashlib.sha256(encoded).hexdigest() == request_id
+          protocol = json.loads(Path(os.environ["PROTOCOL_PATH"]).read_text(encoding="utf-8"))
+          assert request["protocol_id"] == protocol["protocol_id"]
+          assert request["target_trajectory_values_opened_before_request"] is False
+          assert request["target_side_retuning_allowed"] is False
+          for path, expected in request["implementation_git_blobs"].items():
+              actual = subprocess.check_output(["git", "hash-object", path], text=True).strip()
+              assert actual == expected, (path, actual, expected)
+          PY
+
+      - name: Set up exact lightweight runtime
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install runtime
+        run: |
+          python -m pip install --disable-pip-version-check "numpy==2.3.5"
+          python -m pip install --disable-pip-version-check --no-deps -e .
+          python -m pip check
+
+      - name: Download and verify official public release
+        id: dataset
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="$RUNNER_TEMP/tracking-cloth-approximate-orbit-calibration-$GITHUB_RUN_ID"
+          rm -rf -- "$root"
+          mkdir -p "$root/data" "$root/output"
+          archive="$root/tracking_dataset.zip"
+          curl --fail --location --retry 8 --retry-all-errors \
+            --connect-timeout 30 --max-time 3600 \
+            --output "$archive" "$ZENODO_URL"
+          printf '%s  %s\n' "$ZENODO_MD5" "$archive" | md5sum --check --strict
+          unzip -q "$archive" -d "$root/data"
+          test "$(find "$root/data" -type f -iname '*.csv' -printf '.' | wc -c)" -eq 120
+          echo "root=$root" >> "$GITHUB_OUTPUT"
+          echo "data=$root/data" >> "$GITHUB_OUTPUT"
+
+      - name: Calibrate without target trajectory access
+        id: experiment
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${{ steps.dataset.outputs.root }}"
+          set +e
+          python "$SCRIPT_PATH" calibrate \
+            --dataset-root "${{ steps.dataset.outputs.data }}" \
+            --protocol "$PROTOCOL_PATH" \
+            --output-dir "$root/output/evaluation" \
+            --source-revision "$(git rev-parse HEAD)" \
+            > "$root/output/stdout.txt" 2> "$root/output/stderr.txt"
+          code=$?
+          set -e
+          printf '%s\n' "$code" > "$root/output/process-exit-code.txt"
+          test "$code" -eq 0 -o "$code" -eq 2
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+
+      - name: Remove raw release before publishing evidence
+        if: always()
+        shell: bash
+        run: |
+          root="${{ steps.dataset.outputs.root }}"
+          rm -rf -- "$root/data" "$root/tracking_dataset.zip"
+          if find "$root/output" -type f \( -iname '*.csv' -o -iname '*.zip' \) \
+              -print -quit | grep -q .; then
+            echo "raw data appeared in evidence" >&2
+            exit 3
+          fi
+
+      - name: Verify calibration seal
+        id: result
+        shell: bash
+        run: |
+          ROOT="${{ steps.dataset.outputs.root }}/output" python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          root = Path(os.environ["ROOT"])
+          value = json.loads((root / "evaluation" / "calibration.json").read_text())
+          supplied = value.pop("calibration_id")
+          encoded = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+          assert hashlib.sha256(encoded).hexdigest() == supplied
+          status = value["status"]
+          assert status in {"calibrated", "calibration-support-negative"}
+          if status == "calibrated":
+              assert value["information_order"]["target_trajectory_values_parsed"] is False
+              assert value["orbit_tube"]["group_count"] == 18
+              assert value["point_ball"]["group_count"] == 18
+          with Path(os.environ["GITHUB_OUTPUT"]).open("a", encoding="utf-8") as stream:
+              stream.write(f"calibrated={'true' if status == 'calibrated' else 'false'}\n")
+              stream.write(f"calibration_id={supplied}\n")
+          PY
+
+      - name: Upload compact calibration evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4.6.2
+        with:
+          name: tracking-cloth-approximate-orbit-calibration-${{ github.run_id }}
+          path: ${{ steps.dataset.outputs.root }}/output
+          if-no-files-found: error
+          retention-days: 90
+
+  evaluate:
+    name: Evaluate nine untouched self-collision recordings
+    needs: calibrate
+    if: needs.calibrate.outputs.calibrated == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    steps:
+      - name: Check out exact request revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          clean: true
+
+      - name: Set up exact lightweight runtime
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install runtime
+        run: |
+          python -m pip install --disable-pip-version-check "numpy==2.3.5"
+          python -m pip install --disable-pip-version-check --no-deps -e .
+          python -m pip check
+
+      - name: Download exact calibration seal
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: tracking-cloth-approximate-orbit-calibration-${{ github.run_id }}
+          path: ${{ runner.temp }}/calibration
+
+      - name: Verify calibration before target access
+        shell: bash
+        env:
+          EXPECTED_CALIBRATION_ID: ${{ needs.calibrate.outputs.calibration_id }}
+        run: |
+          CALIBRATION="${{ runner.temp }}/calibration/evaluation/calibration.json" python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          path = Path(os.environ["CALIBRATION"])
+          value = json.loads(path.read_text())
+          supplied = value.pop("calibration_id")
+          encoded = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+          assert hashlib.sha256(encoded).hexdigest() == supplied
+          assert supplied == os.environ["EXPECTED_CALIBRATION_ID"]
+          assert value["status"] == "calibrated"
+          assert value["information_order"]["target_trajectory_values_parsed"] is False
+          PY
+
+      - name: Download and verify official public release
+        id: dataset
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="$RUNNER_TEMP/tracking-cloth-approximate-orbit-target-$GITHUB_RUN_ID"
+          rm -rf -- "$root"
+          mkdir -p "$root/data" "$root/output"
+          archive="$root/tracking_dataset.zip"
+          curl --fail --location --retry 8 --retry-all-errors \
+            --connect-timeout 30 --max-time 3600 \
+            --output "$archive" "$ZENODO_URL"
+          printf '%s  %s\n' "$ZENODO_MD5" "$archive" | md5sum --check --strict
+          unzip -q "$archive" -d "$root/data"
+          test "$(find "$root/data" -type f -iname '*.csv' -printf '.' | wc -c)" -eq 120
+          echo "root=$root" >> "$GITHUB_OUTPUT"
+          echo "data=$root/data" >> "$GITHUB_OUTPUT"
+
+      - name: Open only the frozen target split and evaluate
+        id: experiment
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${{ steps.dataset.outputs.root }}"
+          set +e
+          python "$SCRIPT_PATH" evaluate \
+            --dataset-root "${{ steps.dataset.outputs.data }}" \
+            --protocol "$PROTOCOL_PATH" \
+            --calibration "${{ runner.temp }}/calibration/evaluation/calibration.json" \
+            --output-dir "$root/output/evaluation" \
+            --source-revision "$(git rev-parse HEAD)" \
+            > "$root/output/stdout.txt" 2> "$root/output/stderr.txt"
+          code=$?
+          set -e
+          printf '%s\n' "$code" > "$root/output/process-exit-code.txt"
+          test "$code" -eq 0 -o "$code" -eq 2 -o "$code" -eq 3
+          echo "exit_code=$code" >> "$GITHUB_OUTPUT"
+
+      - name: Remove raw release before publishing evidence
+        if: always()
+        shell: bash
+        run: |
+          root="${{ steps.dataset.outputs.root }}"
+          rm -rf -- "$root/data" "$root/tracking_dataset.zip"
+          if find "$root/output" -type f \( -iname '*.csv' -o -iname '*.zip' \) \
+              -print -quit | grep -q .; then
+            echo "raw data appeared in evidence" >&2
+            exit 3
+          fi
+
+      - name: Independently verify terminal result identity and frozen criteria
+        shell: bash
+        run: |
+          RESULT="${{ steps.dataset.outputs.root }}/output/evaluation/result.json" python - <<'PY'
+          import hashlib
+          import json
+          import os
+          from pathlib import Path
+
+          value = json.loads(Path(os.environ["RESULT"]).read_text())
+          supplied = value.pop("result_id")
+          encoded = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+          assert hashlib.sha256(encoded).hexdigest() == supplied
+          assert value["status"] in {
+              "target-support-negative",
+              "approximate-orbit-tube-positive",
+              "approximate-orbit-tube-mixed",
+          }
+          assert value["information_order"]["target_side_retuning"] is False
+          assert value["information_order"]["target_groups_replaced"] is False
+          if value["status"] != "target-support-negative":
+              assert value["cohort"]["target_group_count"] == 9
+              assert value["calibration"]["calibration_group_count"] == 18
+              assert len(value["criteria"]) == 6
+          PY
+
+      - name: Upload compact target evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4.6.2
+        with:
+          name: tracking-cloth-approximate-orbit-result-${{ github.run_id }}
+          path: ${{ steps.dataset.outputs.root }}/output
+          if-no-files-found: error
+          retention-days: 90

--- a/docs/tracking-cloth-approximate-orbit-tube-v1.md
+++ b/docs/tracking-cloth-approximate-orbit-tube-v1.md
@@ -1,0 +1,87 @@
+# Tracking Cloth approximate-orbit tube v1
+
+Status: **prospectively registered; target trajectory values unopened**.
+
+## Question
+
+Can a trajectory-level calibrated Euclidean tube around an estimated axial
+orbit absorb departures from exact symmetry while remaining sharper and more
+decision-useful than a generic point-centered conformal ball?
+
+This is the prospective experiment corresponding to the approximate-orbit
+corollary in the focused query-identifiability manuscript. It is not a learned
+visual-provider experiment.
+
+## Fresh cohort
+
+The previous Tracking Cloth support audit inspected marker headers for 27 A2
+cotton/denim/wool Self-collisions recordings but parsed no trajectory values.
+Those exact 27 content-bound group IDs form this study's complete cohort.
+
+Within each material, file names are ordered by a frozen SHA-256 rule:
+
+- six recordings enter calibration;
+- three recordings remain target-only.
+
+This yields 18 calibration and nine target recordings. Target trajectory values
+may be opened only after a content-addressed calibration artifact exists.
+
+## Estimated orbit
+
+For consecutive registered frames, two selected anchors define the current
+axis. The previous probe state supplies:
+
+- normalized axial fraction along the anchor segment;
+- normalized radial distance from the segment.
+
+Applying those normalized quantities to the current anchor geometry defines an
+estimated circular orbit. The probe's angle around the axis remains unresolved.
+
+The point baseline transports the previous radial direction by the deterministic
+minimal rotation between consecutive anchor axes. The orbit and point baseline
+therefore share the same axial/radial prediction and differ only in whether the
+unresolved angle is retained.
+
+## Calibration
+
+For each complete calibration recording:
+
+- orbit score: maximum point-to-estimated-circle distance;
+- point score: maximum Euclidean error of the transported canonical point.
+
+The calibration radius is the split-conformal order statistic over the 18
+complete-recording maxima at requested miscoverage 0.10. Frames and marker
+coordinates are nested observations, not independent calibration samples.
+
+## Registered query
+
+The scalar query is the probe coordinate along the current anchor axis relative
+to a calibration-only threshold. The threshold is the median normalized axial
+query center over calibration pairs and is sealed before target values are
+opened. For this rotation-invariant affine query, an orbit tube of radius `rho`
+gives the exact interval
+
+```text
+query_center ± rho.
+```
+
+A generic point ball gives the same center but radius `R`. Any width or
+threshold-decision difference is therefore caused by preserving the residual
+gauge rather than by changing the point prediction.
+
+## Comparators
+
+1. exact estimated orbit (`rho = 0`);
+2. group-calibrated approximate-orbit tube;
+3. group-calibrated canonical-point ball.
+
+The primary endpoints are complete-recording simultaneous coverage, scalar
+interval width, threshold-decision admission, and harmful accepted decisions.
+
+## Claim boundary
+
+A positive outcome would establish a public real-trajectory calibration result
+for an estimated orbit under a controlled observation restriction. It would not
+establish visual discovery of the orbit, complete physical-state recovery,
+BayesianPhysTwin or Causal4D benefit, closed-loop robot performance, deployment
+safety, or state of the art.

--- a/protocols/tracking-cloth-approximate-orbit-tube-v1.json
+++ b/protocols/tracking-cloth-approximate-orbit-tube-v1.json
@@ -1,0 +1,132 @@
+{
+  "analysis": {
+    "bootstrap_replicates": 20000,
+    "bootstrap_seed": 92117,
+    "equal_weighting": "complete target recordings",
+    "frames_are_nested": true
+  },
+  "calibration": {
+    "finite_sample_statement": "conditional split-conformal coverage over exchangeable complete recordings",
+    "independent_unit": "complete-recording",
+    "orbit_score": "maximum point-to-estimated-circle distance over registered pairs",
+    "order_statistic": "ceil((n+1)*(1-alpha))",
+    "point_score": "maximum Euclidean error of the canonical transported point",
+    "requested_miscoverage": 0.1
+  },
+  "claim_boundary": {
+    "bayesian_phystwin_benefit": false,
+    "closed_loop_robot_control": false,
+    "controlled_observation_restriction": true,
+    "deployment_safety": false,
+    "estimated_orbit": true,
+    "fresh_self_collision_target_values": true,
+    "group_calibrated_orbit_tube": true,
+    "learned_visual_provider": false,
+    "physical_state_recovery": false,
+    "public_real_trajectories": true,
+    "state_of_the_art": false
+  },
+  "criteria": {
+    "exact_orbit_must_have_lower_simultaneous_coverage": true,
+    "maximum_orbit_to_ball_width_ratio": 0.75,
+    "minimum_orbit_simultaneous_covered_groups": 8,
+    "minimum_orbit_tube_admission_gain": 0.05,
+    "support_all_target_groups": true
+  },
+  "dataset": {
+    "allowed_materials": [
+      "cotton",
+      "denim",
+      "wool"
+    ],
+    "archive_filename": "tracking_dataset.zip",
+    "archive_md5": "b4868b702f8a42b2ea1069d0f1a3b8f6",
+    "cohort": "A2 cotton/denim/wool Self-collisions recordings",
+    "expected_cohort_files": 27,
+    "expected_csv_files": 120,
+    "prior_header_only_group_ids": [
+      "974be715d5d079a0",
+      "698ce880bacd2b8e",
+      "51b60a70fc57756f",
+      "56f4a92725ddfe31",
+      "c427db49dfb80888",
+      "f184b99d3b3b8a85",
+      "8bc21a918a541bf5",
+      "72c6fdec0573cbd0",
+      "d06dd772e7c2ec40",
+      "fe29865c1811b653",
+      "8c70cc0dad85fd73",
+      "5efe6d7c6bd60c63",
+      "da39b55672253a9b",
+      "c61ac901d973953f",
+      "554c4b900d5342da",
+      "e19a78562bf7b067",
+      "2067355116c1bf21",
+      "411a07a713174cdb",
+      "3a3c613f01984226",
+      "50dc47f83f3bba95",
+      "9d5e702cadf59222",
+      "15fd7c589857a06e",
+      "ece4f2cea23137f1",
+      "8effb04911c3601c",
+      "89bcfcf1849af7bf",
+      "7e66cdee601fa56d",
+      "689bd75517b8bf6f"
+    ],
+    "prior_header_only_support": {
+      "artifact_digest": "sha256:c7c61a117c1e3dbcf33997c528fb1703bfae44cbdfb560d176a9880bc04b05e3",
+      "artifact_id": 9810268001,
+      "protocol_id": "4652d72f9e8d4c80c69df86b7a48a6f4e307e4131ea3bea04e09deed10db5eb0",
+      "run_id": 33532387635,
+      "support_id": "2d3b385f69bbeace010412771ad988bc51509cfe61e071cdc6ed0f7803938abb",
+      "target_trajectory_values_parsed": false
+    },
+    "record_name": "Tracking Cloth Deformation",
+    "required_size": "A2",
+    "zenodo_record": "14644526"
+  },
+  "information_order": {
+    "all_cohort_headers_may_be_read_before_split_execution": true,
+    "calibration_values_may_be_read_before_calibration_seal": true,
+    "target_group_replacement_allowed": false,
+    "target_side_retuning_allowed": false,
+    "target_values_may_be_read_during_calibration": false,
+    "target_values_require_content_addressed_calibration": true
+  },
+  "marker_selection": {
+    "maximum_common_marker_count": 32,
+    "minimum_anchor_distance_mm": 100.0,
+    "minimum_probe_radius_mm": 20.0,
+    "score": "min(anchor_distance_q10_mm, 2*probe_radius_q10_mm)",
+    "selection_frames_per_recording": 12,
+    "selection_uses_calibration_trajectory_values": true,
+    "selection_uses_target_trajectory_values": false,
+    "support_namespace": "labels common to all 27 cohort headers"
+  },
+  "prediction": {
+    "canonical_point": "minimal-rotation transport of previous radial direction",
+    "decision_threshold_selection": "median calibration query-center fraction; target values excluded",
+    "minimum_valid_pairs": 64,
+    "orbit_model": "previous normalized axial fraction and radius ratio on current anchor line",
+    "pairs_per_recording": 256,
+    "query": "probe coordinate along current anchor axis minus a calibration-median normalized axial threshold"
+  },
+  "protocol_id": "8aa317f041b151282ea83eaa5018af0e1c869d3794d7480477e4006a28014fbc",
+  "schema": "prob4d.tracking-cloth-approximate-orbit-tube.v1",
+  "split": {
+    "calibration_per_material": 6,
+    "expected_calibration_groups": 18,
+    "expected_target_groups": 9,
+    "method": "within-material-sha256-order-v1",
+    "salt": "prob4d-tracking-cloth-approximate-orbit-tube-v1",
+    "target_per_material": 3,
+    "target_trajectory_values_opened_before_protocol_freeze": false
+  },
+  "terminal_statuses": [
+    "calibration-support-negative",
+    "target-support-negative",
+    "approximate-orbit-tube-positive",
+    "approximate-orbit-tube-mixed",
+    "technical-failure"
+  ]
+}

--- a/scripts/science/run_tracking_cloth_approximate_orbit_tube_v1.py
+++ b/scripts/science/run_tracking_cloth_approximate_orbit_tube_v1.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Prospective approximate-orbit tube calibration on Tracking Cloth self-collisions.
+
+The 27 A2 cotton/denim/wool Self-collisions recordings were retained as a
+header-only support-negative cohort. This study calibrates on 18 complete
+recordings and opens nine deterministic target recordings only after a
+content-addressed calibration seal exists.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from prob4d._tracking_cloth_approximate_orbit_calibration import _calibrate
+from prob4d._tracking_cloth_approximate_orbit_io import _load_protocol
+from prob4d._tracking_cloth_approximate_orbit_target import _evaluate
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="mode", required=True)
+    for name in ("calibrate", "evaluate"):
+        child = subparsers.add_parser(name)
+        child.add_argument("--dataset-root", required=True)
+        child.add_argument("--protocol", required=True)
+        child.add_argument("--output-dir", required=True)
+        child.add_argument("--source-revision", required=True)
+        if name == "evaluate":
+            child.add_argument("--calibration", required=True)
+    return parser
+
+
+def main() -> int:
+    args = build_parser().parse_args()
+    protocol = _load_protocol(Path(args.protocol).resolve())
+    if args.mode == "calibrate":
+        return _calibrate(args, protocol)
+    return _evaluate(args, protocol)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/prob4d/_tracking_cloth_approximate_orbit_calibration.py
+++ b/src/prob4d/_tracking_cloth_approximate_orbit_calibration.py
@@ -1,0 +1,159 @@
+"""Calibration stage for the prospective Tracking Cloth approximate-orbit study."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from prob4d._tracking_cloth_approximate_orbit_data import (
+    _collect_selection_samples,
+    _discover,
+    _select_triplet,
+    _split,
+)
+from prob4d._tracking_cloth_approximate_orbit_evaluation import PairEvidence, _recording_pairs
+from prob4d._tracking_cloth_approximate_orbit_io import (
+    CALIBRATION_SCHEMA,
+    _sha256,
+    _write_json,
+)
+from prob4d.orbit_tube import calibrate_group_maximum_radius
+
+
+def _calibrate(args: argparse.Namespace, protocol: dict[str, Any]) -> int:
+    dataset_root = Path(args.dataset_root).resolve()
+    output = Path(args.output_dir).resolve()
+    if output.exists():
+        raise ValueError("output directory already exists")
+    output.mkdir(parents=True)
+    cohort, common_labels, header_metadata = _discover(dataset_root, protocol)
+    calibration_groups, target_groups = _split(cohort, protocol)
+
+    selection_samples, selection_metadata = _collect_selection_samples(
+        calibration_groups,
+        common_labels,
+        int(protocol["marker_selection"]["selection_frames_per_recording"]),
+    )
+    triplet, selection = _select_triplet(selection_samples, common_labels, protocol)
+
+    orbit_scores: list[float] = []
+    point_scores: list[float] = []
+    group_ids: list[str] = []
+    calibration_pairs: list[PairEvidence] = []
+    pair_metadata: list[dict[str, object]] = []
+    minimum_pairs = int(protocol["prediction"]["minimum_valid_pairs"])
+    for recording in calibration_groups:
+        pairs, metadata = _recording_pairs(recording, triplet, protocol)
+        pair_metadata.append(metadata)
+        if len(pairs) < minimum_pairs:
+            result = {
+                "schema": CALIBRATION_SCHEMA,
+                "status": "calibration-support-negative",
+                "protocol_id": protocol["protocol_id"],
+                "source_revision": args.source_revision,
+                "failed_group_id": recording.group_id,
+                "valid_pair_count": len(pairs),
+                "minimum_valid_pairs": minimum_pairs,
+                "target_trajectory_values_parsed": False,
+            }
+            result["calibration_id"] = _sha256(result)
+            _write_json(output / "calibration.json", result)
+            return 2
+        calibration_pairs.extend(pairs)
+        for pair in pairs:
+            orbit_scores.append(pair.orbit_score_mm)
+            point_scores.append(pair.point_score_mm)
+            group_ids.append(recording.group_id)
+
+    miscoverage = float(protocol["calibration"]["requested_miscoverage"])
+    orbit_calibration = calibrate_group_maximum_radius(
+        np.asarray(orbit_scores),
+        group_ids,
+        miscoverage=miscoverage,
+    )
+    point_calibration = calibrate_group_maximum_radius(
+        np.asarray(point_scores),
+        group_ids,
+        miscoverage=miscoverage,
+    )
+    if point_calibration.radius <= 0.0:
+        raise ValueError("generic point calibration radius must be positive")
+    normalized_query_centers = np.asarray(
+        [
+            pair.query_center_mm / pair.anchor_length_mm + 0.5
+            for pair in calibration_pairs
+        ],
+        dtype=np.float64,
+    )
+    if normalized_query_centers.size == 0 or not np.all(
+        np.isfinite(normalized_query_centers)
+    ):
+        raise ValueError("calibration decision threshold could not be estimated")
+    decision_threshold_fraction = float(np.median(normalized_query_centers))
+    value: dict[str, Any] = {
+        "schema": CALIBRATION_SCHEMA,
+        "status": "calibrated",
+        "protocol_id": protocol["protocol_id"],
+        "source_revision": args.source_revision,
+        "dataset": {
+            "cohort_group_ids": sorted(recording.group_id for recording in cohort),
+            "cohort_relative_paths": sorted(recording.relative_path for recording in cohort),
+            "common_marker_labels": common_labels,
+            "header_metadata": header_metadata,
+        },
+        "split": {
+            "calibration_group_ids": [recording.group_id for recording in calibration_groups],
+            "calibration_relative_paths": [
+                recording.relative_path for recording in calibration_groups
+            ],
+            "target_group_ids": [recording.group_id for recording in target_groups],
+            "target_relative_paths": [recording.relative_path for recording in target_groups],
+        },
+        "marker_selection": {
+            "triplet": list(triplet),
+            "statistics": selection,
+            "selection_metadata": selection_metadata,
+        },
+        "pair_metadata": pair_metadata,
+        "orbit_tube": orbit_calibration.to_dict(),
+        "point_ball": point_calibration.to_dict(),
+        "decision_threshold": {
+            "normalized_axial_fraction": decision_threshold_fraction,
+            "statistic": "median calibration query-center fraction",
+            "target_values_used": False,
+        },
+        "information_order": {
+            "all_cohort_headers_parsed": True,
+            "calibration_trajectory_values_parsed": True,
+            "target_trajectory_values_parsed": False,
+            "calibration_sealed_before_target_access": True,
+        },
+        "claim_boundary": protocol["claim_boundary"],
+    }
+    value["calibration_id"] = _sha256(value)
+    _write_json(output / "calibration.json", value)
+    (output / "summary.md").write_text(
+        "\n".join(
+            [
+                "# Tracking Cloth approximate-orbit calibration",
+                "",
+                "Status: **calibrated**",
+                "",
+                f"Protocol ID: `{protocol['protocol_id']}`",
+                f"Calibration ID: `{value['calibration_id']}`",
+                f"Selected marker triplet: `{triplet[0]}/{triplet[1]}/{triplet[2]}`",
+                f"Orbit-tube radius: {orbit_calibration.radius:.6f} mm",
+                f"Point-ball radius: {point_calibration.radius:.6f} mm",
+                f"Radius ratio: {orbit_calibration.radius / point_calibration.radius:.6f}",
+                f"Decision threshold fraction: {decision_threshold_fraction:.6f}",
+                "",
+                "No target trajectory value was parsed.",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return 0

--- a/src/prob4d/_tracking_cloth_approximate_orbit_data.py
+++ b/src/prob4d/_tracking_cloth_approximate_orbit_data.py
@@ -1,0 +1,227 @@
+"""Frozen Tracking Cloth cohort, split, and marker-selection helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from prob4d.motive_csv import common_marker_labels, read_motive_layout, read_motive_markers
+
+FloatArray = NDArray[np.float64]
+
+
+@dataclass(frozen=True, slots=True)
+class Recording:
+    path: Path
+    relative_path: str
+    group_id: str
+    material: str
+
+
+def _stable_id(relative_path: str) -> str:
+    return hashlib.sha256(relative_path.encode()).hexdigest()[:16]
+
+
+def _tokens(value: str) -> set[str]:
+    return {token for token in re.split(r"[^a-z0-9]+", value.casefold()) if token}
+
+
+def _material(relative_path: str, allowed: tuple[str, ...]) -> str:
+    tokens = _tokens(relative_path)
+    found = [material for material in allowed if material in tokens]
+    if len(found) != 1:
+        raise ValueError(f"material metadata is ambiguous: {relative_path}")
+    return found[0]
+
+
+def _discover(
+    dataset_root: Path,
+    protocol: dict[str, Any],
+) -> tuple[list[Recording], list[str], list[dict[str, object]]]:
+    dataset = protocol["dataset"]
+    all_paths = sorted(path for path in dataset_root.rglob("*.csv") if path.is_file())
+    if len(all_paths) != dataset["expected_csv_files"]:
+        raise ValueError(
+            f"official CSV roster changed: {len(all_paths)} != {dataset['expected_csv_files']}"
+        )
+    allowed = tuple(dataset["allowed_materials"])
+    cohort: list[Recording] = []
+    headers: list[dict[str, object]] = []
+    for path in all_paths:
+        relative = path.relative_to(dataset_root).as_posix()
+        tokens = _tokens(relative)
+        is_self_collision = "self" in tokens and any(
+            token.startswith("collision") for token in tokens
+        )
+        if (
+            not is_self_collision
+            or "a2" not in tokens
+            or not any(item in tokens for item in allowed)
+        ):
+            continue
+        material = _material(relative, allowed)
+        group_id = _stable_id(relative)
+        layout = read_motive_layout(path)
+        cohort.append(Recording(path, relative, group_id, material))
+        headers.append(
+            {
+                "group_id": group_id,
+                "relative_path": relative,
+                "material": material,
+                "available_marker_count": len(layout.markers),
+                "marker_labels": list(layout.marker_labels),
+                "length_units": layout.length_units,
+                "parser": "strict-motive-multirow-marker-v1",
+            }
+        )
+    if len(cohort) != dataset["expected_cohort_files"]:
+        raise ValueError(f"expected 27 Self-collisions recordings, found {len(cohort)}")
+    actual_ids = sorted(recording.group_id for recording in cohort)
+    expected_ids = sorted(dataset["prior_header_only_group_ids"])
+    if actual_ids != expected_ids:
+        raise ValueError("Self-collisions cohort differs from prior header-only support audit")
+    common = common_marker_labels(
+        [recording.path for recording in cohort],
+        int(protocol["marker_selection"]["maximum_common_marker_count"]),
+    )
+    if len(common) < 3:
+        raise ValueError("Self-collisions cohort has fewer than three common markers")
+    return cohort, common, headers
+
+
+def _split(
+    cohort: list[Recording],
+    protocol: dict[str, Any],
+) -> tuple[list[Recording], list[Recording]]:
+    split = protocol["split"]
+    calibration: list[Recording] = []
+    target: list[Recording] = []
+    for material in protocol["dataset"]["allowed_materials"]:
+        members = [recording for recording in cohort if recording.material == material]
+        members.sort(
+            key=lambda recording: hashlib.sha256(
+                f"{split['salt']}\0{recording.relative_path}".encode()
+            ).hexdigest()
+        )
+        expected = split["calibration_per_material"] + split["target_per_material"]
+        if len(members) != expected:
+            raise ValueError(
+                f"expected {expected} {material} Self-collisions recordings, found {len(members)}"
+            )
+        calibration.extend(members[: split["calibration_per_material"]])
+        target.extend(members[split["calibration_per_material"] :])
+    calibration.sort(key=lambda recording: recording.group_id)
+    target.sort(key=lambda recording: recording.group_id)
+    if len(calibration) != split["expected_calibration_groups"]:
+        raise ValueError("calibration group count changed")
+    if len(target) != split["expected_target_groups"]:
+        raise ValueError("target group count changed")
+    if set(recording.group_id for recording in calibration) & set(
+        recording.group_id for recording in target
+    ):
+        raise ValueError("calibration and target groups overlap")
+    return calibration, target
+
+
+def _sample_indices(length: int, maximum: int) -> NDArray[np.int64]:
+    if length <= 0 or maximum <= 0:
+        return np.empty(0, dtype=np.int64)
+    return np.unique(np.linspace(0, length - 1, min(length, maximum), dtype=np.int64))
+
+
+def _pair_indices(length: int, maximum: int) -> NDArray[np.int64]:
+    if length < 2 or maximum <= 0:
+        return np.empty(0, dtype=np.int64)
+    return np.unique(np.linspace(0, length - 2, min(length - 1, maximum), dtype=np.int64))
+
+
+def _collect_selection_samples(
+    recordings: list[Recording],
+    marker_labels: list[str],
+    maximum_frames: int,
+) -> tuple[FloatArray, list[dict[str, object]]]:
+    samples: list[FloatArray] = []
+    metadata: list[dict[str, object]] = []
+    for recording in recordings:
+        coordinates, scale, details = read_motive_markers(recording.path, marker_labels)
+        selected = coordinates[_sample_indices(coordinates.shape[0], maximum_frames)]
+        usable = np.count_nonzero(
+            np.sum(np.all(np.isfinite(selected), axis=2), axis=1) >= 3
+        )
+        if selected.size:
+            samples.append(selected)
+        metadata.append(
+            {
+                "group_id": recording.group_id,
+                "relative_path": recording.relative_path,
+                "material": recording.material,
+                "sampled_frames_with_at_least_three_markers": int(usable),
+                "unit_scale_to_mm": scale,
+                **details,
+            }
+        )
+    if not samples:
+        raise ValueError("calibration recordings yielded no selection frames")
+    return np.concatenate(samples, axis=0), metadata
+
+
+def _select_triplet(
+    samples: FloatArray,
+    marker_labels: list[str],
+    protocol: dict[str, Any],
+) -> tuple[tuple[str, str, str], dict[str, float]]:
+    settings = protocol["marker_selection"]
+    minimum_anchor = float(settings["minimum_anchor_distance_mm"])
+    minimum_probe = float(settings["minimum_probe_radius_mm"])
+    best: tuple[float, str, str, str] | None = None
+    details: dict[str, float] | None = None
+    for first in range(len(marker_labels)):
+        for second in range(first + 1, len(marker_labels)):
+            a = samples[:, first]
+            b = samples[:, second]
+            delta = b - a
+            distances = np.linalg.norm(delta, axis=1)
+            valid_distance = np.isfinite(distances) & (distances > 1e-9)
+            if not np.any(valid_distance):
+                continue
+            for probe in range(len(marker_labels)):
+                if probe in {first, second}:
+                    continue
+                p = samples[:, probe]
+                valid = valid_distance & np.all(np.isfinite(p), axis=1)
+                if np.count_nonzero(valid) < max(8, samples.shape[0] // 4):
+                    continue
+                direction = delta[valid] / distances[valid, None]
+                relative = p[valid] - a[valid]
+                axial = np.einsum("ij,ij->i", relative, direction)
+                radial = relative - axial[:, None] * direction
+                radii = np.linalg.norm(radial, axis=1)
+                anchor_q10 = float(np.quantile(distances[valid], 0.10))
+                radius_q10 = float(np.quantile(radii, 0.10))
+                radius_median = float(np.median(radii))
+                if anchor_q10 < minimum_anchor or radius_q10 < minimum_probe:
+                    continue
+                score = min(anchor_q10, 2.0 * radius_q10)
+                candidate = (
+                    score,
+                    marker_labels[first],
+                    marker_labels[second],
+                    marker_labels[probe],
+                )
+                if best is None or candidate > best:
+                    best = candidate
+                    details = {
+                        "score": score,
+                        "anchor_distance_q10_mm": anchor_q10,
+                        "probe_radius_q10_mm": radius_q10,
+                        "probe_radius_median_mm": radius_median,
+                    }
+    if best is None or details is None:
+        raise ValueError("calibration geometry contains no support-qualified marker triplet")
+    return (best[1], best[2], best[3]), details

--- a/src/prob4d/_tracking_cloth_approximate_orbit_evaluation.py
+++ b/src/prob4d/_tracking_cloth_approximate_orbit_evaluation.py
@@ -1,0 +1,143 @@
+"""Geometry scores and decision metrics for approximate axial-orbit evaluation."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from prob4d._tracking_cloth_approximate_orbit_data import Recording, _pair_indices
+from prob4d.motive_csv import read_motive_markers
+from prob4d.orbit_tube import AxialCircleOrbit, minimal_rotation_transport
+
+FloatArray = NDArray[np.float64]
+
+
+@dataclass(frozen=True, slots=True)
+class PairEvidence:
+    orbit_score_mm: float
+    point_score_mm: float
+    query_true_mm: float
+    query_center_mm: float
+    anchor_length_mm: float
+
+
+def _pair_evidence(previous: FloatArray, current: FloatArray) -> PairEvidence | None:
+    a0, b0, p0 = previous
+    a1, b1, p1 = current
+    line0 = b0 - a0
+    line1 = b1 - a1
+    length0 = float(np.linalg.norm(line0))
+    length1 = float(np.linalg.norm(line1))
+    if not all(math.isfinite(value) and value > 1e-9 for value in (length0, length1)):
+        return None
+    axis0 = line0 / length0
+    axis1 = line1 / length1
+    relative0 = p0 - a0
+    axial0 = float(relative0 @ axis0)
+    radial0 = relative0 - axial0 * axis0
+    radius0 = float(np.linalg.norm(radial0))
+    if not math.isfinite(radius0) or radius0 <= 1e-9:
+        return None
+    axial_fraction = axial0 / length0
+    radius_fraction = radius0 / length0
+    center = a1 + axial_fraction * length1 * axis1
+    radius = radius_fraction * length1
+    orbit = AxialCircleOrbit(center=center, axis=axis1, radius=radius)
+
+    radial_direction = minimal_rotation_transport(radial0 / radius0, axis0, axis1)
+    radial_direction = radial_direction - float(radial_direction @ axis1) * axis1
+    radial_norm = float(np.linalg.norm(radial_direction))
+    if not math.isfinite(radial_norm) or radial_norm <= 1e-9:
+        return None
+    canonical = center + radius * radial_direction / radial_norm
+    orbit_score = orbit.point_distance(p1)
+    point_score = float(np.linalg.norm(p1 - canonical))
+    query_true = float((p1 - a1) @ axis1 - 0.5 * length1)
+    query_center = float((center - a1) @ axis1 - 0.5 * length1)
+    values = (orbit_score, point_score, query_true, query_center, length1)
+    if not all(math.isfinite(value) for value in values):
+        return None
+    return PairEvidence(*values)
+
+
+def _recording_pairs(
+    recording: Recording,
+    marker_triplet: tuple[str, str, str],
+    protocol: dict[str, Any],
+) -> tuple[list[PairEvidence], dict[str, object]]:
+    coordinates, scale, details = read_motive_markers(recording.path, marker_triplet)
+    maximum = int(protocol["prediction"]["pairs_per_recording"])
+    pairs: list[PairEvidence] = []
+    for index in _pair_indices(coordinates.shape[0], maximum):
+        previous = coordinates[int(index)]
+        current = coordinates[int(index) + 1]
+        if not np.all(np.isfinite(previous)) or not np.all(np.isfinite(current)):
+            continue
+        evidence = _pair_evidence(previous, current)
+        if evidence is not None:
+            pairs.append(evidence)
+    metadata = {
+        "group_id": recording.group_id,
+        "relative_path": recording.relative_path,
+        "material": recording.material,
+        "valid_pair_count": len(pairs),
+        "unit_scale_to_mm": scale,
+        **details,
+    }
+    return pairs, metadata
+
+
+def _method_metrics(
+    query_true: FloatArray,
+    query_center: FloatArray,
+    radius: float,
+) -> dict[str, object]:
+    lower = query_center - radius
+    upper = query_center + radius
+    covered = (query_true >= lower) & (query_true <= upper)
+    positive = lower > 0.0
+    negative = upper < 0.0
+    admitted = positive | negative
+    predicted = np.where(positive, 1, np.where(negative, -1, 0))
+    truth = np.sign(query_true).astype(np.int64)
+    harmful = admitted & (predicted != truth)
+    return {
+        "radius_mm": float(radius),
+        "interval_width_mm": float(2.0 * radius),
+        "marginal_coverage": float(np.mean(covered)),
+        "simultaneous_coverage": bool(np.all(covered)),
+        "admission_fraction": float(np.mean(admitted)),
+        "harmful_accepted_fraction_all_cases": float(np.mean(harmful)),
+        "harmful_fraction_among_accepted": (
+            float(np.count_nonzero(harmful) / np.count_nonzero(admitted))
+            if np.any(admitted)
+            else 0.0
+        ),
+        "accepted_count": int(np.count_nonzero(admitted)),
+        "harmful_accepted_count": int(np.count_nonzero(harmful)),
+    }
+
+
+def _bootstrap_difference(
+    values_a: FloatArray,
+    values_b: FloatArray,
+    *,
+    seed: int,
+    replicates: int,
+) -> dict[str, float]:
+    if values_a.shape != values_b.shape or values_a.ndim != 1:
+        raise ValueError("bootstrap inputs must be equal one-dimensional arrays")
+    rng = np.random.default_rng(seed)
+    indices = rng.integers(0, values_a.size, size=(replicates, values_a.size))
+    differences = np.mean(values_a[indices] - values_b[indices], axis=1)
+    return {
+        "mean": float(np.mean(values_a - values_b)),
+        "lower": float(np.quantile(differences, 0.025)),
+        "upper": float(np.quantile(differences, 0.975)),
+        "replicates": replicates,
+        "seed": seed,
+    }

--- a/src/prob4d/_tracking_cloth_approximate_orbit_io.py
+++ b/src/prob4d/_tracking_cloth_approximate_orbit_io.py
@@ -1,0 +1,82 @@
+"""Content-addressed protocol and result I/O for the Tracking Cloth study."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+PROTOCOL_SCHEMA = "prob4d.tracking-cloth-approximate-orbit-tube.v1"
+CALIBRATION_SCHEMA = "prob4d.tracking-cloth-approximate-orbit-calibration.v1"
+RESULT_SCHEMA = "prob4d.tracking-cloth-approximate-orbit-result.v1"
+
+
+def _canonical(value: object) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), allow_nan=False).encode()
+
+
+def _sha256(value: object) -> str:
+    return hashlib.sha256(_canonical(value)).hexdigest()
+
+
+def _write_json(path: Path, value: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(value, indent=2, sort_keys=True, allow_nan=False) + "\n",
+        encoding="utf-8",
+        newline="\n",
+    )
+
+
+def _load_protocol(path: Path) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if type(value) is not dict:
+        raise ValueError("protocol must be one JSON object")
+    unsigned = dict(value)
+    supplied = unsigned.pop("protocol_id", None)
+    if type(supplied) is not str or _sha256(unsigned) != supplied:
+        raise ValueError("protocol identity changed")
+    if value.get("schema") != PROTOCOL_SCHEMA:
+        raise ValueError("protocol schema changed")
+    dataset = value["dataset"]
+    if dataset["expected_csv_files"] != 120 or dataset["expected_cohort_files"] != 27:
+        raise ValueError("dataset roster changed")
+    prior_ids = dataset["prior_header_only_group_ids"]
+    if sorted(prior_ids) != sorted(set(prior_ids)):
+        raise ValueError("prior header-only group IDs must be unique")
+    if len(dataset["prior_header_only_group_ids"]) != 27:
+        raise ValueError("expected exactly 27 prior header-only groups")
+    split = value["split"]
+    if split["calibration_per_material"] != 6 or split["target_per_material"] != 3:
+        raise ValueError("within-material split changed")
+    if split["expected_calibration_groups"] != 18 or split["expected_target_groups"] != 9:
+        raise ValueError("split group counts changed")
+    if split["target_trajectory_values_opened_before_protocol_freeze"] is not False:
+        raise ValueError("target trajectory values were already opened")
+    calibration = value["calibration"]
+    if calibration["requested_miscoverage"] != 0.10:
+        raise ValueError("miscoverage changed")
+    if calibration["independent_unit"] != "complete-recording":
+        raise ValueError("independent unit changed")
+    if value["information_order"]["target_values_may_be_read_during_calibration"] is not False:
+        raise ValueError("calibration may not read target values")
+    if value["information_order"]["target_side_retuning_allowed"] is not False:
+        raise ValueError("target-side retuning was enabled")
+    return value
+
+
+def _load_calibration(path: Path, protocol: dict[str, Any]) -> dict[str, Any]:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if type(value) is not dict or value.get("schema") != CALIBRATION_SCHEMA:
+        raise ValueError("unexpected calibration schema")
+    unsigned = dict(value)
+    supplied = unsigned.pop("calibration_id", None)
+    if type(supplied) is not str or _sha256(unsigned) != supplied:
+        raise ValueError("calibration identity changed")
+    if value.get("protocol_id") != protocol["protocol_id"]:
+        raise ValueError("calibration protocol does not match")
+    information_order = value.get("information_order", {})
+    if information_order.get("target_trajectory_values_parsed") is not False:
+        raise ValueError("calibration accessed target trajectory values")
+    return value

--- a/src/prob4d/_tracking_cloth_approximate_orbit_target.py
+++ b/src/prob4d/_tracking_cloth_approximate_orbit_target.py
@@ -1,0 +1,293 @@
+"""Sealed target stage for the prospective Tracking Cloth approximate-orbit study."""
+
+from __future__ import annotations
+
+import argparse
+import math
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+from prob4d._tracking_cloth_approximate_orbit_data import _discover, _split
+from prob4d._tracking_cloth_approximate_orbit_evaluation import (
+    _bootstrap_difference,
+    _method_metrics,
+    _recording_pairs,
+)
+from prob4d._tracking_cloth_approximate_orbit_io import (
+    RESULT_SCHEMA,
+    _load_calibration,
+    _sha256,
+    _write_json,
+)
+
+FloatArray = NDArray[np.float64]
+
+
+def _evaluate(args: argparse.Namespace, protocol: dict[str, Any]) -> int:
+    dataset_root = Path(args.dataset_root).resolve()
+    output = Path(args.output_dir).resolve()
+    if output.exists():
+        raise ValueError("output directory already exists")
+    output.mkdir(parents=True)
+    calibration = _load_calibration(Path(args.calibration).resolve(), protocol)
+    if calibration.get("status") != "calibrated":
+        raise ValueError("target evaluation requires a successful calibration")
+
+    cohort, common_labels, _ = _discover(dataset_root, protocol)
+    calibration_groups, target_groups = _split(cohort, protocol)
+    split = calibration["split"]
+    if [recording.group_id for recording in calibration_groups] != split[
+        "calibration_group_ids"
+    ]:
+        raise ValueError("calibration split changed")
+    if [recording.group_id for recording in target_groups] != split["target_group_ids"]:
+        raise ValueError("target split changed")
+    if common_labels != calibration["dataset"]["common_marker_labels"]:
+        raise ValueError("common marker namespace changed")
+    triplet = tuple(calibration["marker_selection"]["triplet"])
+    if len(triplet) != 3:
+        raise ValueError("calibration marker triplet changed")
+
+    orbit_radius = float(calibration["orbit_tube"]["radius"])
+    point_radius = float(calibration["point_ball"]["radius"])
+    minimum_pairs = int(protocol["prediction"]["minimum_valid_pairs"])
+    groups: list[dict[str, object]] = []
+    for recording in target_groups:
+        pairs, metadata = _recording_pairs(recording, triplet, protocol)
+        if len(pairs) < minimum_pairs:
+            value = {
+                "schema": RESULT_SCHEMA,
+                "status": "target-support-negative",
+                "protocol_id": protocol["protocol_id"],
+                "calibration_id": calibration["calibration_id"],
+                "source_revision": args.source_revision,
+                "failed_group_id": recording.group_id,
+                "valid_pair_count": len(pairs),
+                "minimum_valid_pairs": minimum_pairs,
+                "target_groups_replaced": False,
+                "information_order": {
+                    "calibration_artifact_verified_before_target_access": True,
+                    "target_trajectory_values_parsed_during_calibration": False,
+                    "target_side_retuning": False,
+                    "target_groups_replaced": False,
+                },
+                "claim_boundary": protocol["claim_boundary"],
+            }
+            value["result_id"] = _sha256(value)
+            _write_json(output / "result.json", value)
+            return 2
+        threshold_fraction = float(
+            calibration["decision_threshold"]["normalized_axial_fraction"]
+        )
+        query_true = np.asarray(
+            [
+                pair.query_true_mm
+                + (0.5 - threshold_fraction) * pair.anchor_length_mm
+                for pair in pairs
+            ],
+            dtype=np.float64,
+        )
+        query_center = np.asarray(
+            [
+                pair.query_center_mm
+                + (0.5 - threshold_fraction) * pair.anchor_length_mm
+                for pair in pairs
+            ],
+            dtype=np.float64,
+        )
+        exact = _method_metrics(query_true, query_center, 0.0)
+        orbit = _method_metrics(query_true, query_center, orbit_radius)
+        point = _method_metrics(query_true, query_center, point_radius)
+        groups.append(
+            {
+                **metadata,
+                "query_center_rmse_mm": float(
+                    math.sqrt(float(np.mean((query_true - query_center) ** 2)))
+                ),
+                "maximum_orbit_score_mm": max(pair.orbit_score_mm for pair in pairs),
+                "maximum_point_score_mm": max(pair.point_score_mm for pair in pairs),
+                "exact_estimated_orbit": exact,
+                "conformal_orbit_tube": orbit,
+                "generic_conformal_point_ball": point,
+            }
+        )
+
+    def array(method: str, metric: str) -> FloatArray:
+        return np.asarray([float(group[method][metric]) for group in groups], dtype=np.float64)
+
+    methods = (
+        "exact_estimated_orbit",
+        "conformal_orbit_tube",
+        "generic_conformal_point_ball",
+    )
+    aggregate: dict[str, object] = {}
+    for method in methods:
+        aggregate[method] = {
+            "equal_recording_marginal_coverage": float(
+                np.mean(array(method, "marginal_coverage"))
+            ),
+            "simultaneously_covered_recordings": int(
+                np.sum(array(method, "simultaneous_coverage"))
+            ),
+            "simultaneous_recording_coverage_fraction": float(
+                np.mean(array(method, "simultaneous_coverage"))
+            ),
+            "equal_recording_admission_fraction": float(
+                np.mean(array(method, "admission_fraction"))
+            ),
+            "equal_recording_harmful_accepted_fraction_all_cases": float(
+                np.mean(array(method, "harmful_accepted_fraction_all_cases"))
+            ),
+            "total_accepted_count": int(
+                sum(int(group[method]["accepted_count"]) for group in groups)
+            ),
+            "total_harmful_accepted_count": int(
+                sum(int(group[method]["harmful_accepted_count"]) for group in groups)
+            ),
+            "interval_width_mm": float(groups[0][method]["interval_width_mm"]),
+        }
+
+    width_ratio = orbit_radius / point_radius
+    orbit_admission = array("conformal_orbit_tube", "admission_fraction")
+    point_admission = array("generic_conformal_point_ball", "admission_fraction")
+    exact_coverage = array("exact_estimated_orbit", "simultaneous_coverage")
+    orbit_coverage = array("conformal_orbit_tube", "simultaneous_coverage")
+    criteria = {
+        "all_target_groups_supported": len(groups)
+        == int(protocol["split"]["expected_target_groups"]),
+        "orbit_simultaneous_coverage_at_least_registered_minimum": int(
+            np.sum(orbit_coverage)
+        )
+        >= int(protocol["criteria"]["minimum_orbit_simultaneous_covered_groups"]),
+        "orbit_tube_sharper_than_registered_ratio": width_ratio
+        <= float(protocol["criteria"]["maximum_orbit_to_ball_width_ratio"]),
+        "orbit_tube_admission_gain_at_least_registered_minimum": float(
+            np.mean(orbit_admission - point_admission)
+        )
+        >= float(protocol["criteria"]["minimum_orbit_tube_admission_gain"]),
+        "orbit_tube_no_more_harmful_than_point_ball": float(
+            aggregate["conformal_orbit_tube"][
+                "equal_recording_harmful_accepted_fraction_all_cases"
+            ]
+        )
+        <= float(
+            aggregate["generic_conformal_point_ball"][
+                "equal_recording_harmful_accepted_fraction_all_cases"
+            ]
+        )
+        + 1e-15,
+        "approximate_tube_improves_over_exact_orbit_coverage": float(
+            np.mean(orbit_coverage)
+        )
+        > float(np.mean(exact_coverage)),
+    }
+    status = (
+        "approximate-orbit-tube-positive"
+        if all(criteria.values())
+        else "approximate-orbit-tube-mixed"
+    )
+    result: dict[str, Any] = {
+        "schema": RESULT_SCHEMA,
+        "status": status,
+        "protocol_id": protocol["protocol_id"],
+        "calibration_id": calibration["calibration_id"],
+        "source_revision": args.source_revision,
+        "cohort": {
+            "target_group_count": len(groups),
+            "target_group_ids": [recording.group_id for recording in target_groups],
+            "target_relative_paths": [recording.relative_path for recording in target_groups],
+            "materials": sorted(set(recording.material for recording in target_groups)),
+            "independent_unit": "complete-recording",
+        },
+        "marker_triplet": list(triplet),
+        "calibration": {
+            "requested_miscoverage": calibration["orbit_tube"]["requested_miscoverage"],
+            "finite_sample_coverage_level": calibration["orbit_tube"][
+                "finite_sample_coverage_level"
+            ],
+            "order_statistic_rank": calibration["orbit_tube"]["order_statistic_rank"],
+            "calibration_group_count": calibration["orbit_tube"]["group_count"],
+            "orbit_tube_radius_mm": orbit_radius,
+            "generic_point_ball_radius_mm": point_radius,
+            "orbit_to_point_radius_ratio": width_ratio,
+        },
+        "groups": groups,
+        "aggregate": aggregate,
+        "paired_recording_bootstrap": {
+            "orbit_minus_point_admission_fraction": _bootstrap_difference(
+                orbit_admission,
+                point_admission,
+                seed=int(protocol["analysis"]["bootstrap_seed"]),
+                replicates=int(protocol["analysis"]["bootstrap_replicates"]),
+            ),
+            "orbit_minus_point_harmful_fraction": _bootstrap_difference(
+                array(
+                    "conformal_orbit_tube",
+                    "harmful_accepted_fraction_all_cases",
+                ),
+                array(
+                    "generic_conformal_point_ball",
+                    "harmful_accepted_fraction_all_cases",
+                ),
+                seed=int(protocol["analysis"]["bootstrap_seed"]) + 1,
+                replicates=int(protocol["analysis"]["bootstrap_replicates"]),
+            ),
+        },
+        "criteria": criteria,
+        "information_order": {
+            "calibration_artifact_verified_before_target_access": True,
+            "target_trajectory_values_parsed_during_calibration": False,
+            "target_side_retuning": False,
+            "target_groups_replaced": False,
+        },
+        "claim_boundary": protocol["claim_boundary"],
+    }
+    result["result_id"] = _sha256(result)
+    _write_json(output / "result.json", result)
+
+    orbit_summary = aggregate["conformal_orbit_tube"]
+    ball_summary = aggregate["generic_conformal_point_ball"]
+    exact_summary = aggregate["exact_estimated_orbit"]
+    (output / "summary.md").write_text(
+        "\n".join(
+            [
+                "# Tracking Cloth approximate-orbit tube result",
+                "",
+                f"Status: **{status}**",
+                "",
+                f"Protocol ID: `{protocol['protocol_id']}`",
+                f"Calibration ID: `{calibration['calibration_id']}`",
+                f"Result ID: `{result['result_id']}`",
+                "",
+                f"- target recordings: {len(groups)}",
+                f"- orbit-tube radius: {orbit_radius:.6f} mm",
+                f"- generic point-ball radius: {point_radius:.6f} mm",
+                f"- width ratio: {width_ratio:.6f}",
+                (
+                    "- simultaneous coverage (exact/orbit tube/point ball): "
+                    f"{exact_summary['simultaneously_covered_recordings']}/"
+                    f"{orbit_summary['simultaneously_covered_recordings']}/"
+                    f"{ball_summary['simultaneously_covered_recordings']} of {len(groups)}"
+                ),
+                (
+                    "- equal-recording decision admission (orbit tube / point ball): "
+                    f"{orbit_summary['equal_recording_admission_fraction']:.6f} / "
+                    f"{ball_summary['equal_recording_admission_fraction']:.6f}"
+                ),
+                (
+                    "- harmful accepted fraction (orbit tube / point ball): "
+                    f"{orbit_summary['equal_recording_harmful_accepted_fraction_all_cases']:.6f} / "
+                    f"{ball_summary['equal_recording_harmful_accepted_fraction_all_cases']:.6f}"
+                ),
+                "",
+                "This is a trajectory-level calibration test on an estimated orbit. "
+                "It does not establish learned visual-provider competence or robot safety.",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return 0 if status == "approximate-orbit-tube-positive" else 3

--- a/src/prob4d/orbit_tube.py
+++ b/src/prob4d/orbit_tube.py
@@ -1,8 +1,8 @@
 """Calibrated Euclidean tubes around estimated axial gauge orbits.
 
-An estimated axial orbit is a circle in three-dimensional space. The circle may
+An estimated axial orbit is a circle in three-dimensional space.  The circle may
 capture a residual rotation while remaining imperfect because its line, axial
-coordinate, or radius were estimated from partial observations. This module
+coordinate, or radius were estimated from partial observations.  This module
 provides:
 
 * exact point-to-circle distance;
@@ -11,7 +11,7 @@ provides:
 * split-conformal calibration of one radius from maxima over independent groups.
 
 The finite-sample statement is conditional on exchangeable independent groups
-and the supplied nonconformity score. It is not a provider-quality, physical
+and the supplied nonconformity score.  It is not a provider-quality, physical
 state-recovery, or deployment-safety guarantee.
 """
 
@@ -32,7 +32,7 @@ FloatArray: TypeAlias = NDArray[np.float64]
 
 
 def _scalar(value: object, name: str, *, nonnegative: bool = False) -> float:
-    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+    if isinstance(value, bool | np.bool_) or not isinstance(value, Real):
         raise TypeError(f"{name} must be a real scalar")
     result = float(value)
     if not math.isfinite(result):
@@ -143,7 +143,7 @@ class AxialCircleOrbit:
     ) -> ScalarBounds:
         """Exact bounds of ``offset + direction @ point`` over an orbit tube.
 
-        ``tube_radius`` expands the circle by a closed Euclidean ball. The
+        ``tube_radius`` expands the circle by a closed Euclidean ball.  The
         expansion is exact for an affine scalar query because its Lipschitz
         constant under Euclidean distance is ``||direction||``.
         """
@@ -248,7 +248,7 @@ def calibrate_group_maximum_radius(
         raise ValueError("scores must be a nonempty one-dimensional array")
     if not np.all(np.isfinite(values)) or np.any(values < 0.0):
         raise ValueError("scores must be finite and nonnegative")
-    if isinstance(group_ids, (str, bytes)):
+    if isinstance(group_ids, str | bytes):
         raise TypeError("group_ids must be a sequence")
     supplied = tuple(group_ids)
     if len(supplied) != values.size:

--- a/src/prob4d/orbit_tube.py
+++ b/src/prob4d/orbit_tube.py
@@ -1,0 +1,312 @@
+"""Calibrated Euclidean tubes around estimated axial gauge orbits.
+
+An estimated axial orbit is a circle in three-dimensional space. The circle may
+capture a residual rotation while remaining imperfect because its line, axial
+coordinate, or radius were estimated from partial observations. This module
+provides:
+
+* exact point-to-circle distance;
+* exact affine-query bounds for a Euclidean tube around the circle;
+* deterministic minimal-rotation transport for a canonical point baseline; and
+* split-conformal calibration of one radius from maxima over independent groups.
+
+The finite-sample statement is conditional on exchangeable independent groups
+and the supplied nonconformity score. It is not a provider-quality, physical
+state-recovery, or deployment-safety guarantee.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass
+from numbers import Real
+from typing import TypeAlias
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+
+FloatArray: TypeAlias = NDArray[np.float64]
+
+
+def _scalar(value: object, name: str, *, nonnegative: bool = False) -> float:
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+        raise TypeError(f"{name} must be a real scalar")
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"{name} must be finite")
+    if nonnegative and result < 0.0:
+        raise ValueError(f"{name} must be nonnegative")
+    return result
+
+
+def _vector(value: ArrayLike, name: str) -> FloatArray:
+    result = np.asarray(value, dtype=np.float64)
+    if result.shape != (3,) or not np.all(np.isfinite(result)):
+        raise ValueError(f"{name} must be a finite three-vector")
+    return np.frombuffer(result.tobytes(), dtype=np.float64)
+
+
+def _unit_vector(value: ArrayLike, name: str) -> FloatArray:
+    result = _vector(value, name)
+    norm = math.hypot(*(float(entry) for entry in result))
+    if not math.isfinite(norm) or norm <= 0.0:
+        raise ValueError(f"{name} must have positive norm")
+    return _vector(result / norm, f"normalized {name}")
+
+
+def _validated_group_id(value: object, index: int) -> str:
+    if type(value) is not str:
+        raise TypeError(f"group_ids[{index}] must be a string")
+    if not value or value.strip() != value:
+        raise ValueError(f"group_ids[{index}] must be a nonempty trimmed string")
+    if any(ord(character) < 32 or ord(character) == 127 for character in value):
+        raise ValueError(f"group_ids[{index}] must not contain control characters")
+    if len(value.encode("utf-8")) > 128:
+        raise ValueError(f"group_ids[{index}] must contain at most 128 UTF-8 bytes")
+    return value
+
+
+@dataclass(frozen=True, slots=True)
+class ScalarBounds:
+    """Closed scalar interval."""
+
+    lower: float
+    upper: float
+
+    def __post_init__(self) -> None:
+        lower = _scalar(self.lower, "lower")
+        upper = _scalar(self.upper, "upper")
+        if lower > upper:
+            raise ValueError("lower must not exceed upper")
+        object.__setattr__(self, "lower", lower)
+        object.__setattr__(self, "upper", upper)
+
+    @property
+    def width(self) -> float:
+        return self.upper - self.lower
+
+    def contains(self, value: float, *, atol: float = 0.0) -> bool:
+        point = _scalar(value, "value")
+        tolerance = _scalar(atol, "atol", nonnegative=True)
+        return self.lower - tolerance <= point <= self.upper + tolerance
+
+    def threshold_sign(self, threshold: float = 0.0, *, margin: float = 0.0) -> int | None:
+        """Return a certified threshold side, or ``None`` when the interval overlaps."""
+
+        level = _scalar(threshold, "threshold")
+        gap = _scalar(margin, "margin", nonnegative=True)
+        if self.lower > level + gap:
+            return 1
+        if self.upper < level - gap:
+            return -1
+        return None
+
+
+@dataclass(frozen=True, slots=True, eq=False)
+class AxialCircleOrbit:
+    """One estimated circular orbit around a fixed axis."""
+
+    center: FloatArray
+    axis: FloatArray
+    radius: float
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "center", _vector(self.center, "center"))
+        object.__setattr__(self, "axis", _unit_vector(self.axis, "axis"))
+        object.__setattr__(
+            self,
+            "radius",
+            _scalar(self.radius, "radius", nonnegative=True),
+        )
+
+    def point_distance(self, point: ArrayLike) -> float:
+        """Exact Euclidean distance from a point to the circular orbit."""
+
+        delta = _vector(point, "point") - self.center
+        axial = float(delta @ self.axis)
+        radial = delta - axial * self.axis
+        radial_norm = math.hypot(*(float(entry) for entry in radial))
+        result = math.hypot(axial, radial_norm - self.radius)
+        if not math.isfinite(result):
+            raise ValueError("point-to-orbit distance overflowed")
+        return result
+
+    def affine_query_bounds(
+        self,
+        direction: ArrayLike,
+        *,
+        offset: float = 0.0,
+        tube_radius: float = 0.0,
+    ) -> ScalarBounds:
+        """Exact bounds of ``offset + direction @ point`` over an orbit tube.
+
+        ``tube_radius`` expands the circle by a closed Euclidean ball. The
+        expansion is exact for an affine scalar query because its Lipschitz
+        constant under Euclidean distance is ``||direction||``.
+        """
+
+        vector = _vector(direction, "direction")
+        offset_value = _scalar(offset, "offset")
+        tube = _scalar(tube_radius, "tube_radius", nonnegative=True)
+        direction_norm = math.hypot(*(float(entry) for entry in vector))
+        parallel = float(vector @ self.axis)
+        perpendicular_norm = math.sqrt(max(direction_norm**2 - parallel**2, 0.0))
+        center_value = offset_value + float(vector @ self.center)
+        half_width = self.radius * perpendicular_norm + tube * direction_norm
+        return ScalarBounds(center_value - half_width, center_value + half_width)
+
+
+@dataclass(frozen=True, slots=True)
+class GroupMaximumRadiusCalibration:
+    """Split-conformal radius from complete-group maximum scores."""
+
+    requested_miscoverage: float
+    calibration_group_ids: tuple[str, ...]
+    calibration_group_maximum_scores: tuple[float, ...]
+    group_assignment_sha256: str
+    order_statistic_rank: int
+    finite_sample_coverage_level: float
+    radius: float
+
+    def __post_init__(self) -> None:
+        alpha = _scalar(self.requested_miscoverage, "requested_miscoverage")
+        if not 0.0 < alpha < 1.0:
+            raise ValueError("requested_miscoverage must lie in (0, 1)")
+        if not isinstance(self.calibration_group_ids, tuple):
+            raise TypeError("calibration_group_ids must be a tuple")
+        if not isinstance(self.calibration_group_maximum_scores, tuple):
+            raise TypeError("calibration_group_maximum_scores must be a tuple")
+        if len(self.calibration_group_ids) == 0:
+            raise ValueError("at least one calibration group is required")
+        if len(self.calibration_group_ids) != len(self.calibration_group_maximum_scores):
+            raise ValueError("group IDs and maximum scores must have equal length")
+        ids = tuple(
+            _validated_group_id(value, index)
+            for index, value in enumerate(self.calibration_group_ids)
+        )
+        if tuple(sorted(ids)) != ids or len(set(ids)) != len(ids):
+            raise ValueError("calibration_group_ids must be unique and sorted")
+        maxima = tuple(
+            _scalar(value, f"calibration_group_maximum_scores[{index}]", nonnegative=True)
+            for index, value in enumerate(self.calibration_group_maximum_scores)
+        )
+        rank = self.order_statistic_rank
+        if isinstance(rank, bool) or not isinstance(rank, int):
+            raise TypeError("order_statistic_rank must be an integer")
+        if not 1 <= rank <= len(ids):
+            raise ValueError("order_statistic_rank is inconsistent with group count")
+        level = _scalar(self.finite_sample_coverage_level, "finite_sample_coverage_level")
+        expected_level = rank / (len(ids) + 1)
+        if not math.isclose(level, expected_level, rel_tol=0.0, abs_tol=1e-15):
+            raise ValueError("finite_sample_coverage_level does not equal rank/(n+1)")
+        radius = _scalar(self.radius, "radius", nonnegative=True)
+        expected_radius = sorted(maxima)[rank - 1]
+        if not math.isclose(radius, expected_radius, rel_tol=0.0, abs_tol=1e-15):
+            raise ValueError("radius does not equal the registered order statistic")
+        payload = json.dumps(ids, ensure_ascii=True, separators=(",", ":")).encode()
+        expected_digest = hashlib.sha256(payload).hexdigest()
+        if self.group_assignment_sha256 != expected_digest:
+            raise ValueError("group_assignment_sha256 does not match calibration_group_ids")
+        object.__setattr__(self, "requested_miscoverage", alpha)
+        object.__setattr__(self, "calibration_group_ids", ids)
+        object.__setattr__(self, "calibration_group_maximum_scores", maxima)
+        object.__setattr__(self, "finite_sample_coverage_level", level)
+        object.__setattr__(self, "radius", radius)
+
+    @property
+    def group_count(self) -> int:
+        return len(self.calibration_group_ids)
+
+    def covers(self, score: float, *, atol: float = 0.0) -> bool:
+        value = _scalar(score, "score", nonnegative=True)
+        tolerance = _scalar(atol, "atol", nonnegative=True)
+        return value <= self.radius + tolerance
+
+    def to_dict(self) -> dict[str, object]:
+        result: dict[str, object] = asdict(self)
+        result["group_count"] = self.group_count
+        result["requested_coverage"] = 1.0 - self.requested_miscoverage
+        return result
+
+
+def calibrate_group_maximum_radius(
+    scores: ArrayLike,
+    group_ids: Sequence[str],
+    *,
+    miscoverage: float,
+) -> GroupMaximumRadiusCalibration:
+    """Calibrate a radius from maxima over exchangeable independent groups."""
+
+    alpha = _scalar(miscoverage, "miscoverage")
+    if not 0.0 < alpha < 1.0:
+        raise ValueError("miscoverage must lie in (0, 1)")
+    values = np.asarray(scores, dtype=np.float64)
+    if values.ndim != 1 or values.size == 0:
+        raise ValueError("scores must be a nonempty one-dimensional array")
+    if not np.all(np.isfinite(values)) or np.any(values < 0.0):
+        raise ValueError("scores must be finite and nonnegative")
+    if isinstance(group_ids, (str, bytes)):
+        raise TypeError("group_ids must be a sequence")
+    supplied = tuple(group_ids)
+    if len(supplied) != values.size:
+        raise ValueError("group_ids must contain one entry per score")
+    validated = tuple(_validated_group_id(value, index) for index, value in enumerate(supplied))
+    unique = tuple(sorted(set(validated)))
+    maxima = tuple(
+        float(np.max(values[np.asarray([group == selected for group in validated])]))
+        for selected in unique
+    )
+    rank = math.ceil((len(unique) + 1) * (1.0 - alpha))
+    if rank > len(unique):
+        minimum = math.ceil(1.0 / alpha) - 1
+        raise ValueError(
+            "too few independent groups for a finite split-conformal radius; "
+            f"need at least {minimum}"
+        )
+    radius = sorted(maxima)[rank - 1]
+    payload = json.dumps(unique, ensure_ascii=True, separators=(",", ":")).encode()
+    return GroupMaximumRadiusCalibration(
+        requested_miscoverage=alpha,
+        calibration_group_ids=unique,
+        calibration_group_maximum_scores=maxima,
+        group_assignment_sha256=hashlib.sha256(payload).hexdigest(),
+        order_statistic_rank=rank,
+        finite_sample_coverage_level=rank / (len(unique) + 1),
+        radius=radius,
+    )
+
+
+def minimal_rotation_transport(
+    vector: ArrayLike,
+    source_axis: ArrayLike,
+    target_axis: ArrayLike,
+) -> FloatArray:
+    """Transport a vector by a deterministic shortest rotation between axes."""
+
+    value = _vector(vector, "vector")
+    source = _unit_vector(source_axis, "source_axis")
+    target = _unit_vector(target_axis, "target_axis")
+    cosine = float(np.clip(source @ target, -1.0, 1.0))
+    cross = np.cross(source, target)
+    sine = math.hypot(*(float(entry) for entry in cross))
+    if sine <= 1e-12:
+        if cosine >= 0.0:
+            return _vector(value, "transported vector")
+        basis = np.eye(3, dtype=np.float64)[int(np.argmin(np.abs(source)))]
+        rotation_axis = np.cross(source, basis)
+        rotation_axis /= np.linalg.norm(rotation_axis)
+        rotated = 2.0 * rotation_axis * float(rotation_axis @ value) - value
+        return _vector(rotated, "transported vector")
+    skew = np.asarray(
+        [
+            [0.0, -cross[2], cross[1]],
+            [cross[2], 0.0, -cross[0]],
+            [-cross[1], cross[0], 0.0],
+        ],
+        dtype=np.float64,
+    )
+    rotation = np.eye(3, dtype=np.float64) + skew + skew @ skew * ((1.0 - cosine) / sine**2)
+    return _vector(rotation @ value, "transported vector")

--- a/tests/test_orbit_tube.py
+++ b/tests/test_orbit_tube.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from prob4d.orbit_tube import (
+    AxialCircleOrbit,
+    ScalarBounds,
+    calibrate_group_maximum_radius,
+    minimal_rotation_transport,
+)
+
+
+def test_point_distance_is_exact_for_axial_and_radial_departures() -> None:
+    orbit = AxialCircleOrbit(
+        center=np.array([1.0, 2.0, 3.0]),
+        axis=np.array([0.0, 0.0, 2.0]),
+        radius=4.0,
+    )
+    assert orbit.point_distance([5.0, 2.0, 3.0]) == pytest.approx(0.0)
+    assert orbit.point_distance([6.0, 2.0, 3.0]) == pytest.approx(1.0)
+    assert orbit.point_distance([5.0, 2.0, 5.0]) == pytest.approx(2.0)
+    assert orbit.point_distance([6.0, 2.0, 5.0]) == pytest.approx(math.sqrt(5.0))
+
+
+def test_affine_query_bounds_match_dense_circle_and_tube_formula() -> None:
+    orbit = AxialCircleOrbit(
+        center=np.array([1.0, -2.0, 0.5]),
+        axis=np.array([1.0, 1.0, 1.0]),
+        radius=2.5,
+    )
+    direction = np.array([0.3, -0.5, 0.8])
+    bounds = orbit.affine_query_bounds(direction, offset=1.2, tube_radius=0.4)
+
+    axis = orbit.axis
+    basis = np.eye(3)[int(np.argmin(np.abs(axis)))]
+    first = np.cross(axis, basis)
+    first /= np.linalg.norm(first)
+    second = np.cross(axis, first)
+    angles = np.linspace(0.0, 2.0 * math.pi, 100_001)
+    circle = (
+        orbit.center[None]
+        + orbit.radius * np.cos(angles)[:, None] * first[None]
+        + orbit.radius * np.sin(angles)[:, None] * second[None]
+    )
+    values = 1.2 + circle @ direction
+    expansion = 0.4 * np.linalg.norm(direction)
+    assert bounds.lower == pytest.approx(float(values.min()) - expansion, abs=1e-9)
+    assert bounds.upper == pytest.approx(float(values.max()) + expansion, abs=1e-9)
+
+
+def test_group_maximum_calibration_uses_complete_groups() -> None:
+    group_ids = [f"group-{index:02d}" for index in range(18) for _ in range(2)]
+    scores = np.asarray(
+        [value for index in range(18) for value in (float(index), index + 0.25)],
+        dtype=np.float64,
+    )
+    calibration = calibrate_group_maximum_radius(
+        scores,
+        group_ids,
+        miscoverage=0.10,
+    )
+    assert calibration.group_count == 18
+    assert calibration.order_statistic_rank == 18
+    assert calibration.finite_sample_coverage_level == pytest.approx(18.0 / 19.0)
+    assert calibration.radius == pytest.approx(17.25)
+    assert calibration.covers(17.25)
+    assert not calibration.covers(17.26)
+
+
+def test_group_calibration_requires_enough_independent_groups() -> None:
+    with pytest.raises(ValueError, match="too few independent groups"):
+        calibrate_group_maximum_radius(
+            np.arange(8, dtype=np.float64),
+            [f"group-{index}" for index in range(8)],
+            miscoverage=0.10,
+        )
+
+
+def test_minimal_rotation_transport_maps_axes_and_handles_antipodes() -> None:
+    mapped = minimal_rotation_transport([1.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 1.0, 0.0])
+    assert np.linalg.norm(mapped) == pytest.approx(1.0)
+    assert mapped @ np.array([0.0, 1.0, 0.0]) == pytest.approx(0.0, abs=1e-12)
+
+    source = np.array([0.2, -0.3, 0.9])
+    source /= np.linalg.norm(source)
+    target = -source
+    radial = np.cross(source, np.array([1.0, 0.0, 0.0]))
+    if np.linalg.norm(radial) < 1e-8:
+        radial = np.cross(source, np.array([0.0, 1.0, 0.0]))
+    radial /= np.linalg.norm(radial)
+    transported = minimal_rotation_transport(radial, source, target)
+    assert np.linalg.norm(transported) == pytest.approx(1.0)
+    assert transported @ target == pytest.approx(0.0, abs=1e-12)
+
+
+def test_scalar_bounds_threshold_decision_is_fail_closed() -> None:
+    assert ScalarBounds(1.0, 2.0).threshold_sign() == 1
+    assert ScalarBounds(-2.0, -1.0).threshold_sign() == -1
+    assert ScalarBounds(-1.0, 2.0).threshold_sign() is None
+    assert ScalarBounds(0.1, 0.2).threshold_sign(margin=0.15) is None
+
+
+@pytest.mark.parametrize(
+    ("factory", "message"),
+    [
+        (lambda: AxialCircleOrbit([0, 0, 0], [0, 0, 0], 1.0), "positive norm"),
+        (lambda: AxialCircleOrbit([0, 0, 0], [0, 0, 1], -1.0), "nonnegative"),
+        (lambda: ScalarBounds(2.0, 1.0), "lower must not exceed"),
+    ],
+)
+def test_invalid_inputs_fail_closed(factory: object, message: str) -> None:
+    with pytest.raises((TypeError, ValueError), match=message):
+        factory()  # type: ignore[operator]

--- a/tests/test_tracking_cloth_approximate_orbit_tube_v1.py
+++ b/tests/test_tracking_cloth_approximate_orbit_tube_v1.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from prob4d._tracking_cloth_approximate_orbit_data import (
+    Recording,
+    _split,
+    _stable_id,
+)
+from prob4d._tracking_cloth_approximate_orbit_evaluation import (
+    _method_metrics,
+    _pair_evidence,
+)
+from prob4d._tracking_cloth_approximate_orbit_io import (
+    CALIBRATION_SCHEMA,
+    _load_calibration,
+    _load_protocol,
+    _sha256,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+PROTOCOL = ROOT / "protocols" / "tracking-cloth-approximate-orbit-tube-v1.json"
+
+
+def test_protocol_is_content_addressed() -> None:
+    value = _load_protocol(PROTOCOL)
+    unsigned = dict(value)
+    supplied = unsigned.pop("protocol_id")
+    encoded = json.dumps(unsigned, sort_keys=True, separators=(",", ":")).encode()
+    assert hashlib.sha256(encoded).hexdigest() == supplied
+    assert value["split"]["expected_calibration_groups"] == 18
+    assert value["split"]["expected_target_groups"] == 9
+
+
+def test_within_material_split_is_disjoint_and_balanced() -> None:
+    protocol = _load_protocol(PROTOCOL)
+    cohort = []
+    for material in ("cotton", "denim", "wool"):
+        for index in range(9):
+            relative = f"tracking_dataset/Self-collisions/{material}_A2_case_{index}.csv"
+            cohort.append(
+                Recording(
+                    path=Path(relative),
+                    relative_path=relative,
+                    group_id=_stable_id(relative),
+                    material=material,
+                )
+            )
+    calibration, target = _split(cohort, protocol)
+    assert len(calibration) == 18
+    assert len(target) == 9
+    assert not ({row.group_id for row in calibration} & {row.group_id for row in target})
+    for material in ("cotton", "denim", "wool"):
+        assert sum(row.material == material for row in calibration) == 6
+        assert sum(row.material == material for row in target) == 3
+
+
+def test_pair_evidence_removes_unresolved_angle_from_orbit_score() -> None:
+    previous = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.0, 0.0, 100.0],
+            [20.0, 0.0, 25.0],
+        ]
+    )
+    current = np.array(
+        [
+            [10.0, 5.0, -2.0],
+            [10.0, 5.0, 98.0],
+            [10.0, 25.0, 23.0],
+        ]
+    )
+    evidence = _pair_evidence(previous, current)
+    assert evidence is not None
+    assert evidence.orbit_score_mm == pytest.approx(0.0, abs=1e-12)
+    assert evidence.point_score_mm == pytest.approx(np.sqrt(800.0))
+    assert evidence.query_true_mm == pytest.approx(-25.0)
+    assert evidence.query_center_mm == pytest.approx(-25.0)
+
+
+def test_pair_evidence_orbit_distance_tracks_axial_and_radial_drift() -> None:
+    previous = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.0, 0.0, 100.0],
+            [20.0, 0.0, 25.0],
+        ]
+    )
+    current = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [0.0, 0.0, 100.0],
+            [23.0, 0.0, 29.0],
+        ]
+    )
+    evidence = _pair_evidence(previous, current)
+    assert evidence is not None
+    assert evidence.orbit_score_mm == pytest.approx(5.0)
+    assert evidence.query_true_mm - evidence.query_center_mm == pytest.approx(4.0)
+
+
+def test_method_metrics_abstains_when_interval_crosses_threshold() -> None:
+    truth = np.array([-2.0, 3.0, 10.0])
+    center = np.array([-1.0, 1.0, 8.0])
+    exact = _method_metrics(truth, center, 0.0)
+    wide = _method_metrics(truth, center, 2.0)
+    assert exact["accepted_count"] == 3
+    assert wide["accepted_count"] == 1
+    assert wide["harmful_accepted_count"] == 0
+
+
+def test_calibration_loader_rejects_target_access(tmp_path: Path) -> None:
+    protocol = _load_protocol(PROTOCOL)
+    value = {
+        "schema": CALIBRATION_SCHEMA,
+        "protocol_id": protocol["protocol_id"],
+        "information_order": {"target_trajectory_values_parsed": True},
+    }
+    value["calibration_id"] = _sha256(value)
+    path = tmp_path / "calibration.json"
+    path.write_text(json.dumps(value), encoding="utf-8")
+    with pytest.raises(ValueError, match="accessed target"):
+        _load_calibration(path, protocol)


### PR DESCRIPTION
## Purpose

Add a prospectively frozen public-data experiment for the largest remaining limitation of the primary Prob4D query-identifiability paper: the current real-trajectory evidence assumes an exact controlled residual orbit.

This study estimates an axial circle from restricted real trajectory observations and calibrates a complete-recording Euclidean tube around that estimated orbit before opening a target split.

## Fresh evidence boundary

The exact cohort is the 27 A2 cotton/denim/wool Tracking Cloth `Self-collisions` recordings previously retained as marker-header-only support negatives. The earlier audit parsed marker layouts but explicitly did not parse their trajectory values.

The protocol freezes a deterministic within-material split:

- 18 complete calibration recordings: six per material;
- 9 target-only recordings: three per material.

Target trajectory values are forbidden during marker selection, orbit calibration, threshold selection, and calibration sealing. No execution request is included in this PR.

## Method

For each consecutive registered frame pair:

1. two selected anchors define the current axis;
2. the previous probe supplies its normalized axial fraction and radial ratio;
3. these quantities define an estimated circular orbit around the current axis;
4. the nonconformity score is the point-to-circle distance of the realized probe;
5. a generic comparator predicts one canonical point by minimal-rotation transport and uses Euclidean point error.

Both radii are calibrated from maxima over complete independent recordings using the split-conformal order statistic at requested miscoverage 0.10. Frames, coordinates, and marker samples remain nested observations.

The registered invariant scalar query uses the same center for both methods. The orbit tube has radius `rho`; the generic point ball has radius `R`. Thus width and threshold-decision differences isolate preservation of the unresolved angle rather than a different point prediction.

## Registered target endpoints

- complete-recording simultaneous coverage;
- interval width and orbit/point-ball width ratio;
- threshold-decision admission;
- harmful accepted decisions;
- paired recording bootstrap comparisons.

A positive classification requires all nine groups, at least 8/9 simultaneous orbit-tube coverage, width ratio at most 0.75, at least 0.05 admission gain over the generic point ball, no greater harmful-decision rate, and improved simultaneous coverage over the unexpanded estimated orbit.

## Claim boundary

A positive result would establish estimated-orbit and group-calibrated tube evidence under a controlled observation restriction on public real trajectories. It would not establish learned visual-provider competence, full physical-state recovery, BayesianPhysTwin/Causal4D benefit, closed-loop robot performance, deployment safety, or state of the art.

## Implementation

- reusable exact point-to-circle and affine orbit-tube geometry;
- group-maximum split-conformal calibration with finite-sample rank checks;
- deterministic antipode-safe minimal-rotation transport;
- content-addressed protocol/calibration/result records;
- separate calibration and target CLI stages;
- request-only push workflow with raw-data removal before artifact publication;
- focused fail-closed tests and Ruff checks.

The existing primary paper remains viable regardless of this experiment's terminal result. No target-side retuning or replacement is allowed.