### PR TITLE
Evaluate Bayesian CUT3R prefix updates against matched controls

### DIFF
--- a/CHANGELOG.d/cut3r-bayesian-prefix-development.md
+++ b/CHANGELOG.d/cut3r-bayesian-prefix-development.md
@@ -1,0 +1,4 @@
+Add a fixed CPU-only exploratory CUT3R sparse-prefix comparison using existing
+Gaussian conditioning, matched deterministic controls, sealed predictions, and
+retained real DOT source evidence. The Bayesian correction beats metric alignment
+but does not beat last-residual correction in aggregate point error.

--- a/docs/cut3r-bayesian-prefix-development-v1.md
+++ b/docs/cut3r-bayesian-prefix-development-v1.md
@@ -59,3 +59,10 @@ on previously seen identities, not a disjoint-hidden-identity test. With only
 three previously opened source sequences, no confirmatory CI or SOTA claim is made.
 Any positive result must beat the full-prefix alignment and last-residual controls
 before it motivates a distinct, larger public-data evaluation.
+
+## Completed result
+
+The [retained result](../evidence/cut3r-bayesian-prefix-dev-v1/README.md) covers
+all three sequences. Shared-error Bayes improves RMSE by 78.38% over full-prefix
+metric alignment, but is 10.21% worse than last-residual correction overall.
+The strongest simple point baseline therefore remains unbeaten in this test.

--- a/docs/cut3r-bayesian-prefix-development-v1.md
+++ b/docs/cut3r-bayesian-prefix-development-v1.md
@@ -1,0 +1,61 @@
+# CUT3R Bayesian prefix development comparison
+
+This is a new **exploratory** experiment on already-open public DOT R01-R03.
+It reuses immutable native CUT3R continuous predictions from run 33329701704;
+it does not rerun or modify any closed experiment, access R04-R70, decode new
+RGB, or access BayesianPhysTwin/Causal4D/held-v8/DLO4/DLO5 artifacts.
+
+## Question
+
+Can sparse early 3D measurements make later CUT3R reconstruction more accurate,
+and does accounting for shared observation error improve Bayesian conditioning?
+This is observed-frame reconstruction with sparse prefix supervision, **not**
+unseen-future simulation, fully marker-free tracking, or a fresh-object result.
+The current-frame RGB and released 2D query locations are common to every arm.
+
+## Fixed comparison
+
+- Initial metric alignment: robust proper Sim(3) using frames 1-2.
+- Bayesian residual observations: frames 3-5 only.
+- Scored 3D marker measurements: frames 6-7, opened only after all three
+  predictions or technical dispositions have been sealed by this new runner.
+- Full-prefix deterministic control: Sim(3) refit using all frames 1-5.
+- Last-residual control: each identity's last valid residual anywhere in frames
+  1-5, with zero correction for previously unsupported identities.
+- Bayesian arms: the same zero-mean spatial residual GP, either independent
+  observation noise or a shared camera-bias nuisance with correlation 0.8.
+- GP covariance: `0.1^2 * (0.5 + 0.5 * exp(-distance^2 / (2 * 0.25^2)))`.
+- Observation standard deviation: 0.02. Both likelihoods have the same row
+  marginal variance; only their off-diagonal dependence differs.
+- Coordinates are normalized by the frame-1/2 marker bounding-box diagonal.
+  No unverified metre/millimetre conversion is claimed.
+- No hyperparameter search, rank-defect requirement, outcome-selected camera,
+  confidence-to-probability conversion, residual clipping, or automatic promotion.
+
+The existing `condition_gaussian_query` and structured covariance operators
+perform the Bayesian update. The covariance is a model assumption for this
+development test, not a pre-established calibration guarantee. Deterministic
+controls receive the same fixed Gaussian wrapper as the initial prior; reported
+NLL does not imply that vanilla CUT3R natively outputs calibrated covariance.
+The shared camera nuisance is not identified separately from the residual field.
+
+## Safeguards and metrics
+
+Inputs and implementations are hash-bound before measurement access. Duplicate
+frame/identity observations are collapsed if exact and rejected if conflicting.
+Missing early observations are not fabricated. Insufficient residual-update
+support retains the exact initial-alignment prediction and covariance; insufficient
+alignment or later scoring support is a retained technical failure, not replacement.
+
+Report 3D point RMSE / prefix span, marginal 3D Gaussian NLL per coordinate,
+NEES / 3, 90% ellipsoid coverage, and 90% marginal coordinate full width / span.
+Aggregate equally over the two supported score frames, then over the three
+sequences. Every arm uses exactly the same scored rows. A missing sequence means
+only descriptive subset metrics, never a complete-denominator claim.
+
+The spatial kernel uses provider geometry, not scored 3D truth. Marker identities
+follow the existing released row-order convention. Results are temporal transfer
+on previously seen identities, not a disjoint-hidden-identity test. With only
+three previously opened source sequences, no confirmatory CI or SOTA claim is made.
+Any positive result must beat the full-prefix alignment and last-residual controls
+before it motivates a distinct, larger public-data evaluation.

--- a/evidence/cut3r-bayesian-prefix-dev-v1/README.md
+++ b/evidence/cut3r-bayesian-prefix-dev-v1/README.md
@@ -1,0 +1,81 @@
+# Real DOT/CUT3R Bayesian prefix development result
+
+**Decision: strong improvement over metric-aligned CUT3R, but no overall Bayesian
+point-accuracy superiority over last-residual correction. No automatic promotion.**
+
+The fixed CPU experiment completed on all three already-open DOT source sequences:
+3 ordinary predictions, 0 support fallbacks, 0 unsealable cases, 3 scored
+sequences, and 28 scored 3D marker rows across six later frames. All predictions
+were sealed before this run accessed later 3D scoring measurements. No new CUT3R
+inference, RGB decoding, recording, or protected-target access occurred.
+
+## Equal-sequence results
+
+RMSE and full coordinate interval width are percentages of the prefix-only
+marker bounding-box diagonal. NLL is per coordinate in these normalized units;
+lower is better. Coverage is marginal 3D 90% ellipsoid coverage. Frames are
+weighted equally within each sequence and sequences equally in the aggregate.
+
+| Arm | 3D RMSE (% span) | NLL/coordinate | NEES/3 | Coverage | Full width (% span) |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| CUT3R, initial frames 1-2 alignment | 20.0325 | -0.6494 | 1.4292 | 85.00% | 33.5486 |
+| CUT3R, full frames 1-5 alignment | 13.5885 | -1.0436 | 0.6409 | 91.67% | 33.5486 |
+| Last residual | **2.6661** | -1.3502 | 0.0277 | 100.00% | 33.5486 |
+| Bayesian, independent observation noise | 3.2058 | **-2.4873** | 0.6329 | 100.00% | 7.9538 |
+| Bayesian, shared observation error | 2.9383 | -2.4552 | 0.4217 | 100.00% | 9.1256 |
+
+The shared-error Bayesian arm reduces aggregate RMSE by **78.3765%** relative
+to full-prefix-aligned CUT3R and improves all three sequences. It improves RMSE
+by **8.3427%** relative to independent-noise Bayes, but has slightly worse NLL
+(+0.03215 nats/coordinate). It is **10.2120% worse** in aggregate RMSE than
+last-residual correction, despite beating that control on two of three sequences.
+
+| Sequence | Full-prefix CUT3R | Last residual | Bayes independent | Bayes shared |
+| --- | ---: | ---: | ---: | ---: |
+| R01 | 19.0405 | **1.8284** | 3.4900 | 3.7871 |
+| R02 | 11.2198 | 1.9856 | 2.2562 | **1.6717** |
+| R03 | 10.5053 | 4.1841 | 3.8711 | **3.3562** |
+
+## What this does and does not establish
+
+Early sparse 3D residual correction clearly helps this CUT3R reconstruction
+interface. Bayesian conditioning works numerically and can substantially reduce
+error, but the simplest last-residual mean remains best overall on this test.
+This is evidence for prefix correction, not evidence that Bayesian inference is
+necessary to obtain the point-accuracy improvement.
+
+The Bayesian intervals are narrower and score better than the fixed Gaussian
+wrappers on the deterministic controls. Those wrappers were **not independently
+calibrated**, however. Therefore this does not show superiority over a calibrated
+last-residual/conformal baseline. Likewise 100% coverage on 28 dependent rows
+does not establish 90% population calibration. Shared dependence did not jointly
+win on both mean accuracy and proper score against the independent Bayesian arm.
+
+This is sparse-prefix-supervised, observed-frame reconstruction with common
+current-frame RGB and released 2D marker query locations. The later 3D markers
+are held out by this run, but these source sequences were already opened in
+earlier work. It is not a fresh-object confirmation, unseen-future physical
+forecast, fully automatic tracker, BayesianPhysTwin transfer, or SOTA result.
+The next comparison should include source-calibrated last-residual uncertainty;
+this result does not authorize opening a larger protected cohort or retuning
+the frozen arms on these scoring measurements.
+
+## Provenance
+
+- Frozen implementation: `d70e0a426d1ec3e5da512e941c4e72f7915fb8b7`.
+- Protocol ID: `30ce2d2825f3ef68798b402ae2945d0c4cd74216c36b35c327a37994f5837c14`.
+- Result ID: `f8d138921e3bf9ce02721a9d4f7154ae5a4182fd56360dd2c40134a34e2a4941`.
+- Result file SHA-256: `4cfaa725dbb740daf3e84d3d1f9a2eb8809443ec3055ba1d543718869848395b`.
+- Barrier ID: `9a7d448192121533228c4ebbc5cb3ff9a16f0752d04ecb979ed992ccfc5492ab`.
+- Provider bundle: `952421d140731b2a6eb99df3cbd348653e04863fa457aaa490be31fe0b4c06a7`.
+- Downloaded provider ZIP SHA-256: `565667959ca697c744a57528cd21308d0f040127bcb9296a4b8e9138b5c521c6`.
+- Native execution: Python 3.10.12, NumPy 2.2.6; no GPU used.
+- Raw predictions: `gpuserver4090:/home/florianpfaff/source-only/cut3r-bayesian-prefix-dev-v1-result`.
+
+A second, scalar-form metric computation from the unchanged sealed predictions
+and source scoring markers matched all per-sequence metrics within
+`4.45e-16`. It also reverified prediction hashes and canonical result/barrier
+identities. This is numerical reproduction by the same task, not independent
+human review or independent data. Its receipt is `numerical-verification.json`.
+The raw result's aggregate `scored_rows` is the mean count per sequence; the
+total scored-row count is 28, as recorded by the verification receipt.

