### PR TITLE
Add group-calibrated approximate-orbit certificates

### DIFF
--- a/.github/workflows/group-calibrated-orbit-tube-mechanism.yml
+++ b/.github/workflows/group-calibrated-orbit-tube-mechanism.yml
@@ -1,0 +1,116 @@
+name: Group-calibrated orbit-tube mechanism
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/group-calibrated-orbit-tube-mechanism.yml"
+      - "src/prob4d/orbit_tube.py"
+      - "tests/test_orbit_tube.py"
+      - "protocols/group-calibrated-orbit-tube-mechanism-v1.json"
+      - "scripts/science/run_group_calibrated_orbit_tube_mechanism.py"
+      - "docs/group-calibrated-orbit-tubes.md"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/group-calibrated-orbit-tube-mechanism.yml"
+      - "src/prob4d/orbit_tube.py"
+      - "tests/test_orbit_tube.py"
+      - "protocols/group-calibrated-orbit-tube-mechanism-v1.json"
+      - "scripts/science/run_group_calibrated_orbit_tube_mechanism.py"
+      - "docs/group-calibrated-orbit-tubes.md"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: group-calibrated-orbit-tube-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  mechanism:
+    name: Complete-group calibration and fail-closed certificate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Check out exact revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          clean: true
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v6.0.0
+        with:
+          python-version: "3.12"
+          cache: pip
+
+      - name: Install package and test tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e . pytest
+
+      - name: Run focused unit tests
+        run: python -m pytest -q tests/test_orbit_tube.py
+
+      - name: Run frozen controlled mechanism study
+        run: |
+          mkdir -p outputs/group-calibrated-orbit-tube-mechanism-v1
+          python scripts/science/run_group_calibrated_orbit_tube_mechanism.py \
+            --protocol protocols/group-calibrated-orbit-tube-mechanism-v1.json \
+            --output outputs/group-calibrated-orbit-tube-mechanism-v1/result.json
+
+      - name: Validate scientific and claim boundaries
+        shell: bash
+        run: |
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          path = Path("outputs/group-calibrated-orbit-tube-mechanism-v1/result.json")
+          result = json.loads(path.read_text(encoding="utf-8"))
+          assert result["schema"] == "prob4d.group-calibrated-orbit-tube-mechanism.v1"
+          assert result["evidence_class"] == "constructed-exchangeable-group-mechanism"
+          assert len(result["result_id"]) == 64
+          assert result["finite_sample"]["group_coverage_lower_bound"] == 0.9
+
+          arms = result["arms"]
+          group = arms["complete_group_split_conformal"]
+          pooled = arms["pooled_frames_as_independent"]
+          maximum = arms["largest_calibration_group"]
+          exact = arms["exact_orbit_without_tube"]
+
+          if not 0.88 <= group["group_coverage"] <= 0.92:
+              raise SystemExit("seeded complete-group coverage left its audit band")
+          if not group["group_coverage"] > pooled["group_coverage"] + 0.65:
+              raise SystemExit("frame-pooling control no longer exposes group undercoverage")
+          if not maximum["group_coverage"] > group["group_coverage"]:
+              raise SystemExit("maximum-score control must remain more conservative")
+          if not group["acceptance_fraction"] > maximum["acceptance_fraction"]:
+              raise SystemExit("conformal radius must retain utility over maximum score")
+          if not group["harmful_accepted_fraction"] <= 1.0 - group["group_coverage"] + 1e-12:
+              raise SystemExit("harmful acceptance escaped the noncoverage event")
+          if not exact["group_coverage"] < pooled["group_coverage"]:
+              raise SystemExit("zero-radius control must remain the least covered")
+
+          boundary = " ".join(result["claim_boundary"]).lower()
+          for phrase in (
+              "constructed mechanism",
+              "not public real-data evidence",
+              "does not establish provider competence",
+              "does not establish conditional subgroup coverage",
+          ):
+              if phrase not in boundary:
+                  raise SystemExit(f"missing claim boundary: {phrase}")
+          PY
+
+      - name: Upload compact evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4.6.2
+        with:
+          name: group-calibrated-orbit-tube-mechanism-${{ github.sha }}
+          path: |
+            outputs/group-calibrated-orbit-tube-mechanism-v1/result.json
+            protocols/group-calibrated-orbit-tube-mechanism-v1.json
+            docs/group-calibrated-orbit-tubes.md
+          if-no-files-found: error
+          retention-days: 30

