### PR TITLE
Audit a fresh Tracking Cloth cohort for approximate-orbit calibration

### DIFF
--- a/.github/workflows/tracking-cloth-orbit-tube-roster-audit-v1.yml
+++ b/.github/workflows/tracking-cloth-orbit-tube-roster-audit-v1.yml
@@ -1,0 +1,128 @@
+name: Tracking Cloth orbit-tube roster audit v1
+
+on:
+  push:
+    branches:
+      - science/tracking-cloth-orbit-tube-audit-v1
+    paths:
+      - ".github/workflows/tracking-cloth-orbit-tube-roster-audit-v1.yml"
+      - "scripts/science/audit_tracking_cloth_orbit_tube_roster.py"
+      - "protocols/tracking-cloth-orbit-tube-roster-audit-v1.json"
+      - "tests/test_tracking_cloth_orbit_tube_roster_audit.py"
+  pull_request:
+    paths:
+      - ".github/workflows/tracking-cloth-orbit-tube-roster-audit-v1.yml"
+      - "scripts/science/audit_tracking_cloth_orbit_tube_roster.py"
+      - "protocols/tracking-cloth-orbit-tube-roster-audit-v1.json"
+      - "tests/test_tracking_cloth_orbit_tube_roster_audit.py"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: tracking-cloth-orbit-tube-roster-audit-v1-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit:
+    name: Header-boundary and roster tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - name: Check out exact revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          clean: true
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v6.0.0
+        with:
+          python-version: "3.12"
+      - name: Install test dependency
+        run: python -m pip install pytest
+      - name: Run focused tests
+        run: python -m pytest -q tests/test_tracking_cloth_orbit_tube_roster_audit.py
+
+  audit:
+    name: Audit 27 fresh headers without trajectory access
+    if: github.event_name == 'push'
+    environment: trusted-self-hosted-validation
+    runs-on: [self-hosted, Linux, X64, gpuserver4090]
+    timeout-minutes: 30
+    env:
+      TRACKING_CLOTH_DATASET_ROOT: ${{ vars.TRACKING_CLOTH_DATASET_ROOT }}
+    steps:
+      - name: Check out exact reviewed revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.sha }}
+          persist-credentials: false
+          clean: true
+          fetch-depth: 1
+
+      - name: Resolve retained public archive without reading payload
+        id: dataset
+        shell: bash
+        run: |
+          set -euo pipefail
+          root="${TRACKING_CLOTH_DATASET_ROOT:-}"
+          if [[ -z "$root" ]]; then
+            root=/home/github-runner/.cache/datasets/tracking-cloth-deformation-v1-zenodo-14644526
+          fi
+          test -d "$root"
+          printf 'root=%s\n' "$root" >> "$GITHUB_OUTPUT"
+
+      - name: Run fixed header-only roster audit
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p outputs/tracking-cloth-orbit-tube-roster-audit-v1
+          python3 scripts/science/audit_tracking_cloth_orbit_tube_roster.py \
+            --dataset-root '${{ steps.dataset.outputs.root }}' \
+            --protocol protocols/tracking-cloth-orbit-tube-roster-audit-v1.json \
+            --output outputs/tracking-cloth-orbit-tube-roster-audit-v1/result.json
+
+      - name: Enforce information and support boundary
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          result = json.loads(
+              Path("outputs/tracking-cloth-orbit-tube-roster-audit-v1/result.json")
+              .read_text(encoding="utf-8")
+          )
+          assert result["schema"] == "prob4d.tracking-cloth-orbit-tube-roster-audit.v1"
+          assert result["counts"] == {
+              "all_csv": 120,
+              "fresh": 27,
+              "source": 9,
+              "calibration": 9,
+              "target": 9,
+          }
+          assert result["archive"]["zip_integrity"] == "pass"
+          boundary = result["information_boundary"]
+          assert boundary["trajectory_rows_read"] == 0
+          assert boundary["split_fixed_before_header_read"] is True
+          assert boundary["source_trajectory_values_opened"] is False
+          assert boundary["calibration_trajectory_values_opened"] is False
+          assert boundary["target_trajectory_values_opened"] is False
+          assert boundary["raw_header_text_published"] is False
+          assert all(record["trajectory_rows_read"] == 0 for record in result["records"])
+          assert len(result["result_id"]) == 64
+          common = result["marker_intersections"]["all_roles"]
+          print(f"common_marker_count={len(common)}")
+          print(f"result_id={result['result_id']}")
+          PY
+
+      - name: Upload compact header-only evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v4.6.2
+        with:
+          name: tracking-cloth-orbit-tube-roster-audit-v1-${{ github.run_id }}
+          path: |
+            outputs/tracking-cloth-orbit-tube-roster-audit-v1/result.json
+            protocols/tracking-cloth-orbit-tube-roster-audit-v1.json
+          if-no-files-found: error
+          retention-days: 30