--- a/evidence/cut3r-bayesian-prefix-dev-v1/numerical-verification.json
+++ b/evidence/cut3r-bayesian-prefix-dev-v1/numerical-verification.json
@@ -1,0 +1,15 @@
+{
+  "artifact_id": "09b7b1f3d82a9dde88b9585f2a5b0012895ea676e8f9ef99e420b677a73480c7",
+  "canonical_result_and_barrier_verified": true,
+  "maximum_metric_difference": 4.440892098500626e-16,
+  "method": "independent scalar metric recomputation from unchanged sealed predictions and authorized source scoring markers",
+  "new_prediction_generated": false,
+  "prediction_barrier_id": "9a7d448192121533228c4ebbc5cb3ff9a16f0752d04ecb979ed992ccfc5492ab",
+  "prediction_hashes_verified": true,
+  "protected_targets_accessed": false,
+  "provider_inference_rerun": false,
+  "result_id": "f8d138921e3bf9ce02721a9d4f7154ae5a4182fd56360dd2c40134a34e2a4941",
+  "schema": "prob4d.cut3r-bayesian-prefix-numerical-replay-v1",
+  "scored_rows": 28,
+  "source_sequence_count": 3
+}

--- a/evidence/cut3r-bayesian-prefix-dev-v1/prediction-barrier.json
+++ b/evidence/cut3r-bayesian-prefix-dev-v1/prediction-barrier.json
@@ -1,0 +1,38 @@
+{
+  "artifact_id": "9a7d448192121533228c4ebbc5cb3ff9a16f0752d04ecb979ed992ccfc5492ab",
+  "cases": {
+    "R01": {
+      "file": "R01-predictions.npz",
+      "prefix_count": 20,
+      "query_count": 8,
+      "sha256": "483de5b89b84599ebef2dcad710a5446f3cde3a8aeadb1cef3001cd09835b30b",
+      "status": "ordinary_success",
+      "update_count": 12
+    },
+    "R02": {
+      "file": "R02-predictions.npz",
+      "prefix_count": 25,
+      "query_count": 10,
+      "sha256": "353cb304e62fae14b6d241565b4e654d84ceadca87e2abd3a6c9f1a2f5febbed",
+      "status": "ordinary_success",
+      "update_count": 15
+    },
+    "R03": {
+      "file": "R03-predictions.npz",
+      "prefix_count": 25,
+      "query_count": 10,
+      "sha256": "93cd139f8c503e939f3027bf502180a8e2e6bd08f91e24adb421671745dac20a",
+      "status": "ordinary_success",
+      "update_count": 15
+    }
+  },
+  "future_3d_opened": false,
+  "implementation_revision": "d70e0a426d1ec3e5da512e941c4e72f7915fb8b7",
+  "protocol_id": "30ce2d2825f3ef68798b402ae2945d0c4cd74216c36b35c327a37994f5837c14",
+  "provider_bundle_id": "952421d140731b2a6eb99df3cbd348653e04863fa457aaa490be31fe0b4c06a7",
+  "runtime": {
+    "numpy": "2.2.6",
+    "python": "3.10.12"
+  },
+  "schema": "prob4d.cut3r-bayesian-prefix-prediction-barrier-v1"
+}

