### PR TITLE
Add native causal CUT3R inference and verified provider export

### DIFF
--- a/CHANGELOG.d/cut3r-native-inference.md
+++ b/CHANGELOG.d/cut3r-native-inference.md
@@ -1,0 +1,4 @@
+- Add optional native causal RGB CUT3R inference with compiled-RoPE and trusted
+  checkpoint verification, streaming state, bounded image/video input, direct
+  provider export, and a dataset-free upstream-equivalence smoke. Existing frozen
+  CUT3R experiment runners and import semantics are unchanged.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,6 +9,7 @@ include setup.py
 include src/prob4d/__init__.pyi
 graft docs
 graft protocols
+include runtime/cut3r-modern-aten-sm89.patch
 prune .github
 prune evidence
 prune environments

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ and model checkpoints remain optional external dependencies.
 
 ## Supported interfaces
 
+The optional [native CUT3R RGB runner](docs/cut3r-native-inference.md) adds streaming
+state updates and verified direct-point-map export via `prob4d prediction run-cut3r`.
+Its software support is separate from the frozen provider-evidence snapshot above.
+
 Prob4D 0.5 has one command and one current Python façade:
 
 ```text

--- a/docs/cut3r-native-inference.md
+++ b/docs/cut3r-native-inference.md
@@ -141,6 +141,18 @@ against the shorter-prefix replay. Peak allocated GPU memory was 3,691,858,432
 bytes (about 3.44 GiB). The three production source modules' hashes in the receipt
 were independently compared with the delivered files and matched exactly.
 
+These recorded module hashes identify the initial image-path implementation
+at commit `6b92dc8`; the subsequent FFmpeg compatibility repair changes only
+video staging/error reporting, not the native RGB recurrence or the image path.
+The real video CLI was also verified using a three-frame synthetic FFV1 clip
+with an exclusive two-frame bound on FFmpeg 4.4.2. It published exactly two
+predictions, whose point-map files were byte-identical to the corresponding
+image-path files. This caught and repaired an unsupported `-fps_mode` option;
+the command now uses the compatible `-vsync 0` form and retains decoder errors
+in failure receipts. The separate video receipt binds the updated provider hash.
+The distributed build patch was applied to pristine pinned upstream files, and
+both resulting source hashes matched the runtime's expected compatibility hashes.
+
 The software check first encountered a checkpoint-file permission error before
 model loading; that failed synthetic workspace was retained. A readable copy of
 the same digest-verified official checkpoint was then transferred directly

--- a/docs/cut3r-native-inference.md
+++ b/docs/cut3r-native-inference.md
@@ -1,0 +1,151 @@
+# Native CUT3R support
+
+`prob4d prediction run-cut3r` runs a pinned official CUT3R model on RGB frames or
+a bounded video prefix and publishes a verified, provider-neutral prediction
+manifest. This is the reusable execution path, separate from the frozen science
+runners. The existing depth and direct-point-map import commands remain unchanged.
+
+## Runtime
+
+Use a dedicated Python 3.11 environment with a compatible CUDA PyTorch build,
+CUT3R's dependencies, and Prob4D installed. PyTorch 2.5.1 with CUDA 12.1 is a
+conservative upstream-era build choice; newer PyTorch can require the build-only
+compatibility variant below. Prob4D itself still requires only NumPy;
+importing it or requesting CLI help does not load Torch, CUT3R, or a viewer.
+Follow the [official installation instructions](https://github.com/CUT3R/CUT3R)
+for CUDA/PyTorch and compile native RoPE in the exact source checkout:
+
+```bash
+git clone https://github.com/CUT3R/CUT3R.git /path/to/CUT3R
+git -C /path/to/CUT3R checkout 8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf
+python -m pip install -r /path/to/CUT3R/requirements.txt
+cd /path/to/CUT3R/src/croco/models/curope
+python setup.py build_ext --inplace
+python -m pip install /path/to/Prob4D
+```
+
+Start each execution in a fresh Python process. No `demo.py`/viser import is
+needed. A missing native RoPE extension, dirty tracked source, wrong revision,
+or incorrect checkpoint digest fails before input staging. The supported revision
+is intentionally explicit because the RGB stepping API is upstream-private.
+
+An opt-in `--allow-native-build-compatibility` accepts only the reviewed,
+SHA-256-pinned modern-ATen/SM89 variant: `tokens.type()` becomes
+`tokens.scalar_type()` in `kernels.cu`, and `setup.py` targets compute/sm 89.
+Every other tracked edit is still rejected. The exact accepted file digests are
+in `NATIVE_BUILD_COMPATIBILITY_SHA256`; the runtime receipt binds both source and
+compiled binary. This option does not edit the checkout or accept arbitrary
+locally patched kernels. It is for the separately identified compatible build,
+not a claim that its bytes equal the pristine upstream runtime.
+To reproduce that exact variant in a fresh checkout, apply
+[`runtime/cut3r-modern-aten-sm89.patch`](../runtime/cut3r-modern-aten-sm89.patch)
+with `git apply` before building RoPE, then pass the opt-in flag. The patch retains
+the original attribution and noncommercial CC BY-NC-SA 4.0 source licensing.
+Its historical comment identifies the origin of this already-used build variant;
+it confers no authority to execute the named dataset study.
+
+Use trusted official weights only: the upstream loader unpickles a configuration
+and evaluates its architecture. The runner verifies the supplied SHA-256 **before**
+loading and scopes Torch's legacy-checkpoint compatibility to that load without
+editing the checkout. A digest establishes identity, not trust in an arbitrary
+download. The official 512 DPT checkpoint used here has SHA-256
+`45f7e98a0a64dbeb54901ae2b878cd8cd125f20a4497316483f0bd6f109f8103`.
+The 224 linear architecture is supported by the interface using `--image-size 224`
+and its own independently verified checkpoint digest; this does not imply that
+both checkpoints have been empirically qualified. Upstream licensing applies to
+CUT3R code and weights separately from Prob4D.
+
+## Inference
+
+Frames must have exact six-digit names (`000000.png`, `000001.png`, ...).
+Only the requested interval is staged; a missing or malformed future file is never
+read. `--frame-stop` is always required and exclusive. A nonzero start resets the
+state there, without secretly initializing it from earlier frames.
+
+```bash
+CUDA_VISIBLE_DEVICES=0 prob4d prediction run-cut3r \
+  --cut3r-checkout /path/to/CUT3R \
+  --checkpoint /path/to/cut3r_512_dpt_4_64.pth \
+  --checkpoint-sha256 45f7e98a0a64dbeb54901ae2b878cd8cd125f20a4497316483f0bd6f109f8103 \
+  --frames /path/to/permitted-frames --frame-start 0 --frame-stop 12 \
+  --sequence-id my-sequence --output /path/to/new-output
+```
+
+For video, replace `--frames` with `--video /path/to/video.mp4`; FFmpeg must be
+installed. No emitted frame at or after the bound reaches CUT3R. Compressed-video
+decoders can internally read reference/lookahead frames: protocols requiring
+strict decode custody should supply a separately staged permitted image prefix.
+The output parent must exist, and the output directory must not already exist.
+Use `--frame-extension .jpg` for JPEG sequences. Mixed output resolutions within
+a dense window are rejected; no hidden padding or geometry resampling is used.
+
+The runtime encodes one RGB image and updates the official recurrent decoder per
+step. It does **not** call CUT3R's ray-query `inference_step`, replay the prefix,
+retain all GPU image features, revisit observations, or run global alignment.
+State is reset at each invocation. Raw per-frame outputs are written incrementally.
+
+## Products and semantics
+
+```text
+new-output/
+  direct/{points,depth,conf,camera}/...
+  prediction/provider.json
+  prediction/payloads/...
+  run.json
+```
+
+- `points`: original camera-frame XYZ, not depth-reprojected approximations.
+- `depth`: the direct map's Z component; `conf`: raw CUT3R source confidence.
+- `camera`: camera-to-sequence pose and estimated intrinsics.
+- Canonical payload: sequence-local XYZ, valid mask, camera-origin unit rays,
+  exact frame indices, and causal lineage through the current frame only.
+- Coordinates remain **sequence-local Sim(3)**, not registered metres. A separately
+  validated gauge is required before metric BayesianPhysTwin assimilation.
+- No material identity, scene flow, deformation mask, or calibrated covariance is
+  invented from dense point-map differences or confidence. Dense pixels and views
+  remain dependent evidence. Existing covariance/calibration adapters are separate.
+- `run.json` binds runtime/source/kernel/checkpoint, inputs, raw outputs, manifest,
+  and implementation hashes. For image directories, the legacy importer's
+  `input_video_sha256` slot holds the ordered-prefix inventory digest; `run.json`
+  explicitly identifies it as `image-prefix`, not an actual video-file hash.
+
+The `prediction` directory appears only after complete inference and successful
+manifest verification. A technical failure retains a failure receipt and partial
+raw generated outputs, never a successful manifest. Generated staging images are
+cleaned on either outcome; source files are not modified. A repeated output path
+is rejected rather than overwriting evidence.
+
+## Dataset-free verification
+
+```bash
+PYTHONPATH=src python scripts/smoke_cut3r_native.py \
+  --cut3r-checkout /path/to/CUT3R \
+  --checkpoint /path/to/cut3r_512_dpt_4_64.pth \
+  --device cuda:0 --output /path/to/new-synthetic-smoke
+```
+
+This generates three synthetic RGB frames, runs the complete export, checks the
+manifest, tests reset/prefix closure, and compares streamed XYZ to upstream's
+`forward_recurrent` on the same frames. It tests software compatibility only.
+Historical quarantines, failed/no-retry studies, protected cohorts, and scientific
+promotion decisions are not reopened or superseded by this command.
+
+### Verified software result
+
+The [synthetic smoke summary](../evidence/cut3r-native-software-smoke-v1/summary.json)
+records a successful native run of the official 512 DPT checkpoint on an RTX 4090,
+Torch 2.11.0+cu126, using the explicitly bound native-build compatibility variant.
+All three 384x512 direct point maps exported and the manifest verified. Maximum
+absolute XYZ difference was **0** both against official `forward_recurrent` and
+against the shorter-prefix replay. Peak allocated GPU memory was 3,691,858,432
+bytes (about 3.44 GiB). The three production source modules' hashes in the receipt
+were independently compared with the delivered files and matched exactly.
+
+The software check first encountered a checkpoint-file permission error before
+model loading; that failed synthetic workspace was retained. A readable copy of
+the same digest-verified official checkpoint was then transferred directly
+between hosts for the successful software run. No historical scientific attempt
+was retried. Raw synthetic outputs and full runtime receipts remain at
+`gpuserver4090:/home/florianpfaff/source-only/cut3r-native-support-v1-synthetic-smoke-readable`.
+This result qualifies the RGB execution/export interface for that runtime, not
+real-data accuracy, metric scale, uncertainty calibration, or transfer.

--- a/evidence/cut3r-native-software-smoke-v1/summary.json
+++ b/evidence/cut3r-native-software-smoke-v1/summary.json
@@ -1,0 +1,29 @@
+{
+  "schema": "prob4d.cut3r-native-software-verification-v1",
+  "status": "success",
+  "evidence_kind": "synthetic-software-compatibility-only",
+  "dataset_accessed": false,
+  "historical_experiment_retried": false,
+  "scientific_accuracy_claimed": false,
+  "cut3r_revision": "8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf",
+  "checkpoint_sha256": "45f7e98a0a64dbeb54901ae2b878cd8cd125f20a4497316483f0bd6f109f8103",
+  "torch": "2.11.0+cu126",
+  "torch_cuda": "12.6",
+  "gpu": "NVIDIA GeForce RTX 4090",
+  "native_build_variant": "modern-aten-sm89",
+  "frames_exported": 3,
+  "point_shape": [384, 512, 3],
+  "prefix_point_max_abs_error": 0.0,
+  "official_recurrent_point_max_abs_error": 0.0,
+  "peak_cuda_allocated_bytes": 3691858432,
+  "raw_smoke_artifact_id": "f2601201d6cc5b97c82b653d64c36a320850140fff68afa3a5914d5e45334871",
+  "raw_smoke_file_sha256": "1b0f5c417a159cc46c2528d494c8060811f8606ec9a784c0c5d5e686972a0939",
+  "production_artifact_id": "b1cd5ca54c325f7a6c4289ac7693883fad9bf746191523cbd7c5a6c91defb3a9",
+  "manifest_sha256": "9c66fcc918e5ed086e4020e74cdb01ff8e2a4165c5381018582a585b303d724f",
+  "implementation_sha256s": {
+    "cut3r_native_provider.py": "bdbf28894d255f18bbb6095baf0068c6f895208072ff2313314983a6da58e15a",
+    "cut3r_native_runtime.py": "23f22ed06d03857ef201fa27243d519e0cd028b57477928eeca7e4de702631ff",
+    "_cut3r_native_cli.py": "7ead4717cc6ec1f413eeae89cb723fcd8c36a5eeafbf6f8dd44f5b462bd67e07",
+    "scripts/smoke_cut3r_native.py": "ba2dfcd2b53ed0a10f784ab2bbff164090af585535b9f7890cb205eaa397631e"
+  }
+}

--- a/evidence/cut3r-native-software-smoke-v1/summary.json
+++ b/evidence/cut3r-native-software-smoke-v1/summary.json
@@ -20,6 +20,19 @@
   "raw_smoke_file_sha256": "1b0f5c417a159cc46c2528d494c8060811f8606ec9a784c0c5d5e686972a0939",
   "production_artifact_id": "b1cd5ca54c325f7a6c4289ac7693883fad9bf746191523cbd7c5a6c91defb3a9",
   "manifest_sha256": "9c66fcc918e5ed086e4020e74cdb01ff8e2a4165c5381018582a585b303d724f",
+  "video_cli_verification": {
+    "status": "success",
+    "ffmpeg_version": "4.4.2",
+    "input_synthetic_frame_count": 3,
+    "requested_prefix_frame_count": 2,
+    "frames_completed": 2,
+    "prediction_published": true,
+    "point_maps_byte_identical_to_image_path": true,
+    "artifact_id": "71851b6f07f4fa8d2b16b0268148a3a217dea34ab1e9728e4e7d0518e2c3ef2b",
+    "receipt_file_sha256": "8beffb82d3399373c12ae3d3b4189049aedd2bb494cb0fae693c6c92e65aa852",
+    "manifest_sha256": "b30afef6511ef167055f3528d9e7d50037518ba1b5b454320e1fa8d6c254c077",
+    "provider_implementation_sha256": "7089a5fdec1ada2b219fd48ce8d57a70cd95ae8428f44e1158c97cb0bad667e8"
+  },
   "implementation_sha256s": {
     "cut3r_native_provider.py": "bdbf28894d255f18bbb6095baf0068c6f895208072ff2313314983a6da58e15a",
     "cut3r_native_runtime.py": "23f22ed06d03857ef201fa27243d519e0cd028b57477928eeca7e4de702631ff",

--- a/runtime/cut3r-modern-aten-sm89.patch
+++ b/runtime/cut3r-modern-aten-sm89.patch
@@ -1,15 +1,11 @@
 diff --git a/src/croco/models/curope/kernels.cu b/src/croco/models/curope/kernels.cu
 --- a/src/croco/models/curope/kernels.cu
 +++ b/src/croco/models/curope/kernels.cu
-@@ -98,7 +98,7 @@ void rope_2d_cuda( torch::Tensor tokens, const torch::Tensor pos, const float ba
-     const int N_BLOCKS = B * N; // each block takes care of H*D values
-     const int SHARED_MEM = sizeof(float) * (D + D/4);
+@@ -100,3 +100,3 @@
  
 -    AT_DISPATCH_FLOATING_TYPES_AND_HALF(tokens.type(), "rope_2d_cuda", ([&] {
 +    AT_DISPATCH_FLOATING_TYPES_AND_HALF(tokens.scalar_type(), "rope_2d_cuda", ([&] {
          rope_2d_cuda_kernel<scalar_t> <<<N_BLOCKS, THREADS_PER_BLOCK, SHARED_MEM>>> (
-             //tokens.data_ptr<scalar_t>(),
-             tokens.packed_accessor32<scalar_t,4,torch::RestrictPtrTraits>(),
 diff --git a/src/croco/models/curope/setup.py b/src/croco/models/curope/setup.py
 --- a/src/croco/models/curope/setup.py
 +++ b/src/croco/models/curope/setup.py

--- a/runtime/cut3r-modern-aten-sm89.patch
+++ b/runtime/cut3r-modern-aten-sm89.patch
@@ -2,7 +2,7 @@ diff --git a/src/croco/models/curope/kernels.cu b/src/croco/models/curope/kernel
 --- a/src/croco/models/curope/kernels.cu
 +++ b/src/croco/models/curope/kernels.cu
 @@ -100,3 +100,3 @@
- 
+
 -    AT_DISPATCH_FLOATING_TYPES_AND_HALF(tokens.type(), "rope_2d_cuda", ([&] {
 +    AT_DISPATCH_FLOATING_TYPES_AND_HALF(tokens.scalar_type(), "rope_2d_cuda", ([&] {
          rope_2d_cuda_kernel<scalar_t> <<<N_BLOCKS, THREADS_PER_BLOCK, SHARED_MEM>>> (
@@ -11,11 +11,11 @@ diff --git a/src/croco/models/curope/setup.py b/src/croco/models/curope/setup.py
 +++ b/src/croco/models/curope/setup.py
 @@ -2,11 +2,12 @@
  # Licensed under CC BY-NC-SA 4.0 (non-commercial use only).
- 
+
  from setuptools import setup
 -from torch import cuda
  from torch.utils.cpp_extension import BuildExtension, CUDAExtension
- 
+
 -# compile for all possible CUDA architectures
 -all_cuda_archs = cuda.get_gencode_flags().replace("compute=", "arch=").split()
 +# The registered DOT execution uses an RTX 4090.  CUT3R's original build asks

--- a/runtime/cut3r-modern-aten-sm89.patch
+++ b/runtime/cut3r-modern-aten-sm89.patch
@@ -1,0 +1,31 @@
+diff --git a/src/croco/models/curope/kernels.cu b/src/croco/models/curope/kernels.cu
+--- a/src/croco/models/curope/kernels.cu
++++ b/src/croco/models/curope/kernels.cu
+@@ -98,7 +98,7 @@ void rope_2d_cuda( torch::Tensor tokens, const torch::Tensor pos, const float ba
+     const int N_BLOCKS = B * N; // each block takes care of H*D values
+     const int SHARED_MEM = sizeof(float) * (D + D/4);
+ 
+-    AT_DISPATCH_FLOATING_TYPES_AND_HALF(tokens.type(), "rope_2d_cuda", ([&] {
++    AT_DISPATCH_FLOATING_TYPES_AND_HALF(tokens.scalar_type(), "rope_2d_cuda", ([&] {
+         rope_2d_cuda_kernel<scalar_t> <<<N_BLOCKS, THREADS_PER_BLOCK, SHARED_MEM>>> (
+             //tokens.data_ptr<scalar_t>(),
+             tokens.packed_accessor32<scalar_t,4,torch::RestrictPtrTraits>(),
+diff --git a/src/croco/models/curope/setup.py b/src/croco/models/curope/setup.py
+--- a/src/croco/models/curope/setup.py
++++ b/src/croco/models/curope/setup.py
+@@ -2,11 +2,12 @@
+ # Licensed under CC BY-NC-SA 4.0 (non-commercial use only).
+ 
+ from setuptools import setup
+-from torch import cuda
+ from torch.utils.cpp_extension import BuildExtension, CUDAExtension
+ 
+-# compile for all possible CUDA architectures
+-all_cuda_archs = cuda.get_gencode_flags().replace("compute=", "arch=").split()
++# The registered DOT execution uses an RTX 4090.  CUT3R's original build asks
++# PyTorch for every architecture compiled into the wheel, including targets no
++# longer accepted by CUDA 12.6.  Build exactly for the registered SM 89 device.
++all_cuda_archs = ["-gencode", "arch=compute_89,code=sm_89"]
+ # alternatively, you can list cuda archs that you want, eg:
+ # all_cuda_archs = [
+ # '-gencode', 'arch=compute_70,code=sm_70',

--- a/scripts/smoke_cut3r_native.py
+++ b/scripts/smoke_cut3r_native.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Dataset-free native CUT3R check: export, streaming equivalence and prefix closure."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+
+from prob4d.cut3r_native_provider import content_id, run_cut3r_native
+from prob4d.cut3r_native_runtime import (
+    OFFICIAL_512_CHECKPOINT_SHA256,
+    Cut3RNativeRuntime,
+)
+from prob4d.prediction_provider_manifest import verify_prediction_provider_manifest
+
+
+def make_frames(root: Path) -> list[Path]:
+    from PIL import Image
+
+    root.mkdir()
+    y, x = np.indices((384, 512))
+    paths = []
+    for i in range(3):
+        rgb = np.stack(
+            [
+                (x + i * 8) % 256,
+                (y * 2) % 256,
+                (((x + i * 8) // 24 + y // 24) % 2) * 180 + 40,
+            ],
+            axis=-1,
+        ).astype(np.uint8)
+        path = root / f"{i:06d}.png"
+        Image.fromarray(rgb).save(path)
+        paths.append(path)
+    return paths
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cut3r-checkout", type=Path, required=True)
+    parser.add_argument("--checkpoint", type=Path, required=True)
+    parser.add_argument("--checkpoint-sha256", default=OFFICIAL_512_CHECKPOINT_SHA256)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--image-size", type=int, choices=(224, 512), default=512)
+    parser.add_argument("--allow-native-build-compatibility", action="store_true")
+    args = parser.parse_args()
+    args.output.mkdir(exist_ok=False)
+    report = {
+        "schema": "prob4d.cut3r-native-synthetic-smoke-v1",
+        "dataset_accessed": False,
+        "scientific_accuracy_claimed": False,
+        "status": "failed",
+    }
+    try:
+        paths = make_frames(args.output / "synthetic")
+        runtime = Cut3RNativeRuntime(
+            args.cut3r_checkout,
+            args.checkpoint,
+            checkpoint_sha256=args.checkpoint_sha256,
+            device=args.device,
+            image_size=args.image_size,
+            allow_native_build_compatibility=args.allow_native_build_compatibility,
+        )
+        torch = runtime.torch
+        torch.cuda.reset_peak_memory_stats(runtime.device)
+        run = run_cut3r_native(
+            paths[0].parent,
+            args.output / "production",
+            runtime_factory=lambda: runtime,
+            sequence_id="synthetic-runtime-check",
+            frame_start=0,
+            frame_stop=3,
+        )
+        verify_prediction_provider_manifest(args.output / "production/prediction/provider.json")
+        direct = args.output / "production/direct"
+        expected = [np.load(direct / "points" / f"{i:06d}.npy") for i in range(3)]
+        runtime.reset()
+        prefix_error = max(
+            float(np.max(np.abs(runtime.step(path)["points"] - expected[i])))
+            for i, path in enumerate(paths[:2])
+        )
+        runtime.reset()
+        with torch.inference_mode(), torch.autocast(device_type="cuda", enabled=False):
+            views = [runtime.prepare_view(path) for path in paths]
+            for view in views:
+                height, width = view["img"].shape[-2:]
+                view["ray_map"] = torch.full(
+                    (1, height, width, 6), torch.nan, device=runtime.device
+                )
+            predictions, _ = runtime.model.forward_recurrent(views, runtime.device)
+            reference_error = max(
+                float(np.max(np.abs(runtime.decode_prediction(pred)["points"] - expected[i])))
+                for i, pred in enumerate(predictions)
+            )
+        if prefix_error > 1e-6 or reference_error > 1e-5:
+            raise ValueError("synthetic streaming/prefix equivalence tolerance exceeded")
+        report.update(
+            {
+                "status": "success",
+                "production_artifact_id": run["artifact_id"],
+                "manifest_sha256": run["manifest_sha256"],
+                "runtime": runtime.identity,
+                "frames_exported": 3,
+                "point_shape": list(expected[0].shape),
+                "prefix_point_max_abs_error": prefix_error,
+                "official_recurrent_point_max_abs_error": reference_error,
+                "peak_cuda_allocated_bytes": torch.cuda.max_memory_allocated(runtime.device),
+            }
+        )
+    except Exception as error:
+        report["error"] = f"{type(error).__name__}: {error}"
+        raise
+    finally:
+        report["artifact_id"] = content_id(report)
+        with (args.output / "smoke.json").open("x") as stream:
+            json.dump(report, stream, indent=2, sort_keys=True, allow_nan=False)
+            stream.write("\n")
+    print(json.dumps({key: value for key, value in report.items() if key != "runtime"}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/prob4d/_cut3r_native_cli.py
+++ b/src/prob4d/_cut3r_native_cli.py
@@ -1,0 +1,73 @@
+"""Lazy CLI for optional native CUT3R inference."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Sequence
+from pathlib import Path
+
+from .cut3r_native_provider import run_cut3r_native
+from .cut3r_native_runtime import SUPPORTED_CUT3R_REVISION, Cut3RNativeRuntime
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="prob4d prediction run-cut3r")
+    inputs = parser.add_mutually_exclusive_group(required=True)
+    inputs.add_argument("--frames", type=Path, help="directory of six-digit numbered images")
+    inputs.add_argument("--video", type=Path, help="video from which to emit a bounded prefix")
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--sequence-id", required=True)
+    parser.add_argument("--frame-start", type=int, default=0)
+    parser.add_argument("--frame-stop", type=int, required=True, help="exclusive causal bound")
+    parser.add_argument("--frame-extension", choices=(".png", ".jpg", ".jpeg"), default=".png")
+    parser.add_argument("--cut3r-checkout", type=Path, required=True)
+    parser.add_argument("--cut3r-revision", default=SUPPORTED_CUT3R_REVISION)
+    parser.add_argument("--checkpoint", type=Path, required=True)
+    parser.add_argument("--checkpoint-sha256", required=True, help="digest of trusted weights")
+    parser.add_argument("--image-size", type=int, choices=(224, 512), default=512)
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--allow-native-build-compatibility",
+        action="store_true",
+        help="accept only the hash-pinned modern-ATen/SM89 build variant",
+    )
+    parser.add_argument("--confidence-threshold", type=float, default=1.5)
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    def runtime() -> Cut3RNativeRuntime:
+        return Cut3RNativeRuntime(
+            args.cut3r_checkout,
+            args.checkpoint,
+            checkpoint_sha256=args.checkpoint_sha256,
+            revision=args.cut3r_revision,
+            image_size=args.image_size,
+            device=args.device,
+            seed=args.seed,
+            allow_native_build_compatibility=args.allow_native_build_compatibility,
+        )
+
+    receipt = run_cut3r_native(
+        args.video if args.video is not None else args.frames,
+        args.output,
+        runtime_factory=runtime,
+        sequence_id=args.sequence_id,
+        frame_start=args.frame_start,
+        frame_stop=args.frame_stop,
+        video=args.video is not None,
+        extension=args.frame_extension,
+        confidence_threshold=args.confidence_threshold,
+    )
+    print(
+        json.dumps(
+            {
+                "status": receipt["status"],
+                "artifact_id": receipt["artifact_id"],
+                "frames_completed": receipt["frames_completed"],
+                "provider_manifest": str(args.output / "prediction/provider.json"),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0

--- a/src/prob4d/cut3r_native_provider.py
+++ b/src/prob4d/cut3r_native_provider.py
@@ -1,0 +1,281 @@
+"""Transactional native CUT3R production using only an explicitly bounded prefix."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import subprocess
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, Protocol
+
+import numpy as np
+
+from ._strict_json import require_exact_integer, require_json_number
+from .cut3r_direct_provider_adapter import import_cut3r_direct_prediction_manifest
+from .cut3r_native_runtime import file_sha256, ordinary_path
+from .prediction_provider_manifest import verify_prediction_provider_manifest
+
+
+class NativeRuntime(Protocol):
+    identity: dict[str, Any]
+
+    def reset(self) -> None: ...
+    def step(self, path: Path) -> dict[str, np.ndarray]: ...
+
+
+def content_id(value: object) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            value,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ).encode()
+    ).hexdigest()
+
+
+def _write_json(path: Path, value: dict[str, Any]) -> None:
+    with path.open("x", encoding="utf-8") as stream:
+        json.dump(value, stream, indent=2, sort_keys=True, allow_nan=False)
+        stream.write("\n")
+
+
+def _stage_inputs(
+    source: Path,
+    destination: Path,
+    *,
+    frame_start: int,
+    frame_stop: int,
+    video: bool,
+    extension: str,
+) -> tuple[list[Path], dict[str, Any]]:
+    source = ordinary_path(source)
+    destination.mkdir()
+    count = frame_stop - frame_start
+    paths = [destination / f"{i:06d}{extension}" for i in range(count)]
+    records: list[dict[str, Any]] = []
+    if video:
+        if not source.is_file():
+            raise ValueError("video input must be a file")
+        digest = file_sha256(source)
+        size = source.stat().st_size
+        # Stop emission at the exclusive bound. A video codec can internally
+        # decode lookahead/reference frames, but none are supplied to the model.
+        subprocess.run(
+            [
+                "ffmpeg",
+                "-nostdin",
+                "-v",
+                "error",
+                "-i",
+                str(source),
+                "-vf",
+                f"select=between(n\\,{frame_start}\\,{frame_stop - 1})",
+                "-fps_mode",
+                "passthrough",
+                "-frames:v",
+                str(count),
+                "-start_number",
+                "0",
+                str(destination / "%06d.png"),
+            ],
+            check=True,
+            capture_output=True,
+        )
+        if file_sha256(source) != digest or source.stat().st_size != size:
+            raise ValueError("video changed during prefix extraction")
+        paths = [destination / f"{i:06d}.png" for i in range(count)]
+        input_identity = {"kind": "video", "sha256": digest, "byte_count": size}
+    else:
+        if not source.is_dir():
+            raise ValueError("frame input must be a directory")
+        # Do not glob, read, or inspect the suffix; names are exact frame IDs.
+        for index, destination_path in enumerate(paths):
+            original = ordinary_path(source / f"{index + frame_start:06d}{extension}")
+            if not original.is_file():
+                raise ValueError("frame input must be an ordinary file")
+            digest = file_sha256(original)
+            shutil.copyfile(original, destination_path)
+            if file_sha256(destination_path) != digest or file_sha256(original) != digest:
+                raise ValueError("frame changed during prefix staging")
+            records.append(
+                {
+                    "frame_id": index + frame_start,
+                    "sha256": digest,
+                    "byte_count": destination_path.stat().st_size,
+                }
+            )
+        input_identity = {
+            "kind": "image-prefix",
+            "sha256": content_id(records),
+            "byte_count": sum(row["byte_count"] for row in records),
+        }
+    if any(not path.is_file() for path in paths):
+        raise ValueError("input does not contain the complete requested prefix")
+    return paths, {
+        **input_identity,
+        "frame_start": frame_start,
+        "frame_stop_exclusive": frame_stop,
+        "frames": records
+        or [
+            {
+                "frame_id": i + frame_start,
+                "sha256": file_sha256(path),
+                "byte_count": path.stat().st_size,
+            }
+            for i, path in enumerate(paths)
+        ],
+    }
+
+
+def _save_frame(root: Path, index: int, frame: dict[str, np.ndarray]) -> tuple[int, int]:
+    if set(frame) != {"points", "confidence", "pose", "intrinsics"}:
+        raise ValueError("native CUT3R frame fields changed")
+    points, confidence = frame["points"], frame["confidence"]
+    pose, intrinsics = frame["pose"], frame["intrinsics"]
+    if points.ndim != 3 or points.shape[-1] != 3 or confidence.shape != points.shape[:2]:
+        raise ValueError("native CUT3R point/confidence shape mismatch")
+    if pose.shape != (4, 4) or intrinsics.shape != (3, 3):
+        raise ValueError("native CUT3R camera shape mismatch")
+    if not all(np.isfinite(value).all() for value in frame.values()):
+        raise ValueError("native CUT3R frame contains non-finite values")
+    if (
+        not np.allclose(pose[3], [0, 0, 0, 1], atol=1e-6)
+        or not np.allclose(
+            pose[:3, :3].T @ pose[:3, :3],
+            np.eye(3),
+            atol=1e-4,
+        )
+        or not np.isclose(np.linalg.det(pose[:3, :3]), 1, atol=1e-4)
+    ):
+        raise ValueError("native CUT3R camera pose is not rigid")
+    if intrinsics[0, 0] <= 0 or intrinsics[1, 1] <= 0:
+        raise ValueError("native CUT3R focal length is invalid")
+    stem = f"{index:06d}"
+    np.save(root / "points" / f"{stem}.npy", points, allow_pickle=False)
+    np.save(root / "depth" / f"{stem}.npy", points[..., 2], allow_pickle=False)
+    np.save(root / "conf" / f"{stem}.npy", confidence, allow_pickle=False)
+    np.savez(root / "camera" / f"{stem}.npz", pose=pose, intrinsics=intrinsics)
+    return int(points.shape[0]), int(points.shape[1])
+
+
+def run_cut3r_native(
+    source: Path,
+    output: Path,
+    *,
+    runtime_factory: Callable[[], NativeRuntime],
+    sequence_id: str,
+    frame_start: int,
+    frame_stop: int,
+    video: bool = False,
+    extension: str = ".png",
+    confidence_threshold: float = 1.5,
+) -> dict[str, Any]:
+    """Publish a verified direct provider only after the entire prefix succeeds.
+
+    The output root is write-once. A failure retains a small receipt and partial
+    generated outputs, never a successfully published prediction directory.
+    """
+    start = require_exact_integer(frame_start, name="frame_start", minimum=0)
+    stop = require_exact_integer(frame_stop, name="frame_stop", minimum=start + 1)
+    if stop - start > 4096:
+        raise ValueError("native CUT3R prefix exceeds the 4096-frame limit")
+    if extension not in (".png", ".jpg", ".jpeg"):
+        raise ValueError("frame extension must be .png, .jpg or .jpeg")
+    threshold = require_json_number(confidence_threshold, name="confidence_threshold")
+    if threshold < 0 or type(sequence_id) is not str or not sequence_id:
+        raise ValueError("invalid confidence threshold or sequence ID")
+    parent = ordinary_path(output.parent)
+    output = parent / output.name
+    output.mkdir(exist_ok=False)
+    staging = output / "staging"
+    staging.mkdir()
+    receipt: dict[str, Any] = {
+        "schema": "prob4d.cut3r-native-production-v1",
+        "status": "failed",
+        "stage": "runtime-initialization",
+        "frames_completed": 0,
+        "prediction_published": False,
+        "uses_truth": False,
+        "future_frames_supplied_to_model": False,
+        "metric_scale_claimed": False,
+        "calibrated_covariance_claimed": False,
+        "scene_flow_claimed": False,
+        "implementation_sha256s": {
+            name: file_sha256(Path(__file__).parent / name)
+            for name in (
+                "cut3r_native_provider.py",
+                "cut3r_native_runtime.py",
+                "_cut3r_native_cli.py",
+            )
+        },
+    }
+    decoded = staging / "decoded"
+    try:
+        runtime = runtime_factory()
+        receipt["runtime"] = runtime.identity
+        receipt["stage"] = "prefix-staging"
+        paths, inputs = _stage_inputs(
+            source,
+            decoded,
+            frame_start=start,
+            frame_stop=stop,
+            video=video,
+            extension=extension,
+        )
+        receipt["input"] = inputs
+        direct = output / "direct"
+        direct.mkdir()
+        for name in ("points", "depth", "conf", "camera"):
+            (direct / name).mkdir()
+        runtime.reset()
+        shape = None
+        receipt["stage"] = "provider-inference"
+        for index, path in enumerate(paths):
+            frame = runtime.step(path)
+            current_shape = _save_frame(direct, index, frame)
+            if shape is not None and current_shape != shape:
+                raise ValueError("input aspect ratio changed within one dense CUT3R window")
+            shape = current_shape
+            receipt["frames_completed"] = index + 1
+        receipt["stage"] = "provider-publication"
+        bundle = staging / "prediction"
+        bundle.mkdir()
+        manifest = import_cut3r_direct_prediction_manifest(
+            direct,
+            bundle / "provider.json",
+            sequence_id=sequence_id,
+            cut3r_revision=runtime.identity["cut3r_revision"],
+            checkpoint_sha256=runtime.identity["checkpoint_sha256"],
+            input_video_sha256=inputs["sha256"],
+            input_video_byte_count=inputs["byte_count"],
+            frame_start=start,
+            confidence_threshold=threshold,
+        )
+        verify_prediction_provider_manifest(bundle / "provider.json")
+        receipt["provider_run_id"] = manifest.provider_run_id
+        receipt["manifest_sha256"] = file_sha256(bundle / "provider.json")
+        receipt["direct_members"] = [
+            {
+                "path": path.relative_to(output).as_posix(),
+                "sha256": file_sha256(path),
+                "byte_count": path.stat().st_size,
+            }
+            for path in sorted(direct.rglob("*"))
+            if path.is_file()
+        ]
+        bundle.rename(output / "prediction")
+        receipt.update(status="success", stage="complete", prediction_published=True)
+    except Exception as error:
+        receipt["error_type"] = type(error).__name__
+        receipt["error"] = str(error)[:2000]
+        raise
+    finally:
+        # This is our newly created staging tree, never an input or historical attempt.
+        if decoded.exists():
+            shutil.rmtree(decoded)
+        receipt["artifact_id"] = content_id(receipt)
+        _write_json(output / "run.json", receipt)
+    return receipt

--- a/src/prob4d/cut3r_native_provider.py
+++ b/src/prob4d/cut3r_native_provider.py
@@ -63,27 +63,28 @@ def _stage_inputs(
         size = source.stat().st_size
         # Stop emission at the exclusive bound. A video codec can internally
         # decode lookahead/reference frames, but none are supplied to the model.
-        subprocess.run(
-            [
-                "ffmpeg",
-                "-nostdin",
-                "-v",
-                "error",
-                "-i",
-                str(source),
-                "-vf",
-                f"select=between(n\\,{frame_start}\\,{frame_stop - 1})",
-                "-fps_mode",
-                "passthrough",
-                "-frames:v",
-                str(count),
-                "-start_number",
-                "0",
-                str(destination / "%06d.png"),
-            ],
-            check=True,
-            capture_output=True,
-        )
+        command = [
+            "ffmpeg",
+            "-nostdin",
+            "-v",
+            "error",
+            "-i",
+            str(source),
+            "-vf",
+            f"select=between(n\\,{frame_start}\\,{frame_stop - 1})",
+            "-vsync",
+            "0",
+            "-frames:v",
+            str(count),
+            "-start_number",
+            "0",
+            str(destination / "%06d.png"),
+        ]
+        try:
+            subprocess.run(command, check=True, capture_output=True)
+        except subprocess.CalledProcessError as error:
+            detail = (error.stderr or b"").decode("utf-8", errors="replace")[-2000:]
+            raise RuntimeError(f"FFmpeg prefix extraction failed: {detail}") from error
         if file_sha256(source) != digest or source.stat().st_size != size:
             raise ValueError("video changed during prefix extraction")
         paths = [destination / f"{i:06d}.png" for i in range(count)]

--- a/src/prob4d/cut3r_native_runtime.py
+++ b/src/prob4d/cut3r_native_runtime.py
@@ -1,0 +1,260 @@
+"""Optional, causal RGB execution against a pinned official CUT3R checkout.
+
+Torch is deliberately imported only when constructing the runtime. The NumPy
+importers and the rest of Prob4D do not acquire a GPU dependency.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import os
+import random
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from ._strict_json import require_sha256
+from .cut3r_runtime_contract import require_compiled_cut3r_rope
+
+SUPPORTED_CUT3R_REVISION = "8bc15dc92a6d7fd92920b4ec81540d3dec7d3ecf"
+OFFICIAL_512_CHECKPOINT_SHA256 = "45f7e98a0a64dbeb54901ae2b878cd8cd125f20a4497316483f0bd6f109f8103"
+
+# Reviewed build-only variant: modern ATen scalar_type(), and SM89 compilation.
+# No model, preprocessing, state-update, or prediction source is changed.
+NATIVE_BUILD_COMPATIBILITY_SHA256 = {
+    "src/croco/models/curope/kernels.cu": (
+        "0ae1a9517eba744fd619f98b3761766d384ab090d35df4314d8946db72c5ca51"
+    ),
+    "src/croco/models/curope/setup.py": (
+        "aaec74fff578fe13ba17a90506e9c70fd08abe03e5a468dfb2f6162cda0e0c0a"
+    ),
+}
+
+
+def file_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for block in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def ordinary_path(path: Path) -> Path:
+    """Resolve an existing path without accepting symlinked ancestors."""
+    path = path.expanduser().absolute()
+    if any(part.is_symlink() for part in (path, *path.parents)):
+        raise ValueError("CUT3R input/runtime paths must not traverse symbolic links")
+    return path.resolve(strict=True)
+
+
+def verify_checkout(
+    checkout: Path,
+    revision: str,
+    *,
+    allow_native_build_compatibility: bool = False,
+) -> dict[str, str]:
+    if revision != SUPPORTED_CUT3R_REVISION:
+        raise ValueError("unsupported CUT3R revision; qualify the changed RGB interface first")
+    root = ordinary_path(checkout)
+
+    def git(*arguments: str) -> bytes:
+        return subprocess.run(
+            ["git", "-C", str(root), *arguments],
+            check=True,
+            capture_output=True,
+        ).stdout
+
+    if git("rev-parse", "HEAD").decode().strip() != revision:
+        raise ValueError("CUT3R checkout HEAD differs from the requested revision")
+    if git("status", "--porcelain", "--untracked-files=no"):
+        changed = git("diff", "HEAD", "--name-only", "-z").decode().strip("\0").split("\0")
+        if not allow_native_build_compatibility or any(
+            name not in NATIVE_BUILD_COMPATIBILITY_SHA256
+            or file_sha256(ordinary_path(root / name)) != NATIVE_BUILD_COMPATIBILITY_SHA256[name]
+            for name in changed
+        ):
+            raise ValueError(
+                "CUT3R tracked source is dirty outside the reviewed native build variant"
+            )
+    # Also bind untracked Python modules: an earlier runtime repair may shadow
+    # the compiled kernel or an upstream import without changing tracked files.
+    sources = {}
+    for directory in (root / "src",):
+        for path in sorted(directory.rglob("*.py")):
+            if path.is_symlink():
+                raise ValueError("CUT3R Python source must not be symlinked")
+            sources[path.relative_to(root).as_posix()] = file_sha256(ordinary_path(path))
+    if "src/dust3r/model.py" not in sources:
+        raise ValueError("CUT3R model source missing")
+    return sources
+
+
+class Cut3RNativeRuntime:
+    """One recurrent state per sequence, one RGB frame resident at a time.
+
+    The official ``inference_step`` is a ray-map query API, not an RGB state update.
+    We instead reuse the official RGB encoder and recurrent decoder step. No
+    revisiting, global alignment, or sequence-wide image encoding is performed.
+    """
+
+    def __init__(
+        self,
+        checkout: Path,
+        checkpoint: Path,
+        *,
+        checkpoint_sha256: str,
+        revision: str = SUPPORTED_CUT3R_REVISION,
+        device: str = "cuda:0",
+        image_size: int = 512,
+        seed: int = 42,
+        allow_native_build_compatibility: bool = False,
+    ) -> None:
+        if image_size not in (224, 512):
+            raise ValueError("CUT3R image_size must be 224 or 512")
+        if type(seed) is not int or not 0 <= seed < 2**32:
+            raise ValueError("seed must be an unsigned 32-bit integer")
+        expected = require_sha256(checkpoint_sha256, name="trusted checkpoint SHA-256")
+        checkpoint = ordinary_path(checkpoint)
+        if not checkpoint.is_file() or file_sha256(checkpoint) != expected:
+            raise ValueError("CUT3R checkpoint SHA-256 mismatch")
+        checkout = ordinary_path(checkout)
+        sources = verify_checkout(
+            checkout,
+            revision,
+            allow_native_build_compatibility=allow_native_build_compatibility,
+        )
+        for name in ("dust3r", "src.dust3r", "models"):
+            if name in sys.modules:
+                raise RuntimeError("start a fresh process before initializing native CUT3R")
+        for path in (checkout, checkout / "src"):
+            sys.path.insert(0, str(path))
+        try:
+            rope = require_compiled_cut3r_rope(checkout)
+            torch = importlib.import_module("torch")
+            model_module = importlib.import_module("dust3r.model")
+            image_module = importlib.import_module("dust3r.utils.image")
+            camera_module = importlib.import_module("dust3r.utils.camera")
+            post_module = importlib.import_module("dust3r.post_process")
+        except ImportError as error:
+            raise RuntimeError(
+                "CUT3R runtime dependencies missing; see docs/cut3r-native-inference.md"
+            ) from error
+        selected_device = torch.device(device)
+        if selected_device.type != "cuda" or not torch.cuda.is_available():
+            raise ValueError("native CUT3R requires CUDA with compiled RoPE")
+        self.torch: Any = torch
+        self.device = selected_device
+        self.image_size = image_size
+        self.seed = seed
+        self.load_images = image_module.load_images
+        self.decode_pose = camera_module.pose_encoding_to_camera
+        self.estimate_focal = post_module.estimate_focal_knowing_depth
+        self.reset()
+        # Official checkpoints contain argparse/config objects and load_model
+        # evaluates their architecture. Only use trusted, digest-verified weights.
+        # Scope modern Torch compatibility to loading; do not patch upstream files.
+        previous = os.environ.get("TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD")
+        os.environ["TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD"] = "1"
+        try:
+            self.model = model_module.load_model(str(checkpoint), "cpu", verbose=False)
+        finally:
+            if previous is None:
+                os.environ.pop("TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD", None)
+            else:
+                os.environ["TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD"] = previous
+        head = self.model.head_type
+        if (head == "dpt" and image_size != 512) or (head == "linear" and image_size != 224):
+            raise ValueError("CUT3R checkpoint head and image_size disagree")
+        self.model = self.model.to(selected_device).eval()
+        self.identity: dict[str, Any] = {
+            "cut3r_revision": revision,
+            "checkpoint_sha256": expected,
+            "checkpoint_byte_count": checkpoint.stat().st_size,
+            "source_sha256s": sources,
+            "native_rope": rope,
+            "torch": str(torch.__version__),
+            "torch_cuda": str(torch.version.cuda),
+            "device": str(selected_device),
+            "image_size": image_size,
+            "seed": seed,
+            "execution_mode": "rgb-recurrent-stream-v1",
+            "revisit_count": 1,
+            "global_alignment": False,
+            "sequence_wide_encoding": False,
+            "native_build_compatibility_permitted": allow_native_build_compatibility,
+        }
+
+    def reset(self) -> None:
+        random.seed(self.seed)
+        np.random.seed(self.seed)
+        self.torch.manual_seed(self.seed)
+        self.torch.cuda.manual_seed_all(self.seed)
+        self.torch.backends.cudnn.benchmark = False
+        self.state: tuple[Any, ...] | None = None
+        self.frame_count = 0
+
+    def prepare_view(self, path: Path) -> dict[str, Any]:
+        torch = self.torch
+        image = self.load_images([str(path)], size=self.image_size, verbose=False)[0]
+        tensor = image["img"].to(self.device)
+        return {
+            "img": tensor,
+            "true_shape": torch.as_tensor(image["true_shape"], device=self.device),
+            "img_mask": torch.ones(1, dtype=torch.bool, device=self.device),
+            "ray_mask": torch.zeros(1, dtype=torch.bool, device=self.device),
+            "update": torch.ones(1, dtype=torch.bool, device=self.device),
+            "reset": torch.zeros(1, dtype=torch.bool, device=self.device),
+        }
+
+    def step(self, path: Path) -> dict[str, np.ndarray]:
+        torch = self.torch
+        with torch.inference_mode(), torch.autocast(device_type="cuda", enabled=False):
+            view = self.prepare_view(path)
+            features, positions, _ = self.model._encode_image(view["img"], view["true_shape"])
+            feature = features[-1]
+            first = self.state is None
+            if first:
+                state_feat, state_pos = self.model._init_state(feature, positions)
+                memory = self.model.pose_retriever.mem.expand(feature.shape[0], -1, -1)
+                self.state = (state_feat, state_pos, state_feat.clone(), memory, memory.clone())
+            assert self.state is not None
+            state_feat, state_pos, initial_feat, memory, initial_mem = self.state
+            # The upstream index selects the initial pose token versus a memory
+            # query; only views[i] is accessed. Keep this container constant-size.
+            prediction, (state_feat, memory) = self.model._forward_decoder_step(
+                [view, view],
+                int(not first),
+                feature,
+                positions,
+                view["true_shape"],
+                initial_feat,
+                initial_mem,
+                state_feat,
+                state_pos,
+                memory,
+            )
+            self.state = (state_feat, state_pos, initial_feat, memory, initial_mem)
+            self.frame_count += 1
+            return self.decode_prediction(prediction)
+
+    def decode_prediction(self, prediction: dict[str, Any]) -> dict[str, np.ndarray]:
+        torch = self.torch
+        points = prediction["pts3d_in_self_view"].detach().float().cpu()
+        confidence = prediction["conf_self"].detach().float().cpu()
+        poses = self.decode_pose(prediction["camera_pose"].clone()).detach().cpu()
+        _, height, width, _ = points.shape
+        principal = torch.tensor([[width // 2, height // 2]], dtype=points.dtype)
+        focal = self.estimate_focal(points, principal, focal_mode="weiszfeld")
+        intrinsics = torch.eye(3)
+        intrinsics[0, 0] = intrinsics[1, 1] = focal[0]
+        intrinsics[:2, 2] = principal[0]
+        return {
+            "points": points[0].numpy(),
+            "confidence": confidence[0].numpy(),
+            "pose": poses[0].numpy().astype(np.float64),
+            "intrinsics": intrinsics.numpy().astype(np.float64),
+        }

--- a/src/prob4d/prediction_cli.py
+++ b/src/prob4d/prediction_cli.py
@@ -16,6 +16,9 @@ def _help_parser() -> argparse.ArgumentParser:
     )
     subparsers = parser.add_subparsers(dest="command")
     subparsers.add_parser(
+        "run-cut3r", help="run native causal RGB CUT3R and export a verified direct provider",
+    )
+    subparsers.add_parser(
         "import-motioncrafter",
         help="convert an integrity-bound MotionCrafter prediction bundle",
     )
@@ -90,6 +93,10 @@ def main(argv: Sequence[str] | None = None) -> int:
     if arguments[0] in {"-h", "--help"}:
         _help_parser().parse_args(arguments)
         return 0
+    if arguments[0] == "run-cut3r":
+        from ._cut3r_native_cli import main as native_cut3r_main
+
+        return int(native_cut3r_main(arguments[1:]))
     if arguments[0] == "import-vggt":
         from .vggt_provider_adapter import main as vggt_main
 

--- a/src/prob4d/prediction_cli.py
+++ b/src/prob4d/prediction_cli.py
@@ -16,7 +16,8 @@ def _help_parser() -> argparse.ArgumentParser:
     )
     subparsers = parser.add_subparsers(dest="command")
     subparsers.add_parser(
-        "run-cut3r", help="run native causal RGB CUT3R and export a verified direct provider",
+        "run-cut3r",
+        help="run native causal RGB CUT3R and export a verified direct provider",
     )
     subparsers.add_parser(
         "import-motioncrafter",

--- a/tests/test_cut3r_native_provider.py
+++ b/tests/test_cut3r_native_provider.py
@@ -1,0 +1,425 @@
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from contextlib import nullcontext
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+import pytest
+
+from prob4d import cut3r_native_provider as provider
+from prob4d import cut3r_native_runtime as native
+from prob4d.data import PredictionWindow
+from prob4d.prediction_cli import main
+from prob4d.prediction_provider_manifest import verify_prediction_provider_manifest
+
+
+class FakeRuntime:
+    identity = {"cut3r_revision": "a" * 40, "checkpoint_sha256": "b" * 64}
+
+    def __init__(self, *, fail_at: int | None = None) -> None:
+        self.fail_at = fail_at
+        self.seen: list[bytes] = []
+        self.index = 0
+
+    def reset(self) -> None:
+        self.index = 0
+
+    def step(self, path: Path) -> dict[str, np.ndarray]:
+        if self.index == self.fail_at:
+            raise RuntimeError("synthetic provider failure")
+        self.seen.append(path.read_bytes())
+        self.index += 1
+        points = np.ones((2, 3, 3), dtype=np.float32)
+        points[..., 0] = self.index * 0.1
+        return {
+            "points": points,
+            "confidence": np.full((2, 3), 2, dtype=np.float32),
+            "pose": np.eye(4),
+            "intrinsics": np.eye(3),
+        }
+
+
+def _frames(root: Path, count: int = 3) -> Path:
+    root.mkdir()
+    for i in range(count):
+        (root / f"{i:06d}.png").write_bytes(f"synthetic frame {i}".encode())
+    return root
+
+
+def _run(tmp_path: Path, *, runtime: FakeRuntime | None = None, stop: int = 2) -> dict[str, Any]:
+    return provider.run_cut3r_native(
+        tmp_path / "frames",
+        tmp_path / "out",
+        runtime_factory=lambda: runtime or FakeRuntime(),
+        sequence_id="synthetic",
+        frame_start=0,
+        frame_stop=stop,
+    )
+
+
+def test_native_export_is_causal_direct_and_loadable(tmp_path: Path) -> None:
+    frames = _frames(tmp_path / "frames")
+    (frames / "000002.png").unlink()
+    (frames / "000002.png").symlink_to("unreadable-future")
+    runtime = FakeRuntime()
+    receipt = _run(tmp_path, runtime=runtime)
+    assert receipt["status"] == "success"
+    assert receipt["frames_completed"] == 2
+    assert runtime.seen == [b"synthetic frame 0", b"synthetic frame 1"]
+    assert not (tmp_path / "out/staging/decoded").exists()
+    unsigned = dict(receipt)
+    assert unsigned.pop("artifact_id") == provider.content_id(unsigned)
+    output = tmp_path / "out/prediction/provider.json"
+    manifest, _ = verify_prediction_provider_manifest(output)
+    assert manifest.coordinate_semantics == "sequence-local-sim3"
+    assert manifest.flow_semantics == "absent"
+    assert manifest.metadata["confidence_is_support_not_reliability"]
+    payload = manifest.payloads[0]
+    assert [row.source_frame_stop_exclusive for row in payload.frame_lineage] == [1, 2]
+    window = PredictionWindow.from_npz(output.parent / payload.path, dense_storage_dtype="float32")
+    assert window.point_map.shape == (2, 2, 3, 3)
+    np.testing.assert_array_equal(window.point_map[0, ..., 0], np.full((2, 3), 0.1, np.float32))
+    assert window.ray_directions is not None
+
+
+def test_failure_never_publishes_manifest_and_cannot_clobber(tmp_path: Path) -> None:
+    _frames(tmp_path / "frames")
+    with pytest.raises(RuntimeError, match="synthetic provider failure"):
+        _run(tmp_path, runtime=FakeRuntime(fail_at=1))
+    receipt = json.loads((tmp_path / "out/run.json").read_text())
+    assert receipt["status"] == "failed"
+    assert receipt["frames_completed"] == 1
+    assert receipt["stage"] == "provider-inference"
+    assert not receipt["prediction_published"]
+    assert not (tmp_path / "out/prediction").exists()
+    assert not (tmp_path / "out/staging/decoded").exists()
+    before = (tmp_path / "out/run.json").read_bytes()
+    with pytest.raises(FileExistsError):
+        _run(tmp_path)
+    assert (tmp_path / "out/run.json").read_bytes() == before
+
+
+def test_runtime_failure_occurs_before_any_frame_staging(tmp_path: Path) -> None:
+    def failed() -> FakeRuntime:
+        raise RuntimeError("runtime unavailable")
+
+    with pytest.raises(RuntimeError, match="runtime unavailable"):
+        provider.run_cut3r_native(
+            tmp_path / "not-opened",
+            tmp_path / "out",
+            runtime_factory=failed,
+            sequence_id="synthetic",
+            frame_start=0,
+            frame_stop=1,
+        )
+    receipt = json.loads((tmp_path / "out/run.json").read_text())
+    assert receipt["stage"] == "runtime-initialization"
+    assert receipt["frames_completed"] == 0
+    assert "input" not in receipt
+
+
+@pytest.mark.parametrize("stop", [0, -1, True, 4097])
+def test_invalid_interval_precedes_runtime(tmp_path: Path, stop: int) -> None:
+    with pytest.raises(ValueError):
+        _run(tmp_path, stop=stop)
+    assert not (tmp_path / "out").exists()
+
+
+@pytest.mark.parametrize("extension", [".tiff", "../a", "png"])
+def test_invalid_extension(tmp_path: Path, extension: str) -> None:
+    with pytest.raises(ValueError, match="extension"):
+        provider.run_cut3r_native(
+            tmp_path / "none",
+            tmp_path / "out",
+            runtime_factory=FakeRuntime,
+            sequence_id="x",
+            frame_start=0,
+            frame_stop=1,
+            extension=extension,
+        )
+
+
+def test_missing_selected_frame_fails_closed(tmp_path: Path) -> None:
+    _frames(tmp_path / "frames", count=1)
+    with pytest.raises(FileNotFoundError):
+        _run(tmp_path)
+    assert not (tmp_path / "out/prediction").exists()
+
+
+def test_symlinked_selected_frame_rejected(tmp_path: Path) -> None:
+    frames = _frames(tmp_path / "frames")
+    (frames / "000000.png").unlink()
+    (frames / "000000.png").symlink_to(frames / "000001.png")
+    with pytest.raises(ValueError, match="symbolic"):
+        _run(tmp_path)
+
+
+def test_frame_mutation_detected(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _frames(tmp_path / "frames")
+    copy = shutil.copyfile
+
+    def corrupt(source: Path, destination: Path) -> None:
+        copy(source, destination)
+        destination.write_bytes(b"changed")
+
+    monkeypatch.setattr(shutil, "copyfile", corrupt)
+    with pytest.raises(ValueError, match="changed"):
+        _run(tmp_path)
+
+
+def test_video_emission_is_bounded(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    video = tmp_path / "input.mp4"
+    video.write_bytes(b"synthetic video")
+    calls: list[list[str]] = []
+
+    def ffmpeg(command: list[str], **kwargs: Any) -> None:
+        calls.append(command)
+        destination = Path(command[-1]).parent
+        for i in range(2):
+            (destination / f"{i:06d}.png").write_bytes(b"frame")
+
+    monkeypatch.setattr(subprocess, "run", ffmpeg)
+    provider.run_cut3r_native(
+        video,
+        tmp_path / "out",
+        runtime_factory=FakeRuntime,
+        sequence_id="video",
+        frame_start=3,
+        frame_stop=5,
+        video=True,
+    )
+    command = calls[0]
+    assert command[command.index("-frames:v") + 1] == "2"
+    assert command[command.index("-vf") + 1] == "select=between(n\\,3\\,4)"
+    assert "-nostdin" in command
+
+
+@pytest.mark.parametrize("mutation", ["nan", "shape", "pose", "focal", "empty"])
+def test_bad_prediction_never_published(tmp_path: Path, mutation: str) -> None:
+    frames = _frames(tmp_path / "frames")
+
+    class BadRuntime(FakeRuntime):
+        def step(self, path: Path) -> dict[str, np.ndarray]:
+            value = super().step(path)
+            if mutation == "nan":
+                value["points"][0, 0, 0] = np.nan
+            elif mutation == "shape":
+                value["confidence"] = np.ones((1, 1))
+            elif mutation == "pose":
+                value["pose"][0, 0] = 2
+            elif mutation == "focal":
+                value["intrinsics"][0, 0] = -1
+            else:
+                value["confidence"][:] = 0
+            return value
+
+    with pytest.raises(ValueError):
+        provider.run_cut3r_native(
+            frames,
+            tmp_path / "out",
+            runtime_factory=BadRuntime,
+            sequence_id="x",
+            frame_start=0,
+            frame_stop=1,
+        )
+    assert not (tmp_path / "out/prediction").exists()
+
+
+def test_cli_help_does_not_import_torch() -> None:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; from prob4d.prediction_cli import main; "
+            "main(['--help']); assert 'torch' not in sys.modules",
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert "run-cut3r" in result.stdout
+
+
+def test_cli_dispatch(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from prob4d import _cut3r_native_cli as cli
+
+    calls = []
+
+    def run(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        calls.append((args, kwargs))
+        return {"status": "success", "artifact_id": "a" * 64, "frames_completed": 2}
+
+    monkeypatch.setattr(cli, "run_cut3r_native", run)
+    assert (
+        main(
+            [
+                "run-cut3r",
+                "--frames",
+                str(tmp_path),
+                "--output",
+                str(tmp_path / "out"),
+                "--sequence-id",
+                "test",
+                "--frame-stop",
+                "2",
+                "--cut3r-checkout",
+                str(tmp_path),
+                "--checkpoint",
+                "trusted.pth",
+                "--checkpoint-sha256",
+                "b" * 64,
+            ]
+        )
+        == 0
+    )
+    assert calls[0][1]["frame_stop"] == 2
+    assert calls[0][1]["video"] is False
+
+
+def test_native_runtime_validates_before_optional_imports(tmp_path: Path) -> None:
+    checkpoint = tmp_path / "weights.pth"
+    checkpoint.write_bytes(b"not actual weights")
+    with pytest.raises(ValueError, match="SHA-256 mismatch"):
+        native.Cut3RNativeRuntime(tmp_path, checkpoint, checkpoint_sha256="a" * 64)
+    with pytest.raises(ValueError, match="image_size"):
+        native.Cut3RNativeRuntime(tmp_path, checkpoint, checkpoint_sha256="a" * 64, image_size=128)
+
+
+def test_checkout_verification_rejects_dirty_and_wrong_revision(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    model = tmp_path / "src/dust3r/model.py"
+    model.parent.mkdir(parents=True)
+    model.write_text("# synthetic source\n")
+    status = b""
+
+    def git(command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[bytes]:
+        data = native.SUPPORTED_CUT3R_REVISION.encode() if command[3] == "rev-parse" else status
+        return subprocess.CompletedProcess(command, 0, stdout=data)
+
+    monkeypatch.setattr(subprocess, "run", git)
+    assert "src/dust3r/model.py" in native.verify_checkout(
+        tmp_path, native.SUPPORTED_CUT3R_REVISION
+    )
+    status = b" M src/dust3r/model.py"
+    with pytest.raises(ValueError, match="dirty"):
+        native.verify_checkout(tmp_path, native.SUPPORTED_CUT3R_REVISION)
+    with pytest.raises(ValueError, match="unsupported"):
+        native.verify_checkout(tmp_path, "a" * 40)
+
+
+def test_rgb_step_carries_state_and_encodes_only_current_frame(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class Tensor:
+        shape = (1, 2, 3)
+
+        def __init__(self, value: int) -> None:
+            self.value = value
+
+        def clone(self) -> Tensor:
+            return Tensor(self.value)
+
+        def expand(self, *args: int) -> Tensor:
+            return self
+
+    encoded: list[int] = []
+    indices: list[int] = []
+
+    class Model:
+        pose_retriever = SimpleNamespace(mem=Tensor(0))
+
+        def _encode_image(self, img: int, shape: Any) -> tuple[Any, ...]:
+            encoded.append(img)
+            return [Tensor(img)], Tensor(0), None
+
+        def _init_state(self, feature: Tensor, pos: Tensor) -> tuple[Tensor, Tensor]:
+            return Tensor(0), pos
+
+        def _forward_decoder_step(
+            self,
+            views: list[Any],
+            i: int,
+            feat: Tensor,
+            pos: Any,
+            shape: Any,
+            initial: Tensor,
+            initial_mem: Tensor,
+            state: Tensor,
+            state_pos: Any,
+            memory: Tensor,
+        ) -> tuple[dict[str, np.ndarray], tuple[Tensor, Tensor]]:
+            assert len(views) == 2  # no prefix-sized container or re-encoding
+            indices.append(i)
+            updated = Tensor(state.value + feat.value)
+            return {"points": np.array(updated.value)}, (updated, memory)
+
+    runtime = native.Cut3RNativeRuntime.__new__(native.Cut3RNativeRuntime)
+    runtime.torch = SimpleNamespace(
+        inference_mode=nullcontext,
+        autocast=lambda **kwargs: nullcontext(),
+        manual_seed=lambda seed: None,
+        cuda=SimpleNamespace(manual_seed_all=lambda seed: None),
+        backends=SimpleNamespace(cudnn=SimpleNamespace(benchmark=True)),
+    )
+    runtime.seed = 42
+    runtime.model = Model()
+    monkeypatch.setattr(
+        runtime, "prepare_view", lambda p: {"img": int(p.name), "true_shape": (2, 3)}
+    )
+    monkeypatch.setattr(runtime, "decode_prediction", lambda prediction: prediction)
+    runtime.reset()
+    assert runtime.step(tmp_path / "1")["points"] == 1
+    assert runtime.step(tmp_path / "2")["points"] == 3
+    assert runtime.step(tmp_path / "3")["points"] == 6
+    assert encoded == [1, 2, 3]
+    assert indices == [0, 1, 1]
+    runtime.reset()
+    assert runtime.step(tmp_path / "1")["points"] == 1
+    assert runtime.frame_count == 1
+
+
+def test_build_variant_is_exact_and_opt_in(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    relative = "src/croco/models/curope/kernels.cu"
+    member = tmp_path / relative
+    member.parent.mkdir(parents=True)
+    member.write_bytes(b"synthetic known kernel")
+    model = tmp_path / "src/dust3r/model.py"
+    model.parent.mkdir()
+    model.write_text("# model\n")
+    monkeypatch.setattr(
+        native,
+        "NATIVE_BUILD_COMPATIBILITY_SHA256",
+        {
+            relative: native.file_sha256(member),
+        },
+    )
+
+    def git(command: list[str], **kwargs: Any) -> subprocess.CompletedProcess[bytes]:
+        if command[3] == "rev-parse":
+            data = native.SUPPORTED_CUT3R_REVISION.encode()
+        elif command[3] == "status":
+            data = f" M {relative}".encode()
+        else:
+            data = relative.encode() + b"\0"
+        return subprocess.CompletedProcess(command, 0, stdout=data)
+
+    monkeypatch.setattr(subprocess, "run", git)
+    with pytest.raises(ValueError, match="dirty"):
+        native.verify_checkout(tmp_path, native.SUPPORTED_CUT3R_REVISION)
+    native.verify_checkout(
+        tmp_path, native.SUPPORTED_CUT3R_REVISION, allow_native_build_compatibility=True
+    )
+    member.write_bytes(b"arbitrary different kernel")
+    with pytest.raises(ValueError, match="dirty"):
+        native.verify_checkout(
+            tmp_path, native.SUPPORTED_CUT3R_REVISION, allow_native_build_compatibility=True
+        )

--- a/tests/test_cut3r_native_provider.py
+++ b/tests/test_cut3r_native_provider.py
@@ -196,8 +196,37 @@ def test_video_emission_is_bounded(tmp_path: Path, monkeypatch: pytest.MonkeyPat
     )
     command = calls[0]
     assert command[command.index("-frames:v") + 1] == "2"
+    assert command[command.index("-vsync") + 1] == "0"
+    assert "-fps_mode" not in command  # supported by FFmpeg 4.4 as well as newer releases
     assert command[command.index("-vf") + 1] == "select=between(n\\,3\\,4)"
     assert "-nostdin" in command
+
+
+def test_video_error_preserves_decoder_diagnostic(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    video = tmp_path / "input.mp4"
+    video.write_bytes(b"synthetic")
+
+    def failed(command: list[str], **kwargs: Any) -> None:
+        raise subprocess.CalledProcessError(1, command, stderr=b"invalid synthetic video")
+
+    monkeypatch.setattr(subprocess, "run", failed)
+    with pytest.raises(RuntimeError, match="invalid synthetic video"):
+        provider.run_cut3r_native(
+            video,
+            tmp_path / "out",
+            runtime_factory=FakeRuntime,
+            sequence_id="test",
+            frame_start=0,
+            frame_stop=1,
+            video=True,
+        )
+    receipt = json.loads((tmp_path / "out/run.json").read_text())
+    assert receipt["stage"] == "prefix-staging"
+    assert "invalid synthetic video" in receipt["error"]
+    assert not (tmp_path / "out/prediction").exists()
 
 
 @pytest.mark.parametrize("mutation", ["nan", "shape", "pose", "focal", "empty"])


### PR DESCRIPTION
## Summary
- Add `prob4d prediction run-cut3r`: bounded RGB image/video inputs, genuine native recurrent CUT3R inference, and verified direct-geometry export.
- Keep Torch/CUT3R optional and lazy-loaded; verify source, trusted checkpoint, and compiled native RoPE provenance.
- Preserve existing importers, frozen experiments, quarantines, and all scientific promotion gates.

## Verification
- Native RTX 4090 / official 512 DPT synthetic image smoke: 3 frames exported; XYZ exactly matches official recurrent inference and shorter-prefix replay; peak allocated GPU memory 3.44 GiB.
- Native video CLI on FFmpeg 4.4: exactly 2 of 3 synthetic frames exported; point-map files byte-identical to the image path.
- Full local suite: 2,367 passed, 8 skipped (optional h5py and unavailable historical Git object).
- Native-provider plus CLI focused suite: 43 passed. Changed-file Ruff, formatting, strict focused MyPy, wheel/sdist build, and twine validation pass.
- The hash-pinned optional modern-ATen/SM89 build patch reproduces the exact runtime source hashes when applied to pristine upstream files.

## Claim boundary
This qualifies the native RGB execution/export interface on the tested runtime. It does not establish real-data accuracy, metric scale, calibrated uncertainty, material tracking, or BayesianPhysTwin transfer. No real dataset, old quarantine, source truth, target, held-v8, or Causal4D empirical artifact was accessed or reopened. CUDA and the official 512 DPT model were tested; the 224 interface is not natively qualified.

See `docs/cut3r-native-inference.md` and `evidence/cut3r-native-software-smoke-v1/summary.json`.