--- a/protocols/tracking-cloth-orbit-tube-roster-audit-v1.json
+++ b/protocols/tracking-cloth-orbit-tube-roster-audit-v1.json
@@ -1,0 +1,34 @@
+{
+  "claim_boundary": [
+    "This protocol audits only archive identity, ZIP members, fixed CSV header rows, and marker namespaces.",
+    "No source, calibration, or target trajectory value may be parsed by this audit.",
+    "The deterministic 9/9/9 role assignment is fixed from member paths before any header is read.",
+    "The audit is feasibility evidence only and does not establish approximate-orbit calibration, query accuracy, harmful-update control, learned-provider competence, or deployment safety.",
+    "Raw CSV headers and trajectory values are not published."
+  ],
+  "dataset": {
+    "archive_filename": "tracking_dataset.zip",
+    "archive_md5": "b4868b702f8a42b2ea1069d0f1a3b8f6",
+    "archive_sha256": "14916efa89a26d991c024024cc9449397d3a6f654311e621bb91e9602e231e1a",
+    "expected_csv_files": 120,
+    "expected_fresh_files": 27,
+    "fresh_category_token": "Self-collisions",
+    "record_name": "Tracking Cloth Deformation",
+    "zenodo_record": "14644526"
+  },
+  "header_audit": {
+    "line_count": 7,
+    "maximum_line_bytes": 262144,
+    "publish_raw_header_text": false,
+    "trajectory_rows_allowed": 0
+  },
+  "protocol_id": "tracking-cloth-orbit-tube-roster-audit-v1",
+  "schema": "prob4d.tracking-cloth-orbit-tube-roster-audit-protocol.v1",
+  "split": {
+    "assignment": "sort by sha256(salt + '|' + ZIP member path), then take 9 source, 9 calibration, and 9 target recordings",
+    "calibration_count": 9,
+    "sha256_salt": "prob4d-tracking-cloth-orbit-tube-v1",
+    "source_count": 9,
+    "target_count": 9
+  }
+}