--- a/evidence/cut3r-bayesian-prefix-dev-v1/result.json
+++ b/evidence/cut3r-bayesian-prefix-dev-v1/result.json
@@ -1,0 +1,440 @@
+{
+  "aggregate": {
+    "bayesian_iid": {
+      "coverage90": 1.0,
+      "full_coordinate_width90_prefix_span": 0.07953809957437373,
+      "nll_per_coordinate": -2.4873377956637013,
+      "normalized_nees": 0.6329481669180687,
+      "rmse_prefix_span": 0.03205764621305082,
+      "scored_rows": 9.333333333333334
+    },
+    "bayesian_shared": {
+      "coverage90": 1.0,
+      "full_coordinate_width90_prefix_span": 0.09125586280389031,
+      "nll_per_coordinate": -2.4551873612937407,
+      "normalized_nees": 0.4217323830160886,
+      "rmse_prefix_span": 0.029383184749615477,
+      "scored_rows": 9.333333333333334
+    },
+    "cut3r_full_prefix_alignment": {
+      "coverage90": 0.9166666666666666,
+      "full_coordinate_width90_prefix_span": 0.33548562963317696,
+      "nll_per_coordinate": -1.043604041370233,
+      "normalized_nees": 0.6408643236849988,
+      "rmse_prefix_span": 0.1358853664563937,
+      "scored_rows": 9.333333333333334
+    },
+    "cut3r_initial_alignment": {
+      "coverage90": 0.85,
+      "full_coordinate_width90_prefix_span": 0.33548562963317696,
+      "nll_per_coordinate": -0.6494164011496147,
+      "normalized_nees": 1.4292396041262354,
+      "rmse_prefix_span": 0.20032480631773986,
+      "scored_rows": 9.333333333333334
+    },
+    "last_residual": {
+      "coverage90": 1.0,
+      "full_coordinate_width90_prefix_span": 0.33548562963317696,
+      "nll_per_coordinate": -1.3501750269098924,
+      "normalized_nees": 0.0277223526056803,
+      "rmse_prefix_span": 0.026660604984818828,
+      "scored_rows": 9.333333333333334
+    }
+  },
+  "aggregate_scope": "all_three",
+  "artifact_id": "f8d138921e3bf9ce02721a9d4f7154ae5a4182fd56360dd2c40134a34e2a4941",
+  "autopromotion": false,
+  "calibration_guarantee": false,
+  "claim": "exploratory sparse-prefix 3D-supervised observed-frame reconstruction only",
+  "complete_denominator": true,
+  "implementation_revision": "d70e0a426d1ec3e5da512e941c4e72f7915fb8b7",
+  "locked_sequence_count": 3,
+  "new_future_3d_access_only_after_prediction_barrier": true,
+  "new_rgb_decoding": false,
+  "opened_coordinate_members": [
+    {
+      "member": "R01/coordinates/2d/frame000001_cam001.txt",
+      "sha256": "62c1b975b684569367e0adf3aa2c026b832a26a8e45be67858f6bad6eb4d466b",
+      "stage": "prediction"
+    },
+    {
+      "member": "R01/coordinates/3d/frame000001_cam001.txt",
+      "sha256": "a8c0e0e3051c9fabf3eaef14223f8782f52d0447ae803c07b7ace6459e3bd994",
+      "stage": "prediction"
+    },
+    {
+      "member": "R01/coordinates/2d/frame000002_cam001.txt",
+      "sha256": "245cd8fe6bfaa35e549085cf3ab91f3e2e4b3817f530765b6a5c06d1ab22abf3",
+      "stage": "prediction"
+    },
+    {
+      "member": "R01/coordinates/3d/frame000002_cam001.txt",
+      "sha256": "38f6edf451f3c1941a9088f2384dc720c61f5b4d067da0bafba18fa8da203470",
+      "stage": "prediction"
+    },
+    {
+      "member": "R01/coordinates/2d/frame000003_cam001.txt",
+      "sha256": "21f008275103000f06cb38f8630649597785978d785a78cba08fcbe7dc5b03e6",
+      "stage": "prediction"
+    },
+    {
+      "member": "R01/coordinates/3d/frame000003_cam001.txt",
+      "sha256": "8d20be0537b2a5a11483562c2834318545b0a13b5902964371f9df0edfbe78d9",
+      "stage": "prediction"
+    },
+    {
+      "member": "R01/coordinates/2d/frame000004_cam001.txt",
+      "sha256": "066a9ad6d9d56e643ffff09fdc09009adb69450c5eafa9cf28c956b9567de459",
+      "stage": "prediction"
+    },
+    {
+      "member": "R01/coordinates/3d/frame000004_cam001.txt",
+      "sha256": "e364977f67d8f4da04dafecc350aedd16fe91182acb766a53caa82badc3a493d",
+      "stage": "prediction"
+    },
+    {
+      "member": "R01/coordinates/2d/frame000005_cam001.txt",
+      "sha256": "213fc8a1994b7786fecc3380c020ea1242f404278a351950c1848384461188c8",
+      "stage": "prediction"
+    },
+    {
+      "member": "R01/coordinates/3d/frame000005_cam001.txt",
+      "sha256": "3e9e6cb3a242f860e7e888470a405f4f83165f34116db6b12738caed316a1e91",
+      "stage": "prediction"
+    },
+    {
+      "member": "R01/coordinates/2d/frame000006_cam001.txt",
+      "sha256": "d806d5a4bef2b343659b015e322d365090e630234e5127f71b95844bea656ebd",
+      "stage": "prediction"
+    },
+    {
+      "member": "R01/coordinates/2d/frame000007_cam001.txt",
+      "sha256": "10a45c05a0fac21b8421e9c33ef13895f9fc546e2067a50d1285cfeb308bb75a",
+      "stage": "prediction"
+    },
+    {
+      "member": "R02/coordinates/2d/frame000001_cam001.txt",
+      "sha256": "41d3a4551e63a8a297b2074699167857c575f9db16aa135c75083ccccfcf40c9",
+      "stage": "prediction"
+    },
+    {
+      "member": "R02/coordinates/3d/frame000001_cam001.txt",
+      "sha256": "e9c7338152944059582557d97861220069ac648331213f085e6f132296b2d88a",
+      "stage": "prediction"
+    },
+    {
+      "member": "R02/coordinates/2d/frame000002_cam001.txt",
+      "sha256": "c8504d3206b1c91c4fd8f1b8dae39f4439def2127e9730ef526337851a5e0212",
+      "stage": "prediction"
+    },
+    {
+      "member": "R02/coordinates/3d/frame000002_cam001.txt",
+      "sha256": "affcd856738e705faba1c546b15162e5f68fa7bb4d9b2520f80757eaa6d52efa",
+      "stage": "prediction"
+    },
+    {
+      "member": "R02/coordinates/2d/frame000003_cam001.txt",
+      "sha256": "4f0201c5213d82091dd31689b9e1093f8b04e83b8bacf561a46a30b06ec79efa",
+      "stage": "prediction"
+    },
+    {
+      "member": "R02/coordinates/3d/frame000003_cam001.txt",
+      "sha256": "1b7f14a12e750c4b53349c76f905fbaebd0817cdeb4b40067acc4bb9d54c31eb",
+      "stage": "prediction"
+    },
+    {
+      "member": "R02/coordinates/2d/frame000004_cam001.txt",
+      "sha256": "c4b024ebcdcc2401d3c816e994404eb7a247d99ad8742fc97489c5592b4919a6",
+      "stage": "prediction"
+    },
+    {
+      "member": "R02/coordinates/3d/frame000004_cam001.txt",
+      "sha256": "b919e5f75c042b93b8542eb885bf21af8bef6eb247d8f7a96239dfbfc959de0f",
+      "stage": "prediction"
+    },
+    {
+      "member": "R02/coordinates/2d/frame000005_cam001.txt",
+      "sha256": "0872b8e9a2595de5c959292b535b97126e7d6979db00e5599396e07d8d86af12",
+      "stage": "prediction"
+    },
+    {
+      "member": "R02/coordinates/3d/frame000005_cam001.txt",
+      "sha256": "3a10c6b77e24883d1b772abd6f6a6fe65020eba41cea2b95dd699bf2cfe51648",
+      "stage": "prediction"
+    },
+    {
+      "member": "R02/coordinates/2d/frame000006_cam001.txt",
+      "sha256": "091b0d7bbc67916cff89a9298cf70fbb2478ba73c9e210aacedcf778ac8b188e",
+      "stage": "prediction"
+    },
+    {
+      "member": "R02/coordinates/2d/frame000007_cam001.txt",
+      "sha256": "7282b426fd926e0cf9e0cb9518430bf39befbee6cf2991a2c15419902a841853",
+      "stage": "prediction"
+    },
+    {
+      "member": "R03/coordinates/2d/frame000001_cam001.txt",
+      "sha256": "9d5a2eb57314edece74334d715b9faa9d03c41bc17ad86394fd89adeab16f4ba",
+      "stage": "prediction"
+    },
+    {
+      "member": "R03/coordinates/3d/frame000001_cam001.txt",
+      "sha256": "876a82a4c40cc86aab3599b2733eade6b00eb74eb0189be64cbb6e6168fedf2c",
+      "stage": "prediction"
+    },
+    {
+      "member": "R03/coordinates/2d/frame000002_cam001.txt",
+      "sha256": "f57dd8197beaf0bac0a82021138c5598190ebf6be01a15358a29a6a9baddf118",
+      "stage": "prediction"
+    },
+    {
+      "member": "R03/coordinates/3d/frame000002_cam001.txt",
+      "sha256": "279340921da859ed7dc3667044675ab2d2ae78368919095b968151a2a369120f",
+      "stage": "prediction"
+    },
+    {
+      "member": "R03/coordinates/2d/frame000003_cam001.txt",
+      "sha256": "6b939a8cd8b5d93b9252f3bbaf8dc9fbdb2082ffdbda807a999ccffc1a75d632",
+      "stage": "prediction"
+    },
+    {
+      "member": "R03/coordinates/3d/frame000003_cam001.txt",
+      "sha256": "f26ebefbde544b77f695e472be5a769eca21be09a6350a47a7bb95e64087dc0b",
+      "stage": "prediction"
+    },
+    {
+      "member": "R03/coordinates/2d/frame000004_cam001.txt",
+      "sha256": "bf37e6c500ec6bb2483a67f67b5704b66b805d588dd7802a386b492d5046a26b",
+      "stage": "prediction"
+    },
+    {
+      "member": "R03/coordinates/3d/frame000004_cam001.txt",
+      "sha256": "0be4b2bb6ad6e528cf11d6484b867e8ee385f31d851a033a51b8f774ce138050",
+      "stage": "prediction"
+    },
+    {
+      "member": "R03/coordinates/2d/frame000005_cam001.txt",
+      "sha256": "7fe7134e6b42f9aebcc5dc6f90b22e5a745ced1e1a373ce8c47da823a8d10a85",
+      "stage": "prediction"
+    },
+    {
+      "member": "R03/coordinates/3d/frame000005_cam001.txt",
+      "sha256": "856a8dc77c010ff7b3997be973ea0e606671962b39d001696098e072828826f8",
+      "stage": "prediction"
+    },
+    {
+      "member": "R03/coordinates/2d/frame000006_cam001.txt",
+      "sha256": "b917e967dda85c3a691a3022d2a0c9273106fc17c52d0fd5a762f5a08e22b15f",
+      "stage": "prediction"
+    },
+    {
+      "member": "R03/coordinates/2d/frame000007_cam001.txt",
+      "sha256": "82e532c6ceee7dc7f60be15e1c97bf88f280ba4fa74ceda52b4495f743e82e51",
+      "stage": "prediction"
+    },
+    {
+      "member": "R01/coordinates/3d/frame000006_cam001.txt",
+      "sha256": "5a5b276988351685f3be1dd3233f7fa1765027c5a5f9c916c5b1766027c4724d",
+      "stage": "scoring"
+    },
+    {
+      "member": "R01/coordinates/3d/frame000007_cam001.txt",
+      "sha256": "3bb20932fbd909be74f5fe9111800624c812c98a75bcafc1e8fe948c9aa2c0a8",
+      "stage": "scoring"
+    },
+    {
+      "member": "R02/coordinates/3d/frame000006_cam001.txt",
+      "sha256": "b9fe03fcd5ceea3e0e3b45a5faa658547a18e7862f83f805823f083d12a2f877",
+      "stage": "scoring"
+    },
+    {
+      "member": "R02/coordinates/3d/frame000007_cam001.txt",
+      "sha256": "686577932de5ca5d76b78ac72be0b3222da03fdc51b5c473607e133a6a4634fb",
+      "stage": "scoring"
+    },
+    {
+      "member": "R03/coordinates/3d/frame000006_cam001.txt",
+      "sha256": "86cdb06fcf2f82653177c3080cb2c46f127e1eed5460d3707a97cb6a8936ee85",
+      "stage": "scoring"
+    },
+    {
+      "member": "R03/coordinates/3d/frame000007_cam001.txt",
+      "sha256": "a319e3e6be323947dc048ca02c40dd6301b20786cf11707ad665a76513d2596f",
+      "stage": "scoring"
+    }
+  ],
+  "per_sequence": {
+    "R01": {
+      "metrics": {
+        "bayesian_iid": {
+          "coverage90": 1.0,
+          "full_coordinate_width90_prefix_span": 0.07908557186486839,
+          "nll_per_coordinate": -2.45351362714013,
+          "normalized_nees": 0.712048549266435,
+          "rmse_prefix_span": 0.034900339610748045,
+          "scored_rows": 8.0
+        },
+        "bayesian_shared": {
+          "coverage90": 1.0,
+          "full_coordinate_width90_prefix_span": 0.09113427265698791,
+          "nll_per_coordinate": -2.3503896092934706,
+          "normalized_nees": 0.6341223346650576,
+          "rmse_prefix_span": 0.03787086311313494,
+          "scored_rows": 8.0
+        },
+        "cut3r_full_prefix_alignment": {
+          "coverage90": 0.75,
+          "full_coordinate_width90_prefix_span": 0.33548562963317696,
+          "nll_per_coordinate": -0.7822674761938913,
+          "normalized_nees": 1.1635374540376824,
+          "rmse_prefix_span": 0.19040494899278076,
+          "scored_rows": 8.0
+        },
+        "cut3r_initial_alignment": {
+          "coverage90": 0.75,
+          "full_coordinate_width90_prefix_span": 0.33548562963317696,
+          "nll_per_coordinate": -0.08821097928304011,
+          "normalized_nees": 2.5516504478593847,
+          "rmse_prefix_span": 0.2821538129219884,
+          "scored_rows": 8.0
+        },
+        "last_residual": {
+          "coverage90": 1.0,
+          "full_coordinate_width90_prefix_span": 0.33548562963317696,
+          "nll_per_coordinate": -1.3583541872734601,
+          "normalized_nees": 0.011364031878544982,
+          "rmse_prefix_span": 0.01828419682636263,
+          "scored_rows": 8.0
+        }
+      },
+      "status": "scored"
+    },
+    "R02": {
+      "metrics": {
+        "bayesian_iid": {
+          "coverage90": 1.0,
+          "full_coordinate_width90_prefix_span": 0.0809127587179955,
+          "nll_per_coordinate": -2.6455263805507734,
+          "normalized_nees": 0.2821464951341466,
+          "rmse_prefix_span": 0.02256180653960787,
+          "scored_rows": 10.0
+        },
+        "bayesian_shared": {
+          "coverage90": 1.0,
+          "full_coordinate_width90_prefix_span": 0.09101935081754362,
+          "nll_per_coordinate": -2.60665190922831,
+          "normalized_nees": 0.12386905868596813,
+          "rmse_prefix_span": 0.016716734974439606,
+          "scored_rows": 10.0
+        },
+        "cut3r_full_prefix_alignment": {
+          "coverage90": 1.0,
+          "full_coordinate_width90_prefix_span": 0.33548562963317696,
+          "nll_per_coordinate": -1.1618953426523362,
+          "normalized_nees": 0.40428172112079286,
+          "rmse_prefix_span": 0.11219765550067472,
+          "scored_rows": 10.0
+        },
+        "cut3r_initial_alignment": {
+          "coverage90": 0.8,
+          "full_coordinate_width90_prefix_span": 0.33548562963317696,
+          "nll_per_coordinate": -0.7228542506817757,
+          "normalized_nees": 1.2823639050619133,
+          "rmse_prefix_span": 0.19993779076182183,
+          "scored_rows": 10.0
+        },
+        "last_residual": {
+          "coverage90": 1.0,
+          "full_coordinate_width90_prefix_span": 0.33548562963317696,
+          "nll_per_coordinate": -1.3574941300875412,
+          "normalized_nees": 0.013084146250382681,
+          "rmse_prefix_span": 0.019856171017969274,
+          "scored_rows": 10.0
+        }
+      },
+      "status": "scored"
+    },
+    "R03": {
+      "metrics": {
+        "bayesian_iid": {
+          "coverage90": 1.0,
+          "full_coordinate_width90_prefix_span": 0.07861596814025729,
+          "nll_per_coordinate": -2.3629733793002003,
+          "normalized_nees": 0.9046494563536243,
+          "rmse_prefix_span": 0.03871079248879655,
+          "scored_rows": 10.0
+        },
+        "bayesian_shared": {
+          "coverage90": 1.0,
+          "full_coordinate_width90_prefix_span": 0.09161396493713939,
+          "nll_per_coordinate": -2.408520565359442,
+          "normalized_nees": 0.5072057556972401,
+          "rmse_prefix_span": 0.03356195616127188,
+          "scored_rows": 10.0
+        },
+        "cut3r_full_prefix_alignment": {
+          "coverage90": 1.0,
+          "full_coordinate_width90_prefix_span": 0.33548562963317696,
+          "nll_per_coordinate": -1.186649305264472,
+          "normalized_nees": 0.35477379589652114,
+          "rmse_prefix_span": 0.10505349487572563,
+          "scored_rows": 10.0
+        },
+        "cut3r_initial_alignment": {
+          "coverage90": 1.0,
+          "full_coordinate_width90_prefix_span": 0.33548562963317696,
+          "nll_per_coordinate": -1.1371839734840283,
+          "normalized_nees": 0.4537044594574083,
+          "rmse_prefix_span": 0.11888281526940932,
+          "scored_rows": 10.0
+        },
+        "last_residual": {
+          "coverage90": 1.0,
+          "full_coordinate_width90_prefix_span": 0.33548562963317696,
+          "nll_per_coordinate": -1.3346767633686758,
+          "normalized_nees": 0.05871887968811323,
+          "rmse_prefix_span": 0.04184144711012458,
+          "scored_rows": 10.0
+        }
+      },
+      "status": "scored"
+    }
+  },
+  "prediction_accounting": {
+    "R01": {
+      "file": "R01-predictions.npz",
+      "prefix_count": 20,
+      "query_count": 8,
+      "sha256": "483de5b89b84599ebef2dcad710a5446f3cde3a8aeadb1cef3001cd09835b30b",
+      "status": "ordinary_success",
+      "update_count": 12
+    },
+    "R02": {
+      "file": "R02-predictions.npz",
+      "prefix_count": 25,
+      "query_count": 10,
+      "sha256": "353cb304e62fae14b6d241565b4e654d84ceadca87e2abd3a6c9f1a2f5febbed",
+      "status": "ordinary_success",
+      "update_count": 15
+    },
+    "R03": {
+      "file": "R03-predictions.npz",
+      "prefix_count": 25,
+      "query_count": 10,
+      "sha256": "93cd139f8c503e939f3027bf502180a8e2e6bd08f91e24adb421671745dac20a",
+      "status": "ordinary_success",
+      "update_count": 15
+    }
+  },
+  "prediction_barrier_id": "9a7d448192121533228c4ebbc5cb3ff9a16f0752d04ecb979ed992ccfc5492ab",
+  "prior_source_outcomes_already_opened": true,
+  "protected_targets_accessed": false,
+  "protocol_id": "30ce2d2825f3ef68798b402ae2945d0c4cd74216c36b35c327a37994f5837c14",
+  "provider_inference_rerun": false,
+  "runtime": {
+    "numpy": "2.2.6",
+    "python": "3.10.12"
+  },
+  "schema": "prob4d.cut3r-bayesian-prefix-development-result-v1",
+  "scored_sequence_count": 3
+}