--- a/docs/group-calibrated-orbit-tubes.md
+++ b/docs/group-calibrated-orbit-tubes.md
@@ -1,0 +1,117 @@
+# Group-calibrated approximate-orbit certificates
+
+## Purpose
+
+Prob4D's finite-orbit query certificate is exact when a compatible state is
+known to lie on a declared residual orbit. A learned or geometric provider will
+usually estimate that orbit imperfectly. This module adds an explicit tube around
+the estimated orbit without pretending that approximate symmetry is exact.
+
+The implementation is in `prob4d.orbit_tube`.
+
+## Independent calibration unit
+
+Let recording, object, or trajectory `i` contain nested residual scores
+`r[i, t]`, measuring distance of the compatible complete state from the estimated
+orbit at frame or query instance `t`. The calibration score is
+
+```text
+R_i = max_t r[i, t].
+```
+
+The maximum is deliberate. Treating frames as exchangeable would calibrate a
+random frame, not simultaneous coverage of the complete future trajectory.
+
+For `n` complete calibration groups and miscoverage `alpha`, define
+
+```text
+k = ceil((n + 1) * (1 - alpha)).
+```
+
+When `k <= n`, the tube radius is the `k`-th sorted group score. Under
+exchangeability of the complete calibration groups and one future group,
+
+```text
+P(R_new <= rho_alpha) >= 1 - alpha.
+```
+
+When `k = n + 1`, the requested finite-sample confidence cannot be supported by
+`n` groups. Prob4D records `rho_alpha = infinity` and the downstream certificate
+rejects. It does not silently use the largest calibration score as if it supplied
+the requested coverage.
+
+## Query and decision bounds
+
+Let `O_hat` be the estimated residual orbit, and suppose every compatible state
+lies within metric distance `rho` of `O_hat`.
+
+For an `L_q`-Lipschitz query,
+
+```text
+diam q(C) <= diam q(O_hat) + 2 L_q rho.
+```
+
+For fallback-minus-candidate advantage `D` that is `L_D`-Lipschitz,
+
+```text
+inf_C D >= inf_O_hat D - L_D rho.
+```
+
+With omitted-effect envelope `epsilon`, numerical slack `delta`, and required
+margin `m`, the complete candidate is admitted only if
+
+```text
+inf_O_hat D - L_D rho - epsilon - delta > m
+```
+
+and the inflated query diameter is no larger than its registered tolerance.
+Every other outcome is a rejection. The module returns a decision record only;
+the caller remains responsible for returning the complete fallback state,
+covariance, identity, and provenance atomically.
+
+## Example
+
+```python
+from prob4d.orbit_tube import (
+    certify_orbit_tube,
+    fit_groupwise_orbit_tube,
+)
+
+calibration = fit_groupwise_orbit_tube(
+    complete_recording_scores,
+    miscoverage=0.1,
+)
+
+decision = certify_orbit_tube(
+    calibration,
+    exact_orbit_query_diameter=0.01,
+    query_lipschitz=1.8,
+    query_tolerance=0.05,
+    exact_orbit_advantage_lower_bound=0.20,
+    advantage_lipschitz=2.5,
+    omitted_effect_bound=0.01,
+    numerical_slack=1e-6,
+    required_advantage_margin=0.02,
+)
+
+if decision.accepted:
+    use_complete_candidate()
+else:
+    use_exact_complete_fallback()
+```
+
+## Guarantee boundary
+
+The conformal statement is marginal over an exchangeable future group. It does
+not establish that:
+
+- the orbit estimator has the correct physical symmetry class;
+- calibration and deployment groups are exchangeable;
+- the distance metric is task-complete;
+- the supplied Lipschitz constants or omitted-effect envelope are valid;
+- conditional subgroup coverage holds; or
+- an accepted update is generally safe outside the registered query and loss.
+
+These assumptions must be source-qualified and retained in the evidence record.
+Calibration groups must not be frames from the same trajectory, overlapping
+windows, vertices, particles, or angular quadrature atoms.

--- a/protocols/group-calibrated-orbit-tube-mechanism-v1.json
+++ b/protocols/group-calibrated-orbit-tube-mechanism-v1.json
@@ -1,0 +1,39 @@
+{
+  "claim_boundary": [
+    "Constructed exchangeable-group mechanism study only.",
+    "No public dataset, learned provider, BayesianPhysTwin, or Causal4D outcome is opened.",
+    "Complete simulated trajectories are the independent units.",
+    "The orbit estimator, metric, and Lipschitz constants are assumed correct.",
+    "The study does not establish conditional subgroup coverage or deployment safety."
+  ],
+  "comparison": {
+    "complete_group_split_conformal": "one maximum nonconformity score per complete trajectory",
+    "exact_orbit_without_tube": "sets rho to zero despite approximate-orbit departures",
+    "largest_calibration_group": "conservative maximum complete-group score",
+    "pooled_frames_as_independent": "invalid control that calibrates a random frame rather than a complete trajectory"
+  },
+  "decision_model": {
+    "candidate_advantage": "fallback-minus-candidate advantage before approximate-orbit penalty",
+    "harmful_accept": "the candidate is admitted although the test trajectory maximum departure exceeds its exact-orbit advantage",
+    "query_lipschitz": 1.0,
+    "query_tolerance": "twice the per-trial exact-orbit advantage",
+    "robust_advantage_lipschitz": 1.0
+  },
+  "protocol_id": "group-calibrated-orbit-tube-mechanism-v1",
+  "schema": "prob4d.group-calibrated-orbit-tube-mechanism-protocol.v1",
+  "settings": {
+    "advantage_max": 0.15,
+    "advantage_min": 0.07,
+    "background_fraction_max": 0.15,
+    "background_fraction_min": 0.02,
+    "calibration_groups": 39,
+    "chunk_size": 500,
+    "frames_per_group": 24,
+    "miscoverage": 0.1,
+    "peak_beta_a": 2.0,
+    "peak_beta_b": 5.0,
+    "peak_scale": 0.22,
+    "seed": 240319,
+    "trials": 20000
+  }
+}