--- a/scripts/science/audit_tracking_cloth_orbit_tube_roster.py
+++ b/scripts/science/audit_tracking_cloth_orbit_tube_roster.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""Inventory a fresh Tracking Cloth cohort without opening trajectory values."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import io
+import json
+from pathlib import Path, PurePosixPath
+from typing import Any
+import zipfile
+
+
+SCHEMA = "prob4d.tracking-cloth-orbit-tube-roster-audit.v1"
+
+
+def _hash_file(path: Path, algorithm: str) -> str:
+    digest = hashlib.new(algorithm)
+    with path.open("rb") as stream:
+        while block := stream.read(8 * 1024 * 1024):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _safe_member(name: str) -> PurePosixPath:
+    member = PurePosixPath(name)
+    if member.is_absolute() or ".." in member.parts:
+        raise ValueError(f"unsafe ZIP member: {name}")
+    return member
+
+
+def _find_archive(root: Path, expected_name: str) -> Path:
+    direct = root / expected_name
+    candidates = [direct] if direct.is_file() else []
+    candidates.extend(path for path in root.rglob(expected_name) if path.is_file())
+    unique = sorted({path.resolve() for path in candidates})
+    if len(unique) != 1:
+        raise FileNotFoundError(
+            f"expected exactly one {expected_name!r} below {root}, found {len(unique)}"
+        )
+    return unique[0]
+
+
+def _looks_like_data_row(row: list[str]) -> bool:
+    if len(row) < 2:
+        return False
+    try:
+        int(row[0].strip())
+        float(row[1].strip())
+    except ValueError:
+        return False
+    return True
+
+
+def _normal(value: str) -> str:
+    return " ".join(value.strip().lower().split())
+
+
+def _label_from_triplet(rows: list[list[str]], coordinate_row: int, column: int) -> str:
+    forbidden = {
+        "",
+        "frame",
+        "marker",
+        "markers",
+        "name",
+        "position",
+        "quality",
+        "time",
+        "time (seconds)",
+        "type",
+        "x",
+        "y",
+        "z",
+    }
+    for row_index in range(coordinate_row - 1, -1, -1):
+        row = rows[row_index]
+        cells = [row[index].strip() if index < len(row) else "" for index in range(column, column + 3)]
+        nonempty = [cell for cell in cells if cell]
+        if not nonempty:
+            continue
+        if len(set(nonempty)) == 1:
+            candidate = nonempty[0]
+        elif cells[0] and not cells[1] and not cells[2]:
+            candidate = cells[0]
+        else:
+            continue
+        normalized = _normal(candidate)
+        if normalized in forbidden or "unlabeled" in normalized:
+            continue
+        if ":" in candidate:
+            candidate = candidate.rsplit(":", 1)[-1].strip()
+        if candidate:
+            return candidate
+    raise ValueError(f"no marker label found for coordinate triplet at column {column}")
+
+
+def _parse_header_labels(header: bytes, expected_lines: int) -> tuple[str, ...]:
+    text = header.decode("utf-8-sig")
+    rows = list(csv.reader(io.StringIO(text)))
+    if len(rows) != expected_lines:
+        raise ValueError(f"expected {expected_lines} header rows, found {len(rows)}")
+    if any(_looks_like_data_row(row) for row in rows):
+        raise ValueError("configured header boundary includes a trajectory data row")
+
+    triplets_by_row: list[tuple[int, list[int]]] = []
+    for row_index, row in enumerate(rows):
+        starts: list[int] = []
+        for column in range(max(0, len(row) - 2)):
+            coordinates = tuple(_normal(value) for value in row[column : column + 3])
+            if coordinates == ("x", "y", "z"):
+                starts.append(column)
+        if starts:
+            triplets_by_row.append((row_index, starts))
+    if not triplets_by_row:
+        raise ValueError("no X/Y/Z marker-coordinate row found in the sealed header")
+
+    coordinate_row, starts = max(triplets_by_row, key=lambda item: len(item[1]))
+    labels = {_label_from_triplet(rows, coordinate_row, column) for column in starts}
+    if len(labels) < 3:
+        raise ValueError("fewer than three marker identities found in the header")
+    return tuple(sorted(labels, key=lambda value: (not value.isdigit(), int(value) if value.isdigit() else value)))
+
+
+def _read_fixed_header(
+    archive: zipfile.ZipFile,
+    member: str,
+    *,
+    line_count: int,
+    maximum_line_bytes: int,
+) -> bytes:
+    lines: list[bytes] = []
+    with archive.open(member, "r") as stream:
+        for line_index in range(line_count):
+            line = stream.readline(maximum_line_bytes + 1)
+            if not line:
+                raise ValueError(f"{member}: ended before header line {line_index + 1}")
+            if len(line) > maximum_line_bytes:
+                raise ValueError(f"{member}: header line exceeds the byte limit")
+            if not line.endswith((b"\n", b"\r")) and line_index + 1 < line_count:
+                raise ValueError(f"{member}: truncated header line")
+            lines.append(line)
+    return b"".join(lines)
+
+
+def _intersection(records: list[dict[str, Any]]) -> list[str]:
+    if not records:
+        return []
+    common = set(records[0]["marker_labels"])
+    for record in records[1:]:
+        common.intersection_update(record["marker_labels"])
+    return sorted(
+        common,
+        key=lambda value: (not value.isdigit(), int(value) if value.isdigit() else value),
+    )
+
+
+def run_audit(protocol: dict[str, Any], dataset_root: Path) -> dict[str, Any]:
+    dataset = protocol["dataset"]
+    archive_path = _find_archive(dataset_root, dataset["archive_filename"])
+    md5 = _hash_file(archive_path, "md5")
+    sha256 = _hash_file(archive_path, "sha256")
+    if md5 != dataset["archive_md5"]:
+        raise ValueError("Tracking Cloth archive MD5 mismatch")
+    if sha256 != dataset["archive_sha256"]:
+        raise ValueError("Tracking Cloth archive SHA-256 mismatch")
+
+    with zipfile.ZipFile(archive_path) as archive:
+        bad = archive.testzip()
+        if bad is not None:
+            raise ValueError(f"ZIP integrity failure at {bad}")
+        csv_members = sorted(
+            info.filename
+            for info in archive.infolist()
+            if not info.is_dir() and info.filename.lower().endswith(".csv")
+        )
+        for member in csv_members:
+            _safe_member(member)
+        if len(csv_members) != dataset["expected_csv_files"]:
+            raise ValueError("unexpected total Tracking Cloth CSV count")
+
+        token = dataset["fresh_category_token"].casefold()
+        fresh_members = [
+            member
+            for member in csv_members
+            if token in PurePosixPath(member).as_posix().casefold()
+        ]
+        if len(fresh_members) != dataset["expected_fresh_files"]:
+            raise ValueError("unexpected fresh self-collision recording count")
+
+        salt = protocol["split"]["sha256_salt"]
+        ordered = sorted(
+            fresh_members,
+            key=lambda member: hashlib.sha256(f"{salt}|{member}".encode()).hexdigest(),
+        )
+        source_count = int(protocol["split"]["source_count"])
+        calibration_count = int(protocol["split"]["calibration_count"])
+        target_count = int(protocol["split"]["target_count"])
+        if source_count + calibration_count + target_count != len(ordered):
+            raise ValueError("split counts do not cover the fresh roster exactly")
+        roles = {
+            **{member: "source" for member in ordered[:source_count]},
+            **{
+                member: "calibration"
+                for member in ordered[source_count : source_count + calibration_count]
+            },
+            **{member: "target" for member in ordered[-target_count:]},
+        }
+
+        records: list[dict[str, Any]] = []
+        header_lines = int(protocol["header_audit"]["line_count"])
+        maximum_line_bytes = int(protocol["header_audit"]["maximum_line_bytes"])
+        for member in ordered:
+            header = _read_fixed_header(
+                archive,
+                member,
+                line_count=header_lines,
+                maximum_line_bytes=maximum_line_bytes,
+            )
+            labels = _parse_header_labels(header, header_lines)
+            records.append(
+                {
+                    "path": member,
+                    "path_sha256": hashlib.sha256(member.encode()).hexdigest(),
+                    "role": roles[member],
+                    "header_sha256": hashlib.sha256(header).hexdigest(),
+                    "header_line_count": header_lines,
+                    "marker_labels": labels,
+                    "trajectory_rows_read": 0,
+                }
+            )
+
+    by_role = {
+        role: [record for record in records if record["role"] == role]
+        for role in ("source", "calibration", "target")
+    }
+    result: dict[str, Any] = {
+        "schema": SCHEMA,
+        "schema_version": 1,
+        "protocol_id": protocol["protocol_id"],
+        "archive": {
+            "filename": archive_path.name,
+            "size_bytes": archive_path.stat().st_size,
+            "md5": md5,
+            "sha256": sha256,
+            "zip_integrity": "pass",
+        },
+        "counts": {
+            "all_csv": len(csv_members),
+            "fresh": len(records),
+            "source": len(by_role["source"]),
+            "calibration": len(by_role["calibration"]),
+            "target": len(by_role["target"]),
+        },
+        "marker_intersections": {
+            role: _intersection(role_records)
+            for role, role_records in by_role.items()
+        }
+        | {"all_roles": _intersection(records)},
+        "records": records,
+        "information_boundary": {
+            "zip_directory_opened": True,
+            "fixed_header_rows_opened": True,
+            "raw_header_text_published": False,
+            "trajectory_rows_read": 0,
+            "source_trajectory_values_opened": False,
+            "calibration_trajectory_values_opened": False,
+            "target_trajectory_values_opened": False,
+            "split_fixed_before_header_read": True,
+        },
+        "claim_boundary": protocol["claim_boundary"],
+    }
+    canonical = json.dumps(
+        result,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    result["result_id"] = hashlib.sha256(canonical).hexdigest()
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dataset-root", type=Path, required=True)
+    parser.add_argument(
+        "--protocol",
+        type=Path,
+        default=Path("protocols/tracking-cloth-orbit-tube-roster-audit-v1.json"),
+    )
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    protocol = json.loads(args.protocol.read_text(encoding="utf-8"))
+    result = run_audit(protocol, args.dataset_root)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(result, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_tracking_cloth_orbit_tube_roster_audit.py
+++ b/tests/test_tracking_cloth_orbit_tube_roster_audit.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import io
+import json
+from pathlib import Path
+import sys
+import zipfile
+
+import pytest
+
+
+SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "scripts"
+    / "science"
+    / "audit_tracking_cloth_orbit_tube_roster.py"
+)
+SPEC = importlib.util.spec_from_file_location(
+    "audit_tracking_cloth_orbit_tube_roster",
+    SCRIPT,
+)
+assert SPEC is not None and SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = MODULE
+SPEC.loader.exec_module(MODULE)
+
+
+def _header(*labels: str, include_data: bool = True) -> bytes:
+    rows = [
+        ["Format Version", "1.23", "Take Name", "synthetic"],
+        ["Frame", "Time (Seconds)"]
+        + sum((["Marker", "", ""] for _ in labels), []),
+        ["", ""] + sum((["Position", "", ""] for _ in labels), []),
+        ["", ""] + sum(([f"cloth:{label}", "", ""] for label in labels), []),
+        ["", ""] + sum(([label, "", ""] for label in labels), []),
+        ["", ""] + sum((["X", "Y", "Z"] for _ in labels), []),
+        ["", ""] + sum((["Millimeters", "Millimeters", "Millimeters"] for _ in labels), []),
+    ]
+    if include_data:
+        rows.append(["0", "0.000"] + ["1.0", "2.0", "3.0"] * len(labels))
+    stream = io.StringIO(newline="")
+    import csv
+
+    writer = csv.writer(stream, lineterminator="\n")
+    writer.writerows(rows)
+    return stream.getvalue().encode("utf-8")
+
+
+def _hash(path: Path, algorithm: str) -> str:
+    digest = hashlib.new(algorithm)
+    digest.update(path.read_bytes())
+    return digest.hexdigest()
+
+
+def test_parse_header_labels_ignores_trajectory_values() -> None:
+    payload = _header("1", "5", "20")
+    first_seven = b"\n".join(payload.splitlines()[:7]) + b"\n"
+    assert MODULE._parse_header_labels(first_seven, 7) == ("1", "5", "20")
+
+
+def test_parse_header_rejects_a_data_row_inside_the_boundary() -> None:
+    rows = _header("1", "5", "20").splitlines()
+    bad_header = b"\n".join(rows[:6] + [rows[7]]) + b"\n"
+    with pytest.raises(ValueError, match="trajectory data row"):
+        MODULE._parse_header_labels(bad_header, 7)
+
+
+def test_safe_member_rejects_path_traversal() -> None:
+    with pytest.raises(ValueError, match="unsafe ZIP member"):
+        MODULE._safe_member("../outside.csv")
+
+
+def test_complete_audit_fixes_roles_before_header_read(tmp_path: Path) -> None:
+    archive_path = tmp_path / "tracking_dataset.zip"
+    fresh = [
+        "tracking_dataset/Self-collisions/cotton_A2_a.csv",
+        "tracking_dataset/Self-collisions/denim_A2_b.csv",
+        "tracking_dataset/Self-collisions/wool_A2_c.csv",
+    ]
+    with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for index, member in enumerate(fresh):
+            labels = ("1", "5", "20") if index != 1 else ("1", "5", "20", "21")
+            archive.writestr(member, _header(*labels))
+        archive.writestr("tracking_dataset/Hitting/cotton_A2_hitting.csv", _header("1", "5", "20"))
+
+    protocol = {
+        "protocol_id": "synthetic-sealed-audit",
+        "dataset": {
+            "archive_filename": archive_path.name,
+            "archive_md5": _hash(archive_path, "md5"),
+            "archive_sha256": _hash(archive_path, "sha256"),
+            "expected_csv_files": 4,
+            "fresh_category_token": "Self-collisions",
+            "expected_fresh_files": 3,
+        },
+        "split": {
+            "sha256_salt": "fixed-before-header-read",
+            "source_count": 1,
+            "calibration_count": 1,
+            "target_count": 1,
+        },
+        "header_audit": {
+            "line_count": 7,
+            "maximum_line_bytes": 65536,
+        },
+        "claim_boundary": ["synthetic test"],
+    }
+
+    result = MODULE.run_audit(protocol, tmp_path)
+    assert result["counts"] == {
+        "all_csv": 4,
+        "fresh": 3,
+        "source": 1,
+        "calibration": 1,
+        "target": 1,
+    }
+    assert result["marker_intersections"]["all_roles"] == ["1", "5", "20"]
+    assert sum(record["trajectory_rows_read"] for record in result["records"]) == 0
+    assert result["information_boundary"] == {
+        "zip_directory_opened": True,
+        "fixed_header_rows_opened": True,
+        "raw_header_text_published": False,
+        "trajectory_rows_read": 0,
+        "source_trajectory_values_opened": False,
+        "calibration_trajectory_values_opened": False,
+        "target_trajectory_values_opened": False,
+        "split_fixed_before_header_read": True,
+    }
+    assert {record["role"] for record in result["records"]} == {
+        "source",
+        "calibration",
+        "target",
+    }
+    assert len(result["result_id"]) == 64
+
+
+def test_audit_rejects_wrong_archive_identity(tmp_path: Path) -> None:
+    archive_path = tmp_path / "tracking_dataset.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr(
+            "tracking_dataset/Self-collisions/a.csv",
+            _header("1", "5", "20"),
+        )
+    protocol = {
+        "protocol_id": "bad-identity",
+        "dataset": {
+            "archive_filename": archive_path.name,
+            "archive_md5": "0" * 32,
+            "archive_sha256": "0" * 64,
+            "expected_csv_files": 1,
+            "fresh_category_token": "Self-collisions",
+            "expected_fresh_files": 1,
+        },
+        "split": {
+            "sha256_salt": "x",
+            "source_count": 1,
+            "calibration_count": 0,
+            "target_count": 0,
+        },
+        "header_audit": {"line_count": 7, "maximum_line_bytes": 65536},
+        "claim_boundary": [],
+    }
+    with pytest.raises(ValueError, match="MD5 mismatch"):
+        MODULE.run_audit(protocol, tmp_path)
+
+
+def test_protocol_contains_only_header_level_information() -> None:
+    protocol_path = (
+        Path(__file__).resolve().parents[1]
+        / "protocols"
+        / "tracking-cloth-orbit-tube-roster-audit-v1.json"
+    )
+    protocol = json.loads(protocol_path.read_text(encoding="utf-8"))
+    assert protocol["split"] == {
+        "assignment": "sort by sha256(salt + '|' + ZIP member path), then take 9 source, 9 calibration, and 9 target recordings",
+        "calibration_count": 9,
+        "sha256_salt": "prob4d-tracking-cloth-orbit-tube-v1",
+        "source_count": 9,
+        "target_count": 9,
+    }
+    assert protocol["header_audit"]["trajectory_rows_allowed"] == 0
+    assert protocol["header_audit"]["publish_raw_header_text"] is False