--- a/protocols/cut3r-bayesian-prefix-dev-v1.json
+++ b/protocols/cut3r-bayesian-prefix-dev-v1.json
@@ -1,0 +1,62 @@
+{
+  "aggregation": "equal_supported_score_frame_then_equal_sequence",
+  "alignment_frames": [
+    1,
+    2
+  ],
+  "archive_sha256": "07b2222808e7fef1e4a7fd86ee0329da7c50e31cac2992d4773db0e8ffc105d7",
+  "arms": [
+    "cut3r_initial_alignment",
+    "cut3r_full_prefix_alignment",
+    "last_residual",
+    "bayesian_iid",
+    "bayesian_shared"
+  ],
+  "artifact_id": "30ce2d2825f3ef68798b402ae2945d0c4cd74216c36b35c327a37994f5837c14",
+  "autopromotion": false,
+  "baseline_uncertainty": "same fixed Gaussian wrapper, not native CUT3R covariance",
+  "calibration_guarantee": false,
+  "camera": "cam001",
+  "claim": "exploratory sparse-prefix 3D-supervised observed-frame reconstruction only",
+  "closed_studies_reopened": false,
+  "future_2d_marker_locations_are_common_query_inputs": true,
+  "future_3d_permitted_only_after_all_predictions_sealed": true,
+  "future_rgb_is_in_existing_causal_provider_outputs": true,
+  "hyperparameter_search": false,
+  "metric_units": "prefix_span_not_asserted_metres",
+  "new_rgb_decoding": false,
+  "normalization": "bbox_diagonal_of_finite_frame_1_2_marker_rows",
+  "observation_std_prefix_span": 0.02,
+  "prior_global_fraction": 0.5,
+  "prior_std_prefix_span": 0.1,
+  "prospective_new_object_confirmation": false,
+  "protected_targets_accessed": false,
+  "provider_bundle_id": "952421d140731b2a6eb99df3cbd348653e04863fa457aaa490be31fe0b4c06a7",
+  "provider_inference_rerun": false,
+  "rbf_length_prefix_span": 0.25,
+  "residual_update_frames": [
+    3,
+    4,
+    5
+  ],
+  "schema": "prob4d.cut3r-bayesian-prefix-development-v1",
+  "score_frames": [
+    6,
+    7
+  ],
+  "sequences": [
+    "R01",
+    "R02",
+    "R03"
+  ],
+  "shared_observation_correlation": 0.8,
+  "source_files_sha256": {
+    "scripts/science/evaluate_dot_rope_cut3r_pooled.py": "2b214a227e3594aec94545159bea059970ac85ddbde8d88de603c206218396cf",
+    "scripts/science/run_cut3r_bayesian_prefix_dev.py": "87eaee9c51797bfdd72f27b820845971b08f13c524ea61c8e6f152e2e2098774",
+    "scripts/science/run_dot_rope_cut3r_native_provider.py": "211106432826b915f4332fcbdf72e087ce131e9c58bd4a72aa56510cc5ea20cc",
+    "src/prob4d/cut3r_bayesian_prefix_dev.py": "57bc8ff97fa1127d41c0f61ead9242816d1e92f8e67ca9ff5d1fde86d572045f",
+    "src/prob4d/dot_rope_cut3r_study.py": "166f2d83adeb3eb606766b31c4d83d509b8cbb4a29ae8731c70ba7941f4b76f9",
+    "src/prob4d/query_posterior.py": "34dbd61a5a1a1329e3e65b19fac1d7033033b8490b22d38bd1e1a06343e5a379",
+    "tests/test_cut3r_bayesian_prefix_dev.py": "dbee239f7b237798f85139303a8a2a14f7ead9b5da7f48aa6baba9047e9104cf"
+  }
+}