--- a/scripts/science/run_group_calibrated_orbit_tube_mechanism.py
+++ b/scripts/science/run_group_calibrated_orbit_tube_mechanism.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Controlled study for complete-group versus pooled-frame orbit calibration."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+SCHEMA = "prob4d.group-calibrated-orbit-tube-mechanism.v1"
+
+
+def _finite_sample_rank(count: int, miscoverage: float) -> int:
+    return math.ceil((count + 1) * (1.0 - miscoverage))
+
+
+def _summarize_arm(
+    *,
+    radii: np.ndarray,
+    test_scores: np.ndarray,
+    exact_advantages: np.ndarray,
+) -> dict[str, float | int]:
+    covered = test_scores <= radii
+    accepted = radii < exact_advantages
+    harmful = test_scores > exact_advantages
+    harmful_accepted = accepted & harmful
+    accepted_count = int(np.count_nonzero(accepted))
+    harmful_count = int(np.count_nonzero(harmful_accepted))
+    return {
+        "trials": int(radii.size),
+        "mean_radius": float(np.mean(radii)),
+        "group_coverage": float(np.mean(covered)),
+        "acceptance_fraction": float(np.mean(accepted)),
+        "harmful_accepted_fraction": float(np.mean(harmful_accepted)),
+        "harmful_fraction_among_accepted": (
+            float(harmful_count / accepted_count) if accepted_count else 0.0
+        ),
+        "accepted": accepted_count,
+        "harmful_accepted": harmful_count,
+    }
+
+
+def run_study(protocol: dict[str, Any]) -> dict[str, Any]:
+    settings = protocol["settings"]
+    seed = int(settings["seed"])
+    trials = int(settings["trials"])
+    calibration_groups = int(settings["calibration_groups"])
+    frames_per_group = int(settings["frames_per_group"])
+    miscoverage = float(settings["miscoverage"])
+    chunk_size = int(settings["chunk_size"])
+
+    if trials <= 0 or calibration_groups <= 0 or frames_per_group <= 1:
+        raise ValueError("trial, group, and frame counts must be positive")
+    if not 0.0 < miscoverage < 1.0:
+        raise ValueError("miscoverage must lie strictly between zero and one")
+
+    group_rank = _finite_sample_rank(calibration_groups, miscoverage)
+    if group_rank > calibration_groups:
+        raise ValueError("protocol requests an unsupported finite group radius")
+    frame_count = calibration_groups * frames_per_group
+    frame_rank = _finite_sample_rank(frame_count, miscoverage)
+    if frame_rank > frame_count:
+        raise ValueError("protocol requests an unsupported finite frame radius")
+
+    rng = np.random.default_rng(seed)
+    group_radii: list[np.ndarray] = []
+    pooled_radii: list[np.ndarray] = []
+    maximum_radii: list[np.ndarray] = []
+    zero_radii: list[np.ndarray] = []
+    test_scores_parts: list[np.ndarray] = []
+    advantage_parts: list[np.ndarray] = []
+
+    completed = 0
+    while completed < trials:
+        batch = min(chunk_size, trials - completed)
+        total_groups = calibration_groups + 1
+
+        # Each exchangeable trajectory has one short-lived maximum departure
+        # from its estimated orbit. The remaining frames are correlated, small
+        # departures. This makes a frame-wise quantile a deliberately invalid
+        # substitute for complete-trajectory coverage.
+        group_peaks = (
+            float(settings["peak_scale"])
+            * rng.beta(
+                float(settings["peak_beta_a"]),
+                float(settings["peak_beta_b"]),
+                size=(batch, total_groups),
+            )
+        )
+        residuals = group_peaks[:, :, None] * rng.uniform(
+            float(settings["background_fraction_min"]),
+            float(settings["background_fraction_max"]),
+            size=(batch, total_groups, frames_per_group),
+        )
+        peak_indices = rng.integers(
+            0,
+            frames_per_group,
+            size=(batch, total_groups),
+        )
+        batch_indices = np.arange(batch)[:, None]
+        group_indices = np.arange(total_groups)[None, :]
+        residuals[batch_indices, group_indices, peak_indices] = group_peaks
+
+        calibration_residuals = residuals[:, :calibration_groups, :]
+        calibration_group_scores = np.max(calibration_residuals, axis=2)
+        test_group_scores = np.max(residuals[:, -1, :], axis=1)
+
+        group_radius = np.partition(
+            calibration_group_scores,
+            group_rank - 1,
+            axis=1,
+        )[:, group_rank - 1]
+        pooled = calibration_residuals.reshape(batch, frame_count)
+        pooled_radius = np.partition(
+            pooled,
+            frame_rank - 1,
+            axis=1,
+        )[:, frame_rank - 1]
+        maximum_radius = np.max(calibration_group_scores, axis=1)
+
+        exact_advantage = rng.uniform(
+            float(settings["advantage_min"]),
+            float(settings["advantage_max"]),
+            size=batch,
+        )
+
+        group_radii.append(group_radius)
+        pooled_radii.append(pooled_radius)
+        maximum_radii.append(maximum_radius)
+        zero_radii.append(np.zeros(batch, dtype=float))
+        test_scores_parts.append(test_group_scores)
+        advantage_parts.append(exact_advantage)
+        completed += batch
+
+    test_scores = np.concatenate(test_scores_parts)
+    advantages = np.concatenate(advantage_parts)
+    arms = {
+        "complete_group_split_conformal": _summarize_arm(
+            radii=np.concatenate(group_radii),
+            test_scores=test_scores,
+            exact_advantages=advantages,
+        ),
+        "pooled_frames_as_independent": _summarize_arm(
+            radii=np.concatenate(pooled_radii),
+            test_scores=test_scores,
+            exact_advantages=advantages,
+        ),
+        "largest_calibration_group": _summarize_arm(
+            radii=np.concatenate(maximum_radii),
+            test_scores=test_scores,
+            exact_advantages=advantages,
+        ),
+        "exact_orbit_without_tube": _summarize_arm(
+            radii=np.concatenate(zero_radii),
+            test_scores=test_scores,
+            exact_advantages=advantages,
+        ),
+    }
+
+    group_arm = arms["complete_group_split_conformal"]
+    coverage_failure = 1.0 - float(group_arm["group_coverage"])
+    harmful_acceptance = float(group_arm["harmful_accepted_fraction"])
+    if harmful_acceptance > coverage_failure + 1e-12:
+        raise AssertionError("harmful group acceptance must imply tube noncoverage")
+
+    result: dict[str, Any] = {
+        "schema": SCHEMA,
+        "schema_version": 1,
+        "evidence_class": "constructed-exchangeable-group-mechanism",
+        "protocol_id": protocol["protocol_id"],
+        "settings": settings,
+        "finite_sample": {
+            "group_quantile_rank": group_rank,
+            "group_coverage_lower_bound": group_rank
+            / (calibration_groups + 1.0),
+            "minimum_miscoverage_for_finite_radius": 1.0
+            / (calibration_groups + 1.0),
+            "pooled_frame_quantile_rank": frame_rank,
+            "pooled_frame_claim": (
+                "random-frame coverage only; not simultaneous future-group coverage"
+            ),
+        },
+        "arms": arms,
+        "algebraic_checks": {
+            "harmful_group_accept_implies_noncoverage": True,
+            "group_harmful_accepted_fraction_no_larger_than_noncoverage": True,
+        },
+        "claim_boundary": [
+            "This is a constructed mechanism study, not public real-data evidence.",
+            "The exchangeable unit is one complete simulated trajectory.",
+            "The exact orbit estimator, metric, and Lipschitz constants are assumed.",
+            "The study does not establish conditional subgroup coverage.",
+            "The study does not establish provider competence or deployment safety.",
+        ],
+    }
+    canonical = json.dumps(
+        result,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    result["result_id"] = hashlib.sha256(canonical).hexdigest()
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--protocol",
+        type=Path,
+        default=Path("protocols/group-calibrated-orbit-tube-mechanism-v1.json"),
+    )
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    protocol = json.loads(args.protocol.read_text(encoding="utf-8"))
+    result = run_study(protocol)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(result, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/prob4d/orbit_tube.py
+++ b/src/prob4d/orbit_tube.py
@@ -1,0 +1,343 @@
+"""Group-calibrated tubes around estimated residual transformation orbits.
+
+The finite-orbit certificate in :mod:`prob4d.axial_query_certificate` is exact
+when the compatible state is known to lie on the declared orbit.  Real
+providers usually supply only an estimated orbit.  This module adds a small,
+auditable bridge: calibrate a radius from *complete independent groups* and
+penalize query diameter and candidate advantage by Lipschitz bounds.
+
+The statistical guarantee is marginal and conditional on exchangeability of
+the calibration groups and the future group.  It is not a guarantee that the
+orbit estimator, metric, or Lipschitz constants are physically correct.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+import hashlib
+import json
+import math
+
+
+_CALIBRATION_SCHEMA = "prob4d.split-conformal-orbit-tube.v1"
+
+
+def _finite_nonnegative(value: float, *, name: str) -> float:
+    result = float(value)
+    if not math.isfinite(result) or result < 0.0:
+        raise ValueError(f"{name} must be finite and nonnegative")
+    return result
+
+
+def _finite(value: float, *, name: str) -> float:
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"{name} must be finite")
+    return result
+
+
+def group_max_nonconformity(groups: Iterable[Iterable[float]]) -> tuple[float, ...]:
+    """Collapse nested observations to one maximum score per independent group.
+
+    A trajectory-level statement requires trajectories (or another declared
+    complete group) as the exchangeable units.  Pooling frames would calibrate
+    frame coverage and does not generally control simultaneous coverage of a
+    future trajectory.
+    """
+
+    maxima: list[float] = []
+    for group_index, group in enumerate(groups):
+        values = tuple(
+            _finite_nonnegative(value, name=f"groups[{group_index}] score")
+            for value in group
+        )
+        if not values:
+            raise ValueError(f"groups[{group_index}] must not be empty")
+        maxima.append(max(values))
+    if not maxima:
+        raise ValueError("at least one calibration group is required")
+    return tuple(maxima)
+
+
+@dataclass(frozen=True, slots=True)
+class SplitConformalOrbitTube:
+    """A split-conformal radius calibrated from complete-group scores."""
+
+    miscoverage: float
+    radius: float
+    calibration_group_count: int
+    quantile_rank: int
+    coverage_lower_bound: float
+    sorted_group_scores: tuple[float, ...]
+    calibration_id: str
+
+    @property
+    def finite_radius(self) -> bool:
+        """Whether the requested confidence is supportable with finite radius."""
+
+        return math.isfinite(self.radius)
+
+    @property
+    def minimum_miscoverage_for_finite_radius(self) -> float:
+        """Smallest nominal miscoverage supportable by this sample size."""
+
+        return 1.0 / (self.calibration_group_count + 1.0)
+
+    def covers(self, group_score: float) -> bool:
+        """Return whether one complete-group score lies inside the tube."""
+
+        score = _finite_nonnegative(group_score, name="group_score")
+        return score <= self.radius
+
+
+def fit_split_conformal_orbit_tube(
+    group_scores: Iterable[float],
+    *,
+    miscoverage: float,
+) -> SplitConformalOrbitTube:
+    """Fit the standard finite-sample split-conformal ``higher`` quantile.
+
+    Let ``n`` be the number of complete calibration groups and
+    ``k = ceil((n + 1) * (1 - miscoverage))``.  The radius is the ``k``-th
+    calibration order statistic.  When ``k == n + 1``, finite calibration is
+    impossible from ``n`` groups, so the radius is infinity and every downstream
+    certificate fails closed.
+    """
+
+    alpha = float(miscoverage)
+    if not math.isfinite(alpha) or not 0.0 < alpha < 1.0:
+        raise ValueError("miscoverage must lie strictly between zero and one")
+
+    scores = tuple(
+        sorted(
+            _finite_nonnegative(score, name="group_score")
+            for score in group_scores
+        )
+    )
+    if not scores:
+        raise ValueError("at least one calibration group score is required")
+
+    count = len(scores)
+    rank = math.ceil((count + 1) * (1.0 - alpha))
+    radius = scores[rank - 1] if rank <= count else math.inf
+    coverage_lower_bound = min(rank / (count + 1.0), 1.0)
+
+    payload = {
+        "schema": _CALIBRATION_SCHEMA,
+        "miscoverage": alpha,
+        "quantile_rank": rank,
+        "radius": radius if math.isfinite(radius) else "infinity",
+        "sorted_group_scores": scores,
+    }
+    encoded = json.dumps(
+        payload,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    calibration_id = hashlib.sha256(encoded).hexdigest()
+
+    return SplitConformalOrbitTube(
+        miscoverage=alpha,
+        radius=radius,
+        calibration_group_count=count,
+        quantile_rank=rank,
+        coverage_lower_bound=coverage_lower_bound,
+        sorted_group_scores=scores,
+        calibration_id=calibration_id,
+    )
+
+
+def fit_groupwise_orbit_tube(
+    groups: Iterable[Iterable[float]],
+    *,
+    miscoverage: float,
+) -> SplitConformalOrbitTube:
+    """Collapse complete groups and fit a split-conformal orbit tube."""
+
+    return fit_split_conformal_orbit_tube(
+        group_max_nonconformity(groups),
+        miscoverage=miscoverage,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class OrbitTubeDecision:
+    """Auditable result of a query-and-advantage tube certificate."""
+
+    accepted: bool
+    reasons: tuple[str, ...]
+    calibration_id: str
+    tube_radius: float
+    exact_orbit_query_diameter: float
+    query_tube_penalty: float
+    query_diameter_upper_bound: float
+    query_tolerance: float
+    exact_orbit_advantage_lower_bound: float
+    advantage_tube_penalty: float
+    omitted_effect_bound: float
+    numerical_slack: float
+    robust_advantage_lower_bound: float
+    required_advantage_margin: float
+
+
+def query_diameter_tube_bound(
+    *,
+    exact_orbit_diameter: float,
+    query_lipschitz: float,
+    radius: float,
+) -> float:
+    """Bound query diameter on a radius-``rho`` tube around an orbit.
+
+    If ``q`` is ``L_q``-Lipschitz and every compatible state lies within
+    ``rho`` of the estimated orbit, then
+
+    ``diam(q(C)) <= diam(q(O_hat)) + 2 * L_q * rho``.
+    """
+
+    diameter = _finite_nonnegative(
+        exact_orbit_diameter,
+        name="exact_orbit_diameter",
+    )
+    lipschitz = _finite_nonnegative(query_lipschitz, name="query_lipschitz")
+    rho = float(radius)
+    if math.isnan(rho) or rho < 0.0:
+        raise ValueError("radius must be nonnegative and not NaN")
+    if not math.isfinite(rho):
+        return diameter if lipschitz == 0.0 else math.inf
+    return diameter + 2.0 * lipschitz * rho
+
+
+def robust_advantage_tube_bound(
+    *,
+    exact_orbit_advantage_lower_bound: float,
+    advantage_lipschitz: float,
+    radius: float,
+    omitted_effect_bound: float = 0.0,
+    numerical_slack: float = 0.0,
+) -> float:
+    """Lower-bound candidate advantage on an approximate-orbit tube.
+
+    For fallback-minus-candidate advantage ``D`` that is ``L_D``-Lipschitz,
+
+    ``inf_C D >= inf_O_hat D - L_D * rho``.
+
+    Declared omitted-effect and numerical envelopes are subtracted as additional
+    fail-closed penalties.
+    """
+
+    advantage = _finite(
+        exact_orbit_advantage_lower_bound,
+        name="exact_orbit_advantage_lower_bound",
+    )
+    lipschitz = _finite_nonnegative(
+        advantage_lipschitz,
+        name="advantage_lipschitz",
+    )
+    omitted = _finite_nonnegative(
+        omitted_effect_bound,
+        name="omitted_effect_bound",
+    )
+    slack = _finite_nonnegative(numerical_slack, name="numerical_slack")
+    rho = float(radius)
+    if math.isnan(rho) or rho < 0.0:
+        raise ValueError("radius must be nonnegative and not NaN")
+    if not math.isfinite(rho):
+        return advantage - omitted - slack if lipschitz == 0.0 else -math.inf
+    return advantage - lipschitz * rho - omitted - slack
+
+
+def certify_orbit_tube(
+    calibration: SplitConformalOrbitTube,
+    *,
+    exact_orbit_query_diameter: float,
+    query_lipschitz: float,
+    query_tolerance: float,
+    exact_orbit_advantage_lower_bound: float,
+    advantage_lipschitz: float,
+    required_advantage_margin: float = 0.0,
+    omitted_effect_bound: float = 0.0,
+    numerical_slack: float = 0.0,
+) -> OrbitTubeDecision:
+    """Certify a complete candidate under group-calibrated approximate symmetry.
+
+    Admission requires a finite calibrated radius, a query-diameter upper bound
+    no larger than the registered tolerance, and a strict robust-advantage lower
+    bound above the requested margin.  Otherwise callers must use the complete
+    fallback; this function never constructs a partially updated state.
+    """
+
+    tolerance = float(query_tolerance)
+    if math.isnan(tolerance) or tolerance < 0.0:
+        raise ValueError("query_tolerance must be nonnegative and not NaN")
+    margin = _finite_nonnegative(
+        required_advantage_margin,
+        name="required_advantage_margin",
+    )
+
+    exact_diameter = _finite_nonnegative(
+        exact_orbit_query_diameter,
+        name="exact_orbit_query_diameter",
+    )
+    q_lipschitz = _finite_nonnegative(query_lipschitz, name="query_lipschitz")
+    exact_advantage = _finite(
+        exact_orbit_advantage_lower_bound,
+        name="exact_orbit_advantage_lower_bound",
+    )
+    d_lipschitz = _finite_nonnegative(
+        advantage_lipschitz,
+        name="advantage_lipschitz",
+    )
+    omitted = _finite_nonnegative(
+        omitted_effect_bound,
+        name="omitted_effect_bound",
+    )
+    slack = _finite_nonnegative(numerical_slack, name="numerical_slack")
+
+    query_upper = query_diameter_tube_bound(
+        exact_orbit_diameter=exact_diameter,
+        query_lipschitz=q_lipschitz,
+        radius=calibration.radius,
+    )
+    advantage_lower = robust_advantage_tube_bound(
+        exact_orbit_advantage_lower_bound=exact_advantage,
+        advantage_lipschitz=d_lipschitz,
+        radius=calibration.radius,
+        omitted_effect_bound=omitted,
+        numerical_slack=slack,
+    )
+
+    if math.isfinite(calibration.radius):
+        query_penalty = 2.0 * q_lipschitz * calibration.radius
+        advantage_tube_penalty = d_lipschitz * calibration.radius
+    else:
+        query_penalty = 0.0 if q_lipschitz == 0.0 else math.inf
+        advantage_tube_penalty = 0.0 if d_lipschitz == 0.0 else math.inf
+
+    reasons: list[str] = []
+    if not calibration.finite_radius:
+        reasons.append("finite-sample-confidence-not-supportable")
+    if query_upper > tolerance:
+        reasons.append("query-diameter-exceeds-tolerance")
+    if not advantage_lower > margin:
+        reasons.append("robust-advantage-not-above-margin")
+    if not reasons:
+        reasons.append("certified")
+
+    return OrbitTubeDecision(
+        accepted=reasons == ["certified"],
+        reasons=tuple(reasons),
+        calibration_id=calibration.calibration_id,
+        tube_radius=calibration.radius,
+        exact_orbit_query_diameter=exact_diameter,
+        query_tube_penalty=query_penalty,
+        query_diameter_upper_bound=query_upper,
+        query_tolerance=tolerance,
+        exact_orbit_advantage_lower_bound=exact_advantage,
+        advantage_tube_penalty=advantage_tube_penalty,
+        omitted_effect_bound=omitted,
+        numerical_slack=slack,
+        robust_advantage_lower_bound=advantage_lower,
+        required_advantage_margin=margin,
+    )

--- a/tests/test_orbit_tube.py
+++ b/tests/test_orbit_tube.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from prob4d.orbit_tube import (
+    certify_orbit_tube,
+    fit_groupwise_orbit_tube,
+    fit_split_conformal_orbit_tube,
+    group_max_nonconformity,
+    query_diameter_tube_bound,
+    robust_advantage_tube_bound,
+)
+
+
+def test_group_max_nonconformity_uses_complete_groups() -> None:
+    scores = group_max_nonconformity(
+        [
+            [0.1, 0.3, 0.2],
+            [0.05, 0.04],
+            [0.7],
+        ]
+    )
+    assert scores == (0.3, 0.05, 0.7)
+
+
+def test_group_max_nonconformity_fails_closed_on_bad_groups() -> None:
+    with pytest.raises(ValueError, match="at least one calibration group"):
+        group_max_nonconformity([])
+    with pytest.raises(ValueError, match="must not be empty"):
+        group_max_nonconformity([[0.1], []])
+    with pytest.raises(ValueError, match="finite and nonnegative"):
+        group_max_nonconformity([[0.1, math.nan]])
+    with pytest.raises(ValueError, match="finite and nonnegative"):
+        group_max_nonconformity([[0.1, -0.2]])
+
+
+def test_split_conformal_uses_finite_sample_higher_rank() -> None:
+    calibration = fit_split_conformal_orbit_tube(
+        range(1, 10),
+        miscoverage=0.2,
+    )
+    # n=9 and ceil((n+1)*(1-alpha))=ceil(8)=8.
+    assert calibration.quantile_rank == 8
+    assert calibration.radius == 8.0
+    assert calibration.coverage_lower_bound == pytest.approx(0.8)
+    assert calibration.minimum_miscoverage_for_finite_radius == pytest.approx(0.1)
+    assert calibration.finite_radius
+    assert calibration.covers(8.0)
+    assert not calibration.covers(8.1)
+
+
+def test_calibration_identity_is_order_invariant() -> None:
+    forward = fit_split_conformal_orbit_tube(
+        [0.3, 0.1, 0.2, 0.4],
+        miscoverage=0.25,
+    )
+    reverse = fit_split_conformal_orbit_tube(
+        [0.4, 0.2, 0.1, 0.3],
+        miscoverage=0.25,
+    )
+    assert forward == reverse
+    assert len(forward.calibration_id) == 64
+
+
+def test_impossible_finite_sample_confidence_returns_infinite_radius() -> None:
+    calibration = fit_split_conformal_orbit_tube(
+        [0.1, 0.2, 0.3, 0.4],
+        miscoverage=0.05,
+    )
+    # Four groups cannot support 95% finite split-conformal coverage:
+    # ceil(5*0.95)=5, but only four calibration order statistics exist.
+    assert calibration.quantile_rank == 5
+    assert calibration.coverage_lower_bound == 1.0
+    assert math.isinf(calibration.radius)
+    assert not calibration.finite_radius
+
+    decision = certify_orbit_tube(
+        calibration,
+        exact_orbit_query_diameter=0.0,
+        query_lipschitz=0.0,
+        query_tolerance=0.0,
+        exact_orbit_advantage_lower_bound=1.0,
+        advantage_lipschitz=0.0,
+    )
+    assert not decision.accepted
+    assert decision.reasons == ("finite-sample-confidence-not-supportable",)
+
+
+def test_zero_radius_recovers_exact_orbit_certificate() -> None:
+    calibration = fit_split_conformal_orbit_tube(
+        [0.0] * 9,
+        miscoverage=0.2,
+    )
+    decision = certify_orbit_tube(
+        calibration,
+        exact_orbit_query_diameter=0.02,
+        query_lipschitz=10.0,
+        query_tolerance=0.02,
+        exact_orbit_advantage_lower_bound=0.5,
+        advantage_lipschitz=20.0,
+        required_advantage_margin=0.1,
+        omitted_effect_bound=0.05,
+        numerical_slack=0.01,
+    )
+    assert decision.accepted
+    assert decision.reasons == ("certified",)
+    assert decision.query_diameter_upper_bound == pytest.approx(0.02)
+    assert decision.robust_advantage_lower_bound == pytest.approx(0.44)
+
+
+def test_lipschitz_tube_penalties_are_exactly_reported() -> None:
+    calibration = fit_split_conformal_orbit_tube(
+        [0.2] * 9,
+        miscoverage=0.2,
+    )
+    decision = certify_orbit_tube(
+        calibration,
+        exact_orbit_query_diameter=0.1,
+        query_lipschitz=2.0,
+        query_tolerance=0.9,
+        exact_orbit_advantage_lower_bound=1.0,
+        advantage_lipschitz=1.5,
+        required_advantage_margin=0.5,
+        omitted_effect_bound=0.1,
+        numerical_slack=0.02,
+    )
+    assert decision.query_tube_penalty == pytest.approx(0.8)
+    assert decision.query_diameter_upper_bound == pytest.approx(0.9)
+    assert decision.advantage_tube_penalty == pytest.approx(0.3)
+    assert decision.robust_advantage_lower_bound == pytest.approx(0.58)
+    assert decision.accepted
+
+
+def test_query_and_advantage_failures_are_distinguished() -> None:
+    calibration = fit_groupwise_orbit_tube(
+        [[0.1, 0.2], [0.2, 0.2], [0.15], [0.2]],
+        miscoverage=0.25,
+    )
+    decision = certify_orbit_tube(
+        calibration,
+        exact_orbit_query_diameter=0.3,
+        query_lipschitz=1.0,
+        query_tolerance=0.5,
+        exact_orbit_advantage_lower_bound=0.2,
+        advantage_lipschitz=1.0,
+        required_advantage_margin=0.1,
+    )
+    assert not decision.accepted
+    assert decision.reasons == (
+        "query-diameter-exceeds-tolerance",
+        "robust-advantage-not-above-margin",
+    )
+
+
+def test_standalone_bounds_handle_zero_lipschitz_and_infinite_radius() -> None:
+    assert query_diameter_tube_bound(
+        exact_orbit_diameter=0.3,
+        query_lipschitz=0.0,
+        radius=math.inf,
+    ) == pytest.approx(0.3)
+    assert robust_advantage_tube_bound(
+        exact_orbit_advantage_lower_bound=0.4,
+        advantage_lipschitz=0.0,
+        radius=math.inf,
+        omitted_effect_bound=0.1,
+        numerical_slack=0.02,
+    ) == pytest.approx(0.28)
+
+
+def test_invalid_calibration_and_certificate_inputs_fail_closed() -> None:
+    with pytest.raises(ValueError, match="strictly between"):
+        fit_split_conformal_orbit_tube([0.1], miscoverage=0.0)
+    with pytest.raises(ValueError, match="strictly between"):
+        fit_split_conformal_orbit_tube([0.1], miscoverage=1.0)
+    with pytest.raises(ValueError, match="at least one"):
+        fit_split_conformal_orbit_tube([], miscoverage=0.2)
+    with pytest.raises(ValueError, match="finite and nonnegative"):
+        fit_split_conformal_orbit_tube([math.inf], miscoverage=0.2)
+
+    calibration = fit_split_conformal_orbit_tube(
+        [0.1] * 9,
+        miscoverage=0.2,
+    )
+    with pytest.raises(ValueError, match="query_tolerance"):
+        certify_orbit_tube(
+            calibration,
+            exact_orbit_query_diameter=0.0,
+            query_lipschitz=1.0,
+            query_tolerance=-1.0,
+            exact_orbit_advantage_lower_bound=1.0,
+            advantage_lipschitz=1.0,
+        )


### PR DESCRIPTION
## Purpose

Extend the finite-orbit query gate from exact declared symmetry to an auditable tube around an estimated orbit, without pretending that approximate symmetry is exact.

## Method

This PR adds `prob4d.orbit_tube` with:

- one maximum nonconformity score per complete independent calibration group;
- the finite-sample split-conformal higher quantile;
- an explicit infinite-radius outcome when the requested confidence cannot be supported by the available number of groups;
- the query bound `diam q(C) <= diam q(O_hat) + 2 L_q rho`;
- the robust-advantage bound `inf_C D >= inf_O_hat D - L_D rho`;
- omitted-effect and numerical penalties;
- strict complete-candidate admission or rejection records suitable for exact caller-owned fallback; and
- content-addressed calibration identity.

The API deliberately does not construct or mutate a physical belief. It returns an auditable certificate; callers retain responsibility for atomic complete fallback.

## Tests

Focused tests cover:

- complete-group maximum aggregation;
- exact finite-sample rank selection;
- impossible confidence levels returning infinite radius and rejection;
- order-invariant calibration identity;
- recovery of the exact-orbit certificate at `rho=0`;
- exact Lipschitz penalties;
- independent query and advantage failure reasons; and
- fail-closed invalid inputs.

## Controlled mechanism study

A frozen 20,000-trial study compares:

1. complete-group split conformal calibration;
2. incorrectly pooled correlated frames;
3. the largest calibration-group score; and
4. an exact-orbit zero-radius control.

The study uses complete simulated trajectories as exchangeable units. It tests the expected tradeoff: group calibration controls future-trajectory coverage while retaining more admissions than the maximum-score rule; pooled frames calibrate a random frame and under-cover complete trajectories.

## Claim boundary

This PR introduces a general method and a constructed mechanism study. It does not provide public real-data calibration of an estimated orbit, learned-provider competence, conditional subgroup coverage, BayesianPhysTwin/Causal4D benefit, deployment safety, or state of the art. A separate source-frozen public-data protocol is still required before promoting the approximate-orbit layer into the paper's empirical claim.