### PR DESCRIPTION
## Purpose

Establish whether the 27 previously unused Tracking Cloth `Self-collisions` recordings can support a prospective approximate-orbit calibration/test experiment, without opening any trajectory value.

## Information order

The audit:

- verifies the retained Zenodo archive by MD5 and SHA-256;
- fixes a deterministic path-hash 9/9/9 source/calibration/target split before reading any CSV header;
- reads exactly seven declared Motive header rows per selected recording;
- rejects the run if that boundary contains a numeric trajectory row;
- extracts marker namespaces and per-role intersections;
- publishes only path/header hashes and parsed marker labels, not raw headers; and
- records zero source, calibration, and target trajectory rows opened.

The resulting roster can be used to decide support feasibility only. It cannot select methods, thresholds, marker trajectories, or favorable outcomes.

## Execution

The self-hosted audit targets `[self-hosted, Linux, X64, gpuserver4090]` and the retained public archive. A hosted job first validates the header parser and the exact information boundary on synthetic ZIP fixtures.

## Claim boundary

This PR produces at most a trajectory-value-sealed support/namespace result. It does not establish approximate-orbit calibration, finite-sample query coverage, learned-provider competence, harmful-update control, BayesianPhysTwin/Causal4D benefit, deployment safety, or state of the art. A separate immutable source/calibration/target protocol will be required before opening any trajectory values.