--- a/scripts/science/run_cut3r_bayesian_prefix_dev.py
+++ b/scripts/science/run_cut3r_bayesian_prefix_dev.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Freeze/run a CPU-only exploratory Bayesian CUT3R prefix comparison."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import platform
+import subprocess
+import zipfile
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from prob4d.cut3r_bayesian_prefix_dev import ARMS, Rows, predict_arms, score_arms
+from prob4d.dot_rope_cut3r_study import bilinear_sample, content_id
+
+ROOT = Path(__file__).resolve().parents[2]
+SEQUENCES = ("R01", "R02", "R03")
+PROVIDER_ID = "952421d140731b2a6eb99df3cbd348653e04863fa457aaa490be31fe0b4c06a7"
+ARCHIVE_SHA = "07b2222808e7fef1e4a7fd86ee0329da7c50e31cac2992d4773db0e8ffc105d7"
+BOUND_FILES = (
+    "src/prob4d/cut3r_bayesian_prefix_dev.py",
+    "scripts/science/run_cut3r_bayesian_prefix_dev.py",
+    "src/prob4d/query_posterior.py",
+    "src/prob4d/dot_rope_cut3r_study.py",
+    "scripts/science/evaluate_dot_rope_cut3r_pooled.py",
+    "scripts/science/run_dot_rope_cut3r_native_provider.py",
+    "tests/test_cut3r_bayesian_prefix_dev.py",
+)
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for block in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def seal(path: Path, record: dict[str, Any]) -> dict[str, Any]:
+    result = dict(record)
+    result["artifact_id"] = content_id(record)
+    with path.open("x", encoding="utf-8") as handle:
+        handle.write(json.dumps(result, indent=2, sort_keys=True, allow_nan=False) + "\n")
+    return result
+
+
+def protocol() -> dict[str, Any]:
+    return {
+        "schema": "prob4d.cut3r-bayesian-prefix-development-v1",
+        "sequences": list(SEQUENCES),
+        "provider_bundle_id": PROVIDER_ID,
+        "archive_sha256": ARCHIVE_SHA,
+        "alignment_frames": [1, 2],
+        "residual_update_frames": [3, 4, 5],
+        "score_frames": [6, 7],
+        "camera": "cam001",
+        "arms": list(ARMS),
+        "prior_std_prefix_span": 0.1,
+        "observation_std_prefix_span": 0.02,
+        "rbf_length_prefix_span": 0.25,
+        "prior_global_fraction": 0.5,
+        "shared_observation_correlation": 0.8,
+        "normalization": "bbox_diagonal_of_finite_frame_1_2_marker_rows",
+        "aggregation": "equal_supported_score_frame_then_equal_sequence",
+        "source_files_sha256": {name: sha256(ROOT / name) for name in BOUND_FILES},
+        "claim": "exploratory sparse-prefix 3D-supervised observed-frame reconstruction only",
+        "prospective_new_object_confirmation": False,
+        "provider_inference_rerun": False,
+        "new_rgb_decoding": False,
+        "future_3d_permitted_only_after_all_predictions_sealed": True,
+        "future_rgb_is_in_existing_causal_provider_outputs": True,
+        "future_2d_marker_locations_are_common_query_inputs": True,
+        "metric_units": "prefix_span_not_asserted_metres",
+        "baseline_uncertainty": "same fixed Gaussian wrapper, not native CUT3R covariance",
+        "calibration_guarantee": False,
+        "autopromotion": False,
+        "hyperparameter_search": False,
+        "closed_studies_reopened": False,
+        "protected_targets_accessed": False,
+    }
+
+
+def _load_module(path: Path, name: str) -> Any:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError("cannot load frozen helper")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _sample(run: dict[str, Any], frame: int, coordinates: np.ndarray, pooled: Any) -> Rows:
+    selected = np.flatnonzero(run["frames"] == frame)
+    if len(selected) != 1:
+        raise ValueError("requested frame absent or repeated")
+    index = int(selected[0])
+    points = np.asarray(run["points"][index], dtype=np.float64)
+    confidence = np.asarray(run["confidence"][index], dtype=np.float64)
+    width, height = run["original_sizes"][index]
+    pixels, in_image, _ = pooled.cut3r_output_coordinates(
+        coordinates,
+        original_width=int(width),
+        original_height=int(height),
+        output_width=int(points.shape[1]),
+        output_height=int(points.shape[0]),
+    )
+    xyz, valid = bilinear_sample(points, pixels)
+    quality, quality_valid = bilinear_sample(confidence[..., None], pixels)
+    valid &= in_image & quality_valid & np.isfinite(xyz).all(axis=1)
+    valid &= np.isfinite(quality[:, 0]) & (quality[:, 0] > 0)
+    identities = np.flatnonzero(valid)
+    return Rows(np.full(len(identities), frame), identities, xyz[valid])
+
+
+def _concat(parts: list[Rows]) -> Rows:
+    return Rows(
+        np.concatenate([part.frame for part in parts]),
+        np.concatenate([part.identity for part in parts]),
+        np.concatenate([part.points for part in parts]),
+    )
+
+
+def run_study(archive_path: Path, bundle: Path, output: Path, lock: Path) -> dict[str, Any]:
+    expected = protocol()
+    actual = json.loads(lock.read_text())
+    artifact_id = actual.pop("artifact_id")
+    if actual != expected or artifact_id != content_id(expected):
+        raise ValueError("protocol or source bytes changed")
+    revision = subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=ROOT, text=True).strip()
+    if subprocess.check_output(
+        ["git", "status", "--porcelain", "--untracked-files=no"], cwd=ROOT, text=True
+    ).strip():
+        raise ValueError("tracked source worktree must be clean")
+    output.mkdir(parents=False, exist_ok=False)
+    if sha256(archive_path) != ARCHIVE_SHA:
+        raise ValueError("official source archive bytes changed")
+    base = _load_module(ROOT / BOUND_FILES[5], "cut3r_prefix_base")
+    pooled = _load_module(ROOT / BOUND_FILES[4], "cut3r_prefix_pooled")
+    pooled._ACTIVE_COORDINATE_COLUMNS = (0, 1)
+    pooled._ACTIVE_COORDINATE_MODE = "pixel-zero-based"
+    original_protocol = json.loads(
+        (ROOT / "protocols/dot-rope-cut3r-native-provider-v1.json").read_text()
+    )
+    manifest = base._verify_provider_bundle(bundle, original_protocol)
+    if manifest["provider_bundle_id"] != PROVIDER_ID:
+        raise ValueError("wrong sealed provider")
+    records = {row["sequence"]: row for row in manifest["outputs"] if row["run"] == "continuous"}
+    if set(records) != set(SEQUENCES):
+        raise ValueError("source provider roster changed")
+
+    opened: list[dict[str, Any]] = []
+    sealed: dict[str, dict[str, Any]] = {}
+    cached: dict[str, tuple[dict[str, Any], Rows]] = {}
+    stage = "prediction"
+    barrier_written = False
+    with zipfile.ZipFile(archive_path) as archive:
+
+        def read_coordinates(sequence: str, dimension: int, frame: int) -> np.ndarray:
+            if sequence not in SEQUENCES or frame not in range(1, 8) or dimension not in (2, 3):
+                raise ValueError("source member outside allowlist")
+            if dimension == 3 and frame > 5 and not barrier_written:
+                raise ValueError("score truth requested before prediction barrier")
+            member = base._coordinate_member(sequence, dimension, frame, "cam001")
+            raw = archive.read(member)
+            opened.append(
+                {"member": member, "sha256": hashlib.sha256(raw).hexdigest(), "stage": stage}
+            )
+            return np.asarray(
+                pooled._parse_coordinate_text(raw.decode("utf-8"), dimension), dtype=np.float64
+            )
+
+        for sequence in SEQUENCES:
+            try:
+                source_run = base._load_run(bundle, records[sequence])
+                prefix_parts: list[Rows] = []
+                prefix_truth: list[np.ndarray] = []
+                query_parts: list[Rows] = []
+                for frame in range(1, 8):
+                    coordinates = read_coordinates(sequence, 2, frame)
+                    rows = _sample(source_run, frame, coordinates, pooled)
+                    if frame <= 5:
+                        truth = read_coordinates(sequence, 3, frame)
+                        if len(truth) != len(coordinates):
+                            raise ValueError("prefix 2D/3D row identity count mismatch")
+                        valid = np.isfinite(truth[rows.identity]).all(axis=1)
+                        prefix_parts.append(
+                            Rows(rows.frame[valid], rows.identity[valid], rows.points[valid])
+                        )
+                        prefix_truth.append(truth[rows.identity[valid]])
+                    else:
+                        query_parts.append(rows)
+                query = _concat(query_parts)
+                prediction = predict_arms(
+                    _concat(prefix_parts), np.concatenate(prefix_truth), query
+                )
+                arrays = {
+                    **{f"mean_{name}": prediction["means"][name] for name in ARMS},
+                    **{f"covariance_{name}": prediction["covariances"][name] for name in ARMS},
+                    "query_frame": query.frame,
+                    "query_identity": query.identity,
+                    "query_provider_points": query.points,
+                    "normalization_center": prediction["normalization_center"],
+                    "normalization_span": np.asarray(prediction["normalization_span"]),
+                }
+                path = output / f"{sequence}-predictions.npz"
+                np.savez_compressed(path, **arrays)
+                cached[sequence] = (prediction, query)
+                sealed[sequence] = {
+                    "status": "exact_fallback"
+                    if prediction["bayesian_fallback"]
+                    else "ordinary_success",
+                    "file": path.name,
+                    "sha256": sha256(path),
+                    "prefix_count": prediction["prefix_count"],
+                    "update_count": prediction["update_count"],
+                    "query_count": len(query.frame),
+                }
+            except (ValueError, RuntimeError, KeyError, np.linalg.LinAlgError) as error:
+                sealed[sequence] = {
+                    "status": "unsealable",
+                    "error": f"{type(error).__name__}: {error}",
+                }
+        barrier = seal(
+            output / "prediction-barrier.json",
+            {
+                "schema": "prob4d.cut3r-bayesian-prefix-prediction-barrier-v1",
+                "protocol_id": artifact_id,
+                "implementation_revision": revision,
+                "runtime": {"python": platform.python_version(), "numpy": np.__version__},
+                "provider_bundle_id": PROVIDER_ID,
+                "cases": sealed,
+                "future_3d_opened": False,
+            },
+        )
+        if set(barrier["cases"]) != set(SEQUENCES):
+            raise ValueError("incomplete prediction denominator")
+        for sequence, record in sealed.items():
+            if sequence in cached and sha256(output / record["file"]) != record["sha256"]:
+                raise ValueError("sealed prediction changed")
+        barrier_written = True
+        stage = "scoring"
+        scored: dict[str, Any] = {}
+        for sequence, (prediction, query) in cached.items():
+            try:
+                later = {frame: read_coordinates(sequence, 3, frame) for frame in (6, 7)}
+                truth = np.full(query.points.shape, np.nan)
+                for index, (frame, identity) in enumerate(
+                    zip(query.frame, query.identity, strict=True)
+                ):
+                    if identity < len(later[int(frame)]):
+                        truth[index] = later[int(frame)][identity]
+                scored[sequence] = {
+                    "status": "scored",
+                    "metrics": score_arms(prediction, query, truth),
+                }
+            except (ValueError, RuntimeError, KeyError, np.linalg.LinAlgError) as error:
+                scored[sequence] = {
+                    "status": "score_failure",
+                    "error": f"{type(error).__name__}: {error}",
+                }
+    complete = [record["metrics"] for record in scored.values() if record["status"] == "scored"]
+    aggregate = (
+        {
+            name: {
+                key: float(np.mean([row[name][key] for row in complete]))
+                for key in complete[0][name]
+            }
+            for name in ARMS
+        }
+        if complete
+        else {}
+    )
+    return seal(
+        output / "result.json",
+        {
+            "schema": "prob4d.cut3r-bayesian-prefix-development-result-v1",
+            "protocol_id": artifact_id,
+            "implementation_revision": revision,
+            "runtime": {"python": platform.python_version(), "numpy": np.__version__},
+            "prediction_barrier_id": barrier["artifact_id"],
+            "locked_sequence_count": 3,
+            "prediction_accounting": sealed,
+            "scored_sequence_count": len(complete),
+            "complete_denominator": len(complete) == 3,
+            "per_sequence": scored,
+            "aggregate": aggregate,
+            "aggregate_scope": "all_three"
+            if len(complete) == 3
+            else "descriptive_scorable_subset_only",
+            "opened_coordinate_members": opened,
+            "claim": expected["claim"],
+            "prior_source_outcomes_already_opened": True,
+            "provider_inference_rerun": False,
+            "new_rgb_decoding": False,
+            "protected_targets_accessed": False,
+            "new_future_3d_access_only_after_prediction_barrier": True,
+            "calibration_guarantee": False,
+            "autopromotion": False,
+        },
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    commands = parser.add_subparsers(dest="command", required=True)
+    freeze = commands.add_parser("freeze")
+    freeze.add_argument("--output", type=Path, required=True)
+    execute = commands.add_parser("run")
+    execute.add_argument("--archive", type=Path, required=True)
+    execute.add_argument("--provider-bundle", type=Path, required=True)
+    execute.add_argument("--protocol", type=Path, required=True)
+    execute.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    if args.command == "freeze":
+        record = seal(args.output, protocol())
+    else:
+        record = run_study(args.archive, args.provider_bundle, args.output, args.protocol)
+    print(
+        json.dumps(
+            {"artifact_id": record["artifact_id"], "output": str(args.output)}, sort_keys=True
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/prob4d/cut3r_bayesian_prefix_dev.py
+++ b/src/prob4d/cut3r_bayesian_prefix_dev.py
@@ -1,0 +1,265 @@
+"""Fixed, exploratory sparse-prefix residual conditioning for CUT3R.
+
+All numerical coordinates are normalized by a prefix-only span. The generic
+Gaussian operator is used algebraically; no metre-valued observation artifact
+is exported from this experiment.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from .api.v2 import StackedObservationFactors, build_observation_gaussian_operator
+from .dot_rope_cut3r_study import robust_fit_sim3
+from .query_posterior import augment_observation_gaussian_operator, condition_gaussian_query
+
+ARMS = (
+    "cut3r_initial_alignment",
+    "cut3r_full_prefix_alignment",
+    "last_residual",
+    "bayesian_iid",
+    "bayesian_shared",
+)
+PREFIX_STOP = 5
+PRIOR_STD = 0.10
+NOISE_STD = 0.02
+LENGTH_SCALE = 0.25
+SHARED_CORRELATION = 0.80
+CHI2_3_90 = 6.251388631170325
+
+
+@dataclass(frozen=True)
+class Rows:
+    frame: np.ndarray
+    identity: np.ndarray
+    points: np.ndarray
+
+    def __post_init__(self) -> None:
+        frame = np.asarray(self.frame)
+        identity = np.asarray(self.identity)
+        points = np.asarray(self.points, dtype=np.float64)
+        if (
+            frame.ndim != 1
+            or identity.shape != frame.shape
+            or points.shape != (len(frame), 3)
+            or frame.dtype.kind not in "iu"
+            or identity.dtype.kind not in "iu"
+            or np.any(frame < 1)
+            or np.any(identity < 0)
+            or not np.isfinite(points).all()
+        ):
+            raise ValueError("invalid finite frame/identity/point rows")
+        for name, value in (("frame", frame), ("identity", identity), ("points", points)):
+            copied = value.copy()
+            copied.setflags(write=False)
+            object.__setattr__(self, name, copied)
+
+
+def kernel(first: np.ndarray, second: np.ndarray) -> np.ndarray:
+    squared = np.sum((first[:, None] - second[None, :]) ** 2, axis=-1)
+    return PRIOR_STD**2 * (0.5 + 0.5 * np.exp(-squared / (2 * LENGTH_SCALE**2)))
+
+
+def _deduplicate(rows: Rows, values: np.ndarray) -> tuple[Rows, np.ndarray]:
+    indices: dict[tuple[int, int], int] = {}
+    for index, key in enumerate(zip(rows.frame.tolist(), rows.identity.tolist(), strict=True)):
+        if key in indices:
+            old = indices[key]
+            if not np.array_equal(rows.points[old], rows.points[index]) or not np.array_equal(
+                values[old], values[index]
+            ):
+                raise ValueError("conflicting duplicate observation")
+        else:
+            indices[key] = index
+    selected = np.asarray([indices[key] for key in sorted(indices)], dtype=np.int64)
+    return Rows(rows.frame[selected], rows.identity[selected], rows.points[selected]), values[
+        selected
+    ]
+
+
+def bayesian_residual(
+    observations: Rows,
+    residual: np.ndarray,
+    queries: np.ndarray,
+    *,
+    shared_correlation: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Condition a fixed spatial residual GP through the existing Gaussian API."""
+    values = np.asarray(residual, dtype=np.float64)
+    query = np.asarray(queries, dtype=np.float64)
+    if values.shape != observations.points.shape or not np.isfinite(values).all():
+        raise ValueError("residual shape/values invalid")
+    if query.ndim != 2 or query.shape[1] != 3 or not np.isfinite(query).all():
+        raise ValueError("query shape/values invalid")
+    if np.any(observations.frame > PREFIX_STOP):
+        raise ValueError("future observation in prefix update")
+    if not 0 <= shared_correlation < 1:
+        raise ValueError("correlation must be in [0, 1)")
+    observations, values = _deduplicate(observations, values)
+    count = len(values)
+    if count == 0:
+        return np.zeros_like(query), np.broadcast_to(
+            np.eye(3) * (PRIOR_STD**2 + NOISE_STD**2), (len(query), 3, 3)
+        ).copy()
+
+    conditional = np.broadcast_to(
+        np.eye(3) * NOISE_STD**2 * (1 - shared_correlation), (count, 3, 3)
+    ).copy()
+    zero_gauge = np.zeros((count, 3, 7))
+    stack = StackedObservationFactors(
+        world_mean_m=np.zeros((count, 3)),
+        conditional_world_covariance_m2=conditional,
+        marginal_world_covariance_m2=conditional,
+        gauge_jacobian=zero_gauge,
+        gauge_prior_covariance=np.zeros((7, 7)),
+        association_probability=np.ones(count),
+        prior_reliability=np.ones(count),
+        prior_nominal_probability=np.ones(count),
+        composite_weight=np.ones(count),
+        point_ids=observations.identity,
+        frame_indices=observations.frame,
+        view_ids=("cam001",) * count,
+        factor_ids=tuple(f"prefix-{index}" for index in range(count)),
+        correlation_group_ids=("shared-camera",) * count,
+        gauge_ids=("zero-gauge",),
+        causal_frame_stop=PREFIX_STOP + 1,
+    )
+    base = build_observation_gaussian_operator(stack)
+    prior = kernel(observations.points, observations.points)
+    eigenvalues, vectors = np.linalg.eigh(prior)
+    root = vectors * np.sqrt(np.maximum(eigenvalues, 0.0))
+    # Keep a shared camera-bias nuisance in R, separate from the residual GP.
+    shared = np.full((count, 1), NOISE_STD * np.sqrt(shared_correlation))
+    factor = np.kron(np.concatenate((root, shared), axis=1), np.eye(3))
+    operator = augment_observation_gaussian_operator(base, factor.reshape(count, 3, -1))
+    cross = kernel(query, observations.points)
+    means: list[np.ndarray] = []
+    covariances: list[np.ndarray] = []
+    for row in cross:
+        posterior = condition_gaussian_query(
+            prior_mean=np.zeros(3),
+            prior_covariance=np.eye(3) * PRIOR_STD**2,
+            innovation=values,
+            query_observation_cross_covariance=np.kron(row[None], np.eye(3)),
+            innovation_operator=operator,
+        )
+        means.append(posterior.posterior_mean)
+        covariances.append(posterior.posterior_covariance + np.eye(3) * NOISE_STD**2)
+    return np.asarray(means).reshape(-1, 3), np.asarray(covariances).reshape(-1, 3, 3)
+
+
+def last_residual_shift(prefix: Rows, residual: np.ndarray, identities: np.ndarray) -> np.ndarray:
+    """Retain each identity's last valid residual, not just the final frame."""
+    rows, values = _deduplicate(prefix, np.asarray(residual, dtype=np.float64))
+    if np.any(rows.frame > PREFIX_STOP):
+        raise ValueError("future observation in last-residual update")
+    latest: dict[int, np.ndarray] = {}
+    for identity, value in zip(rows.identity, values, strict=True):
+        latest[int(identity)] = value
+    return np.asarray([latest.get(int(identity), np.zeros(3)) for identity in identities])
+
+
+def predict_arms(prefix: Rows, truth: np.ndarray, query: Rows) -> dict[str, Any]:
+    values = np.asarray(truth, dtype=np.float64)
+    if values.shape != prefix.points.shape or not np.isfinite(values).all():
+        raise ValueError("invalid prefix truth")
+    if np.any(prefix.frame > PREFIX_STOP) or np.any(query.frame <= PREFIX_STOP):
+        raise ValueError("prefix/query time boundary violated")
+    prefix, values = _deduplicate(prefix, values)
+    initial = prefix.frame <= 2
+    update = (prefix.frame >= 3) & (prefix.frame <= PREFIX_STOP)
+    if np.count_nonzero(initial) < 6:
+        raise ValueError("fewer than six initial alignment correspondences")
+    if len(np.unique(prefix.frame[initial])) < 2:
+        raise ValueError("initial alignment requires two nonempty frame clusters")
+    initial_fit, _ = robust_fit_sim3(prefix.points[initial], values[initial])
+    full_fit, _ = robust_fit_sim3(prefix.points, values)
+    center = np.mean(values[initial], axis=0)
+    span = float(np.linalg.norm(np.ptp(values[initial], axis=0)))
+    if not np.isfinite(span) or span <= 1e-12:
+        raise ValueError("invalid prefix-only normalization span")
+    initial_query = (initial_fit.apply(query.points) - center) / span
+    initial_prefix = (initial_fit.apply(prefix.points) - center) / span
+    normalized_truth = (values - center) / span
+    residual = normalized_truth - initial_prefix
+    baseline_covariance = np.broadcast_to(
+        np.eye(3) * (PRIOR_STD**2 + NOISE_STD**2), (len(query.points), 3, 3)
+    ).copy()
+    means = {
+        "cut3r_initial_alignment": initial_query,
+        "cut3r_full_prefix_alignment": (full_fit.apply(query.points) - center) / span,
+        "last_residual": initial_query + last_residual_shift(prefix, residual, query.identity),
+    }
+    covariances = {name: baseline_covariance.copy() for name in means}
+    update_rows = Rows(prefix.frame[update], prefix.identity[update], initial_prefix[update])
+    for name, correlation in (("bayesian_iid", 0.0), ("bayesian_shared", SHARED_CORRELATION)):
+        if np.count_nonzero(update) < 3 or len(np.unique(prefix.frame[update])) < 2:
+            means[name] = initial_query.copy()
+            covariances[name] = baseline_covariance.copy()
+        else:
+            shift, covariance = bayesian_residual(
+                update_rows, residual[update], initial_query, shared_correlation=correlation
+            )
+            means[name] = initial_query + shift
+            covariances[name] = covariance
+    return {
+        "means": means,
+        "covariances": covariances,
+        "normalization_center": center,
+        "normalization_span": span,
+        "prefix_count": len(values),
+        "update_count": int(np.count_nonzero(update)),
+        "bayesian_fallback": bool(
+            np.count_nonzero(update) < 3 or len(np.unique(prefix.frame[update])) < 2
+        ),
+    }
+
+
+def score_arms(
+    predictions: Mapping[str, Any], query: Rows, truth: np.ndarray
+) -> dict[str, dict[str, float]]:
+    values = np.asarray(truth, dtype=np.float64)
+    if values.shape != query.points.shape:
+        raise ValueError("score truth shape differs from sealed query rows")
+    normalized = (values - predictions["normalization_center"]) / predictions["normalization_span"]
+    valid = np.isfinite(normalized).all(axis=1)
+    if np.count_nonzero(valid) < 2 or len(np.unique(query.frame[valid])) != 2:
+        raise ValueError("score requires two supported later frames and two rows")
+    result: dict[str, dict[str, float]] = {}
+    for name in ARMS:
+        mean = np.asarray(predictions["means"][name])[valid]
+        covariance = np.asarray(predictions["covariances"][name])[valid]
+        error = normalized[valid] - mean
+        if not np.isfinite(mean).all() or not np.isfinite(covariance).all():
+            raise ValueError("nonfinite prediction")
+        np.linalg.cholesky(covariance)
+        solved = np.linalg.solve(covariance, error[..., None])[..., 0]
+        nees = np.sum(error * solved, axis=1)
+        nll = 0.5 * (3 * np.log(2 * np.pi) + np.linalg.slogdet(covariance)[1] + nees) / 3
+        frame_metrics = []
+        for frame in sorted(np.unique(query.frame[valid])):
+            selected = query.frame[valid] == frame
+            frame_metrics.append(
+                {
+                    "rmse_prefix_span": float(
+                        np.sqrt(np.mean(np.sum(error[selected] ** 2, axis=1)))
+                    ),
+                    "nll_per_coordinate": float(np.mean(nll[selected])),
+                    "normalized_nees": float(np.mean(nees[selected]) / 3),
+                    "coverage90": float(np.mean(nees[selected] <= CHI2_3_90)),
+                    "full_coordinate_width90_prefix_span": float(
+                        2
+                        * 1.6448536269514722
+                        * np.mean(np.sqrt(np.diagonal(covariance[selected], axis1=-2, axis2=-1)))
+                    ),
+                }
+            )
+        result[name] = {
+            key: float(np.mean([frame[key] for frame in frame_metrics])) for key in frame_metrics[0]
+        }
+        result[name]["scored_rows"] = float(np.count_nonzero(valid))
+    return result

--- a/tests/test_cut3r_bayesian_prefix_dev.py
+++ b/tests/test_cut3r_bayesian_prefix_dev.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import zipfile
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from prob4d.cut3r_bayesian_prefix_dev import (
+    ARMS,
+    NOISE_STD,
+    PRIOR_STD,
+    Rows,
+    bayesian_residual,
+    kernel,
+    last_residual_shift,
+    predict_arms,
+    score_arms,
+)
+from prob4d.dot_rope_cut3r_study import parse_coordinate_text
+
+
+def _observations() -> tuple[Rows, np.ndarray, np.ndarray]:
+    points = np.asarray([[0.0, 0, 0], [0.2, 0, 0], [0, 0.2, 0]])
+    rows = Rows(np.asarray([3, 4, 5]), np.asarray([0, 1, 2]), points)
+    residual = np.asarray([[0.05, 0, 0], [0.04, 0.01, 0], [0.06, 0, 0]])
+    return rows, residual, points + 0.01
+
+
+@pytest.mark.parametrize("correlation", [0.0, 0.8])
+def test_existing_operator_matches_dense_conditioning(correlation: float) -> None:
+    rows, residual, query = _observations()
+    mean, covariance = bayesian_residual(rows, residual, query, shared_correlation=correlation)
+    noise = NOISE_STD**2 * ((1 - correlation) * np.eye(3) + correlation * np.ones((3, 3)))
+    innovation = kernel(rows.points, rows.points) + noise
+    cross = kernel(query, rows.points)
+    expected_mean = cross @ np.linalg.solve(innovation, residual)
+    expected_variance = PRIOR_STD**2 - np.sum(
+        cross * np.linalg.solve(innovation, cross.T).T, axis=1
+    )
+    np.testing.assert_allclose(mean, expected_mean, atol=1e-12)
+    np.testing.assert_allclose(
+        covariance, (expected_variance + NOISE_STD**2)[:, None, None] * np.eye(3), atol=1e-12
+    )
+    assert np.linalg.eigvalsh(covariance).min() > 0
+
+
+def test_shared_noise_is_consumed_and_zero_innovation_stays_zero() -> None:
+    rows, residual, query = _observations()
+    independent = bayesian_residual(rows, residual, query, shared_correlation=0)
+    shared = bayesian_residual(rows, residual, query, shared_correlation=0.8)
+    assert not np.allclose(independent[0], shared[0])
+    assert not np.allclose(independent[1], shared[1])
+    mean, _ = bayesian_residual(rows, np.zeros_like(residual), query, shared_correlation=0.8)
+    np.testing.assert_array_equal(mean, 0)
+
+
+def test_duplicate_evidence_does_not_change_posterior() -> None:
+    rows, residual, query = _observations()
+    repeated = Rows(
+        np.tile(rows.frame, 10), np.tile(rows.identity, 10), np.tile(rows.points, (10, 1))
+    )
+    first = bayesian_residual(rows, residual, query, shared_correlation=0.8)
+    second = bayesian_residual(repeated, np.tile(residual, (10, 1)), query, shared_correlation=0.8)
+    for left, right in zip(first, second, strict=True):
+        np.testing.assert_array_equal(left, right)
+
+
+def test_conflicting_duplicate_and_future_observation_rejected() -> None:
+    rows, residual, query = _observations()
+    conflict = Rows(np.asarray([3, 3, 5]), np.asarray([0, 0, 2]), rows.points)
+    with pytest.raises(ValueError, match="conflicting"):
+        bayesian_residual(conflict, residual, query, shared_correlation=0.8)
+    future = Rows(np.asarray([3, 4, 6]), rows.identity, rows.points)
+    with pytest.raises(ValueError, match="future"):
+        bayesian_residual(future, residual, query, shared_correlation=0.8)
+
+
+def test_last_valid_residual_not_only_final_frame() -> None:
+    rows = Rows(np.asarray([5, 3, 4]), np.asarray([0, 1, 0]), np.zeros((3, 3)))
+    residual = np.asarray([[5.0, 0, 0], [3, 0, 0], [4, 0, 0]])
+    result = last_residual_shift(rows, residual, np.asarray([0, 1, 2]))
+    np.testing.assert_array_equal(result, [[5, 0, 0], [3, 0, 0], [0, 0, 0]])
+
+
+def _prefix() -> tuple[Rows, np.ndarray, Rows]:
+    points = np.asarray([[0.0, 0, 0], [1, 0, 0], [0, 1, 0]])
+    prefix = Rows(np.repeat(np.arange(1, 6), 3), np.tile(np.arange(3), 5), np.tile(points, (5, 1)))
+    truth = prefix.points.copy()
+    truth[prefix.frame >= 3, 2] += 0.05
+    query = Rows(np.repeat([6, 7], 3), np.tile(np.arange(3), 2), np.tile(points, (2, 1)))
+    return prefix, truth, query
+
+
+def test_matched_controls_and_prediction_shape() -> None:
+    prefix, truth, query = _prefix()
+    predictions = predict_arms(prefix, truth, query)
+    assert set(predictions["means"]) == set(ARMS)
+    future = query.points + np.asarray([0, 0, 0.05])
+    metrics = score_arms(predictions, query, future)
+    assert metrics["last_residual"]["rmse_prefix_span"] < 1e-12
+    assert (
+        metrics["bayesian_shared"]["rmse_prefix_span"]
+        < metrics["cut3r_initial_alignment"]["rmse_prefix_span"]
+    )
+    assert not predictions["bayesian_fallback"]
+    for name in ARMS:
+        assert predictions["means"][name].shape == (6, 3)
+        assert predictions["covariances"][name].shape == (6, 3, 3)
+
+
+def test_insufficient_update_is_exact_initial_fallback() -> None:
+    prefix, truth, query = _prefix()
+    selected = prefix.frame <= 2
+    prediction = predict_arms(
+        Rows(prefix.frame[selected], prefix.identity[selected], prefix.points[selected]),
+        truth[selected],
+        query,
+    )
+    assert prediction["bayesian_fallback"]
+    for name in ("bayesian_iid", "bayesian_shared"):
+        np.testing.assert_array_equal(
+            prediction["means"][name], prediction["means"]["cut3r_initial_alignment"]
+        )
+        np.testing.assert_array_equal(
+            prediction["covariances"][name], prediction["covariances"]["cut3r_initial_alignment"]
+        )
+
+
+def test_prefix_future_truth_boundary_and_score_support() -> None:
+    prefix, truth, query = _prefix()
+    with pytest.raises(ValueError, match="time boundary"):
+        predict_arms(Rows(prefix.frame + 1, prefix.identity, prefix.points), truth, query)
+    predictions = predict_arms(prefix, truth, query)
+    future = query.points.copy()
+    future[query.frame == 7] = np.nan
+    with pytest.raises(ValueError, match="two supported"):
+        score_arms(predictions, query, future)
+
+
+def test_metrics_use_equal_frame_not_coordinate_pooling() -> None:
+    query = Rows(np.asarray([6, 7, 7, 7]), np.arange(4), np.zeros((4, 3)))
+    means = {name: np.zeros((4, 3)) for name in ARMS}
+    covariance = {name: np.tile(np.eye(3), (4, 1, 1)) for name in ARMS}
+    prediction = {
+        "means": means,
+        "covariances": covariance,
+        "normalization_center": np.zeros(3),
+        "normalization_span": 1.0,
+    }
+    truth = np.asarray([[1.0, 0, 0], [3, 0, 0], [3, 0, 0], [3, 0, 0]])
+    result = score_arms(prediction, query, truth)
+    for row in result.values():
+        assert row["rmse_prefix_span"] == 2.0
+        assert row["normalized_nees"] == pytest.approx((1 + 9) / 6)
+
+
+def _runner():
+    path = Path(__file__).resolve().parents[1] / "scripts/science/run_cut3r_bayesian_prefix_dev.py"
+    spec = importlib.util.spec_from_file_location("cut3r_prefix_runner_test", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_runner_seals_all_predictions_before_later_truth(tmp_path: Path, monkeypatch) -> None:
+    runner = _runner()
+    points = np.asarray([[0.0, 0, 0], [1, 0, 0], [0, 1, 0]])
+    archive_path = tmp_path / "source.zip"
+
+    def member(sequence, dimension, frame, camera):
+        return f"{sequence}/{dimension}d/{frame}.txt"
+
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        for sequence in runner.SEQUENCES:
+            for frame in range(1, 8):
+                for dimension in (2, 3):
+                    values = points[:, :dimension].copy()
+                    if dimension == 3 and frame >= 3:
+                        values[:, 2] += 0.05
+                    text = "\n".join(",".join(str(float(value)) for value in row) for row in values)
+                    archive.writestr(member(sequence, dimension, frame, "cam001"), text)
+    monkeypatch.setattr(runner, "ARCHIVE_SHA", runner.sha256(archive_path))
+    manifest = {
+        "provider_bundle_id": runner.PROVIDER_ID,
+        "outputs": [{"sequence": seq, "run": "continuous"} for seq in runner.SEQUENCES],
+    }
+    base = SimpleNamespace(
+        _verify_provider_bundle=lambda *args: manifest,
+        _load_run=lambda *args: {},
+        _coordinate_member=member,
+    )
+    pooled = SimpleNamespace(_parse_coordinate_text=parse_coordinate_text)
+    monkeypatch.setattr(
+        runner, "_load_module", lambda path, name: pooled if "pooled" in name else base
+    )
+    monkeypatch.setattr(
+        runner,
+        "_sample",
+        lambda run, frame, coords, module: Rows(np.full(3, frame), np.arange(3), points),
+    )
+    monkeypatch.setattr(
+        runner.subprocess,
+        "check_output",
+        lambda args, **kwargs: "a" * 40 if "rev-parse" in args else "",
+    )
+    lock = tmp_path / "protocol.json"
+    runner.seal(lock, runner.protocol())
+    output = tmp_path / "result"
+    original_read = zipfile.ZipFile.read
+    scored_reads = []
+
+    def checked_read(self, name, *args, **kwargs):
+        if "/3d/" in name and name.endswith(("6.txt", "7.txt")):
+            barrier = json.loads((output / "prediction-barrier.json").read_text())
+            assert len(barrier["cases"]) == 3
+            assert all(row["status"] == "ordinary_success" for row in barrier["cases"].values())
+            assert barrier["future_3d_opened"] is False
+            scored_reads.append(name)
+        return original_read(self, name, *args, **kwargs)
+
+    monkeypatch.setattr(zipfile.ZipFile, "read", checked_read)
+    result = runner.run_study(archive_path, tmp_path, output, lock)
+    assert len(scored_reads) == 6
+    assert result["scored_sequence_count"] == 3
+    assert result["complete_denominator"] is True
+    assert result["protected_targets_accessed"] is False
+    assert not any(
+        "/3d/6" in row["member"] or "/3d/7" in row["member"]
+        for row in result["opened_coordinate_members"]
+        if row["stage"] == "prediction"
+    )
+    with pytest.raises(FileExistsError):
+        runner.run_study(archive_path, tmp_path, output, lock)

--- a/tests/test_cut3r_bayesian_prefix_result.py
+++ b/tests/test_cut3r_bayesian_prefix_result.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from prob4d.dot_rope_cut3r_study import content_id
+
+ROOT = Path(__file__).resolve().parents[1]
+EVIDENCE = ROOT / "evidence/cut3r-bayesian-prefix-dev-v1"
+
+
+@pytest.mark.parametrize(
+    "name", ["result.json", "prediction-barrier.json", "numerical-verification.json"]
+)
+def test_published_evidence_content_identity(name: str) -> None:
+    record = json.loads((EVIDENCE / name).read_text())
+    identity = record.pop("artifact_id")
+    assert identity == content_id(record)
+
+
+def test_complete_denominator_and_honest_no_superiority_decision() -> None:
+    result = json.loads((EVIDENCE / "result.json").read_text())
+    verification = json.loads((EVIDENCE / "numerical-verification.json").read_text())
+    barrier = json.loads((EVIDENCE / "prediction-barrier.json").read_text())
+    assert result["scored_sequence_count"] == 3
+    assert result["complete_denominator"] is True
+    assert all(row["status"] == "ordinary_success" for row in barrier["cases"].values())
+    assert verification["scored_rows"] == 28
+    assert verification["maximum_metric_difference"] < 1e-11
+    assert verification["result_id"] == result["artifact_id"]
+    assert result["prediction_barrier_id"] == barrier["artifact_id"]
+    assert barrier["future_3d_opened"] is False
+    assert result["provider_inference_rerun"] is False
+    assert result["protected_targets_accessed"] is False
+    assert result["autopromotion"] is False
+    aggregate = result["aggregate"]
+    shared = aggregate["bayesian_shared"]["rmse_prefix_span"]
+    assert shared < aggregate["cut3r_full_prefix_alignment"]["rmse_prefix_span"]
+    assert shared > aggregate["last_residual"]["rmse_prefix_span"]
+    assert (
+        aggregate["bayesian_shared"]["nll_per_coordinate"]
+        > aggregate["bayesian_iid"]["nll_per_coordinate"]
+    )


### PR DESCRIPTION
## Scope
A separately frozen, CPU-only exploratory comparison on already-open public DOT R01-R03. Reuses immutable native CUT3R predictions and existing Prob4D Gaussian-conditioning APIs. No new RGB decoding, provider inference, protected target, held-v8, DLO4/DLO5, or closed-study rerun.

## Result
All 3 sequences produced ordinary sealed predictions and were scored: 28 later 3D marker rows. The shared-error Bayesian arm reduces RMSE by 78.38% versus full-prefix Sim(3)-aligned CUT3R, but is 10.21% worse overall than last-residual correction. It improves RMSE by 8.34% versus independent-noise Bayes while slightly worsening NLL. Thus no overall Bayesian point-accuracy superiority is claimed and no promotion is authorized.

## Fairness and boundaries
All arms have the same permitted early 3D markers and current-frame RGB/2D query locations. Frames 1-2 fit the initial gauge, frames 3-5 condition residuals, and frames 6-7 3D markers are read only after every prediction/disposition is sealed. Full-prefix alignment and last-residual controls are included. This is sparse-prefix-supervised observed-frame reconstruction, not unseen-future physics or an independent cohort. Uncertainty comparisons against fixed Gaussian wrappers are not claims against independently calibrated baselines.

## Verification
- Method and protocol pushed at d70e0a426d1ec3e5da512e941c4e72f7915fb8b7 before this execution.
- Full local suite: 2,352 passed, 8 skipped; final focused source/result/conditioning suite: 34 passed.
- Native server focused suite: 11 passed. Ruff/format and strict focused MyPy pass.
- Independent scalar-form metric recomputation from unchanged predictions matches within 4.45e-16; canonical IDs and prediction file hashes reverified.
- Raw source predictions remain on gpuserver4090. Only compact JSON evidence and result interpretation are committed.

See evidence/cut3r-bayesian-prefix-dev-v1/README.md.